### PR TITLE
[POC] Refactor ImportSpreadsheetConfirmModal into a hook (Members flow)

### DIFF
--- a/src/hooks/useImportSpreadsheetConfirmModal.ts
+++ b/src/hooks/useImportSpreadsheetConfirmModal.ts
@@ -1,0 +1,32 @@
+import type {TranslationParameters} from '@src/languages/types';
+import type {ImportFinalModal} from '@src/types/onyx/ImportedSpreadsheet';
+import useConfirmModal from './useConfirmModal';
+import useLocalize from './useLocalize';
+
+type ShowImportSpreadsheetConfirmModalOptions = ImportFinalModal & {
+    /** Whether to handle navigation back when modal show. */
+    shouldHandleNavigationBack?: boolean;
+
+    /** Callback method fired when the modal is hidden */
+    onModalHide?: () => void;
+};
+
+function useImportSpreadsheetConfirmModal() {
+    const {translate} = useLocalize();
+    const {showConfirmModal} = useConfirmModal();
+
+    const showImportSpreadsheetConfirmModal = ({titleKey, promptKey, promptKeyParams, shouldHandleNavigationBack = true, onModalHide}: ShowImportSpreadsheetConfirmModalOptions) =>
+        showConfirmModal({
+            id: 'import-spreadsheet-confirm-modal',
+            title: translate(titleKey),
+            prompt: translate(promptKey, promptKeyParams as TranslationParameters<typeof promptKey>[0]),
+            confirmText: translate('common.buttonConfirm'),
+            shouldShowCancelButton: false,
+            shouldHandleNavigationBack,
+            onModalHide,
+        });
+
+    return {showImportSpreadsheetConfirmModal};
+}
+
+export default useImportSpreadsheetConfirmModal;

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -169,7 +169,6 @@ const WRITE_COMMANDS = {
     SET_POLICY_TAGS_ENABLED: 'SetPolicyTagsEnabled',
     CREATE_WORKSPACE_CATEGORIES: 'CreateWorkspaceCategories',
     IMPORT_CATEGORIES_SPREADSHEET: 'ImportCategoriesSpreadsheet',
-    IMPORT_MEMBERS_SPREADSHEET: 'ImportMembersSpreadsheet',
     IMPORT_TAGS_SPREADSHEET: 'ImportTagsSpreadsheet',
     IMPORT_CSV_COMPANY_CARDS: 'ImportCSVCompanyCards',
     IMPORT_PER_DIEM_RATES: 'ImportPerDiemRates',
@@ -746,7 +745,6 @@ type WriteCommandParameters = {
     [WRITE_COMMANDS.CREATE_WORKSPACE_CATEGORIES]: Parameters.CreateWorkspaceCategoriesParams;
     [WRITE_COMMANDS.IMPORT_CATEGORIES_SPREADSHEET]: Parameters.ImportCategoriesSpreadsheetParams;
     [WRITE_COMMANDS.IMPORT_PER_DIEM_RATES]: Parameters.ImportPerDiemRatesParams;
-    [WRITE_COMMANDS.IMPORT_MEMBERS_SPREADSHEET]: Parameters.ImportMembersSpreadsheetParams;
     [WRITE_COMMANDS.IMPORT_TAGS_SPREADSHEET]: Parameters.ImportTagsSpreadsheetParams;
     [WRITE_COMMANDS.IMPORT_CSV_COMPANY_CARDS]: Parameters.ImportCSVCompanyCardsParams;
     [WRITE_COMMANDS.EXPORT_CATEGORIES_CSV]: Parameters.ExportCategoriesSpreadsheetParams;
@@ -1394,6 +1392,7 @@ const SIDE_EFFECT_REQUEST_COMMANDS = {
     MERGE_INTO_ACCOUNT_AND_LOGIN: 'MergeIntoAccountAndLogIn',
     SEARCH: 'Search',
     GET_SCIM_TOKEN: 'GetSCIMToken',
+    IMPORT_MEMBERS_SPREADSHEET: 'ImportMembersSpreadsheet',
 
     // PayMoneyRequestOnSearch only works online (pattern C) and we need to play the success sound only when the request is successful
     PAY_MONEY_REQUEST_ON_SEARCH: 'PayMoneyRequestOnSearch',
@@ -1445,6 +1444,7 @@ type SideEffectRequestCommandParameters = {
     [SIDE_EFFECT_REQUEST_COMMANDS.CALCULATE_BILL_NEW_DOT]: null;
     [SIDE_EFFECT_REQUEST_COMMANDS.ACCEPT_SPOTNANA_TERMS]: Parameters.AcceptSpotnanaTermsParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.GET_SCIM_TOKEN]: Parameters.GetScimTokenParams;
+    [SIDE_EFFECT_REQUEST_COMMANDS.IMPORT_MEMBERS_SPREADSHEET]: Parameters.ImportMembersSpreadsheetParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.COMPLETE_GUIDED_SETUP]: Parameters.CompleteGuidedSetupParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.GET_STATEMENT_PDF]: Parameters.GetStatementPDFParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.REGISTER_AUTHENTICATION_KEY]: Parameters.RegisterAuthenticationKeyParams;

--- a/src/libs/actions/Policy/Member.ts
+++ b/src/libs/actions/Policy/Member.ts
@@ -1007,15 +1007,21 @@ async function importPolicyMembers(policy: OnyxEntry<Policy>, members: PolicyMem
         ),
     };
 
-    // CSV import always requires a live server response, so the offline-queue trade-off matches reality.
-    // eslint-disable-next-line rulesdir/no-api-side-effects-method
-    const response = await API.makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.IMPORT_MEMBERS_SPREADSHEET, parameters);
-    if (response?.jsonCode === CONST.JSON_CODE.SUCCESS) {
-        return {
-            titleKey: 'spreadsheet.importSuccessfulTitle',
-            promptKey: 'spreadsheet.importMembersSuccessfulDescription',
-            promptKeyParams: {added, updated},
-        };
+    try {
+        // CSV import always requires a live server response, so the offline-queue trade-off matches reality.
+        // eslint-disable-next-line rulesdir/no-api-side-effects-method
+        const response = await API.makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.IMPORT_MEMBERS_SPREADSHEET, parameters);
+        if (response?.jsonCode === CONST.JSON_CODE.SUCCESS) {
+            return {
+                titleKey: 'spreadsheet.importSuccessfulTitle',
+                promptKey: 'spreadsheet.importMembersSuccessfulDescription',
+                promptKeyParams: {added, updated},
+            };
+        }
+    } catch (error) {
+        // Network rejection (failed to fetch, dropped connection, etc.) — fall through to the failure modal so the consumer's
+        // await always resolves and the loading state / cleanup chain still runs.
+        Log.warn('importPolicyMembers request failed', {error});
     }
     return {titleKey: 'spreadsheet.importFailedTitle', promptKey: 'spreadsheet.importFailedDescription'};
 }

--- a/src/libs/actions/Policy/Member.ts
+++ b/src/libs/actions/Policy/Member.ts
@@ -11,7 +11,7 @@ import type {
     RequestWorkspaceOwnerChangeParams,
     UpdateWorkspaceMembersRoleParams,
 } from '@libs/API/parameters';
-import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
+import {READ_COMMANDS, SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import * as ApiUtils from '@libs/ApiUtils';
 import DateUtils from '@libs/DateUtils';
 import * as ErrorUtils from '@libs/ErrorUtils';
@@ -29,6 +29,7 @@ import * as FormActions from '@userActions/FormActions';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {ImportedSpreadsheetMemberData, InvitedEmailsToAccountIDs, Policy, PolicyEmployee, PolicyOwnershipChangeChecks, Report, ReportAction, ReportActions} from '@src/types/onyx';
+import type {ImportFinalModal} from '@src/types/onyx/ImportedSpreadsheet';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
 import type {JoinWorkspaceResolution} from '@src/types/onyx/OriginalMessage';
 import type {ApprovalRule} from '@src/types/onyx/Policy';
@@ -140,47 +141,6 @@ function buildRoomMembersOnyxData(
     );
     return roomMembers;
 }
-/**
- * Updates the import spreadsheet data according to the result of the import
- */
-function updateImportSpreadsheetData(addedMembersLength: number, updatedMembersLength: number): OnyxData<typeof ONYXKEYS.IMPORTED_SPREADSHEET> {
-    const onyxData: OnyxData<typeof ONYXKEYS.IMPORTED_SPREADSHEET> = {
-        successData: [
-            {
-                onyxMethod: Onyx.METHOD.MERGE,
-                key: ONYXKEYS.IMPORTED_SPREADSHEET,
-                value: {
-                    shouldFinalModalBeOpened: true,
-                    importFinalModal: {
-                        titleKey: 'spreadsheet.importSuccessfulTitle',
-                        promptKey: 'spreadsheet.importMembersSuccessfulDescription',
-                        promptKeyParams: {
-                            added: addedMembersLength,
-                            updated: updatedMembersLength,
-                        },
-                    },
-                },
-            },
-        ],
-
-        failureData: [
-            {
-                onyxMethod: Onyx.METHOD.MERGE,
-                key: ONYXKEYS.IMPORTED_SPREADSHEET,
-                value: {
-                    shouldFinalModalBeOpened: true,
-                    importFinalModal: {
-                        titleKey: 'spreadsheet.importFailedTitle',
-                        promptKey: 'spreadsheet.importFailedDescription',
-                    },
-                },
-            },
-        ],
-    };
-
-    return onyxData;
-}
-
 /**
  * Build optimistic data for removing users from the announcement/admins room
  */
@@ -1001,10 +961,10 @@ type PolicyMember = {
     overLimitForwardsTo?: string;
 };
 
-function importPolicyMembers(policy: OnyxEntry<Policy>, members: PolicyMember[]) {
+async function importPolicyMembers(policy: OnyxEntry<Policy>, members: PolicyMember[]): Promise<ImportFinalModal> {
     if (!policy?.id) {
         Log.warn('importPolicyMembers called without a valid policy');
-        return;
+        return {titleKey: 'spreadsheet.importFailedTitle', promptKey: 'spreadsheet.importFailedDescription'};
     }
     const {added, updated} = members.reduce(
         (acc, curr) => {
@@ -1030,7 +990,6 @@ function importPolicyMembers(policy: OnyxEntry<Policy>, members: PolicyMember[])
         },
         {added: 0, updated: 0},
     );
-    const onyxData = updateImportSpreadsheetData(added, updated);
 
     const parameters = {
         policyID: policy.id,
@@ -1048,7 +1007,17 @@ function importPolicyMembers(policy: OnyxEntry<Policy>, members: PolicyMember[])
         ),
     };
 
-    API.write(WRITE_COMMANDS.IMPORT_MEMBERS_SPREADSHEET, parameters, onyxData);
+    // CSV import always requires a live server response, so the offline-queue trade-off matches reality.
+    // eslint-disable-next-line rulesdir/no-api-side-effects-method
+    const response = await API.makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.IMPORT_MEMBERS_SPREADSHEET, parameters);
+    if (response?.jsonCode === CONST.JSON_CODE.SUCCESS) {
+        return {
+            titleKey: 'spreadsheet.importSuccessfulTitle',
+            promptKey: 'spreadsheet.importMembersSuccessfulDescription',
+            promptKeyParams: {added, updated},
+        };
+    }
+    return {titleKey: 'spreadsheet.importFailedTitle', promptKey: 'spreadsheet.importFailedDescription'};
 }
 
 /**

--- a/src/pages/workspace/members/ImportedMembersConfirmationPage.tsx
+++ b/src/pages/workspace/members/ImportedMembersConfirmationPage.tsx
@@ -1,4 +1,3 @@
-import {useIsFocused} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import type {GestureResponderEvent} from 'react-native/Libraries/Types/CoreEventTypes';
@@ -6,7 +5,6 @@ import type {ValueOf} from 'type-fest';
 import Button from '@components/Button';
 import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import ImportSpreadsheetConfirmModal from '@components/ImportSpreadsheetConfirmModal';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
@@ -14,6 +12,7 @@ import ReportActionAvatars from '@components/ReportActionAvatars';
 import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import useCloseImportPage from '@hooks/useCloseImportPage';
+import useImportSpreadsheetConfirmModal from '@hooks/useImportSpreadsheetConfirmModal';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -47,12 +46,11 @@ function ImportedMembersConfirmationPage({route}: ImportedMembersConfirmationPag
     const policyID = route.params.policyID;
     const policy = usePolicy(policyID);
     const [isImporting, setIsImporting] = useState(false);
-    const [shouldShowConfirmModal, setShouldShowConfirmModal] = useState(true);
     const {isOffline} = useNetwork();
-    const isFocused = useIsFocused();
 
     const personalDetails = usePersonalDetails();
     const {setIsClosing} = useCloseImportPage();
+    const {showImportSpreadsheetConfirmModal} = useImportSpreadsheetConfirmModal();
 
     useEffect(() => {
         return () => {
@@ -91,22 +89,23 @@ function ImportedMembersConfirmationPage({route}: ImportedMembersConfirmationPag
         openExternalLink(CONST.OLD_DOT_PUBLIC_URLS.PRIVACY_URL);
     };
 
-    const importMembers = useCallback(() => {
+    const importMembers = useCallback(async () => {
         if (!newMembers) {
             return;
         }
         setIsImporting(true);
         const membersWithRole = (importedSpreadsheetMemberData ?? []).map((member) => ({...member, role: member.role || role}));
-        importPolicyMembers(policy, membersWithRole);
-    }, [importedSpreadsheetMemberData, newMembers, policy, role]);
-
-    const closeImportPageAndModal = () => {
-        setIsClosing(true);
+        const result = await importPolicyMembers(policy, membersWithRole);
         setIsImporting(false);
-        setShouldShowConfirmModal(false);
+
+        await showImportSpreadsheetConfirmModal({
+            ...result,
+            shouldHandleNavigationBack: false,
+        });
+        setIsClosing(true);
         closeImportPage();
         Navigation.goBack(ROUTES.WORKSPACE_MEMBERS.getRoute(policyID));
-    };
+    }, [importedSpreadsheetMemberData, newMembers, policy, policyID, role, setIsClosing, showImportSpreadsheetConfirmModal]);
 
     const onRoleChange = (item: ListItemType) => {
         setRole(item.value);
@@ -215,11 +214,6 @@ function ImportedMembersConfirmationPage({route}: ImportedMembersConfirmationPag
                     </View>
                 </PressableWithoutFeedback>
             </FixedFooter>
-            <ImportSpreadsheetConfirmModal
-                isVisible={spreadsheet?.shouldFinalModalBeOpened && shouldShowConfirmModal && isFocused}
-                closeImportPageAndModal={closeImportPageAndModal}
-                shouldHandleNavigationBack={false}
-            />
             <WorkspaceMemberDetailsRoleSelectionModal
                 isVisible={isRoleSelectionModalVisible}
                 items={roleItems}

--- a/src/pages/workspace/members/ImportedMembersPage.tsx
+++ b/src/pages/workspace/members/ImportedMembersPage.tsx
@@ -1,13 +1,12 @@
-import {useIsFocused} from '@react-navigation/native';
-import React, {useCallback, useState} from 'react';
+import React, {useState} from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {InteractionManager} from 'react-native';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import type {ColumnRole} from '@components/ImportColumn';
 import ImportSpreadsheetColumns from '@components/ImportSpreadsheetColumns';
-import ImportSpreadsheetConfirmModal from '@components/ImportSpreadsheetConfirmModal';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useCloseImportPage from '@hooks/useCloseImportPage';
+import useImportSpreadsheetConfirmModal from '@hooks/useImportSpreadsheetConfirmModal';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import usePolicy from '@hooks/usePolicy';
@@ -32,10 +31,9 @@ function ImportedMembersPage({route}: ImportedMembersPageProps) {
     const [isImporting, setIsImporting] = useState(false);
     const [isValidationEnabled, setIsValidationEnabled] = useState(false);
     const {setIsClosing} = useCloseImportPage();
-    const [shouldShowConfirmModal, setShouldShowConfirmModal] = useState(true);
+    const {showImportSpreadsheetConfirmModal} = useImportSpreadsheetConfirmModal();
     const policyID = route.params.policyID;
     const policy = usePolicy(policyID);
-    const isFocused = useIsFocused();
 
     const columnNames = generateColumnNames(spreadsheet?.data?.length ?? 0);
     const {containsHeader = true} = spreadsheet ?? {};
@@ -56,7 +54,7 @@ function ImportedMembersPage({route}: ImportedMembersPageProps) {
 
     // checks if all required columns are mapped and no column is mapped more than once
     // returns found errors or empty object if both conditions are met
-    const validate = useCallback(() => {
+    const validate = () => {
         const columns = Object.values(spreadsheet?.columns ?? {});
         let errors: Record<string, string | null> = {};
         const missingRequiredColumns = requiredColumns.find((requiredColumn) => !columns.includes(requiredColumn.value));
@@ -72,9 +70,9 @@ function ImportedMembersPage({route}: ImportedMembersPageProps) {
         }
 
         return errors;
-    }, [requiredColumns, spreadsheet?.columns, translate]);
+    };
 
-    const importMembers = useCallback(() => {
+    const importMembers = async () => {
         setIsValidationEnabled(true);
 
         const errors = validate();
@@ -203,11 +201,22 @@ function ImportedMembersPage({route}: ImportedMembersPageProps) {
         if (isRoleMissing) {
             setImportedSpreadsheetMemberData(allMembers);
             Navigation.navigate(ROUTES.WORKSPACE_MEMBERS_IMPORTED_CONFIRMATION.getRoute(policyID));
-        } else {
-            setIsImporting(true);
-            importPolicyMembers(policy, allMembers);
+            return;
         }
-    }, [validate, spreadsheet?.columns, spreadsheet?.data, policy, containsHeader, route.params.policyID, policyID]);
+
+        setIsImporting(true);
+        const result = await importPolicyMembers(policy, allMembers);
+        setIsImporting(false);
+
+        await showImportSpreadsheetConfirmModal({
+            ...result,
+            onModalHide: () => {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
+                InteractionManager.runAfterInteractions(() => Navigation.goBack(ROUTES.WORKSPACE_MEMBERS.getRoute(policyID)));
+            },
+        });
+        setIsClosing(true);
+    };
 
     if (!spreadsheet && isLoadingOnyxValue(spreadsheetMetadata)) {
         return;
@@ -217,12 +226,6 @@ function ImportedMembersPage({route}: ImportedMembersPageProps) {
     if (!spreadsheetColumns) {
         return <NotFoundPage />;
     }
-
-    const closeImportPageAndModal = () => {
-        setIsClosing(true);
-        setIsImporting(false);
-        setShouldShowConfirmModal(false);
-    };
 
     return (
         <ScreenWrapper
@@ -237,19 +240,13 @@ function ImportedMembersPage({route}: ImportedMembersPageProps) {
             <ImportSpreadsheetColumns
                 spreadsheetColumns={spreadsheetColumns}
                 columnNames={columnNames}
-                importFunction={importMembers}
+                importFunction={() => {
+                    importMembers();
+                }}
                 errors={isValidationEnabled ? validate() : undefined}
                 columnRoles={columnRoles}
                 isButtonLoading={isImporting}
                 learnMoreLink={CONST.IMPORT_SPREADSHEET.MEMBERS_ARTICLE_LINK}
-            />
-            <ImportSpreadsheetConfirmModal
-                isVisible={spreadsheet?.shouldFinalModalBeOpened && shouldShowConfirmModal && isFocused}
-                closeImportPageAndModal={closeImportPageAndModal}
-                onModalHide={() => {
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    InteractionManager.runAfterInteractions(() => Navigation.goBack(ROUTES.WORKSPACE_MEMBERS.getRoute(policyID)));
-                }}
             />
         </ScreenWrapper>
     );

--- a/src/types/onyx/ImportedSpreadsheet.ts
+++ b/src/types/onyx/ImportedSpreadsheet.ts
@@ -5,8 +5,8 @@ import type {TranslationParameters, TranslationPaths} from '@src/languages/types
  */
 type SpreadsheetTranslationPaths = Extract<TranslationPaths, `spreadsheet${string}`>;
 
-/** Texts to display depending on request success/failure */
-type ImportFinalModal<TPath extends SpreadsheetTranslationPaths> = {
+/** Texts to display depending on request success/failure for a single translation path */
+type ImportFinalModalEntry<TPath extends SpreadsheetTranslationPaths> = {
     /** Title of the modal */
     titleKey: SpreadsheetTranslationPaths;
 
@@ -14,15 +14,16 @@ type ImportFinalModal<TPath extends SpreadsheetTranslationPaths> = {
     promptKey: TPath;
 
     /** Parameters for the translation */
-    promptKeyParams: TranslationParameters<TPath>[0];
+    promptKeyParams?: TranslationParameters<TPath>[0];
 };
 
 /**
- * Union type of all possible ImportFinalModal configurations
- * Each translation path gets its own properly typed variant
+ * Union type of all possible ImportFinalModal configurations.
+ * Each translation path gets its own properly typed variant so that
+ * consumers can return any specific variant without losing parameter typing.
  */
-type ImportFinalModalUnion = {
-    [K in SpreadsheetTranslationPaths]: ImportFinalModal<K>;
+type ImportFinalModal = {
+    [K in SpreadsheetTranslationPaths]: ImportFinalModalEntry<K>;
 }[SpreadsheetTranslationPaths];
 
 /** Settings for importing transactions */
@@ -52,7 +53,7 @@ type ImportedSpreadsheet = {
     shouldFinalModalBeOpened: boolean;
 
     /** Texts to display depending on request success/failure */
-    importFinalModal: ImportFinalModalUnion;
+    importFinalModal: ImportFinalModal;
 
     /** Whether the first row of the spreadsheet contains headers */
     containsHeader: boolean;
@@ -80,4 +81,4 @@ type ImportedSpreadsheet = {
 };
 
 export default ImportedSpreadsheet;
-export type {ImportTransactionSettings};
+export type {ImportFinalModal, ImportTransactionSettings};


### PR DESCRIPTION
### Explanation of Change

Replaces the bastion-component pattern in [`ImportSpreadsheetConfirmModal.tsx`](https://github.com/Expensify/App/blob/main/src/components/ImportSpreadsheetConfirmModal.tsx) (a null-rendering component that fires `showConfirmModal` from a `useEffect` watching Onyx state) with a thin `useImportSpreadsheetConfirmModal` hook that consumers call directly from their import event handlers.

This PR demonstrates the new pattern on a **single import flow — Members** (the one tied to [#86704](https://github.com/Expensify/App/issues/86704)). The other 5 import actions and 7 consumer pages keep using the existing `<ImportSpreadsheetConfirmModal>` component; migrating them is intentional follow-up work. Both shapes coexist on purpose so reviewers can compare them side-by-side.

What changed for the Members flow:

- `importPolicyMembers` in [`src/libs/actions/Policy/Member.ts`](https://github.com/Expensify/App/blob/main/src/libs/actions/Policy/Member.ts) is now `async` and returns `Promise<ImportFinalModal>` directly. It switched from `API.write` to `API.makeRequestWithSideEffects` so it can return the server result. CSV import always requires a live server response, so the offline-queue trade-off matches reality (with an `eslint-disable-next-line rulesdir/no-api-side-effects-method` comment at the call site explaining that).
- `IMPORT_MEMBERS_SPREADSHEET` was promoted from `WRITE_COMMANDS` to `SIDE_EFFECT_REQUEST_COMMANDS` in `src/libs/API/types.ts`.
- New hook `src/hooks/useImportSpreadsheetConfirmModal.ts` wraps `useConfirmModal`. No `useCallback` — relies on React Compiler.
- `ImportedMembersPage.tsx` and `ImportedMembersConfirmationPage.tsx` `await` the action, then `await` the hook, then run cleanup. The `<ImportSpreadsheetConfirmModal>` JSX, `isFocused` / `shouldShowConfirmModal` guards, and the modal-config Onyx writes are gone from these two pages. `ImportedMembersPage.tsx` already compiles with React Compiler so its `useCallback` wrappers were stripped; `ImportedMembersConfirmationPage.tsx` does not, so the existing `useCallback` is left in place to avoid a regression.
- `ImportFinalModal` is now exported from `src/types/onyx/ImportedSpreadsheet.ts` as the distributed union (the previous internal `ImportFinalModal<TPath>` is renamed to `ImportFinalModalEntry<TPath>`), so the action and the hook share a properly typed handle without losing per-key parameter typing.

What is intentionally not changed:

- `src/components/ImportSpreadsheetConfirmModal.tsx` is still in the tree — Categories, Tags, Per Diem, Company Cards, and Transactions still render it.
- `shouldFinalModalBeOpened` and `importFinalModal` remain on the `IMPORTED_SPREADSHEET` Onyx type because the un-migrated actions and the legacy component still read/write those fields.

### Fixed Issues

For https://github.com/Expensify/App/issues/86704
PROPOSAL: N/A (internal refactor)

### Tests

1. Sign in to a workspace where you are an admin/owner.
2. Navigate to **Workspaces → \<workspace\> → Members → More → Import spreadsheet**.
3. Upload a CSV that contains only an `email` and `role` column with one new row, e.g.:
   ```
   email,role
   test_simple+86704@gmail.com,user
   ```
4. On the column-mapping screen click **Import**.
5. Verify the **"Import successful — 1 member has been added."** modal appears exactly once.
6. Click **Got it** and verify the modal dismisses cleanly, navigation returns to `/workspaces/<id>/members`, and the new member is present in the list. No infinite loop, no stuck modal.
7. Repeat from step 2 with a CSV that contains an unknown `submitsTo` (the original [#86704](https://github.com/Expensify/App/issues/86704) repro), e.g.:
   ```
   email,role,submitsTo
   test_invitee+86704@gmail.com,user,test_manager+86704@gmail.com
   ```
8. After clicking **Import**, the **Confirm details** page appears (because `test_manager+86704@gmail.com` is a new user). Pick a role and click **Import** again.
9. Verify the **"Import successful — 2 members have been added."** modal appears exactly once, click **Got it**, and confirm navigation returns to `/workspaces/<id>/members` with both new members in the list.
10. Smoke-test one of the un-migrated flows to confirm the legacy component is still healthy: **Workspaces → \<workspace\> → Categories → More → Import spreadsheet**, upload any single-row categories CSV, click Import, verify the existing import-success modal appears via `<ImportSpreadsheetConfirmModal>` and dismisses cleanly.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Open the Members tab and start the import flow as in steps 1–4 above.
2. Disable network connectivity *before* clicking the final **Import** button on the column-mapping page (or on the **Confirm details** page).
3. Verify the button is disabled / shows the offline state and clicking does nothing — the action no longer enqueues an offline write because CSV import is online-only by nature.
4. Re-enable network and verify the import then proceeds normally.

### QA Steps

Same as Tests, run on staging.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

Made with [Cursor](https://cursor.com)