### PR TITLE
[No QA] Update help site docs for bulk change approver feature

### DIFF
--- a/docs/articles/new-expensify/reports-and-expenses/Approve-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Approve-Expenses.md
@@ -75,7 +75,7 @@ Workspace admins can bypass the approval workflow on a report to final approve i
 4. Select **Add approver** or **Bypass approvers**.
 5. If you selected **Add approver**, choose the approver and click **Save**.
 
-**Note:** When selecting reports across multiple workspaces, only members who belong to all selected workspaces will appear in the approver list. Bulk change approver is only available for reports submitted on Control plan workspaces with approval workflows enabled. Non-Control workspaces will prompt you to upgrade.
+**Note:** When selecting reports across multiple workspaces, only members who belong to all selected workspaces will appear in the approver list.
 
 ---
 

--- a/docs/articles/new-expensify/reports-and-expenses/Approve-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Approve-Expenses.md
@@ -67,6 +67,18 @@ Workspace admins can bypass the approval workflow on a report to final approve i
 
 ---
 
+## How to change the approver for multiple reports at once
+
+1. In the navigation tabs (on the left on web, and at the bottom on mobile), go to **Reports > Reports**.
+2. Select two or more reports using the checkboxes.
+3. Choose **Selected**, then **Change approver**.
+4. Select **Add approver** or **Bypass approvers**.
+5. If you selected **Add approver**, choose the approver and click **Save**.
+
+**Note:** When selecting reports across multiple workspaces, only members who belong to all selected workspaces will appear in the approver list. Bulk change approver is only available for reports submitted on Control plan workspaces with approval workflows enabled. Non-Control workspaces will prompt you to upgrade.
+
+---
+
 ## How to hold an expense
 
 1. In the navigation tabs (on the left on web, and at the bottom on mobile), go to **Spend > All expenses**.

--- a/docs/articles/new-expensify/reports-and-expenses/Understanding-Report-Statuses-and-Actions.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Understanding-Report-Statuses-and-Actions.md
@@ -35,8 +35,9 @@ The grey **More** button is always visible in the report header. Tap it to acces
 - Unapprove
 - Duplicate report
 - Download as CSV
-- **Print**
+- Print
 - Change Workspace
+- Change Approver
 - View Details
 - Delete
 - Reject

--- a/docs/articles/new-expensify/reports-and-expenses/Understanding-Report-Statuses-and-Actions.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Understanding-Report-Statuses-and-Actions.md
@@ -37,8 +37,8 @@ The grey **More** button is always visible in the report header. Tap it to acces
 - Download as CSV
 - Print
 - Change Workspace
-- Change Approver
-- View Details
+- Change approver
+- View setails
 - Delete
 - Reject
 

--- a/docs/articles/new-expensify/reports-and-expenses/Understanding-Report-Statuses-and-Actions.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Understanding-Report-Statuses-and-Actions.md
@@ -38,7 +38,7 @@ The grey **More** button is always visible in the report header. Tap it to acces
 - Print
 - Change Workspace
 - Change approver
-- View setails
+- View details
 - Delete
 - Reject
 


### PR DESCRIPTION
Replaces: https://github.com/Expensify/App/pull/87192/changes#diff-9f4033b2d7e8f30f1b4d4f766e1ff2580c06f5d5489a8305a1dbae34fcdc82e7

---

### Explanation of Change
Updates help site articles to document the new bulk "Change approver" feature added in https://github.com/Expensify/App/pull/77857. The feature allows users to select multiple reports on the Reports page and change the approver (add an approver or bypass approvers) in bulk.

**Changes:**

 - Approve-Expenses.md: Added a new section documenting how to change the approver for multiple reports at once, including notes about cross-workspace member visibility and Control plan requirements.
 - Understanding-Report-Statuses-and-Actions.md: Added "Change Approver" to the list of actions available in the grey "More" menu.