### PR TITLE
Add Avatar column to Reports column selector

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -7646,6 +7646,7 @@ const CONST = {
                     ACTION: this.TABLE_COLUMNS.ACTION,
                 },
                 EXPENSE_REPORT: {
+                    AVATAR: this.TABLE_COLUMNS.AVATAR,
                     DATE: this.TABLE_COLUMNS.DATE,
                     SUBMITTED: this.TABLE_COLUMNS.SUBMITTED,
                     APPROVED: this.TABLE_COLUMNS.APPROVED,
@@ -7690,17 +7691,20 @@ const CONST = {
         get GROUP_CUSTOM_COLUMNS() {
             return {
                 FROM: {
+                    AVATAR: this.TABLE_COLUMNS.AVATAR,
                     FROM: this.TABLE_COLUMNS.GROUP_FROM,
                     EXPENSES: this.TABLE_COLUMNS.GROUP_EXPENSES,
                     TOTAL: this.TABLE_COLUMNS.GROUP_TOTAL,
                 },
                 CARD: {
+                    AVATAR: this.TABLE_COLUMNS.AVATAR,
                     CARD: this.TABLE_COLUMNS.GROUP_CARD,
                     FEED: this.TABLE_COLUMNS.GROUP_FEED,
                     EXPENSES: this.TABLE_COLUMNS.GROUP_EXPENSES,
                     TOTAL: this.TABLE_COLUMNS.GROUP_TOTAL,
                 },
                 WITHDRAWAL_ID: {
+                    AVATAR: this.TABLE_COLUMNS.AVATAR,
                     WITHDRAWN: this.TABLE_COLUMNS.GROUP_WITHDRAWN,
                     WITHDRAWAL_STATUS: this.TABLE_COLUMNS.GROUP_WITHDRAWAL_STATUS,
                     BANK_ACCOUNT: this.TABLE_COLUMNS.GROUP_BANK_ACCOUNT,
@@ -7758,6 +7762,7 @@ const CONST = {
                     this.TABLE_COLUMNS.TOTAL_AMOUNT,
                 ],
                 EXPENSE_REPORT: [
+                    this.TABLE_COLUMNS.AVATAR,
                     this.TABLE_COLUMNS.DATE,
                     this.TABLE_COLUMNS.STATUS,
                     this.TABLE_COLUMNS.TITLE,
@@ -7774,9 +7779,10 @@ const CONST = {
         },
         get GROUP_DEFAULT_COLUMNS() {
             return {
-                FROM: [this.TABLE_COLUMNS.GROUP_FROM, this.TABLE_COLUMNS.GROUP_EXPENSES, this.TABLE_COLUMNS.GROUP_TOTAL],
-                CARD: [this.TABLE_COLUMNS.GROUP_CARD, this.TABLE_COLUMNS.GROUP_FEED, this.TABLE_COLUMNS.GROUP_EXPENSES, this.TABLE_COLUMNS.GROUP_TOTAL],
+                FROM: [this.TABLE_COLUMNS.AVATAR, this.TABLE_COLUMNS.GROUP_FROM, this.TABLE_COLUMNS.GROUP_EXPENSES, this.TABLE_COLUMNS.GROUP_TOTAL],
+                CARD: [this.TABLE_COLUMNS.AVATAR, this.TABLE_COLUMNS.GROUP_CARD, this.TABLE_COLUMNS.GROUP_FEED, this.TABLE_COLUMNS.GROUP_EXPENSES, this.TABLE_COLUMNS.GROUP_TOTAL],
                 WITHDRAWAL_ID: [
+                    this.TABLE_COLUMNS.AVATAR,
                     this.TABLE_COLUMNS.GROUP_WITHDRAWN,
                     this.TABLE_COLUMNS.GROUP_WITHDRAWAL_STATUS,
                     this.TABLE_COLUMNS.GROUP_BANK_ACCOUNT,

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -182,6 +182,7 @@ const translations: TranslationDeepObject<typeof en> = {
         members: 'Mitglieder',
         invite: 'Einladen',
         here: 'hier',
+        avatar: 'Avatar',
         date: 'Datum',
         dob: 'Geburtsdatum',
         currentYear: 'Laufendes Jahr',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -182,7 +182,6 @@ const translations: TranslationDeepObject<typeof en> = {
         members: 'Mitglieder',
         invite: 'Einladen',
         here: 'hier',
-        avatar: 'Avatar',
         date: 'Datum',
         dob: 'Geburtsdatum',
         currentYear: 'Laufendes Jahr',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -188,6 +188,7 @@ const translations = {
         members: 'Members',
         invite: 'Invite',
         here: 'here',
+        avatar: 'Avatar',
         date: 'Date',
         dob: 'Date of birth',
         currentYear: 'Current year',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -120,6 +120,7 @@ const translations: TranslationDeepObject<typeof en> = {
         members: 'Miembros',
         invite: 'Invitar',
         here: 'aquí',
+        avatar: 'Avatar',
         date: 'Fecha',
         dob: 'Fecha de nacimiento',
         currentYear: 'Año actual',

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -4010,6 +4010,8 @@ function getCustomColumnDefault(value?: SearchDataTypes | SearchGroupBy): Search
 
 function getSearchColumnTranslationKey(column: SearchColumnType): TranslationPaths {
     switch (column) {
+        case CONST.SEARCH.TABLE_COLUMNS.AVATAR:
+            return 'common.avatar';
         case CONST.SEARCH.TABLE_COLUMNS.DATE:
             return 'common.date';
         case CONST.SEARCH.TABLE_COLUMNS.SUBMITTED:

--- a/src/pages/Search/SearchColumnsPage.tsx
+++ b/src/pages/Search/SearchColumnsPage.tsx
@@ -26,6 +26,7 @@ function SearchColumnsPage() {
     // We need at least one element with flex1 in the table to ensure the table looks good in the UI, so we don't allow removing the total columns
     // since it makes sense for them to show up in an expense management App and it fixes the layout issues.
     const requiredColumns = new Set<SearchCustomColumnIds>([
+        CONST.SEARCH.TABLE_COLUMNS.AVATAR,
         CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT,
         CONST.SEARCH.TABLE_COLUMNS.TOTAL,
         CONST.SEARCH.TABLE_COLUMNS.GROUP_CARD,


### PR DESCRIPTION
### Explanation of Change

The `Avatar` column is rendered as a required column on `type:expense-report` views and on `group-by:from`, `group-by:card`, and `group-by:withdrawal-id` queries (see `getColumnsToShow` and `groupByRequiredColumns` in `SearchUIUtils.ts`). However, it was missing from `TYPE_CUSTOM_COLUMNS` and `GROUP_CUSTOM_COLUMNS`, so the column selector never listed it.

This PR:
- Adds `AVATAR` to `TYPE_CUSTOM_COLUMNS.EXPENSE_REPORT` and `TYPE_DEFAULT_COLUMNS.EXPENSE_REPORT`.
- Adds `AVATAR` to `GROUP_CUSTOM_COLUMNS` / `GROUP_DEFAULT_COLUMNS` for `FROM`, `CARD`, and `WITHDRAWAL_ID` (the group-bys that already force-render avatar).
- Adds an `'common.avatar'` translation case in `getSearchColumnTranslationKey`.
- Marks `AVATAR` as a required (non-deselectable) column in `SearchColumnsPage`, mirroring `getColumnsToShow`'s required-column behavior so users can see it but not remove it.

Other locales will be auto-filled by the `generateTranslations` workflow.

### Fixed Issues

$ https://github.com/Expensify/App/issues/84393
PROPOSAL: N/A — implementation by assigned contributor; aligned with the column-selector pattern established in #83981.

### Tests

1. Sign in to an account with multiple expense reports.
2. Navigate to **Reports** tab.
3. Click **Edit columns**.
4. Verify that **Avatar** appears in the column list and is selected with a disabled toggle (cannot be unchecked).
5. Group by **From** (or **Card**, or **Withdrawal ID**) and open **Edit columns**.
6. Verify **Avatar** appears in the **Group columns** section with a disabled toggle.
7. Verify the avatar still renders in the table itself for all the above views.
- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as **Tests**.

### QA Steps

1. Go to https://staging.new.expensify.com/.
2. Navigate to **Reports** tab.
3. Click **Edit columns** and verify that **Avatar** is now in the column list (selected and disabled).
4. Switch the search to `group-by:from` (and `card`, `withdrawal-id`); verify **Avatar** is listed in **Group columns** in the column selector.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I followed the [guidelines as stated in the Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).