### PR TITLE
[cp staging] fix(iOS): keep ScrollAnchor mounted to prevent scroll reset when MVCP toggles

### DIFF
--- a/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
+++ b/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js 
 index ee42f63..4e8d8c0 100644
 --- a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
 +++ b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
-@@ -380,16 +380,14 @@ const RecyclerViewComponent = (props, ref) => {
+@@ -380,16 +380,15 @@ const RecyclerViewComponent = (props, ref) => {
          }
          return onScrollHandler;
      }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
@@ -11,7 +11,7 @@ index ee42f63..4e8d8c0 100644
 -        if (shouldMaintainVisibleContentPosition) {
 +        if (maintainVisibleContentPosition != null) {
              return {
--                ...maintainVisibleContentPosition,
+                 ...maintainVisibleContentPosition,
                  minIndexForVisible: 0,
              };
          }
@@ -39,7 +39,7 @@ diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx 
 index b2bd67a..d4bf02d 100644
 --- a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
 +++ b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
-@@ -572,18 +572,14 @@ const RecyclerViewComponent = <T,>(
+@@ -572,18 +572,15 @@ const RecyclerViewComponent = <T,>(
      return onScrollHandler;
    }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
  
@@ -50,7 +50,7 @@ index b2bd67a..d4bf02d 100644
 -    if (shouldMaintainVisibleContentPosition) {
 +    if (maintainVisibleContentPosition != null) {
        return {
--        ...maintainVisibleContentPosition,
+         ...maintainVisibleContentPosition,
          minIndexForVisible: 0,
        };
      }

--- a/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
+++ b/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
@@ -1,0 +1,79 @@
+diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
+index ee42f63c6f38..4e8d8c057f71 100644
+--- a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
++++ b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
+@@ -380,16 +380,14 @@ const RecyclerViewComponent = (props, ref) => {
+         }
+         return onScrollHandler;
+     }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
+-    const shouldMaintainVisibleContentPosition = recyclerViewManager.shouldMaintainVisibleContentPosition();
+     const maintainVisibleContentPositionInternal = useMemo(() => {
+-        if (shouldMaintainVisibleContentPosition) {
++        if (maintainVisibleContentPosition != null) {
+             return {
+-                ...maintainVisibleContentPosition,
+                 minIndexForVisible: 0,
+             };
+         }
+         return undefined;
+-    }, [maintainVisibleContentPosition, shouldMaintainVisibleContentPosition]);
++    }, [maintainVisibleContentPosition]);
+     const shouldRenderFromBottom = recyclerViewManager.getDataLength() > 0 &&
+         ((_d = maintainVisibleContentPosition === null || maintainVisibleContentPosition === void 0 ? void 0 : maintainVisibleContentPosition.startRenderingFromBottom) !== null && _d !== void 0 ? _d : false);
+     // Create view for measuring bounded size
+@@ -401,11 +399,11 @@ const RecyclerViewComponent = (props, ref) => {
+             }, ref: firstChildViewRef }));
+     }, [horizontal, stickyHeaderOffset]);
+     const scrollAnchor = useMemo(() => {
+-        if (shouldMaintainVisibleContentPosition) {
++        if (maintainVisibleContentPosition != null) {
+             return (React.createElement(ScrollAnchor, { horizontal: Boolean(horizontal), scrollAnchorRef: scrollAnchorRef }));
+         }
+         return null;
+-    }, [horizontal, shouldMaintainVisibleContentPosition]);
++    }, [horizontal, maintainVisibleContentPosition]);
+     // console.log("render", recyclerViewManager.getRenderStack());
+     // Render the main RecyclerView structure
+     return (React.createElement(RecyclerViewContextProvider, { value: recyclerViewContext },
+diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
+index b2bd67a4152b..d4bf02d12103 100644
+--- a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
++++ b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
+@@ -572,18 +572,14 @@ const RecyclerViewComponent = <T,>(
+     return onScrollHandler;
+   }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
+
+-  const shouldMaintainVisibleContentPosition =
+-    recyclerViewManager.shouldMaintainVisibleContentPosition();
+-
+   const maintainVisibleContentPositionInternal = useMemo(() => {
+-    if (shouldMaintainVisibleContentPosition) {
++    if (maintainVisibleContentPosition != null) {
+       return {
+-        ...maintainVisibleContentPosition,
+         minIndexForVisible: 0,
+       };
+     }
+     return undefined;
+-  }, [maintainVisibleContentPosition, shouldMaintainVisibleContentPosition]);
++  }, [maintainVisibleContentPosition]);
+
+   const shouldRenderFromBottom =
+     recyclerViewManager.getDataLength() > 0 &&
+@@ -604,7 +600,7 @@ const RecyclerViewComponent = <T,>(
+   }, [horizontal, stickyHeaderOffset]);
+
+   const scrollAnchor = useMemo(() => {
+-    if (shouldMaintainVisibleContentPosition) {
++    if (maintainVisibleContentPosition != null) {
+       return (
+         <ScrollAnchor
+           horizontal={Boolean(horizontal)}
+@@ -613,7 +609,7 @@ const RecyclerViewComponent = <T,>(
+       );
+     }
+     return null;
+-  }, [horizontal, shouldMaintainVisibleContentPosition]);
++  }, [horizontal, maintainVisibleContentPosition]);
+
+   // console.log("render", recyclerViewManager.getRenderStack());

--- a/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
+++ b/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
-index ee42f63c6f38..4e8d8c057f71 100644
+index ee42f63..4e8d8c0 100644
 --- a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
 +++ b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
 @@ -380,16 +380,14 @@ const RecyclerViewComponent = (props, ref) => {
@@ -36,13 +36,13 @@ index ee42f63c6f38..4e8d8c057f71 100644
      // Render the main RecyclerView structure
      return (React.createElement(RecyclerViewContextProvider, { value: recyclerViewContext },
 diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
-index b2bd67a4152b..d4bf02d12103 100644
+index b2bd67a..d4bf02d 100644
 --- a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
 +++ b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
 @@ -572,18 +572,14 @@ const RecyclerViewComponent = <T,>(
      return onScrollHandler;
    }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
-
+ 
 -  const shouldMaintainVisibleContentPosition =
 -    recyclerViewManager.shouldMaintainVisibleContentPosition();
 -
@@ -57,12 +57,12 @@ index b2bd67a4152b..d4bf02d12103 100644
      return undefined;
 -  }, [maintainVisibleContentPosition, shouldMaintainVisibleContentPosition]);
 +  }, [maintainVisibleContentPosition]);
-
+ 
    const shouldRenderFromBottom =
      recyclerViewManager.getDataLength() > 0 &&
 @@ -604,7 +600,7 @@ const RecyclerViewComponent = <T,>(
    }, [horizontal, stickyHeaderOffset]);
-
+ 
    const scrollAnchor = useMemo(() => {
 -    if (shouldMaintainVisibleContentPosition) {
 +    if (maintainVisibleContentPosition != null) {
@@ -75,5 +75,6 @@ index b2bd67a4152b..d4bf02d12103 100644
      return null;
 -  }, [horizontal, shouldMaintainVisibleContentPosition]);
 +  }, [horizontal, maintainVisibleContentPosition]);
-
+ 
    // console.log("render", recyclerViewManager.getRenderStack());
+ 

--- a/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
+++ b/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
@@ -1,7 +1,8 @@
 diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
+index ee42f63..4e8d8c0 100644
 --- a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
 +++ b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
-@@ -308,16 +308,15 @@
+@@ -380,16 +380,14 @@ const RecyclerViewComponent = (props, ref) => {
          }
          return onScrollHandler;
      }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
@@ -10,7 +11,7 @@ diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js 
 -        if (shouldMaintainVisibleContentPosition) {
 +        if (maintainVisibleContentPosition != null) {
              return {
-                 ...maintainVisibleContentPosition,
+-                ...maintainVisibleContentPosition,
                  minIndexForVisible: 0,
              };
          }
@@ -20,7 +21,7 @@ diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js 
      const shouldRenderFromBottom = recyclerViewManager.getDataLength() > 0 &&
          ((_d = maintainVisibleContentPosition === null || maintainVisibleContentPosition === void 0 ? void 0 : maintainVisibleContentPosition.startRenderingFromBottom) !== null && _d !== void 0 ? _d : false);
      // Create view for measuring bounded size
-@@ -329,11 +328,11 @@
+@@ -401,11 +399,11 @@ const RecyclerViewComponent = (props, ref) => {
              }, ref: firstChildViewRef }));
      }, [horizontal, stickyHeaderOffset]);
      const scrollAnchor = useMemo(() => {
@@ -35,9 +36,10 @@ diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js 
      // Render the main RecyclerView structure
      return (React.createElement(RecyclerViewContextProvider, { value: recyclerViewContext },
 diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
+index b2bd67a..d4bf02d 100644
 --- a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
 +++ b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
-@@ -480,18 +480,15 @@
+@@ -572,18 +572,14 @@ const RecyclerViewComponent = <T,>(
      return onScrollHandler;
    }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
  
@@ -48,7 +50,7 @@ diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx 
 -    if (shouldMaintainVisibleContentPosition) {
 +    if (maintainVisibleContentPosition != null) {
        return {
-         ...maintainVisibleContentPosition,
+-        ...maintainVisibleContentPosition,
          minIndexForVisible: 0,
        };
      }
@@ -58,7 +60,7 @@ diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx 
  
    const shouldRenderFromBottom =
      recyclerViewManager.getDataLength() > 0 &&
-@@ -512,7 +509,7 @@
+@@ -604,7 +600,7 @@ const RecyclerViewComponent = <T,>(
    }, [horizontal, stickyHeaderOffset]);
  
    const scrollAnchor = useMemo(() => {
@@ -67,7 +69,7 @@ diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx 
        return (
          <ScrollAnchor
            horizontal={Boolean(horizontal)}
-@@ -521,7 +518,7 @@
+@@ -613,7 +609,7 @@ const RecyclerViewComponent = <T,>(
        );
      }
      return null;

--- a/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
+++ b/patches/@shopify/flash-list/@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch
@@ -1,8 +1,7 @@
 diff --git a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
-index ee42f63..4e8d8c0 100644
 --- a/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
 +++ b/node_modules/@shopify/flash-list/dist/recyclerview/RecyclerView.js
-@@ -380,16 +380,14 @@ const RecyclerViewComponent = (props, ref) => {
+@@ -308,16 +308,15 @@
          }
          return onScrollHandler;
      }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
@@ -11,7 +10,7 @@ index ee42f63..4e8d8c0 100644
 -        if (shouldMaintainVisibleContentPosition) {
 +        if (maintainVisibleContentPosition != null) {
              return {
--                ...maintainVisibleContentPosition,
+                 ...maintainVisibleContentPosition,
                  minIndexForVisible: 0,
              };
          }
@@ -21,7 +20,7 @@ index ee42f63..4e8d8c0 100644
      const shouldRenderFromBottom = recyclerViewManager.getDataLength() > 0 &&
          ((_d = maintainVisibleContentPosition === null || maintainVisibleContentPosition === void 0 ? void 0 : maintainVisibleContentPosition.startRenderingFromBottom) !== null && _d !== void 0 ? _d : false);
      // Create view for measuring bounded size
-@@ -401,11 +399,11 @@ const RecyclerViewComponent = (props, ref) => {
+@@ -329,11 +328,11 @@
              }, ref: firstChildViewRef }));
      }, [horizontal, stickyHeaderOffset]);
      const scrollAnchor = useMemo(() => {
@@ -36,10 +35,9 @@ index ee42f63..4e8d8c0 100644
      // Render the main RecyclerView structure
      return (React.createElement(RecyclerViewContextProvider, { value: recyclerViewContext },
 diff --git a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
-index b2bd67a..d4bf02d 100644
 --- a/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
 +++ b/node_modules/@shopify/flash-list/src/recyclerview/RecyclerView.tsx
-@@ -572,18 +572,14 @@ const RecyclerViewComponent = <T,>(
+@@ -480,18 +480,15 @@
      return onScrollHandler;
    }, [onScrollHandler, scrollY, stickyHeaders, stickyHeaderUseNativeDriver]);
  
@@ -50,7 +48,7 @@ index b2bd67a..d4bf02d 100644
 -    if (shouldMaintainVisibleContentPosition) {
 +    if (maintainVisibleContentPosition != null) {
        return {
--        ...maintainVisibleContentPosition,
+         ...maintainVisibleContentPosition,
          minIndexForVisible: 0,
        };
      }
@@ -60,7 +58,7 @@ index b2bd67a..d4bf02d 100644
  
    const shouldRenderFromBottom =
      recyclerViewManager.getDataLength() > 0 &&
-@@ -604,7 +600,7 @@ const RecyclerViewComponent = <T,>(
+@@ -512,7 +509,7 @@
    }, [horizontal, stickyHeaderOffset]);
  
    const scrollAnchor = useMemo(() => {
@@ -69,7 +67,7 @@ index b2bd67a..d4bf02d 100644
        return (
          <ScrollAnchor
            horizontal={Boolean(horizontal)}
-@@ -613,7 +609,7 @@ const RecyclerViewComponent = <T,>(
+@@ -521,7 +518,7 @@
        );
      }
      return null;

--- a/patches/@shopify/flash-list/details.md
+++ b/patches/@shopify/flash-list/details.md
@@ -48,3 +48,11 @@
 - Upstream PR/issue: TBD
 - E/App issue: https://github.com/Expensify/App/issues/33725
 - PR introducing patch: https://github.com/Expensify/App/pull/85114
+
+### [@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch](@shopify+flash-list+2.3.0+007+fix-scroll-anchor-unmount-on-ios.patch)
+
+- Reason: Fixes a scroll position reset on iOS when `maintainVisibleContentPosition.disabled` toggles from `true` to `false` (e.g. when `shouldMaintainVisibleContentPosition` changes based on scroll offset). Root cause: `ScrollAnchor` was conditionally rendered based on `shouldMaintainVisibleContentPosition()`. When MVCP was disabled, the anchor unmounted, which made the native Fabric `_firstVisibleView` weak-ref become nil. When MVCP was re-enabled, the anchor remounted at `top: 1,000,000` (its initial position), but `_prevFirstVisibleFrame` was stale at `1,000,000 + X` from the prior anchor instance. `_adjustForMaintainVisibleContentPosition` then computed `deltaY = 0 - (1,000,000 + X)` — a massive negative offset — causing the list to jump to the start. The fix decouples anchor lifetime from the `disabled` flag: `ScrollAnchor` is now always mounted (and `maintainVisibleContentPositionInternal` always non-null) whenever `maintainVisibleContentPosition` prop is defined. The `disabled` flag continues to gate JS-level `scrollBy` corrections in `applyOffsetCorrection` (via `shouldMaintainVisibleContentPosition()`), so the anchor stays in place when MVCP is logically off — the native side always has a live `_firstVisibleView` and a fresh `_prevFirstVisibleFrame` to diff against.
+- Files changed: Both `src/recyclerview/RecyclerView.tsx` and `dist/recyclerview/RecyclerView.js`.
+- Upstream PR/issue: TBD
+- E/App issue: https://github.com/Expensify/App/issues/33725
+- PR introducing patch: TBD


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Adds FlashList patch 007 that keeps `ScrollAnchor` always mounted when the `maintainVisibleContentPosition` (MVCP) prop is defined, regardless of the `disabled` flag on that prop.

**Root cause**: When `maintainVisibleContentPosition.disabled` toggled from `true` to `false` (e.g. when a user scrolls up in a permalinked report), the `ScrollAnchor` component unmounted. On the native Fabric side, this caused `_firstVisibleView`'s weak reference to become `nil`. On remount, `_prevFirstVisibleFrame` held a stale origin of `1,000,000 + X`, so the computed `deltaY = -(1,000,000 + X)` produced a massive upward scroll jump, resetting the list to the top.

**Fix**: Keep `ScrollAnchor` always mounted when the MVCP prop is present. JS-level `scrollBy` corrections remain gated by `shouldMaintainVisibleContentPosition()`, so the anchor stays visually inert when MVCP is logically off — only the native view lifecycle changes.

### Fixed Issues
$ https://github.com/Expensify/App/issues/88238
$ https://github.com/Expensify/App/issues/88955
$ https://github.com/Expensify/App/issues/89052
PROPOSAL:

### Tests

**Scenario 1**
**Prequisities**: have a chat between user A and user B
1. From user B send a lot of messages to user A
2. Send an IOU money request from B to A
3. Send another couple of messages 
    a. The idea is there is scrolling possible and money request is in between
4. User A: log in on iOS device
5. Go to chat with User B
6. Scroll mutliple times UP and DOWN
7.  Verify scrolling is smooth


**Scenario 2**
1. Launch Expensify app.
2. Go to empty chat.
5. Send three images.
6. Tap on the composer.
7. Swipe all the way to the top quickly.

**Scenario 3**
Preconditions:
a. Set Submissions to Instantly
b. Disable Approvals and Payments
Steps:

1. Go to workspace chat
2. Create two non-reimbursable expenses
3. Retract each report (open report > More > Retract)
4. Go to Spend > Expenses
5. Bulk select both expenses
6. Click dropdown button > Duplicate expenses
7. Go back to workspace chat
8. Try to scroll the workspace chat

### Offline tests

N/A

### QA Steps

Same as tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/9d3b7e6b-dae0-4de8-93b2-f5c9fb4f7713


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/6fb0b123-2e41-4f0c-94f0-1bb792fa097f


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/6752eb30-66f8-47e3-bee8-231dd67d215c

</details>