### PR TITLE
Allow bulk editing of coding fields on split expenses

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4831,11 +4831,6 @@ function canEditMultipleTransactions(
             continue;
         }
 
-        // Do not allow editing split expenses in bulk
-        if (transaction.comment?.source === CONST.IOU.TYPE.SPLIT || transaction.comment?.splits) {
-            return false;
-        }
-
         const reportActionsKey = `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${transaction.reportID}` as const;
         const actionsForReport = {...(searchSnapshotData?.[reportActionsKey] ?? {}), ...(reportActions?.[reportActionsKey] ?? {})};
         const reportAction = getIOUActionForTransactionID(Object.values(actionsForReport), transaction.transactionID);

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -2661,8 +2661,12 @@ function isExpenseSplit(transaction: OnyxEntry<Transaction>, originalTransaction
     return !originalTransaction?.comment?.splits;
 }
 
+function isSplitChildTransaction(transaction: OnyxEntry<Transaction> | Transaction): boolean {
+    return transaction?.comment?.source === CONST.IOU.TYPE.SPLIT;
+}
+
 function hasSplitExpenseInSelection(transactions: Transaction[]): boolean {
-    return transactions.some((transaction) => transaction.comment?.source === CONST.IOU.TYPE.SPLIT);
+    return transactions.some(isSplitChildTransaction);
 }
 
 const getOriginalTransactionWithSplitInfo = (transaction: OnyxEntry<Transaction>, originalTransaction: OnyxEntry<Transaction>) => {
@@ -2948,6 +2952,7 @@ export {
     hasTransactionBeenRejected,
     isExpenseSplit,
     hasSplitExpenseInSelection,
+    isSplitChildTransaction,
     getAttendeesListDisplayString,
     isCorporateCardTransaction,
     isExpenseUnreported,

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -2661,6 +2661,10 @@ function isExpenseSplit(transaction: OnyxEntry<Transaction>, originalTransaction
     return !originalTransaction?.comment?.splits;
 }
 
+function hasSplitExpenseInSelection(transactions: Transaction[]): boolean {
+    return transactions.some((transaction) => transaction.comment?.source === CONST.IOU.TYPE.SPLIT);
+}
+
 const getOriginalTransactionWithSplitInfo = (transaction: OnyxEntry<Transaction>, originalTransaction: OnyxEntry<Transaction>) => {
     const {originalTransactionID, source, splits} = transaction?.comment ?? {};
 
@@ -2943,6 +2947,7 @@ export {
     shouldShowViolation,
     hasTransactionBeenRejected,
     isExpenseSplit,
+    hasSplitExpenseInSelection,
     getAttendeesListDisplayString,
     isCorporateCardTransaction,
     isExpenseUnreported,

--- a/src/libs/actions/IOU/BulkEdit.ts
+++ b/src/libs/actions/IOU/BulkEdit.ts
@@ -149,6 +149,9 @@ function updateMultipleMoneyRequests({
         // Category, tag, tax, and billable only apply to expense/invoice reports and unreported (track) expenses.
         // For plain IOU transactions these fields are not applicable and must be silently skipped.
         const supportsExpenseFields = isUnreportedExpense || isFromExpenseReport || isInvoiceReportReportUtils(baseIouReport ?? undefined);
+        // Split children must keep their amount/currency/tax in sync with the split parent's totals.
+        // Allow coding fields (category, tag, merchant, etc.) but block these so we never desync the split.
+        const isSplitChild = transaction.comment?.source === CONST.IOU.TYPE.SPLIT;
         // Use the transaction's own policy for all per-transaction checks (permissions, tax, change-diffing).
         // Falls back to the shared bulk-edit policy when the transaction's workspace cannot be resolved.
         const transactionPolicy = (iouReport?.policyID ? allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${iouReport.policyID}`] : undefined) ?? policy;
@@ -170,7 +173,7 @@ function updateMultipleMoneyRequests({
         if (changes.created && canEditField(CONST.EDIT_REQUEST_FIELD.DATE)) {
             transactionChanges.created = changes.created;
         }
-        if (changes.amount !== undefined && canEditField(CONST.EDIT_REQUEST_FIELD.AMOUNT)) {
+        if (changes.amount !== undefined && !isSplitChild && canEditField(CONST.EDIT_REQUEST_FIELD.AMOUNT)) {
             transactionChanges.amount = changes.amount;
         }
         // When bulk-editing amount on a taxed expense without also changing taxCode, recompute
@@ -178,7 +181,7 @@ function updateMultipleMoneyRequests({
         // queued payload stay in sync with the new amount. Skip when the rate can't be resolved
         // (e.g. cross-policy bulk edit where the transaction's own policy is missing from cache)
         // to avoid silently overwriting a non-zero taxAmount with 0.
-        if (changes.amount !== undefined && !changes.taxCode && transaction.taxCode && supportsExpenseFields && canEditField(CONST.EDIT_REQUEST_FIELD.TAX_RATE)) {
+        if (changes.amount !== undefined && !isSplitChild && !changes.taxCode && transaction.taxCode && supportsExpenseFields && canEditField(CONST.EDIT_REQUEST_FIELD.TAX_RATE)) {
             const taxValue = getTaxValue(transactionPolicy, transaction, transaction.taxCode);
             if (taxValue) {
                 const decimals = getCurrencyDecimals(getCurrency(transaction));
@@ -186,7 +189,7 @@ function updateMultipleMoneyRequests({
                 transactionChanges.taxAmount = convertToBackendAmount(taxAmount);
             }
         }
-        if (changes.currency && canEditField(CONST.EDIT_REQUEST_FIELD.CURRENCY)) {
+        if (changes.currency && !isSplitChild && canEditField(CONST.EDIT_REQUEST_FIELD.CURRENCY)) {
             transactionChanges.currency = changes.currency;
         }
         if (changes.category !== undefined && supportsExpenseFields && canEditField(CONST.EDIT_REQUEST_FIELD.CATEGORY)) {
@@ -198,7 +201,7 @@ function updateMultipleMoneyRequests({
         if (changes.comment && canEditField(CONST.EDIT_REQUEST_FIELD.DESCRIPTION)) {
             transactionChanges.comment = getParsedComment(changes.comment);
         }
-        if (changes.taxCode && supportsExpenseFields && canEditField(CONST.EDIT_REQUEST_FIELD.TAX_RATE)) {
+        if (changes.taxCode && supportsExpenseFields && !isSplitChild && canEditField(CONST.EDIT_REQUEST_FIELD.TAX_RATE)) {
             transactionChanges.taxCode = changes.taxCode;
             const taxValue = getTaxValue(transactionPolicy, transaction, changes.taxCode);
             transactionChanges.taxValue = taxValue;

--- a/src/libs/actions/IOU/BulkEdit.ts
+++ b/src/libs/actions/IOU/BulkEdit.ts
@@ -22,7 +22,7 @@ import {
     isSelfDM,
     shouldEnableNegative,
 } from '@libs/ReportUtils';
-import {calculateTaxAmount, getAmount, getClearedPendingFields, getCurrency, getTaxValue, getUpdatedTransaction, isOnHold} from '@libs/TransactionUtils';
+import {calculateTaxAmount, getAmount, getClearedPendingFields, getCurrency, getTaxValue, getUpdatedTransaction, isOnHold, isSplitChildTransaction} from '@libs/TransactionUtils';
 import ViolationsUtils from '@libs/Violations/ViolationsUtils';
 import {createTransactionThreadReport} from '@userActions/Report';
 import CONST from '@src/CONST';
@@ -151,7 +151,7 @@ function updateMultipleMoneyRequests({
         const supportsExpenseFields = isUnreportedExpense || isFromExpenseReport || isInvoiceReportReportUtils(baseIouReport ?? undefined);
         // Split children must keep their amount/currency/tax in sync with the split parent's totals.
         // Allow coding fields (category, tag, merchant, etc.) but block these so we never put the split out of sync.
-        const isSplitChild = transaction.comment?.source === CONST.IOU.TYPE.SPLIT;
+        const isSplitChild = isSplitChildTransaction(transaction);
         // Use the transaction's own policy for all per-transaction checks (permissions, tax, change-diffing).
         // Falls back to the shared bulk-edit policy when the transaction's workspace cannot be resolved.
         const transactionPolicy = (iouReport?.policyID ? allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${iouReport.policyID}`] : undefined) ?? policy;

--- a/src/libs/actions/IOU/BulkEdit.ts
+++ b/src/libs/actions/IOU/BulkEdit.ts
@@ -150,7 +150,7 @@ function updateMultipleMoneyRequests({
         // For plain IOU transactions these fields are not applicable and must be silently skipped.
         const supportsExpenseFields = isUnreportedExpense || isFromExpenseReport || isInvoiceReportReportUtils(baseIouReport ?? undefined);
         // Split children must keep their amount/currency/tax in sync with the split parent's totals.
-        // Allow coding fields (category, tag, merchant, etc.) but block these so we never desync the split.
+        // Allow coding fields (category, tag, merchant, etc.) but block these so we never put the split out of sync.
         const isSplitChild = transaction.comment?.source === CONST.IOU.TYPE.SPLIT;
         // Use the transaction's own policy for all per-transaction checks (permissions, tax, change-diffing).
         // Falls back to the shared bulk-edit policy when the transaction's workspace cannot be resolved.

--- a/src/pages/Search/SearchEditMultiple/SearchEditMultiplePage.tsx
+++ b/src/pages/Search/SearchEditMultiple/SearchEditMultiplePage.tsx
@@ -20,7 +20,7 @@ import {getCleanedTagName, getTagLists, hasDependentTags as hasDependentTagsPoli
 import {canEditFieldOfMoneyRequest, isInvoiceReport, isIOUReport} from '@libs/ReportUtils';
 import {getSearchBulkEditPolicyID} from '@libs/SearchUIUtils';
 import {hasEnabledTags, shouldShowDependentTagList} from '@libs/TagsOptionsListUtils';
-import {getTagArrayFromName, getTaxName, isDistanceRequest, isManagedCardTransaction, isPerDiemRequest, isTimeRequest} from '@libs/TransactionUtils';
+import {getTagArrayFromName, getTaxName, hasSplitExpenseInSelection, isDistanceRequest, isManagedCardTransaction, isPerDiemRequest, isTimeRequest} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -68,6 +68,8 @@ function SearchEditMultiplePage() {
     const hasCustomUnitTransaction = selectedTransactionContexts.some(({transaction}) => isDistanceRequest(transaction) || isPerDiemRequest(transaction));
 
     const hasPerDiemOrTimeTransaction = selectedTransactionContexts.some(({transaction}) => isPerDiemRequest(transaction) || isTimeRequest(transaction));
+
+    const hasSplitTransaction = hasSplitExpenseInSelection(selectedTransactionContexts.map(({transaction}) => transaction));
 
     const isFieldDisabledForAnyTransaction = (field: ValueOf<typeof CONST.EDIT_REQUEST_FIELD>) =>
         selectedTransactionContexts.some(({transaction, report, reportAction, transactionPolicy}) => {
@@ -227,7 +229,7 @@ function SearchEditMultiplePage() {
             description: translate('iou.amount'),
             title: draftTransaction?.amount !== undefined ? convertToDisplayStringWithoutCurrency(draftTransaction.amount, currency) : '',
             route: ROUTES.SEARCH_EDIT_MULTIPLE_AMOUNT_RHP,
-            disabled: hasCustomUnitTransaction || hasPartiallyEditableTransaction,
+            disabled: hasCustomUnitTransaction || hasPartiallyEditableTransaction || hasSplitTransaction,
         },
         {
             description: translate('common.description'),
@@ -263,7 +265,7 @@ function SearchEditMultiplePage() {
                       description: policy?.taxRates?.name ?? translate('common.tax'),
                       title: draftTransaction?.taxCode ? (getTaxName(policy, draftTransaction) ?? '') : '',
                       route: ROUTES.SEARCH_EDIT_MULTIPLE_TAX_RHP,
-                      disabled: hasPartiallyEditableTaxRateTransaction,
+                      disabled: hasPartiallyEditableTaxRateTransaction || hasSplitTransaction,
                   },
               ]
             : []),

--- a/tests/actions/IOUTest/BulkEditTest.ts
+++ b/tests/actions/IOUTest/BulkEditTest.ts
@@ -1093,6 +1093,76 @@ describe('actions/IOU/BulkEdit', () => {
             canEditFieldSpy.mockRestore();
         });
 
+        it('applies category to split children but skips amount, currency, and tax', () => {
+            const transactionID = 'transaction-split-1';
+            const transactionThreadReportID = 'thread-split-1';
+            const iouReportID = 'iou-split-1';
+            const policy = createRandomPolicy(50, CONST.POLICY.TYPE.TEAM);
+
+            const transactionThread: Report = {
+                ...createRandomReport(50, undefined),
+                reportID: transactionThreadReportID,
+                parentReportID: iouReportID,
+                policyID: policy.id,
+            };
+            const iouReport: Report = {
+                ...createRandomReport(51, undefined),
+                reportID: iouReportID,
+                policyID: policy.id,
+                type: CONST.REPORT.TYPE.EXPENSE,
+            };
+
+            const reports = {
+                [`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`]: transactionThread,
+                [`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`]: iouReport,
+            };
+
+            const splitTransaction: Transaction = {
+                ...createRandomTransaction(50),
+                transactionID,
+                reportID: iouReportID,
+                transactionThreadReportID,
+                amount: -1000,
+                currency: CONST.CURRENCY.USD,
+                category: 'OldCategory',
+                comment: {source: CONST.IOU.TYPE.SPLIT},
+            };
+            const transactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`]: splitTransaction,
+            };
+
+            const canEditFieldSpy = jest.spyOn(require('@libs/ReportUtils'), 'canEditFieldOfMoneyRequest').mockReturnValue(true);
+            // eslint-disable-next-line rulesdir/no-multiple-api-calls
+            const writeSpy = jest.spyOn(API, 'write').mockImplementation(jest.fn());
+
+            updateMultipleMoneyRequests({
+                transactionIDs: [transactionID],
+                changes: {category: 'Food', amount: 5000, currency: CONST.CURRENCY.EUR, taxCode: 'id_TAX_RATE_1'},
+                policy,
+                reports,
+                transactions,
+                reportActions: {},
+                policyCategories: undefined,
+                policyTags: {},
+                hash: undefined,
+                introSelected: undefined,
+                betas: undefined,
+            });
+
+            expect(writeSpy).toHaveBeenCalled();
+            const params = writeSpy.mock.calls.at(0)?.[1] as {updates: string};
+            const updates = JSON.parse(params.updates) as Record<string, unknown>;
+            expect(updates.category).toBe('Food');
+            expect(updates.amount).toBeUndefined();
+            expect(updates.currency).toBeUndefined();
+            expect(updates.taxCode).toBeUndefined();
+            expect(updates.taxValue).toBeUndefined();
+            expect(updates.taxAmount).toBeUndefined();
+
+            writeSpy.mockRestore();
+            canEditFieldSpy.mockRestore();
+        });
+
         it('uses per-transaction policy for category tax mapping in cross-policy bulk edit', () => {
             // Given: two different policies – transactionPolicy has expense rules mapping "Advertising" → "id_TAX_RATE_1",
             // while the shared bulk-edit policy has no expense rules at all.

--- a/tests/actions/IOUTest/BulkEditTest.ts
+++ b/tests/actions/IOUTest/BulkEditTest.ts
@@ -1147,6 +1147,8 @@ describe('actions/IOU/BulkEdit', () => {
                 hash: undefined,
                 introSelected: undefined,
                 betas: undefined,
+                currentUserLogin: 'test@example.com',
+                currentUserAccountID: 1,
             });
 
             expect(writeSpy).toHaveBeenCalled();

--- a/tests/unit/canEditMultipleTransactionsTest.ts
+++ b/tests/unit/canEditMultipleTransactionsTest.ts
@@ -227,7 +227,16 @@ describe('canEditMultipleTransactions', () => {
         expect(result).toBe(true);
     });
 
-    it('returns false when selecting an unreported expense and a split expense', () => {
+    it('returns true when selecting a reported split expense with editable coding fields', () => {
+        const {transaction1, transaction2, reports, policies, reportActions} = buildTestData();
+
+        const splitTransaction: Transaction = {...transaction2, comment: {source: CONST.IOU.TYPE.SPLIT}};
+
+        const result = canEditMultipleTransactions([transaction1, splitTransaction], reportActions, reports, policies);
+        expect(result).toBe(true);
+    });
+
+    it('returns true when selecting an unreported expense and a reported split expense', () => {
         const {transaction1, transaction2, reports, policies, reportActions} = buildTestData();
 
         const unreportedTransaction: Transaction = {...transaction1, reportID: CONST.REPORT.UNREPORTED_REPORT_ID};
@@ -235,11 +244,11 @@ describe('canEditMultipleTransactions', () => {
 
         // Unreported first, split second
         const result = canEditMultipleTransactions([unreportedTransaction, splitTransaction], reportActions, reports, policies);
-        expect(result).toBe(false);
+        expect(result).toBe(true);
 
         // Split first, unreported second
         const resultReversed = canEditMultipleTransactions([splitTransaction, unreportedTransaction], reportActions, reports, policies);
-        expect(resultReversed).toBe(false);
+        expect(resultReversed).toBe(true);
     });
 
     it('returns false when selecting an unreported expense and an approved expense', () => {


### PR DESCRIPTION
### Explanation of Change

Right now if any split expense is in your bulk-edit selection the entire action is blocked, even for fields like category, tag, or merchant that have nothing to do with split-total validation. This just removes that blanket guard and replaces it with a narrower one.

Specifically:
- Removed the `if (transaction.comment?.source === CONST.IOU.TYPE.SPLIT || transaction.comment?.splits) { return false; }` block from `canEditMultipleTransactions`. Split children on open, unapproved reports can now return `true`.
- Added `hasSplitExpenseInSelection` to `TransactionUtils` — returns `true` if any selected transaction is a split child (`comment.source === 'split'`).
- `SearchEditMultiplePage` uses that flag to disable the amount and tax rows when a split is in the selection (same pattern as `hasCustomUnitTransaction` for distance/per-diem).
- `BulkEdit.ts` skips amount, currency, and tax assignments per-transaction when `isSplitChild` is true — defense-in-depth so the write path doesn't apply blocked fields even if the UI somehow allows it.
- Bill-split parents (`comment.splits`) are still fully blocked since those represent IOU flows between people, not the typical coding-field scenario.

No backend change needed. Auth's `UpdateMoneyRequest.cpp` only has split-specific logic for amount changes (sum validation). Category/tag/merchant go through the standard `moneyRequest.verifyUserCanModify` path like any other transaction.

### Fixed Issues

$ https://github.com/Expensify/App/issues/89416

### Tests

1. In Search, create a report with a split expense.
2. Select the split expense alongside at least one regular expense.
3. Tap "Edit multiple."
4. Verify the category, tag, merchant, date, and description fields are enabled.
5. Verify the amount and tax fields are disabled (grayed out / not tappable).
6. Edit category on the selection and save.
7. Verify the category updated on the split expense.
8. Verify that no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Put the device offline.
2. Repeat steps 1–7 from Tests.
3. Verify the category change is reflected optimistically before reconnecting.
4. Reconnect and verify the change persists.

### QA Steps

**Prerequisites:** Have a workspace with at least one report containing a split expense and at least one regular expense.

**Scenario 1: Coding fields are editable on splits**

1. Navigate to the Search tab and filter to see expenses.
1. Select a split expense and a regular expense.
1. Tap "Edit multiple" and select Category.
1. Choose a category and save.
1. Verify both the split and the regular expense now show that category.

**Scenario 2: Amount and tax are blocked on splits**

1. In the same "Edit multiple" flow with a split in the selection, verify the amount field is disabled/grayed out.
1. Verify the tax field is also disabled/grayed out.
1. Verify there are no console errors.

**Scenario 3: Pure split selection**

1. Select only split expenses (no regular expenses).
1. Tap "Edit multiple."
1. Verify merchant, description, category, tag, and date fields are all available.
1. Verify amount and tax fields are disabled.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="366" height="616" alt="Screenshot 2026-05-01 at 2 28 13 PM" src="https://github.com/user-attachments/assets/fb313ec9-12e9-444f-9d0e-2d388e8b0e41" />

<img width="1481" height="912" alt="Screenshot 2026-05-01 at 2 26 30 PM" src="https://github.com/user-attachments/assets/88ce3188-54eb-4347-b84a-0db6b35ced12" />

</details>