### PR TITLE
[CP Staging] Fix `maintainVisibleContentPosition` behaviour after migration to FlashList

### DIFF
--- a/src/components/FlashList/InvertedFlashList/index.tsx
+++ b/src/components/FlashList/InvertedFlashList/index.tsx
@@ -20,7 +20,7 @@ type InvertedFlashListProps<T> = FlashListProps<T> & {
 };
 
 function InvertedFlashList<T>({data, keyExtractor, initialScrollKey, onStartReached: onStartReachedProp, ...restProps}: InvertedFlashListProps<T>) {
-    const {displayedData, onStartReached} = useFlashListScrollKey<T>({
+    const {displayedData, onStartReached, maintainVisibleContentPosition} = useFlashListScrollKey<T>({
         data,
         keyExtractor,
         initialScrollKey,
@@ -36,6 +36,7 @@ function InvertedFlashList<T>({data, keyExtractor, initialScrollKey, onStartReac
             data={displayedData}
             keyExtractor={keyExtractor}
             CellRendererComponent={CellRendererComponent}
+            maintainVisibleContentPosition={maintainVisibleContentPosition}
         />
     );
 }

--- a/src/components/FlashList/useFlashListScrollKey.ts
+++ b/src/components/FlashList/useFlashListScrollKey.ts
@@ -17,26 +17,36 @@ type FlashListScrollKeyProps<T> = {
 
 export default function useFlashListScrollKey<T>({data, keyExtractor, initialScrollKey, onStartReached}: FlashListScrollKeyProps<T>) {
     const [isInitialRender, setIsInitialRender] = useState(true);
+    const [hasLinkingSettled, setHasLinkingSettled] = useState(!initialScrollKey);
 
-    // After the first render with sliced data, give FlashList one frame to lay out,
-    // then switch to the full data array. maintainVisibleContentPosition keeps the target pinned.
+    // Two-frame handoff for deep-link:
+    // RAF 1: switch from sliced data to the full array — FlashList's default MVCP pins the
+    //        linked item through the data swap.
+    // RAF 2: pinning has happened, disable MVCP so it doesn't cause later jumps.
     useEffect(() => {
         if (!isInitialRender || !initialScrollKey) {
             return;
         }
-        requestAnimationFrame(() => setIsInitialRender(false));
+        requestAnimationFrame(() => {
+            setIsInitialRender(false);
+            requestAnimationFrame(() => setHasLinkingSettled(true));
+        });
     }, [isInitialRender, initialScrollKey]);
 
+    // `undefined` = leave FlashList's default (MVCP enabled) while we're still pinning the linked item.
+    // `{disabled: true}` once that's done so MVCP can't interfere afterward.
+    const maintainVisibleContentPosition: FlashListProps<T>['maintainVisibleContentPosition'] = hasLinkingSettled ? {disabled: true} : undefined;
+
     if (!isInitialRender || !initialScrollKey) {
-        return {displayedData: data, onStartReached};
+        return {displayedData: data, onStartReached, maintainVisibleContentPosition};
     }
 
     const targetIndex = data.findIndex((item, index) => keyExtractor(item, index) === initialScrollKey);
     if (targetIndex <= 0) {
-        return {displayedData: data, onStartReached};
+        return {displayedData: data, onStartReached, maintainVisibleContentPosition};
     }
 
     // On the first render, slice from the target onward so the target item
     // appears at the visual bottom of the inverted list — no scrolling needed.
-    return {displayedData: data.slice(targetIndex), onStartReached: () => {}};
+    return {displayedData: data.slice(targetIndex), onStartReached: () => {}, maintainVisibleContentPosition};
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

After the FlashList migration in https://github.com/Expensify/App/pull/85114, `maintainVisibleContentPosition` was left at FlashList's default — which is **enabled**, unlike FlatList where the `useFlashListScrollKey` hook was returning `undefined` (i.e. off) most of the time. MVCP staying on past the deep-link pinning window was causing layout jumps during the arrival of new messages.

This PR restores the intended behavior inside `useFlashListScrollKey`:

- When opening a chat **without** a linked action, MVCP is disabled from the first render (`{disabled: true}`), matching the pre-migration FlatList behavior. New-message auto-scroll is already handled by `useScrollToEndOnNewMessageReceived`, so we don't need MVCP for that.
- When opening a chat **with** a linked action (`initialScrollKey`), it handles linking first and only then disables MVCP.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88089
$ https://github.com/Expensify/App/issues/88078
$ ~~https://github.com/Expensify/App/issues/88238~~
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

[Expense - Report is scrolled up then scrolled down after creating an expense](https://github.com/Expensify/App/issues/88078)

1. Open the app
2. Create a workspace.
3. Go to workspace chat.
4. Create an expense.
5. See the report is not scroll up after creating an expense.

[iOS - Attachment - Chat does not scroll to bottom when sending a PDF file](https://github.com/Expensify/App/issues/88089)

1. Open the chat
2. On a conversation, click on the + button in the compose box
3. Click on add attachment
4. Upload a PDF
5. The chat should automatically scrolls to the latest message after sending a PDF file, and the PDF preview should be fully visible in the chat.

**Deep linking test**
1. Click a link to a specific message in a chat
2. The chat should open scrolled to that specific message
3. The linked message should be visible on screen (not hidden above/below viewport)
4. After the initial scroll, scrolling up/down from the linked message should work normally

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same, as in **Tests** section

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

Same, as in **Tests** section

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/89d31493-ede8-42ab-99a6-864ae549740b



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/60441742-0ef8-4f03-a4db-1c144e1d19d0


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/e1f66358-7688-4749-ba36-59d6365b3f1a



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/73c53895-81b2-4157-b149-8b74b5d48526



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/8cb64e54-3ba6-4110-af1b-742553158544


https://github.com/user-attachments/assets/e4d07301-5ba5-4bc0-8ba3-4d873c0da93d


</details>