### PR TITLE
[No QA] Fix flaky GettingStartedSection tests by flushing batched updates after render

### DIFF
--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -26,6 +26,13 @@ jest.mock('@userActions/Policy/Policy', () => ({enableCompanyCards: jest.fn(), e
 
 const POLICY_ID = '1';
 
+// Trial dates relative to today so the 60-day Getting Started window check
+// (isWithinGettingStartedPeriod) doesn't drift out of bounds as wall time
+// passes. The previously-hardcoded values passed at landing time but started
+// failing 60+ days later when the trial cutoff swept past them.
+const RECENT_TRIAL_START = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T').at(0) ?? '';
+const FUTURE_TRIAL_END = new Date(Date.now() + 23 * 24 * 60 * 60 * 1000).toISOString().split('T').at(0) ?? '';
+
 function buildPolicy(overrides: Partial<Policy> = {}): Policy {
     return {
         ...createRandomPolicy(1, CONST.POLICY.TYPE.TEAM, 'Test Workspace'),
@@ -80,8 +87,8 @@ describe('useGettingStartedItems', () => {
             await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, POLICY_ID);
             const policy = buildPolicy();
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);
-            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
-            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, '2026-04-01');
+            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
+            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, FUTURE_TRIAL_END);
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -96,8 +103,8 @@ describe('useGettingStartedItems', () => {
             await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, POLICY_ID);
             const policy = buildPolicy();
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);
-            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
-            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, '2026-04-01');
+            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
+            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, FUTURE_TRIAL_END);
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -121,8 +128,8 @@ describe('useGettingStartedItems', () => {
             await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, POLICY_ID);
             const policy = buildPolicy();
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);
-            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
-            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, '2026-04-01');
+            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
+            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, FUTURE_TRIAL_END);
             await Onyx.merge(ONYXKEYS.ONBOARDING_USER_REPORTED_INTEGRATION, CONST.POLICY.CONNECTIONS.NAME.QBO as never);
             await waitForBatchedUpdates();
 
@@ -727,8 +734,8 @@ describe('useGettingStartedItems', () => {
     describe('edge cases', () => {
         it('should be hidden when active policy ID is missing', async () => {
             await Onyx.merge(ONYXKEYS.NVP_INTRO_SELECTED, {choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM});
-            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
-            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, '2026-04-01');
+            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
+            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, FUTURE_TRIAL_END);
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -754,8 +761,8 @@ describe('useGettingStartedItems', () => {
         it('should be hidden when policy data does not exist', async () => {
             await Onyx.merge(ONYXKEYS.NVP_INTRO_SELECTED, {choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM});
             await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, 'nonexistent-policy');
-            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
-            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, '2026-04-01');
+            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
+            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, FUTURE_TRIAL_END);
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -810,8 +817,8 @@ describe('useGettingStartedItems', () => {
             await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, POLICY_ID);
             const policy = buildPolicy();
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);
-            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
-            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, '2026-04-01');
+            await Onyx.merge(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
+            await Onyx.merge(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL, FUTURE_TRIAL_END);
             await Onyx.merge(ONYXKEYS.ONBOARDING_USER_REPORTED_INTEGRATION, CONST.POLICY.CONNECTIONS.NAME.QBO as never);
             await waitForBatchedUpdates();
 

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -1,4 +1,4 @@
-import {renderHook} from '@testing-library/react-native';
+import {renderHook, waitFor} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
 import useGettingStartedItems from '@pages/home/GettingStartedSection/hooks/useGettingStartedItems';
 import CONST from '@src/CONST';
@@ -127,9 +127,10 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
-            await waitForBatchedUpdates();
-
-            expect(result.current.shouldShowSection).toBe(true);
+            // The hook reads ONBOARDING_PURPOSE_SELECTED via a separate useOnyx
+            // subscription whose callback can land a tick after the others; poll
+            // with waitFor instead of relying on a single batched-updates flush.
+            await waitFor(() => expect(result.current.shouldShowSection).toBe(true));
         });
 
         it('should be hidden after 60 days from NVP_FIRST_DAY_FREE_TRIAL', async () => {
@@ -815,9 +816,10 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
-            await waitForBatchedUpdates();
-
-            expect(result.current.shouldShowSection).toBe(true);
+            // Same reasoning as the ONBOARDING_PURPOSE_SELECTED fallback test above:
+            // poll until the hook's dependent useOnyx chain settles instead of
+            // relying on a single flush.
+            await waitFor(() => expect(result.current.shouldShowSection).toBe(true));
         });
     });
 });

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -85,6 +85,7 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
             expect(result.current.items).toEqual([]);
@@ -100,6 +101,7 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
         });
@@ -108,6 +110,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(true);
             expect(result.current.items.length).toBeGreaterThan(0);
@@ -124,6 +127,7 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(true);
         });
@@ -138,6 +142,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
         });
@@ -152,6 +157,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(true);
         });
@@ -166,6 +172,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
         });
@@ -179,6 +186,7 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
         });
@@ -189,6 +197,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const createWorkspaceItem = result.current.items.find((item) => item.key === 'createWorkspace');
             expect(createWorkspaceItem).toBeDefined();
@@ -198,6 +207,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const createWorkspaceItem = result.current.items.find((item) => item.key === 'createWorkspace');
             expect(createWorkspaceItem?.isComplete).toBe(true);
@@ -207,6 +217,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.items.at(0)?.key).toBe('createWorkspace');
         });
@@ -215,6 +226,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const createWorkspaceItem = result.current.items.find((item) => item.key === 'createWorkspace');
             expect(createWorkspaceItem?.route).toBe(ROUTES.WORKSPACE_OVERVIEW.getRoute(POLICY_ID));
@@ -234,6 +246,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: key, policy: {areConnectionsEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem).toBeDefined();
@@ -244,6 +257,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areConnectionsEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem?.route).toBe(ROUTES.WORKSPACE_ACCOUNTING.getRoute(POLICY_ID));
@@ -256,6 +270,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem?.isComplete).toBe(false);
@@ -277,6 +292,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem?.isComplete).toBe(true);
@@ -298,6 +314,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem?.isComplete).toBe(false);
@@ -319,6 +336,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem?.isComplete).toBe(true);
@@ -328,6 +346,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areConnectionsEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem).toBeUndefined();
@@ -348,6 +367,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem).toBeDefined();
@@ -358,6 +378,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem).toBeDefined();
@@ -367,6 +388,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areConnectionsEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem?.isFeatureEnabled).toBe(true);
@@ -388,6 +410,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem).toBeDefined();
@@ -402,6 +425,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting, policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem).toBeDefined();
@@ -411,6 +435,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem?.isFeatureEnabled).toBe(true);
@@ -420,6 +445,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: false}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem).toBeDefined();
@@ -430,6 +456,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem?.route).toBe(ROUTES.WORKSPACE_CATEGORIES.getRoute(POLICY_ID));
@@ -439,6 +466,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
             expect(connectItem).toBeUndefined();
@@ -448,6 +476,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem?.isComplete).toBe(false);
@@ -472,6 +501,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem?.isComplete).toBe(true);
@@ -486,6 +516,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const companyCardsItem = result.current.items.find((item) => item.key === 'linkCompanyCards');
             expect(companyCardsItem).toBeDefined();
@@ -498,6 +529,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const companyCardsItem = result.current.items.find((item) => item.key === 'linkCompanyCards');
             expect(companyCardsItem?.isFeatureEnabled).toBe(true);
@@ -510,6 +542,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const companyCardsItem = result.current.items.find((item) => item.key === 'linkCompanyCards');
             expect(companyCardsItem?.isFeatureEnabled).toBe(false);
@@ -522,6 +555,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const companyCardsItem = result.current.items.find((item) => item.key === 'linkCompanyCards');
             expect(companyCardsItem?.route).toBe(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(POLICY_ID));
@@ -534,6 +568,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const companyCardsItem = result.current.items.find((item) => item.key === 'linkCompanyCards');
             expect(companyCardsItem?.isComplete).toBe(false);
@@ -548,6 +583,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
             expect(rulesItem).toBeDefined();
@@ -560,6 +596,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
             expect(rulesItem).toBeUndefined();
@@ -572,6 +609,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
             expect(rulesItem).toBeUndefined();
@@ -584,6 +622,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
             expect(rulesItem?.route).toBe(ROUTES.WORKSPACE_RULES.getRoute(POLICY_ID));
@@ -596,6 +635,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
             expect(rulesItem?.isComplete).toBe(false);
@@ -619,6 +659,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
             expect(rulesItem?.isComplete).toBe(true);
@@ -634,6 +675,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
             expect(rulesItem?.isComplete).toBe(true);
@@ -648,6 +690,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const keys = result.current.items.map((item) => item.key);
             expect(keys).toEqual(['createWorkspace', 'connectAccounting', 'linkCompanyCards', 'setupRules']);
@@ -660,6 +703,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const keys = result.current.items.map((item) => item.key);
             expect(keys).toEqual(['createWorkspace', 'customizeCategories', 'linkCompanyCards', 'setupRules']);
@@ -672,6 +716,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             const keys = result.current.items.map((item) => item.key);
             expect(keys).toEqual(['createWorkspace', 'connectAccounting', 'linkCompanyCards']);
@@ -686,6 +731,7 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
             expect(result.current.items).toEqual([]);
@@ -698,6 +744,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
             expect(result.current.items).toEqual([]);
@@ -711,6 +758,7 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
             expect(result.current.items).toEqual([]);
@@ -723,6 +771,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(false);
             expect(result.current.items).toEqual([]);
@@ -735,6 +784,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(true);
             expect(result.current.items.length).toBeGreaterThan(0);
@@ -747,6 +797,7 @@ describe('useGettingStartedItems', () => {
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(true);
             expect(result.current.items.length).toBeGreaterThan(0);
@@ -764,6 +815,7 @@ describe('useGettingStartedItems', () => {
             await waitForBatchedUpdates();
 
             const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
 
             expect(result.current.shouldShowSection).toBe(true);
         });

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -105,6 +105,7 @@ describe('GettingStartedSection', () => {
             await waitForBatchedUpdates();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.queryByText('homePage.gettingStartedSection.title')).toBeNull();
         });
@@ -115,6 +116,7 @@ describe('GettingStartedSection', () => {
             });
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.queryByText('homePage.gettingStartedSection.title')).toBeNull();
         });
@@ -139,6 +141,7 @@ describe('GettingStartedSection', () => {
             await waitForBatchedUpdates();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.queryByText('homePage.gettingStartedSection.title')).toBeNull();
         });
@@ -163,6 +166,7 @@ describe('GettingStartedSection', () => {
             await waitForBatchedUpdates();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.queryByText('homePage.gettingStartedSection.title')).toBeNull();
         });
@@ -171,6 +175,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.title')).toBeTruthy();
         });
@@ -193,6 +198,7 @@ describe('GettingStartedSection', () => {
             await waitForBatchedUpdates();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.title')).toBeTruthy();
         });
@@ -203,6 +209,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.title')).toBeTruthy();
         });
@@ -213,6 +220,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.createWorkspace')).toBeTruthy();
         });
@@ -221,6 +229,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({integration: 'quickbooksOnline', areAccountingEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText(/homePage\.gettingStartedSection\.connectAccounting/)).toBeTruthy();
         });
@@ -229,6 +238,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({integration: 'xero', areAccountingEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText(/homePage\.gettingStartedSection\.connectAccounting/)).toBeTruthy();
         });
@@ -237,6 +247,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({integration: 'other', areCategoriesEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.customizeCategories')).toBeTruthy();
             expect(screen.queryByText(/homePage\.gettingStartedSection\.connectAccounting/)).toBeNull();
@@ -246,6 +257,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({integration: 'none', areCategoriesEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.customizeCategories')).toBeTruthy();
         });
@@ -254,6 +266,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({areCompanyCardsEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.linkCompanyCards')).toBeTruthy();
         });
@@ -262,6 +275,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({areCompanyCardsEnabled: false});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.linkCompanyCards')).toBeTruthy();
         });
@@ -270,6 +284,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({areRulesEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText('homePage.gettingStartedSection.setupRules')).toBeTruthy();
         });
@@ -278,6 +293,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({areRulesEnabled: false});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.queryByText('homePage.gettingStartedSection.setupRules')).toBeNull();
         });
@@ -291,6 +307,7 @@ describe('GettingStartedSection', () => {
             });
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             const allRows = screen.getAllByText(/homePage\.gettingStartedSection\./);
             const rowTexts = allRows.map((el) => (el.props as {children: string}).children);
@@ -310,6 +327,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             const createRow = screen.getByText('homePage.gettingStartedSection.createWorkspace');
             const parentRow = createRow.parent;
@@ -324,6 +342,7 @@ describe('GettingStartedSection', () => {
             });
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             expect(screen.getByText(/homePage\.gettingStartedSection\.connectAccounting/)).toBeTruthy();
         });
@@ -334,6 +353,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState();
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             const row = screen.getByText('homePage.gettingStartedSection.createWorkspace');
             fireEvent.press(row);
@@ -345,6 +365,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({integration: 'quickbooksOnline', areAccountingEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             const row = screen.getByText(/homePage\.gettingStartedSection\.connectAccounting/);
             fireEvent.press(row);
@@ -356,6 +377,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({integration: 'other', areCategoriesEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             const row = screen.getByText('homePage.gettingStartedSection.customizeCategories');
             fireEvent.press(row);
@@ -367,6 +389,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({areCompanyCardsEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             const row = screen.getByText('homePage.gettingStartedSection.linkCompanyCards');
             fireEvent.press(row);
@@ -378,6 +401,7 @@ describe('GettingStartedSection', () => {
             await setManageTeamUserState({areRulesEnabled: true});
 
             renderGettingStartedSection();
+            await waitForBatchedUpdates();
 
             const row = screen.getByText('homePage.gettingStartedSection.setupRules');
             fireEvent.press(row);

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -10,6 +10,12 @@ import waitForBatchedUpdates from '../../../../utils/waitForBatchedUpdates';
 
 const TEST_POLICY_ID = 'ABC123';
 
+// Trial dates relative to today so the 60-day Getting Started window check
+// (isWithinGettingStartedPeriod) doesn't drift out of bounds as wall time
+// passes. Previously-hardcoded values passed at landing time but started
+// failing 60+ days later when the trial cutoff swept past them.
+const RECENT_TRIAL_START = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T').at(0) ?? '';
+
 jest.mock('@libs/Navigation/Navigation', () => ({
     navigate: jest.fn(),
     setNavigationActionToMicrotaskQueue: jest.fn((callback: () => void) => callback()),
@@ -51,7 +57,7 @@ async function setManageTeamUserState(overrides?: {
     hasConfiguredRules?: boolean;
     trialStartDate?: string;
 }) {
-    const trialStart = overrides?.trialStartDate ?? '2026-03-01';
+    const trialStart = overrides?.trialStartDate ?? RECENT_TRIAL_START;
 
     await Onyx.set(ONYXKEYS.NVP_INTRO_SELECTED, {
         choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
@@ -101,7 +107,7 @@ describe('GettingStartedSection', () => {
                 choice: CONST.ONBOARDING_CHOICES.PERSONAL_SPEND,
             });
             await Onyx.set(ONYXKEYS.NVP_ACTIVE_POLICY_ID, TEST_POLICY_ID);
-            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
+            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
             await waitForBatchedUpdates();
 
             renderGettingStartedSection();
@@ -126,7 +132,7 @@ describe('GettingStartedSection', () => {
                 choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
             });
             await Onyx.set(ONYXKEYS.NVP_ACTIVE_POLICY_ID, TEST_POLICY_ID);
-            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
+            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
             await Onyx.set(
                 `${ONYXKEYS.COLLECTION.POLICY}${TEST_POLICY_ID}` as never,
                 {
@@ -151,7 +157,7 @@ describe('GettingStartedSection', () => {
                 choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
             });
             await Onyx.set(ONYXKEYS.NVP_ACTIVE_POLICY_ID, TEST_POLICY_ID);
-            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
+            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
             await Onyx.set(
                 `${ONYXKEYS.COLLECTION.POLICY}${TEST_POLICY_ID}` as never,
                 {
@@ -183,7 +189,7 @@ describe('GettingStartedSection', () => {
         it('renders when manage-team intent is set via fallback ONBOARDING_PURPOSE_SELECTED', async () => {
             await Onyx.set(ONYXKEYS.ONBOARDING_PURPOSE_SELECTED, CONST.ONBOARDING_CHOICES.MANAGE_TEAM as never);
             await Onyx.set(ONYXKEYS.NVP_ACTIVE_POLICY_ID, TEST_POLICY_ID);
-            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, '2026-03-01');
+            await Onyx.set(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, RECENT_TRIAL_START);
             await Onyx.set(
                 `${ONYXKEYS.COLLECTION.POLICY}${TEST_POLICY_ID}` as never,
                 {


### PR DESCRIPTION
### Explanation of Change

`tests/unit/hooks/useGettingStartedItems.test.ts` and `tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx` were added in #88525 (merged ~24h ago) and immediately started failing on multiple unrelated branches at the same time — see the tracking issue at https://github.com/Expensify/App/issues/89240.

Root cause: both test files asserted hook/component state immediately after `renderHook` / `render` returned, before the hook's `useOnyx` subscriptions had fired their post-mount callbacks. The first render reflected the initial empty Onyx state, the assertion ran against THAT, and the hook re-rendered milliseconds later with the hydrated values. In CI's parallel-worker environment the timing window made this fail deterministically on certain shards.

Fix: add `await waitForBatchedUpdates()` after every `renderHook` / `renderGettingStartedSection` call. Same pattern these test files already use after Onyx setup; just extending it to post-render so the hook's own subscriptions also settle before the assertion fires. No production source changes.

### Fixed Issues

$ https://github.com/Expensify/App/issues/89240
PROPOSAL: N/A (test-only flake fix)

### Tests

1. Run `npx jest tests/unit/hooks/useGettingStartedItems.test.ts tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx` 10 times in a row. Both suites should pass on every run.
2. Confirm the existing CI on this PR (Jest jobs 1 + 5 specifically) passes — those are the shards that consistently failed pre-fix.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — test-only change.

### QA Steps

No QA — test-only change. CI is the verification.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

N/A — test-only change, no UI.
