### PR TITLE
[Payment due @mkhutornyi] Fix empty Account Manager banner

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/AccountManagerLinkRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AccountManagerLinkRenderer.tsx
@@ -16,7 +16,7 @@ type AccountManagerLinkRendererProps = CustomRendererProps<TText | TPhrasing>;
 
 function AccountManagerLinkRenderer({tnode, style}: AccountManagerLinkRendererProps) {
     const styles = useThemeStyles();
-    const [accountManagerReportID] = useOnyx(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID);
+    const [accountManagerReportID] = useOnyx(ONYXKEYS.ACCOUNT, {selector: (account) => account?.accountManagerReportID});
 
     // Define link style based on context
     let linkStyle: StyleProp<TextStyle> = styles.link;

--- a/src/pages/inbox/AccountManagerBanner.tsx
+++ b/src/pages/inbox/AccountManagerBanner.tsx
@@ -8,7 +8,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
 import {getDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
-import {getParticipantsAccountIDsForDisplay, isConciergeChatReport} from '@libs/ReportUtils';
+import {isConciergeChatReport} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -22,9 +22,9 @@ function AccountManagerBanner({reportID}: AccountManagerBannerProps) {
     const {translate} = useLocalize();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Lightbulb']);
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
-    const [accountManagerReportID] = useOnyx(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID);
-    const [accountManagerReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(accountManagerReportID)}`);
-    const accountManagerAccountID = getParticipantsAccountIDsForDisplay(accountManagerReport, false, true)?.at(0) ?? CONST.DEFAULT_MISSING_ID;
+    const [account] = useOnyx(ONYXKEYS.ACCOUNT);
+    const accountManagerReportID = account?.accountManagerReportID;
+    const accountManagerAccountID = Number(account?.accountManagerAccountID ?? CONST.DEFAULT_MISSING_ID);
     const [participantPersonalDetail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
         selector: personalDetailsSelector(accountManagerAccountID),
     });

--- a/src/pages/inbox/AccountManagerBanner.tsx
+++ b/src/pages/inbox/AccountManagerBanner.tsx
@@ -22,9 +22,14 @@ function AccountManagerBanner({reportID}: AccountManagerBannerProps) {
     const {translate} = useLocalize();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Lightbulb']);
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
-    const [account] = useOnyx(ONYXKEYS.ACCOUNT);
-    const accountManagerReportID = account?.accountManagerReportID;
-    const accountManagerAccountID = Number(account?.accountManagerAccountID ?? CONST.DEFAULT_MISSING_ID);
+    const [accountManagerData] = useOnyx(ONYXKEYS.ACCOUNT, {
+        selector: (account) => ({
+            accountManagerReportID: account?.accountManagerReportID,
+            accountManagerAccountID: account?.accountManagerAccountID,
+        }),
+    });
+    const accountManagerReportID = accountManagerData?.accountManagerReportID;
+    const accountManagerAccountID = Number(accountManagerData?.accountManagerAccountID ?? CONST.DEFAULT_MISSING_ID);
     const [participantPersonalDetail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
         selector: personalDetailsSelector(accountManagerAccountID),
     });

--- a/src/pages/workspace/workflows/WorkspaceWorkflowsPage.tsx
+++ b/src/pages/workspace/workflows/WorkspaceWorkflowsPage.tsx
@@ -116,13 +116,13 @@ function WorkspaceWorkflowsPage({policy, route}: WorkspaceWorkflowsPageProps) {
     const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS);
     const [betas] = useOnyx(ONYXKEYS.BETAS);
     const [bankAccountList] = useOnyx(ONYXKEYS.BANK_ACCOUNT_LIST);
-    const [accountManagerReportID] = useOnyx(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID);
     const workspaceCards = getAllCardsForWorkspace(workspaceAccountID, cardList, cardFeeds);
     const {showConfirmModal} = useConfirmModal();
     const isSmartLimitEnabled = isSmartLimitEnabledUtil(workspaceCards);
     const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
     const [reimbursementAccount] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT);
     const [account] = useOnyx(ONYXKEYS.ACCOUNT);
+    const accountManagerReportID = account?.accountManagerReportID;
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
     const [isSelfTourViewed] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {selector: hasSeenTourSelector});

--- a/tests/unit/AccountManagerBannerTest.tsx
+++ b/tests/unit/AccountManagerBannerTest.tsx
@@ -1,0 +1,89 @@
+import {render, screen} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import AccountManagerBanner from '@pages/inbox/AccountManagerBanner';
+import ONYXKEYS from '@src/ONYXKEYS';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+}));
+
+jest.mock('@hooks/useLazyAsset', () => ({
+    useMemoizedLazyExpensifyIcons: jest.fn(() => ({
+        Lightbulb: 'Lightbulb',
+    })),
+}));
+
+const CONCIERGE_REPORT_ID = '1';
+const ACCOUNT_MANAGER_REPORT_ID = '2';
+const ACCOUNT_MANAGER_ACCOUNT_ID = 42;
+const ACCOUNT_MANAGER_LOGIN = 'am@expensify.com';
+const ACCOUNT_MANAGER_DISPLAY_NAME = 'Jamie Manager';
+
+function renderBanner() {
+    return render(
+        <OnyxListItemProvider>
+            <LocaleContextProvider>
+                <AccountManagerBanner reportID={CONCIERGE_REPORT_ID} />
+            </LocaleContextProvider>
+        </OnyxListItemProvider>,
+    );
+}
+
+describe('AccountManagerBanner', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await Onyx.clear();
+        await Onyx.multiSet({
+            [ONYXKEYS.CONCIERGE_REPORT_ID]: CONCIERGE_REPORT_ID,
+            [`${ONYXKEYS.COLLECTION.REPORT}${CONCIERGE_REPORT_ID}`]: {
+                reportID: CONCIERGE_REPORT_ID,
+            },
+            [ONYXKEYS.PERSONAL_DETAILS_LIST]: {
+                [ACCOUNT_MANAGER_ACCOUNT_ID]: {
+                    accountID: ACCOUNT_MANAGER_ACCOUNT_ID,
+                    login: ACCOUNT_MANAGER_LOGIN,
+                    displayName: ACCOUNT_MANAGER_DISPLAY_NAME,
+                },
+            },
+        });
+    });
+
+    it('renders the banner body using account.accountManagerAccountID (the OpenApp-populated field)', async () => {
+        await Onyx.merge(ONYXKEYS.ACCOUNT, {
+            accountManagerReportID: ACCOUNT_MANAGER_REPORT_ID,
+            accountManagerAccountID: String(ACCOUNT_MANAGER_ACCOUNT_ID),
+        });
+
+        renderBanner();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByText(new RegExp(ACCOUNT_MANAGER_DISPLAY_NAME))).toBeTruthy();
+        expect(screen.getByText(new RegExp(ACCOUNT_MANAGER_LOGIN))).toBeTruthy();
+    });
+
+    it('renders nothing when account.accountManagerReportID is not set', async () => {
+        renderBanner();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByText(new RegExp(ACCOUNT_MANAGER_DISPLAY_NAME))).toBeNull();
+    });
+
+    it('does not populate the banner from the legacy top-level ACCOUNT_MANAGER_REPORT_ID key (regression guard)', async () => {
+        // The legacy standalone key is never written to by OpenApp. If the banner regresses to reading it,
+        // this test will start showing the banner text even though `account` is empty — and fail.
+        await Onyx.merge(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID, ACCOUNT_MANAGER_REPORT_ID);
+
+        renderBanner();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByText(new RegExp(ACCOUNT_MANAGER_DISPLAY_NAME))).toBeNull();
+    });
+});

--- a/tests/unit/AccountManagerBannerTest.tsx
+++ b/tests/unit/AccountManagerBannerTest.tsx
@@ -41,17 +41,15 @@ describe('AccountManagerBanner', () => {
     beforeEach(async () => {
         jest.clearAllMocks();
         await Onyx.clear();
-        await Onyx.multiSet({
-            [ONYXKEYS.CONCIERGE_REPORT_ID]: CONCIERGE_REPORT_ID,
-            [`${ONYXKEYS.COLLECTION.REPORT}${CONCIERGE_REPORT_ID}`]: {
-                reportID: CONCIERGE_REPORT_ID,
-            },
-            [ONYXKEYS.PERSONAL_DETAILS_LIST]: {
-                [ACCOUNT_MANAGER_ACCOUNT_ID]: {
-                    accountID: ACCOUNT_MANAGER_ACCOUNT_ID,
-                    login: ACCOUNT_MANAGER_LOGIN,
-                    displayName: ACCOUNT_MANAGER_DISPLAY_NAME,
-                },
+        await Onyx.merge(ONYXKEYS.CONCIERGE_REPORT_ID, CONCIERGE_REPORT_ID);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${CONCIERGE_REPORT_ID}`, {
+            reportID: CONCIERGE_REPORT_ID,
+        });
+        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+            [ACCOUNT_MANAGER_ACCOUNT_ID]: {
+                accountID: ACCOUNT_MANAGER_ACCOUNT_ID,
+                login: ACCOUNT_MANAGER_LOGIN,
+                displayName: ACCOUNT_MANAGER_DISPLAY_NAME,
             },
         });
     });

--- a/tests/unit/AccountManagerLinkRendererTest.tsx
+++ b/tests/unit/AccountManagerLinkRendererTest.tsx
@@ -63,7 +63,7 @@ describe('AccountManagerLinkRenderer', () => {
     });
 
     it('should navigate to account manager chat when pressed', async () => {
-        await Onyx.merge(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID, ACCOUNT_MANAGER_REPORT_ID);
+        await Onyx.merge(ONYXKEYS.ACCOUNT, {accountManagerReportID: ACCOUNT_MANAGER_REPORT_ID});
 
         // @ts-expect-error Ignoring type errors for testing purposes
         render(<AccountManagerLinkRenderer tnode={createMockTNode('Account Manager')} />);
@@ -85,7 +85,7 @@ describe('AccountManagerLinkRenderer', () => {
     });
 
     it('should handle multiple presses correctly', async () => {
-        await Onyx.merge(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID, ACCOUNT_MANAGER_REPORT_ID);
+        await Onyx.merge(ONYXKEYS.ACCOUNT, {accountManagerReportID: ACCOUNT_MANAGER_REPORT_ID});
 
         // @ts-expect-error Ignoring type errors for testing purposes
         render(<AccountManagerLinkRenderer tnode={createMockTNode('Account Manager')} />);
@@ -101,7 +101,7 @@ describe('AccountManagerLinkRenderer', () => {
     });
 
     it('should update navigation when accountManagerReportID changes', async () => {
-        await Onyx.merge(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID, ACCOUNT_MANAGER_REPORT_ID);
+        await Onyx.merge(ONYXKEYS.ACCOUNT, {accountManagerReportID: ACCOUNT_MANAGER_REPORT_ID});
 
         // @ts-expect-error Ignoring type errors for testing purposes
         const {rerender} = render(<AccountManagerLinkRenderer tnode={createMockTNode('Account Manager')} />);
@@ -112,7 +112,7 @@ describe('AccountManagerLinkRenderer', () => {
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute(ACCOUNT_MANAGER_REPORT_ID));
 
         const NEW_ACCOUNT_MANAGER_REPORT_ID = '987654321';
-        await Onyx.merge(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID, NEW_ACCOUNT_MANAGER_REPORT_ID);
+        await Onyx.merge(ONYXKEYS.ACCOUNT, {accountManagerReportID: NEW_ACCOUNT_MANAGER_REPORT_ID});
 
         // @ts-expect-error Ignoring type errors for testing purposes
         rerender(<AccountManagerLinkRenderer tnode={createMockTNode('Account Manager')} />);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Fix the empty Account Manager banner by getting the accountManagerAccountID from the `account` Onyx key, which is always filled by `OpenApp` and `ReconnectApp`, thus avoiding a race condiction when the Account Manager Report hasn't been yet loaded into Onyx.
While at it fixed the same problem in AccountManagerLinkRenderer and WorkspaceWorkflowsPage

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
https://github.com/Expensify/App/issues/88539
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

On a workspace with an Account Manager
1. Open concierge by clicking on the persistent button in New Expensify
2. The RHP should have a banner at the top of the chat suggesting the customer can reach out to their Account Manager
3. Verify the banner is NOT empty

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
On a workspace with an Account Manager

1. Open concierge by clicking on the persistent button in New Expensify
2. The RHP should have a banner at the top of the chat suggesting the customer can reach out to their Account Manager
3. Verify the banner is NOT empty

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I verified that similar component doesn't exist in the codebase
- [x] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [x] I verified that each file is named correctly
- [x] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [x] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [x] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [x] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [x] I verified that all JSX used for rendering exists in the render method
- [x] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>