### PR TITLE
[] Fix: Apply foreign currency default tax rate in skip-confirmation path

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepAmount.tsx
+++ b/src/pages/iou/request/step/IOURequestStepAmount.tsx
@@ -246,6 +246,16 @@ function IOURequestStepAmount({
                     participant,
                     transactionReportID: report?.reportID,
                 });
+
+                // Compute the correct tax code for foreign currency transactions
+                // (same logic as the isMovingTransactionFromTrackExpense path above)
+                const skipConfirmationTaxCode = getDefaultTaxCode(policy, transaction, selectedCurrency);
+                let skipConfirmationTaxAmount: number | undefined;
+                if (skipConfirmationTaxCode) {
+                    const taxPercentage = getTaxValue(policy, transaction, skipConfirmationTaxCode) ?? '';
+                    skipConfirmationTaxAmount = convertToBackendAmount(calculateTaxAmount(taxPercentage, backendAmount, decimals));
+                }
+
                 if (iouType === CONST.IOU.TYPE.PAY || iouType === CONST.IOU.TYPE.SEND) {
                     const {optimisticChatReportID, chatReportID} = resolveOptimisticChatReportID(
                         [participants.at(0)?.accountID ?? CONST.DEFAULT_NUMBER_ID, currentUserAccountIDParam],
@@ -288,6 +298,7 @@ function IOURequestStepAmount({
                             merchant: CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT,
                             attendees: transaction?.comment?.attendees,
                             reimbursable: defaultReimbursable,
+                            ...(skipConfirmationTaxCode ? {taxCode: skipConfirmationTaxCode, taxAmount: skipConfirmationTaxAmount} : {}),
                         },
                         backToReport,
                         shouldGenerateTransactionThreadReport: false,
@@ -319,6 +330,7 @@ function IOURequestStepAmount({
                             created: transaction?.created,
                             merchant: CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT,
                             reimbursable: defaultReimbursable,
+                            ...(skipConfirmationTaxCode ? {taxCode: skipConfirmationTaxCode, taxAmount: skipConfirmationTaxAmount} : {}),
                         },
                         isASAPSubmitBetaEnabled,
                         currentUserAccountIDParam,


### PR DESCRIPTION
## Explanation of Changes

**$ #87499**

When submitting an expense via the quick-submit (skip-confirmation) path in `IOURequestStepAmount.tsx`, the `taxCode` was not included in `transactionParams`. This caused the server to fall back to the workspace default tax rate instead of the foreign currency default tax rate.

### Root Cause

The `shouldSkipConfirmation` block in `IOURequestStepAmount.tsx` (lines 253-281) calls `requestMoney` and `trackExpense` without computing or passing `taxCode`/`taxAmount` in `transactionParams`. The correct tax selection logic exists in:

1. The `isMovingTransactionFromTrackExpense` path (lines 200-210) — correctly computes tax code based on currency comparison
2. The `getDefaultTaxCode()` function in `TransactionUtils` — correctly selects `foreignTaxDefault` when transaction currency differs from policy output currency
3. The `TaxController` component — handles this in the normal (non-skip) flow via a `useEffect`

When confirmation is skipped, none of these paths execute.

### Fix

Added tax code computation before the `requestMoney` and `trackExpense` calls in the `shouldSkipConfirmation` block, using the existing `getDefaultTaxCode()` function. This is the same pattern already used in the `isMovingTransactionFromTrackExpense` path.

**Changes:** `src/pages/iou/request/step/IOURequestStepAmount.tsx` (+12 lines)

### Testing

1. Set up a workspace with default currency CAD and a foreign currency default tax rate (e.g., USD tax rate ≠ CAD tax rate)
2. Create an expense in USD using the quick-submit path (skip confirmation)
3. Verify the foreign currency default tax rate is applied, not the workspace default

---

📋 **Contributor details**
- **Email:** haoyousun60@outlook.com
- **Upwork Profile:** https://www.upwork.com/freelancers/haoyousun60