### PR TITLE
perf: drop fabricated timestamp writes from setOptimisticTransactionThread

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -7374,8 +7374,6 @@ function setOptimisticTransactionThread(reportID?: string, parentReportID?: stri
         return;
     }
 
-    // Use merge with selective updates to avoid overwriting existing comprehensive data
-    // This will only add/update the specified fields without overwriting existing data
     Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
         reportID,
         policyID,
@@ -7383,9 +7381,6 @@ function setOptimisticTransactionThread(reportID?: string, parentReportID?: stri
         parentReportActionID,
         chatReportID: parentReportID,
         type: CONST.REPORT.TYPE.CHAT,
-        // Add additional fields to ensure complete report structure
-        lastReadTime: DateUtils.getDBTime(),
-        lastVisibleActionCreated: DateUtils.getDBTime(),
     });
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

**TLDR:** On every transaction-row tap, `setOptimisticTransactionThread` writes `lastReadTime` / `lastVisibleActionCreated` with `DateUtils.getDBTime()` into `report_${id}`. Because that timestamp is monotonic, the merge ALWAYS produces a diff → `report_` collection subscribers fire → 6 derivations recompute (`sortedReportActions`, `outstandingReportsByPolicyID`, `visibleReportActions`, `openAndSubmittedReportsByPolicyID`, `todos`, `reportAttributes`). Measured cost: **156ms–2685ms per tap**, sitting before navigation starts → user-perceived press-to-mount jank.

Dropping the two timestamp writes. Structural fields stay; Onyx dedupes them on existing threads → zero cascade.

### Why this is safe

Those two lines are armor around an unrelated fix in the same commit (`e84c0ad4dbd` in PR #72001). That commit narrowed the `CREATED`-placeholder gate in `ReportActionsView.tsx`:

```diff
- (isMoneyRequestReport(report) || isInvoiceReport(report) || isReportTransactionThread) && !allReportActions?.findLast(isCreatedAction)
+ if (isReportTransactionThread) {
+     return !allReportActions?.findLast(isCreatedAction) && isLoadingInitialReportActions;
+ }
```

The gate is the real fix. The timestamp writes were redundant defensive armor. Keeping the gate, dropping the armor.

`lastReadTime` continues to be written post-mount by `readNewestAction` in `ReportActionsList.handleReportChangeMarkAsRead` (gated on `isUnread() + isVisible + scroll-near-bottom`). `lastVisibleActionCreated` is action-derived — set by action-creating flows (IOU, Task, etc.) with real action timestamps. Neither needs a nav-time fabrication.

### Evidence

- Original function in PR [#72001](https://github.com/Expensify/App/pull/72001) (commit `ff567683672`, 2025-08-22) wrote only `parentReportID` + `parentReportActionID`. No timestamps.
- Timestamps added later in same PR via commit `e84c0ad4dbd` (2025-09-19, "fix optimistic create report transaction") alongside the `ReportActionsView` gate change. This PR effectively reverts just the timestamp additions from that commit.
- Related companion: PR #88613 (reportMetadata split) exposed the `report_` fan-out problem this PR kills at the source.

### Measured impact (warm transaction thread re-tap, offline, 5 trials, iOS)

| Metric | Pre-fix | Post-fix |
|---|---|---|
| 6-derivation cascade per tap | 156 / 162 / 2685 ms (3 trials) | 0 / 0 / 0 / 0 / 0 ms (5 trials) |
| `ManualOpenReport` span median | 697 ms | 574 ms (~−18%) |
| p95 tail (cascade+span) | ~3400 ms | ~580 ms |

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88595
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Covered in QA steps (offline warm-tap is the primary validation path).

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. **Existing transaction thread — LHN unread dot:**
   - Have a transaction thread with an unread report action (ask another user to comment on it).
   - Observe LHN shows unread dot.
   - Tap the thread row from `MoneyRequestReportView`.
   - Verify unread dot clears within ~1 frame after `ReportActionsList` mounts (post-nav), not instantly on press. Matches chat-flow behavior.

2. **Arrow navigation in RHP (prev/next):**
   - Open a transaction thread in RHP via a multi-transaction expense report.
   - Click prev/next navigation arrows.
   - Verify navigation lands on the correct sibling thread and report header populates correctly. Structural context fields are still written.

3. **Optimistic thread creation (new, never-navigated thread):**
   - Create a new expense, then tap the transaction row *before* the server returns (or while offline).
   - Verify the CREATED placeholder renders correctly — must NOT show duplicated, out-of-order, or at wrong position. Thread sorts correctly in LHN.
   - This is the original bug #72001 was fixing; `ReportActionsView` gate (unchanged) should still suppress the issue.

4. **Sort ordering in LHN after tap:**
   - Note a tapped thread's position in LHN before tap.
   - Tap, navigate in, navigate out.
   - Verify row order didn't shift up unnaturally — previously `lastVisibleActionCreated = now` could cause artificial reordering.

5. **Offline warm-tap, same thread 3× in a row (the perf validation):**
   - Go offline.
   - Tap same transaction thread 3 times with 1s between taps (back out each time).
   - Check Sentry `ManualOpenReport` spans and `OnyxDerivedCompute_*` spans.
   - Expected: no `report_${reportID}` merge with `hasChanged: true` pre-nav; no 6-derivation cascade on taps 2 and 3.

6. **Sentry production metric to watch post-merge:**
   - `OnyxDerivedCompute_outstandingReportsByPolicyID` p50/p95 for warm users
   - `OnyxDerivedCompute_visibleReportActions` p50/p95
   - `ManualOpenReport` with `is_transaction_thread: true` — watch for p50 drop

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>