### PR TITLE
Expose Accounting saved searches to Auditors

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -1047,11 +1047,11 @@ function getSuggestedSearchesVisibility(
         const isPolicyEligibleForApproveSuggestion = isPaidPolicy && isEligibleForApproveSuggestion(policy.approvalMode, isUserApprover, isSubmittedTo);
         const isEligibleForExportSuggestion = isExporter && !hasExportError;
         const isEligibleForStatementsSuggestion = isPaidPolicy && !!policy.areCompanyCardsEnabled && hasCardFeed;
-        const isEligibleForUnapprovedCashSuggestion = isPaidPolicy && isAdmin && isApprovalEnabled && isPaymentEnabled;
-        const isEligibleForUnapprovedCardSuggestion = isPaidPolicy && isAdmin && isApprovalEnabled && (hasCardFeed || !!defaultExpensifyCard);
-        const isEligibleForExpensifyCardSuggestion = isPaidPolicy && isAdmin && isECardEnabled;
-        const isEligibleForReimbursementsSuggestion = isPaidPolicy && isAdmin && isPaymentEnabled && hasVBBA && hasReimburser;
         const isAuditor = policy.role === CONST.POLICY.ROLE.AUDITOR;
+        const isEligibleForUnapprovedCashSuggestion = isPaidPolicy && (isAdmin || isAuditor) && isApprovalEnabled && isPaymentEnabled;
+        const isEligibleForUnapprovedCardSuggestion = isPaidPolicy && (isAdmin || isAuditor) && isApprovalEnabled && (hasCardFeed || !!defaultExpensifyCard);
+        const isEligibleForExpensifyCardSuggestion = isPaidPolicy && (isAdmin || isAuditor) && isECardEnabled;
+        const isEligibleForReimbursementsSuggestion = isPaidPolicy && (isAdmin || isAuditor) && isPaymentEnabled && hasVBBA && hasReimburser;
         const memberCount = Object.keys(policy.employeeList ?? {}).length;
         const isEligibleForTopSpendersSuggestion = isPaidPolicy && (isAdmin || isAuditor || isUserApprover) && memberCount >= 2;
         const isEligibleForTopCategoriesSuggestion = isPaidPolicy && policy.areCategoriesEnabled === true;


### PR DESCRIPTION
### Problem

Accounting saved searches (Unapproved Cash, Unapproved Card, Expensify Card, Reconciliation/Reimbursements) were only visible to workspace Admins. Auditors already have read-only access to all workspace reports, so there is no reason to exclude them from these saved searches.

$ #89173

### Root cause

In `getSuggestedSearchesVisibility` (`src/libs/SearchUIUtils.ts`), the four accounting eligibility checks all required `isAdmin`:

```ts
const isEligibleForUnapprovedCashSuggestion = isPaidPolicy && isAdmin && ...
const isEligibleForUnapprovedCardSuggestion = isPaidPolicy && isAdmin && ...
const isEligibleForExpensifyCardSuggestion  = isPaidPolicy && isAdmin && ...
const isEligibleForReimbursementsSuggestion = isPaidPolicy && isAdmin && ...
```

Additionally, `isAuditor` was declared **after** these lines, making it unavailable at the point of use.

### Fix

Moved `const isAuditor` declaration before the eligibility checks and added `|| isAuditor` to each condition:

```ts
const isAuditor = policy.role === CONST.POLICY.ROLE.AUDITOR;
const isEligibleForUnapprovedCashSuggestion = isPaidPolicy && (isAdmin || isAuditor) && ...
const isEligibleForUnapprovedCardSuggestion = isPaidPolicy && (isAdmin || isAuditor) && ...
const isEligibleForExpensifyCardSuggestion  = isPaidPolicy && (isAdmin || isAuditor) && ...
const isEligibleForReimbursementsSuggestion = isPaidPolicy && (isAdmin || isAuditor) && ...
```

### Testing

- [ ] Verify Auditor role on a workspace sees Accounting saved searches in the Search sidebar
- [ ] Verify Admin still sees all Accounting saved searches
- [ ] Verify non-Auditor/Admin members do not see Accounting saved searches