### PR TITLE
fix: [$250] Nested table rows no longer highlight on hover or open exp

### DIFF
--- a/src/components/Report/TransactionRow/index.css
+++ b/src/components/Report/TransactionRow/index.css
@@ -1,0 +1,68 @@
+.transactionRow {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    padding: 12px 20px;
+    border-bottom: 1px solid #F2F2F2;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.transactionRow:hover {
+    background-color: #F5F5F5;
+}
+
+.transactionRow:active {
+    background-color: #ECECEC;
+}
+
+.transactionRow .chevronCell {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    flex-shrink: 0;
+}
+
+.transactionRow .chevronCell .icon {
+    width: 20px;
+    height: 20px;
+    color: #999;
+    transition: transform 0.2s ease;
+}
+
+.transactionRow:hover .chevronCell .icon {
+    color: #333;
+    transform: translateX(2px);
+}
+
+.transactionRow .contentCell {
+    flex: 1;
+    min-width: 0;
+    padding: 0 12px;
+}
+
+.transactionRow .contentCell .title {
+    font-weight: 600;
+    font-size: 15px;
+    color: #333;
+    margin-bottom: 4px;
+}
+
+.transactionRow .contentCell .description {
+    font-size: 13px;
+    color: #999;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.transactionRow .amountCell {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    min-width: 80px;
+    font-weight: 600;
+    font-size: 15px;
+    color: #333;
+}

--- a/src/components/Report/TransactionRow/index.js
+++ b/src/components/Report/TransactionRow/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {TouchableOpacity, View} from 'react-native';
+import Icon from '../Icon';
+import * as Expensicons from '../Icon/Expensicons';
+import Text from '../Text';
+import styles from './styles';
+
+const TransactionRow = ({transaction, onPress}) => (
+    <TouchableOpacity style={styles.transactionRow} onPress={onPress}>
+        <View style={styles.chevronCell}>
+            <Icon src={Expensicons.ArrowRight} />
+        </View>
+        <View style={styles.contentCell}>
+            <Text style={styles.title}>{transaction.description}</Text>
+            <Text style={styles.description}>{transaction.merchant}</Text>
+        </View>
+        <View style={styles.amountCell}>
+            <Text>{transaction.amount}</Text>
+        </View>
+    </TouchableOpacity>
+);
+
+TransactionRow.propTypes = {
+    transaction: PropTypes.shape({
+        description: PropTypes.string.isRequired,
+        merchant: PropTypes.string.isRequired,
+        amount: PropTypes.string.isRequired,
+    }).isRequired,
+    onPress: PropTypes.func.isRequired,
+};
+
+export default TransactionRow;

--- a/src/components/Report/TransactionRow/styles.js
+++ b/src/components/Report/TransactionRow/styles.js
@@ -1,0 +1,48 @@
+import {StyleSheet} from 'react-native';
+import themeColors from '../../styles/themes/default';
+
+const styles = StyleSheet.create({
+    transactionRow: {
+        flexDirection: 'row',
+        paddingVertical: 12,
+        paddingHorizontal: 20,
+        borderBottomWidth: 1,
+        borderBottomColor: themeColors.border,
+        cursor: 'pointer',
+    },
+    chevronCell: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: 40,
+        flexShrink: 0,
+    },
+    contentCell: {
+        flex: 1,
+        minWidth: 0,
+        paddingHorizontal: 12,
+        justifyContent: 'center',
+    },
+    title: {
+        fontWeight: '600',
+        fontSize: 15,
+        color: themeColors.text,
+        marginBottom: 4,
+    },
+    description: {
+        fontSize: 13,
+        color: themeColors.textSupporting,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
+    amountCell: {
+        justifyContent: 'center',
+        alignItems: 'flex-end',
+        minWidth: 80,
+        fontWeight: '600',
+        fontSize: 15,
+        color: themeColors.text,
+    },
+});
+
+export default styles;


### PR DESCRIPTION
**PR Description:**

Restores hover highlighting and click functionality for nested table rows in the report view. Previously, users had to click the `>` chevron exactly to open an expense in the RHP, but this change ensures the entire row is interactive again.

This fixes a regression introduced by the compact table styles update (#86283).

$ #88296

$ #88729