### PR TITLE
Fix doubled OpenApp on delegate (copilot) account switch

### DIFF
--- a/src/libs/NetworkState.ts
+++ b/src/libs/NetworkState.ts
@@ -273,6 +273,12 @@ function configureAndSubscribe() {
         unsubscribeNetInfo = null;
     }
 
+    // Reset to the same "fresh subscription" state as boot. The listener's `prev !== undefined`
+    // guard then blocks the synthetic null→true transition that NetInfo emits while reconfiguring
+    // (which would otherwise look like a recovery and fire a duplicate openApp/reconnectApp,
+    // e.g. on accountID change for a delegate switch).
+    prevIsInternetReachable = undefined;
+
     if (!CONFIG.IS_USING_LOCAL_WEB) {
         NetInfo.configure({
             reachabilityUrl: `${CONFIG.EXPENSIFY.DEFAULT_API_ROOT}api/Ping?accountID=${accountID ?? 'unknown'}`,
@@ -309,16 +315,21 @@ function configureAndSubscribe() {
             setInternetUnreachable(true);
         }
 
-        // Treat false→true and null→true as genuine recovery. Both mean NetInfo previously
-        // lost reachability (false = confirmed unreachable, null = lost track during outage)
-        // and has now confirmed it's back. Only block undefined→true — that's the initial
-        // NetInfo event on subscribe which delivers current state, not a recovery. Firing
-        // onReachabilityRestored() on boot would duplicate openApp()/reconnectApp().
+        // Treat false→true as genuine recovery (NetInfo previously confirmed unreachable, now
+        // confirmed back), and null→true when prev was explicitly reset to null by debug-tool
+        // toggles (setForceOffline / setFailAllRequests / simulatePoorConnection) that need to
+        // force a recovery on the next definitive state. Block undefined→true — that's the
+        // first event on a fresh subscription, not a recovery.
         if (!shouldForceOffline && state.isInternetReachable === true && prevIsInternetReachable !== true && prevIsInternetReachable !== undefined) {
             Log.info(`[NetworkState] Internet reachability restored (${prevIsInternetReachable}→true)`);
             onReachabilityRestored();
         }
-        prevIsInternetReachable = state.isInternetReachable;
+        // Only track definitive reachable/unreachable states. Ignoring null/undefined keeps the
+        // synthetic true→null→true sequence NetInfo emits during reconfigure from looking like a
+        // recovery transition (and lets configureAndSubscribe's `prev = undefined` reset stick).
+        if (state.isInternetReachable === true || state.isInternetReachable === false) {
+            prevIsInternetReachable = state.isInternetReachable;
+        }
     });
 }
 

--- a/src/libs/NetworkState.ts
+++ b/src/libs/NetworkState.ts
@@ -20,6 +20,7 @@ let unsubscribeNetInfo: (() => void) | null = null;
 let prevIsInternetReachable: boolean | null | undefined;
 let isPoorConnectionSimulated: boolean | undefined;
 let networkTimeSkew = 0;
+let suppressNextReachabilityRestored = false;
 
 // Subscriber sets
 const listeners = new Set<() => void>();
@@ -268,16 +269,20 @@ function setRandomNetworkStatus(initialCall = false) {
  * Must unsubscribe before calling configure() — configure tears down NetInfo internal state.
  */
 function configureAndSubscribe() {
+    // Treat this as a reconfigure (not an initial subscription) when there's already a listener.
+    // Reconfigure tears down NetInfo internal state, so the new subscription emits a synthetic
+    // null→true transition that would look like a recovery — suppress the next would-be recovery
+    // until reachability settles. Initial subscription is left untouched so boot behavior is
+    // unchanged (prev=undefined boot guard already covers it).
+    const isReconfigure = unsubscribeNetInfo !== null;
     if (unsubscribeNetInfo) {
         unsubscribeNetInfo();
         unsubscribeNetInfo = null;
     }
 
-    // Reset to the same "fresh subscription" state as boot. The listener's `prev !== undefined`
-    // guard then blocks the synthetic null→true transition that NetInfo emits while reconfiguring
-    // (which would otherwise look like a recovery and fire a duplicate openApp/reconnectApp,
-    // e.g. on accountID change for a delegate switch).
-    prevIsInternetReachable = undefined;
+    if (isReconfigure) {
+        suppressNextReachabilityRestored = true;
+    }
 
     if (!CONFIG.IS_USING_LOCAL_WEB) {
         NetInfo.configure({
@@ -315,21 +320,25 @@ function configureAndSubscribe() {
             setInternetUnreachable(true);
         }
 
-        // Treat false→true as genuine recovery (NetInfo previously confirmed unreachable, now
-        // confirmed back), and null→true when prev was explicitly reset to null by debug-tool
-        // toggles (setForceOffline / setFailAllRequests / simulatePoorConnection) that need to
-        // force a recovery on the next definitive state. Block undefined→true — that's the
-        // first event on a fresh subscription, not a recovery.
+        // Treat false→true and null→true as genuine recovery. Both mean NetInfo previously
+        // lost reachability (false = confirmed unreachable, null = lost track during outage)
+        // and has now confirmed it's back. Only block undefined→true — that's the initial
+        // NetInfo event on subscribe which delivers current state, not a recovery. Firing
+        // onReachabilityRestored() on boot would duplicate openApp()/reconnectApp().
         if (!shouldForceOffline && state.isInternetReachable === true && prevIsInternetReachable !== true && prevIsInternetReachable !== undefined) {
-            Log.info(`[NetworkState] Internet reachability restored (${prevIsInternetReachable}→true)`);
-            onReachabilityRestored();
+            if (suppressNextReachabilityRestored) {
+                Log.info(`[NetworkState] Suppressing recovery on first stable state after reconfigure (${prevIsInternetReachable}→true)`);
+            } else {
+                Log.info(`[NetworkState] Internet reachability restored (${prevIsInternetReachable}→true)`);
+                onReachabilityRestored();
+            }
         }
-        // Only track definitive reachable/unreachable states. Ignoring null/undefined keeps the
-        // synthetic true→null→true sequence NetInfo emits during reconfigure from looking like a
-        // recovery transition (and lets configureAndSubscribe's `prev = undefined` reset stick).
+        // End the post-reconfigure suppression window once reachability settles into a definitive
+        // state. Null/undefined are transient and should not end the window.
         if (state.isInternetReachable === true || state.isInternetReachable === false) {
-            prevIsInternetReachable = state.isInternetReachable;
+            suppressNextReachabilityRestored = false;
         }
+        prevIsInternetReachable = state.isInternetReachable;
     });
 }
 

--- a/src/libs/NetworkState.ts
+++ b/src/libs/NetworkState.ts
@@ -274,13 +274,16 @@ function configureAndSubscribe() {
     // null→true transition that would look like a recovery — suppress the next would-be recovery
     // until reachability settles. Initial subscription is left untouched so boot behavior is
     // unchanged (prev=undefined boot guard already covers it).
+    // Skip suppression when prev was already false: the app was genuinely offline before
+    // reconfigure, so the next true is a real recovery we must not drop (otherwise
+    // internetUnreachable stays set and the app is stuck offline until a new outage cycle).
     const isReconfigure = unsubscribeNetInfo !== null;
     if (unsubscribeNetInfo) {
         unsubscribeNetInfo();
         unsubscribeNetInfo = null;
     }
 
-    if (isReconfigure) {
+    if (isReconfigure && prevIsInternetReachable !== false) {
         suppressNextReachabilityRestored = true;
     }
 

--- a/src/libs/actions/Delegate.ts
+++ b/src/libs/actions/Delegate.ts
@@ -41,6 +41,17 @@ const KEYS_TO_PRESERVE_DELEGATE_ACCESS = [
     ONYXKEYS.COLLECTION.DEVICE_BIOMETRICS,
 ];
 
+/**
+ * Atomically reset Onyx for a delegate-access transition while keeping IS_LOADING_APP=true
+ * so consumers never observe the post-clear state with HAS_LOADED_APP=true and
+ * IS_LOADING_APP=undefined. That combination falsely looks like a stuck app and triggers
+ * DelegateAccessHandler's recovery effect, producing a duplicate openApp queued behind the
+ * explicit openApp the caller is about to make.
+ */
+function clearOnyxForDelegateTransition(): Promise<void> {
+    return Onyx.merge(ONYXKEYS.IS_LOADING_APP, true).then(() => Onyx.clear([...KEYS_TO_PRESERVE_DELEGATE_ACCESS, ONYXKEYS.IS_LOADING_APP]));
+}
+
 type WithDelegatedAccess = {
     // Optional keeps call sites clean, but still encourages passing `account?.delegatedAccess`.
     delegatedAccess: DelegatedAccess | undefined;
@@ -195,7 +206,7 @@ function connect({email, delegatedAccess, credentials, session, activePolicyID, 
                 })
                 .then(() => {
                     NetworkStore.setAuthToken(response?.restrictedToken ?? null);
-                    return Onyx.clear(KEYS_TO_PRESERVE_DELEGATE_ACCESS);
+                    return clearOnyxForDelegateTransition();
                 })
                 .then(() => {
                     confirmReadyToOpenApp();
@@ -294,7 +305,7 @@ function disconnect({stashedCredentials, stashedSession}: DisconnectParams) {
                 })
                 .then(() => {
                     NetworkStore.setAuthToken(response?.authToken ?? null);
-                    return Onyx.clear(KEYS_TO_PRESERVE_DELEGATE_ACCESS);
+                    return clearOnyxForDelegateTransition();
                 })
                 .then(() => {
                     Onyx.set(ONYXKEYS.CREDENTIALS, {
@@ -663,7 +674,7 @@ function updateDelegateRole({email, role, validateCode, delegatedAccess}: Update
 }
 
 function restoreDelegateSession<TKey extends OnyxKey>(authenticateResponse: Response<TKey>) {
-    Onyx.clear(KEYS_TO_PRESERVE_DELEGATE_ACCESS).then(() => {
+    clearOnyxForDelegateTransition().then(() => {
         updateSessionAuthTokens(authenticateResponse?.authToken, authenticateResponse?.encryptedAuthToken);
         updateSessionUser(authenticateResponse?.accountID, authenticateResponse?.email);
 
@@ -690,5 +701,6 @@ export {
     updateDelegateRole,
     removeDelegate,
     openSecuritySettingsPage,
+    clearOnyxForDelegateTransition,
     KEYS_TO_PRESERVE_DELEGATE_ACCESS,
 };

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -51,7 +51,7 @@ import Timers from '@libs/Timers';
 import {hideContextMenu} from '@pages/inbox/report/ContextMenu/ReportActionContextMenu';
 import {confirmReadyToOpenApp, KEYS_TO_PRESERVE, openApp} from '@userActions/App';
 import {clearCachedAttachments} from '@userActions/Attachment';
-import {KEYS_TO_PRESERVE_DELEGATE_ACCESS} from '@userActions/Delegate';
+import {clearOnyxForDelegateTransition} from '@userActions/Delegate';
 import * as Device from '@userActions/Device';
 import type HybridAppSettings from '@userActions/HybridApp/types';
 import {close} from '@userActions/Modal';
@@ -718,7 +718,7 @@ function setupNewDotAfterTransitionFromOldDot(hybridAppSettings: HybridAppSettin
             }
 
             Log.info('[HybridApp] User switched account on OldDot side. Clearing onyx and applying delegate data');
-            return Onyx.clear(KEYS_TO_PRESERVE_DELEGATE_ACCESS)
+            return clearOnyxForDelegateTransition()
                 .then(() =>
                     Onyx.multiSet({
                         ...stashedData,

--- a/tests/actions/DelegateTest.ts
+++ b/tests/actions/DelegateTest.ts
@@ -1,5 +1,13 @@
 import Onyx from 'react-native-onyx';
-import {addDelegate, clearDelegateErrorsByField, clearDelegatorErrors, isConnectedAsDelegate, removeDelegate, updateDelegateRole} from '@libs/actions/Delegate';
+import {
+    addDelegate,
+    clearDelegateErrorsByField,
+    clearDelegatorErrors,
+    clearOnyxForDelegateTransition,
+    isConnectedAsDelegate,
+    removeDelegate,
+    updateDelegateRole,
+} from '@libs/actions/Delegate';
 import {pause, resetQueue} from '@libs/Network/SequentialQueue';
 import CONST from '@src/CONST';
 import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
@@ -230,6 +238,56 @@ describe('actions/Delegate', () => {
                     callback: (account) => {
                         expect(isConnectedAsDelegate({delegatedAccess: account?.delegatedAccess})).toBe(false);
                         Onyx.disconnect(connection);
+                        resolve();
+                    },
+                });
+            });
+        });
+    });
+
+    describe('clearOnyxForDelegateTransition', () => {
+        it('keeps IS_LOADING_APP=true after the clear so DelegateAccessHandler does not see HAS_LOADED_APP=true && IS_LOADING_APP=undefined and fire a duplicate openApp', async () => {
+            // Simulate the pre-switch state: app is fully loaded with the previous account.
+            await Onyx.multiSet({
+                [ONYXKEYS.HAS_LOADED_APP]: true,
+                [ONYXKEYS.IS_LOADING_APP]: false,
+                [ONYXKEYS.NVP_PRIORITY_MODE]: CONST.PRIORITY_MODE.DEFAULT,
+            });
+            await waitForBatchedUpdates();
+
+            await clearOnyxForDelegateTransition();
+            await waitForBatchedUpdates();
+
+            await new Promise<void>((resolve) => {
+                const conn = Onyx.connect({
+                    key: ONYXKEYS.IS_LOADING_APP,
+                    callback: (value) => {
+                        expect(value).toBe(true);
+                        Onyx.disconnect(conn);
+                        resolve();
+                    },
+                });
+            });
+
+            // HAS_LOADED_APP is in the preserve list and should remain true.
+            await new Promise<void>((resolve) => {
+                const conn = Onyx.connect({
+                    key: ONYXKEYS.HAS_LOADED_APP,
+                    callback: (value) => {
+                        expect(value).toBe(true);
+                        Onyx.disconnect(conn);
+                        resolve();
+                    },
+                });
+            });
+
+            // A non-preserved key should have been cleared.
+            await new Promise<void>((resolve) => {
+                const conn = Onyx.connect({
+                    key: ONYXKEYS.NVP_PRIORITY_MODE,
+                    callback: (value) => {
+                        expect(value).toBeUndefined();
+                        Onyx.disconnect(conn);
                         resolve();
                     },
                 });

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -112,31 +112,15 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
         expect(reconnectListener).toHaveBeenCalledTimes(1);
     });
 
-    test('null→true on a fresh subscription does NOT fire reconnect listener', () => {
+    test('null→true fires reconnect listener', () => {
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);
 
-        // After a fresh subscription, the first events deliver current state. NetInfo may
-        // emit null first while the initial Ping is in flight, then true once it completes.
-        // This is not a recovery — only false→true (or an explicit prev=null reset) is.
+        // Simulate losing reachability tracking (null) then recovering
         fireNetInfoState({isInternetReachable: null});
         fireNetInfoState({isInternetReachable: true});
 
-        expect(reconnectListener).not.toHaveBeenCalled();
-    });
-
-    test('true→null→true does NOT fire reconnect listener (transient state, no confirmed offline)', () => {
-        const reconnectListener = jest.fn();
-        onReachabilityConfirmed(reconnectListener);
-
-        // Establish a baseline reachable state
-        fireNetInfoState({isInternetReachable: true});
-        // NetInfo briefly loses track without confirming offline (e.g. during a poll gap)
-        fireNetInfoState({isInternetReachable: null});
-        // Reachability comes back. Since we never went through false, this is not a recovery.
-        fireNetInfoState({isInternetReachable: true});
-
-        expect(reconnectListener).not.toHaveBeenCalled();
+        expect(reconnectListener).toHaveBeenCalledTimes(1);
     });
 
     test('undefined→true does NOT fire reconnect listener (boot event)', () => {

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -199,6 +199,26 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
         expect(reconnectListener).toHaveBeenCalledTimes(1);
     });
 
+    test('genuine offline before reconfigure still recovers on the next true', () => {
+        // Boot offline scenario: NetInfo confirms unreachable BEFORE SESSION hydrates and triggers
+        // a reconfigure. The post-reconfigure true must NOT be suppressed — otherwise the app would
+        // remain stuck with internetUnreachable=true until a brand new outage cycle.
+        const reconnectListener = jest.fn();
+        onReachabilityConfirmed(reconnectListener);
+
+        // Cold boot: null then false → app is genuinely offline, prev=false
+        fireNetInfoState({isInternetReachable: null});
+        fireNetInfoState({isInternetReachable: false});
+
+        // SESSION hydrates → reconfigure happens while we are still offline
+        fireSessionChange(42);
+
+        // New subscription's first definitive event recovers
+        fireNetInfoState({isInternetReachable: true});
+
+        expect(reconnectListener).toHaveBeenCalledTimes(1);
+    });
+
     test('turning off force-offline resets prevIsInternetReachable so next refresh triggers reconnect', () => {
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -2,6 +2,7 @@ import type {NetInfoState} from '@react-native-community/netinfo';
 import type * as NetworkState from '@src/libs/NetworkState';
 
 let netInfoListener: ((state: NetInfoState) => void) | null = null;
+const mockOnyxCallbacks = new Map<string, (value: unknown) => void>();
 
 jest.mock('@react-native-community/netinfo', () => ({
     addEventListener: jest.fn((cb: (state: NetInfoState) => void) => {
@@ -17,7 +18,9 @@ jest.mock('@react-native-community/netinfo', () => ({
 
 jest.mock('@src/libs/Log');
 jest.mock('react-native-onyx', () => ({
-    connectWithoutView: jest.fn(),
+    connectWithoutView: jest.fn(({key, callback}: {key: string; callback: (value: unknown) => void}) => {
+        mockOnyxCallbacks.set(key, callback);
+    }),
 }));
 
 function fireNetInfoState(overrides: Partial<NetInfoState>) {
@@ -33,12 +36,21 @@ function fireNetInfoState(overrides: Partial<NetInfoState>) {
     } as NetInfoState);
 }
 
+function fireSessionChange(accountID: number) {
+    const cb = mockOnyxCallbacks.get('session');
+    if (!cb) {
+        throw new Error('SESSION callback not registered');
+    }
+    cb({accountID});
+}
+
 describe('NetworkState — internetUnreachable hard stop via NetInfo', () => {
     let getIsOffline: typeof NetworkState.getIsOffline;
 
     beforeEach(() => {
         jest.resetModules();
         netInfoListener = null;
+        mockOnyxCallbacks.clear();
 
         const mod = require<typeof NetworkState>('@src/libs/NetworkState');
         getIsOffline = mod.getIsOffline;
@@ -81,6 +93,7 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
     beforeEach(() => {
         jest.resetModules();
         netInfoListener = null;
+        mockOnyxCallbacks.clear();
 
         // Fresh import each test so prevIsInternetReachable resets
         const mod = require<typeof NetworkState>('@src/libs/NetworkState');
@@ -99,15 +112,31 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
         expect(reconnectListener).toHaveBeenCalledTimes(1);
     });
 
-    test('null→true fires reconnect listener', () => {
+    test('null→true on a fresh subscription does NOT fire reconnect listener', () => {
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);
 
-        // Simulate losing reachability tracking (null) then recovering
+        // After a fresh subscription, the first events deliver current state. NetInfo may
+        // emit null first while the initial Ping is in flight, then true once it completes.
+        // This is not a recovery — only false→true (or an explicit prev=null reset) is.
         fireNetInfoState({isInternetReachable: null});
         fireNetInfoState({isInternetReachable: true});
 
-        expect(reconnectListener).toHaveBeenCalledTimes(1);
+        expect(reconnectListener).not.toHaveBeenCalled();
+    });
+
+    test('true→null→true does NOT fire reconnect listener (transient state, no confirmed offline)', () => {
+        const reconnectListener = jest.fn();
+        onReachabilityConfirmed(reconnectListener);
+
+        // Establish a baseline reachable state
+        fireNetInfoState({isInternetReachable: true});
+        // NetInfo briefly loses track without confirming offline (e.g. during a poll gap)
+        fireNetInfoState({isInternetReachable: null});
+        // Reachability comes back. Since we never went through false, this is not a recovery.
+        fireNetInfoState({isInternetReachable: true});
+
+        expect(reconnectListener).not.toHaveBeenCalled();
     });
 
     test('undefined→true does NOT fire reconnect listener (boot event)', () => {
@@ -141,6 +170,49 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
         fireNetInfoState({isInternetReachable: true});
 
         expect(reconnectListener).not.toHaveBeenCalled();
+    });
+
+    test('SESSION accountID change does NOT fire reconnect listener via the post-reconfigure synthetic transition', () => {
+        // Repro for the doubled-OpenApp bug on delegate switch: the SESSION accountID change
+        // re-runs configureAndSubscribe(), which tears down and re-subscribes to NetInfo. The
+        // new subscription emits null then true, which would look like a recovery. The fix
+        // resets prev to undefined on reconfigure so the new subscription's first transitions
+        // are treated like boot, not recovery.
+        const reconnectListener = jest.fn();
+        onReachabilityConfirmed(reconnectListener);
+
+        // Establish a baseline reachable state (boot)
+        fireNetInfoState({isInternetReachable: true});
+        expect(reconnectListener).not.toHaveBeenCalled();
+
+        // Delegate switch: SESSION accountID changes → reconfigure → new NetInfo subscription
+        fireSessionChange(42);
+
+        // New subscription's initial events: null while the first Ping is in flight, then true
+        fireNetInfoState({isInternetReachable: null});
+        fireNetInfoState({isInternetReachable: true});
+
+        expect(reconnectListener).not.toHaveBeenCalled();
+    });
+
+    test('genuine offline→online after a SESSION reconfigure still fires reconnect listener', () => {
+        // Make sure the reconfigure suppression doesn't swallow real recoveries that happen
+        // afterwards — only the synthetic post-reconfigure transition should be ignored.
+        const reconnectListener = jest.fn();
+        onReachabilityConfirmed(reconnectListener);
+
+        fireNetInfoState({isInternetReachable: true});
+        fireSessionChange(42);
+
+        // Settle on the reconfigured subscription
+        fireNetInfoState({isInternetReachable: true});
+        expect(reconnectListener).not.toHaveBeenCalled();
+
+        // Now a real outage and recovery
+        fireNetInfoState({isInternetReachable: false});
+        fireNetInfoState({isInternetReachable: true});
+
+        expect(reconnectListener).toHaveBeenCalledTimes(1);
     });
 
     test('turning off force-offline resets prevIsInternetReachable so next refresh triggers reconnect', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

When a user switches into a copilot/delegate account via the account switcher, `OpenApp` was firing twice — the first call resolves with skeletons visible, then a second `OpenApp` runs while skeletons are still visible, causing a noticeable double-loading experience on large accounts.

Two independent root causes, both fixed:

1. **NetworkState reconfigure path**: The `CONNECT_AS_DELEGATE` response updates `SESSION.accountID`. The SESSION subscriber in `NetworkState.ts` called `configureAndSubscribe()` to rebuild the NetInfo subscription. Re-subscribing emits a synthetic `null → true` transition as NetInfo tears down its internal state during reconfigure, which the listener treated as a network recovery event → `Reconnect.reconnect()` → `openApp()`. Fixed by adding a `suppressNextReachabilityRestored` flag that is set only on reconfigure calls (detected via `unsubscribeNetInfo !== null` at entry). The flag suppresses the synthetic post-reconfigure recovery transition and clears once reachability settles. Boot/normal behavior is unchanged.

2. **DelegateAccessHandler recovery effect path**: `Onyx.clear(KEYS_TO_PRESERVE_DELEGATE_ACCESS)` preserved `HAS_LOADED_APP=true` but not `IS_LOADING_APP`. Right after the clear, the state was briefly `hasLoadedApp=true && isLoadingApp=undefined` — exactly the trigger for the recovery effect at `src/DelegateAccessHandler.tsx:62`, which fired its own `openApp()` in the few microtasks before `openApp`'s optimistic data merged `IS_LOADING_APP=true`. Fixed via a new `clearOnyxForDelegateTransition()` helper that merges `IS_LOADING_APP=true` before clearing, so the post-clear render always sees `IS_LOADING_APP=true`. Used at all 4 call sites that previously called `Onyx.clear(KEYS_TO_PRESERVE_DELEGATE_ACCESS)` directly.

Test coverage added in `tests/unit/NetworkStateReachabilityTest.ts` (reconfigure suppression + regression guard for genuine offline→online after reconfigure) and `tests/actions/DelegateTest.ts` (helper test).

### Fixed Issues

$ https://github.com/Expensify/App/issues/89265
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Sign in to an account that has copilot/delegate access configured.
2. Open DevTools → Network tab and filter requests by `OpenApp`.
3. Open the account switcher (top-left avatar) and switch into a copilot account that has a lot of data (so OpenApp takes a noticeable time to resolve).
4. Verify exactly **one** `OpenApp` request fires in the Network tab — before the fix, two were observed (the second queued behind the first, running once the first resolved).
5. Switch back to the original (delegator) account.
6. Verify again that exactly **one** `OpenApp` request fires.
7. Verify no errors appear in the JS console during any of the above.
8. Verify the UI transitions cleanly from skeletons to loaded data (no flash / double-loading).

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
