### PR TITLE
Fix issue #88942: Fix navigation after pressing Change Approver button

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -491,7 +491,15 @@ const ROUTES = {
             return `search/move-transactions/search/${encodeURIComponent(backTo)}` as const;
         },
     },
-    CHANGE_APPROVER_SEARCH_RHP: 'search/change-approver',
+    CHANGE_APPROVER_SEARCH_RHP: {
+        route: 'search/change-approver/search/:backTo?',
+        getRoute: (backTo?: string) => {
+            if (!backTo) {
+                return 'search/change-approver/search' as const;
+            }
+            return `search/change-approver/search/${encodeURIComponent(backTo)}` as const;
+        },
+    },
     CHANGE_APPROVER_ADD_APPROVER_SEARCH_RHP: 'search/change-approver/add',
 
     // This is a utility route used to go to the user's concierge chat, or the sign-in page if the user's not authenticated

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -1189,7 +1189,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 text: translate('iou.changeApprover.title'),
                 value: CONST.SEARCH.BULK_ACTION_TYPES.CHANGE_APPROVER,
                 shouldCloseModalOnSelect: true,
-                onSelected: () => Navigation.navigate(ROUTES.CHANGE_APPROVER_SEARCH_RHP),
+                onSelected: () => navigateToSearchRHP(ROUTES.CHANGE_APPROVER_SEARCH_RHP),
             });
         }
 

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -1949,7 +1949,10 @@ const config: LinkingOptions<RootNavigatorParamList>['config'] = {
                             path: ROUTES.MOVE_TRANSACTIONS_SEARCH_RHP.route,
                             exact: true,
                         },
-                        [SCREENS.SEARCH.CHANGE_APPROVER.ROOT]: ROUTES.CHANGE_APPROVER_SEARCH_RHP,
+                        [SCREENS.SEARCH.CHANGE_APPROVER.ROOT]: {
+                            path: ROUTES.CHANGE_APPROVER_SEARCH_RHP.route,
+                            exact: true,
+                        },
                         [SCREENS.SEARCH.CHANGE_APPROVER.ADD_APPROVER]: ROUTES.CHANGE_APPROVER_ADD_APPROVER_SEARCH_RHP,
                     },
                 },

--- a/src/pages/Search/SearchChangeApproverPage.tsx
+++ b/src/pages/Search/SearchChangeApproverPage.tsx
@@ -96,9 +96,10 @@ function SearchChangeApproverPage() {
     const [onyxReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: getOnyxReports});
 
     const hasAutoAppliedRef = useRef(false);
-    // True once changeApprover() has dispatched a cross-navigator hop to WORKSPACE_UPGRADE.
-    // Guards the auto-close in useLayoutEffect against firing during the upgrade round-trip,
-    // which would dismiss the RHP that should reopen on the Add Approver page after upgrade.
+    // Set when navigating to WORKSPACE_UPGRADE; prevents the auto-close from dismissing the RHP
+    // during the upgrade round-trip before it reopens on the Add Approver page.
+    // TODO: drop this ref once the CHANGE_APPROVER_SEARCH_RHP `backTo` is removed so navigation matches the regular
+    // "Change approver" flow after upgrading workspace. See https://github.com/Expensify/App/pull/89192.
     const hasInitiatedUpgradeRef = useRef(false);
     const prevSelectedReportsLength = useRef(0);
     useEffect(() => {
@@ -218,9 +219,8 @@ function SearchChangeApproverPage() {
             return;
         }
 
-        // Skip the auto-close while an upgrade round-trip is in flight: selectedReports may be
-        // transiently empty as navigation hops to WORKSPACE_UPGRADE and back, and dismissing
-        // the RHP here would close the Add Approver flow that is about to take over.
+        // Skip during an upgrade round-trip: selectedReports may be transiently empty while
+        // navigating to WORKSPACE_UPGRADE, and closing the RHP would kill the Add Approver flow.
         if (hasInitiatedUpgradeRef.current) {
             return;
         }

--- a/src/pages/Search/SearchChangeApproverPage.tsx
+++ b/src/pages/Search/SearchChangeApproverPage.tsx
@@ -137,7 +137,7 @@ function SearchChangeApproverPage() {
             if (policiesToUpgrade.length > 1) {
                 // Bulk upgrade is not supported, so show a general page to guide the user to upgrade manually
                 hasInitiatedUpgradeRef.current = true;
-                Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(undefined, undefined, ROUTES.CHANGE_APPROVER_ADD_APPROVER_SEARCH_RHP));
+                Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(undefined, undefined, ROUTES.CHANGE_APPROVER_ADD_APPROVER_SEARCH_RHP), {forceReplace: true});
                 return;
             }
             if (policiesToUpgrade.length === 1) {
@@ -148,6 +148,7 @@ function SearchChangeApproverPage() {
                         CONST.UPGRADE_FEATURE_INTRO_MAPPING.multiApprovalLevels.alias,
                         ROUTES.CHANGE_APPROVER_ADD_APPROVER_SEARCH_RHP,
                     ),
+                    {forceReplace: true},
                 );
                 return;
             }

--- a/src/pages/Search/SearchChangeApproverPage.tsx
+++ b/src/pages/Search/SearchChangeApproverPage.tsx
@@ -96,6 +96,10 @@ function SearchChangeApproverPage() {
     const [onyxReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: getOnyxReports});
 
     const hasAutoAppliedRef = useRef(false);
+    // True once changeApprover() has dispatched a cross-navigator hop to WORKSPACE_UPGRADE.
+    // Guards the auto-close in useLayoutEffect against firing during the upgrade round-trip,
+    // which would dismiss the RHP that should reopen on the Add Approver page after upgrade.
+    const hasInitiatedUpgradeRef = useRef(false);
     const prevSelectedReportsLength = useRef(0);
     useEffect(() => {
         if (!hasLoadedApp || !selectedReports.length || prevSelectedReportsLength.current === selectedReports.length) {
@@ -123,12 +127,18 @@ function SearchChangeApproverPage() {
             const policiesToUpgrade = selectedPolicies.filter((policy) => !isControlPolicy(policy));
             if (policiesToUpgrade.length > 1) {
                 // Bulk upgrade is not supported, so show a general page to guide the user to upgrade manually
-                Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(undefined, undefined, ROUTES.CHANGE_APPROVER_SEARCH_RHP));
+                hasInitiatedUpgradeRef.current = true;
+                Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(undefined, undefined, ROUTES.CHANGE_APPROVER_SEARCH_RHP.getRoute()));
                 return;
             }
             if (policiesToUpgrade.length === 1) {
+                hasInitiatedUpgradeRef.current = true;
                 Navigation.navigate(
-                    ROUTES.WORKSPACE_UPGRADE.getRoute(policiesToUpgrade.at(0)?.id, CONST.UPGRADE_FEATURE_INTRO_MAPPING.multiApprovalLevels.alias, ROUTES.CHANGE_APPROVER_SEARCH_RHP),
+                    ROUTES.WORKSPACE_UPGRADE.getRoute(
+                        policiesToUpgrade.at(0)?.id,
+                        CONST.UPGRADE_FEATURE_INTRO_MAPPING.multiApprovalLevels.alias,
+                        ROUTES.CHANGE_APPROVER_SEARCH_RHP.getRoute(),
+                    ),
                 );
                 return;
             }
@@ -205,6 +215,13 @@ function SearchChangeApproverPage() {
     // avoiding a single-frame flash of an empty list after reports are cleared.
     useLayoutEffect(() => {
         if (selectedReports.length && approverTypes.at(0)) {
+            return;
+        }
+
+        // Skip the auto-close while an upgrade round-trip is in flight: selectedReports may be
+        // transiently empty as navigation hops to WORKSPACE_UPGRADE and back, and dismissing
+        // the RHP here would close the Add Approver flow that is about to take over.
+        if (hasInitiatedUpgradeRef.current) {
             return;
         }
 

--- a/src/pages/Search/SearchChangeApproverPage.tsx
+++ b/src/pages/Search/SearchChangeApproverPage.tsx
@@ -96,8 +96,8 @@ function SearchChangeApproverPage() {
     const [onyxReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: getOnyxReports});
 
     const hasAutoAppliedRef = useRef(false);
-    // Set when navigating to WORKSPACE_UPGRADE; prevents the auto-close from dismissing the RHP
-    // during the upgrade round-trip before it reopens on the Add Approver page.
+    // Set when navigating to WORKSPACE_UPGRADE; prevents the auto-close in useLayoutEffect from
+    // dismissing the RHP if selectedReports goes transiently empty before this page unmounts
     // TODO: drop this ref once the CHANGE_APPROVER_SEARCH_RHP `backTo` is removed so navigation matches the regular
     // "Change approver" flow after upgrading workspace. See https://github.com/Expensify/App/pull/89192.
     const hasInitiatedUpgradeRef = useRef(false);
@@ -137,7 +137,7 @@ function SearchChangeApproverPage() {
             if (policiesToUpgrade.length > 1) {
                 // Bulk upgrade is not supported, so show a general page to guide the user to upgrade manually
                 hasInitiatedUpgradeRef.current = true;
-                Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(undefined, undefined, ROUTES.CHANGE_APPROVER_SEARCH_RHP.getRoute()));
+                Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(undefined, undefined, ROUTES.CHANGE_APPROVER_ADD_APPROVER_SEARCH_RHP));
                 return;
             }
             if (policiesToUpgrade.length === 1) {
@@ -146,7 +146,7 @@ function SearchChangeApproverPage() {
                     ROUTES.WORKSPACE_UPGRADE.getRoute(
                         policiesToUpgrade.at(0)?.id,
                         CONST.UPGRADE_FEATURE_INTRO_MAPPING.multiApprovalLevels.alias,
-                        ROUTES.CHANGE_APPROVER_SEARCH_RHP.getRoute(),
+                        ROUTES.CHANGE_APPROVER_ADD_APPROVER_SEARCH_RHP,
                     ),
                 );
                 return;

--- a/src/pages/Search/SearchChangeApproverPage.tsx
+++ b/src/pages/Search/SearchChangeApproverPage.tsx
@@ -104,9 +104,10 @@ function SearchChangeApproverPage() {
     const prevSelectedReportsLength = useRef(0);
 
     useEffect(() => {
-        if (selectedReports.length > 0) {
-            hasInitiatedUpgradeRef.current = false;
+        if (selectedReports.length === 0) {
+            return;
         }
+        hasInitiatedUpgradeRef.current = false;
     }, [selectedReports.length]);
 
     useEffect(() => {

--- a/src/pages/Search/SearchChangeApproverPage.tsx
+++ b/src/pages/Search/SearchChangeApproverPage.tsx
@@ -102,6 +102,13 @@ function SearchChangeApproverPage() {
     // "Change approver" flow after upgrading workspace. See https://github.com/Expensify/App/pull/89192.
     const hasInitiatedUpgradeRef = useRef(false);
     const prevSelectedReportsLength = useRef(0);
+
+    useEffect(() => {
+        if (selectedReports.length > 0) {
+            hasInitiatedUpgradeRef.current = false;
+        }
+    }, [selectedReports.length]);
+
     useEffect(() => {
         if (!hasLoadedApp || !selectedReports.length || prevSelectedReportsLength.current === selectedReports.length) {
             return;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR fixes the navigation triggered from the Change Approver bulk action in Search. The `CHANGE_APPROVER_SEARCH_RHP` route was converted from a static path into a parameterized route with an optional `backTo` (it's a temporary solution, to be improved in the future, as we're currently migrating away from `backTo`). The bulk action now opens it through `navigateToSearchRHP` so the originating Search context is preserved on the back stack. The linking config and the existing `WORKSPACE_UPGRADE` `backTo` callsites were updated to consume the new builder, ensuring the user is returned to the correct Search view after upgrading a workspace.

Additionally, a `hasInitiatedUpgradeRef` guard was added in `SearchChangeApproverPage` to prevent the auto-close useLayoutEffect from dismissing the RHP during the cross-navigator hop to `WORKSPACE_UPGRADE`. Without this guard, `selectedReports` becomes transiently empty mid-navigation and the RHP would close the `Add Approver` flow that is supposed to take over after the upgrade round-trip.

> [!IMPORTANT]
> Once the workspace  upgrade is approved ("Got it, thanks" button described in test steps), the user will follow the same flow as each subsequent time they click "Change approver" button. Previously (currently on prod), the navigation differed, leading to screen previous to "Add approver", which is now visible immediately. This behaviour is to be fixed in the follow-up PR with getting rid of added `backTo`

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88942

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to the new workspace chat.
2. Create two expenses.
3. Open the report.
4. Bulk select both expenses via checkbox.
5. Click dropdown button > Move to report > New report.
6. Close the RHP.
7. Open the new report from Step 5.
8. Click Submit.
9. Open any expense.
10. Click report link in "moved this expense from" message.
11. Go to Spend > All reports.
12. Select the outstanding report from Step 7 via checkbox.
13. Click dropdown button > Change approver.
14. Verify approver RHP opens and you're NOT navigated to the inbox All expenses.
15. Notice [add approver screen opens once](https://github.com/Expensify/App/pull/88991#issuecomment-4334861456) after upgrading the workspace and then accepting the effect via "Got it, thanks" button
16. Notice [report/expense from Spend Flow opens normally](https://github.com/Expensify/App/pull/88991#issuecomment-4333390727)

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


**After changes:**

https://github.com/user-attachments/assets/624b7805-2e0a-4bfc-a9a7-7b0b8ff81e98

---

**On prod:**

https://github.com/user-attachments/assets/815541d4-2f15-491e-ab42-d13d4bd9a7d5

</details>