### PR TITLE
[NoQA] Run Claude PR reviewer when a Contributor+ approves a PR

### DIFF
--- a/.github/actions/composite/isContributorPlus/action.yml
+++ b/.github/actions/composite/isContributorPlus/action.yml
@@ -1,0 +1,33 @@
+name: Is Contributor+
+description: Check whether a GitHub user is a member of the Expensify/contributor-plus team. Sets IS_CPLUS=true when the user is a member, IS_CPLUS=false otherwise.
+
+inputs:
+  USERNAME:
+    description: The GitHub login of the user to check.
+    required: true
+  OS_BOTIFY_TOKEN:
+    description: OSBotify token. Needed to read team memberships (the default GITHUB_TOKEN lacks the read:org scope).
+    required: true
+
+outputs:
+  IS_CPLUS:
+    description: "'true' if the user is a member of Expensify/contributor-plus, 'false' otherwise."
+    value: ${{ steps.check.outputs.IS_CPLUS }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check Contributor+ membership
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.OS_BOTIFY_TOKEN }}
+        USERNAME: ${{ inputs.USERNAME }}
+      run: |
+        if gh api "/orgs/Expensify/teams/contributor-plus/memberships/$USERNAME" --silent; then
+          echo "::notice::✅ $USERNAME is a Contributor+ member"
+          echo "IS_CPLUS=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "::notice::$USERNAME is not a Contributor+ member"
+          echo "IS_CPLUS=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,8 @@ permissions:
 on:
   pull_request_target:
     types: [opened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.html_url }}
@@ -14,18 +16,43 @@ concurrency:
 
 jobs:
   validate:
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/contributorValidationGate.yml
     with:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
 
+  checkCPlusApproval:
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      IS_CPLUS: ${{ steps.check.outputs.IS_CPLUS }}
+    steps:
+      - name: Check Contributor+ membership
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          REVIEWER: ${{ github.event.review.user.login }}
+        run: |
+          if gh api "/orgs/Expensify/teams/contributor-plus/memberships/$REVIEWER" --silent; then
+            echo "::notice::✅ Reviewer $REVIEWER is a Contributor+ member"
+            echo "IS_CPLUS=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Reviewer $REVIEWER is not a Contributor+ member; skipping Claude review"
+            echo "IS_CPLUS=false" >> "$GITHUB_OUTPUT"
+          fi
+
   review:
-    needs: [validate]
+    needs: [validate, checkCPlusApproval]
     if: |
-      needs.validate.outputs.IS_AUTHORIZED == 'true'
+      !cancelled()
       && github.event.pull_request.draft != true
       && !contains(github.event.pull_request.title, 'Revert')
+      && (
+        (github.event_name == 'pull_request_target' && needs.validate.outputs.IS_AUTHORIZED == 'true')
+        || (github.event_name == 'pull_request_review' && needs.checkCPlusApproval.outputs.IS_CPLUS == 'true')
+      )
     runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,19 +29,17 @@ jobs:
     outputs:
       IS_CPLUS: ${{ steps.check.outputs.IS_CPLUS }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
       - name: Check Contributor+ membership
         id: check
-        env:
-          GH_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          REVIEWER: ${{ github.event.review.user.login }}
-        run: |
-          if gh api "/orgs/Expensify/teams/contributor-plus/memberships/$REVIEWER" --silent; then
-            echo "::notice::✅ Reviewer $REVIEWER is a Contributor+ member"
-            echo "IS_CPLUS=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Reviewer $REVIEWER is not a Contributor+ member; skipping Claude review"
-            echo "IS_CPLUS=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/composite/isContributorPlus
+        with:
+          USERNAME: ${{ github.event.review.user.login }}
+          OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   review:
     needs: [validate, checkCPlusApproval]


### PR DESCRIPTION
### Explanation of Change

#### Problem
Today, the Claude PR reviewer in [`.github/workflows/claude-review.yml`](https://github.com/Expensify/App/blob/main/.github/workflows/claude-review.yml) only runs once per PR — when it is `opened` or marked `ready_for_review`. When a PR evolves a lot over time between that first run and Contributor+ (C+) review (additional commits, refactors based on reviewer feedback, merges from `main`, etc.), Claude never re-inspects the latest code. There is a high chance that rule violations introduced in later commits slip through, since C+ reviewers don't get a fresh Claude pass on the code they're actually about to approve.

#### Solution
Extend the workflow so the Claude review also runs when a member of the [`contributor-plus`](https://github.com/orgs/Expensify/teams/contributor-plus) GitHub team submits an approved review. This gives C+ reviewers (and by extension internal reviewers downstream) a Claude pass on the PR as it actually stands at approval time. The existing `opened` / `ready_for_review` trigger is preserved.

Implementation:
- Adds `pull_request_review: types: [submitted]` to the workflow triggers.
- Gates the existing `validate` (author-authorization) job on `github.event_name == 'pull_request_target'`.
- Adds a new reusable composite action [`.github/actions/composite/isContributorPlus`](https://github.com/Expensify/App/blob/main/.github/actions/composite/isContributorPlus/action.yml) that wraps the `gh api /orgs/Expensify/teams/contributor-plus/memberships/<user> --silent` lookup (same pattern used for `mobile-deployers` in [`validateActor/action.yml`](https://github.com/Expensify/App/blob/main/.github/actions/composite/validateActor/action.yml#L38)) and exposes an `IS_CPLUS` output.
- Adds a parallel `checkCPlusApproval` job that calls the composite action for the approver.
- Updates the `review` job's `needs` and `if` so it runs when either gate passes.
- Existing `concurrency` group with `cancel-in-progress: true` debounces rapid re-approvals on the same PR.

### Fixed Issues
$ https://github.com/Expensify/App/issues/88582
PROPOSAL: N/A (CI-only change requested directly by maintainer)

### Tests
CI-only workflow change; not exercisable from a local dev environment.
1. After merge, open a fresh PR — verify the Claude review still runs once on `opened` (or `ready_for_review` if drafted first).
2. Have a member of the `contributor-plus` team submit an "Approve" review on a PR — verify a new Claude review run starts (workflow: "PR Reviews with Claude Code") and inspects the latest commits.
3. Have a non-C+ reviewer submit an "Approve" review — verify `checkCPlusApproval` runs, sets `IS_CPLUS=false`, and the `review` job is skipped.
4. Have any reviewer submit a "Request changes" or "Comment" review — verify `checkCPlusApproval` is skipped (event filter on `review.state == 'approved'`) and no Claude run is triggered.
5. Have a C+ approve, then push more commits, then re-approve — verify the in-progress run from the first approval is cancelled by the concurrency group and the second run completes.

- [x] Verify that no errors appear in the JS console (N/A — CI workflow change)

### Offline tests
N/A — CI workflow change.

### QA Steps
Same as Tests.

- [x] Verify that no errors appear in the JS console (N/A — CI workflow change)

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>