### PR TITLE
Add useCardFeeds regression tests for empty linkedPolicyIDs

### DIFF
--- a/tests/unit/hooks/useCardFeeds.test.ts
+++ b/tests/unit/hooks/useCardFeeds.test.ts
@@ -2,6 +2,7 @@
 import {renderHook, waitFor} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
 import useCardFeeds from '@hooks/useCardFeeds';
+import {getCardFeedWithDomainID} from '@libs/CardUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
@@ -111,6 +112,8 @@ describe('useCardFeeds', () => {
     });
 
     describe('linkedPolicyIDs predicate filtering', () => {
+        const combinedFeedKey = getCardFeedWithDomainID(oauthFeed, domainID);
+
         const setupDomainFeed = async (companyCardSettings: {preferredPolicy: string; linkedPolicyIDs?: string[]}) => {
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
             await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
@@ -135,10 +138,9 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
-            await waitFor(() => expect(result.current[1].status).toBe('loaded'));
-
-            const feedKeys = Object.keys(result.current[0] ?? {});
-            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
+            // The combined feed key contains '.', so wrap it in an array to disable
+            // jest's nested-path interpretation in toHaveProperty.
+            await waitFor(() => expect(result.current[0]).toHaveProperty([combinedFeedKey]));
         });
 
         it('includes domain feeds when linkedPolicyIDs is an empty array and preferredPolicy matches', async () => {
@@ -147,10 +149,7 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
-            await waitFor(() => expect(result.current[1].status).toBe('loaded'));
-
-            const feedKeys = Object.keys(result.current[0] ?? {});
-            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
+            await waitFor(() => expect(result.current[0]).toHaveProperty([combinedFeedKey]));
         });
 
         it('excludes feeds when linkedPolicyIDs explicitly lists other policies and preferredPolicy does not match', async () => {
@@ -159,10 +158,10 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
+            // Wait for the hook to finish loading before asserting absence, so the negative
+            // assertion can't pass vacuously while Onyx is still hydrating.
             await waitFor(() => expect(result.current[1].status).toBe('loaded'));
-
-            const feedKeys = Object.keys(result.current[0] ?? {});
-            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(false);
+            expect(result.current[0]).not.toHaveProperty([combinedFeedKey]);
         });
 
         it('includes feeds when policyID is one of multiple meaningful entries in linkedPolicyIDs', async () => {
@@ -171,10 +170,7 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
-            await waitFor(() => expect(result.current[1].status).toBe('loaded'));
-
-            const feedKeys = Object.keys(result.current[0] ?? {});
-            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
+            await waitFor(() => expect(result.current[0]).toHaveProperty([combinedFeedKey]));
         });
     });
 });

--- a/tests/unit/hooks/useCardFeeds.test.ts
+++ b/tests/unit/hooks/useCardFeeds.test.ts
@@ -131,11 +131,11 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
-            await waitFor(() => {
-                const [workspaceFeeds] = result.current;
-                const feedKeys = Object.keys(workspaceFeeds ?? {});
-                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
-            });
+            await waitFor(() => expect(result.current[1].status).toBe('loaded'));
+
+            const [workspaceFeeds] = result.current;
+            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
         });
 
         it('includes domain feeds when linkedPolicyIDs is an empty array and preferredPolicy matches', async () => {
@@ -158,11 +158,11 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
-            await waitFor(() => {
-                const [workspaceFeeds] = result.current;
-                const feedKeys = Object.keys(workspaceFeeds ?? {});
-                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
-            });
+            await waitFor(() => expect(result.current[1].status).toBe('loaded'));
+
+            const [workspaceFeeds] = result.current;
+            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
         });
 
         it('excludes feeds when linkedPolicyIDs explicitly lists other policies and preferredPolicy does not match', async () => {
@@ -185,11 +185,11 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
-            await waitFor(() => {
-                const [workspaceFeeds] = result.current;
-                const feedKeys = Object.keys(workspaceFeeds ?? {});
-                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(false);
-            });
+            await waitFor(() => expect(result.current[1].status).toBe('loaded'));
+
+            const [workspaceFeeds] = result.current;
+            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(false);
         });
 
         it('includes feeds when policyID is one of multiple meaningful entries in linkedPolicyIDs', async () => {
@@ -212,11 +212,11 @@ describe('useCardFeeds', () => {
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
-            await waitFor(() => {
-                const [workspaceFeeds] = result.current;
-                const feedKeys = Object.keys(workspaceFeeds ?? {});
-                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
-            });
+            await waitFor(() => expect(result.current[1].status).toBe('loaded'));
+
+            const [workspaceFeeds] = result.current;
+            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
         });
     });
 });

--- a/tests/unit/hooks/useCardFeeds.test.ts
+++ b/tests/unit/hooks/useCardFeeds.test.ts
@@ -109,4 +109,119 @@ describe('useCardFeeds', () => {
             });
         });
     });
+
+    describe('linkedPolicyIDs predicate filtering', () => {
+        // Regression guard for https://github.com/Expensify/Expensify/issues/548636. Domain feeds
+        // can persist `linkedPolicyIDs: ['']` (legacy shape from older clients and from the backend
+        // default in DomainAPI when `preferredPolicy` was empty). The predicate previously treated
+        // any truthy `linkedPolicyIDs` as the source of truth and short-circuited, dropping feeds
+        // that had a matching `preferredPolicy`. These tests pin the corrected behavior.
+        it('includes domain feeds when linkedPolicyIDs contains only an empty string and preferredPolicy matches', async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
+                settings: {
+                    companyCards: {
+                        [oauthFeed]: {preferredPolicy: policyID, linkedPolicyIDs: [''], liabilityType: 'corporate'},
+                    },
+                    oAuthAccountDetails: {
+                        [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
+                    },
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${domainID}_${oauthFeed}`, {
+                '123': {cardID: 123, cardName: 'Card 1'},
+            });
+            await waitForBatchedUpdates();
+
+            const {result} = renderHook(() => useCardFeeds(policyID));
+            await waitForBatchedUpdates();
+
+            await waitFor(() => {
+                const [workspaceFeeds] = result.current;
+                const feedKeys = Object.keys(workspaceFeeds ?? {});
+                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
+            });
+        });
+
+        it('includes domain feeds when linkedPolicyIDs is an empty array and preferredPolicy matches', async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
+                settings: {
+                    companyCards: {
+                        [oauthFeed]: {preferredPolicy: policyID, linkedPolicyIDs: [], liabilityType: 'corporate'},
+                    },
+                    oAuthAccountDetails: {
+                        [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
+                    },
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${domainID}_${oauthFeed}`, {
+                '123': {cardID: 123, cardName: 'Card 1'},
+            });
+            await waitForBatchedUpdates();
+
+            const {result} = renderHook(() => useCardFeeds(policyID));
+            await waitForBatchedUpdates();
+
+            await waitFor(() => {
+                const [workspaceFeeds] = result.current;
+                const feedKeys = Object.keys(workspaceFeeds ?? {});
+                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
+            });
+        });
+
+        it('excludes feeds when linkedPolicyIDs explicitly lists other policies and preferredPolicy does not match', async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
+                settings: {
+                    companyCards: {
+                        [oauthFeed]: {preferredPolicy: 'OTHER_POLICY', linkedPolicyIDs: ['OTHER_POLICY'], liabilityType: 'corporate'},
+                    },
+                    oAuthAccountDetails: {
+                        [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
+                    },
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${domainID}_${oauthFeed}`, {
+                '123': {cardID: 123, cardName: 'Card 1'},
+            });
+            await waitForBatchedUpdates();
+
+            const {result} = renderHook(() => useCardFeeds(policyID));
+            await waitForBatchedUpdates();
+
+            await waitFor(() => {
+                const [workspaceFeeds] = result.current;
+                const feedKeys = Object.keys(workspaceFeeds ?? {});
+                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(false);
+            });
+        });
+
+        it('includes feeds when policyID is one of multiple meaningful entries in linkedPolicyIDs', async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
+                settings: {
+                    companyCards: {
+                        [oauthFeed]: {preferredPolicy: 'OTHER_POLICY', linkedPolicyIDs: ['OTHER_POLICY', policyID], liabilityType: 'corporate'},
+                    },
+                    oAuthAccountDetails: {
+                        [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
+                    },
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${domainID}_${oauthFeed}`, {
+                '123': {cardID: 123, cardName: 'Card 1'},
+            });
+            await waitForBatchedUpdates();
+
+            const {result} = renderHook(() => useCardFeeds(policyID));
+            await waitForBatchedUpdates();
+
+            await waitFor(() => {
+                const [workspaceFeeds] = result.current;
+                const feedKeys = Object.keys(workspaceFeeds ?? {});
+                expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
+            });
+        });
+    });
 });

--- a/tests/unit/hooks/useCardFeeds.test.ts
+++ b/tests/unit/hooks/useCardFeeds.test.ts
@@ -111,11 +111,6 @@ describe('useCardFeeds', () => {
     });
 
     describe('linkedPolicyIDs predicate filtering', () => {
-        // Regression guard for https://github.com/Expensify/Expensify/issues/548636. Domain feeds
-        // can persist `linkedPolicyIDs: ['']` (legacy shape from older clients and from the backend
-        // default in DomainAPI when `preferredPolicy` was empty). The predicate previously treated
-        // any truthy `linkedPolicyIDs` as the source of truth and short-circuited, dropping feeds
-        // that had a matching `preferredPolicy`. These tests pin the corrected behavior.
         it('includes domain feeds when linkedPolicyIDs contains only an empty string and preferredPolicy matches', async () => {
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
             await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {

--- a/tests/unit/hooks/useCardFeeds.test.ts
+++ b/tests/unit/hooks/useCardFeeds.test.ts
@@ -111,12 +111,12 @@ describe('useCardFeeds', () => {
     });
 
     describe('linkedPolicyIDs predicate filtering', () => {
-        it('includes domain feeds when linkedPolicyIDs contains only an empty string and preferredPolicy matches', async () => {
+        const setupDomainFeed = async (companyCardSettings: {preferredPolicy: string; linkedPolicyIDs?: string[]}) => {
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
             await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
                 settings: {
                     companyCards: {
-                        [oauthFeed]: {preferredPolicy: policyID, linkedPolicyIDs: [''], liabilityType: 'corporate'},
+                        [oauthFeed]: {...companyCardSettings, liabilityType: 'corporate'},
                     },
                     oAuthAccountDetails: {
                         [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
@@ -127,95 +127,53 @@ describe('useCardFeeds', () => {
                 '123': {cardID: 123, cardName: 'Card 1'},
             });
             await waitForBatchedUpdates();
+        };
+
+        it('includes domain feeds when linkedPolicyIDs contains only an empty string and preferredPolicy matches', async () => {
+            await setupDomainFeed({preferredPolicy: policyID, linkedPolicyIDs: ['']});
 
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
             await waitFor(() => expect(result.current[1].status).toBe('loaded'));
 
-            const [workspaceFeeds] = result.current;
-            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            const feedKeys = Object.keys(result.current[0] ?? {});
             expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
         });
 
         it('includes domain feeds when linkedPolicyIDs is an empty array and preferredPolicy matches', async () => {
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
-                settings: {
-                    companyCards: {
-                        [oauthFeed]: {preferredPolicy: policyID, linkedPolicyIDs: [], liabilityType: 'corporate'},
-                    },
-                    oAuthAccountDetails: {
-                        [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
-                    },
-                },
-            });
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${domainID}_${oauthFeed}`, {
-                '123': {cardID: 123, cardName: 'Card 1'},
-            });
-            await waitForBatchedUpdates();
+            await setupDomainFeed({preferredPolicy: policyID, linkedPolicyIDs: []});
 
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
             await waitFor(() => expect(result.current[1].status).toBe('loaded'));
 
-            const [workspaceFeeds] = result.current;
-            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            const feedKeys = Object.keys(result.current[0] ?? {});
             expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
         });
 
         it('excludes feeds when linkedPolicyIDs explicitly lists other policies and preferredPolicy does not match', async () => {
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
-                settings: {
-                    companyCards: {
-                        [oauthFeed]: {preferredPolicy: 'OTHER_POLICY', linkedPolicyIDs: ['OTHER_POLICY'], liabilityType: 'corporate'},
-                    },
-                    oAuthAccountDetails: {
-                        [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
-                    },
-                },
-            });
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${domainID}_${oauthFeed}`, {
-                '123': {cardID: 123, cardName: 'Card 1'},
-            });
-            await waitForBatchedUpdates();
+            await setupDomainFeed({preferredPolicy: 'OTHER_POLICY', linkedPolicyIDs: ['OTHER_POLICY']});
 
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
             await waitFor(() => expect(result.current[1].status).toBe('loaded'));
 
-            const [workspaceFeeds] = result.current;
-            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            const feedKeys = Object.keys(result.current[0] ?? {});
             expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(false);
         });
 
         it('includes feeds when policyID is one of multiple meaningful entries in linkedPolicyIDs', async () => {
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {workspaceAccountID: 0});
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${domainID}`, {
-                settings: {
-                    companyCards: {
-                        [oauthFeed]: {preferredPolicy: 'OTHER_POLICY', linkedPolicyIDs: ['OTHER_POLICY', policyID], liabilityType: 'corporate'},
-                    },
-                    oAuthAccountDetails: {
-                        [oauthFeed]: {credentials: 'xxxx', expiration: 9999999999, accountList: ['Card 1']},
-                    },
-                },
-            });
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${domainID}_${oauthFeed}`, {
-                '123': {cardID: 123, cardName: 'Card 1'},
-            });
-            await waitForBatchedUpdates();
+            await setupDomainFeed({preferredPolicy: 'OTHER_POLICY', linkedPolicyIDs: ['OTHER_POLICY', policyID]});
 
             const {result} = renderHook(() => useCardFeeds(policyID));
             await waitForBatchedUpdates();
 
             await waitFor(() => expect(result.current[1].status).toBe('loaded'));
 
-            const [workspaceFeeds] = result.current;
-            const feedKeys = Object.keys(workspaceFeeds ?? {});
+            const feedKeys = Object.keys(result.current[0] ?? {});
             expect(feedKeys.some((key) => key.includes(oauthFeed))).toBe(true);
         });
     });


### PR DESCRIPTION
### Explanation of Change
[PR #88136](https://github.com/Expensify/App/pull/88136) (merged earlier today) fixed the `useCardFeeds` include predicate so domain feeds whose `linkedPolicyIDs` is `[]` or `['']` no longer get silently dropped, falling back to `preferredPolicy` / `domainID` matching as intended. That PR didn't add coverage in `useCardFeeds.test.ts`, so this PR pins the corrected behavior with regression tests against the exact onyx shape that triggered the customer issue.

- `linkedPolicyIDs: ['']` with matching `preferredPolicy` -> feed is included.
- `linkedPolicyIDs: []` with matching `preferredPolicy` -> feed is included.
- `linkedPolicyIDs: ['OTHER_POLICY']`, current `policyID` not in the list -> feed is excluded (regression guard for non-empty `linkedPolicyIDs` semantics).
- `linkedPolicyIDs: ['OTHER_POLICY', policyID]` -> feed is included (multi-policy linkage).

I verified locally that all 4 new tests fail when the predicate is reverted to the pre-#88136 short-circuit version, and pass against `main`.

No production code is changed.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/548636
PROPOSAL:

### Tests
1. Run \`npx jest tests/unit/hooks/useCardFeeds.test.ts\` locally.
2. Verify all 7 tests pass (3 existing + 4 new).
3. (Optional) Revert the predicate in \`src/hooks/useCardFeeds.tsx\` to:
   \`\`\`ts
   if (combinedCardFeed?.linkedPolicyIDs) {
       return combinedCardFeed.linkedPolicyIDs.includes(policyID);
   }
   \`\`\`
   and confirm the two new \`includes domain feeds when linkedPolicyIDs ...\` tests fail.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - tests-only change.

### QA Steps
N/A - tests-only change, no production code modified.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>