### PR TITLE
[CP staging] fix: prevent DatePicker autofocus from reopening calendar

### DIFF
--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -46,7 +46,7 @@ function DatePicker({
     const anchorRef = useRef<View>(null);
     const [isInverted, setIsInverted] = useState(false);
 
-    const {inputCallbackRef: autoFocusCallbackRef} = useAutoFocusInput();
+    const {inputCallbackRef: autoFocusCallbackRef, cancelAutoFocus} = useAutoFocusInput();
     const autoFocusCallbackRefRef = useRef(autoFocusCallbackRef);
     autoFocusCallbackRefRef.current = autoFocusCallbackRef;
 
@@ -77,11 +77,12 @@ function DatePicker({
     }, [windowHeight]);
 
     const showDatePickerModal = useCallback(() => {
+        cancelAutoFocus();
         // Blur the input before showing the modal, so the focus won't be returned after the modal is closed
         textInputRef.current?.blur();
         calculatePopoverPosition();
         setIsModalVisible(true);
-    }, [calculatePopoverPosition]);
+    }, [calculatePopoverPosition, cancelAutoFocus]);
 
     const closeDatePicker = useCallback(() => {
         setIsModalVisible(false);

--- a/src/hooks/useAutoFocusInput.ts
+++ b/src/hooks/useAutoFocusInput.ts
@@ -45,11 +45,11 @@ export default function useAutoFocusInput(isMultiline = false): UseAutoFocusInpu
         transitionEndTimeoutRef.current = null;
     }, []);
 
-    const cancelAutoFocus = useCallback(() => {
+    const cancelAutoFocus = () => {
         isAutoFocusCancelledRef.current = true;
         clearTransitionEndTimeout();
         setIsScreenTransitionEnded(false);
-    }, [clearTransitionEndTimeout]);
+    };
 
     useEffect(() => {
         if (

--- a/src/hooks/useAutoFocusInput.ts
+++ b/src/hooks/useAutoFocusInput.ts
@@ -19,6 +19,7 @@ import useSidePanelState from './useSidePanelState';
 type UseAutoFocusInput = {
     inputCallbackRef: (ref: TextInput | null) => void;
     inputRef: RefObject<TextInput | null>;
+    cancelAutoFocus: () => void;
 };
 
 export default function useAutoFocusInput(isMultiline = false): UseAutoFocusInput {
@@ -34,6 +35,7 @@ export default function useAutoFocusInput(isMultiline = false): UseAutoFocusInpu
 
     const inputRef = useRef<TextInput | null>(null);
     const transitionEndTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const isAutoFocusCancelledRef = useRef(false);
 
     const clearTransitionEndTimeout = useCallback(() => {
         if (!transitionEndTimeoutRef.current) {
@@ -42,6 +44,12 @@ export default function useAutoFocusInput(isMultiline = false): UseAutoFocusInpu
         clearTimeout(transitionEndTimeoutRef.current);
         transitionEndTimeoutRef.current = null;
     }, []);
+
+    const cancelAutoFocus = useCallback(() => {
+        isAutoFocusCancelledRef.current = true;
+        clearTransitionEndTimeout();
+        setIsScreenTransitionEnded(false);
+    }, [clearTransitionEndTimeout]);
 
     useEffect(() => {
         if (
@@ -71,13 +79,17 @@ export default function useAutoFocusInput(isMultiline = false): UseAutoFocusInpu
 
     useFocusEffect(
         useCallback(() => {
+            isAutoFocusCancelledRef.current = false;
             setIsScreenTransitionEnded(false);
             transitionEndTimeoutRef.current = setTimeout(() => {
+                if (isAutoFocusCancelledRef.current) {
+                    return;
+                }
                 setIsScreenTransitionEnded(true);
             }, CONST.SCREEN_TRANSITION_END_TIMEOUT);
 
             const unsubscribeTransitionEnd = navigation.addListener?.('transitionEnd', (event) => {
-                if (event?.data?.closing) {
+                if (event?.data?.closing || isAutoFocusCancelledRef.current) {
                     return;
                 }
                 clearTransitionEndTimeout();
@@ -124,5 +136,5 @@ export default function useAutoFocusInput(isMultiline = false): UseAutoFocusInpu
         setIsInputInitialized(true);
     };
 
-    return {inputCallbackRef, inputRef};
+    return {inputCallbackRef, inputRef, cancelAutoFocus};
 }


### PR DESCRIPTION
### Explanation of Change

This fixes a regression from https://github.com/Expensify/App/pull/88367 where the DatePicker calendar could reopen after selecting a DOB in the Add bank account flow.

`DatePicker` is a special auto-focus consumer because focusing its input opens a calendar popover. If the user manually focuses the DOB input before the delayed `useAutoFocusInput` focus runs, the pending auto-focus can survive while the popover is open and then fire after the popover closes, reopening the calendar.

This adds an explicit `cancelAutoFocus` API to `useAutoFocusInput` and calls it when `DatePicker` opens its popover. The cancellation also gates the pending timeout and navigation `transitionEnd` path so the cancelled auto-focus cannot be re-armed during the same screen focus cycle.

### Fixed Issues

$ https://github.com/Expensify/App/issues/89044
PROPOSAL: https://github.com/Expensify/App/issues/89044#issuecomment-4332320138

### Tests

1. Go to Workspaces > Workflows.
2. Click Add bank account.
3. Select Connect manually.
4. Click Confirm, add routing and account number.
5. Add first and last name.
6. Click Next and quickly click the DOB field.
7. Select any date.
8. Verify the calendar closes and does not reopen after selecting the DOB.
9. Verify that no errors appear in the JS console.

### Offline tests

Same as Tests. This is a local UI focus timing fix and does not depend on network state.

### QA Steps

Same as Tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: N/A
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar`, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A - regression reported on Web only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A - regression reported on desktop Web only.

</details>

<details>
<summary>iOS: Native</summary>

N/A - regression reported on Web only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A - regression reported on desktop Web only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/d62ff3a0-4b73-455b-97d6-97e6c0097392

</details>

