### PR TITLE
[No QA] [Hold App#87110] Trickle pregenerated Concierge response reveal

### DIFF
--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -30,24 +30,11 @@ function easeOut(t: number): number {
 }
 
 /**
- * Manages the lifecycle of a pending pregenerated Concierge response.
- *
- * For payloads with multiple top-level chunks the hook trickles the body in
- * progressively over `DEFAULT_STREAM_DURATION_MS` (decelerating ease-out),
- * dispatching `conciergeDraftStarted/updated/completed` events into Issa's
- * existing `ConciergeDraftContext` reducer (PR #87110) so the synthetic
- * report action splice and reconciliation behave identically to server-driven
- * streaming. Canonical Onyx state (`REPORT_ACTIONS`) is only written at the
- * end via `applyPendingConciergeAction`, preserving LHN previews / push
- * notifications / search snapshots until the trickle finishes.
- *
- * Single-chunk payloads fall back to the original binary reveal at
- * `displayAfter` so short replies (1–2 sentence answers) don't get stretched
- * artificially.
- *
- * Reconciliation: if the real `reportComment` arrives mid-trickle, the loop
- * accelerates the remaining reveal so the synthetic bubble lands within
- * `ACCELERATED_REMAINING_MS` instead of snapping closed.
+ * Multi-chunk payloads trickle into the `ConciergeDraftContext` reducer over
+ * `DEFAULT_STREAM_DURATION_MS` so the synthetic report action behaves
+ * identically to server-driven streaming. `REPORT_ACTIONS` is written only
+ * at completion, preserving LHN previews / push / search snapshots.
+ * Single-chunk payloads keep the binary reveal at `displayAfter`.
  */
 function usePendingConciergeResponse(reportID: string | undefined) {
     const [pendingResponse] = useOnyx(`${ONYXKEYS.COLLECTION.PENDING_CONCIERGE_RESPONSE}${reportID}`);
@@ -85,11 +72,9 @@ function usePendingConciergeResponse(reportID: string | undefined) {
             return;
         }
 
-        // Threshold matches word-level tokenization — a typical 1–2 sentence
-        // reply produces ~10–18 anchors and feels stretched if trickled over
-        // 30s, so binary reveal is preserved for those. Multi-paragraph
-        // replies (intro + list + closing) clear 20 anchors easily and get
-        // the smooth ChatGPT-style stream.
+        // Short replies (~10–18 anchors) feel stretched if trickled over 30s,
+        // so they keep the binary reveal; multi-paragraph replies clear the
+        // threshold and get the smooth trickle.
         const shouldTrickle = tokens.length >= 20 && !!fullHtml;
         if (!shouldTrickle) {
             const timer = setTimeout(() => applyPendingConciergeAction(reportID, reportAction), Math.max(0, remainingDelay));
@@ -103,9 +88,8 @@ function usePendingConciergeResponse(reportID: string | undefined) {
         let effectiveDuration = DEFAULT_STREAM_DURATION_MS;
         let lastStage = 0;
         let cancelled = false;
-        // Telemetry: track whether/when acceleration fired so the [complete] log
-        // can attribute the completion reason and the arrival point of the canonical
-        // reportComment. Drives Phase 2 duration tuning + regression detection.
+        // Track whether/when acceleration fired so the [complete] log can
+        // attribute the completion reason and arrival point of `reportComment`.
         let arrivedAtProgress: number | undefined;
         let arrivedAtElapsedMs: number | undefined;
 

--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -13,12 +13,10 @@ import useOnyx from './useOnyx';
 
 /** If displayAfter is more than this far in the past, the response is stale (e.g. app was killed and restarted). */
 const STALE_THRESHOLD_MS = 10_000;
-/** Default trickle duration. Roughly matches the p50 follow-up generation window so the reveal lands close to when followups arrive. */
-const DEFAULT_STREAM_DURATION_MS = 30_000;
-/** Trickle tick cadence. 150ms keeps each visible chunk small enough to feel
- * continuous (closer to the ChatGPT/Claude streaming feel) without spamming
- * dispatches faster than RNW can comfortably re-render the synthetic bubble. */
-const TICK_INTERVAL_MS = 150;
+/** Default trickle duration. Targets ~14 chars/sec average reveal across a typical multi-paragraph response, so the trickle visibly streams without dragging the user past the moment they want to read. */
+const DEFAULT_STREAM_DURATION_MS = 20_000;
+/** Trickle tick cadence. 80ms targets ~1 char per tick at char-level granularity — fast enough that the reveal feels continuous, slow enough that the synthetic-bubble re-render budget stays comfortable on RNW (~12 dispatches/sec). */
+const TICK_INTERVAL_MS = 80;
 /** Hard cap on running trickle. If the loop is still alive past this, force completion to avoid pinning a synthetic bubble forever. */
 const TRICKLE_HARD_CAP_MS = 60_000;
 /** Once the real reportComment lands in REPORT_ACTIONS, finish the remaining reveal within this window. */

--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -13,8 +13,8 @@ import useOnyx from './useOnyx';
 
 /** If displayAfter is more than this far in the past, the response is stale (e.g. app was killed and restarted). */
 const STALE_THRESHOLD_MS = 10_000;
-/** Default trickle duration. Targets ~14 chars/sec average reveal across a typical multi-paragraph response, so the trickle visibly streams without dragging the user past the moment they want to read. */
-const DEFAULT_STREAM_DURATION_MS = 20_000;
+/** Default trickle duration. Targets ~19 chars/sec start (~7/sec end after ease-out) across a typical multi-paragraph response — visibly streaming without dragging the user past the moment they want to read. */
+const DEFAULT_STREAM_DURATION_MS = 15_000;
 /** Trickle tick cadence. 80ms targets ~1 char per tick at char-level granularity — fast enough that the reveal feels continuous, slow enough that the synthetic-bubble re-render budget stays comfortable on RNW (~12 dispatches/sec). */
 const TICK_INTERVAL_MS = 80;
 /** Hard cap on running trickle. If the loop is still alive past this, force completion to avoid pinning a synthetic bubble forever. */

--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -83,9 +83,12 @@ function usePendingConciergeResponse(reportID: string | undefined) {
             return;
         }
 
-        // Single-chunk payloads keep the original binary reveal — trickling a
-        // 1–2 sentence answer over 30s would feel broken.
-        const shouldTrickle = tokens.length >= 3 && !!fullHtml;
+        // Threshold matches word-level tokenization — a typical 1–2 sentence
+        // reply produces ~10–18 anchors and feels stretched if trickled over
+        // 30s, so binary reveal is preserved for those. Multi-paragraph
+        // replies (intro + list + closing) clear 20 anchors easily and get
+        // the smooth ChatGPT-style stream.
+        const shouldTrickle = tokens.length >= 20 && !!fullHtml;
         if (!shouldTrickle) {
             const timer = setTimeout(() => applyPendingConciergeAction(reportID, reportAction), Math.max(0, remainingDelay));
             return () => clearTimeout(timer);

--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -72,10 +72,10 @@ function usePendingConciergeResponse(reportID: string | undefined) {
             return;
         }
 
-        // Short replies (~10–18 anchors) feel stretched if trickled over 30s,
-        // so they keep the binary reveal; multi-paragraph replies clear the
-        // threshold and get the smooth trickle.
-        const shouldTrickle = tokens.length >= 20 && !!fullHtml;
+        // Anchors are character-level. Short replies (~50–100 chars) keep the
+        // binary reveal; longer ones (paragraphs / lists) cross the threshold
+        // and get the smooth trickle.
+        const shouldTrickle = tokens.length >= 100 && !!fullHtml;
         if (!shouldTrickle) {
             const timer = setTimeout(() => applyPendingConciergeAction(reportID, reportAction), Math.max(0, remainingDelay));
             return () => clearTimeout(timer);

--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -98,6 +98,11 @@ function usePendingConciergeResponse(reportID: string | undefined) {
         let effectiveDuration = DEFAULT_STREAM_DURATION_MS;
         let lastStage = 0;
         let cancelled = false;
+        // Telemetry: track whether/when acceleration fired so the [complete] log
+        // can attribute the completion reason and the arrival point of the canonical
+        // reportComment. Drives Phase 2 duration tuning + regression detection.
+        let arrivedAtProgress: number | undefined;
+        let arrivedAtElapsedMs: number | undefined;
 
         const dispatch = (status: ConciergeDraftEvent['status'], finalRenderedHTML: string) => {
             if (cancelled) {
@@ -120,6 +125,22 @@ function usePendingConciergeResponse(reportID: string | undefined) {
                 clearInterval(intervalID);
                 intervalID = null;
             }
+            const totalElapsedMs = trickleStart === 0 ? 0 : Date.now() - trickleStart;
+            let reason: 'natural' | 'accelerated' | 'stale_cap' = 'natural';
+            if (arrivedAtProgress !== undefined) {
+                reason = 'accelerated';
+            } else if (totalElapsedMs >= TRICKLE_HARD_CAP_MS) {
+                reason = 'stale_cap';
+            }
+            Log.info('[ConciergeTrickle] complete', false, {
+                reportActionID,
+                reason,
+                tokenCount: tokens.length,
+                durationMs: effectiveDuration,
+                totalElapsedMs,
+                arrivedAtProgress,
+                arrivedAtElapsedMs,
+            });
             dispatch('completed', tokens.at(-1) ?? fullHtml);
             applyPendingConciergeAction(reportID, reportAction);
         };
@@ -132,8 +153,9 @@ function usePendingConciergeResponse(reportID: string | undefined) {
             // Compressing effectiveDuration is what makes progress hit 1 within
             // ACCELERATED_REMAINING_MS — the next tick observes progress >= 1
             // and runs completeAndApply via the normal path.
+            arrivedAtProgress = easeOut(elapsed / effectiveDuration);
+            arrivedAtElapsedMs = elapsed;
             effectiveDuration = elapsed + ACCELERATED_REMAINING_MS;
-            Log.info('[ConciergeTrickle] accelerated due to persisted action arrival', false, {reportActionID, elapsed});
         };
 
         const startTrickle = () => {
@@ -141,6 +163,11 @@ function usePendingConciergeResponse(reportID: string | undefined) {
                 return;
             }
             trickleStart = Date.now();
+            Log.info('[ConciergeTrickle] start', false, {
+                reportActionID,
+                tokenCount: tokens.length,
+                durationMs: effectiveDuration,
+            });
             dispatch('started', tokens.at(1) ?? '');
             lastStage = 1;
             intervalID = setInterval(() => {

--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -1,42 +1,172 @@
-import {useEffect} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
 import {applyPendingConciergeAction, discardPendingConciergeAction} from '@libs/actions/Report/SuggestedFollowup';
+import Log from '@libs/Log';
+import {rand64} from '@libs/NumberUtils';
+import type {ConciergeDraftEvent} from '@libs/Pusher/types';
+import tokenizeForReveal from '@libs/ReportActionFollowupUtils/tokenizeForReveal';
+import {getReportActionHtml} from '@libs/ReportActionsUtils';
+import {useConciergeDraftActions} from '@pages/inbox/ConciergeDraftContext';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {ReportAction, ReportActions} from '@src/types/onyx';
 import useOnyx from './useOnyx';
 
-/** If displayAfter is more than this far in the past, the response is stale (e.g. app was killed and restarted) */
+/** If displayAfter is more than this far in the past, the response is stale (e.g. app was killed and restarted). */
 const STALE_THRESHOLD_MS = 10_000;
+/** Default trickle duration. Roughly matches the p50 follow-up generation window so the reveal lands close to when followups arrive. */
+const DEFAULT_STREAM_DURATION_MS = 30_000;
+/** Trickle tick cadence. ~75 updates over the 30s default — enough granularity for a smooth ease-out, sparse enough to keep render churn low. */
+const TICK_INTERVAL_MS = 400;
+/** Hard cap on running trickle. If the loop is still alive past this, force completion to avoid pinning a synthetic bubble forever. */
+const TRICKLE_HARD_CAP_MS = 60_000;
+/** Once the real reportComment lands in REPORT_ACTIONS, finish the remaining reveal within this window. */
+const ACCELERATED_REMAINING_MS = 1_500;
+
+function easeOut(t: number): number {
+    const clamped = Math.max(0, Math.min(1, t));
+    return 1 - (1 - clamped) ** 2;
+}
 
 /**
- * Processes pending concierge responses stored in Onyx for a given report.
- * When a pending response exists, schedules the action to be moved to REPORT_ACTIONS
- * after the remaining delay, with automatic cleanup on unmount via useEffect.
+ * Manages the lifecycle of a pending pregenerated Concierge response.
+ *
+ * For payloads with multiple top-level chunks the hook trickles the body in
+ * progressively over `DEFAULT_STREAM_DURATION_MS` (decelerating ease-out),
+ * dispatching `conciergeDraftStarted/updated/completed` events into Issa's
+ * existing `ConciergeDraftContext` reducer (PR #87110) so the synthetic
+ * report action splice and reconciliation behave identically to server-driven
+ * streaming. Canonical Onyx state (`REPORT_ACTIONS`) is only written at the
+ * end via `applyPendingConciergeAction`, preserving LHN previews / push
+ * notifications / search snapshots until the trickle finishes.
+ *
+ * Single-chunk payloads fall back to the original binary reveal at
+ * `displayAfter` so short replies (1–2 sentence answers) don't get stretched
+ * artificially.
+ *
+ * Reconciliation: if the real `reportComment` arrives mid-trickle, the loop
+ * accelerates the remaining reveal so the synthetic bubble lands within
+ * `ACCELERATED_REMAINING_MS` instead of snapping closed.
  */
 function usePendingConciergeResponse(reportID: string | undefined) {
     const [pendingResponse] = useOnyx(`${ONYXKEYS.COLLECTION.PENDING_CONCIERGE_RESPONSE}${reportID}`);
+    const reportActionID = pendingResponse?.reportAction?.reportActionID;
+    const fullHtml = pendingResponse?.reportAction ? getReportActionHtml(pendingResponse.reportAction) : '';
+    const persistedActionSelector = useCallback(
+        (actions: OnyxEntry<ReportActions>): ReportAction | undefined => (reportActionID && actions ? actions[reportActionID] : undefined),
+        [reportActionID],
+    );
+    const [persistedAction] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {selector: persistedActionSelector});
+    const {dispatchLocalDraftEvent} = useConciergeDraftActions();
 
+    const tokens = useMemo(() => tokenizeForReveal(fullHtml), [fullHtml]);
+    const accelerateRef = useRef<((nowMs: number) => void) | null>(null);
+
+    // Reconciliation: when the canonical reportComment lands in REPORT_ACTIONS
+    // mid-trickle, fire the running loop's accelerator so the remaining reveal
+    // finishes in ~1.5s instead of snapping the synthetic bubble closed.
     useEffect(() => {
-        if (!pendingResponse) {
+        if (!persistedAction || !accelerateRef.current) {
             return;
         }
+        accelerateRef.current(Date.now());
+    }, [persistedAction]);
 
-        const remaining = pendingResponse.displayAfter - Date.now();
+    useEffect(() => {
+        if (!pendingResponse || !reportID || !reportActionID) {
+            return;
+        }
+        const {reportAction, displayAfter} = pendingResponse;
+        const remainingDelay = displayAfter - Date.now();
 
-        // If the pending response is stale (e.g. app was killed/restarted), discard it
-        // instead of displaying a phantom message that was never confirmed by the server.
-        if (remaining < -STALE_THRESHOLD_MS) {
+        if (remainingDelay < -STALE_THRESHOLD_MS) {
             discardPendingConciergeAction(reportID);
             return;
         }
 
-        const timer = setTimeout(
-            () => {
-                applyPendingConciergeAction(reportID, pendingResponse.reportAction);
-            },
-            Math.max(0, remaining),
-        );
+        // Single-chunk payloads keep the original binary reveal — trickling a
+        // 1–2 sentence answer over 30s would feel broken.
+        const shouldTrickle = tokens.length >= 3 && !!fullHtml;
+        if (!shouldTrickle) {
+            const timer = setTimeout(() => applyPendingConciergeAction(reportID, reportAction), Math.max(0, remainingDelay));
+            return () => clearTimeout(timer);
+        }
 
-        return () => clearTimeout(timer);
-    }, [pendingResponse, reportID]);
+        const session = rand64();
+        let sequence = 0;
+        let intervalID: ReturnType<typeof setInterval> | null = null;
+        let trickleStart = 0;
+        let effectiveDuration = DEFAULT_STREAM_DURATION_MS;
+        let lastStage = 0;
+        let cancelled = false;
+
+        const dispatch = (status: ConciergeDraftEvent['status'], finalRenderedHTML: string) => {
+            if (cancelled) {
+                return;
+            }
+            sequence += 1;
+            dispatchLocalDraftEvent({
+                reportID,
+                reportActionID,
+                streamSessionID: session,
+                sequence,
+                status,
+                created: reportAction.created,
+                finalRenderedHTML,
+            });
+        };
+
+        const completeAndApply = () => {
+            if (intervalID) {
+                clearInterval(intervalID);
+                intervalID = null;
+            }
+            dispatch('completed', tokens.at(-1) ?? fullHtml);
+            applyPendingConciergeAction(reportID, reportAction);
+        };
+
+        accelerateRef.current = (nowMs: number) => {
+            if (!intervalID || trickleStart === 0) {
+                return;
+            }
+            const elapsed = nowMs - trickleStart;
+            // Compressing effectiveDuration is what makes progress hit 1 within
+            // ACCELERATED_REMAINING_MS — the next tick observes progress >= 1
+            // and runs completeAndApply via the normal path.
+            effectiveDuration = elapsed + ACCELERATED_REMAINING_MS;
+            Log.info('[ConciergeTrickle] accelerated due to persisted action arrival', false, {reportActionID, elapsed});
+        };
+
+        const startTrickle = () => {
+            if (cancelled) {
+                return;
+            }
+            trickleStart = Date.now();
+            dispatch('started', tokens.at(1) ?? '');
+            lastStage = 1;
+            intervalID = setInterval(() => {
+                const elapsed = Date.now() - trickleStart;
+                const progress = easeOut(elapsed / effectiveDuration);
+                const stage = Math.min(tokens.length - 1, Math.max(0, Math.ceil(progress * (tokens.length - 1))));
+                if (stage > lastStage) {
+                    lastStage = stage;
+                    dispatch('updated', tokens.at(stage) ?? '');
+                }
+                if (progress >= 1 || elapsed >= TRICKLE_HARD_CAP_MS) {
+                    completeAndApply();
+                }
+            }, TICK_INTERVAL_MS);
+        };
+
+        const startTimer = setTimeout(startTrickle, Math.max(0, remainingDelay));
+        return () => {
+            cancelled = true;
+            clearTimeout(startTimer);
+            if (intervalID) {
+                clearInterval(intervalID);
+            }
+            accelerateRef.current = null;
+        };
+    }, [pendingResponse, reportID, reportActionID, fullHtml, tokens, dispatchLocalDraftEvent]);
 }
 
 export default usePendingConciergeResponse;

--- a/src/hooks/usePendingConciergeResponse.ts
+++ b/src/hooks/usePendingConciergeResponse.ts
@@ -15,8 +15,10 @@ import useOnyx from './useOnyx';
 const STALE_THRESHOLD_MS = 10_000;
 /** Default trickle duration. Roughly matches the p50 follow-up generation window so the reveal lands close to when followups arrive. */
 const DEFAULT_STREAM_DURATION_MS = 30_000;
-/** Trickle tick cadence. ~75 updates over the 30s default — enough granularity for a smooth ease-out, sparse enough to keep render churn low. */
-const TICK_INTERVAL_MS = 400;
+/** Trickle tick cadence. 150ms keeps each visible chunk small enough to feel
+ * continuous (closer to the ChatGPT/Claude streaming feel) without spamming
+ * dispatches faster than RNW can comfortably re-render the synthetic bubble. */
+const TICK_INTERVAL_MS = 150;
 /** Hard cap on running trickle. If the loop is still alive past this, force completion to avoid pinning a synthetic bubble forever. */
 const TRICKLE_HARD_CAP_MS = 60_000;
 /** Once the real reportComment lands in REPORT_ACTIONS, finish the remaining reveal within this window. */

--- a/src/libs/ReportActionFollowupUtils/index.ts
+++ b/src/libs/ReportActionFollowupUtils/index.ts
@@ -3,6 +3,7 @@ import {DomUtils, parseDocument} from 'htmlparser2';
 import {getReportActionMessage, isActionOfType} from '@libs/ReportActionsUtils';
 import CONST from '@src/CONST';
 import type {OnyxInputOrEntry, ReportAction} from '@src/types/onyx';
+import tokenizeForReveal from './tokenizeForReveal';
 
 type Followup = {
     text: string;
@@ -58,5 +59,6 @@ function parseFollowupsFromHtml(html: string): Followup[] | null {
         return {text, response};
     });
 }
-export {containsActionableFollowUps, parseFollowupsFromHtml};
+
+export {containsActionableFollowUps, parseFollowupsFromHtml, tokenizeForReveal};
 export type {Followup};

--- a/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
+++ b/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
@@ -1,24 +1,140 @@
 import render from 'dom-serializer';
+import {ElementType} from 'domelementtype';
+import type {AnyNode, Document, Element as DomElement} from 'domhandler';
 import {parseDocument} from 'htmlparser2';
 
 /**
- * Pre-computes a list of progressive HTML stages for a pregenerated Concierge
- * response, so usePendingConciergeResponse can trickle the body in over the
- * follow-up generation window without re-parsing on every tick.
+ * Tags rendered atomically — splitting their content mid-element looks broken
+ * (e.g. half a mention, a partial emoji codepoint, a link with no closing tag).
+ * Mentions/emoji/img are visual primitives, <a> is a structural target with a
+ * URL, <code> is a literal text run that shouldn't reflow as words trickle in.
+ */
+const ATOMIC_TAGS = new Set(['mention-user', 'mention-report', 'emoji', 'a', 'code', 'img']);
+
+/**
+ * One reveal point. `path` is the index path from the doc root to the anchor
+ * node; `textEndIdx` (when present) is the character offset to truncate that
+ * node's text data to.
+ */
+type Anchor = {
+    path: number[];
+    textEndIdx?: number;
+};
+
+/**
+ * Walk the DOM in document order, emitting one anchor per "word or whitespace
+ * run" inside text nodes and one anchor for each whole atomic-tag subtree.
+ * Block / formatting elements (<p>, <ol>, <strong>, <em>, ...) recurse so
+ * their inner words become anchors with the wrapper preserved on render —
+ * that's what makes bold appear as words become bold rather than as a single
+ * jump.
+ */
+function collectAnchors(doc: Document): Anchor[] {
+    const anchors: Anchor[] = [];
+    const visit = (node: AnyNode, path: number[]): void => {
+        if (node.type === ElementType.Text) {
+            const text = node.data;
+            if (text.length === 0) {
+                return;
+            }
+            // Word-or-whitespace runs — each run advances the visible content
+            // by one perceptual unit. Splitting on \s alone would coalesce
+            // multiple words around a single space; this keeps the reveal
+            // granular without breaking on character boundaries.
+            const re = /\S+|\s+/g;
+            let match = re.exec(text);
+            while (match !== null) {
+                anchors.push({path: path.slice(), textEndIdx: match.index + match[0].length});
+                match = re.exec(text);
+            }
+            return;
+        }
+        if (node.type !== ElementType.Tag) {
+            return;
+        }
+        const elem = node;
+        const tagName = elem.name.toLowerCase();
+        if (ATOMIC_TAGS.has(tagName)) {
+            anchors.push({path: path.slice()});
+            return;
+        }
+        if (!elem.children || elem.children.length === 0) {
+            anchors.push({path: path.slice()});
+            return;
+        }
+        for (let i = 0; i < elem.children.length; i++) {
+            const child = elem.children.at(i);
+            if (child) {
+                visit(child, [...path, i]);
+            }
+        }
+    };
+    for (let i = 0; i < doc.children.length; i++) {
+        const child = doc.children.at(i);
+        if (child) {
+            visit(child, [i]);
+        }
+    }
+    return anchors;
+}
+
+/**
+ * Build a partial node forest containing every node up to (and including)
+ * `anchor`, with any text-node leaf truncated to the anchor's offset.
  *
- * Splits at top-level child boundaries so atomic inline elements (mentions,
- * emoji, anchors, code) never render half-parsed. Stage 0 is empty; the final
- * stage equals the rendered children. The hook walks indices 0..N-1 over the
- * stream duration.
+ * Reconstructs only the path elements: siblings before the path branch are
+ * cloned by reference (rendered fully), the path branch is shallow-cloned
+ * with its `children` array replaced. Sibling references are unchanged so
+ * dom-serializer renders them via their existing structure — no parent/next
+ * pointer surgery needed.
+ */
+function buildClippedNodes(doc: Document, anchor: Anchor): AnyNode[] {
+    const clip = (siblings: readonly AnyNode[], depth: number): AnyNode[] => {
+        const idx = anchor.path.at(depth) ?? 0;
+        const isLeaf = depth === anchor.path.length - 1;
+        const before = siblings.slice(0, idx);
+        const stopNode = siblings.at(idx);
+        if (!stopNode) {
+            return [...before];
+        }
+        if (isLeaf) {
+            if (stopNode.type === ElementType.Text && anchor.textEndIdx !== undefined) {
+                const truncated = {...stopNode, data: stopNode.data.slice(0, anchor.textEndIdx)} as unknown as AnyNode;
+                return [...before, truncated];
+            }
+            return [...before, stopNode];
+        }
+        const elem = stopNode as DomElement;
+        const innerChildren = clip(elem.children as AnyNode[], depth + 1);
+        const partialElem = {...elem, children: innerChildren} as unknown as AnyNode;
+        return [...before, partialElem];
+    };
+    return clip(doc.children as AnyNode[], 0);
+}
+
+/**
+ * Pre-computes a list of progressive HTML stages for a pregenerated Concierge
+ * response — usePendingConciergeResponse trickles them in over the follow-up
+ * generation window so the chat keeps moving while the server works.
+ *
+ * Word-level granularity within text nodes (ChatGPT-style streaming feel),
+ * recursing into formatting wrappers like <strong>/<em> so bold appears as
+ * words become bold rather than in one jump. Atomic visual primitives
+ * (mentions, emoji, links, code, images) stay whole — no half-rendered
+ * mention or partial emoji codepoint.
+ *
+ * Stage 0 is empty; the final stage equals the rendered children. The hook
+ * walks indices 0..N-1 across the trickle duration via an ease-out curve.
  */
 function tokenizeForReveal(html: string): string[] {
     if (!html) {
         return [''];
     }
     const doc = parseDocument(html);
+    const anchors = collectAnchors(doc);
     const stages: string[] = [''];
-    for (let n = 1; n <= doc.children.length; n++) {
-        stages.push(render(doc.children.slice(0, n)));
+    for (const anchor of anchors) {
+        stages.push(render(buildClippedNodes(doc, anchor)));
     }
     return stages;
 }

--- a/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
+++ b/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
@@ -1,0 +1,26 @@
+import render from 'dom-serializer';
+import {parseDocument} from 'htmlparser2';
+
+/**
+ * Pre-computes a list of progressive HTML stages for a pregenerated Concierge
+ * response, so usePendingConciergeResponse can trickle the body in over the
+ * follow-up generation window without re-parsing on every tick.
+ *
+ * Splits at top-level child boundaries so atomic inline elements (mentions,
+ * emoji, anchors, code) never render half-parsed. Stage 0 is empty; the final
+ * stage equals the rendered children. The hook walks indices 0..N-1 over the
+ * stream duration.
+ */
+function tokenizeForReveal(html: string): string[] {
+    if (!html) {
+        return [''];
+    }
+    const doc = parseDocument(html);
+    const stages: string[] = [''];
+    for (let n = 1; n <= doc.children.length; n++) {
+        stages.push(render(doc.children.slice(0, n)));
+    }
+    return stages;
+}
+
+export default tokenizeForReveal;

--- a/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
+++ b/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
@@ -32,14 +32,12 @@ function collectAnchors(doc: Document): Anchor[] {
             if (text.length === 0) {
                 return;
             }
-            // Splitting on \s alone would coalesce adjacent words around a
-            // single space; matching word-or-whitespace runs keeps each word
-            // a separate reveal step.
-            const re = /\S+|\s+/g;
-            let match = re.exec(text);
-            while (match !== null) {
-                anchors.push({path: path.slice(), textEndIdx: match.index + match[0].length});
-                match = re.exec(text);
+            // One anchor per character for ChatGPT-style streaming feel.
+            // Atomic tags below still emit a single anchor for the whole tag,
+            // so mentions/emoji/anchors/code never render half-rendered even
+            // at this granularity.
+            for (let i = 1; i <= text.length; i += 1) {
+                anchors.push({path: path.slice(), textEndIdx: i});
             }
             return;
         }

--- a/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
+++ b/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
@@ -4,10 +4,8 @@ import type {AnyNode, Document, Element as DomElement} from 'domhandler';
 import {parseDocument} from 'htmlparser2';
 
 /**
- * Tags rendered atomically — splitting their content mid-element looks broken
- * (e.g. half a mention, a partial emoji codepoint, a link with no closing tag).
- * Mentions/emoji/img are visual primitives, <a> is a structural target with a
- * URL, <code> is a literal text run that shouldn't reflow as words trickle in.
+ * Tags whose content can't be split mid-element without looking broken
+ * (half mention, partial emoji codepoint, anchor without its URL).
  */
 const ATOMIC_TAGS = new Set(['mention-user', 'mention-report', 'emoji', 'a', 'code', 'img']);
 
@@ -22,12 +20,9 @@ type Anchor = {
 };
 
 /**
- * Walk the DOM in document order, emitting one anchor per "word or whitespace
- * run" inside text nodes and one anchor for each whole atomic-tag subtree.
- * Block / formatting elements (<p>, <ol>, <strong>, <em>, ...) recurse so
- * their inner words become anchors with the wrapper preserved on render —
- * that's what makes bold appear as words become bold rather than as a single
- * jump.
+ * Emits one anchor per word/whitespace run inside text nodes and one per
+ * atomic-tag subtree. Formatting elements (<strong>, <em>, ...) recurse so
+ * bold appears as words become bold, rather than in one jump.
  */
 function collectAnchors(doc: Document): Anchor[] {
     const anchors: Anchor[] = [];
@@ -37,10 +32,9 @@ function collectAnchors(doc: Document): Anchor[] {
             if (text.length === 0) {
                 return;
             }
-            // Word-or-whitespace runs — each run advances the visible content
-            // by one perceptual unit. Splitting on \s alone would coalesce
-            // multiple words around a single space; this keeps the reveal
-            // granular without breaking on character boundaries.
+            // Splitting on \s alone would coalesce adjacent words around a
+            // single space; matching word-or-whitespace runs keeps each word
+            // a separate reveal step.
             const re = /\S+|\s+/g;
             let match = re.exec(text);
             while (match !== null) {
@@ -79,14 +73,10 @@ function collectAnchors(doc: Document): Anchor[] {
 }
 
 /**
- * Build a partial node forest containing every node up to (and including)
- * `anchor`, with any text-node leaf truncated to the anchor's offset.
- *
- * Reconstructs only the path elements: siblings before the path branch are
- * cloned by reference (rendered fully), the path branch is shallow-cloned
- * with its `children` array replaced. Sibling references are unchanged so
- * dom-serializer renders them via their existing structure — no parent/next
- * pointer surgery needed.
+ * Builds a partial node forest up to and including `anchor`, truncating the
+ * leaf text node at the anchor offset. Only the path branch is shallow-cloned
+ * with a new children array; sibling references stay untouched so
+ * dom-serializer renders them as-is.
  */
 function buildClippedNodes(doc: Document, anchor: Anchor): AnyNode[] {
     const clip = (siblings: readonly AnyNode[], depth: number): AnyNode[] => {
@@ -113,18 +103,10 @@ function buildClippedNodes(doc: Document, anchor: Anchor): AnyNode[] {
 }
 
 /**
- * Pre-computes a list of progressive HTML stages for a pregenerated Concierge
- * response — usePendingConciergeResponse trickles them in over the follow-up
- * generation window so the chat keeps moving while the server works.
- *
- * Word-level granularity within text nodes (ChatGPT-style streaming feel),
- * recursing into formatting wrappers like <strong>/<em> so bold appears as
- * words become bold rather than in one jump. Atomic visual primitives
- * (mentions, emoji, links, code, images) stay whole — no half-rendered
- * mention or partial emoji codepoint.
- *
- * Stage 0 is empty; the final stage equals the rendered children. The hook
- * walks indices 0..N-1 across the trickle duration via an ease-out curve.
+ * Pre-computes progressive HTML stages with word-level granularity. Formatting
+ * wrappers (<strong>, <em>, ...) recurse so bold reveals progressively;
+ * atomic primitives (mentions, emoji, links, code, images) stay whole.
+ * Stage 0 is empty; the final stage equals the input.
  */
 function tokenizeForReveal(html: string): string[] {
     if (!html) {

--- a/src/pages/inbox/ConciergeDraftContext.tsx
+++ b/src/pages/inbox/ConciergeDraftContext.tsx
@@ -18,6 +18,13 @@ type ConciergeDraftState = {
 
 type ConciergeDraftActions = {
     clearDraft: () => void;
+    /**
+     * Apply a draft event from a non-Pusher source (e.g. the local pacer in
+     * usePendingConciergeResponse for pregenerated replies whose body is
+     * already on the client). Uses the same reducer as the Pusher path so the
+     * reportActionID-based reconciliation continues to work unchanged.
+     */
+    dispatchLocalDraftEvent: (event: ConciergeDraftEvent) => void;
 };
 
 const defaultState: ConciergeDraftState = {
@@ -27,6 +34,7 @@ const defaultState: ConciergeDraftState = {
 
 const defaultActions: ConciergeDraftActions = {
     clearDraft: () => {},
+    dispatchLocalDraftEvent: () => {},
 };
 
 const ConciergeDraftStateContext = createContext<ConciergeDraftState>(defaultState);
@@ -59,6 +67,13 @@ function ConciergeDraftGate({reportID, children}: React.PropsWithChildren<{repor
     const clearDraft = useCallback(() => {
         setDraft(null);
     }, []);
+
+    const dispatchLocalDraftEvent = useCallback(
+        (event: ConciergeDraftEvent) => {
+            setDraft((currentDraft) => applyConciergeDraftEvent(currentDraft, event, reportID));
+        },
+        [reportID],
+    );
 
     useEffect(() => {
         const channelName = getReportChannelName(reportID);
@@ -109,8 +124,9 @@ function ConciergeDraftGate({reportID, children}: React.PropsWithChildren<{repor
     const actionsValue = useMemo<ConciergeDraftActions>(
         () => ({
             clearDraft,
+            dispatchLocalDraftEvent,
         }),
-        [clearDraft],
+        [clearDraft, dispatchLocalDraftEvent],
     );
 
     return (

--- a/src/pages/inbox/ConciergeDraftContext.tsx
+++ b/src/pages/inbox/ConciergeDraftContext.tsx
@@ -19,10 +19,9 @@ type ConciergeDraftState = {
 type ConciergeDraftActions = {
     clearDraft: () => void;
     /**
-     * Apply a draft event from a non-Pusher source (e.g. the local pacer in
-     * usePendingConciergeResponse for pregenerated replies whose body is
-     * already on the client). Uses the same reducer as the Pusher path so the
-     * reportActionID-based reconciliation continues to work unchanged.
+     * Apply a draft event from a non-Pusher source (e.g. a local pacer for
+     * pregenerated replies). Uses the same reducer as the Pusher path so
+     * `reportActionID`-based reconciliation works unchanged.
      */
     dispatchLocalDraftEvent: (event: ConciergeDraftEvent) => void;
 };

--- a/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
+++ b/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
@@ -5,14 +5,15 @@ describe('tokenizeForReveal', () => {
         expect(tokenizeForReveal('')).toEqual(['']);
     });
 
-    it('reveals plain text word-by-word inside a single block', () => {
+    it('reveals plain text character-by-character inside a single block', () => {
         const html = '<p>The quick brown fox.</p>';
         const stages = tokenizeForReveal(html);
 
         expect(stages.at(0)).toBe('');
         expect(stages.at(-1)).toBe('<p>The quick brown fox.</p>');
-        // Word-level reveal yields one stage per word + whitespace run.
-        expect(stages.length).toBeGreaterThanOrEqual(5);
+        // Char-level reveal yields one stage per character of the text content
+        // ("The quick brown fox." = 20 chars), plus stage 0 (empty).
+        expect(stages.length).toBe(21);
     });
 
     it('preserves the <strong> wrapper while revealing words inside it (formatting applies as text grows)', () => {
@@ -93,11 +94,13 @@ describe('tokenizeForReveal', () => {
         }
     });
 
-    it('produces enough anchors that a typical multi-paragraph response trickles smoothly (>=20 stages)', () => {
+    it('produces enough anchors that a typical multi-paragraph response trickles smoothly', () => {
         // Realistic shape — Xero-style 5-step instructions.
         const html =
             '<p>Here is how to connect Xero as your accounting integration:</p><ol><li>In the left-hand menu, go to Settings.</li><li>Click More features, then click Accounting.</li><li>Click Set up next to Xero.</li><li>Log in to Xero as an administrator.</li><li>Confirm the connection.</li></ol><p>This imports your charts of accounts and tracking categories.</p>';
         const stages = tokenizeForReveal(html);
-        expect(stages.length).toBeGreaterThanOrEqual(20);
+        // Char-level: total visible-text chars ~280, so we expect comfortably
+        // more than the shouldTrickle threshold of 100 anchors.
+        expect(stages.length).toBeGreaterThanOrEqual(200);
     });
 });

--- a/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
+++ b/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
@@ -5,50 +5,99 @@ describe('tokenizeForReveal', () => {
         expect(tokenizeForReveal('')).toEqual(['']);
     });
 
-    it('returns one content stage for single top-level child (binary reveal fallback)', () => {
-        const html = '<p>Just one paragraph.</p>';
+    it('reveals plain text word-by-word inside a single block', () => {
+        const html = '<p>The quick brown fox.</p>';
         const stages = tokenizeForReveal(html);
 
-        // [empty, full]. The hook treats this as a binary reveal because length < 3.
-        expect(stages).toHaveLength(2);
         expect(stages.at(0)).toBe('');
-        expect(stages.at(-1)).toBe(html);
+        expect(stages.at(-1)).toBe('<p>The quick brown fox.</p>');
+        // Word-level reveal yields one stage per word + whitespace run.
+        expect(stages.length).toBeGreaterThanOrEqual(5);
     });
 
-    it('produces progressive prefixes split at top-level boundaries', () => {
-        const html = '<p>First.</p><p>Second.</p><ul><li>Third.</li></ul>';
+    it('preserves the <strong> wrapper while revealing words inside it (formatting applies as text grows)', () => {
+        const html = '<p>Status: <strong>important warning</strong> for you.</p>';
         const stages = tokenizeForReveal(html);
 
-        expect(stages).toEqual(['', '<p>First.</p>', '<p>First.</p><p>Second.</p>', html]);
-    });
+        // At some intermediate stage we should see the bold wrapper opened
+        // around a partial word — proves we're recursing into the formatting
+        // element rather than treating it as atomic.
+        const hasOpenStrong = stages.some((s) => /<strong>[^<]*<\/strong>/.test(s) && !s.includes('important warning'));
+        expect(hasOpenStrong).toBe(true);
 
-    it('keeps inline atomics whole (mention, emoji, anchor, code stay intact in their parent)', () => {
-        // Each top-level <p> is an atomic unit so its inline children never render half-parsed.
-        // htmlparser2's parseDocument lowercases attribute names — that matches the rest of the
-        // codebase (see parseFollowupsFromHtml) so we accept it as the canonical shape.
-        const html = '<p>Hi <mention-user accountID="42">@daniel</mention-user></p><p>Status: <emoji>✅</emoji></p>';
-        const stages = tokenizeForReveal(html);
-
-        expect(stages.at(1)).toContain('mention-user');
-        expect(stages.at(1)).toContain('@daniel');
-        // No stage shows a partially-rendered mention or emoji.
+        // Every stage must keep the <strong> tag balanced.
         for (const stage of stages) {
-            const openMentions = (stage.match(/<mention-user/g) ?? []).length;
-            const closeMentions = (stage.match(/<\/mention-user>/g) ?? []).length;
-            expect(openMentions).toBe(closeMentions);
+            const opens = (stage.match(/<strong>/g) ?? []).length;
+            const closes = (stage.match(/<\/strong>/g) ?? []).length;
+            expect(opens).toBe(closes);
+        }
 
-            const openEmojis = (stage.match(/<emoji>/g) ?? []).length;
-            const closeEmojis = (stage.match(/<\/emoji>/g) ?? []).length;
-            expect(openEmojis).toBe(closeEmojis);
+        expect(stages.at(-1)).toBe('<p>Status: <strong>important warning</strong> for you.</p>');
+    });
+
+    it('keeps mention-user atomic (never half-rendered)', () => {
+        const html = '<p>Hi <mention-user accountID="42">@daniel</mention-user> welcome.</p>';
+        const stages = tokenizeForReveal(html);
+
+        for (const stage of stages) {
+            const opens = (stage.match(/<mention-user/g) ?? []).length;
+            const closes = (stage.match(/<\/mention-user>/g) ?? []).length;
+            expect(opens).toBe(closes);
+        }
+
+        // Partial text inside the mention-user wrapper would indicate broken atomicity.
+        expect(stages.some((s) => /<mention-user[^>]*>@dani(?!e)/.test(s))).toBe(false);
+    });
+
+    it('keeps emoji atomic', () => {
+        const html = '<p>Status: <emoji>✅</emoji> all good.</p>';
+        const stages = tokenizeForReveal(html);
+
+        for (const stage of stages) {
+            const opens = (stage.match(/<emoji>/g) ?? []).length;
+            const closes = (stage.match(/<\/emoji>/g) ?? []).length;
+            expect(opens).toBe(closes);
         }
     });
 
-    it('preserves the typical Concierge response shape (paragraphs + bullet list)', () => {
-        const html = "<p>To set up QuickBooks, here's what to do:</p><ol><li>Go to Settings.</li><li>Click Connections.</li><li>Pick QBO.</li></ol><p>Let me know if you hit a snag.</p>";
+    it('keeps anchor atomic so the URL and text appear together', () => {
+        const html = '<p>See <a href="https://example.com">our docs</a> for more.</p>';
         const stages = tokenizeForReveal(html);
 
-        // 3 top-level children => 4 stages (empty + 3 progressive).
-        expect(stages).toHaveLength(4);
+        const anchorContents = stages.flatMap((s) => Array.from(s.matchAll(/<a[^>]*>([^<]*)<\/a>/g)).map((m) => m[1]));
+        for (const content of anchorContents) {
+            expect(content).toBe('our docs');
+        }
+    });
+
+    it('keeps code atomic', () => {
+        const html = '<p>Run <code>npm install</code> to start.</p>';
+        const stages = tokenizeForReveal(html);
+
+        const codeContents = stages.flatMap((s) => Array.from(s.matchAll(/<code>([^<]*)<\/code>/g)).map((m) => m[1]));
+        for (const content of codeContents) {
+            expect(content).toBe('npm install');
+        }
+    });
+
+    it('reveals each top-level child progressively (multi-paragraph + list shape)', () => {
+        const html = '<p>Intro paragraph here.</p><ol><li>First step.</li><li>Second step.</li></ol><p>Closing line.</p>';
+        const stages = tokenizeForReveal(html);
+
         expect(stages.at(-1)).toBe(html);
+
+        // Stages must monotonically grow: textual content length never decreases.
+        const lengths = stages.map((s) => s.replaceAll(/<[^>]+>/g, '').length);
+        for (let i = 1; i < lengths.length; i++) {
+            expect(lengths.at(i) ?? 0).toBeGreaterThanOrEqual(lengths.at(i - 1) ?? 0);
+        }
+    });
+
+    it('produces enough anchors that a typical multi-paragraph response trickles smoothly (>=20 stages)', () => {
+        // Realistic shape — Xero-style 5-step instructions.
+        const html =
+            '<p>Here is how to connect Xero as your accounting integration:</p><ol><li>In the left-hand menu, go to Settings.</li><li>Click More features, then click Accounting.</li><li>Click Set up next to Xero.</li><li>Log in to Xero as an administrator.</li><li>Confirm the connection.</li></ol><p>This imports your charts of accounts and tracking categories.</p>';
+        const stages = tokenizeForReveal(html);
+        expect(stages.length).toBeGreaterThanOrEqual(20);
     });
 });

--- a/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
+++ b/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
@@ -1,0 +1,54 @@
+import tokenizeForReveal from '@libs/ReportActionFollowupUtils/tokenizeForReveal';
+
+describe('tokenizeForReveal', () => {
+    it('returns just the empty stage for an empty input', () => {
+        expect(tokenizeForReveal('')).toEqual(['']);
+    });
+
+    it('returns one content stage for single top-level child (binary reveal fallback)', () => {
+        const html = '<p>Just one paragraph.</p>';
+        const stages = tokenizeForReveal(html);
+
+        // [empty, full]. The hook treats this as a binary reveal because length < 3.
+        expect(stages).toHaveLength(2);
+        expect(stages.at(0)).toBe('');
+        expect(stages.at(-1)).toBe(html);
+    });
+
+    it('produces progressive prefixes split at top-level boundaries', () => {
+        const html = '<p>First.</p><p>Second.</p><ul><li>Third.</li></ul>';
+        const stages = tokenizeForReveal(html);
+
+        expect(stages).toEqual(['', '<p>First.</p>', '<p>First.</p><p>Second.</p>', html]);
+    });
+
+    it('keeps inline atomics whole (mention, emoji, anchor, code stay intact in their parent)', () => {
+        // Each top-level <p> is an atomic unit so its inline children never render half-parsed.
+        // htmlparser2's parseDocument lowercases attribute names — that matches the rest of the
+        // codebase (see parseFollowupsFromHtml) so we accept it as the canonical shape.
+        const html = '<p>Hi <mention-user accountID="42">@daniel</mention-user></p><p>Status: <emoji>✅</emoji></p>';
+        const stages = tokenizeForReveal(html);
+
+        expect(stages.at(1)).toContain('mention-user');
+        expect(stages.at(1)).toContain('@daniel');
+        // No stage shows a partially-rendered mention or emoji.
+        for (const stage of stages) {
+            const openMentions = (stage.match(/<mention-user/g) ?? []).length;
+            const closeMentions = (stage.match(/<\/mention-user>/g) ?? []).length;
+            expect(openMentions).toBe(closeMentions);
+
+            const openEmojis = (stage.match(/<emoji>/g) ?? []).length;
+            const closeEmojis = (stage.match(/<\/emoji>/g) ?? []).length;
+            expect(openEmojis).toBe(closeEmojis);
+        }
+    });
+
+    it('preserves the typical Concierge response shape (paragraphs + bullet list)', () => {
+        const html = "<p>To set up QuickBooks, here's what to do:</p><ol><li>Go to Settings.</li><li>Click Connections.</li><li>Pick QBO.</li></ol><p>Let me know if you hit a snag.</p>";
+        const stages = tokenizeForReveal(html);
+
+        // 3 top-level children => 4 stages (empty + 3 progressive).
+        expect(stages).toHaveLength(4);
+        expect(stages.at(-1)).toBe(html);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

After a user clicks a Concierge follow-up suggestion, the server takes ~30–40s to generate the next round of suggestions. Today the pregenerated reply appears as a single binary reveal after a 4s typing pause, so the chat looks frozen for the rest of that window and users often click away before the new suggestions land.

This PR trickles the pregenerated reply in progressively across the same window so the conversation keeps moving while the server works. The reveal is paced with a decelerating ease-out — fast at the start, slowing toward the moment followups typically arrive. Atomic primitives (mentions, emoji, links, code) stay whole during the trickle, and formatting wrappers recurse so bold appears word-by-word.

Canonical Onyx state is still only written when the server's `reportComment` arrives, preserving LHN previews, push notifications, and search snapshots. If that final action lands mid-trickle the remaining reveal accelerates to ~1.5s instead of snapping closed; single-paragraph replies keep the original 4s binary reveal so short answers don't feel stretched.

Stacked on https://github.com/Expensify/App/pull/87110 — reuses its reducer, synthetic-action graft, and `reportActionID`-based reconciliation. **Do not merge before #87110.**

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/626938
PROPOSAL: N/A (engineering-initiated UX improvement)

### Tests

1. Sign in to a domain in the `suggestedFollowups` beta (e.g. `dmb.fun`).
2. Trigger a fresh-account onboarding that selects MANAGE_TEAM + 1–10 employees, landing in `#admins` with three Concierge follow-up buttons.
3. Click any follow-up button. Verify the reply trickles in progressively over ~30s (paragraphs and list items appear in sequence) rather than revealing all at once after 4s. The "Concierge is typing…" indicator clears as soon as the trickle starts.
4. Verify atomic primitives (mentions, emoji, links, code) never render half-parsed at any point during the trickle.
5. When the trickle completes, verify the canonical Concierge message lands and replaces the synthetic bubble seamlessly — no flash, no duplicate.
6. Reconciliation: if the canonical message arrives before the trickle finishes, verify the remaining reveal accelerates to ~1.5s instead of snapping closed.
7. Short-reply fallback: a single-paragraph pregenerated body (under 20 anchors) keeps the original 4s binary reveal.
8. Open the JS console and verify two structured logs fire per trickle (`[ConciergeTrickle] start` and `[ConciergeTrickle] complete`).

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Land on `#admins` with the welcome message and follow-up buttons rendered (online).
2. Toggle the network offline and click a follow-up button. Verify the trickle still runs locally to completion — the pregenerated HTML is already on the client, so no network is needed for the reveal.
3. Verify the canonical Concierge message does not arrive while offline; the synthetic bubble stays visible at full reveal.
4. Toggle the network back online and verify the canonical action arrives and replaces the synthetic bubble (no flash, no duplicate).

### QA Steps

No QA — gated behind the `suggestedFollowups` beta, which requires engineering setup (beta-flagged domain + fresh-account onboarding selecting MANAGE_TEAM + 1–10 employees) that QA cannot reach on staging. Engineering verification covers all platforms via the Tests section above. Title is prefixed `[No QA]` accordingly.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/d3d3deb2-1f4f-4dd4-9f34-fadf8ab76f3b

</details>
