### PR TITLE
[WIP] Onboarding: extend bespoke welcome to all MANAGE_TEAM sizes

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11641,15 +11641,6 @@ type PrepareOnboardingOnyxDataParams = {
 function getBespokeWelcomeMessage(companySize: OnboardingCompanySize | undefined, userReportedIntegration?: OnboardingAccounting): string {
     // Use markdown (not HTML) because buildOptimisticAddCommentReportAction -> getParsedComment
     // escapes HTML entities before parsing, so raw HTML tags would render as literal text.
-    //
-    // Speaker is Concierge (was "Expensify setup specialist"). For TEAM 11+ users, the
-    // server-side append in queueAdminsRoomWelcome (Web-Expensify PR #52519) inserts a
-    // separate "you also have <guide name> assigned" paragraph with a book-a-call link
-    // before the followup-list — so the human onboarding specialist gets introduced
-    // distinctly from Concierge.
-    //
-    // PLACEHOLDER COPY — pending team review on lighter (~50w) vs. middle (~70w)
-    // variants and per-tier vs. uniform value-teaser language.
     const welcomeHeader = "# Your free trial has started! Let's get you set up.\n👋 Hey there! I'm Concierge — I'll help you get Expensify working for your team. ";
 
     let message = welcomeHeader;
@@ -11711,12 +11702,6 @@ function prepareOnboardingOnyxData({
         onboardingMessage = getOnboardingMessages().onboardingMessages[CONST.ONBOARDING_CHOICES.SUBMIT];
     }
 
-    // All MANAGE_TEAM cohorts now go through the bespoke welcome path. The previous
-    // gate restricted to MICRO sizes (1-10) while we proved out the deterministic
-    // pregenerated followups; with the server-side guide-block append shipped on
-    // Web-Expensify (PR #52519) for non-Concierge guides, TEAM 11+ users also see
-    // the bespoke welcome — Concierge as the speaker plus an introduction to their
-    // assigned onboarding specialist with a book-a-call link.
     const isPhase1Cohort =
         companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO_SMALL ||
         companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO_MEDIUM ||

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11641,36 +11641,45 @@ type PrepareOnboardingOnyxDataParams = {
 function getBespokeWelcomeMessage(companySize: OnboardingCompanySize | undefined, userReportedIntegration?: OnboardingAccounting): string {
     // Use markdown (not HTML) because buildOptimisticAddCommentReportAction -> getParsedComment
     // escapes HTML entities before parsing, so raw HTML tags would render as literal text.
-    const welcomeHeader = "# Your free trial has started! Let's get you set up.\n👋 Hey there! I'm your Expensify setup specialist. ";
+    //
+    // Speaker is Concierge (was "Expensify setup specialist"). For TEAM 11+ users, the
+    // server-side append in queueAdminsRoomWelcome (Web-Expensify PR #52519) inserts a
+    // separate "you also have <guide name> assigned" paragraph with a book-a-call link
+    // before the followup-list — so the human onboarding specialist gets introduced
+    // distinctly from Concierge.
+    //
+    // PLACEHOLDER COPY — pending team review on lighter (~50w) vs. middle (~70w)
+    // variants and per-tier vs. uniform value-teaser language.
+    const welcomeHeader = "# Your free trial has started! Let's get you set up.\n👋 Hey there! I'm Concierge — I'll help you get Expensify working for your team. ";
 
     let message = welcomeHeader;
     switch (companySize) {
         case CONST.ONBOARDING_COMPANY_SIZE.MEDIUM:
         case CONST.ONBOARDING_COMPANY_SIZE.LARGE:
             message +=
-                'For an organization your size, the fastest path to value is setting up approval workflows, ' +
-                'connecting your accounting software, and rolling out the Expensify Card to your team. ' +
-                "I'm here to walk you through each step — just ask!";
+                'For an organization your size, the fastest path to value is connecting your accounting software, ' +
+                'setting up multi-level approval workflows, and rolling out the Expensify Card across your team. ' +
+                'Pick a starting point below, or just ask me anything in chat.';
             break;
         case CONST.ONBOARDING_COMPANY_SIZE.SMALL:
         case CONST.ONBOARDING_COMPANY_SIZE.MEDIUM_SMALL:
             message +=
-                'For a growing team like yours, the fastest way to get value is to set up expense categories, ' +
-                'configure approval workflows, and invite your team members. ' +
-                "I'm here to walk you through each step — just ask!";
+                'For a growing team like yours, the fastest path to value is connecting your accounting software, ' +
+                'setting up approval workflows, and inviting everyone. ' +
+                'Pick a suggestion below, or just ask me anything in chat.';
             break;
         default:
             message +=
                 'For a small team like yours, the fastest way to get value is to set up a few expense categories, ' +
                 'invite your team members, and have them start snapping receipts right away. ' +
-                "I'm here to walk you through each step — just ask!";
+                'Pick a suggestion below, or just ask me anything in chat.';
             break;
     }
 
     if (userReportedIntegration && userReportedIntegration !== 'other') {
         const friendlyName = CONST.ONBOARDING_ACCOUNTING_MAPPING[userReportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING];
         if (friendlyName) {
-            message += `\n\nSince you use ${friendlyName}, I can help you connect it so your expenses sync automatically — just say the word!`;
+            message += `\n\nSince you use ${friendlyName}, I can help you connect it so your expenses sync automatically.`;
         }
     }
 
@@ -11702,11 +11711,20 @@ function prepareOnboardingOnyxData({
         onboardingMessage = getOnboardingMessages().onboardingMessages[CONST.ONBOARDING_CHOICES.SUBMIT];
     }
 
-    // Phase 1 cohort (MANAGE_TEAM + micro company size) bypasses the beta gate — the backend
-    // handles gating via NVP, so all micro users get followups without needing the beta flag.
-    // Includes MICRO_SMALL, MICRO_MEDIUM, and the deprecated MICRO for backwards compatibility.
+    // All MANAGE_TEAM cohorts now go through the bespoke welcome path. The previous
+    // gate restricted to MICRO sizes (1-10) while we proved out the deterministic
+    // pregenerated followups; with the server-side guide-block append shipped on
+    // Web-Expensify (PR #52519) for non-Concierge guides, TEAM 11+ users also see
+    // the bespoke welcome — Concierge as the speaker plus an introduction to their
+    // assigned onboarding specialist with a book-a-call link.
     const isPhase1Cohort =
-        companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO_SMALL || companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO_MEDIUM || companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO;
+        companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO_SMALL ||
+        companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO_MEDIUM ||
+        companySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO ||
+        companySize === CONST.ONBOARDING_COMPANY_SIZE.SMALL ||
+        companySize === CONST.ONBOARDING_COMPANY_SIZE.MEDIUM_SMALL ||
+        companySize === CONST.ONBOARDING_COMPANY_SIZE.MEDIUM ||
+        companySize === CONST.ONBOARDING_COMPANY_SIZE.LARGE;
     // Followups path: MANAGE_TEAM + (Phase 1 cohort OR suggestedFollowups beta). Reaches every
     // MANAGE_TEAM cohort user, including `+` aliases and phone-primary sign-ups.
     const shouldUseFollowupsInsteadOfTasks =

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -577,7 +577,7 @@ describe('ReportUtils', () => {
             prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
+                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -590,7 +590,7 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
+                companySize: undefined,
             });
 
             expect(title).toHaveBeenCalledWith(
@@ -607,7 +607,7 @@ describe('ReportUtils', () => {
             prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
+                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -620,7 +620,7 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
+                companySize: undefined,
             });
 
             expect(description).toHaveBeenCalledWith(
@@ -878,7 +878,7 @@ describe('ReportUtils', () => {
             prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
+                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -891,18 +891,18 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
+                companySize: undefined,
             });
 
             expect(title).toHaveBeenCalledWith(
                 expect.objectContaining<OnboardingTaskLinks>({
-                    onboardingCompanySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
+                    onboardingCompanySize: undefined,
                 }),
             );
 
             expect(description).toHaveBeenCalledWith(
                 expect.objectContaining<OnboardingTaskLinks>({
-                    onboardingCompanySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
+                    onboardingCompanySize: undefined,
                 }),
             );
         });

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -577,7 +577,7 @@ describe('ReportUtils', () => {
             prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -590,7 +590,6 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                // SMALL keeps this in the tasks path; MICRO routes through Phase 1 followups (no tasks generated).
                 companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
             });
 
@@ -608,7 +607,7 @@ describe('ReportUtils', () => {
             prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -621,7 +620,6 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                // SMALL keeps this in the tasks path; MICRO routes through Phase 1 followups (no tasks generated).
                 companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
             });
 
@@ -772,7 +770,7 @@ describe('ReportUtils', () => {
             expect(result?.bespokeWelcomeMessage).toContain('expenses sync automatically');
         });
 
-        it('should add guidedSetupData when posting into admin room WITHOUT suggestedFollowups beta', async () => {
+        it('should use bespoke welcome path for MANAGE_TEAM when posting into admin room WITHOUT suggestedFollowups beta', async () => {
             const adminsChatReportID = '1';
             // Not having `+` in the email allows for `isPostingTasksInAdminsRoom` flow
             await Onyx.merge(ONYXKEYS.SESSION, {email: 'test@example.com'});
@@ -790,21 +788,10 @@ describe('ReportUtils', () => {
                 selectedInterestedFeatures: ['areCompanyCardsEnabled'],
                 companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
             });
-            // Without the beta, tasks SHOULD be generated (old behavior) — uses SMALL (not MICRO)
-            // because MICRO + MANAGE_TEAM users bypass the beta gate and get followups directly
-            expect(result?.guidedSetupData).toHaveLength(3);
-            const taskReportIDs =
-                result?.guidedSetupData.reduce<string[]>((acc, item) => {
-                    if (item.type === 'task' && typeof item.taskReportID === 'string') {
-                        acc.push(item.taskReportID);
-                    }
-                    return acc;
-                }, []) ?? [];
-            expect(taskReportIDs.length).toBeGreaterThan(0);
-            for (const taskReportID of taskReportIDs) {
-                const taskReportUpdate = result?.optimisticData.find((update) => update.key === `${ONYXKEYS.COLLECTION.REPORT}${taskReportID}`);
-                expect((taskReportUpdate?.value as Report | undefined)?.chatType).toBe(CONST.REPORT.CHAT_TYPE.POLICY_ADMINS);
-            }
+            // All MANAGE_TEAM sizes now route through the bespoke welcome path — tasks are not generated.
+            expect(result?.guidedSetupData.filter((data) => data.type === 'task')).toHaveLength(0);
+            expect(result?.bespokeWelcomeMessage).toBeDefined();
+            expect(result?.optimisticConciergeReportActionID).toBeDefined();
         });
 
         it('should generate followups (not tasks) for `+` email users in the MANAGE_TEAM + MICRO Phase 1 cohort', async () => {
@@ -891,7 +878,7 @@ describe('ReportUtils', () => {
             prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -904,7 +891,6 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                // SMALL keeps the tasks path active; MICRO routes through Phase 1 followups (no tasks generated).
                 companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
             });
 
@@ -983,7 +969,7 @@ describe('ReportUtils', () => {
             const result = prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -996,7 +982,6 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                // SMALL keeps the tasks path active; MANAGE_TEAM + MICRO routes through Phase 1 followups.
                 companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
                 isSelfTourViewed: true,
             });
@@ -1012,7 +997,7 @@ describe('ReportUtils', () => {
             const result = prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -1025,7 +1010,6 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                // SMALL keeps the tasks path active; MANAGE_TEAM + MICRO routes through Phase 1 followups.
                 companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
                 isSelfTourViewed: false,
             });
@@ -1044,7 +1028,7 @@ describe('ReportUtils', () => {
             const result = prepareOnboardingOnyxData({
                 introSelected: undefined,
                 betas: undefined,
-                engagementChoice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                engagementChoice: CONST.ONBOARDING_CHOICES.SUBMIT,
                 onboardingMessage: {
                     message: 'This is a test',
                     tasks: [
@@ -1057,7 +1041,6 @@ describe('ReportUtils', () => {
                     ],
                 },
                 adminsChatReportID: '1',
-                // SMALL keeps the tasks path active; MANAGE_TEAM + MICRO routes through Phase 1 followups.
                 companySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
                 isSelfTourViewed: undefined,
             });


### PR DESCRIPTION
<!-- cc @inimaga -->

### Explanation of Change

Opens the bespoke Concierge welcome path to all MANAGE_TEAM cohorts. Previously only MICRO sizes (1–10 employees) received the optimistic Concierge welcome with pregenerated followup chips; SMALL, MEDIUM_SMALL, MEDIUM, and LARGE (11+ employees) still saw the legacy task-list welcome.

After this lands:
1. Every MANAGE_TEAM signup gets the Concierge welcome body + followup chips in the `#admins` room.
2. For TEAM 11+ accounts, the server-side append in `queueAdminsRoomWelcome` inserts a paragraph introducing the assigned onboarding specialist by name with a book-a-call link — so the human guide is introduced separately from Concierge rather than conflated into a single greeting.

Changes:
- **`isPhase1Cohort` extended** to cover all seven MANAGE_TEAM sizes (SMALL, MEDIUM_SMALL, MEDIUM, LARGE added alongside the existing MICRO_SMALL, MICRO_MEDIUM, MICRO).
- **Welcome speaker changed to Concierge** in `getBespokeWelcomeMessage`. Per-tier value-teaser copy updated to point at the followup chips.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/621176

### Tests

1. Sign up a fresh Gmail account on `dev.new.expensify.com:8082` (incognito).
2. Pick **Manage my team's expenses**, then **11–25 employees** (any TEAM 11+ size). Pick any accounting integration and continue.
3. Open the new `#admins` chat. Wait for the Concierge welcome message with three followup chips.
4. Confirm the message says *"I'm Concierge — I'll help you get Expensify working for your team"* and has three chips at the bottom.
5. Click any chip — the canned answer renders inline.
6. Repeat with **1–4 employees** (MICRO) — confirm welcome still works, speaker now reads *"I'm Concierge"*.

- [ ] Verify that no errors appear in the JS console.

### Offline tests

While offline, the welcome message + chips render optimistically. The server-rendered guide block (for TEAM 11+) materializes on reconnect when the queued request flushes.

### QA Steps

Same flow on staging once both sides are deployed:
1. Fresh signup on `staging.new.expensify.com`.
2. Repeat with **26–100**, **101–1000**, **1001+** employees — confirm bespoke welcome lands for each size.
3. Confirm MICRO (1–10) signup still works (no guide-block paragraph; Concierge is the sole greeter).

- [ ] Verify that no errors appear in the JS console.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors
- [x] I followed proper code patterns
- [x] I verified all code is DRY
- [x] I verified the language code change works through localization