### PR TITLE
fix: The Wallet Settings page is displayed instead of the settings menu page after opening "Add address" modal on the Home page on mobile web

### DIFF
--- a/src/libs/Navigation/helpers/linkTo/index.ts
+++ b/src/libs/Navigation/helpers/linkTo/index.ts
@@ -204,18 +204,39 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
             // Full-screen routes only exist inside TAB_NAVIGATOR, so look at the active tab directly.
             const tabRoute = currentState.routes.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
             const tabState = tabRoute ? getTabState(tabRoute as NavigationPartialRoute) : undefined;
+            const tabNavigatorStateKey = tabRoute?.state?.key;
             const lastFullScreenRoute = tabState?.routes?.at(tabState.index ?? 0) as NavigationPartialRoute | undefined;
             if (matchingFullScreenRoute && lastFullScreenRoute && shouldChangeToMatchingFullScreen(newFocusedRoute, matchingFullScreenRoute, lastFullScreenRoute)) {
-                // Navigate within the existing TAB_NAVIGATOR (tab switch) rather than pushing a new one.
-                const lastRouteInMatchingFullScreen = matchingFullScreenRoute.state?.routes?.at(-1);
-                const additionalAction = CommonActions.navigate({
-                    name: NAVIGATORS.TAB_NAVIGATOR,
-                    params: {
-                        screen: matchingFullScreenRoute.name,
-                        params: lastRouteInMatchingFullScreen ? {screen: lastRouteInMatchingFullScreen.name, params: lastRouteInMatchingFullScreen.params} : matchingFullScreenRoute.params,
-                    },
-                });
-                navigation.dispatch(additionalAction);
+                const matchingFullScreenRouteInTabRootState = tabState?.routes?.find((route) => route.name === matchingFullScreenRoute.name);
+                if (matchingFullScreenRouteInTabRootState && matchingFullScreenRouteInTabRootState.state === undefined) {
+                    // If matchingFullScreenRoute state is uninitialized (has never been visited)
+                    // Dispatch matchingFullScreenRoute as well so that its sidebarScreen route is added to the stack
+                    const additionalAction: StackNavigationAction = {
+                        type: CONST.NAVIGATION.ACTION_TYPE.NAVIGATE,
+                        payload: {
+                            name: matchingFullScreenRoute.name,
+                            params: {
+                                ...(matchingFullScreenRoute.params ?? {}),
+                                ...(matchingFullScreenRoute.state ? {state: matchingFullScreenRoute.state} : {}),
+                            },
+                        },
+                        target: tabNavigatorStateKey,
+                    };
+                    navigation.dispatch(additionalAction);
+                } else {
+                    // Navigate within the existing TAB_NAVIGATOR (tab switch) rather than pushing a new one.
+                    const lastRouteInMatchingFullScreen = matchingFullScreenRoute.state?.routes?.at(-1);
+                    const additionalAction = CommonActions.navigate({
+                        name: NAVIGATORS.TAB_NAVIGATOR,
+                        params: {
+                            screen: matchingFullScreenRoute.name,
+                            params: lastRouteInMatchingFullScreen
+                                ? {screen: lastRouteInMatchingFullScreen.name, params: lastRouteInMatchingFullScreen.params}
+                                : matchingFullScreenRoute.params,
+                        },
+                    });
+                    navigation.dispatch(additionalAction);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
When we navigate to an RHP target route, we usually add an under–fullscreen router overlay. Currently, we only push the `lastRouteInMatchingFullScreen` of the matching fullscreen (e.g., `Settings_Wallet`) into the root state.

After the TabBar PR was merged, the `sidebarScreen` route is no longer automatically added to the root state, so the state becomes `[Settings_Wallet]`.

If we're on a narrow layout and navigate to that matching fullscreen route via the navigation tab bar, the `sidebarScreen` gets added to the root state (becoming `[Settings_Wallet, Settings_Root]`). However, when navigating back again, the state gets rehydrated into `[Settings_Root, Settings_Wallet]` due to the logic here:
[https://github.com/Expensify/App/blob/c71784d127520ceaad54d5305a82591b48206f6a/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts#L55-L68](https://github.com/Expensify/App/blob/c71784d127520ceaad54d5305a82591b48206f6a/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts#L55-L68)
which leads to the current issue.

Therefore, this PR ensures that `sidebarScreen` is added immediately when adding the under–fullscreen router overlay. This prevents the current issue because `Settings_Wallet` already has `Settings_Root` in front, so no rehydration is needed. It also avoids a UI glitch where `Settings_Wallet` briefly appears when `Settings_Root` is added and the state transitions from `[Settings_Wallet]` to `[Settings_Wallet, Settings_Root]`.



### Fixed Issues
$ https://github.com/Expensify/App/issues/88953
PROPOSAL: 

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
_Prerequisite_: The user is assigned a physical Expensify card and has not yet entered their personal information.

1. Open the application on a mobile device or in a narrow layout.
2. On the Home screen, tap the "Add address" button.
3. Tap the back button twice.
4. Note that you are in the Settings menu.
5. Tap "Home" on the tab navigation bar.
6. Tap "Settings" on the tab navigation bar.
7. Note that the Settings menu is displayed.
8. Tap "Home" on the tab navigation bar again.
9. Tap "Settings" on the tab navigation bar.
10. Verify that the Settings menu still displays.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/bf77b9ea-9318-4016-8b19-e5960c3e1b44





</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/c983e2a4-77cd-40db-9731-9160cb1c3e85





</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/e9a591e7-cba7-4c4f-8544-59cd1e030fb0




</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/1f874a85-7975-4c2b-a58f-6f82ae986806




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/7c81e0f7-3687-4e7b-abcb-42a9da09bb4d




</details>


