### PR TITLE
[50] fix: show discount banner when only firstDayFreeTrial is set

### DIFF
--- a/src/libs/SubscriptionUtils.ts
+++ b/src/libs/SubscriptionUtils.ts
@@ -157,10 +157,6 @@ function shouldShowDiscountBanner(
         return false;
     }
 
-    if (!isUserOnFreeTrial(firstDayFreeTrial, lastDayFreeTrial)) {
-        return false;
-    }
-
     if (doesUserHavePaymentCardAdded(userBillingFundID)) {
         return false;
     }
@@ -169,14 +165,23 @@ function shouldShowDiscountBanner(
         return false;
     }
 
-    const dateNow = Math.floor(Date.now() / 1000);
-    const firstDayTimestamp = fromZonedTime(`${firstDayFreeTrial}`, 'UTC').getTime() / 1000;
-    const lastDayTimestamp = fromZonedTime(`${lastDayFreeTrial}`, 'UTC').getTime() / 1000;
-    if (dateNow > lastDayTimestamp) {
+    // Check if we're within the early discount window using firstDayFreeTrial.
+    // This handles the case where lastDayFreeTrial is not yet set but the
+    // user has started their free trial (firstDayFreeTrial is available).
+    if (!isInEarlyDiscountWindow(firstDayFreeTrial)) {
         return false;
     }
 
-    return dateNow <= firstDayTimestamp + CONST.TRIAL_DURATION_DAYS * CONST.DATE.SECONDS_PER_DAY;
+    // If lastDayFreeTrial is set, also verify we haven't passed it
+    if (lastDayFreeTrial) {
+        const dateNow = Math.floor(Date.now() / 1000);
+        const lastDayTimestamp = fromZonedTime(`${lastDayFreeTrial}`, 'UTC').getTime() / 1000;
+        if (dateNow > lastDayTimestamp) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 function getEarlyDiscountInfo(firstDayFreeTrial: string | undefined): DiscountInfo | null {
@@ -428,6 +433,19 @@ function isUserOnFreeTrial(firstDayFreeTrial: string | undefined, lastDayFreeTri
     const lastDayFreeTrialDate = new Date(`${lastDayFreeTrial}Z`);
 
     return isAfter(currentDate, firstDayFreeTrialDate) && isBefore(currentDate, lastDayFreeTrialDate);
+}
+
+/**
+ * Whether the user is within the early discount window based on firstDayFreeTrial alone.
+ * This handles the case where lastDayFreeTrial is not yet set but firstDayFreeTrial is available.
+ */
+function isInEarlyDiscountWindow(firstDayFreeTrial: string | undefined): boolean {
+    if (!firstDayFreeTrial) {
+        return false;
+    }
+    const dateNow = Math.floor(Date.now() / 1000);
+    const firstDayTimestamp = fromZonedTime(`${firstDayFreeTrial}`, 'UTC').getTime() / 1000;
+    return dateNow <= firstDayTimestamp + CONST.TRIAL_DURATION_DAYS * CONST.DATE.SECONDS_PER_DAY;
 }
 
 /**

--- a/src/pages/home/FreeTrialSection/useFreeTrial.ts
+++ b/src/pages/home/FreeTrialSection/useFreeTrial.ts
@@ -62,7 +62,10 @@ function useFreeTrial(): FreeTrialState {
         };
     }, [firstDayFreeTrial, showDiscount]);
 
-    if (!onFreeTrial || hasPaymentCard || !hasOwnedPaidPolicies) {
+    // Show the section if the user is on a free trial OR if the discount banner should be shown.
+    // The discount banner check handles the case where lastDayFreeTrial is not yet set
+    // but firstDayFreeTrial is available and we're within the discount window.
+    if ((!onFreeTrial && !showDiscount) || hasPaymentCard || !hasOwnedPaidPolicies) {
         return {shouldShowFreeTrialSection: false, discountType: null, daysLeft: 0, discountInfo: null};
     }
 


### PR DESCRIPTION
## Problem

When a user's free trial starts and `firstDayFreeTrial` is set but `lastDayFreeTrial` is not yet available, the 50% discount banner doesn't show on the Home page. Instead, only the basic trial banner appears ("Trial: 30 days").

The root cause is that `shouldShowDiscountBanner()` calls `isUserOnFreeTrial()` which requires BOTH `firstDayFreeTrial` AND `lastDayFreeTrial` to be set. When only `firstDayFreeTrial` is available, `isUserOnFreeTrial()` returns false, preventing the discount banner from showing.

## Solution

1. **Added `isInEarlyDiscountWindow()` helper** in `SubscriptionUtils.ts` that checks if we're within the trial duration using only `firstDayFreeTrial` (no `lastDayFreeTrial` required).

2. **Updated `shouldShowDiscountBanner()`** to use the new helper instead of requiring `isUserOnFreeTrial()`. If `lastDayFreeTrial` is set, it still verifies we haven't passed it.

3. **Updated `useFreeTrial` hook** to show the free trial section when `showDiscount` is true, even if `onFreeTrial` is false (which happens when `lastDayFreeTrial` is missing).

## Testing

- Set `nvp_private_firstDayFreeTrial` to today's date via Onyx snippet
- Navigate to Home page
- Verify: stopwatch icon, "50% off your first year" title, countdown timer

$ #88447