### PR TITLE
Fix deploy blockers from filters after introducing Bottom Tab Navigator

### DIFF
--- a/src/components/Search/SearchPageHeader/SearchAdvancedFiltersButton.tsx
+++ b/src/components/Search/SearchPageHeader/SearchAdvancedFiltersButton.tsx
@@ -26,7 +26,6 @@ function SearchAdvancedFiltersButton({queryJSON}: SearchAdvancedFiltersButtonPro
     const {shouldUseNarrowLayout, isMediumScreenWidth} = useResponsiveLayout();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Filter']);
     const filterFormValues = useFilterFormValues(queryJSON);
-    console.log('[fix-first-filter-pill] SearchAdvancedFiltersButton render', {queryHash: queryJSON?.hash, inputQuery: queryJSON?.inputQuery, filterFormValues});
     useSearchFilterSync(queryJSON, filterFormValues);
 
     const openAdvancedFilters = () => {

--- a/src/components/Search/SearchPageHeader/SearchAdvancedFiltersButton.tsx
+++ b/src/components/Search/SearchPageHeader/SearchAdvancedFiltersButton.tsx
@@ -26,7 +26,8 @@ function SearchAdvancedFiltersButton({queryJSON}: SearchAdvancedFiltersButtonPro
     const {shouldUseNarrowLayout, isMediumScreenWidth} = useResponsiveLayout();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Filter']);
     const filterFormValues = useFilterFormValues(queryJSON);
-    useSearchFilterSync(filterFormValues);
+    console.log('[fix-first-filter-pill] SearchAdvancedFiltersButton render', {queryHash: queryJSON?.hash, inputQuery: queryJSON?.inputQuery, filterFormValues});
+    useSearchFilterSync(queryJSON, filterFormValues);
 
     const openAdvancedFilters = () => {
         updateAdvancedFilters(filterFormValues);

--- a/src/components/Search/SearchPageHeader/useSearchFiltersBar.tsx
+++ b/src/components/Search/SearchPageHeader/useSearchFiltersBar.tsx
@@ -191,6 +191,14 @@ function useSearchFiltersBar(queryJSON: SearchQueryJSON): UseSearchFiltersBarRes
         });
     };
 
+    console.log('[fix-first-filter-pill] useSearchFiltersBar render', {
+        formKeys: Object.keys(searchAdvancedFiltersForm ?? {}),
+        formDateAfter: searchAdvancedFiltersForm?.dateAfter,
+        formDateOn: searchAdvancedFiltersForm?.dateOn,
+        formDateBefore: searchAdvancedFiltersForm?.dateBefore,
+        formDateRange: searchAdvancedFiltersForm?.dateRange,
+        inputQuery: queryJSON?.inputQuery,
+    });
     const filters = mapFiltersFormToLabelValueList<FilterItem>(searchAdvancedFiltersForm, queryJSON.policyID, SKIPPED_FILTERS, translate, localeCompare, (filterKey) => {
         const groupConfig = FILTER_GROUP_MAP[filterKey];
         if (groupConfig) {

--- a/src/components/Search/SearchPageHeader/useSearchFiltersBar.tsx
+++ b/src/components/Search/SearchPageHeader/useSearchFiltersBar.tsx
@@ -191,14 +191,6 @@ function useSearchFiltersBar(queryJSON: SearchQueryJSON): UseSearchFiltersBarRes
         });
     };
 
-    console.log('[fix-first-filter-pill] useSearchFiltersBar render', {
-        formKeys: Object.keys(searchAdvancedFiltersForm ?? {}),
-        formDateAfter: searchAdvancedFiltersForm?.dateAfter,
-        formDateOn: searchAdvancedFiltersForm?.dateOn,
-        formDateBefore: searchAdvancedFiltersForm?.dateBefore,
-        formDateRange: searchAdvancedFiltersForm?.dateRange,
-        inputQuery: queryJSON?.inputQuery,
-    });
     const filters = mapFiltersFormToLabelValueList<FilterItem>(searchAdvancedFiltersForm, queryJSON.policyID, SKIPPED_FILTERS, translate, localeCompare, (filterKey) => {
         const groupConfig = FILTER_GROUP_MAP[filterKey];
         if (groupConfig) {

--- a/src/hooks/useSearchFilterSync.ts
+++ b/src/hooks/useSearchFilterSync.ts
@@ -29,17 +29,13 @@ function useSearchFilterSync(queryJSON: SearchQueryJSON | undefined, formValues:
     const isFocused = useIsFocused();
 
     useEffect(() => {
-        const querySig = queryJSON ? buildSearchQueryString(queryJSON) : null;
-        console.log('[fix-first-filter-pill] sync useEffect run', {isFocused, querySig, lastSyncedQuerySig, formValues});
         if (!isFocused) {
-            console.log('[fix-first-filter-pill] sync SKIP not focused');
             return;
         }
+        const querySig = queryJSON ? buildSearchQueryString(queryJSON) : null;
         if (lastSyncedQuerySig === querySig) {
-            console.log('[fix-first-filter-pill] sync SKIP same querySig');
             return;
         }
-        console.log('[fix-first-filter-pill] sync FIRE Onyx.set', {lastSyncedQuerySig, newQuerySig: querySig, formValues});
         lastSyncedQuerySig = querySig;
         updateAdvancedFilters(formValues, true);
     }, [queryJSON, formValues, isFocused]);

--- a/src/hooks/useSearchFilterSync.ts
+++ b/src/hooks/useSearchFilterSync.ts
@@ -1,43 +1,48 @@
 import {useIsFocused} from '@react-navigation/native';
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
+import type {SearchQueryJSON} from '@components/Search/types';
 import {updateAdvancedFilters} from '@libs/actions/Search';
+import {buildSearchQueryString} from '@libs/SearchQueryUtils';
 import type {SearchAdvancedFiltersForm} from '@src/types/form';
 
 /**
- * Syncs computed filter form values to the SEARCH_ADVANCED_FILTERS_FORM Onyx key
- * whenever they change. Call from SearchAdvanceFiltersButton which already computes formValues
- * via useFilterFormValues.
- *
- * The isFocused guard prevents the blurred (previous) SearchPage instance—kept
- * mounted during navigation transition animations—from overwriting the Onyx form
- * state that was already written by the newly focused instance.
- *
- * On narrow layout (iOS native), navigating to Advanced Filters causes this screen
- * to lose focus. When the user returns, the screen regains focus and this effect
- * would re-fire. Without the prevIsFocusedRef guard below, it would overwrite any
- * form changes made by Advanced Filters (e.g. resetting a date range) with stale
- * values derived from the unchanged URL query parameter.
+ * Module-level: tracks the last URL query signature that was synced into the
+ * SEARCH_ADVANCED_FILTERS_FORM Onyx key. We deliberately keep this outside the
+ * hook so it survives unmount/remount of SearchAdvancedFiltersButton. The
+ * button is gated by SearchActionsBarSwitch (`showStatic` flips during
+ * `startTransition` after navigation) which causes the hook to remount and
+ * would otherwise reset a per-component ref to null — causing the sync to
+ * fire again with form values derived from the *old* URL, clobbering any
+ * Onyx.merge that was just done by the Advanced Filters flow (e.g. Save Date
+ * before the URL has been replaced by View Results).
  */
-function useSearchFilterSync(formValues: Partial<SearchAdvancedFiltersForm>) {
+let lastSyncedQuerySig: string | null = null;
+
+/**
+ * Syncs computed filter form values to the SEARCH_ADVANCED_FILTERS_FORM Onyx
+ * key when the URL query string actually changes. The form is the source for
+ * the filter pills shown in the Search header — overwriting it on every
+ * re-render (or every fresh mount with the same URL) would erase concurrent
+ * Onyx.merge writes from Advanced Filters and leave the pill missing.
+ */
+function useSearchFilterSync(queryJSON: SearchQueryJSON | undefined, formValues: Partial<SearchAdvancedFiltersForm>) {
     const isFocused = useIsFocused();
-    const prevIsFocusedRef = useRef(isFocused);
 
     useEffect(() => {
-        const wasPreviouslyFocused = prevIsFocusedRef.current;
-        prevIsFocusedRef.current = isFocused;
-
+        const querySig = queryJSON ? buildSearchQueryString(queryJSON) : null;
+        console.log('[fix-first-filter-pill] sync useEffect run', {isFocused, querySig, lastSyncedQuerySig, formValues});
         if (!isFocused) {
+            console.log('[fix-first-filter-pill] sync SKIP not focused');
             return;
         }
-
-        // Skip syncing when just regaining focus to avoid overwriting form
-        // changes made while this screen was unfocused (e.g. Advanced Filters).
-        if (!wasPreviouslyFocused) {
+        if (lastSyncedQuerySig === querySig) {
+            console.log('[fix-first-filter-pill] sync SKIP same querySig');
             return;
         }
-
+        console.log('[fix-first-filter-pill] sync FIRE Onyx.set', {lastSyncedQuerySig, newQuerySig: querySig, formValues});
+        lastSyncedQuerySig = querySig;
         updateAdvancedFilters(formValues, true);
-    }, [formValues, isFocused]);
+    }, [queryJSON, formValues, isFocused]);
 }
 
 export default useSearchFilterSync;


### PR DESCRIPTION
### Explanation of Change

Fixes the first Search filter pill missing after Advanced Filters → Save → View Results. `useSearchFilterSync` used a per-component ref so a remount (triggered by `SearchActionsBarSwitch` flipping during `startTransition`) reset the guard and clobbered fresh `Onyx.merge` writes with stale URL values. Moved the guard to a module-level `lastSyncedQuerySig` that survives remounts.

### Fixed Issues

$ https://github.com/Expensify/App/issues/88946 (Android & iOS - Spend - Date quick filter is missing when Date filter is applied)
$ https://github.com/Expensify/App/issues/89013 (Filters-Filter chip is still shown in Spend after tapping Reset filters)
$ https://github.com/Expensify/App/issues/89055 (iOS - Spend - The withdrawn filter pill does't appear when selecting the first option)

PROPOSAL:


### Tests

$ https://github.com/Expensify/App/issues/88946 and $ https://github.com/Expensify/App/issues/89055

1. Launch Expensify app.
2. Go to Spend > All expenses.
3. Tap Filters button.
4. Tap Date > Custom range.
5. Select custom range date that will return some results.
6. Tap Save > View results.
7. Ensure the date quick filter is shown on search results page and ensure that the correct option is shown (eg. if last chosen option is "last month" then that should be visible in search).

$ https://github.com/Expensify/App/issues/89013
Prerequisite: above test steps should be done (or any other "Expenses"/advanced filters are applied)

1. Tap filters button
2. Tap reset filters
3. Ensure that no tag chip is displayed on the screen after resetting Advanced filters



### Offline tests

1. Set up the app while online so a query is cached.
5. Turn off network connection.
6. Repeat steps 3–6 from the Tests section.
7. Verify that the Date pill still appears on the Search header (the form sync path is offline-first; only the network search request will be queued).

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/fcb205ed-4bb0-430d-8271-7583c53eb607

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b31f5a7f-b713-4171-b009-b13cf1c39d96


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/da1e96e3-6413-46a8-9987-62ddd8c2a26b


</details>