### PR TITLE
Fix issue: Expensify Card - After clicking View transactions, Workspaces tab resets to initial page

### DIFF
--- a/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
+++ b/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
@@ -35,22 +35,26 @@ function useRestoreWorkspacesTabOnNavigate() {
             return {};
         }
 
-        // Look inside TabNavigator for WORKSPACE_NAVIGATOR
-        const rootTabRoute = rootState?.routes.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
-        const rootTabState = getTabState(rootTabRoute);
-        const workspaceNavigatorRoute = rootTabState?.routes?.find((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
+        // Multiple TAB_NAVIGATOR instances can coexist in the root stack — when navigation from
+        // inside an RHP targets a tab, linkTo PUSHes a fresh TabNavigator above the modal, and that
+        // new instance's WORKSPACE_NAVIGATOR slot starts empty. Older instances kept alive by
+        // ensureTabNavigatorRoutes still hold the previous workspace state, so flatten every
+        // workspace route from every TabNavigator in stack order and take the most recent one.
+        const lastWorkspaceRoute = (rootState?.routes ?? [])
+            .filter((route) => route.name === NAVIGATORS.TAB_NAVIGATOR)
+            .flatMap((tabNavigatorRoute) => {
+                const workspaceNavigatorRoute = getTabState(tabNavigatorRoute)?.routes?.find((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
+                const workspaceNavigatorState = workspaceNavigatorRoute?.state ?? (workspaceNavigatorRoute?.key ? getPreservedNavigatorState(workspaceNavigatorRoute.key) : undefined);
+                return workspaceNavigatorState?.routes?.filter((route) => isWorkspaceNavigatorRouteName(route.name)) ?? [];
+            })
+            .at(-1);
 
-        if (workspaceNavigatorRoute) {
-            const workspaceNavigatorState = workspaceNavigatorRoute.state ?? (workspaceNavigatorRoute.key ? getPreservedNavigatorState(workspaceNavigatorRoute.key) : undefined);
-            const lastWorkspaceRoute = workspaceNavigatorState?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
-            if (lastWorkspaceRoute) {
-                const tabState = lastWorkspaceRoute.state ?? (lastWorkspaceRoute.key ? getPreservedNavigatorState(lastWorkspaceRoute.key) : undefined);
-                return {lastWorkspacesTabNavigatorRoute: lastWorkspaceRoute, workspacesTabState: tabState, topmostFullScreenRoute};
-            }
-            return {topmostFullScreenRoute};
+        if (lastWorkspaceRoute) {
+            const tabState = lastWorkspaceRoute.state ?? (lastWorkspaceRoute.key ? getPreservedNavigatorState(lastWorkspaceRoute.key) : undefined);
+            return {lastWorkspacesTabNavigatorRoute: lastWorkspaceRoute, workspacesTabState: tabState, topmostFullScreenRoute};
         }
 
-        // Fall back to session storage when no route exists in the navigation tree
+        // Fall back to session storage when no workspace route exists anywhere in the navigation tree.
         const sessionRoute = getWorkspacesTabStateFromSessionStorage()
             ?.routes?.findLast((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR)
             ?.state?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));

--- a/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
+++ b/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
@@ -59,7 +59,7 @@ function useRestoreWorkspacesTabOnNavigate() {
             ?.routes?.findLast((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR)
             ?.state?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
         if (sessionRoute) {
-            return {lastWorkspacesTabNavigatorRoute: sessionRoute, workspacesTabState: sessionRoute.state};
+            return {lastWorkspacesTabNavigatorRoute: sessionRoute, workspacesTabState: sessionRoute.state, topmostFullScreenRoute};
         }
 
         return {topmostFullScreenRoute};

--- a/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
+++ b/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
@@ -105,8 +105,9 @@ function useRestoreWorkspacesTabOnNavigate() {
             domain: lastViewedDomain,
             lastWorkspacesTabNavigatorRoute,
             topmostFullScreenRoute,
+            workspacesTabState,
         });
-    }, [shouldUseNarrowLayout, currentUserLogin, lastViewedPolicy, lastViewedDomain, lastWorkspacesTabNavigatorRoute, topmostFullScreenRoute]);
+    }, [shouldUseNarrowLayout, currentUserLogin, lastViewedPolicy, lastViewedDomain, lastWorkspacesTabNavigatorRoute, topmostFullScreenRoute, workspacesTabState]);
 }
 
 export default useRestoreWorkspacesTabOnNavigate;

--- a/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
+++ b/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
@@ -6,11 +6,22 @@ import navigationRef from '@libs/Navigation/navigationRef';
 import {isPendingDeletePolicy, shouldShowPolicy as shouldShowPolicyUtil} from '@libs/PolicyUtils';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ROUTES from '@src/ROUTES';
+import type {Route} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Domain, Policy} from '@src/types/onyx';
 import getActiveTabName from './getActiveTabName';
+import getPathFromState from './getPathFromState';
 
 type RouteType = NavigationState['routes'][number] | PartialState<NavigationState>['routes'][number];
+
+/**
+ * Wraps a leaf navigation state in successive ancestor navigators (outermost first).
+ * Used to reconstruct the linking-config hierarchy that `getPathFromState` walks when
+ * resolving a state subtree to a URL.
+ */
+function wrapStateInNavigators(state: PartialState<NavigationState>, navigators: readonly string[]): PartialState<NavigationState> {
+    return navigators.reduceRight<PartialState<NavigationState>>((acc, name) => ({routes: [{name, state: acc}], index: 0}), state);
+}
 
 type Params = {
     currentUserLogin?: string;
@@ -19,11 +30,18 @@ type Params = {
     domain?: Domain;
     lastWorkspacesTabNavigatorRoute?: RouteType;
     topmostFullScreenRoute?: RouteType;
+    /**
+     * The full WorkspaceSplitNavigator inner state captured by the hook.
+     * Wrapped in a synthetic outer node and fed to `getPathFromState` to reconstruct
+     * the deep URL the user was on (e.g. `/workspaces/POLICY_ID/workflows`). Navigating
+     * via that URL goes through `getStateFromPath` which produces a fully-formed
+     * navigation state — bypassing custom router actions that don't seed nested state
+     * when pushing a fresh TabNavigator on top of an existing fullscreen stack.
+     */
+    workspacesTabState?: NavigationState | PartialState<NavigationState>;
 };
 
-// Navigates to the appropriate workspace tab or workspace list page.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- shouldUseNarrowLayout kept for API compat with callers
-const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, policy, domain, lastWorkspacesTabNavigatorRoute, topmostFullScreenRoute}: Params) => {
+const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, policy, domain, lastWorkspacesTabNavigatorRoute, topmostFullScreenRoute, workspacesTabState}: Params) => {
     const rootState = navigationRef.getRootState();
     const focusedRoute = rootState ? findFocusedRoute(rootState) : undefined;
     const isOnWorkspacesList = focusedRoute?.name === SCREENS.WORKSPACES_LIST;
@@ -61,9 +79,26 @@ const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, poli
                 return;
             }
 
-            // Restore to last-visited workspace — navigate through standard routing which switches the tab
             if (policy?.id) {
-                Navigation.navigate(ROUTES.WORKSPACE_INITIAL.getRoute(policy.id));
+                // Synthesize a URL from the captured WorkspaceSplitNavigator inner state and navigate
+                // to it. URL-based navigation goes through `getStateFromPath`, which produces a fully
+                // formed nested state and reliably handles pushing a fresh TabNavigator on top of an
+                // existing fullscreen stack. The state has to be wrapped with its full ancestor chain
+                // (TAB_NAVIGATOR > WORKSPACE_NAVIGATOR > WORKSPACE_SPLIT_NAVIGATOR) so `getPathFromState`
+                // can match the linking-config hierarchy and produce a real URL like
+                // `/workspaces/POLICY_ID/workflows`; otherwise the resolver falls back to navigator
+                // names as path segments and the result hits 404. Narrow layouts skip the deep-restore
+                // and go to the workspace's initial page (mirrors mobile behavior).
+                const wrappedState =
+                    !shouldUseNarrowLayout && workspacesTabState
+                        ? wrapStateInNavigators(workspacesTabState as PartialState<NavigationState>, [
+                              NAVIGATORS.TAB_NAVIGATOR,
+                              NAVIGATORS.WORKSPACE_NAVIGATOR,
+                              NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                          ])
+                        : undefined;
+                const targetPath = (wrappedState ? getPathFromState(wrappedState) : ROUTES.WORKSPACE_INITIAL.getRoute(policy.id)) as Route;
+                Navigation.navigate(targetPath);
             }
             return;
         }

--- a/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
+++ b/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
@@ -1,7 +1,9 @@
 import {renderHook} from '@testing-library/react-native';
+import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
 import Navigation from '@libs/Navigation/Navigation';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
 import createRandomPolicy from '../../utils/collections/policies';
 
 jest.mock('@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState', () => ({
@@ -12,7 +14,8 @@ jest.mock('@libs/Navigation/helpers/lastVisitedTabPathUtils', () => ({
     getWorkspacesTabStateFromSessionStorage: jest.fn(() => undefined),
 }));
 
-jest.mock('@hooks/useResponsiveLayout', () => () => ({shouldUseNarrowLayout: false}));
+const mockResponsiveLayout = jest.fn(() => ({shouldUseNarrowLayout: false}));
+jest.mock('@hooks/useResponsiveLayout', () => () => mockResponsiveLayout());
 
 jest.mock('@hooks/useCurrentUserPersonalDetails', () => () => ({login: 'test@example.com'}));
 
@@ -24,7 +27,11 @@ jest.mock('@hooks/useOnyx', () => (key: unknown, opts?: unknown) => mockUseOnyx(
 
 jest.mock('@libs/interceptAnonymousUser', () => (cb: () => void) => cb());
 
-jest.mock('@libs/Navigation/navigationRef', () => ({getRootState: jest.fn(() => ({routes: []})), isReady: jest.fn(() => true)}));
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    getRootState: jest.fn(() => ({routes: []})),
+    isReady: jest.fn(() => true),
+    dispatch: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
     findFocusedRoute: jest.fn(() => ({name: 'some-screen'})),
@@ -35,6 +42,11 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     goBack: jest.fn(),
 }));
 
+jest.mock('@libs/Navigation/helpers/getPathFromState', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
 // eslint-disable-next-line no-restricted-syntax
 jest.mock('@libs/PolicyUtils', () => ({
     shouldShowPolicy: jest.fn(() => true),
@@ -43,12 +55,16 @@ jest.mock('@libs/PolicyUtils', () => ({
 
 const fakePolicyID = 'ABCD1234';
 const mockPolicy = {...createRandomPolicy(0), id: fakePolicyID};
+const mockedGetPathFromState = getPathFromState as jest.MockedFunction<typeof getPathFromState>;
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const useRestoreWorkspacesTabOnNavigate = (require('@hooks/useRestoreWorkspacesTabOnNavigate') as {default: () => () => void}).default;
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, no-restricted-syntax
 const PolicyUtils = require('@libs/PolicyUtils') as {shouldShowPolicy: jest.Mock; isPendingDeletePolicy: jest.Mock};
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const lastVisitedTabPathUtils = require('@libs/Navigation/helpers/lastVisitedTabPathUtils') as {getWorkspacesTabStateFromSessionStorage: jest.Mock};
 
 function setupOnyxForPolicy() {
     mockUseOnyx.mockImplementation((_key: unknown, opts?: {selector?: (data: unknown) => unknown}) => {
@@ -83,18 +99,30 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockUseOnyx.mockReturnValue([undefined]);
+        mockResponsiveLayout.mockReturnValue({shouldUseNarrowLayout: false});
+        lastVisitedTabPathUtils.getWorkspacesTabStateFromSessionStorage.mockReturnValue(undefined);
         PolicyUtils.shouldShowPolicy.mockReturnValue(true);
         PolicyUtils.isPendingDeletePolicy.mockReturnValue(false);
+        mockedGetPathFromState.mockReset();
     });
 
     it('restores to the last visited workspace when re-entering the Workspaces tab', () => {
         setupOnyxForPolicy();
-        mockRootState.mockReturnValue(buildStateWithUserOnDifferentTab([{name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, state: {routes: [{params: {policyID: fakePolicyID}}]}}]));
+        const restoredPath = `/workspaces/${fakePolicyID}` as const;
+        mockedGetPathFromState.mockReturnValue(restoredPath);
+        mockRootState.mockReturnValue(
+            buildStateWithUserOnDifferentTab([
+                {
+                    name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                    state: {routes: [{name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}}]},
+                },
+            ]),
+        );
 
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_INITIAL.getRoute(fakePolicyID));
+        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
     });
 
     it('falls back to the workspaces list when no workspace was previously visited', () => {
@@ -117,11 +145,167 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         PolicyUtils.isPendingDeletePolicy.mockReturnValue(true);
 
         setupOnyxForPolicy();
-        mockRootState.mockReturnValue(buildStateWithUserOnDifferentTab([{name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, state: {routes: [{params: {policyID: fakePolicyID}}]}}]));
+        mockRootState.mockReturnValue(
+            buildStateWithUserOnDifferentTab([
+                {
+                    name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                    state: {routes: [{name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}}]},
+                },
+            ]),
+        );
 
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACES_LIST.route);
+    });
+
+    // Regression: clicking the Workspaces tab from any other tab should land the user on the *exact* sub-page
+    // they had open inside the workspace (e.g. Workflows), not the workspace's initial page.
+    it('preserves the focused workspace sub-page (Workflows) when restoring on a wide layout', () => {
+        setupOnyxForPolicy();
+        const restoredPath = `/workspaces/${fakePolicyID}/workflows` as const;
+        mockedGetPathFromState.mockReturnValue(restoredPath);
+        mockRootState.mockReturnValue(
+            buildStateWithUserOnDifferentTab([
+                {
+                    name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                    state: {
+                        index: 1,
+                        routes: [
+                            {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
+                            {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
+                        ],
+                    },
+                },
+            ]),
+        );
+
+        const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
+        result.current();
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
+    });
+
+    // Regression for the original bug (#89106): when an RHP-driven navigation pushes a fresh TabNavigator above
+    // the modal, the new TabNavigator's WORKSPACE_NAVIGATOR is empty. The hook must reach into the *older*
+    // TabNavigator instance still alive in the root stack to recover the user's last workspace sub-page.
+    it('reads workspace state from an older TabNavigator instance when the topmost one is empty', () => {
+        setupOnyxForPolicy();
+        const restoredPath = `/workspaces/${fakePolicyID}/workflows` as const;
+        mockedGetPathFromState.mockReturnValue(restoredPath);
+        mockRootState.mockReturnValue({
+            routes: [
+                // Older TabNavigator: still holds the workspace state with WORKFLOWS focused.
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 1,
+                        routes: [
+                            {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+                            {
+                                name: NAVIGATORS.WORKSPACE_NAVIGATOR,
+                                state: {
+                                    routes: [
+                                        {
+                                            name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                                            state: {
+                                                index: 1,
+                                                routes: [
+                                                    {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
+                                                    {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+                // Newer TabNavigator pushed above the modal: WORKSPACE_NAVIGATOR is empty.
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 0,
+                        routes: [{name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}, {name: NAVIGATORS.WORKSPACE_NAVIGATOR}],
+                    },
+                },
+            ],
+        });
+
+        const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
+        result.current();
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
+    });
+
+    // On narrow layouts (mobile), the URL-based restore is skipped: we always land on the workspace's
+    // initial page so the user can navigate inward via the side-list — matches mobile UX and the docs.
+    it('falls back to the workspace initial page on narrow layouts even when a sub-page is focused', () => {
+        mockResponsiveLayout.mockReturnValue({shouldUseNarrowLayout: true});
+        setupOnyxForPolicy();
+        mockRootState.mockReturnValue(
+            buildStateWithUserOnDifferentTab([
+                {
+                    name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                    state: {
+                        index: 1,
+                        routes: [
+                            {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
+                            {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
+                        ],
+                    },
+                },
+            ]),
+        );
+
+        const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
+        result.current();
+
+        expect(mockedGetPathFromState).not.toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_INITIAL.getRoute(fakePolicyID));
+    });
+
+    // Cold-start path: when no workspace route exists anywhere in the live nav tree, fall back to the
+    // sessionStorage-persisted state so a fresh page-load still restores the user's last workspace sub-page.
+    it('hydrates from sessionStorage when the live navigation tree has no workspace route', () => {
+        setupOnyxForPolicy();
+        const restoredPath = `/workspaces/${fakePolicyID}/workflows` as const;
+        mockedGetPathFromState.mockReturnValue(restoredPath);
+        mockRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {index: 0, routes: [{name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}]},
+                },
+            ],
+        });
+        lastVisitedTabPathUtils.getWorkspacesTabStateFromSessionStorage.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.WORKSPACE_NAVIGATOR,
+                    state: {
+                        routes: [
+                            {
+                                name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                                state: {
+                                    index: 1,
+                                    routes: [
+                                        {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
+                                        {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+
+        const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
+        result.current();
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
     });
 });

--- a/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
+++ b/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
@@ -43,6 +43,7 @@ jest.mock('@libs/Navigation/Navigation', () => ({
 }));
 
 jest.mock('@libs/Navigation/helpers/getPathFromState', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     default: jest.fn(),
 }));

--- a/tests/unit/navigateToWorkspacesPageTest.ts
+++ b/tests/unit/navigateToWorkspacesPageTest.ts
@@ -1,10 +1,12 @@
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
+import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
 import navigateToWorkspacesPage from '@libs/Navigation/helpers/navigateToWorkspacesPage';
 import Navigation from '@libs/Navigation/Navigation';
 // eslint-disable-next-line no-restricted-syntax
 import * as PolicyUtils from '@libs/PolicyUtils';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
 import createRandomPolicy from '../utils/collections/policies';
 
 jest.mock('@libs/Navigation/navigationRef');
@@ -12,6 +14,12 @@ jest.mock('@libs/Navigation/Navigation');
 jest.mock('@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState');
 jest.mock('@libs/PolicyUtils');
 jest.mock('@libs/interceptAnonymousUser');
+jest.mock('@libs/Navigation/helpers/getPathFromState', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+const mockedGetPathFromState = getPathFromState as jest.MockedFunction<typeof getPathFromState>;
 
 const fakePolicyID = '344559B2CCF2B6C1';
 const mockPolicy = {...createRandomPolicy(0), id: fakePolicyID};
@@ -59,7 +67,7 @@ describe('navigateToWorkspacesPage', () => {
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACES_LIST.route);
     });
 
-    it('navigates to workspace initial screen if valid policy and screen exist', () => {
+    it('navigates to the workspace initial URL when no workspacesTabState is provided', () => {
         (PolicyUtils.shouldShowPolicy as jest.Mock).mockReturnValue(true);
         (PolicyUtils.isPendingDeletePolicy as jest.Mock).mockReturnValue(false);
 
@@ -70,6 +78,76 @@ describe('navigateToWorkspacesPage', () => {
             lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, key: 'someKey'},
         });
 
+        expect(mockedGetPathFromState).not.toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_INITIAL.getRoute(fakePolicyID));
+    });
+
+    it('navigates to the URL produced by getPathFromState when workspacesTabState is provided on wide layouts', () => {
+        (PolicyUtils.shouldShowPolicy as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPendingDeletePolicy as jest.Mock).mockReturnValue(false);
+        const restoredPath = `/workspaces/${fakePolicyID}/workflows` as const;
+        mockedGetPathFromState.mockReturnValue(restoredPath);
+
+        mockIntercept();
+        const workspacesTabState = {
+            index: 1,
+            routes: [
+                {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
+                {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
+            ],
+        };
+        navigateToWorkspacesPage({
+            ...baseParams,
+            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, key: 'someKey'},
+            workspacesTabState,
+        });
+
+        // Wrapped with the full TAB_NAVIGATOR > WORKSPACE_NAVIGATOR > WORKSPACE_SPLIT_NAVIGATOR ancestor chain
+        // so getPathFromState can match the linking-config hierarchy.
+        expect(mockedGetPathFromState).toHaveBeenCalledWith({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        routes: [
+                            {
+                                name: NAVIGATORS.WORKSPACE_NAVIGATOR,
+                                state: {
+                                    routes: [{name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, state: workspacesTabState}],
+                                    index: 0,
+                                },
+                            },
+                        ],
+                        index: 0,
+                    },
+                },
+            ],
+            index: 0,
+        });
+        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
+    });
+
+    it('falls back to the workspace initial URL on narrow layouts even when workspacesTabState is provided', () => {
+        (PolicyUtils.shouldShowPolicy as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPendingDeletePolicy as jest.Mock).mockReturnValue(false);
+
+        mockIntercept();
+        navigateToWorkspacesPage({
+            ...baseParams,
+            shouldUseNarrowLayout: true,
+            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, key: 'someKey'},
+            workspacesTabState: {
+                index: 1,
+                routes: [
+                    {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
+                    {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
+                ],
+            },
+        });
+
+        expect(mockedGetPathFromState).not.toHaveBeenCalled();
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_INITIAL.getRoute(fakePolicyID));
     });
 

--- a/tests/unit/navigateToWorkspacesPageTest.ts
+++ b/tests/unit/navigateToWorkspacesPageTest.ts
@@ -15,6 +15,7 @@ jest.mock('@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigat
 jest.mock('@libs/PolicyUtils');
 jest.mock('@libs/interceptAnonymousUser');
 jest.mock('@libs/Navigation/helpers/getPathFromState', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     default: jest.fn(),
 }));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

- The Workspaces tab was resetting to the workspace list after using "View transactions" from an Expensify Card because `useRestoreWorkspacesTabOnNavigate` only inspected the topmost `TAB_NAVIGATOR` in the root stack.
- When navigation is triggered from inside an RHP and targets a tab, `linkTo` PUSHes a fresh `TAB_NAVIGATOR` above the modal. That new instance's `WORKSPACE_NAVIGATOR` slot starts empty, so the hook resolved no last-visited route and fell back to the workspace list.
- Older `TAB_NAVIGATOR` instances kept alive by `ensureTabNavigatorRoutes` still hold the previous workspace state. The hook now flattens the `WORKSPACE_NAVIGATOR` routes from every `TAB_NAVIGATOR` in the root stack and picks the most recent one, so the previously open workspace + sub-page (e.g. Expensify Card) is restored.
- Behaviour is unchanged when there is only a single `TAB_NAVIGATOR` (the common case), and the existing session-storage fallback is preserved for cold-start scenarios.

### Fixed Issues

$ https://github.com/Expensify/App/issues/89009
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests

### QA Steps

Precondition: a workspace with the Expensify Card feature enabled and at least one virtual card assigned to a member.

1. Sign in to staging at `https://staging.new.expensify.com` (Chrome).
2. Go to **Workspace settings → Expensify Card** for the workspace with Expensify Card configured.
3. Click on any card in the list to open the card details.
4. Click **View transactions** — the transactions search results page opens.
5. Click the **Workspaces** tab.
   - Expected: the tab restores **Workspace settings → Expensify Card** exactly where it was left off.
   - Before this PR: the tab resets to the top-level workspaces list.
6. Verify there are no errors in the JS console throughout the flow.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
