### PR TITLE
ReportActionCompose 4/6: extract input hooks

### DIFF
--- a/src/pages/inbox/report/ReportActionCompose/ComposerInput.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerInput.tsx
@@ -1,20 +1,12 @@
-import {useRoute} from '@react-navigation/native';
 import React from 'react';
 import type {MeasureInWindowOnSuccessCallback} from 'react-native';
 import type {LocalizedTranslate} from '@components/LocaleContextProvider';
 import useIsScrollLikelyLayoutTriggered from '@hooks/useIsScrollLikelyLayoutTriggered';
 import useLocalize from '@hooks/useLocalize';
-import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
-import useParentReportAction from '@hooks/useParentReportAction';
 import useReportIsArchived from '@hooks/useReportIsArchived';
-import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
 import FS from '@libs/Fullstory';
-import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
-import {getCombinedReportActions, getFilteredReportActionsForReportView, getOneTransactionThreadReportID, isMoneyRequestAction, isSentMoneyReportAction} from '@libs/ReportActionsUtils';
 import {
-    canEditReportAction,
     canUserPerformWriteAction as canUserPerformWriteActionReportUtils,
     chatIncludesChronos,
     chatIncludesConcierge,
@@ -25,14 +17,13 @@ import {isEmojiPickerVisible} from '@userActions/EmojiPickerAction';
 import {isBlockedFromConcierge as isBlockedFromConciergeUserAction} from '@userActions/User';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import SCREENS from '@src/SCREENS';
 import type {FileObject} from '@src/types/utils/Attachment';
 import {useComposerActions, useComposerMeta, useComposerSendActions, useComposerSendState, useComposerState} from './ComposerContext';
 import ComposerWithSuggestions from './ComposerWithSuggestions';
+import useComposerSubmit from './useComposerSubmit';
 
 type ComposerInputProps = {
     reportID: string;
-    submitForm: (comment: string) => void;
     onPasteFile: (files: FileObject | FileObject[]) => void;
 };
 
@@ -43,14 +34,15 @@ function getRandomPlaceholder(translate: LocalizedTranslate): string {
     return translate(AI_PLACEHOLDER_KEYS[randomIndex]);
 }
 
-function ComposerInput({reportID, submitForm, onPasteFile}: ComposerInputProps) {
+function ComposerInput({reportID, onPasteFile}: ComposerInputProps) {
     const {translate, preferredLocale} = useLocalize();
-    const {isOffline} = useNetwork();
     const {isMenuVisible} = useComposerState();
     const {isBlockedFromConcierge} = useComposerSendState();
     const {setIsFullComposerAvailable, onBlur, onFocus, setComposerRef} = useComposerActions();
     const {handleSendMessage, onValueChange} = useComposerSendActions();
     const {containerRef, suggestionsRef, isNextModalWillOpenRef} = useComposerMeta();
+
+    const submitForm = useComposerSubmit(reportID);
 
     const [isComposerFullSize = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${reportID}`);
     const [shouldShowComposeInput = true] = useOnyx(ONYXKEYS.SHOULD_SHOW_COMPOSE_INPUT);
@@ -65,26 +57,6 @@ function ComposerInput({reportID, submitForm, onPasteFile}: ComposerInputProps) 
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const isReportArchived = useReportIsArchived(report?.reportID);
-
-    // --- lastReportAction derivation (moves to useLastEditableAction hook in PR 4) ---
-    const {reportActions: unfilteredReportActions} = usePaginatedReportActions(report?.reportID);
-    const filteredReportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
-    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.chatReportID}`);
-    const allReportTransactions = useReportTransactionsCollection(reportID);
-    const reportTransactions = getAllNonDeletedTransactions(allReportTransactions, filteredReportActions, isOffline, true);
-    const visibleTransactions = isOffline ? reportTransactions : reportTransactions?.filter((t) => t.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
-    const reportTransactionIDs = visibleTransactions?.map((t) => t.transactionID);
-    const isSentMoneyReport = filteredReportActions.some((action) => isSentMoneyReportAction(action));
-    const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, filteredReportActions, isOffline, reportTransactionIDs);
-    const effectiveTransactionThreadReportID = isSentMoneyReport ? undefined : transactionThreadReportID;
-    const parentReportAction = useParentReportAction(report);
-    const [transactionThreadReportActionsOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${effectiveTransactionThreadReportID}`);
-    const transactionThreadReportActionsArray = transactionThreadReportActionsOnyx ? Object.values(transactionThreadReportActionsOnyx) : [];
-    const combinedReportActions = getCombinedReportActions(filteredReportActions, effectiveTransactionThreadReportID ?? null, transactionThreadReportActionsArray);
-    const route = useRoute();
-    const isOnSearchMoneyRequestReport = route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT || route.name === SCREENS.RIGHT_MODAL.EXPENSE_REPORT;
-    const actionsForLastEditable = isOnSearchMoneyRequestReport ? filteredReportActions : combinedReportActions;
-    const lastReportAction = [...actionsForLastEditable, parentReportAction].find((action) => !isMoneyRequestAction(action) && canEditReportAction(action, undefined));
 
     const includesConcierge = chatIncludesConcierge({participants: report?.participants});
     const isGroupPolicyReport = !!report?.policyID && report.policyID !== CONST.POLICY.ID_FAKE;
@@ -111,7 +83,6 @@ function ComposerInput({reportID, submitForm, onPasteFile}: ComposerInputProps) 
             policyID={report?.policyID}
             includeChronos={chatIncludesChronos(report)}
             isGroupPolicyReport={isGroupPolicyReport}
-            lastReportAction={lastReportAction}
             isMenuVisible={isMenuVisible}
             inputPlaceholder={inputPlaceholder}
             isComposerFullSize={isComposerFullSize}

--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
@@ -53,6 +53,7 @@ import getScrollPosition from '@pages/inbox/report/ReportActionCompose/getScroll
 import type {SuggestionsRef} from '@pages/inbox/report/ReportActionCompose/ReportActionCompose';
 import SilentCommentUpdater from '@pages/inbox/report/ReportActionCompose/SilentCommentUpdater';
 import Suggestions from '@pages/inbox/report/ReportActionCompose/Suggestions';
+import useLastEditableAction from '@pages/inbox/report/ReportActionCompose/useLastEditableAction';
 import {isEmojiPickerVisible} from '@userActions/EmojiPickerAction';
 import type {OnEmojiSelected} from '@userActions/EmojiPickerAction';
 import {inputFocusChange} from '@userActions/InputFocus';
@@ -61,7 +62,6 @@ import {broadcastUserIsTyping, saveReportActionDraft, saveReportDraftComment} fr
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
-import type * as OnyxTypes from '@src/types/onyx';
 import type {FileObject} from '@src/types/utils/Attachment';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 // eslint-disable-next-line no-restricted-imports
@@ -112,9 +112,6 @@ type ComposerWithSuggestionsProps = Partial<ChildrenProps> &
         /** Whether the input is disabled, defaults to false */
         disabled?: boolean;
 
-        /** Function to set whether the comment is empty */
-        setIsCommentEmpty?: (isCommentEmpty: boolean) => void;
-
         /** Function to handle sending a message */
         onEnterKeyPress: () => void;
 
@@ -136,9 +133,6 @@ type ComposerWithSuggestionsProps = Partial<ChildrenProps> &
         /** The ref to the next modal will open */
         isNextModalWillOpenRef: RefObject<boolean | null>;
 
-        /** The last report action */
-        lastReportAction?: OnyxEntry<OnyxTypes.ReportAction>;
-
         /** Whether to include chronos */
         includeChronos?: boolean;
 
@@ -147,9 +141,6 @@ type ComposerWithSuggestionsProps = Partial<ChildrenProps> &
 
         /** policy ID of the report */
         policyID?: string;
-
-        /** Whether the main composer was hidden */
-        didHideComposerInput?: boolean;
 
         /** Reference to the outer element */
         ref?: Ref<ComposerRef | null>;
@@ -214,7 +205,6 @@ function ComposerWithSuggestions({
     // Props: Report
     reportID,
     includeChronos,
-    lastReportAction,
     isGroupPolicyReport,
     policyID,
 
@@ -230,7 +220,6 @@ function ComposerWithSuggestions({
     inputPlaceholder,
     onPasteFile,
     disabled,
-    setIsCommentEmpty,
     onEnterKeyPress,
     shouldShowComposeInput,
     measureParentContainer = () => {},
@@ -246,11 +235,11 @@ function ComposerWithSuggestions({
 
     // For testing
     children,
-    didHideComposerInput,
 
     // Fullstory
     forwardedFSClass,
 }: ComposerWithSuggestionsProps) {
+    const lastReportAction = useLastEditableAction(reportID);
     const route = useRoute();
     const {isKeyboardShown} = useKeyboardState();
     const theme = useTheme();
@@ -293,7 +282,7 @@ function ComposerWithSuggestions({
 
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const maxComposerLines = shouldUseNarrowLayout ? CONST.COMPOSER.MAX_LINES_SMALL_SCREEN : CONST.COMPOSER.MAX_LINES;
-    const shouldAutoFocus = (shouldFocusInputOnScreenFocus || !!draftComment) && shouldShowComposeInput && areAllModalsHidden() && isFocused && !didHideComposerInput;
+    const shouldAutoFocus = (shouldFocusInputOnScreenFocus || !!draftComment) && shouldShowComposeInput && areAllModalsHidden() && isFocused;
     const delayedAutoFocusRouteKeyRef = useRef<string | null>(null);
 
     const valueRef = useRef(value);
@@ -455,13 +444,6 @@ function ComposerWithSuggestions({
                 }
             }
             const newCommentConverted = convertToLTRForComposer(newComment);
-            const isNewCommentEmpty = !!newCommentConverted.match(/^(\s)*$/);
-            const isPrevCommentEmpty = !!commentRef.current.match(/^(\s)*$/);
-
-            /** Only update isCommentEmpty state if it's different from previous one */
-            if (isNewCommentEmpty !== isPrevCommentEmpty) {
-                setIsCommentEmpty?.(isNewCommentEmpty);
-            }
             emojisPresentBefore.current = emojis;
 
             setValue(newCommentConverted);
@@ -497,7 +479,6 @@ function ComposerWithSuggestions({
             preferredLocale,
             preferredSkinTone,
             reportID,
-            setIsCommentEmpty,
             suggestionsRef,
             raiseIsScrollLikelyLayoutTriggered,
             debouncedSaveReportComment,

--- a/src/pages/inbox/report/ReportActionCompose/ReportActionCompose.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ReportActionCompose.tsx
@@ -1,16 +1,11 @@
-import {Str} from 'expensify-common';
-import React, {useContext, useState} from 'react';
+import React, {useState} from 'react';
 import {View} from 'react-native';
-import type {OnyxEntry} from 'react-native-onyx';
 import {scheduleOnUI} from 'react-native-worklets';
 import DragAndDropConsumer from '@components/DragAndDrop/Consumer';
 import DropZoneUI from '@components/DropZone/DropZoneUI';
 import DualDropZone from '@components/DropZone/DualDropZone';
 import OfflineIndicator from '@components/OfflineIndicator';
-import {usePersonalDetails} from '@components/OnyxListItemProvider';
-import useAncestors from '@hooks/useAncestors';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
-import useIsInSidePanel from '@hooks/useIsInSidePanel';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
@@ -20,25 +15,12 @@ import usePreferredPolicy from '@hooks/usePreferredPolicy';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
-import useShortMentionsList from '@hooks/useShortMentionsList';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {addComment} from '@libs/actions/Report';
-import {createTaskAndNavigate, setNewOptimisticAssignee} from '@libs/actions/Task';
 import ComposerFocusManager from '@libs/ComposerFocusManager';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import {isEmailPublicDomain} from '@libs/LoginUtils';
 import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
-import {rand64} from '@libs/NumberUtils';
-import {addDomainToShortMention} from '@libs/ParsingUtils';
-import {
-    getFilteredReportActionsForReportView,
-    getLinkedTransactionID,
-    getOneTransactionThreadReportID,
-    getReportAction,
-    isMoneyRequestAction,
-    isSentMoneyReportAction,
-} from '@libs/ReportActionsUtils';
+import {getFilteredReportActionsForReportView, getLinkedTransactionID, getReportAction, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {
     canEditFieldOfMoneyRequest,
     canUserPerformWriteAction as canUserPerformWriteActionReportUtils,
@@ -51,12 +33,7 @@ import {
     isSettled,
     temporary_getMoneyRequestOptions,
 } from '@libs/ReportUtils';
-import {startSpan} from '@libs/telemetry/activeSpans';
 import {getTransactionID, hasReceipt as hasReceiptTransactionUtils} from '@libs/TransactionUtils';
-import {generateAccountID} from '@libs/UserUtils';
-import {useAgentZeroStatusActions} from '@pages/inbox/AgentZeroStatusContext';
-import {ActionListContext} from '@pages/inbox/ReportScreenContext';
-import {addAttachmentWithComment} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
@@ -87,14 +64,8 @@ function ReportActionComposeInner({reportID}: ReportActionComposeProps) {
     const {translate} = useLocalize();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const {isOffline} = useNetwork();
-    const isInSidePanel = useIsInSidePanel();
-    const {kickoffWaitingIndicator} = useAgentZeroStatusActions();
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
-    const personalDetails = usePersonalDetails();
     const [currentDate] = useOnyx(ONYXKEYS.CURRENT_DATE);
-    const [quickAction] = useOnyx(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE);
-    const {availableLoginsList} = useShortMentionsList();
-    const currentUserEmail = currentUserPersonalDetails.email ?? '';
     const {isRestrictedToPreferredPolicy} = usePreferredPolicy();
 
     // Context: only 2 subscriptions needed for attachment/DropZone logic
@@ -105,23 +76,12 @@ function ReportActionComposeInner({reportID}: ReportActionComposeProps) {
     const [isComposerFullSize = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${reportID}`);
     const {reportActions: unfilteredReportActions} = usePaginatedReportActions(report?.reportID);
     const filteredReportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
-    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.chatReportID}`);
     const allReportTransactions = useReportTransactionsCollection(reportID);
     const reportTransactions = getAllNonDeletedTransactions(allReportTransactions, filteredReportActions, isOffline, true);
-    const visibleTransactions = isOffline ? reportTransactions : reportTransactions?.filter((t) => t.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
-    const reportTransactionIDs = visibleTransactions?.map((t) => t.transactionID);
-    const isSentMoneyReport = filteredReportActions.some((action) => isSentMoneyReportAction(action));
-    const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, filteredReportActions, isOffline, reportTransactionIDs);
-    const effectiveTransactionThreadReportID = isSentMoneyReport ? undefined : transactionThreadReportID;
 
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${report?.policyID}`);
     const [newParentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.parentReportID}`);
     const [betas] = useOnyx(ONYXKEYS.BETAS);
-
-    const [targetReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${effectiveTransactionThreadReportID ?? reportID}`);
-    const reportAncestors = useAncestors(report);
-    const targetReportAncestors = useAncestors(targetReport);
-    const {scrollOffsetRef} = useContext(ActionListContext);
 
     const [isAttachmentPreviewActive, setIsAttachmentPreviewActive] = useState(false);
 
@@ -180,95 +140,6 @@ function ReportActionComposeInner({reportID}: ReportActionComposeProps) {
         ComposerFocusManager.setReadyToFocus();
     };
 
-    const submitForm = (newComment: string) => {
-        const newCommentTrimmed = newComment.trim();
-        kickoffWaitingIndicator();
-
-        if (attachmentFileRef.current) {
-            addAttachmentWithComment({
-                report: targetReport,
-                notifyReportID: reportID,
-                ancestors: targetReportAncestors,
-                attachments: attachmentFileRef.current,
-                currentUserAccountID: currentUserPersonalDetails.accountID,
-                text: newCommentTrimmed,
-                timezone: currentUserPersonalDetails.timezone,
-                shouldPlaySound: true,
-                isInSidePanel,
-            });
-            attachmentFileRef.current = null;
-            return;
-        }
-
-        const taskMatch = newCommentTrimmed.match(CONST.REGEX.TASK_TITLE_WITH_OPTIONAL_SHORT_MENTION);
-        if (taskMatch) {
-            let taskTitle = taskMatch[3] ? taskMatch[3].trim().replaceAll('\n', ' ') : undefined;
-            if (taskTitle) {
-                const mention = taskMatch[1] ? taskMatch[1].trim() : '';
-                const currentUserPrivateDomain = isEmailPublicDomain(currentUserEmail) ? '' : Str.extractEmailDomain(currentUserEmail);
-                const mentionWithDomain = addDomainToShortMention(mention, availableLoginsList, currentUserPrivateDomain) ?? mention;
-                const isValidMention = Str.isValidEmail(mentionWithDomain);
-
-                let assignee: OnyxEntry<OnyxTypes.PersonalDetails>;
-                let assigneeChatReport;
-                if (mentionWithDomain) {
-                    if (isValidMention) {
-                        assignee = Object.values(personalDetails ?? {}).find((value) => value?.login === mentionWithDomain) ?? undefined;
-                        if (!Object.keys(assignee ?? {}).length) {
-                            const optimisticDataForNewAssignee = setNewOptimisticAssignee(currentUserPersonalDetails.accountID, {
-                                accountID: generateAccountID(mentionWithDomain),
-                                login: mentionWithDomain,
-                            });
-                            assignee = optimisticDataForNewAssignee.assignee;
-                            assigneeChatReport = optimisticDataForNewAssignee.assigneeReport;
-                        }
-                    } else {
-                        taskTitle = `@${mentionWithDomain} ${taskTitle}`;
-                    }
-                }
-                createTaskAndNavigate({
-                    parentReport: report,
-                    title: taskTitle,
-                    description: '',
-                    assigneeEmail: assignee?.login ?? '',
-                    currentUserAccountID: currentUserPersonalDetails.accountID,
-                    currentUserEmail,
-                    assigneeAccountID: assignee?.accountID,
-                    assigneeChatReport,
-                    policyID: report?.policyID,
-                    isCreatedUsingMarkdown: true,
-                    quickAction,
-                    ancestors: reportAncestors,
-                });
-                return;
-            }
-        }
-
-        const optimisticReportActionID = rand64();
-        const isScrolledToBottom = scrollOffsetRef.current < CONST.REPORT.ACTIONS.ACTION_VISIBLE_THRESHOLD;
-        if (isScrolledToBottom) {
-            startSpan(`${CONST.TELEMETRY.SPAN_SEND_MESSAGE}_${optimisticReportActionID}`, {
-                name: 'send-message',
-                op: CONST.TELEMETRY.SPAN_SEND_MESSAGE,
-                attributes: {
-                    [CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID,
-                    [CONST.TELEMETRY.ATTRIBUTE_MESSAGE_LENGTH]: newCommentTrimmed.length,
-                },
-            });
-        }
-        addComment({
-            report: targetReport,
-            notifyReportID: reportID,
-            ancestors: targetReportAncestors,
-            text: newCommentTrimmed,
-            timezoneParam: currentUserPersonalDetails.timezone ?? CONST.DEFAULT_TIME_ZONE,
-            currentUserAccountID: currentUserPersonalDetails.accountID,
-            shouldPlaySound: true,
-            isInSidePanel,
-            reportActionID: optimisticReportActionID,
-        });
-    };
-
     const {validateAttachments, onReceiptDropped, PDFValidationComponent, ErrorModal} = useAttachmentUploadValidation({
         policy,
         reportID,
@@ -301,7 +172,6 @@ function ReportActionComposeInner({reportID}: ReportActionComposeProps) {
                     />
                     <ComposerInput
                         reportID={reportID}
-                        submitForm={submitForm}
                         onPasteFile={(files) => validateAttachments({files})}
                     />
                     {shouldDisplayDualDropZone && (

--- a/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
+++ b/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
@@ -1,0 +1,150 @@
+import {Str} from 'expensify-common';
+import {useContext} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
+import {usePersonalDetails} from '@components/OnyxListItemProvider';
+import useAncestors from '@hooks/useAncestors';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useIsInSidePanel from '@hooks/useIsInSidePanel';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
+import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
+import useShortMentionsList from '@hooks/useShortMentionsList';
+import {addAttachmentWithComment, addComment} from '@libs/actions/Report';
+import {createTaskAndNavigate, setNewOptimisticAssignee} from '@libs/actions/Task';
+import {isEmailPublicDomain} from '@libs/LoginUtils';
+import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
+import {rand64} from '@libs/NumberUtils';
+import {addDomainToShortMention} from '@libs/ParsingUtils';
+import {getFilteredReportActionsForReportView, getOneTransactionThreadReportID, isSentMoneyReportAction} from '@libs/ReportActionsUtils';
+import {startSpan} from '@libs/telemetry/activeSpans';
+import {generateAccountID} from '@libs/UserUtils';
+import {useAgentZeroStatusActions} from '@pages/inbox/AgentZeroStatusContext';
+import {ActionListContext} from '@pages/inbox/ReportScreenContext';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type * as OnyxTypes from '@src/types/onyx';
+import {useComposerMeta} from './ComposerContext';
+
+function useComposerSubmit(reportID: string): (comment: string) => void {
+    const {isOffline} = useNetwork();
+    const {kickoffWaitingIndicator} = useAgentZeroStatusActions();
+    const currentUserPersonalDetails = useCurrentUserPersonalDetails();
+    const personalDetails = usePersonalDetails();
+    const {availableLoginsList} = useShortMentionsList();
+    const isInSidePanel = useIsInSidePanel();
+    const [quickAction] = useOnyx(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE);
+
+    const {attachmentFileRef} = useComposerMeta();
+    const {scrollOffsetRef} = useContext(ActionListContext);
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.chatReportID}`);
+
+    const {reportActions: unfilteredReportActions} = usePaginatedReportActions(report?.reportID);
+    const filteredReportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
+    const allReportTransactions = useReportTransactionsCollection(reportID);
+    const reportTransactions = getAllNonDeletedTransactions(allReportTransactions, filteredReportActions, isOffline, true);
+    const visibleTransactions = isOffline ? reportTransactions : reportTransactions?.filter((t) => t.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+    const reportTransactionIDs = visibleTransactions?.map((t) => t.transactionID);
+    const isSentMoneyReport = filteredReportActions.some((action) => isSentMoneyReportAction(action));
+    const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, filteredReportActions, isOffline, reportTransactionIDs);
+    const effectiveTransactionThreadReportID = isSentMoneyReport ? undefined : transactionThreadReportID;
+    const [targetReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${effectiveTransactionThreadReportID ?? reportID}`);
+
+    const reportAncestors = useAncestors(report);
+    const targetReportAncestors = useAncestors(targetReport);
+
+    const currentUserEmail = currentUserPersonalDetails.email ?? '';
+
+    return (newComment: string) => {
+        const newCommentTrimmed = newComment.trim();
+        kickoffWaitingIndicator();
+
+        if (attachmentFileRef.current) {
+            addAttachmentWithComment({
+                report: targetReport,
+                notifyReportID: reportID,
+                ancestors: targetReportAncestors,
+                attachments: attachmentFileRef.current,
+                currentUserAccountID: currentUserPersonalDetails.accountID,
+                text: newCommentTrimmed,
+                timezone: currentUserPersonalDetails.timezone,
+                shouldPlaySound: true,
+                isInSidePanel,
+            });
+            attachmentFileRef.current = null;
+            return;
+        }
+
+        const taskMatch = newCommentTrimmed.match(CONST.REGEX.TASK_TITLE_WITH_OPTIONAL_SHORT_MENTION);
+        if (taskMatch) {
+            let taskTitle = taskMatch[3] ? taskMatch[3].trim().replaceAll('\n', ' ') : undefined;
+            if (taskTitle) {
+                const mention = taskMatch[1] ? taskMatch[1].trim() : '';
+                const currentUserPrivateDomain = isEmailPublicDomain(currentUserEmail) ? '' : Str.extractEmailDomain(currentUserEmail);
+                const mentionWithDomain = addDomainToShortMention(mention, availableLoginsList, currentUserPrivateDomain) ?? mention;
+                const isValidMention = Str.isValidEmail(mentionWithDomain);
+
+                let assignee: OnyxEntry<OnyxTypes.PersonalDetails>;
+                let assigneeChatReport;
+                if (mentionWithDomain) {
+                    if (isValidMention) {
+                        assignee = Object.values(personalDetails ?? {}).find((value) => value?.login === mentionWithDomain) ?? undefined;
+                        if (!Object.keys(assignee ?? {}).length) {
+                            const optimisticDataForNewAssignee = setNewOptimisticAssignee(currentUserPersonalDetails.accountID, {
+                                accountID: generateAccountID(mentionWithDomain),
+                                login: mentionWithDomain,
+                            });
+                            assignee = optimisticDataForNewAssignee.assignee;
+                            assigneeChatReport = optimisticDataForNewAssignee.assigneeReport;
+                        }
+                    } else {
+                        taskTitle = `@${mentionWithDomain} ${taskTitle}`;
+                    }
+                }
+                createTaskAndNavigate({
+                    parentReport: report,
+                    title: taskTitle,
+                    description: '',
+                    assigneeEmail: assignee?.login ?? '',
+                    currentUserAccountID: currentUserPersonalDetails.accountID,
+                    currentUserEmail,
+                    assigneeAccountID: assignee?.accountID,
+                    assigneeChatReport,
+                    policyID: report?.policyID,
+                    isCreatedUsingMarkdown: true,
+                    quickAction,
+                    ancestors: reportAncestors,
+                });
+                return;
+            }
+        }
+
+        const optimisticReportActionID = rand64();
+        const isScrolledToBottom = scrollOffsetRef.current < CONST.REPORT.ACTIONS.ACTION_VISIBLE_THRESHOLD;
+        if (isScrolledToBottom) {
+            startSpan(`${CONST.TELEMETRY.SPAN_SEND_MESSAGE}_${optimisticReportActionID}`, {
+                name: 'send-message',
+                op: CONST.TELEMETRY.SPAN_SEND_MESSAGE,
+                attributes: {
+                    [CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID,
+                    [CONST.TELEMETRY.ATTRIBUTE_MESSAGE_LENGTH]: newCommentTrimmed.length,
+                },
+            });
+        }
+        addComment({
+            report: targetReport,
+            notifyReportID: reportID,
+            ancestors: targetReportAncestors,
+            text: newCommentTrimmed,
+            timezoneParam: currentUserPersonalDetails.timezone ?? CONST.DEFAULT_TIME_ZONE,
+            currentUserAccountID: currentUserPersonalDetails.accountID,
+            shouldPlaySound: true,
+            isInSidePanel,
+            reportActionID: optimisticReportActionID,
+        });
+    };
+}
+
+export default useComposerSubmit;

--- a/src/pages/inbox/report/ReportActionCompose/useLastEditableAction.ts
+++ b/src/pages/inbox/report/ReportActionCompose/useLastEditableAction.ts
@@ -1,0 +1,44 @@
+import {useRoute} from '@react-navigation/native';
+import type {OnyxEntry} from 'react-native-onyx';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
+import useParentReportAction from '@hooks/useParentReportAction';
+import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
+import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
+import {getCombinedReportActions, getFilteredReportActionsForReportView, getOneTransactionThreadReportID, isMoneyRequestAction, isSentMoneyReportAction} from '@libs/ReportActionsUtils';
+import {canEditReportAction} from '@libs/ReportUtils';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+import type * as OnyxTypes from '@src/types/onyx';
+
+function useLastEditableAction(reportID: string): OnyxEntry<OnyxTypes.ReportAction> {
+    const {isOffline} = useNetwork();
+    const route = useRoute();
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.chatReportID}`);
+
+    const {reportActions: unfilteredReportActions} = usePaginatedReportActions(report?.reportID);
+    const filteredReportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
+    const allReportTransactions = useReportTransactionsCollection(reportID);
+    const reportTransactions = getAllNonDeletedTransactions(allReportTransactions, filteredReportActions, isOffline, true);
+    const visibleTransactions = isOffline ? reportTransactions : reportTransactions?.filter((t) => t.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+    const reportTransactionIDs = visibleTransactions?.map((t) => t.transactionID);
+    const isSentMoneyReport = filteredReportActions.some((action) => isSentMoneyReportAction(action));
+    const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, filteredReportActions, isOffline, reportTransactionIDs);
+    const effectiveTransactionThreadReportID = isSentMoneyReport ? undefined : transactionThreadReportID;
+
+    const parentReportAction = useParentReportAction(report);
+    const [transactionThreadReportActionsOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${effectiveTransactionThreadReportID}`);
+    const transactionThreadReportActionsArray = transactionThreadReportActionsOnyx ? Object.values(transactionThreadReportActionsOnyx) : [];
+    const combinedReportActions = getCombinedReportActions(filteredReportActions, effectiveTransactionThreadReportID ?? null, transactionThreadReportActionsArray);
+
+    const isOnSearchMoneyRequestReport = route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT || route.name === SCREENS.RIGHT_MODAL.EXPENSE_REPORT;
+    const actionsForLastEditable = isOnSearchMoneyRequestReport ? filteredReportActions : combinedReportActions;
+
+    return [...actionsForLastEditable, parentReportAction].find((action) => !isMoneyRequestAction(action) && canEditReportAction(action, undefined));
+}
+
+export default useLastEditableAction;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

<!-- Explain what your change does and how it addresses the linked issue -->

PR 4/6 in the ReportActionCompose decomposition series ([issue #87097](https://github.com/Expensify/App/issues/87097)).

Extracts two self-contained hooks from the orchestrator and `ComposerInput`:

- **`useComposerSubmit`** (150 LOC) — owns the three submit branches (comment, attachment+caption, task creation). Self-subscribes to all submit-only Onyx data. Consumer: `ComposerInput`.
- **`useLastEditableAction`** (44 LOC) — computes the last editable action for the arrow-up edit shortcut. Self-subscribes to paginated actions + transaction-thread actions. Consumer: `ComposerWithSuggestions`.

**Orchestrator: 350 → 220 LOC.** `submitForm` (88 LOC) + its data derivation (~42 LOC of Onyx subs / ancestor computation) all leave the orchestrator.

**ComposerInput: 133 → 104 LOC.** No more `submitForm` prop; inline `lastReportAction` derivation (19 LOC) deleted.

**Dead code removed from `ComposerWithSuggestions`:**

- `setIsCommentEmpty` prop + call site — zero external callers, optional no-op since PR 3 cleanup.
- `didHideComposerInput` prop — zero external callers, was always `undefined` → `!didHideComposerInput` was always `true`.
- `lastReportAction` prop — replaced by internal `useLastEditableAction(reportID)` call; no parent passes a divergent value.

**Remaining inline in orchestrator for PR 5:** `useAttachmentUploadValidation` hook call + `DualDropZone` / `DragAndDropConsumer` + `DropZoneUI` render + attachment-derivation block (~55 LOC). All extracted in the next PR.

💡 Review with **Hide whitespace**.

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):


Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/Expensify/App/issues/89371
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Critical (PR 4 touches)**

1. **Comment path** — open chat, type `hello`, Enter → message posts.
2. **Task path** — type `My first task`, Enter → task created in the parent report.
3. **Task with valid mention** — type `Ship it @someone@expensify.com`, Enter → task assigned to that user.
4. **Task with invalid mention** — type `Fix it @foo`, Enter → task title prepends `@foo`, no assignee.
5. **Attachment + caption path** — `+` menu → pick image → caption `check this` → send → message posts with attachment and caption.
6. **Arrow-up edit** — empty composer, press ↑ → last own message opens in edit mode. Try twice in a row to confirm draft saves.
7. **Telemetry scroll gate** — scroll up past the threshold in a long chat, send → no span started (cannot observe directly, but no crash/regression). Then scroll to bottom, send → normal send, no error.

**Regression checks (props removed)**

8. **AutoFocus** — `didHideComposerInput` removed. Open a chat on web → composer auto-focuses on arrival. Open RHP over chat → come back → composer re-focuses. No regressions expected; removed prop was always `undefined`.
9. **Character-count warning** — type 4000+ chars → warning renders below composer. (Verifies `setIsCommentEmpty` dead-code removal didn't affect `exceededMaxLength`.)
10. **Concierge placeholder** — open concierge chat in English locale → rotating AI placeholder shows.
11. **Blocked-from-concierge** — on blocked account, open concierge → "blocked from concierge" placeholder.
12. **Chronos** — in chronos chat, ↑ should NOT open edit mode (chronos excluded from shortcut).

**Smoke**

15. Switch between chats → composer state resets, no stale draft leaking.
16. No JS console errors throughout.

- [x] Verify that no errors appear in the JS console

### Offline tests

<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

13. Go offline → type + Enter → message queues with yellow brick road → reconnect → syncs.
14. Offline + attachment via `+` → queues → syncs on reconnect.

### QA Steps

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>