### PR TITLE
perf: lazy-load rare-trigger global modals to shrink ManualAppStartup

### DIFF
--- a/src/GlobalModals.tsx
+++ b/src/GlobalModals.tsx
@@ -54,12 +54,6 @@ function GlobalModals() {
 
     return (
         <>
-            {shouldRenderDeferredModals && (
-                <Suspense fallback={null}>
-                    <LazyUpdateAppModal />
-                </Suspense>
-            )}
-            {/* Those below are only available to the authenticated user. */}
             <GrowlNotification ref={growlRef} />
             <DelegateNoAccessModalProvider>
                 {shouldRenderContextMenu && (
@@ -74,13 +68,19 @@ function GlobalModals() {
             {shouldRenderDeferredModals && (
                 <>
                     {/* Each modal lives in its own Suspense boundary so an unrelated chunk's load latency
-                        or failure cannot delay or suppress the others (e.g. an incoming screen-share request). */}
+                        or failure cannot delay or suppress the others (e.g. an incoming screen-share request).
+                        Order matters: BaseModal hardcodes zIndex: 1 on every modal, so DOM source order
+                        determines stacking when modals coincide. UpdateAppModal is last so the forced-update
+                        prompt sits on top if it ever overlaps with the others. */}
                     <Suspense fallback={null}>
                         {/* Proactive app review modal shown when user has completed a trigger action */}
                         <LazyProactiveAppReviewModalManager />
                     </Suspense>
                     <Suspense fallback={null}>
                         <LazyScreenShareRequestModal />
+                    </Suspense>
+                    <Suspense fallback={null}>
+                        <LazyUpdateAppModal />
                     </Suspense>
                 </>
             )}

--- a/src/GlobalModals.tsx
+++ b/src/GlobalModals.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense, useEffect, useState} from 'react';
+import React, {startTransition, Suspense, useEffect, useState} from 'react';
 import DelegateNoAccessModalProvider from './components/DelegateNoAccessModalProvider';
 import EmojiPicker from './components/EmojiPicker/EmojiPicker';
 import GrowlNotification from './components/GrowlNotification';
@@ -30,25 +30,26 @@ function GlobalModals() {
     const [shouldRenderContextMenu, setShouldRenderContextMenu] = useState(false);
     const [shouldRenderDeferredModals, setShouldRenderDeferredModals] = useState(false);
 
+    // Defer loading the context menu and rare-condition modals until after startup to avoid
+    // pulling in their dependencies (ContextMenuActions, ReportUtils, ModifiedExpenseMessage,
+    // ProactiveAppReviewModal, etc.) and their useOnyx subscriptions during the ManualAppStartup span.
     useEffect(() => {
-        // Defer loading the context menu and rare-condition modals until after startup to avoid
-        // pulling in their dependencies (ContextMenuActions, ReportUtils, ModifiedExpenseMessage,
-        // ProactiveAppReviewModal, etc.) and their useOnyx subscriptions during the ManualAppStartup span.
         const id = requestIdleCallback(
             () => {
-                setShouldRenderContextMenu(true);
-                setShouldRenderDeferredModals(true);
+                startTransition(() => {
+                    setShouldRenderContextMenu(true);
+                    setShouldRenderDeferredModals(true);
+                });
             },
             {timeout: IDLE_CALLBACK_TIMEOUT_MS},
         );
+        return () => cancelIdleCallback(id);
+    }, []);
 
-        // Allow showContextMenu() to force eager mount if the user interacts before the idle callback fires.
+    // Allow showContextMenu() to force eager mount if the user interacts before the idle callback fires.
+    useEffect(() => {
         ReportActionContextMenu.registerEnsureContextMenuMounted(() => setShouldRenderContextMenu(true));
-
-        return () => {
-            cancelIdleCallback(id);
-            ReportActionContextMenu.registerEnsureContextMenuMounted(null);
-        };
+        return () => ReportActionContextMenu.registerEnsureContextMenuMounted(null);
     }, []);
 
     return (

--- a/src/GlobalModals.tsx
+++ b/src/GlobalModals.tsx
@@ -6,10 +6,18 @@ import * as EmojiPickerAction from './libs/actions/EmojiPickerAction';
 import {growlRef} from './libs/Growl';
 import * as ReportActionContextMenu from './pages/inbox/report/ContextMenu/ReportActionContextMenu';
 
-const LazyPopoverReportActionContextMenu = React.lazy(() => import('./pages/inbox/report/ContextMenu/PopoverReportActionContextMenu'));
-const LazyUpdateAppModal = React.lazy(() => import('./components/UpdateAppModal'));
-const LazyScreenShareRequestModal = React.lazy(() => import('./components/ScreenShareRequestModal'));
-const LazyProactiveAppReviewModalManager = React.lazy(() => import('./components/ProactiveAppReviewModalManager'));
+// React.lazy with a no-op fallback if the chunk fails to load (e.g. stale cache, network blip).
+// These modals are non-critical and surface only on rare conditions, so a chunk-load failure must
+// not throw to the nearest error boundary and crash the app.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function lazyWithNullFallback<T extends React.ComponentType<any>>(factory: () => Promise<{default: T}>): React.LazyExoticComponent<T> {
+    return React.lazy(() => factory().catch(() => ({default: (() => null) as unknown as T})));
+}
+
+const LazyPopoverReportActionContextMenu = lazyWithNullFallback(() => import('./pages/inbox/report/ContextMenu/PopoverReportActionContextMenu'));
+const LazyUpdateAppModal = lazyWithNullFallback(() => import('./components/UpdateAppModal'));
+const LazyScreenShareRequestModal = lazyWithNullFallback(() => import('./components/ScreenShareRequestModal'));
+const LazyProactiveAppReviewModalManager = lazyWithNullFallback(() => import('./components/ProactiveAppReviewModalManager'));
 
 // Maximum time (ms) the context menu mount can stay deferred before requestIdleCallback forces it to run,
 // guaranteeing mount even if the main thread never becomes idle.
@@ -63,11 +71,17 @@ function GlobalModals() {
             {/* eslint-disable-next-line react-hooks/refs -- module-level createRef, safe to pass as ref prop */}
             <EmojiPicker ref={EmojiPickerAction.emojiPickerRef} />
             {shouldRenderDeferredModals && (
-                <Suspense fallback={null}>
-                    {/* Proactive app review modal shown when user has completed a trigger action */}
-                    <LazyProactiveAppReviewModalManager />
-                    <LazyScreenShareRequestModal />
-                </Suspense>
+                <>
+                    {/* Each modal lives in its own Suspense boundary so an unrelated chunk's load latency
+                        or failure cannot delay or suppress the others (e.g. an incoming screen-share request). */}
+                    <Suspense fallback={null}>
+                        {/* Proactive app review modal shown when user has completed a trigger action */}
+                        <LazyProactiveAppReviewModalManager />
+                    </Suspense>
+                    <Suspense fallback={null}>
+                        <LazyScreenShareRequestModal />
+                    </Suspense>
+                </>
             )}
         </>
     );

--- a/src/GlobalModals.tsx
+++ b/src/GlobalModals.tsx
@@ -1,11 +1,10 @@
-import React, {startTransition, Suspense, useEffect, useState} from 'react';
-import {ErrorBoundary as ReactErrorBoundary} from 'react-error-boundary';
+import React, {startTransition, useEffect, useState} from 'react';
 import DelegateNoAccessModalProvider from './components/DelegateNoAccessModalProvider';
 import EmojiPicker from './components/EmojiPicker/EmojiPicker';
 import GrowlNotification from './components/GrowlNotification';
+import LazyModalSlot from './components/LazyModalSlot';
 import * as EmojiPickerAction from './libs/actions/EmojiPickerAction';
 import {growlRef} from './libs/Growl';
-import Log from './libs/Log';
 import * as ReportActionContextMenu from './pages/inbox/report/ContextMenu/ReportActionContextMenu';
 
 const LazyPopoverReportActionContextMenu = React.lazy(() => import('./pages/inbox/report/ContextMenu/PopoverReportActionContextMenu'));
@@ -16,24 +15,6 @@ const LazyProactiveAppReviewModalManager = React.lazy(() => import('./components
 // Maximum time (ms) the context menu mount can stay deferred before requestIdleCallback forces it to run,
 // guaranteeing mount even if the main thread never becomes idle.
 const IDLE_CALLBACK_TIMEOUT_MS = 2000;
-
-const logModalChunkFailure = (error: Error, info: {componentStack?: string | null}) =>
-    Log.alert(`[GlobalModals] lazy chunk failure - ${error.message}`, {componentStack: info.componentStack ?? undefined}, false);
-
-/**
- * Wraps a lazy modal in its own ErrorBoundary + Suspense pair so a chunk-load failure
- * (or unrelated load latency) in one modal cannot tear down sibling modals or the rest of GlobalModals.
- */
-function LazyModalSlot({children}: {children: React.ReactNode}) {
-    return (
-        <ReactErrorBoundary
-            fallback={null}
-            onError={logModalChunkFailure}
-        >
-            <Suspense fallback={null}>{children}</Suspense>
-        </ReactErrorBoundary>
-    );
-}
 
 /**
  * Renders global modals and overlays that are mounted once at the top level.

--- a/src/GlobalModals.tsx
+++ b/src/GlobalModals.tsx
@@ -2,14 +2,14 @@ import React, {Suspense, useEffect, useState} from 'react';
 import DelegateNoAccessModalProvider from './components/DelegateNoAccessModalProvider';
 import EmojiPicker from './components/EmojiPicker/EmojiPicker';
 import GrowlNotification from './components/GrowlNotification';
-import ProactiveAppReviewModalManager from './components/ProactiveAppReviewModalManager';
-import ScreenShareRequestModal from './components/ScreenShareRequestModal';
-import UpdateAppModal from './components/UpdateAppModal';
 import * as EmojiPickerAction from './libs/actions/EmojiPickerAction';
 import {growlRef} from './libs/Growl';
 import * as ReportActionContextMenu from './pages/inbox/report/ContextMenu/ReportActionContextMenu';
 
 const LazyPopoverReportActionContextMenu = React.lazy(() => import('./pages/inbox/report/ContextMenu/PopoverReportActionContextMenu'));
+const LazyUpdateAppModal = React.lazy(() => import('./components/UpdateAppModal'));
+const LazyScreenShareRequestModal = React.lazy(() => import('./components/ScreenShareRequestModal'));
+const LazyProactiveAppReviewModalManager = React.lazy(() => import('./components/ProactiveAppReviewModalManager'));
 
 // Maximum time (ms) the context menu mount can stay deferred before requestIdleCallback forces it to run,
 // guaranteeing mount even if the main thread never becomes idle.
@@ -20,12 +20,19 @@ const IDLE_CALLBACK_TIMEOUT_MS = 2000;
  */
 function GlobalModals() {
     const [shouldRenderContextMenu, setShouldRenderContextMenu] = useState(false);
+    const [shouldRenderDeferredModals, setShouldRenderDeferredModals] = useState(false);
 
     useEffect(() => {
-        // Defer loading the context menu until after startup to avoid pulling in heavy
-        // dependencies (ContextMenuActions, ReportUtils, ModifiedExpenseMessage, etc.)
-        // during the ManualAppStartup span.
-        const id = requestIdleCallback(() => setShouldRenderContextMenu(true), {timeout: IDLE_CALLBACK_TIMEOUT_MS});
+        // Defer loading the context menu and rare-condition modals until after startup to avoid
+        // pulling in their dependencies (ContextMenuActions, ReportUtils, ModifiedExpenseMessage,
+        // ProactiveAppReviewModal, etc.) and their useOnyx subscriptions during the ManualAppStartup span.
+        const id = requestIdleCallback(
+            () => {
+                setShouldRenderContextMenu(true);
+                setShouldRenderDeferredModals(true);
+            },
+            {timeout: IDLE_CALLBACK_TIMEOUT_MS},
+        );
 
         // Allow showContextMenu() to force eager mount if the user interacts before the idle callback fires.
         ReportActionContextMenu.registerEnsureContextMenuMounted(() => setShouldRenderContextMenu(true));
@@ -38,7 +45,11 @@ function GlobalModals() {
 
     return (
         <>
-            <UpdateAppModal />
+            {shouldRenderDeferredModals && (
+                <Suspense fallback={null}>
+                    <LazyUpdateAppModal />
+                </Suspense>
+            )}
             {/* Those below are only available to the authenticated user. */}
             <GrowlNotification ref={growlRef} />
             <DelegateNoAccessModalProvider>
@@ -51,9 +62,13 @@ function GlobalModals() {
             </DelegateNoAccessModalProvider>
             {/* eslint-disable-next-line react-hooks/refs -- module-level createRef, safe to pass as ref prop */}
             <EmojiPicker ref={EmojiPickerAction.emojiPickerRef} />
-            {/* Proactive app review modal shown when user has completed a trigger action */}
-            <ProactiveAppReviewModalManager />
-            <ScreenShareRequestModal />
+            {shouldRenderDeferredModals && (
+                <Suspense fallback={null}>
+                    {/* Proactive app review modal shown when user has completed a trigger action */}
+                    <LazyProactiveAppReviewModalManager />
+                    <LazyScreenShareRequestModal />
+                </Suspense>
+            )}
         </>
     );
 }

--- a/src/GlobalModals.tsx
+++ b/src/GlobalModals.tsx
@@ -1,27 +1,39 @@
 import React, {startTransition, Suspense, useEffect, useState} from 'react';
+import {ErrorBoundary as ReactErrorBoundary} from 'react-error-boundary';
 import DelegateNoAccessModalProvider from './components/DelegateNoAccessModalProvider';
 import EmojiPicker from './components/EmojiPicker/EmojiPicker';
 import GrowlNotification from './components/GrowlNotification';
 import * as EmojiPickerAction from './libs/actions/EmojiPickerAction';
 import {growlRef} from './libs/Growl';
+import Log from './libs/Log';
 import * as ReportActionContextMenu from './pages/inbox/report/ContextMenu/ReportActionContextMenu';
 
-// React.lazy with a no-op fallback if the chunk fails to load (e.g. stale cache, network blip).
-// These modals are non-critical and surface only on rare conditions, so a chunk-load failure must
-// not throw to the nearest error boundary and crash the app.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function lazyWithNullFallback<T extends React.ComponentType<any>>(factory: () => Promise<{default: T}>): React.LazyExoticComponent<T> {
-    return React.lazy(() => factory().catch(() => ({default: (() => null) as unknown as T})));
-}
-
-const LazyPopoverReportActionContextMenu = lazyWithNullFallback(() => import('./pages/inbox/report/ContextMenu/PopoverReportActionContextMenu'));
-const LazyUpdateAppModal = lazyWithNullFallback(() => import('./components/UpdateAppModal'));
-const LazyScreenShareRequestModal = lazyWithNullFallback(() => import('./components/ScreenShareRequestModal'));
-const LazyProactiveAppReviewModalManager = lazyWithNullFallback(() => import('./components/ProactiveAppReviewModalManager'));
+const LazyPopoverReportActionContextMenu = React.lazy(() => import('./pages/inbox/report/ContextMenu/PopoverReportActionContextMenu'));
+const LazyUpdateAppModal = React.lazy(() => import('./components/UpdateAppModal'));
+const LazyScreenShareRequestModal = React.lazy(() => import('./components/ScreenShareRequestModal'));
+const LazyProactiveAppReviewModalManager = React.lazy(() => import('./components/ProactiveAppReviewModalManager'));
 
 // Maximum time (ms) the context menu mount can stay deferred before requestIdleCallback forces it to run,
 // guaranteeing mount even if the main thread never becomes idle.
 const IDLE_CALLBACK_TIMEOUT_MS = 2000;
+
+const logModalChunkFailure = (error: Error, info: {componentStack?: string | null}) =>
+    Log.alert(`[GlobalModals] lazy chunk failure - ${error.message}`, {componentStack: info.componentStack ?? undefined}, false);
+
+/**
+ * Wraps a lazy modal in its own ErrorBoundary + Suspense pair so a chunk-load failure
+ * (or unrelated load latency) in one modal cannot tear down sibling modals or the rest of GlobalModals.
+ */
+function LazyModalSlot({children}: {children: React.ReactNode}) {
+    return (
+        <ReactErrorBoundary
+            fallback={null}
+            onError={logModalChunkFailure}
+        >
+            <Suspense fallback={null}>{children}</Suspense>
+        </ReactErrorBoundary>
+    );
+}
 
 /**
  * Renders global modals and overlays that are mounted once at the top level.
@@ -57,31 +69,29 @@ function GlobalModals() {
             <GrowlNotification ref={growlRef} />
             <DelegateNoAccessModalProvider>
                 {shouldRenderContextMenu && (
-                    <Suspense fallback={null}>
+                    <LazyModalSlot>
                         {/* eslint-disable-next-line react-hooks/refs -- module-level createRef, safe to pass as ref prop */}
                         <LazyPopoverReportActionContextMenu ref={ReportActionContextMenu.contextMenuRef} />
-                    </Suspense>
+                    </LazyModalSlot>
                 )}
             </DelegateNoAccessModalProvider>
             {/* eslint-disable-next-line react-hooks/refs -- module-level createRef, safe to pass as ref prop */}
             <EmojiPicker ref={EmojiPickerAction.emojiPickerRef} />
             {shouldRenderDeferredModals && (
                 <>
-                    {/* Each modal lives in its own Suspense boundary so an unrelated chunk's load latency
-                        or failure cannot delay or suppress the others (e.g. an incoming screen-share request).
-                        Order matters: BaseModal hardcodes zIndex: 1 on every modal, so DOM source order
+                    {/* Order matters: BaseModal hardcodes zIndex: 1 on every modal, so DOM source order
                         determines stacking when modals coincide. UpdateAppModal is last so the forced-update
                         prompt sits on top if it ever overlaps with the others. */}
-                    <Suspense fallback={null}>
+                    <LazyModalSlot>
                         {/* Proactive app review modal shown when user has completed a trigger action */}
                         <LazyProactiveAppReviewModalManager />
-                    </Suspense>
-                    <Suspense fallback={null}>
+                    </LazyModalSlot>
+                    <LazyModalSlot>
                         <LazyScreenShareRequestModal />
-                    </Suspense>
-                    <Suspense fallback={null}>
+                    </LazyModalSlot>
+                    <LazyModalSlot>
                         <LazyUpdateAppModal />
-                    </Suspense>
+                    </LazyModalSlot>
                 </>
             )}
         </>

--- a/src/components/LazyModalSlot.tsx
+++ b/src/components/LazyModalSlot.tsx
@@ -1,0 +1,23 @@
+import React, {Suspense} from 'react';
+import {ErrorBoundary as ReactErrorBoundary} from 'react-error-boundary';
+import Log from '@libs/Log';
+
+const logModalChunkFailure = (error: Error, info: {componentStack?: string | null}) =>
+    Log.alert(`[GlobalModals] lazy chunk failure - ${error.message}`, {componentStack: info.componentStack ?? undefined}, false);
+
+/**
+ * Wraps a lazy-loaded child in its own ErrorBoundary + Suspense pair so a chunk-load failure
+ * (or unrelated load latency) in one slot cannot tear down sibling slots or surrounding components.
+ */
+function LazyModalSlot({children}: {children: React.ReactNode}) {
+    return (
+        <ReactErrorBoundary
+            fallback={null}
+            onError={logModalChunkFailure}
+        >
+            <Suspense fallback={null}>{children}</Suspense>
+        </ReactErrorBoundary>
+    );
+}
+
+export default LazyModalSlot;


### PR DESCRIPTION


<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Defer UpdateAppModal, ScreenShareRequestModal, and ProactiveAppReviewModalManager via React.lazy + requestIdleCallback so their module parse, hook execution, and useOnyx subscription registration happen after first interactive paint instead of inside the ManualAppStartup span. Reuses the existing idle callback added for the context menu so no new listener is added.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$https://github.com/Expensify/App/issues/89531
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
  1. Sign in to staging on web with a fresh cold start.                                                                                                                                                              
  2. Verify the app loads and reaches the inbox without console errors.
  3. From a Guides+ account, send a screen-share request to the test account and verify the screen-share request 
      modal appears and Accept/Decline work as expected.                                                  
  5. On a build where a forced update is required, verify the `UpdateAppModal` appears as before.                                                                                                                    
  6. Complete enough trigger actions to surface the proactive app-review prompt and verify it appears.                                                                                                               
  7. Verify no console errors appear at any point during steps 1–5.                                                                                                         
                                                                                                                                                                                                                     
  ### Offline tests                                                                                                                                                                                                  
  1. Cold start the app online, sign in, then go offline.                                                                                                                                                            
  2. Verify the lazy modal chunks were already fetched during the online idle window and the modals continue to 
       mount/render normally while offline.                                                                 
  3. Reload the app while offline and verify the app still boots into the cached UI without console errors related to the   
       lazy chunks (chunks should be served from the service-worker / HTTP cache).                
                                                                                                                                                                                                                     
  ### QA Steps                                                                                                                                                                                                       
  1. Sign in to staging on web with a fresh cold start.                                                                                                                                                              
  2. Verify the app loads and reaches the inbox without console errors.
  3. From a Guides+ account, send a screen-share request to the test account and verify the screen-share request
       modal appears and Accept/Decline work as expected.                                                  
  5. On a build where a forced update is required, verify the `UpdateAppModal` appears as before.                                                                                                                    
  6. Complete enough trigger actions to surface the proactive app-review prompt and verify it appears.                                                                                                               
  7. Verify no console errors appear at any point during steps 1–5.                                                                                                                                                  
                                                                                                                                                                                                                     
  - [x] Verify that no errors appear in the JS console  
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>