### PR TITLE
revert: rollback issue #80294 fix

### DIFF
--- a/src/libs/actions/Policy/Tag.ts
+++ b/src/libs/actions/Policy/Tag.ts
@@ -29,30 +29,20 @@ import {goBackWhenEnableFeature} from '@libs/PolicyUtils';
 import {pushTransactionViolationsOnyxData} from '@libs/ReportUtils';
 import {getTagArrayFromName} from '@libs/TransactionUtils';
 import type {PolicyTagList} from '@pages/workspace/tags/types';
-import {getFinishOnboardingTaskOnyxData} from '@userActions/Task';
+import {completeTask} from '@userActions/Task';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {ImportedSpreadsheet, Policy, PolicyTag, PolicyTagLists, PolicyTags, RecentlyUsedTags, Report, ReportAction} from '@src/types/onyx';
+import type {ImportedSpreadsheet, Policy, PolicyTag, PolicyTagLists, PolicyTags, RecentlyUsedTags, Report} from '@src/types/onyx';
 import type {OnyxValueWithOfflineFeedback} from '@src/types/onyx/OnyxCommon';
 import type {ApprovalRule} from '@src/types/onyx/Policy';
 import type {OnyxData} from '@src/types/onyx/Request';
 
-type CreatePolicyTagParams = {
-    policyData: PolicyData;
-    tagName: string;
-    setupTagsTaskReport: OnyxEntry<Report>;
-    setupTagsTaskParentReport: OnyxEntry<Report>;
-    isSetupTagsTaskParentReportArchived: boolean;
-    setupTagsHasOutstandingChildTask: boolean;
-    setupTagsParentReportAction: OnyxEntry<ReportAction>;
-    setupCategoriesAndTagsTaskReport: OnyxEntry<Report>;
-    setupCategoriesAndTagsTaskParentReport: OnyxEntry<Report>;
-    isSetupCategoriesAndTagsTaskParentReportArchived: boolean;
-    setupCategoriesAndTagsHasOutstandingChildTask: boolean;
-    setupCategoriesAndTagsParentReportAction: OnyxEntry<ReportAction>;
-    currentUserAccountID: number;
-    policyHasCustomCategories: boolean;
-};
+/**
+ * Checks if a task report is incomplete (not approved)
+ */
+function isTaskIncomplete(taskReport: OnyxEntry<Report>): boolean {
+    return !!taskReport && (taskReport.stateNum !== CONST.REPORT.STATE_NUM.APPROVED || taskReport.statusNum !== CONST.REPORT.STATUS_NUM.APPROVED);
+}
 
 function openPolicyTagsPage(policyID: string) {
     if (!policyID) {
@@ -130,22 +120,13 @@ function updateImportSpreadsheetData(tagsLength: number): OnyxData<typeof ONYXKE
     return onyxData;
 }
 
-function createPolicyTag({
-    policyData,
-    tagName,
-    setupTagsTaskReport,
-    setupTagsTaskParentReport,
-    isSetupTagsTaskParentReportArchived,
-    setupTagsHasOutstandingChildTask,
-    setupTagsParentReportAction,
-    setupCategoriesAndTagsTaskReport,
-    setupCategoriesAndTagsTaskParentReport,
-    isSetupCategoriesAndTagsTaskParentReportArchived,
-    setupCategoriesAndTagsHasOutstandingChildTask,
-    setupCategoriesAndTagsParentReportAction,
-    currentUserAccountID,
-    policyHasCustomCategories,
-}: CreatePolicyTagParams) {
+function createPolicyTag(
+    policyData: PolicyData,
+    tagName: string,
+    setupTagsTaskReport?: OnyxEntry<Report>,
+    setupCategoriesAndTagsTaskReport?: OnyxEntry<Report>,
+    policyHasCustomCategories?: boolean,
+) {
     const {policy, tags: policyTags} = policyData;
     const policyID = policy?.id;
     const policyTag = PolicyUtils.getTagLists(policyTags)?.at(0) ?? ({} as PolicyTagList);
@@ -213,34 +194,12 @@ function createPolicyTag({
 
     API.write(WRITE_COMMANDS.CREATE_POLICY_TAG, parameters, onyxData);
 
-    const isTaskForCurrentWorkspace = (taskReport: OnyxEntry<Report>) => !taskReport?.policyID || taskReport.policyID === policyID;
-
-    // Complete the "Set up tags" onboarding task
-    if (setupTagsTaskReport && currentUserAccountID && isTaskForCurrentWorkspace(setupTagsTaskReport)) {
-        getFinishOnboardingTaskOnyxData(
-            setupTagsTaskReport,
-            setupTagsTaskParentReport,
-            isSetupTagsTaskParentReportArchived ?? false,
-            currentUserAccountID,
-            setupTagsHasOutstandingChildTask ?? false,
-            setupTagsParentReportAction,
-            // delegateEmail: will be threaded in PR 16; buildOptimisticTaskReportAction falls back to module-level Onyx.connect value (https://github.com/Expensify/App/issues/66425)
-            undefined,
-        );
+    if (isTaskIncomplete(setupTagsTaskReport)) {
+        completeTask(setupTagsTaskReport, false, false, undefined);
     }
 
-    // Complete the combined "Set up categories and tags" task only if categories already exist
-    if (setupCategoriesAndTagsTaskReport && policyHasCustomCategories && currentUserAccountID && isTaskForCurrentWorkspace(setupCategoriesAndTagsTaskReport)) {
-        getFinishOnboardingTaskOnyxData(
-            setupCategoriesAndTagsTaskReport,
-            setupCategoriesAndTagsTaskParentReport,
-            isSetupCategoriesAndTagsTaskParentReportArchived ?? false,
-            currentUserAccountID,
-            setupCategoriesAndTagsHasOutstandingChildTask ?? false,
-            setupCategoriesAndTagsParentReportAction,
-            // delegateEmail: will be threaded in PR 16; buildOptimisticTaskReportAction falls back to module-level Onyx.connect value (https://github.com/Expensify/App/issues/66425)
-            undefined,
-        );
+    if (isTaskIncomplete(setupCategoriesAndTagsTaskReport) && policyHasCustomCategories) {
+        completeTask(setupCategoriesAndTagsTaskReport, false, false, undefined);
     }
 }
 

--- a/src/pages/workspace/tags/WorkspaceCreateTagPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceCreateTagPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import {Keyboard} from 'react-native';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
@@ -7,9 +7,9 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import TextInput from '@components/TextInput';
 import useAutoFocusInput from '@hooks/useAutoFocusInput';
-import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useLocalize from '@hooks/useLocalize';
 import useOnboardingTaskInformation from '@hooks/useOnboardingTaskInformation';
+import useOnyx from '@hooks/useOnyx';
 import usePolicyData from '@hooks/usePolicyData';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {addErrorMessage} from '@libs/ErrorUtils';
@@ -31,73 +31,51 @@ type WorkspaceCreateTagPageProps =
     | PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS_TAGS.SETTINGS_TAG_CREATE>;
 
 function WorkspaceCreateTagPage({route}: WorkspaceCreateTagPageProps) {
-    const {policyID, backTo} = route.params;
+    const policyID = route.params.policyID;
     const policyData = usePolicyData(policyID);
     const {tags: policyTagLists, categories: policyCategories} = policyData;
+    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
+    const setupTagsTaskReportID = introSelected?.setupTags;
+    const [setupTagsTaskReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${setupTagsTaskReportID}`);
+    const {taskReport: setupCategoriesAndTagsTaskReport} = useOnboardingTaskInformation(CONST.ONBOARDING_TASK_TYPE.SETUP_CATEGORIES_AND_TAGS);
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const {inputCallbackRef} = useAutoFocusInput();
+    const backTo = route.params.backTo;
     const isQuickSettingsFlow = route.name === SCREENS.SETTINGS_TAGS.SETTINGS_TAG_CREATE;
 
     const policyHasCustomCategories = hasCustomCategories(policyCategories);
 
-    const validate = (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM>) => {
-        const errors: FormInputErrors<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM> = {};
-        const tagName = escapeTagName(values.tagName.trim());
-        const {tags} = getTagList(policyTagLists, 0);
+    const validate = useCallback(
+        (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM>) => {
+            const errors: FormInputErrors<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM> = {};
+            const tagName = escapeTagName(values.tagName.trim());
+            const {tags} = getTagList(policyTagLists, 0);
 
-        if (!isRequiredFulfilled(tagName)) {
-            errors.tagName = translate('workspace.tags.tagRequiredError');
-        } else if (tagName === '0') {
-            errors.tagName = translate('workspace.tags.invalidTagNameError');
-        } else if (tags?.[tagName]) {
-            errors.tagName = translate('workspace.tags.existingTagError');
-        } else if ([...tagName].length > CONST.API_TRANSACTION_TAG_MAX_LENGTH) {
-            // Uses the spread syntax to count the number of Unicode code points instead of the number of UTF-16 code units.
-            addErrorMessage(errors, 'tagName', translate('common.error.characterLimitExceedCounter', [...tagName].length, CONST.API_TRANSACTION_TAG_MAX_LENGTH));
-        }
+            if (!isRequiredFulfilled(tagName)) {
+                errors.tagName = translate('workspace.tags.tagRequiredError');
+            } else if (tagName === '0') {
+                errors.tagName = translate('workspace.tags.invalidTagNameError');
+            } else if (tags?.[tagName]) {
+                errors.tagName = translate('workspace.tags.existingTagError');
+            } else if ([...tagName].length > CONST.API_TRANSACTION_TAG_MAX_LENGTH) {
+                // Uses the spread syntax to count the number of Unicode code points instead of the number of UTF-16 code units.
+                addErrorMessage(errors, 'tagName', translate('common.error.characterLimitExceedCounter', [...tagName].length, CONST.API_TRANSACTION_TAG_MAX_LENGTH));
+            }
 
-        return errors;
-    };
+            return errors;
+        },
+        [policyTagLists, translate],
+    );
 
-    const currentUserPersonalDetails = useCurrentUserPersonalDetails();
-
-    const {
-        taskReport: setupTagsTaskReport,
-        taskParentReport: setupTagsTaskParentReport,
-        isOnboardingTaskParentReportArchived: isSetupTagsTaskParentReportArchived,
-        hasOutstandingChildTask: setupTagsHasOutstandingChildTask,
-        parentReportAction: setupTagsParentReportAction,
-    } = useOnboardingTaskInformation(CONST.ONBOARDING_TASK_TYPE.SETUP_TAGS);
-
-    const {
-        taskReport: setupCategoriesAndTagsTaskReport,
-        taskParentReport: setupCategoriesAndTagsTaskParentReport,
-        isOnboardingTaskParentReportArchived: isSetupCategoriesAndTagsTaskParentReportArchived,
-        hasOutstandingChildTask: setupCategoriesAndTagsHasOutstandingChildTask,
-        parentReportAction: setupCategoriesAndTagsParentReportAction,
-    } = useOnboardingTaskInformation(CONST.ONBOARDING_TASK_TYPE.SETUP_CATEGORIES_AND_TAGS);
-
-    const createTag = (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM>) => {
-        createPolicyTag({
-            policyData,
-            tagName: values.tagName.trim(),
-            setupTagsTaskReport,
-            setupTagsTaskParentReport,
-            isSetupTagsTaskParentReportArchived,
-            setupTagsHasOutstandingChildTask,
-            setupTagsParentReportAction,
-            setupCategoriesAndTagsTaskReport,
-            setupCategoriesAndTagsTaskParentReport,
-            isSetupCategoriesAndTagsTaskParentReportArchived,
-            setupCategoriesAndTagsHasOutstandingChildTask,
-            setupCategoriesAndTagsParentReportAction,
-            currentUserAccountID: currentUserPersonalDetails.accountID,
-            policyHasCustomCategories,
-        });
-        Keyboard.dismiss();
-        Navigation.goBack(isQuickSettingsFlow ? ROUTES.SETTINGS_TAGS_ROOT.getRoute(policyID, backTo) : undefined);
-    };
+    const createTag = useCallback(
+        (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM>) => {
+            createPolicyTag(policyData, values.tagName.trim(), setupTagsTaskReport, setupCategoriesAndTagsTaskReport, policyHasCustomCategories);
+            Keyboard.dismiss();
+            Navigation.goBack(isQuickSettingsFlow ? ROUTES.SETTINGS_TAGS_ROOT.getRoute(policyID, backTo) : undefined);
+        },
+        [policyID, policyData, isQuickSettingsFlow, backTo, setupTagsTaskReport, setupCategoriesAndTagsTaskReport, policyHasCustomCategories],
+    );
 
     return (
         <AccessOrNotFoundWrapper

--- a/src/types/onyx/IntroSelected.ts
+++ b/src/types/onyx/IntroSelected.ts
@@ -2,7 +2,7 @@ import type {OnboardingInvite} from '@src/CONST';
 import type {OnboardingPurpose} from './index';
 
 /** The tasks of IntroSelected model */
-type IntroSelectedTask = 'viewTour' | 'createWorkspace' | 'setupCategories' | 'setupTags' | 'setupCategoriesAndTags';
+type IntroSelectedTask = 'viewTour' | 'createWorkspace' | 'setupCategories' | 'setupCategoriesAndTags';
 
 /** Model of onboarding */
 type IntroSelected = {

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -297,22 +297,7 @@ describe('actions/Policy', () => {
             const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
 
             // When creating a new tag
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: undefined,
-                setupTagsTaskParentReport: undefined,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: undefined,
-                setupCategoriesAndTagsTaskParentReport: undefined,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: 0,
-                policyHasCustomCategories: false,
-            });
+            createPolicyTag(policyData.current, newTagName);
             await waitForBatchedUpdates();
 
             // Then the tag should appear optimistically with pending state so the user sees immediate feedback
@@ -352,22 +337,7 @@ describe('actions/Policy', () => {
             const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
 
             // When the API fails
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: undefined,
-                setupTagsTaskParentReport: undefined,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: undefined,
-                setupCategoriesAndTagsTaskParentReport: undefined,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: 0,
-                policyHasCustomCategories: false,
-            });
+            createPolicyTag(policyData.current, newTagName);
             await waitForBatchedUpdates();
             mockFetch.resume();
             await waitForBatchedUpdates();
@@ -393,22 +363,7 @@ describe('actions/Policy', () => {
             const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
 
             // When adding the first tag
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: undefined,
-                setupTagsTaskParentReport: undefined,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: undefined,
-                setupCategoriesAndTagsTaskParentReport: undefined,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: 0,
-                policyHasCustomCategories: false,
-            });
+            createPolicyTag(policyData.current, newTagName);
             await waitForBatchedUpdates();
 
             // Then the tag should be created in a new list with pending state so the user sees immediate feedback
@@ -461,22 +416,7 @@ describe('actions/Policy', () => {
             const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
 
             // When using data from useOnyx hook
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: undefined,
-                setupTagsTaskParentReport: undefined,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: undefined,
-                setupCategoriesAndTagsTaskParentReport: undefined,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: 0,
-                policyHasCustomCategories: false,
-            });
+            createPolicyTag(policyData.current, newTagName);
             await waitForBatchedUpdates();
 
             // Then the tag should appear optimistically with pending state so the user sees immediate feedback
@@ -2301,64 +2241,36 @@ describe('actions/Policy', () => {
     });
 
     describe('createPolicyTag with onboarding task completion', () => {
-        const FAKE_ACCOUNT_ID = 12345;
-        const FAKE_PARENT_REPORT_ID = '999999';
-        const fakeParentReport = {
-            reportID: FAKE_PARENT_REPORT_ID,
-            type: CONST.REPORT.TYPE.CHAT,
-        };
-
         it('should create a new tag and complete SETUP_TAGS task', async () => {
             const fakePolicy = createRandomPolicy(0);
             const fakeTags = createRandomPolicyTags('TestTagList', 2);
             const newTagName = 'New tag';
 
+            // Create a fake task report for SETUP_TAGS
             const fakeTaskReportID = '123456';
             const fakeTaskReport = {
                 reportID: fakeTaskReportID,
                 type: CONST.REPORT.TYPE.TASK,
                 stateNum: CONST.REPORT.STATE_NUM.OPEN,
                 statusNum: CONST.REPORT.STATUS_NUM.OPEN,
-                ownerAccountID: FAKE_ACCOUNT_ID,
-                parentReportID: FAKE_PARENT_REPORT_ID,
-                policyID: fakePolicy.id,
             };
 
             mockFetch?.pause?.();
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`, fakeTags);
             await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`, fakeTaskReport);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_PARENT_REPORT_ID}`, fakeParentReport);
 
             const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
 
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: fakeTaskReport,
-                setupTagsTaskParentReport: fakeParentReport,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: undefined,
-                setupCategoriesAndTagsTaskParentReport: undefined,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: FAKE_ACCOUNT_ID,
-                policyHasCustomCategories: false,
-            });
+            createPolicyTag(policyData.current, newTagName, fakeTaskReport);
 
             await waitForBatchedUpdates();
 
+            // Verify the tag was created
             const policyTags = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`);
             const tagList = Object.values(policyTags ?? {}).at(0);
             const newTag = tagList?.tags?.[newTagName];
             expect(newTag?.name).toBe(newTagName);
-
-            const taskReport = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`);
-            expect(taskReport?.stateNum).toBe(CONST.REPORT.STATE_NUM.APPROVED);
-            expect(taskReport?.statusNum).toBe(CONST.REPORT.STATUS_NUM.APPROVED);
 
             await mockFetch?.resume?.();
             await waitForBatchedUpdates();
@@ -2369,51 +2281,31 @@ describe('actions/Policy', () => {
             const fakeTags = createRandomPolicyTags('TestTagList', 2);
             const newTagName = 'New tag with categories';
 
+            // Create a fake task report for SETUP_CATEGORIES_AND_TAGS
             const fakeTaskReportID = '789012';
             const fakeTaskReport = {
                 reportID: fakeTaskReportID,
                 type: CONST.REPORT.TYPE.TASK,
                 stateNum: CONST.REPORT.STATE_NUM.OPEN,
                 statusNum: CONST.REPORT.STATUS_NUM.OPEN,
-                ownerAccountID: FAKE_ACCOUNT_ID,
-                parentReportID: FAKE_PARENT_REPORT_ID,
-                policyID: fakePolicy.id,
             };
 
             mockFetch?.pause?.();
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`, fakeTags);
             await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`, fakeTaskReport);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_PARENT_REPORT_ID}`, fakeParentReport);
 
             const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: undefined,
-                setupTagsTaskParentReport: undefined,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: fakeTaskReport,
-                setupCategoriesAndTagsTaskParentReport: fakeParentReport,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: FAKE_ACCOUNT_ID,
-                policyHasCustomCategories: true,
-            });
+
+            createPolicyTag(policyData.current, newTagName, undefined, fakeTaskReport, true);
 
             await waitForBatchedUpdates();
 
+            // Verify the tag was created
             const policyTags = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`);
             const tagList = Object.values(policyTags ?? {}).at(0);
             const newTag = tagList?.tags?.[newTagName];
             expect(newTag?.name).toBe(newTagName);
-
-            const taskReport = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`);
-            expect(taskReport?.stateNum).toBe(CONST.REPORT.STATE_NUM.APPROVED);
-            expect(taskReport?.statusNum).toBe(CONST.REPORT.STATUS_NUM.APPROVED);
 
             await mockFetch?.resume?.();
             await waitForBatchedUpdates();
@@ -2424,109 +2316,31 @@ describe('actions/Policy', () => {
             const fakeTags = createRandomPolicyTags('TestTagList', 2);
             const newTagName = 'New tag without categories';
 
+            // Create a fake task report for SETUP_CATEGORIES_AND_TAGS
             const fakeTaskReportID = '345678';
             const fakeTaskReport = {
                 reportID: fakeTaskReportID,
                 type: CONST.REPORT.TYPE.TASK,
                 stateNum: CONST.REPORT.STATE_NUM.OPEN,
                 statusNum: CONST.REPORT.STATUS_NUM.OPEN,
-                ownerAccountID: FAKE_ACCOUNT_ID,
-                parentReportID: FAKE_PARENT_REPORT_ID,
-                policyID: fakePolicy.id,
             };
 
             mockFetch?.pause?.();
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`, fakeTags);
             await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`, fakeTaskReport);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_PARENT_REPORT_ID}`, fakeParentReport);
 
             const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
 
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: undefined,
-                setupTagsTaskParentReport: undefined,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: fakeTaskReport,
-                setupCategoriesAndTagsTaskParentReport: fakeParentReport,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: FAKE_ACCOUNT_ID,
-                policyHasCustomCategories: false,
-            });
+            createPolicyTag(policyData.current, newTagName, undefined, fakeTaskReport, false);
 
             await waitForBatchedUpdates();
 
+            // Verify the tag was created
             const policyTags = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`);
             const tagList = Object.values(policyTags ?? {}).at(0);
             const newTag = tagList?.tags?.[newTagName];
             expect(newTag?.name).toBe(newTagName);
-
-            const taskReport = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`);
-            expect(taskReport?.stateNum).toBe(CONST.REPORT.STATE_NUM.OPEN);
-            expect(taskReport?.statusNum).toBe(CONST.REPORT.STATUS_NUM.OPEN);
-
-            await mockFetch?.resume?.();
-            await waitForBatchedUpdates();
-        });
-
-        it('should NOT complete onboarding task when task belongs to a different workspace', async () => {
-            const fakePolicy = createRandomPolicy(0);
-            const fakeTags = createRandomPolicyTags('TestTagList', 2);
-            const newTagName = 'New tag in different workspace';
-            const differentPolicyID = 'different-policy-id';
-
-            const fakeTaskReportID = '567890';
-            const fakeTaskReport = {
-                reportID: fakeTaskReportID,
-                type: CONST.REPORT.TYPE.TASK,
-                stateNum: CONST.REPORT.STATE_NUM.OPEN,
-                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
-                ownerAccountID: FAKE_ACCOUNT_ID,
-                parentReportID: FAKE_PARENT_REPORT_ID,
-                policyID: differentPolicyID,
-            };
-
-            mockFetch?.pause?.();
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`, fakeTags);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`, fakeTaskReport);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_PARENT_REPORT_ID}`, fakeParentReport);
-
-            const {result: policyData} = renderHook(() => usePolicyData(fakePolicy.id), {wrapper: OnyxListItemProvider});
-
-            createPolicyTag({
-                policyData: policyData.current,
-                tagName: newTagName,
-                setupTagsTaskReport: fakeTaskReport,
-                setupTagsTaskParentReport: fakeParentReport,
-                isSetupTagsTaskParentReportArchived: false,
-                setupTagsHasOutstandingChildTask: false,
-                setupTagsParentReportAction: undefined,
-                setupCategoriesAndTagsTaskReport: fakeTaskReport,
-                setupCategoriesAndTagsTaskParentReport: fakeParentReport,
-                isSetupCategoriesAndTagsTaskParentReportArchived: false,
-                setupCategoriesAndTagsHasOutstandingChildTask: false,
-                setupCategoriesAndTagsParentReportAction: undefined,
-                currentUserAccountID: FAKE_ACCOUNT_ID,
-                policyHasCustomCategories: true,
-            });
-
-            await waitForBatchedUpdates();
-
-            const policyTags = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`);
-            const tagList = Object.values(policyTags ?? {}).at(0);
-            const newTag = tagList?.tags?.[newTagName];
-            expect(newTag?.name).toBe(newTagName);
-
-            const taskReport = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${fakeTaskReportID}`);
-            expect(taskReport?.stateNum).toBe(CONST.REPORT.STATE_NUM.OPEN);
-            expect(taskReport?.statusNum).toBe(CONST.REPORT.STATUS_NUM.OPEN);
 
             await mockFetch?.resume?.();
             await waitForBatchedUpdates();


### PR DESCRIPTION
## Summary
- Revert merge commit `04db3d1bceedd8f15bd5a6f6426115b69dcfa38f` from PR #81814.
- Restore pre-fix behavior for workspace tag creation flow related to issue #80294.
- Resolve revert conflict in `src/libs/actions/Policy/Tag.ts` to match the parent-of-merge behavior.

## Test plan
- [ ] Verify app builds and tests pass in CI.
- [ ] Re-run the original repro flow from issue #80294 and confirm the prior behavior is restored.
- [ ] Verify no regressions in workspace tags create/edit flows.

Made with [Cursor](https://cursor.com)