### PR TITLE
perf: Defer mount of "More" button in Report

### DIFF
--- a/src/components/MoneyReportHeaderActions/MoneyReportHeaderSecondaryActions.tsx
+++ b/src/components/MoneyReportHeaderActions/MoneyReportHeaderSecondaryActions.tsx
@@ -2,13 +2,15 @@ import {delegateEmailSelector, isUserValidatedSelector} from '@selectors/Account
 import {hasSeenTourSelector} from '@selectors/Onboarding';
 import truncate from 'lodash/truncate';
 import React, {useContext, useEffect} from 'react';
-import {InteractionManager} from 'react-native';
+import {InteractionManager, View} from 'react-native';
 import type {ValueOf} from 'type-fest';
+import Button from '@components/Button';
 import type {ButtonWithDropdownMenuRef} from '@components/ButtonWithDropdownMenu/types';
 import {useDelegateNoAccessActions, useDelegateNoAccessState} from '@components/DelegateNoAccessModalProvider';
 import {KYCWallContext} from '@components/KYCWall/KYCWallContext';
 import MoneyReportHeaderKYCDropdown from '@components/MoneyReportHeaderKYCDropdown';
 import {useMoneyReportHeaderModals} from '@components/MoneyReportHeaderModalsContext';
+import NavigationDeferredMount from '@components/NavigationDeferredMount';
 import {usePaymentAnimationsContext} from '@components/PaymentAnimationsContext';
 import type {PopoverMenuItem} from '@components/PopoverMenu';
 import {useSearchStateContext} from '@components/Search/SearchContext';
@@ -30,7 +32,10 @@ import usePaymentOptions from '@hooks/usePaymentOptions';
 import usePermissions from '@hooks/usePermissions';
 import usePolicy from '@hooks/usePolicy';
 import useReportIsArchived from '@hooks/useReportIsArchived';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
+import useStyleUtils from '@hooks/useStyleUtils';
+import useThemeStyles from '@hooks/useThemeStyles';
 import useTransactionsAndViolationsForReport from '@hooks/useTransactionsAndViolationsForReport';
 import {generateDefaultWorkspaceName} from '@libs/actions/Policy/Policy';
 import {search} from '@libs/actions/Search';
@@ -394,15 +399,45 @@ function MoneyReportHeaderSecondaryActionsInner({reportID, primaryAction, isRepo
     );
 }
 
+function MoneyReportHeaderSecondaryActionsPlaceholder({primaryAction}: {primaryAction: ValueOf<typeof CONST.REPORT.PRIMARY_ACTIONS> | ''}) {
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+    const {translate} = useLocalize();
+    const {shouldUseNarrowLayout, isMediumScreenWidth} = useResponsiveLayout();
+    const icons = useMemoizedLazyExpensifyIcons(['DownArrow']);
+    const shouldDisplayNarrowVersion = shouldUseNarrowLayout || isMediumScreenWidth;
+    const wrapperStyle = shouldDisplayNarrowVersion && !primaryAction ? styles.flex1 : undefined;
+    // Match the inner styles the real ButtonWithDropdownMenu applies when isSplitButton=false so text placement stays put on swap.
+    const innerStyles = [StyleUtils.getDropDownButtonHeight(CONST.DROPDOWN_BUTTON_SIZE.MEDIUM), styles.dropDownButtonCartIconView];
+    return (
+        <View style={wrapperStyle}>
+            <Button
+                text={translate('common.more')}
+                iconRight={icons.DownArrow}
+                shouldShowRightIcon
+                innerStyles={innerStyles}
+                onPress={() => {}}
+            />
+        </View>
+    );
+}
+
 function MoneyReportHeaderSecondaryActions({reportID, primaryAction, isReportInSearch, backTo, dropdownMenuRef}: MoneyReportHeaderSecondaryActionsProps) {
     return (
-        <MoneyReportHeaderSecondaryActionsInner
-            reportID={reportID}
-            primaryAction={primaryAction}
-            isReportInSearch={isReportInSearch}
-            backTo={backTo}
-            dropdownMenuRef={dropdownMenuRef}
-        />
+        <NavigationDeferredMount
+            placeholder={<MoneyReportHeaderSecondaryActionsPlaceholder primaryAction={primaryAction} />}
+            // RHPReportScreen remounts this tree on setParams arrow-nav without firing a transition,
+            // so we must not wait for one — see https://github.com/Expensify/App/issues/88931.
+            waitForUpcomingTransition={false}
+        >
+            <MoneyReportHeaderSecondaryActionsInner
+                reportID={reportID}
+                primaryAction={primaryAction}
+                isReportInSearch={isReportInSearch}
+                backTo={backTo}
+                dropdownMenuRef={dropdownMenuRef}
+            />
+        </NavigationDeferredMount>
     );
 }
 

--- a/src/components/NavigationDeferredMount.tsx
+++ b/src/components/NavigationDeferredMount.tsx
@@ -6,33 +6,42 @@ type NavigationDeferredMountProps = {
     /** Shown until `children` hydrate. Render something cheap with stable sizing to avoid layout jumps. */
     placeholder?: ReactNode;
 
-    /** The tree to defer. Mounted as a non-urgent transition after the in-flight (or upcoming) navigation transition ends. */
+    /** The tree to defer. Mounted as a non-urgent transition after any active navigation transition ends. */
     children: ReactNode;
+
+    /**
+     * If true, additionally waits for the next navigation transition to start (and then complete) before mounting.
+     * This is the natural mode for screens reached via real navigation (push/replace) — the placeholder stays
+     * up through the full animation. Default: true.
+     *
+     * Pass `false` when the consumer can be remounted by a parent without a navigation transition firing
+     * (e.g. a parent that uses `key={someParam}` and changes the key via `setParams`). In that case, the
+     * upcoming transition never starts and the safety timeout would make the placeholder visible (and
+     * unresponsive) for up to `MAX_TRANSITION_START_WAIT_MS`.
+     */
+    waitForUpcomingTransition?: boolean;
 };
 
 /**
  * Gates a heavy subtree behind navigation transition completion via `TransitionTracker`, so the tree
- * hydrates only after the nav animation has finished. The swap is wrapped in `startTransition` so React
- * treats the hydrate as non-urgent and can yield to user input.
+ * hydrates only after any in-flight nav animation has finished. The swap is wrapped in `startTransition`
+ * so React treats the hydrate as non-urgent and can yield to user input.
  *
  * Use it for: heavy subtrees that mount as part of a navigation transition (report headers, page-level
  * actions, dropdowns rendered on a freshly navigated screen) where the hydrate risks competing with the
  * nav animation frame budget.
- *
- * Do NOT use it for: subtrees that mount in response to user interaction after navigation has settled
- * (modals, accordions, popovers opened on tap). If no transition is in flight or upcoming, this component
- * waits for the `MAX_TRANSITION_START_WAIT_MS` safety timeout before hydrating, which adds latency with
- * no benefit outside navigation contexts.
  */
-function NavigationDeferredMount({placeholder = null, children}: NavigationDeferredMountProps): ReactNode {
+function NavigationDeferredMount({placeholder = null, children, waitForUpcomingTransition = true}: NavigationDeferredMountProps): ReactNode {
     const [isReady, setIsReady] = useState(false);
 
     useEffect(() => {
         const handle = TransitionTracker.runAfterTransitions({
-            waitForUpcomingTransition: true,
+            waitForUpcomingTransition,
             callback: () => startTransition(() => setIsReady(true)),
         });
         return () => handle.cancel();
+        // `waitForUpcomingTransition` is a one-shot mount-time config — flipping it post-mount shouldn't retrigger the wait.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return isReady ? children : placeholder;

--- a/src/components/NavigationDeferredMount.tsx
+++ b/src/components/NavigationDeferredMount.tsx
@@ -1,4 +1,4 @@
-import {startTransition, useEffect, useState} from 'react';
+import {startTransition, useEffect, useRef, useState} from 'react';
 import type {ReactNode} from 'react';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 
@@ -33,15 +33,15 @@ type NavigationDeferredMountProps = {
  */
 function NavigationDeferredMount({placeholder = null, children, waitForUpcomingTransition = true}: NavigationDeferredMountProps): ReactNode {
     const [isReady, setIsReady] = useState(false);
+    // One-shot mount-time config — flipping the prop after mount shouldn't retrigger the wait.
+    const waitForUpcomingTransitionRef = useRef(waitForUpcomingTransition);
 
     useEffect(() => {
         const handle = TransitionTracker.runAfterTransitions({
-            waitForUpcomingTransition,
+            waitForUpcomingTransition: waitForUpcomingTransitionRef.current,
             callback: () => startTransition(() => setIsReady(true)),
         });
         return () => handle.cancel();
-        // `waitForUpcomingTransition` is a one-shot mount-time config — flipping it post-mount shouldn't retrigger the wait.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return isReady ? children : placeholder;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

`NavigationDeferredMount` previously hardcoded `waitForUpcomingTransition: true`, which means it always waits up to `MAX_TRANSITION_START_WAIT_MS` (1 000 ms) for a nav transition to start before hydrating the deferred tree. That is correct for screens reached via real navigation (push/replace), but breaks down when a parent remounts the tree via `key={someParam}` + `Navigation.setParams` — no transition fires, so the component sits behind a no-op placeholder Button for a full second.

`RHPReportScreen.tsx` does exactly this: it uses `key={route.params?.reportID}`, so arrow-nav between reports (which calls `setParams`) fully remounts the report tree without any transition. That's why the original deferred-mount PR (#88522) was reverted — the More button was unresponsive for ~1 s after every arrow-nav.

**What changed:**

1. `NavigationDeferredMount` gains an optional `waitForUpcomingTransition?: boolean` prop (default `true`, preserving current behavior for all existing consumers). When `false` and no transition is in flight, `runAfterTransitions` fires the callback immediately under `startTransition` — the heavy tree still hydrates at non-urgent priority, but without the safety-timeout stall.

2. `MoneyReportHeaderSecondaryActions` re-applies the deferred-mount wrapper from #88522, now passing `waitForUpcomingTransition={false}` with an inline comment linking to #88931 explaining why.

**Why this is correct, not ideal:**

The proper fix is to remove `key={route.params?.reportID}` from `RHPReportScreen.tsx` so arrow-nav does not remount the entire tree at all (the file even has a TODO calling this out). That would eliminate this entire class of bugs. It's a multi-week scoped project: every downstream component and hook (`ReportActionsView`, `ReportActionsList`, `ReportHeader`, `ReportFooter`/composer, drag-drop provider, action-list context, fetch/lifecycle/route-param handlers, linked-action guard, plus the dozens of `useOnyx`/refs/lazy `useState` initializers inside them) would need an audit for `reportID`-change reset/sync logic without a remount. High regression risk. This PR is the minimal, safe fix that unblocks the perf win while that larger refactor is scoped properly.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88931
$ https://github.com/Expensify/App/issues/88524
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Create a workspace
2. Go to workspace chat.
3. Create two reports.
4. Go to Reports > All reports.
5. Open any report.
6. Click left or right arrow button, then quickly click the More button.
7. Verify: More menu opens (no unresponsive window).

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Go to staging.new.expensify.com.
2. Go to workspace chat.
3. Create two reports.
4. Go to Reports > All reports.
5. Open any report.
6. If the report does not show left & right arrow buttons, open both reports, go to Inbox then return to Reports > All reports, then open any report.
7. Click left or right arrow button, then quickly click the More button.
8. Verify: More menu opens (no unresponsive window).

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>
https://github.com/user-attachments/assets/14f7101f-c925-4991-a68b-c0a9cff4a627
<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/e7c6132a-dafc-4d96-a4c5-082d15529166


<!-- add screenshots or videos here -->

</details>