### PR TITLE
fix: Fix back navigation trap after deleting expense from DM

### DIFF
--- a/src/components/ParentNavigationSubtitle.tsx
+++ b/src/components/ParentNavigationSubtitle.tsx
@@ -10,6 +10,7 @@ import useRootNavigationState from '@hooks/useRootNavigationState';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {isFullScreenName} from '@libs/Navigation/helpers/isNavigatorName';
 import Navigation from '@libs/Navigation/Navigation';
 import type {RightModalNavigatorParamList} from '@libs/Navigation/types';
 import {getReportAction, isReportActionVisible} from '@libs/ReportActionsUtils';
@@ -107,7 +108,8 @@ function ParentNavigationSubtitle({
         const tabState = tabNavigatorRoute?.state;
 
         // Get the active (focused) tab from the tab navigator as the current full-screen route
-        const fullScreenRoute = tabState ? tabState.routes?.[tabState.index ?? 0] : undefined;
+        // and fall back to the previous root-level full-screen lookup for states without tab nesting.
+        const fullScreenRoute = tabState ? tabState.routes?.[tabState.index ?? 0] : state?.routes?.findLast((route) => isFullScreenName(route.name));
 
         // Find the outermost navigator that currently has an active screen stack
         const lastNavigatorWithRoutes = state?.routes ? state.routes.findLast((route) => route.state?.routes && route.state.routes.length > 0) : undefined;

--- a/src/components/ParentNavigationSubtitle.tsx
+++ b/src/components/ParentNavigationSubtitle.tsx
@@ -10,7 +10,6 @@ import useRootNavigationState from '@hooks/useRootNavigationState';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {isFullScreenName} from '@libs/Navigation/helpers/isNavigatorName';
 import Navigation from '@libs/Navigation/Navigation';
 import type {RightModalNavigatorParamList} from '@libs/Navigation/types';
 import {getReportAction, isReportActionVisible} from '@libs/ReportActionsUtils';
@@ -103,15 +102,20 @@ function ParentNavigationSubtitle({
     const isReportInRHP = currentRoute.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
     const hasAccessToParentReport = currentReport?.hasParentAccess !== false;
     const {currentFullScreenRoute, currentFocusedNavigator} = useRootNavigationState((state) => {
-        const fullScreenRoute = state?.routes?.findLast((route) => isFullScreenName(route.name));
+        // Find the tab navigator, which wraps all full-screen navigators
+        const tabNavigatorRoute = state?.routes?.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
+        const tabState = tabNavigatorRoute?.state;
 
-        // We need to track which navigator is focused to handle parent report navigation correctly:
-        // if we are in RHP, and parent report is opened in RHP, we want to go back to the parent report
-        const focusedNavigator = state?.routes
-            ? state.routes.findLast((route) => {
-                  return route.state?.routes && route.state.routes.length > 0;
-              })
-            : undefined;
+        // Get the active (focused) tab from the tab navigator as the current full-screen route
+        const fullScreenRoute = tabState ? tabState.routes?.[tabState.index ?? 0] : undefined;
+
+        // Find the outermost navigator that currently has an active screen stack
+        const lastNavigatorWithRoutes = state?.routes ? state.routes.findLast((route) => route.state?.routes && route.state.routes.length > 0) : undefined;
+
+        // If the tab navigator is focused, resolve to the active tab's navigator so that
+        // focusedNavigatorState reflects the split navigator's screen stack (not the tab list).
+        // If RHP is focused, use the RHP route directly so RHP-specific checks work correctly.
+        const focusedNavigator = lastNavigatorWithRoutes?.name === NAVIGATORS.TAB_NAVIGATOR ? fullScreenRoute : lastNavigatorWithRoutes;
 
         return {
             currentFullScreenRoute: fullScreenRoute,
@@ -185,6 +189,24 @@ function ParentNavigationSubtitle({
                         return;
                     }
                 }
+            }
+        }
+
+        // If the parent report is already the previous screen in the main stack, go back to it
+        // and update its params instead of pushing a new instance. Without this check, repeatedly
+        // tapping the subtitle link builds up a [DM, Expense, DM, Expense, …] stack that traps
+        // the user after an expense is deleted.
+        if ((currentReportIndex ?? 0) > 0 && focusedNavigatorState?.key) {
+            const prevRoute = focusedNavigatorState.routes[(currentReportIndex ?? 0) - 1];
+            const prevRouteReportID = prevRoute?.params && 'reportID' in prevRoute.params ? String(prevRoute.params.reportID) : undefined;
+
+            if (prevRouteReportID === parentReportID && prevRoute?.key) {
+                if (isVisibleAction && parentReportActionID) {
+                    // Set params on the background screen first so it is already correct when revealed.
+                    Navigation.setParams({reportActionID: parentReportActionID}, prevRoute.key, focusedNavigatorState.key);
+                }
+                Navigation.goBack();
+                return;
             }
         }
 

--- a/src/components/ParentNavigationSubtitle.tsx
+++ b/src/components/ParentNavigationSubtitle.tsx
@@ -198,7 +198,7 @@ function ParentNavigationSubtitle({
         // and update its params instead of pushing a new instance. Without this check, repeatedly
         // tapping the subtitle link builds up a [DM, Expense, DM, Expense, …] stack that traps
         // the user after an expense is deleted.
-        if ((currentReportIndex ?? 0) > 0 && focusedNavigatorState?.key) {
+        if ((currentReportIndex ?? 0) > 0 && focusedNavigatorState?.key && currentFocusedNavigator?.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR) {
             const prevRoute = focusedNavigatorState.routes[(currentReportIndex ?? 0) - 1];
             const prevRouteReportID = prevRoute?.params && 'reportID' in prevRoute.params ? String(prevRoute.params.reportID) : undefined;
 

--- a/tests/ui/ParentNavigationSubtitleTest.tsx
+++ b/tests/ui/ParentNavigationSubtitleTest.tsx
@@ -2,12 +2,20 @@ import type {RouteProp} from '@react-navigation/native';
 import {fireEvent, render, screen} from '@testing-library/react-native';
 import React from 'react';
 import Navigation from '@libs/Navigation/Navigation';
+import {isReportActionVisible} from '@libs/ReportActionsUtils';
 import ParentNavigationSubtitle from '../../src/components/ParentNavigationSubtitle';
+import NAVIGATORS from '../../src/NAVIGATORS';
+import SCREENS from '../../src/SCREENS';
 
 jest.mock('@libs/Navigation/Navigation');
 
+jest.mock('@libs/ReportActionsUtils', () => ({
+    getReportAction: jest.fn(() => undefined),
+    isReportActionVisible: jest.fn(() => false),
+}));
+
 const mockUseRootNavigationState = jest.fn();
-jest.mock('@src/hooks/useRootNavigationState', () => ({
+jest.mock('@hooks/useRootNavigationState', () => ({
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     default: (selector?: (state: unknown) => unknown) => mockUseRootNavigationState(selector) as unknown,
@@ -24,11 +32,51 @@ jest.mock('@react-navigation/native', () => {
     };
 });
 
+/** Root state with TabNavigator → Reports split stack [parent DM, expense]; index on expense (matches issue #88499 stack). */
+function getMockRootStateWithReportsSplitStack(parentReportID: string, expenseReportID: string) {
+    const parentRoute = {
+        name: SCREENS.REPORT,
+        params: {reportID: parentReportID},
+        key: 'route-parent-key',
+    };
+    const expenseRoute = {
+        name: SCREENS.REPORT,
+        params: {reportID: expenseReportID},
+        key: 'route-expense-key',
+    };
+    return {
+        routes: [
+            {
+                name: NAVIGATORS.TAB_NAVIGATOR,
+                key: 'tab-root-key',
+                state: {
+                    index: 0,
+                    routes: [
+                        {
+                            name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+                            key: 'reports-split-route-key',
+                            state: {
+                                key: 'reports-split-state-key',
+                                index: 1,
+                                routes: [parentRoute, expenseRoute],
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    };
+}
+
 describe('ParentNavigationSubtitle', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.mocked(isReportActionVisible).mockReturnValue(false);
         Navigation.getTopmostReportId = jest.fn();
         Navigation.dismissModal = jest.fn();
+        Navigation.goBack = jest.fn();
+        Navigation.setParams = jest.fn();
+        Navigation.navigate = jest.fn();
     });
 
     it('if the parent report is already displayed underneath RHP, simply dismiss the modal', () => {
@@ -129,5 +177,110 @@ describe('ParentNavigationSubtitle', () => {
 
         fireEvent(clickableElement, 'press', mockEvent);
         expect(Navigation.dismissModal).not.toHaveBeenCalled();
+    });
+
+    it('goes back without navigating when parent report is already the previous route in Reports split stack under Tab navigator', () => {
+        const parentReportID = 'parent-report';
+        const expenseReportID = 'expense-report';
+        const reportName = 'Parent chat';
+        const workspaceName = 'Workspace';
+
+        mockUseRoute.mockReturnValue({name: SCREENS.REPORT} as AnyRoute);
+        mockUseRootNavigationState.mockImplementation((selector?: (state: unknown) => unknown) => {
+            const mockState = getMockRootStateWithReportsSplitStack(parentReportID, expenseReportID);
+            if (selector) {
+                return selector(mockState);
+            }
+            return undefined;
+        });
+
+        render(
+            <ParentNavigationSubtitle
+                parentNavigationSubtitleData={{reportName, workspaceName}}
+                parentReportID={parentReportID}
+                reportID={expenseReportID}
+            />,
+        );
+
+        fireEvent(screen.getByTestId('parent-navigation-subtitle-link'), 'press', {
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+            nativeEvent: {},
+        });
+
+        expect(Navigation.goBack).toHaveBeenCalled();
+        expect(Navigation.navigate).not.toHaveBeenCalled();
+        expect(Navigation.setParams).not.toHaveBeenCalled();
+    });
+
+    it('sets reportActionID on the previous route then goes back when the parent action is visible', () => {
+        const parentReportID = 'parent-report';
+        const expenseReportID = 'expense-report';
+        const parentReportActionID = 'action-999';
+        const reportName = 'Parent chat';
+        const workspaceName = 'Workspace';
+
+        jest.mocked(isReportActionVisible).mockReturnValue(true);
+
+        mockUseRoute.mockReturnValue({name: SCREENS.REPORT} as AnyRoute);
+        mockUseRootNavigationState.mockImplementation((selector?: (state: unknown) => unknown) => {
+            const mockState = getMockRootStateWithReportsSplitStack(parentReportID, expenseReportID);
+            if (selector) {
+                return selector(mockState);
+            }
+            return undefined;
+        });
+
+        render(
+            <ParentNavigationSubtitle
+                parentNavigationSubtitleData={{reportName, workspaceName}}
+                parentReportID={parentReportID}
+                parentReportActionID={parentReportActionID}
+                reportID={expenseReportID}
+            />,
+        );
+
+        fireEvent(screen.getByTestId('parent-navigation-subtitle-link'), 'press', {
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+            nativeEvent: {},
+        });
+
+        expect(Navigation.setParams).toHaveBeenCalledWith({reportActionID: parentReportActionID}, 'route-parent-key', 'reports-split-state-key');
+        expect(Navigation.goBack).toHaveBeenCalled();
+        expect(Navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates forward when the previous stack route is not the parent report', () => {
+        const parentReportID = 'parent-report';
+        const expenseReportID = 'expense-report';
+        const reportName = 'Parent chat';
+        const workspaceName = 'Workspace';
+
+        mockUseRoute.mockReturnValue({name: SCREENS.REPORT} as AnyRoute);
+        mockUseRootNavigationState.mockImplementation((selector?: (state: unknown) => unknown) => {
+            const mockState = getMockRootStateWithReportsSplitStack('other-report', expenseReportID);
+            if (selector) {
+                return selector(mockState);
+            }
+            return undefined;
+        });
+
+        render(
+            <ParentNavigationSubtitle
+                parentNavigationSubtitleData={{reportName, workspaceName}}
+                parentReportID={parentReportID}
+                reportID={expenseReportID}
+            />,
+        );
+
+        fireEvent(screen.getByTestId('parent-navigation-subtitle-link'), 'press', {
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+            nativeEvent: {},
+        });
+
+        expect(Navigation.goBack).not.toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
- Updated ParentNavigationSubtitle to avoid stacking duplicate DM/expense routes when opening a parent chat from an expense.
It now detects when the parent report is already the previous screen and uses goBack() (with param updates when needed) instead of pushing a new route, fixing the back-navigation trap after deleting an expense.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88499
PROPOSAL: https://github.com/Expensify/App/issues/88499#issuecomment-4326084934


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Sign in to ND with a new account
2. Create a 1:1 chat with another user
3. Create an expense in the chat
4. Open the expense and tap the parent chat link in the header
5. Tap the expense again, tap “More options,” and then tap “Delete.”
6. Tap Back button
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. ""offline"", ""spotty connection"", ""slow internet"", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write ""Same as tests"" if the QA team is able to run the tests in the above ""Tests"" section.
--->
// TODO: These must be filled out, or the issue title must include ""[No QA].""

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained ""why"" the code was doing something instead of only explaining ""what"" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named ""index.js"". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/99a5029a-83bb-4988-8ae8-a08da743fb76


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a055c3d9-ab55-4c9f-822d-c1dd2c03e9a9


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c4185018-d693-468b-9c77-919e5b2e55eb


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a02efcd6-a6df-4b74-9639-740b6c7f76ee


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/d153522c-c6f4-4eb0-872d-2e8c7b55903f


</details>