### PR TITLE
Hide Switch to Classic button when classicRedirect nudge is over a month old

### DIFF
--- a/src/libs/TryNewDotUtils.ts
+++ b/src/libs/TryNewDotUtils.ts
@@ -1,9 +1,22 @@
+import {differenceInDays} from 'date-fns';
 import type {OnyxEntry} from 'react-native-onyx';
 import type {TryNewDot} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
+const CLASSIC_REDIRECT_STALE_THRESHOLD_IN_DAYS = 30;
+
 function isLockedToNewApp(tryNewDot: OnyxEntry<TryNewDot>): boolean {
     return tryNewDot?.isLockedToNewApp === true;
+}
+
+function isClassicRedirectStale(tryNewDot: OnyxEntry<TryNewDot>): boolean {
+    const classicRedirect = tryNewDot?.classicRedirect;
+    if (!classicRedirect || classicRedirect.dismissed !== false || !classicRedirect.timestamp) {
+        return false;
+    }
+
+    const daysSinceNudge = differenceInDays(new Date(), new Date(classicRedirect.timestamp));
+    return daysSinceNudge >= CLASSIC_REDIRECT_STALE_THRESHOLD_IN_DAYS;
 }
 
 function shouldBlockOldAppExit(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryNewDot: boolean, shouldSetNVP: boolean): boolean {
@@ -34,4 +47,4 @@ function shouldUseOldApp(tryNewDot: TryNewDot): boolean | undefined {
     return tryNewDot.classicRedirect.dismissed;
 }
 
-export {isLockedToNewApp, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp};
+export {isClassicRedirectStale, isLockedToNewApp, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp};

--- a/src/libs/TryNewDotUtils.ts
+++ b/src/libs/TryNewDotUtils.ts
@@ -3,20 +3,20 @@ import type {OnyxEntry} from 'react-native-onyx';
 import type {TryNewDot} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
-const CLASSIC_REDIRECT_STALE_THRESHOLD_IN_DAYS = 30;
+const NEW_DOT_MIN_DAYS_BEFORE_HIDING_CLASSIC_REDIRECT = 30;
 
 function isLockedToNewApp(tryNewDot: OnyxEntry<TryNewDot>): boolean {
     return tryNewDot?.isLockedToNewApp === true;
 }
 
-function isClassicRedirectStale(tryNewDot: OnyxEntry<TryNewDot>): boolean {
+function hasBeenInNewDot30Days(tryNewDot: OnyxEntry<TryNewDot>): boolean {
     const classicRedirect = tryNewDot?.classicRedirect;
     if (!classicRedirect || classicRedirect.dismissed !== false || !classicRedirect.timestamp) {
         return false;
     }
 
     const daysSinceNudge = differenceInDays(new Date(), new Date(classicRedirect.timestamp));
-    return daysSinceNudge >= CLASSIC_REDIRECT_STALE_THRESHOLD_IN_DAYS;
+    return daysSinceNudge >= NEW_DOT_MIN_DAYS_BEFORE_HIDING_CLASSIC_REDIRECT;
 }
 
 function shouldBlockOldAppExit(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryNewDot: boolean, shouldSetNVP: boolean): boolean {
@@ -28,7 +28,7 @@ function shouldBlockOldAppExit(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryNewD
 }
 
 function isOldAppRedirectBlocked(tryNewDot: OnyxEntry<TryNewDot>, shouldRespectMobileLock: boolean): boolean {
-    return tryNewDot?.classicRedirect?.isLockedToNewDot === true || isClassicRedirectStale(tryNewDot) || (shouldRespectMobileLock && isLockedToNewApp(tryNewDot));
+    return tryNewDot?.classicRedirect?.isLockedToNewDot === true || hasBeenInNewDot30Days(tryNewDot) || (shouldRespectMobileLock && isLockedToNewApp(tryNewDot));
 }
 
 function shouldHideOldAppRedirect(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryNewDot: boolean, shouldRespectMobileLock: boolean): boolean {
@@ -47,4 +47,4 @@ function shouldUseOldApp(tryNewDot: TryNewDot): boolean | undefined {
     return tryNewDot.classicRedirect.dismissed;
 }
 
-export {isClassicRedirectStale, isLockedToNewApp, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp};
+export {hasBeenInNewDot30Days, isLockedToNewApp, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp};

--- a/src/libs/TryNewDotUtils.ts
+++ b/src/libs/TryNewDotUtils.ts
@@ -28,7 +28,7 @@ function shouldBlockOldAppExit(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryNewD
 }
 
 function isOldAppRedirectBlocked(tryNewDot: OnyxEntry<TryNewDot>, shouldRespectMobileLock: boolean): boolean {
-    return tryNewDot?.classicRedirect?.isLockedToNewDot === true || (shouldRespectMobileLock && isLockedToNewApp(tryNewDot));
+    return tryNewDot?.classicRedirect?.isLockedToNewDot === true || isClassicRedirectStale(tryNewDot) || (shouldRespectMobileLock && isLockedToNewApp(tryNewDot));
 }
 
 function shouldHideOldAppRedirect(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryNewDot: boolean, shouldRespectMobileLock: boolean): boolean {

--- a/tests/unit/TryNewDotUtilsTest.ts
+++ b/tests/unit/TryNewDotUtilsTest.ts
@@ -69,6 +69,28 @@ describe('TryNewDotUtils', () => {
         expect(shouldBlockOldAppExit({isLockedToNewApp: true} as TryNewDot, false, false)).toBe(true);
     });
 
+    it('blocks the OldDot redirect when the classicRedirect nudge has gone stale', () => {
+        const tryNewDot = {
+            classicRedirect: {
+                dismissed: false,
+                timestamp: subDays(new Date(), 31).toISOString(),
+            },
+        } as unknown as TryNewDot;
+
+        expect(isOldAppRedirectBlocked(tryNewDot, false)).toBe(true);
+    });
+
+    it('still shows the OldDot redirect when the classicRedirect nudge is fresh', () => {
+        const tryNewDot = {
+            classicRedirect: {
+                dismissed: false,
+                timestamp: subDays(new Date(), 5).toISOString(),
+            },
+        } as unknown as TryNewDot;
+
+        expect(isOldAppRedirectBlocked(tryNewDot, false)).toBe(false);
+    });
+
     it('treats classicRedirect as stale when the user has not dismissed the nudge for over a month', () => {
         const tryNewDot = {
             classicRedirect: {

--- a/tests/unit/TryNewDotUtilsTest.ts
+++ b/tests/unit/TryNewDotUtilsTest.ts
@@ -1,6 +1,6 @@
 import {subDays} from 'date-fns';
 import Onyx from 'react-native-onyx';
-import {isClassicRedirectStale, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp} from '@src/libs/TryNewDotUtils';
+import {hasBeenInNewDot30Days, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp} from '@src/libs/TryNewDotUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {TryNewDot} from '@src/types/onyx';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
@@ -91,7 +91,7 @@ describe('TryNewDotUtils', () => {
         expect(isOldAppRedirectBlocked(tryNewDot, false)).toBe(false);
     });
 
-    it('treats classicRedirect as stale when the user has not dismissed the nudge for over a month', () => {
+    it('reports that a user has been in NewDot 30 days when the nudge is over a month old and not dismissed', () => {
         const tryNewDot = {
             classicRedirect: {
                 dismissed: false,
@@ -99,10 +99,10 @@ describe('TryNewDotUtils', () => {
             },
         } as unknown as TryNewDot;
 
-        expect(isClassicRedirectStale(tryNewDot)).toBe(true);
+        expect(hasBeenInNewDot30Days(tryNewDot)).toBe(true);
     });
 
-    it('does not treat classicRedirect as stale when the nudge is less than a month old', () => {
+    it('does not report 30 days in NewDot when the nudge is less than a month old', () => {
         const tryNewDot = {
             classicRedirect: {
                 dismissed: false,
@@ -110,10 +110,10 @@ describe('TryNewDotUtils', () => {
             },
         } as unknown as TryNewDot;
 
-        expect(isClassicRedirectStale(tryNewDot)).toBe(false);
+        expect(hasBeenInNewDot30Days(tryNewDot)).toBe(false);
     });
 
-    it('does not treat classicRedirect as stale once the user has dismissed the nudge', () => {
+    it('does not report 30 days in NewDot once the user has dismissed the nudge', () => {
         const tryNewDot = {
             classicRedirect: {
                 dismissed: true,
@@ -121,17 +121,17 @@ describe('TryNewDotUtils', () => {
             },
         } as unknown as TryNewDot;
 
-        expect(isClassicRedirectStale(tryNewDot)).toBe(false);
+        expect(hasBeenInNewDot30Days(tryNewDot)).toBe(false);
     });
 
-    it('does not treat classicRedirect as stale when no timestamp is set', () => {
+    it('does not report 30 days in NewDot when no timestamp is set', () => {
         const tryNewDot = {
             classicRedirect: {
                 dismissed: false,
             },
         } as unknown as TryNewDot;
 
-        expect(isClassicRedirectStale(tryNewDot)).toBe(false);
+        expect(hasBeenInNewDot30Days(tryNewDot)).toBe(false);
     });
 
     it('preserves isLockedToNewApp when nvp_tryNewDot is merged', async () => {

--- a/tests/unit/TryNewDotUtilsTest.ts
+++ b/tests/unit/TryNewDotUtilsTest.ts
@@ -1,5 +1,6 @@
+import {subDays} from 'date-fns';
 import Onyx from 'react-native-onyx';
-import {isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp} from '@src/libs/TryNewDotUtils';
+import {isClassicRedirectStale, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp} from '@src/libs/TryNewDotUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {TryNewDot} from '@src/types/onyx';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
@@ -66,6 +67,49 @@ describe('TryNewDotUtils', () => {
     it('blocks all Hybrid OldApp exits for users locked to NewApp', () => {
         expect(shouldBlockOldAppExit({isLockedToNewApp: true} as TryNewDot, false, true)).toBe(true);
         expect(shouldBlockOldAppExit({isLockedToNewApp: true} as TryNewDot, false, false)).toBe(true);
+    });
+
+    it('treats classicRedirect as stale when the user has not dismissed the nudge for over a month', () => {
+        const tryNewDot = {
+            classicRedirect: {
+                dismissed: false,
+                timestamp: subDays(new Date(), 31).toISOString(),
+            },
+        } as unknown as TryNewDot;
+
+        expect(isClassicRedirectStale(tryNewDot)).toBe(true);
+    });
+
+    it('does not treat classicRedirect as stale when the nudge is less than a month old', () => {
+        const tryNewDot = {
+            classicRedirect: {
+                dismissed: false,
+                timestamp: subDays(new Date(), 10).toISOString(),
+            },
+        } as unknown as TryNewDot;
+
+        expect(isClassicRedirectStale(tryNewDot)).toBe(false);
+    });
+
+    it('does not treat classicRedirect as stale once the user has dismissed the nudge', () => {
+        const tryNewDot = {
+            classicRedirect: {
+                dismissed: true,
+                timestamp: subDays(new Date(), 60).toISOString(),
+            },
+        } as unknown as TryNewDot;
+
+        expect(isClassicRedirectStale(tryNewDot)).toBe(false);
+    });
+
+    it('does not treat classicRedirect as stale when no timestamp is set', () => {
+        const tryNewDot = {
+            classicRedirect: {
+                dismissed: false,
+            },
+        } as unknown as TryNewDot;
+
+        expect(isClassicRedirectStale(tryNewDot)).toBe(false);
     });
 
     it('preserves isLockedToNewApp when nvp_tryNewDot is merged', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

~60% of users nudged from Classic to NewDot don't return to Classic. To standardise NewDot for that chunk of migrated users, we already hide the "Switch to Expensify Classic" button when the user has `classicRedirect.isLockedToNewDot: true`. This PR adds a second condition: also hide the button when the user has `classicRedirect.dismissed: false` with a `classicRedirect.timestamp` of over one month ago.

Implementation lives in `isOldAppRedirectBlocked` inside `App/src/libs/TryNewDotUtils.ts`. Since all existing callers of `shouldHideOldAppRedirect` go through that gate, every entry point that surfaces the "Switch to Expensify Classic" button picks up the new behavior automatically (InitialSettingsPage, TroubleshootPage, MergeResultPage, TwoFactorAuth SuccessPage, ConfirmNavigateExpensifyClassicModal, useRedirectToExpensifyClassic).

Backend already sets both `classicRedirect.dismissed = false` and `classicRedirect.timestamp` the moment a user is nudged, so this is a frontend-only change.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/626046
PROPOSAL: N/A (internal work, assigned via Slack discussion linked on the issue)

### Tests

1. Sign in as a user on NewDot who was nudged from Classic more than a month ago (`classicRedirect.dismissed: false` with a `classicRedirect.timestamp` older than 30 days).
2. Open Settings.
3. Verify the "Switch to Expensify Classic" entry is not present in the menu.
4. Sign in as a user nudged less than a month ago (same `dismissed: false` but a recent `timestamp`).
5. Verify the "Switch to Expensify Classic" entry is present in the menu.
6. Sign in as a user with `classicRedirect.dismissed: true` (has previously been to Classic and come back).
7. Verify the "Switch to Expensify Classic" entry is present in the menu regardless of how old the timestamp is.
8. Sign in as a user with `isLockedToNewDot: true`.
9. Verify the "Switch to Expensify Classic" entry is not present in the menu (unchanged behavior).
10. Verify that no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests. The check is purely client-side against the already-synced `nvp_tryNewDot` NVP, so visibility works offline once the NVP has been synced.

### QA Steps

Since QA cannot easily control server-side NVP values, use `Onyx.merge` from the browser console to simulate each state. Onyx is exposed globally on the web build.

1. Sign in to staging NewDot on the web.
2. Open Settings and confirm the "Switch to Expensify Classic" entry is present (baseline).
3. Open DevTools > Console and run:
    ```js
    Onyx.merge('nvp_tryNewDot', {classicRedirect: {dismissed: false, timestamp: '2026-03-01 12:00:00'}});
    ```
    This simulates a user nudged over a month ago who hasn't dismissed.
4. Reload Settings and verify the "Switch to Expensify Classic" entry is NOT present.
5. In the console, simulate a recent nudge:
    ```js
    Onyx.merge('nvp_tryNewDot', {classicRedirect: {dismissed: false, timestamp: new Date().toISOString()}});
    ```
6. Reload Settings and verify the "Switch to Expensify Classic" entry IS present.
7. In the console, simulate a dismissed user with an old timestamp:
    ```js
    Onyx.merge('nvp_tryNewDot', {classicRedirect: {dismissed: true, timestamp: '2026-01-01 12:00:00'}});
    ```
8. Reload Settings and verify the "Switch to Expensify Classic" entry IS present (dismissed overrides the timestamp check).
9. In the console, simulate a locked user:
    ```js
    Onyx.merge('nvp_tryNewDot', {classicRedirect: {isLockedToNewDot: true}});
    ```
10. Reload Settings and verify the "Switch to Expensify Classic" entry is NOT present (unchanged behavior).
11. Verify that no errors appear in the JS console throughout.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

<img width="1346" height="774" alt="Screenshot 2026-04-21 at 5 35 54 PM" src="https://github.com/user-attachments/assets/510a9516-f8d2-467f-bcd7-5a894371b57c" />

