### PR TITLE
Fix/85943 iou leave notfound loop fix

### DIFF
--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -12,7 +12,17 @@ import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import {isDeletedParentAction} from '@libs/ReportActionsUtils';
-import {isAdminRoom, isAnnounceRoom, isGroupChat, isMoneyRequest, isMoneyRequestReport, isMoneyRequestReportPendingDeletion, isPolicyExpenseChat} from '@libs/ReportUtils';
+import {
+    getReportOrDraftReport,
+    isAdminRoom,
+    isAnnounceRoom,
+    isGroupChat,
+    isMoneyRequest,
+    isMoneyRequestReport,
+    isMoneyRequestReportPendingDeletion,
+    isPolicyExpenseChat,
+    isReportParticipant,
+} from '@libs/ReportUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
 import {navigateToConciergeChat} from '@userActions/Report';
@@ -81,6 +91,7 @@ function ReportNavigateAwayHandler() {
 
     const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
     const {wasDeleted: reportWasDeleted, parentReportID: deletedReportParentID} = useReportWasDeleted(reportIDFromRoute, report, isOptimisticDelete, userLeavingStatus);
+    const [deletedReportParent] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(deletedReportParentID)}`);
 
     // Track whether the current route is an own workspace chat. A vacation delegate split sends
     // a temporary Onyx SET that wipes the report; by the time effects fire, report is undefined
@@ -216,6 +227,13 @@ function ReportNavigateAwayHandler() {
 
         // Try to navigate to parent report if available
         if (deletedReportParentID && !isMoneyRequestReportPendingDeletion(deletedReportParentID)) {
+            if (deletedReportParent && !isReportParticipant(currentUserAccountID, deletedReportParent)) {
+                Navigation.popToSidebar();
+                Navigation.isNavigationReady().then(() => {
+                    navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas);
+                });
+                return;
+            }
             Navigation.isNavigationReady().then(() => {
                 Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(deletedReportParentID));
             });
@@ -226,7 +244,7 @@ function ReportNavigateAwayHandler() {
         Navigation.isNavigationReady().then(() => {
             navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas);
         });
-    }, [reportWasDeleted, isFocused, deletedReportParentID, conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas]);
+    }, [reportWasDeleted, isFocused, deletedReportParentID, deletedReportParent, conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas, isCurrentRouteOwnWorkspaceChatRef]);
 
     return null;
 }

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -244,7 +244,18 @@ function ReportNavigateAwayHandler() {
         Navigation.isNavigationReady().then(() => {
             navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas);
         });
-    }, [reportWasDeleted, isFocused, deletedReportParentID, deletedReportParent, conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas, isCurrentRouteOwnWorkspaceChatRef]);
+    }, [
+        reportWasDeleted,
+        isFocused,
+        deletedReportParentID,
+        deletedReportParent,
+        conciergeReportID,
+        introSelected,
+        currentUserAccountID,
+        isSelfTourViewed,
+        betas,
+        isCurrentRouteOwnWorkspaceChatRef,
+    ]);
 
     return null;
 }

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -13,7 +13,6 @@ import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import {isDeletedParentAction} from '@libs/ReportActionsUtils';
 import {
-    getReportOrDraftReport,
     isAdminRoom,
     isAnnounceRoom,
     isGroupChat,

--- a/tests/navigation/ReportNavigateAwayHandlerTest.tsx
+++ b/tests/navigation/ReportNavigateAwayHandlerTest.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/naming-convention */
 import {render, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import useIsOwnWorkspaceChatRef from '@hooks/useIsOwnWorkspaceChatRef';

--- a/tests/navigation/ReportNavigateAwayHandlerTest.tsx
+++ b/tests/navigation/ReportNavigateAwayHandlerTest.tsx
@@ -6,8 +6,8 @@ import useOnyx from '@hooks/useOnyx';
 import Navigation from '@libs/Navigation/Navigation';
 import {navigateToConciergeChat} from '@userActions/Report';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ReportNavigateAwayHandler from '@src/pages/inbox/ReportNavigateAwayHandler';
 import useReportWasDeleted from '@src/pages/inbox/hooks/useReportWasDeleted';
+import ReportNavigateAwayHandler from '@src/pages/inbox/ReportNavigateAwayHandler';
 
 jest.mock('@react-navigation/native', () => ({
     createNavigationContainerRef: jest.fn(() => ({
@@ -91,6 +91,7 @@ const mockUseOnyx = jest.mocked(useOnyx);
 const mockUseReportWasDeleted = jest.mocked(useReportWasDeleted);
 const mockNavigateToConciergeChat = jest.mocked(navigateToConciergeChat);
 const mockNavigation = jest.mocked(Navigation);
+const onyxMeta = {status: 'loaded'} as const;
 
 describe('ReportNavigateAwayHandler', () => {
     beforeEach(() => {
@@ -106,27 +107,27 @@ describe('ReportNavigateAwayHandler', () => {
 
         mockUseOnyx.mockImplementation((key: string) => {
             if (key === `${ONYXKEYS.COLLECTION.REPORT}123`) {
-                return [{reportID: '123', statusNum: 2} as MinimalReport];
+                return [{reportID: '123', statusNum: 2} as MinimalReport, onyxMeta];
             }
             if (key === `${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}123`) {
-                return [false];
+                return [false, onyxMeta];
             }
             if (key === ONYXKEYS.NVP_INTRO_SELECTED) {
-                return [undefined];
+                return [undefined, onyxMeta];
             }
             if (key === ONYXKEYS.BETAS) {
-                return [[]];
+                return [[], onyxMeta];
             }
             if (key === ONYXKEYS.NVP_ONBOARDING) {
-                return [{selfTourViewed: true}];
+                return [{selfTourViewed: true}, onyxMeta];
             }
             if (key === ONYXKEYS.CONCIERGE_REPORT_ID) {
-                return ['conciergeReportID'];
+                return ['conciergeReportID', onyxMeta];
             }
             if (key === `${ONYXKEYS.COLLECTION.REPORT}parentReportID`) {
-                return [deletedParentReport];
+                return [deletedParentReport, onyxMeta];
             }
-            return [undefined];
+            return [undefined, onyxMeta];
         });
     });
 

--- a/tests/navigation/ReportNavigateAwayHandlerTest.tsx
+++ b/tests/navigation/ReportNavigateAwayHandlerTest.tsx
@@ -1,0 +1,176 @@
+/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import {render, waitFor} from '@testing-library/react-native';
+import React from 'react';
+import useIsOwnWorkspaceChatRef from '@hooks/useIsOwnWorkspaceChatRef';
+import useOnyx from '@hooks/useOnyx';
+import Navigation from '@libs/Navigation/Navigation';
+import {navigateToConciergeChat} from '@userActions/Report';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ReportNavigateAwayHandler from '@src/pages/inbox/ReportNavigateAwayHandler';
+import useReportWasDeleted from '@src/pages/inbox/hooks/useReportWasDeleted';
+
+jest.mock('@react-navigation/native', () => ({
+    createNavigationContainerRef: jest.fn(() => ({
+        current: null,
+        dispatch: jest.fn(),
+        canGoBack: jest.fn(),
+        getRootState: jest.fn(),
+        getCurrentRoute: jest.fn(),
+    })),
+    useIsFocused: jest.fn(() => true),
+    useRoute: jest.fn(() => ({
+        name: 'Report',
+        params: {
+            reportID: '123',
+        },
+    })),
+}));
+
+jest.mock('@hooks/useCurrentReportID', () => ({
+    useCurrentReportIDState: jest.fn(() => ({currentReportID: '123'})),
+}));
+
+jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({accountID: 1})),
+}));
+
+jest.mock('@hooks/useResponsiveLayout', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({isInNarrowPaneModal: false})),
+}));
+
+jest.mock('@hooks/useParentReportAction', () => ({
+    __esModule: true,
+    default: jest.fn(() => undefined),
+}));
+
+jest.mock('@hooks/useIsOwnWorkspaceChatRef', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({current: false})),
+}));
+
+jest.mock('@userActions/Composer', () => ({
+    setShouldShowComposeInput: jest.fn(),
+}));
+
+jest.mock('@userActions/Report', () => ({
+    navigateToConciergeChat: jest.fn(),
+}));
+
+jest.mock('@src/pages/inbox/hooks/useReportWasDeleted', () => jest.fn());
+
+jest.mock('@hooks/useOnyx', () => jest.fn());
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    default: {
+        dismissModal: jest.fn(),
+        getTopmostReportId: jest.fn(() => 'different-report-id'),
+        getTopmostSearchReportID: jest.fn(() => undefined),
+        popToSidebar: jest.fn(),
+        navigate: jest.fn(),
+        isNavigationReady: jest.fn(() => Promise.resolve()),
+    },
+    navigationRef: {
+        getCurrentRoute: jest.fn(() => ({name: 'Report', params: {reportID: '123'}})),
+    },
+}));
+
+type MinimalReport = {
+    reportID?: string;
+    participants?: Record<number, {notificationPreference?: string}>;
+    statusNum?: number;
+};
+
+let deletedParentReport: MinimalReport | undefined;
+let deletedReportParentID: string | undefined;
+let reportWasDeleted = true;
+
+const mockUseOnyx = jest.mocked(useOnyx);
+const mockUseReportWasDeleted = jest.mocked(useReportWasDeleted);
+const mockNavigateToConciergeChat = jest.mocked(navigateToConciergeChat);
+const mockNavigation = jest.mocked(Navigation);
+
+describe('ReportNavigateAwayHandler', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        deletedParentReport = undefined;
+        deletedReportParentID = 'parentReportID';
+        reportWasDeleted = true;
+
+        mockUseReportWasDeleted.mockReturnValue({
+            wasDeleted: reportWasDeleted,
+            parentReportID: deletedReportParentID,
+        });
+
+        mockUseOnyx.mockImplementation((key: string) => {
+            if (key === `${ONYXKEYS.COLLECTION.REPORT}123`) {
+                return [{reportID: '123', statusNum: 2} as MinimalReport];
+            }
+            if (key === `${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}123`) {
+                return [false];
+            }
+            if (key === ONYXKEYS.NVP_INTRO_SELECTED) {
+                return [undefined];
+            }
+            if (key === ONYXKEYS.BETAS) {
+                return [[]];
+            }
+            if (key === ONYXKEYS.NVP_ONBOARDING) {
+                return [{selfTourViewed: true}];
+            }
+            if (key === ONYXKEYS.CONCIERGE_REPORT_ID) {
+                return ['conciergeReportID'];
+            }
+            if (key === `${ONYXKEYS.COLLECTION.REPORT}parentReportID`) {
+                return [deletedParentReport];
+            }
+            return [undefined];
+        });
+    });
+
+    it('navigates to concierge when deleted parent exists but user is not a participant', async () => {
+        const participants: Record<number, {notificationPreference?: string}> = {};
+        participants[999] = {};
+        deletedParentReport = {reportID: 'parentReportID', participants};
+
+        render(<ReportNavigateAwayHandler />);
+
+        await waitFor(() => {
+            expect(mockNavigation.popToSidebar).toHaveBeenCalledTimes(1);
+            expect(mockNavigateToConciergeChat).toHaveBeenCalledTimes(1);
+        });
+
+        expect(mockNavigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates to deleted parent when user is a participant', async () => {
+        const participants: Record<number, {notificationPreference?: string}> = {};
+        participants[1] = {};
+        deletedParentReport = {reportID: 'parentReportID', participants};
+
+        render(<ReportNavigateAwayHandler />);
+
+        await waitFor(() => {
+            expect(mockNavigation.navigate).toHaveBeenCalledWith(expect.stringContaining('parentReportID'));
+        });
+
+        expect(mockNavigation.popToSidebar).not.toHaveBeenCalled();
+        expect(mockNavigateToConciergeChat).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate away when own workspace chat ref is true', async () => {
+        const mockUseIsOwnWorkspaceChatRef = jest.mocked(useIsOwnWorkspaceChatRef);
+        mockUseIsOwnWorkspaceChatRef.mockReturnValue({current: true});
+        const participants: Record<number, {notificationPreference?: string}> = {};
+        participants[999] = {};
+        deletedParentReport = {reportID: 'parentReportID', participants};
+
+        render(<ReportNavigateAwayHandler />);
+
+        expect(mockNavigation.popToSidebar).not.toHaveBeenCalled();
+        expect(mockNavigation.navigate).not.toHaveBeenCalled();
+        expect(mockNavigateToConciergeChat).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR updates IOU leave navigation for invitees so we only navigate to a parent report when the current user is a participant of that parent report.  
If the user is not a participant, we navigate to Concierge instead of routing to an inaccessible report, which prevents the repeated "Hm... it's not here" navigation loop.

It also removes the local `REPORT_USER_IS_LEAVING_ROOM` write from `leaveRoom()` to align with the reviewed scope.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/85943
PROPOSAL: https://github.com/Expensify/App/issues/85943#issuecomment-4266725442

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. As User A and User B, create a 1:1 chat and send 2 IOUs.
2. Mention User C (invitee) in the IOU report and send the invite.
3. Log in as User C.
4. Open the IOU report.
5. Tap `More` > `Leave`.
6. Verify app navigates to an accessible destination (Concierge) instead of opening a "Hm... it's not here" loop.
7. Press Back and verify there is no infinite not-found bounce between inaccessible reports.
8. Repeat the flow once more to confirm consistent behavior.

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Start from the same setup and open the IOU report as User C.
2. Turn network off.
3. Tap `More` > `Leave`.
4. Turn network back on and allow updates to sync.
5. Verify User C is not trapped in a repeated "Hm... it's not here" back loop after navigation settles.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as Tests.

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/657dd303-8852-4d55-b816-5d249651db2e


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<VIDEO_LINK_ANDROID_MWEB>

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/dc1e5db6-4c9d-4f1b-944b-fbf67136c6bb



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<VIDEO_LINK_IOS_MWEB>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<VIDEO_LINK_WEB_DESKTOP>

</details>