### PR TITLE
refactor: PureReportActionItem, shrink state and prop surface

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -29,6 +29,7 @@ import type {
     VisibleReportActionsDerivedValue,
 } from '@src/types/onyx';
 import type {
+    DecisionName,
     JoinWorkspaceResolution,
     OriginalMessageChangeLog,
     OriginalMessageExportIntegration,
@@ -257,6 +258,19 @@ function isReversedTransaction(reportAction: OnyxInputOrEntry<ReportAction | Opt
 
 function isPendingRemove(reportAction: OnyxInputOrEntry<ReportAction>): boolean {
     return getReportActionMessage(reportAction)?.moderationDecision?.decision === CONST.MODERATION.MODERATOR_DECISION_PENDING_REMOVE;
+}
+
+/**
+ * Derives the moderation decision and whether the action is flagged from the action itself.
+ * Used by leaves that previously received the equivalent values as props from PureReportActionItem.
+ */
+function getModerationFlagState(reportAction: OnyxInputOrEntry<ReportAction>): {latestDecision: DecisionName | undefined; hasBeenFlagged: boolean} {
+    const latestDecision = getReportActionMessage(reportAction)?.moderationDecision?.decision;
+    const hasBeenFlagged =
+        !!latestDecision &&
+        ![CONST.MODERATION.MODERATOR_DECISION_APPROVED, CONST.MODERATION.MODERATOR_DECISION_PENDING].some((item) => item === latestDecision) &&
+        !isPendingRemove(reportAction);
+    return {latestDecision, hasBeenFlagged};
 }
 
 function isMoneyRequestAction(reportAction: OnyxInputOrEntry<ReportAction>): reportAction is ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.IOU> {
@@ -4634,6 +4648,7 @@ export {
     isOldDotReportAction,
     isPayAction,
     isPendingRemove,
+    getModerationFlagState,
     isPolicyChangeLogAction,
     isReimbursementDeQueuedOrCanceledAction,
     isReimbursementQueuedAction,

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -265,6 +265,10 @@ function isPendingRemove(reportAction: OnyxInputOrEntry<ReportAction>): boolean 
  * Used by leaves that previously received the equivalent values as props from PureReportActionItem.
  */
 function getModerationFlagState(reportAction: OnyxInputOrEntry<ReportAction>): {latestDecision: DecisionName | undefined; hasBeenFlagged: boolean} {
+    // Moderation only applies to ADD_COMMENT actions
+    if (reportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT) {
+        return {latestDecision: undefined, hasBeenFlagged: false};
+    }
     const latestDecision = getReportActionMessage(reportAction)?.moderationDecision?.decision;
     const hasBeenFlagged =
         !!latestDecision &&

--- a/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
+++ b/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
@@ -19,8 +19,9 @@ type DelegateOnBehalfOfTextProps = {
 function DelegateOnBehalfOfText({mainAccountID, fallbackLogin}: DelegateOnBehalfOfTextProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const loginSelector = useCallback((list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => (mainAccountID ? list?.[mainAccountID]?.login : undefined), [mainAccountID]);
-    const [resolvedLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: loginSelector});
+    const [resolvedLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+        selector: (list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => (mainAccountID ? list?.[mainAccountID]?.login : undefined),
+    });
     const mainAccountLogin = resolvedLogin ?? fallbackLogin;
     const accountOwnerDetails = getPersonalDetailByEmail(String(mainAccountLogin ?? ''));
     return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', accountOwnerDetails?.displayName ?? '')}</Text>;

--- a/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
+++ b/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
@@ -19,10 +19,10 @@ type DelegateOnBehalfOfTextProps = {
 function DelegateOnBehalfOfText({mainAccountID, fallbackLogin}: DelegateOnBehalfOfTextProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const [resolvedLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
-        selector: (list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => (mainAccountID ? list?.[mainAccountID]?.login : undefined),
+    const [resolvedDetail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+        selector: (list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => (mainAccountID ? list?.[mainAccountID] : undefined),
     });
-    const mainAccountLogin = resolvedLogin ?? fallbackLogin;
+    const mainAccountLogin = resolvedDetail?.login ?? fallbackLogin;
     const accountOwnerDetails = getPersonalDetailByEmail(String(mainAccountLogin ?? ''));
     return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', accountOwnerDetails?.displayName ?? '')}</Text>;
 }

--- a/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
+++ b/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
@@ -3,10 +3,23 @@ import React from 'react';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
+import usePersonalDetailsByLogin from '@hooks/usePersonalDetailsByLogin';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+
+type DelegateOnBehalfOfTextFallbackProps = {
+    /** Fallback login looked up in the personal-details map when the account ID is not yet hydrated. */
+    fallbackLogin: string | undefined;
+};
+
+function DelegateOnBehalfOfTextFallback({fallbackLogin}: DelegateOnBehalfOfTextFallbackProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const personalDetailsByLogin = usePersonalDetailsByLogin();
+    const detail = personalDetailsByLogin[fallbackLogin?.toLowerCase() ?? ''];
+    return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', detail?.displayName ?? '')}</Text>;
+}
 
 type DelegateOnBehalfOfTextProps = {
     /** The account ID whose login drives the "on behalf of" name. */
@@ -20,9 +33,11 @@ function DelegateOnBehalfOfText({mainAccountID, fallbackLogin}: DelegateOnBehalf
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const [resolvedDetail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: personalDetailsSelector(mainAccountID ?? CONST.DEFAULT_NUMBER_ID)});
-    const mainAccountLogin = resolvedDetail?.login ?? fallbackLogin;
-    const accountOwnerDetails = getPersonalDetailByEmail(String(mainAccountLogin ?? ''));
-    return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', accountOwnerDetails?.displayName ?? '')}</Text>;
+
+    if (!resolvedDetail?.login) {
+        return <DelegateOnBehalfOfTextFallback fallbackLogin={fallbackLogin} />;
+    }
+    return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', resolvedDetail.displayName ?? '')}</Text>;
 }
 
 export default DelegateOnBehalfOfText;

--- a/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
+++ b/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
@@ -1,12 +1,12 @@
+import {personalDetailsSelector} from '@selectors/PersonalDetails';
 import React from 'react';
-import type {OnyxEntry} from 'react-native-onyx';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type * as OnyxTypes from '@src/types/onyx';
 
 type DelegateOnBehalfOfTextProps = {
     /** The account ID whose login drives the "on behalf of" name. */
@@ -19,9 +19,7 @@ type DelegateOnBehalfOfTextProps = {
 function DelegateOnBehalfOfText({mainAccountID, fallbackLogin}: DelegateOnBehalfOfTextProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const [resolvedDetail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
-        selector: (list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => (mainAccountID ? list?.[mainAccountID] : undefined),
-    });
+    const [resolvedDetail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: personalDetailsSelector(mainAccountID ?? CONST.DEFAULT_NUMBER_ID)});
     const mainAccountLogin = resolvedDetail?.login ?? fallbackLogin;
     const accountOwnerDetails = getPersonalDetailByEmail(String(mainAccountLogin ?? ''));
     return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', accountOwnerDetails?.displayName ?? '')}</Text>;

--- a/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
+++ b/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
@@ -1,0 +1,29 @@
+import React, {useCallback} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type * as OnyxTypes from '@src/types/onyx';
+
+type DelegateOnBehalfOfTextProps = {
+    /** The account ID whose login drives the "on behalf of" name. */
+    mainAccountID: number | undefined;
+
+    /** Fallback login if the account is not yet present in personal details. */
+    fallbackLogin: string | undefined;
+};
+
+function DelegateOnBehalfOfText({mainAccountID, fallbackLogin}: DelegateOnBehalfOfTextProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const loginSelector = useCallback((list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => (mainAccountID ? list?.[mainAccountID]?.login : undefined), [mainAccountID]);
+    const [resolvedLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: loginSelector});
+    const mainAccountLogin = resolvedLogin ?? fallbackLogin;
+    const accountOwnerDetails = getPersonalDetailByEmail(String(mainAccountLogin ?? ''));
+    return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', accountOwnerDetails?.displayName ?? '')}</Text>;
+}
+
+export default DelegateOnBehalfOfText;

--- a/src/pages/inbox/report/HumanAgentAssistedByText.tsx
+++ b/src/pages/inbox/report/HumanAgentAssistedByText.tsx
@@ -1,0 +1,24 @@
+import React, {useCallback} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {getHumanAgentFirstName} from '@libs/ReportActionsUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type * as OnyxTypes from '@src/types/onyx';
+
+type HumanAgentAssistedByTextProps = {
+    /** The action whose human agent's first name drives the "assisted by" label. */
+    action: OnyxEntry<OnyxTypes.ReportAction>;
+};
+
+function HumanAgentAssistedByText({action}: HumanAgentAssistedByTextProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const nameSelector = useCallback((list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => getHumanAgentFirstName(action, list), [action]);
+    const [humanAgentName] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: nameSelector});
+    return <Text style={[styles.chatDelegateMessage]}>{translate('reportAction.assistedBy', humanAgentName ?? translate('reportAction.humanSupportAgent'))}</Text>;
+}
+
+export default HumanAgentAssistedByText;

--- a/src/pages/inbox/report/HumanAgentAssistedByText.tsx
+++ b/src/pages/inbox/report/HumanAgentAssistedByText.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
@@ -16,8 +16,9 @@ type HumanAgentAssistedByTextProps = {
 function HumanAgentAssistedByText({action}: HumanAgentAssistedByTextProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const nameSelector = useCallback((list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => getHumanAgentFirstName(action, list), [action]);
-    const [humanAgentName] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: nameSelector});
+    const [humanAgentName] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+        selector: (list: OnyxEntry<OnyxTypes.PersonalDetailsList>) => getHumanAgentFirstName(action, list),
+    });
     return <Text style={[styles.chatDelegateMessage]}>{translate('reportAction.assistedBy', humanAgentName ?? translate('reportAction.humanSupportAgent'))}</Text>;
 }
 

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -92,6 +92,7 @@ import {
 import {
     canWriteInReport,
     getMovedActionMessage,
+    getTransactionsWithReceipts,
     isCompletedTaskReport,
     isExpenseReport,
     isHarvestCreatedExpenseReport as isHarvestCreatedExpenseReportUtils,
@@ -221,9 +222,6 @@ type PureReportActionItemProps = {
     /** Whether the provided report is a closed expense report with no expenses */
     isClosedExpenseReportWithNoExpenses?: boolean;
 
-    /** Gets all transactions on an IOU report with a receipt */
-    getTransactionsWithReceipts?: (iouReportID: string | undefined) => OnyxTypes.Transaction[];
-
     /** User payment card ID */
     userBillingFundID?: number;
 
@@ -275,7 +273,6 @@ function PureReportActionItem({
     isArchivedRoom,
     isChronosReport,
     isClosedExpenseReportWithNoExpenses,
-    getTransactionsWithReceipts = () => [],
     userBillingFundID,
     shouldShowBorder,
     shouldHighlight = false,
@@ -1040,8 +1037,7 @@ function PureReportActionItem({
     const whisperedTo = getWhisperedTo(action);
 
     const iouReportID = isMoneyRequestAction(action) && getOriginalMessage(action)?.IOUReportID ? getOriginalMessage(action)?.IOUReportID?.toString() : undefined;
-    const transactionsWithReceipts = getTransactionsWithReceipts(iouReportID);
-    const isWhisper = whisperedTo.length > 0 && transactionsWithReceipts.length === 0;
+    const isWhisper = whisperedTo.length > 0 && getTransactionsWithReceipts(iouReportID).length === 0;
 
     // Calculating accessibilityLabel for chat message with sender, date and time and the message content.
     const displayName = getDisplayNameOrDefault(personalDetails?.[action.actorAccountID ?? CONST.DEFAULT_NUMBER_ID]);

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -931,7 +931,6 @@ function PureReportActionItem({
                     draftMessage={draftMessage}
                     index={index}
                     isHidden={isHidden}
-                    moderationDecision={moderationDecision}
                     updateHiddenState={updateHiddenState}
                     isArchivedRoom={isArchivedRoom}
                     composerTextInputRef={composerTextInputRef}
@@ -1024,9 +1023,6 @@ function PureReportActionItem({
                     iouReport={iouReport}
                     isHovered={hovered || isContextMenuActive}
                     isActive={isReportActionActive && !isContextMenuActive}
-                    hasBeenFlagged={
-                        ![CONST.MODERATION.MODERATOR_DECISION_APPROVED, CONST.MODERATION.MODERATOR_DECISION_PENDING].some((item) => item === moderationDecision) && !isPendingRemove(action)
-                    }
                 >
                     {content}
                 </ReportActionItemSingle>

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -6,7 +6,6 @@ import React, {memo, useCallback, useContext, useEffect, useMemo, useRef, useSta
 import type {GestureResponderEvent, TextInput} from 'react-native';
 import {Keyboard, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
-import type {ValueOf} from 'type-fest';
 import * as ActionSheetAwareScrollView from '@components/ActionSheetAwareScrollView';
 import Hoverable from '@components/Hoverable';
 import InlineSystemMessage from '@components/InlineSystemMessage';
@@ -218,23 +217,6 @@ type PureReportActionItemProps = {
     /** Whether the room is a chronos report */
     isChronosReport?: boolean;
 
-    /** Function to resolve actionable report mention whisper */
-    resolveActionableReportMentionWhisper?: (
-        report: OnyxEntry<OnyxTypes.Report>,
-        reportAction: OnyxEntry<OnyxTypes.ReportAction>,
-        resolution: ValueOf<typeof CONST.REPORT.ACTIONABLE_REPORT_MENTION_WHISPER_RESOLUTION>,
-        isReportArchived?: boolean,
-    ) => void;
-
-    /** Function to resolve actionable mention whisper */
-    resolveActionableMentionWhisper?: (
-        report: OnyxEntry<OnyxTypes.Report>,
-        reportAction: OnyxEntry<OnyxTypes.ReportAction>,
-        resolution: ValueOf<typeof CONST.REPORT.ACTIONABLE_MENTION_WHISPER_RESOLUTION>,
-        isReportArchived: boolean,
-        parentReport?: OnyxEntry<OnyxTypes.Report>,
-    ) => void;
-
     /** Whether the provided report is a closed expense report with no expenses */
     isClosedExpenseReportWithNoExpenses?: boolean;
 
@@ -303,8 +285,6 @@ function PureReportActionItem({
     deleteReportActionDraft = () => {},
     isArchivedRoom,
     isChronosReport,
-    resolveActionableReportMentionWhisper = () => {},
-    resolveActionableMentionWhisper = () => {},
     isClosedExpenseReportWithNoExpenses,
     getTransactionsWithReceipts = () => [],
     clearError = () => {},
@@ -832,7 +812,6 @@ function PureReportActionItem({
                     report={report}
                     originalReport={originalReport}
                     originalReportID={originalReportID}
-                    resolveActionableMentionWhisper={resolveActionableMentionWhisper}
                 />
             );
         } else if (isActionableReportMentionWhisper(action)) {
@@ -843,7 +822,6 @@ function PureReportActionItem({
                     report={report}
                     originalReport={originalReport}
                     isReportArchived={isReportArchived}
-                    resolveActionableReportMentionWhisper={resolveActionableReportMentionWhisper}
                 />
             );
         } else if (isActionableMentionInviteToSubmitExpenseConfirmWhisper(action)) {

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -101,9 +101,10 @@ import {
 import SelectionScraper from '@libs/SelectionScraper';
 import {ReactionListContext} from '@pages/inbox/ReportScreenContext';
 import AttachmentModalContext from '@pages/media/AttachmentModalScreen/AttachmentModalContext';
-import type {IgnoreDirection} from '@userActions/ClearReportActionErrors';
+import {clearAllRelatedReportActionErrors} from '@userActions/ClearReportActionErrors';
 import {hideEmojiPicker, isActive} from '@userActions/EmojiPickerAction';
 import {expandURLPreview} from '@userActions/Report';
+import {clearError} from '@userActions/Transaction';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
@@ -223,18 +224,6 @@ type PureReportActionItemProps = {
     /** Gets all transactions on an IOU report with a receipt */
     getTransactionsWithReceipts?: (iouReportID: string | undefined) => OnyxTypes.Transaction[];
 
-    /** Function to clear an error from a transaction */
-    clearError?: (transactionID: string) => void;
-
-    /** Function to clear all errors from a report action */
-    clearAllRelatedReportActionErrors?: (
-        reportID: string | undefined,
-        reportAction: OnyxTypes.ReportAction | null | undefined,
-        originalReportID: string | undefined,
-        ignore?: IgnoreDirection,
-        keys?: string[],
-    ) => void;
-
     /** User payment card ID */
     userBillingFundID?: number;
 
@@ -287,8 +276,6 @@ function PureReportActionItem({
     isChronosReport,
     isClosedExpenseReportWithNoExpenses,
     getTransactionsWithReceipts = () => [],
-    clearError = () => {},
-    clearAllRelatedReportActionErrors = () => {},
     userBillingFundID,
     shouldShowBorder,
     shouldHighlight = false,
@@ -365,7 +352,7 @@ function PureReportActionItem({
             clearError(transactionID);
         }
         clearAllRelatedReportActionErrors(reportID, action, originalReportID);
-    }, [action, isSendingMoney, reportID, clearAllRelatedReportActionErrors, originalReportID, isReportActionLinked, report, chatReport, clearError, navigation]);
+    }, [action, isSendingMoney, reportID, originalReportID, isReportActionLinked, report, chatReport, navigation]);
 
     const showDismissReceiptErrorModal = useCallback(async () => {
         const result = await showConfirmModal({

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -333,7 +333,6 @@ function PureReportActionItem({
     const [isPaymentMethodPopoverActive, setIsPaymentMethodPopoverActive] = useState<boolean | undefined>();
     const shouldRenderViewBasedOnAction = useTableReportViewActionRenderConditionals(action);
     const [isHidden, setIsHidden] = useState(false);
-    const [moderationDecision, setModerationDecision] = useState<OnyxTypes.DecisionName>(CONST.MODERATION.MODERATOR_DECISION_APPROVED);
     const {isActiveReportAction: isActiveReactionListReportAction, hideReactionList} = useContext(ReactionListContext);
     const {updateHiddenAttachments} = useContext(AttachmentModalContext);
     const composerTextInputRef = useRef<TextInput | HTMLTextAreaElement>(null);
@@ -487,12 +486,10 @@ function PureReportActionItem({
 
         // Hide reveal message button and show the message if latestDecision is changed to empty
         if (!latestDecision) {
-            setModerationDecision(CONST.MODERATION.MODERATOR_DECISION_APPROVED);
             setIsHidden(false);
             return;
         }
 
-        setModerationDecision(latestDecision);
         if (![CONST.MODERATION.MODERATOR_DECISION_APPROVED, CONST.MODERATION.MODERATOR_DECISION_PENDING].some((item) => item === latestDecision) && !isPendingRemove(action)) {
             setIsHidden(true);
             return;

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -2,7 +2,7 @@
 import {useNavigation} from '@react-navigation/native';
 import {deepEqual} from 'fast-equals';
 import mapValues from 'lodash/mapValues';
-import React, {memo, use, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import React, {memo, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {GestureResponderEvent, TextInput} from 'react-native';
 import {Keyboard, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
@@ -27,7 +27,6 @@ import TaskAction from '@components/ReportActionItem/TaskAction';
 import TaskPreview from '@components/ReportActionItem/TaskPreview';
 import TripRoomPreview from '@components/ReportActionItem/TripRoomPreview';
 import UnreportedTransactionAction from '@components/ReportActionItem/UnreportedTransactionAction';
-import {SearchStateContext} from '@components/Search/SearchContext';
 import {useIsOnSearch} from '@components/Search/SearchScopeProvider';
 import {ShowContextMenuActionsContext, ShowContextMenuStateContext} from '@components/ShowContextMenuContext';
 import UnreadActionIndicator from '@components/UnreadActionIndicator';
@@ -371,11 +370,6 @@ function PureReportActionItem({
     );
 
     const isOnSearch = useIsOnSearch();
-    let currentSearchHash: number | undefined;
-    if (isOnSearch) {
-        const {currentSearchHash: searchContextCurrentSearchHash} = use(SearchStateContext);
-        currentSearchHash = searchContextCurrentSearchHash;
-    }
 
     const navigation = useNavigation<PlatformStackNavigationProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>>();
     const dismissError = useCallback(() => {
@@ -932,7 +926,6 @@ function PureReportActionItem({
                     isArchivedRoom={isArchivedRoom}
                     composerTextInputRef={composerTextInputRef}
                     isOnSearch={isOnSearch}
-                    currentSearchHash={currentSearchHash}
                     contextMenuStateValue={contextMenuStateValue}
                     contextMenuActionsValue={contextMenuActionsValue}
                     userBillingFundID={userBillingFundID}

--- a/src/pages/inbox/report/ReportActionItem.tsx
+++ b/src/pages/inbox/report/ReportActionItem.tsx
@@ -6,9 +6,7 @@ import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportTransactions from '@hooks/useReportTransactions';
 import {getIOUReportIDFromReportActionPreview, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {chatIncludesChronosWithID, getTransactionsWithReceipts, isArchivedNonExpenseReport, isClosedExpenseReportWithNoExpenses} from '@libs/ReportUtils';
-import {clearAllRelatedReportActionErrors} from '@userActions/ClearReportActionErrors';
 import {deleteReportActionDraft} from '@userActions/Report';
-import {clearError} from '@userActions/Transaction';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {PersonalDetailsList, Transaction} from '@src/types/onyx';
 import type {PureReportActionItemProps} from './PureReportActionItem';
@@ -76,8 +74,6 @@ function ReportActionItem({
             isChronosReport={chatIncludesChronosWithID(originalReportID)}
             isClosedExpenseReportWithNoExpenses={isClosedExpenseReportWithNoExpenses(iouReport, transactionsOnIOUReport)}
             getTransactionsWithReceipts={getTransactionsWithReceipts}
-            clearError={clearError}
-            clearAllRelatedReportActionErrors={clearAllRelatedReportActionErrors}
             userBillingFundID={userBillingFundID}
             isTryNewDotNVPDismissed={isTryNewDotNVPDismissed}
         />

--- a/src/pages/inbox/report/ReportActionItem.tsx
+++ b/src/pages/inbox/report/ReportActionItem.tsx
@@ -5,7 +5,7 @@ import useOriginalReportID from '@hooks/useOriginalReportID';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportTransactions from '@hooks/useReportTransactions';
 import {getIOUReportIDFromReportActionPreview, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
-import {chatIncludesChronosWithID, getTransactionsWithReceipts, isArchivedNonExpenseReport, isClosedExpenseReportWithNoExpenses} from '@libs/ReportUtils';
+import {chatIncludesChronosWithID, isArchivedNonExpenseReport, isClosedExpenseReportWithNoExpenses} from '@libs/ReportUtils';
 import {deleteReportActionDraft} from '@userActions/Report';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {PersonalDetailsList, Transaction} from '@src/types/onyx';
@@ -73,7 +73,6 @@ function ReportActionItem({
             isArchivedRoom={isArchivedNonExpenseReport(originalReport, isOriginalReportArchived)}
             isChronosReport={chatIncludesChronosWithID(originalReportID)}
             isClosedExpenseReportWithNoExpenses={isClosedExpenseReportWithNoExpenses(iouReport, transactionsOnIOUReport)}
-            getTransactionsWithReceipts={getTransactionsWithReceipts}
             userBillingFundID={userBillingFundID}
             isTryNewDotNVPDismissed={isTryNewDotNVPDismissed}
         />

--- a/src/pages/inbox/report/ReportActionItem.tsx
+++ b/src/pages/inbox/report/ReportActionItem.tsx
@@ -7,7 +7,7 @@ import useReportTransactions from '@hooks/useReportTransactions';
 import {getIOUReportIDFromReportActionPreview, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {chatIncludesChronosWithID, getTransactionsWithReceipts, isArchivedNonExpenseReport, isClosedExpenseReportWithNoExpenses} from '@libs/ReportUtils';
 import {clearAllRelatedReportActionErrors} from '@userActions/ClearReportActionErrors';
-import {deleteReportActionDraft, resolveActionableMentionWhisper, resolveActionableReportMentionWhisper} from '@userActions/Report';
+import {deleteReportActionDraft} from '@userActions/Report';
 import {clearError} from '@userActions/Transaction';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {PersonalDetailsList, Transaction} from '@src/types/onyx';
@@ -74,8 +74,6 @@ function ReportActionItem({
             deleteReportActionDraft={deleteReportActionDraft}
             isArchivedRoom={isArchivedNonExpenseReport(originalReport, isOriginalReportArchived)}
             isChronosReport={chatIncludesChronosWithID(originalReportID)}
-            resolveActionableReportMentionWhisper={resolveActionableReportMentionWhisper}
-            resolveActionableMentionWhisper={resolveActionableMentionWhisper}
             isClosedExpenseReportWithNoExpenses={isClosedExpenseReportWithNoExpenses(iouReport, transactionsOnIOUReport)}
             getTransactionsWithReceipts={getTransactionsWithReceipts}
             clearError={clearError}

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -23,8 +23,8 @@ import {
     getHumanAgentAccountIDFromReportAction,
     getHumanAgentFirstName,
     getManagerOnVacation,
+    getModerationFlagState,
     getOriginalMessage,
-    getReportActionMessage,
     getSubmittedTo,
     getVacationer,
 } from '@libs/ReportActionsUtils';
@@ -53,9 +53,6 @@ type ReportActionItemSingleProps = Partial<ChildrenProps> & {
     /** Show header for action */
     showHeader?: boolean;
 
-    /** If the message has been flagged for moderation */
-    hasBeenFlagged?: boolean;
-
     /** If the action is being hovered */
     isHovered?: boolean;
 
@@ -79,12 +76,12 @@ function ReportActionItemSingle({
     children,
     wrapperStyle,
     showHeader = true,
-    hasBeenFlagged = false,
     report,
     iouReport: potentialIOUReport,
     isHovered = false,
     isActive = false,
 }: ReportActionItemSingleProps) {
+    const {latestDecision, hasBeenFlagged} = getModerationFlagState(action);
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
@@ -218,7 +215,7 @@ function ReportActionItemSingle({
                                     delegateAccountID={action?.delegateAccountID}
                                     isSingleLine
                                     actorIcon={primaryAvatar}
-                                    moderationDecision={getReportActionMessage(action)?.moderationDecision?.decision}
+                                    moderationDecision={latestDecision}
                                     shouldShowTooltip={avatarType !== CONST.REPORT_ACTION_AVATARS.TYPE.MULTIPLE}
                                 />
                             ))}

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -16,16 +16,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import ControlSelection from '@libs/ControlSelection';
 import DateUtils from '@libs/DateUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
-import {
-    getDelegateAccountIDFromReportAction,
-    getHumanAgentAccountIDFromReportAction,
-    getManagerOnVacation,
-    getModerationFlagState,
-    getOriginalMessage,
-    getSubmittedTo,
-    getVacationer,
-} from '@libs/ReportActionsUtils';
+import {getDelegateAccountIDFromReportAction, getHumanAgentAccountIDFromReportAction, getManagerOnVacation, getModerationFlagState, getVacationer} from '@libs/ReportActionsUtils';
 import {isOptimisticPersonalDetail} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
@@ -35,6 +26,7 @@ import DelegateOnBehalfOfText from './DelegateOnBehalfOfText';
 import HumanAgentAssistedByText from './HumanAgentAssistedByText';
 import ReportActionItemDate from './ReportActionItemDate';
 import ReportActionItemFragment from './ReportActionItemFragment';
+import VacationDelegateText from './VacationDelegateText';
 
 type ReportActionItemSingleProps = Partial<ChildrenProps> & {
     /** All the data of the action */
@@ -98,19 +90,7 @@ function ReportActionItemSingle({
     const mainAccountID = delegateAccountID ? (reportPreviewSenderID ?? potentialIOUReport?.ownerAccountID ?? action?.childOwnerAccountID) : undefined;
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
 
-    // Vacation delegate details for submitted action
-    const vacationer = getVacationer(action);
-    const submittedTo = getSubmittedTo(action);
-    const vacationDelegateDetailsForSubmit = getPersonalDetailByEmail(vacationer ?? '');
-    const submittedToDetails = getPersonalDetailByEmail(submittedTo ?? '');
-
-    // Vacation delegate details for approved action
-    const managerOnVacation = getManagerOnVacation(action);
-    const vacationDelegateDetailsForApprove = getPersonalDetailByEmail(managerOnVacation ?? '');
-
-    // Check if this is an automatic action
-    const originalMessage = getOriginalMessage(action);
-    const isAutomaticAction = originalMessage && 'automaticAction' in originalMessage ? originalMessage.automaticAction : false;
+    const hasVacationDelegate = !!getVacationer(action) || !!getManagerOnVacation(action);
 
     const headingText = avatarType === CONST.REPORT_ACTION_AVATARS.TYPE.MULTIPLE ? `${primaryAvatar.name} & ${secondaryAvatar.name}` : primaryAvatar.name;
 
@@ -233,18 +213,7 @@ function ReportActionItemSingle({
                     />
                 )}
                 {!!humanAgentAccountID && <HumanAgentAssistedByText action={action} />}
-                {!!vacationer && !!submittedTo && (
-                    <Text style={[styles.chatDelegateMessage]}>
-                        {translate(
-                            'statusPage.toAsVacationDelegate',
-                            submittedToDetails?.displayName ?? submittedTo ?? '',
-                            vacationDelegateDetailsForSubmit?.displayName ?? vacationer ?? '',
-                        )}
-                    </Text>
-                )}
-                {!!managerOnVacation && !isAutomaticAction && (
-                    <Text style={[styles.chatDelegateMessage]}>{translate('statusPage.asVacationDelegate', vacationDelegateDetailsForApprove?.displayName ?? managerOnVacation ?? '')}</Text>
-                )}
+                {hasVacationDelegate && <VacationDelegateText action={action} />}
                 <View style={hasBeenFlagged ? styles.blockquote : {}}>{children}</View>
             </View>
         </View>

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -72,8 +72,7 @@ function ReportActionItemSingle({
     isHovered = false,
     isActive = false,
 }: ReportActionItemSingleProps) {
-    const {latestDecision, hasBeenFlagged} =
-        action?.actionName === CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT ? getModerationFlagState(action) : {latestDecision: undefined, hasBeenFlagged: false};
+    const {latestDecision, hasBeenFlagged} = getModerationFlagState(action);
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -81,7 +81,8 @@ function ReportActionItemSingle({
     isHovered = false,
     isActive = false,
 }: ReportActionItemSingleProps) {
-    const {latestDecision, hasBeenFlagged} = getModerationFlagState(action);
+    const {latestDecision, hasBeenFlagged} =
+        action?.actionName === CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT ? getModerationFlagState(action) : {latestDecision: undefined, hasBeenFlagged: false};
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -10,7 +10,6 @@ import Text from '@components/Text';
 import Tooltip from '@components/Tooltip';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useLocalize from '@hooks/useLocalize';
-import useOnyx from '@hooks/useOnyx';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -21,7 +20,6 @@ import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
 import {
     getDelegateAccountIDFromReportAction,
     getHumanAgentAccountIDFromReportAction,
-    getHumanAgentFirstName,
     getManagerOnVacation,
     getModerationFlagState,
     getOriginalMessage,
@@ -30,10 +28,11 @@ import {
 } from '@libs/ReportActionsUtils';
 import {isOptimisticPersonalDetail} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
-import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {Report, ReportAction} from '@src/types/onyx';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
+import DelegateOnBehalfOfText from './DelegateOnBehalfOfText';
+import HumanAgentAssistedByText from './HumanAgentAssistedByText';
 import ReportActionItemDate from './ReportActionItemDate';
 import ReportActionItemFragment from './ReportActionItemFragment';
 
@@ -88,8 +87,6 @@ function ReportActionItemSingle({
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
 
-    const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
-
     const {avatarType, avatars, details, source, reportPreviewSenderID} = useReportActionAvatars({report: potentialIOUReport ?? report, action});
 
     const reportID = source.chatReport?.reportID;
@@ -98,10 +95,7 @@ function ReportActionItemSingle({
     const [primaryAvatar, secondaryAvatar] = avatars;
     const delegateAccountID = getDelegateAccountIDFromReportAction(action);
     const humanAgentAccountID = getHumanAgentAccountIDFromReportAction(action);
-    const humanAgentName = getHumanAgentFirstName(action, personalDetails);
-    const mainAccountID = delegateAccountID ? (reportPreviewSenderID ?? potentialIOUReport?.ownerAccountID ?? action?.childOwnerAccountID) : (details.accountID ?? CONST.DEFAULT_NUMBER_ID);
-    const mainAccountLogin = mainAccountID ? (personalDetails?.[mainAccountID]?.login ?? details.login) : details.login;
-    const accountOwnerDetails = getPersonalDetailByEmail(String(mainAccountLogin ?? ''));
+    const mainAccountID = delegateAccountID ? (reportPreviewSenderID ?? potentialIOUReport?.ownerAccountID ?? action?.childOwnerAccountID) : undefined;
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
 
     // Vacation delegate details for submitted action
@@ -232,10 +226,13 @@ function ReportActionItemSingle({
                         <ReportActionItemDate created={action?.created ?? ''} />
                     </View>
                 ) : null}
-                {!!delegateAccountID && <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', accountOwnerDetails?.displayName ?? '')}</Text>}
-                {!!humanAgentAccountID && (
-                    <Text style={[styles.chatDelegateMessage]}>{translate('reportAction.assistedBy', humanAgentName ?? translate('reportAction.humanSupportAgent'))}</Text>
+                {!!delegateAccountID && (
+                    <DelegateOnBehalfOfText
+                        mainAccountID={mainAccountID}
+                        fallbackLogin={details.login}
+                    />
                 )}
+                {!!humanAgentAccountID && <HumanAgentAssistedByText action={action} />}
                 {!!vacationer && !!submittedTo && (
                     <Text style={[styles.chatDelegateMessage]}>
                         {translate(

--- a/src/pages/inbox/report/VacationDelegateText.tsx
+++ b/src/pages/inbox/report/VacationDelegateText.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import usePersonalDetailsByLogin from '@hooks/usePersonalDetailsByLogin';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {getManagerOnVacation, getOriginalMessage, getSubmittedTo, getVacationer} from '@libs/ReportActionsUtils';
+import type * as OnyxTypes from '@src/types/onyx';
+
+type VacationDelegateTextProps = {
+    /** The action whose vacation context drives the labels. */
+    action: OnyxEntry<OnyxTypes.ReportAction>;
+};
+
+function VacationDelegateText({action}: VacationDelegateTextProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const personalDetailsByLogin = usePersonalDetailsByLogin();
+
+    const vacationer = getVacationer(action);
+    const submittedTo = getSubmittedTo(action);
+    const managerOnVacation = getManagerOnVacation(action);
+    const originalMessage = getOriginalMessage(action);
+    const isAutomaticAction = originalMessage && 'automaticAction' in originalMessage ? originalMessage.automaticAction : false;
+
+    const vacationDelegateDetailsForSubmit = personalDetailsByLogin[vacationer?.toLowerCase() ?? ''];
+    const submittedToDetails = personalDetailsByLogin[submittedTo?.toLowerCase() ?? ''];
+    const vacationDelegateDetailsForApprove = personalDetailsByLogin[managerOnVacation?.toLowerCase() ?? ''];
+
+    return (
+        <>
+            {!!vacationer && !!submittedTo && (
+                <Text style={[styles.chatDelegateMessage]}>
+                    {translate('statusPage.toAsVacationDelegate', submittedToDetails?.displayName ?? submittedTo ?? '', vacationDelegateDetailsForSubmit?.displayName ?? vacationer ?? '')}
+                </Text>
+            )}
+            {!!managerOnVacation && !isAutomaticAction && (
+                <Text style={[styles.chatDelegateMessage]}>{translate('statusPage.asVacationDelegate', vacationDelegateDetailsForApprove?.displayName ?? managerOnVacation ?? '')}</Text>
+            )}
+        </>
+    );
+}
+
+export default VacationDelegateText;

--- a/src/pages/inbox/report/actionContents/ChatMessageContent.tsx
+++ b/src/pages/inbox/report/actionContents/ChatMessageContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {use} from 'react';
 import type {TextInput} from 'react-native';
 import {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
@@ -6,6 +6,7 @@ import {AttachmentContext} from '@components/AttachmentContext';
 import Button from '@components/Button';
 import MentionReportContext from '@components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/MentionReportContext';
 import {useBlockedFromConcierge} from '@components/OnyxListItemProvider';
+import {SearchStateContext} from '@components/Search/SearchContext';
 import {ShowContextMenuActionsContext, ShowContextMenuStateContext} from '@components/ShowContextMenuContext';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
@@ -42,7 +43,6 @@ type ChatMessageContentProps = {
     isArchivedRoom?: boolean;
     composerTextInputRef: React.RefObject<TextInput | HTMLTextAreaElement | null>;
     isOnSearch: boolean;
-    currentSearchHash: number | undefined;
     contextMenuStateValue: {
         anchor: ContextMenuAnchor | null;
         report: OnyxEntry<OnyxTypes.Report>;
@@ -74,7 +74,6 @@ function ChatMessageContent({
     isArchivedRoom,
     composerTextInputRef,
     isOnSearch,
-    currentSearchHash,
     contextMenuStateValue,
     contextMenuActionsValue,
     userBillingFundID,
@@ -86,6 +85,11 @@ function ChatMessageContent({
 
     const mentionReportContextValue = {currentReportID: report?.reportID, exactlyMatch: true};
 
+    let currentSearchHash: number | undefined;
+    if (isOnSearch) {
+        const {currentSearchHash: searchContextCurrentSearchHash} = use(SearchStateContext);
+        currentSearchHash = searchContextCurrentSearchHash;
+    }
     const attachmentContextValue = isOnSearch ? {type: CONST.ATTACHMENT_TYPE.SEARCH, currentSearchHash} : {reportID, type: CONST.ATTACHMENT_TYPE.REPORT};
 
     const {hasBeenFlagged} = getModerationFlagState(action);

--- a/src/pages/inbox/report/actionContents/ChatMessageContent.tsx
+++ b/src/pages/inbox/report/actionContents/ChatMessageContent.tsx
@@ -12,12 +12,12 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {parseFollowupsFromHtml} from '@libs/ReportActionFollowupUtils';
 import {
+    getModerationFlagState,
     getReportActionMessage,
     isActionableAddPaymentCard,
     isActionableTrackExpense,
     isConciergeCategoryOptions,
     isConciergeDescriptionOptions,
-    isPendingRemove,
 } from '@libs/ReportActionsUtils';
 import {chatIncludesConcierge, isArchivedNonExpenseReport} from '@libs/ReportUtils';
 import type {ContextMenuAnchor} from '@pages/inbox/report/ContextMenu/ReportActionContextMenu';
@@ -38,7 +38,6 @@ type ChatMessageContentProps = {
     draftMessage: string | undefined;
     index: number;
     isHidden: boolean;
-    moderationDecision: OnyxTypes.DecisionName;
     updateHiddenState: (isHiddenValue: boolean) => void;
     isArchivedRoom?: boolean;
     composerTextInputRef: React.RefObject<TextInput | HTMLTextAreaElement | null>;
@@ -71,7 +70,6 @@ function ChatMessageContent({
     draftMessage,
     index,
     isHidden,
-    moderationDecision,
     updateHiddenState,
     isArchivedRoom,
     composerTextInputRef,
@@ -90,8 +88,7 @@ function ChatMessageContent({
 
     const attachmentContextValue = isOnSearch ? {type: CONST.ATTACHMENT_TYPE.SEARCH, currentSearchHash} : {reportID, type: CONST.ATTACHMENT_TYPE.REPORT};
 
-    const hasBeenFlagged =
-        ![CONST.MODERATION.MODERATOR_DECISION_APPROVED, CONST.MODERATION.MODERATOR_DECISION_PENDING].some((item) => item === moderationDecision) && !isPendingRemove(action);
+    const {hasBeenFlagged} = getModerationFlagState(action);
 
     const messageHtml = getReportActionMessage(action)?.html;
     const mayHaveActionableButtons =

--- a/src/pages/inbox/report/actionContents/ChatMessageContent.tsx
+++ b/src/pages/inbox/report/actionContents/ChatMessageContent.tsx
@@ -1,4 +1,4 @@
-import React, {use} from 'react';
+import React from 'react';
 import type {TextInput} from 'react-native';
 import {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
@@ -6,7 +6,6 @@ import {AttachmentContext} from '@components/AttachmentContext';
 import Button from '@components/Button';
 import MentionReportContext from '@components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/MentionReportContext';
 import {useBlockedFromConcierge} from '@components/OnyxListItemProvider';
-import {SearchStateContext} from '@components/Search/SearchContext';
 import {ShowContextMenuActionsContext, ShowContextMenuStateContext} from '@components/ShowContextMenuContext';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
@@ -85,12 +84,7 @@ function ChatMessageContent({
 
     const mentionReportContextValue = {currentReportID: report?.reportID, exactlyMatch: true};
 
-    let currentSearchHash: number | undefined;
-    if (isOnSearch) {
-        const {currentSearchHash: searchContextCurrentSearchHash} = use(SearchStateContext);
-        currentSearchHash = searchContextCurrentSearchHash;
-    }
-    const attachmentContextValue = isOnSearch ? {type: CONST.ATTACHMENT_TYPE.SEARCH, currentSearchHash} : {reportID, type: CONST.ATTACHMENT_TYPE.REPORT};
+    const attachmentContextValue = isOnSearch ? {type: CONST.ATTACHMENT_TYPE.SEARCH} : {reportID, type: CONST.ATTACHMENT_TYPE.REPORT};
 
     const {hasBeenFlagged} = getModerationFlagState(action);
 

--- a/src/pages/inbox/report/actionContents/MentionWhisperContent.tsx
+++ b/src/pages/inbox/report/actionContents/MentionWhisperContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
-import type {ValueOf} from 'type-fest';
 import RenderHTML from '@components/RenderHTML';
 import type {ActionableItem} from '@components/ReportActionItem/ActionableItemButtons';
 import ActionableItemButtons from '@components/ReportActionItem/ActionableItemButtons';
@@ -11,6 +10,7 @@ import useReportIsArchived from '@hooks/useReportIsArchived';
 import {isPolicyAdmin, isPolicyMember, isPolicyOwner} from '@libs/PolicyUtils';
 import {getActionableMentionWhisperMessage, getOriginalMessage, isSystemUserMentioned} from '@libs/ReportActionsUtils';
 import ReportActionItemBasicMessage from '@pages/inbox/report/ReportActionItemBasicMessage';
+import {resolveActionableMentionWhisper} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report, ReportAction} from '@src/types/onyx';
@@ -20,16 +20,9 @@ type MentionWhisperContentProps = {
     report: OnyxEntry<Report>;
     originalReport: OnyxEntry<Report>;
     originalReportID: string | undefined;
-    resolveActionableMentionWhisper: (
-        report: OnyxEntry<Report>,
-        reportAction: OnyxEntry<ReportAction>,
-        resolution: ValueOf<typeof CONST.REPORT.ACTIONABLE_MENTION_WHISPER_RESOLUTION>,
-        isReportArchived: boolean,
-        parentReport?: OnyxEntry<Report>,
-    ) => void;
 };
 
-function MentionWhisperContent({action, report, originalReport, originalReportID, resolveActionableMentionWhisper}: MentionWhisperContentProps) {
+function MentionWhisperContent({action, report, originalReport, originalReportID}: MentionWhisperContentProps) {
     const {translate} = useLocalize();
     const isOriginalReportArchived = useReportIsArchived(originalReportID);
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();

--- a/src/pages/inbox/report/actionContents/ReportMentionWhisperContent.tsx
+++ b/src/pages/inbox/report/actionContents/ReportMentionWhisperContent.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
-import type {ValueOf} from 'type-fest';
 import MentionReportContext from '@components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/MentionReportContext';
 import type {ActionableItem} from '@components/ReportActionItem/ActionableItemButtons';
 import ActionableItemButtons from '@components/ReportActionItem/ActionableItemButtons';
 import {getOriginalMessage} from '@libs/ReportActionsUtils';
 import ReportActionItemMessage from '@pages/inbox/report/ReportActionItemMessage';
+import {resolveActionableReportMentionWhisper} from '@userActions/Report';
 import CONST from '@src/CONST';
 import type {Report, ReportAction} from '@src/types/onyx';
 
@@ -16,15 +16,9 @@ type ReportMentionWhisperContentProps = {
     report: OnyxEntry<Report>;
     originalReport: OnyxEntry<Report>;
     isReportArchived: boolean;
-    resolveActionableReportMentionWhisper: (
-        report: OnyxEntry<Report>,
-        reportAction: OnyxEntry<ReportAction>,
-        resolution: ValueOf<typeof CONST.REPORT.ACTIONABLE_REPORT_MENTION_WHISPER_RESOLUTION>,
-        isReportArchived?: boolean,
-    ) => void;
 };
 
-function ReportMentionWhisperContent({action, reportID, report, originalReport, isReportArchived, resolveActionableReportMentionWhisper}: ReportMentionWhisperContentProps) {
+function ReportMentionWhisperContent({action, reportID, report, originalReport, isReportArchived}: ReportMentionWhisperContentProps) {
     const reportActionReport = originalReport ?? report;
     const resolution = getOriginalMessage(action)?.resolution;
     const mentionReportContextValue = {currentReportID: report?.reportID, exactlyMatch: true};

--- a/tests/ui/ClearReportActionErrorsUITest.tsx
+++ b/tests/ui/ClearReportActionErrorsUITest.tsx
@@ -9,7 +9,7 @@ import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import OptionsListContextProvider from '@components/OptionListContextProvider';
 import ScreenWrapper from '@components/ScreenWrapper';
-import {clearAllRelatedReportActionErrors} from '@libs/actions/ClearReportActionErrors';
+import * as ClearReportActionErrorsActions from '@libs/actions/ClearReportActionErrors';
 import {setHasRadio} from '@libs/NetworkState';
 import {getIOUActionForReportID} from '@libs/ReportActionsUtils';
 import PureReportActionItem from '@pages/inbox/report/PureReportActionItem';
@@ -22,10 +22,6 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
 
 jest.mock('@react-navigation/native');
-jest.mock('@libs/actions/ClearReportActionErrors', () => ({
-    clearAllRelatedReportActionErrors: jest.fn(),
-}));
-const mockClearAllRelatedReportActionErrors = clearAllRelatedReportActionErrors as jest.MockedFunction<typeof clearAllRelatedReportActionErrors>;
 
 const ACTOR_ACCOUNT_ID = 123456789;
 const ACTOR_EMAIL = 'test@test.com';
@@ -135,10 +131,10 @@ describe('ClearReportActionErrors UI', () => {
         });
 
         it('should call clearAllRelatedReportActionErrors when error is dismissed', async () => {
-            // Given a rendered report action with errors and a mocked module-level clear function
+            // Given a rendered report action with errors and a spy on the clear function
             const action = getFakeReportAction(Number(REPORT_ACTION_ID), {actorAccountID: ACTOR_ACCOUNT_ID, errors: DEFAULT_ERRORS});
             const report = createMockReport({reportID: REPORT_ID, ownerAccountID: ACTOR_ACCOUNT_ID});
-            mockClearAllRelatedReportActionErrors.mockClear();
+            const spy = jest.spyOn(ClearReportActionErrorsActions, 'clearAllRelatedReportActionErrors');
 
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
@@ -156,7 +152,8 @@ describe('ClearReportActionErrors UI', () => {
             fireEvent.press(dismissButton);
 
             // Then clearAllRelatedReportActionErrors should be called with correct arguments
-            expect(mockClearAllRelatedReportActionErrors).toHaveBeenCalledWith(REPORT_ID, expect.objectContaining({reportActionID: REPORT_ACTION_ID}), REPORT_ID);
+            expect(spy).toHaveBeenCalledWith(REPORT_ID, expect.objectContaining({reportActionID: REPORT_ACTION_ID}), REPORT_ID);
+            spy.mockRestore();
         });
 
         it('should clear error from Onyx when dismissed', async () => {

--- a/tests/ui/ClearReportActionErrorsUITest.tsx
+++ b/tests/ui/ClearReportActionErrorsUITest.tsx
@@ -22,6 +22,10 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
 
 jest.mock('@react-navigation/native');
+jest.mock('@libs/actions/ClearReportActionErrors', () => ({
+    clearAllRelatedReportActionErrors: jest.fn(),
+}));
+const mockClearAllRelatedReportActionErrors = clearAllRelatedReportActionErrors as jest.MockedFunction<typeof clearAllRelatedReportActionErrors>;
 
 const ACTOR_ACCOUNT_ID = 123456789;
 const ACTOR_EMAIL = 'test@test.com';
@@ -82,11 +86,10 @@ describe('ClearReportActionErrors UI', () => {
         action: ReportAction,
         report: Report,
         options?: {
-            clearErrorFn?: typeof clearAllRelatedReportActionErrors;
             originalReportID?: string;
         },
     ) {
-        const {clearErrorFn, originalReportID = report.reportID} = options ?? {};
+        const {originalReportID = report.reportID} = options ?? {};
         return render(
             <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
                 <OptionsListContextProvider>
@@ -100,7 +103,6 @@ describe('ClearReportActionErrors UI', () => {
                                 shouldDisplayNewMarker={false}
                                 index={0}
                                 isFirstVisibleReportAction={false}
-                                clearAllRelatedReportActionErrors={clearErrorFn}
                                 originalReportID={originalReportID}
                             />
                         </PortalProvider>
@@ -133,10 +135,10 @@ describe('ClearReportActionErrors UI', () => {
         });
 
         it('should call clearAllRelatedReportActionErrors when error is dismissed', async () => {
-            // Given a rendered report action with errors and a mock clear function
+            // Given a rendered report action with errors and a mocked module-level clear function
             const action = getFakeReportAction(Number(REPORT_ACTION_ID), {actorAccountID: ACTOR_ACCOUNT_ID, errors: DEFAULT_ERRORS});
             const report = createMockReport({reportID: REPORT_ID, ownerAccountID: ACTOR_ACCOUNT_ID});
-            const mockClearErrors = jest.fn();
+            mockClearAllRelatedReportActionErrors.mockClear();
 
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
@@ -146,10 +148,7 @@ describe('ClearReportActionErrors UI', () => {
             });
             await waitForBatchedUpdatesWithAct();
 
-            renderReportActionItem(action, report, {
-                clearErrorFn: mockClearErrors,
-                originalReportID: REPORT_ID,
-            });
+            renderReportActionItem(action, report, {originalReportID: REPORT_ID});
             await waitForBatchedUpdatesWithAct();
 
             // When the user presses the dismiss button
@@ -157,7 +156,7 @@ describe('ClearReportActionErrors UI', () => {
             fireEvent.press(dismissButton);
 
             // Then clearAllRelatedReportActionErrors should be called with correct arguments
-            expect(mockClearErrors).toHaveBeenCalledWith(REPORT_ID, expect.objectContaining({reportActionID: REPORT_ACTION_ID}), REPORT_ID);
+            expect(mockClearAllRelatedReportActionErrors).toHaveBeenCalledWith(REPORT_ID, expect.objectContaining({reportActionID: REPORT_ACTION_ID}), REPORT_ID);
         });
 
         it('should clear error from Onyx when dismissed', async () => {
@@ -178,7 +177,6 @@ describe('ClearReportActionErrors UI', () => {
             await waitForBatchedUpdatesWithAct();
 
             renderReportActionItem(action, report, {
-                clearErrorFn: clearAllRelatedReportActionErrors,
                 originalReportID: REPORT_ID,
             });
             await waitForBatchedUpdatesWithAct();
@@ -235,7 +233,6 @@ describe('ClearReportActionErrors UI', () => {
             await waitForBatchedUpdatesWithAct();
 
             renderReportActionItem(parentAction, parentReport, {
-                clearErrorFn: clearAllRelatedReportActionErrors,
                 originalReportID: REPORT_ID,
             });
             await waitForBatchedUpdatesWithAct();
@@ -275,7 +272,6 @@ describe('ClearReportActionErrors UI', () => {
             await waitForBatchedUpdatesWithAct();
 
             renderReportActionItem(action, report, {
-                clearErrorFn: clearAllRelatedReportActionErrors,
                 originalReportID: REPORT_ID,
             });
             await waitForBatchedUpdatesWithAct();

--- a/tests/unit/ReportActionItemSingleTest.tsx
+++ b/tests/unit/ReportActionItemSingleTest.tsx
@@ -1,9 +1,13 @@
 import {act, screen, waitFor} from '@testing-library/react-native';
+import React from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+import {StyleSheet} from 'react-native';
 import Onyx from 'react-native-onyx';
+import Text from '@components/Text';
 import {setHasRadio} from '@libs/NetworkState';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {PersonalDetailsList} from '@src/types/onyx';
+import type {PersonalDetailsList, Report, ReportAction} from '@src/types/onyx';
 import {toCollectionDataSet} from '@src/types/utils/CollectionDataSet';
 import * as LHNTestUtils from '../utils/LHNTestUtils';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
@@ -87,6 +91,78 @@ describe('ReportActionItemSingle', () => {
                 await waitFor(() => {
                     expect(screen.getByText(expectedPerson.text ?? '')).toBeOnTheScreen();
                 });
+            });
+        });
+    });
+
+    describe('moderation flagging', () => {
+        const CHILD_TEST_ID = 'children-under-flagged-wrapper';
+
+        function makeActionWithHiddenDecision(actionName: typeof CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT | typeof CONST.REPORT.ACTIONS.TYPE.IOU): ReportAction {
+            return {
+                ...LHNTestUtils.getFakeAdvancedReportAction(actionName),
+                message: [
+                    {
+                        type: 'COMMENT',
+                        html: 'message',
+                        text: 'message',
+                        moderationDecision: {decision: CONST.MODERATION.MODERATOR_DECISION_HIDDEN},
+                    },
+                ],
+            } as ReportAction;
+        }
+
+        async function setupReportActionItemSingle(action: ReportAction, report: Report) {
+            await act(async () => {
+                await Onyx.multiSet({
+                    [ONYXKEYS.IS_LOADING_REPORT_DATA]: false,
+                    [ONYXKEYS.PERSONAL_DETAILS_LIST]: {},
+                    [ONYXKEYS.COLLECTION.REPORT]: {
+                        [`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`]: report,
+                    },
+                });
+                await waitForBatchedUpdatesWithAct();
+            });
+            LHNTestUtils.getDefaultRenderedReportActionItemSingle(report, action, <Text testID={CHILD_TEST_ID}>child</Text>);
+            await waitForBatchedUpdatesWithAct();
+        }
+
+        type Ancestor = {props: {style?: unknown}; parent: Ancestor | null};
+        function findFlaggedAncestor(start: Ancestor | null): Ancestor | null {
+            let cursor = start;
+            while (cursor) {
+                const flat = StyleSheet.flatten(cursor.props.style as StyleProp<ViewStyle>);
+                if (flat?.borderLeftWidth !== undefined) {
+                    return cursor;
+                }
+                cursor = cursor.parent;
+            }
+            return null;
+        }
+
+        it('does not apply blockquote styling for non-ADD_COMMENT actions even when the message carries a hidden decision', async () => {
+            const fakeReport = LHNTestUtils.getFakeReportWithPolicy([1, 2]);
+            const action = makeActionWithHiddenDecision(CONST.REPORT.ACTIONS.TYPE.IOU);
+
+            await setupReportActionItemSingle(action, fakeReport);
+
+            await waitFor(() => {
+                const child = screen.getByTestId(CHILD_TEST_ID);
+                expect(findFlaggedAncestor(child.parent)).toBeNull();
+            });
+        });
+
+        it('applies blockquote styling for ADD_COMMENT actions when the message carries a hidden decision', async () => {
+            const fakeReport = LHNTestUtils.getFakeReportWithPolicy([1, 2]);
+            const action = makeActionWithHiddenDecision(CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT);
+
+            await setupReportActionItemSingle(action, fakeReport);
+
+            await waitFor(() => {
+                const child = screen.getByTestId(CHILD_TEST_ID);
+                const wrapper = findFlaggedAncestor(child.parent);
+                expect(wrapper).not.toBeNull();
+                expect(wrapper).toHaveStyle({borderLeftWidth: 4});
             });
         });
     });

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -28,6 +28,7 @@ import {
     getIntegrationSyncFailedMessage,
     getInvoiceCompanyNameUpdateMessage,
     getInvoiceCompanyWebsiteUpdateMessage,
+    getModerationFlagState,
     getOneTransactionThreadReportID,
     getOriginalMessage,
     getPolicyChangeLogMaxExpenseAgeMessage,
@@ -53,7 +54,7 @@ import {
 import {buildOptimisticCreatedReportForUnapprovedAction} from '../../src/libs/ReportUtils';
 import ONYXKEYS from '../../src/ONYXKEYS';
 import shouldDisplayNewMarkerOnReportAction from '../../src/pages/inbox/report/shouldDisplayNewMarkerOnReportAction';
-import type {Card, OriginalMessageIOU, PersonalDetailsList, Report, ReportAction, ReportActions} from '../../src/types/onyx';
+import type {Card, DecisionName, OriginalMessageIOU, PersonalDetailsList, Report, ReportAction, ReportActions} from '../../src/types/onyx';
 import createRandomReportAction from '../utils/collections/reportActions';
 import {createRandomReport} from '../utils/collections/reports';
 import createRandomTransaction from '../utils/collections/transaction';
@@ -5107,6 +5108,70 @@ describe('ReportActionsUtils', () => {
         it('returns undefined when the agent firstName is only whitespace so the generic fallback can be used', () => {
             const action = makeConciergeAction({humanAgentAccountID: HUMAN_AGENT_ACCOUNT_ID});
             expect(getHumanAgentFirstName(action, makePersonalDetails('   '))).toBeUndefined();
+        });
+    });
+
+    describe('getModerationFlagState', () => {
+        function makeActionWithDecision(decision: DecisionName | undefined): ReportAction {
+            return {
+                ...createRandomReportAction(0),
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                message: [
+                    {
+                        type: 'COMMENT',
+                        html: 'hello',
+                        text: 'hello',
+                        moderationDecision: decision ? {decision} : undefined,
+                    },
+                ],
+            } as ReportAction;
+        }
+
+        it('returns undefined and not flagged when the action is null', () => {
+            expect(getModerationFlagState(null)).toEqual({latestDecision: undefined, hasBeenFlagged: false});
+        });
+
+        it('returns undefined and not flagged when the action is undefined', () => {
+            expect(getModerationFlagState(undefined)).toEqual({latestDecision: undefined, hasBeenFlagged: false});
+        });
+
+        it('returns undefined and not flagged when the message has no moderation decision', () => {
+            expect(getModerationFlagState(makeActionWithDecision(undefined))).toEqual({latestDecision: undefined, hasBeenFlagged: false});
+        });
+
+        it('returns approved and not flagged', () => {
+            expect(getModerationFlagState(makeActionWithDecision(CONST.MODERATION.MODERATOR_DECISION_APPROVED))).toEqual({
+                latestDecision: CONST.MODERATION.MODERATOR_DECISION_APPROVED,
+                hasBeenFlagged: false,
+            });
+        });
+
+        it('returns pending and not flagged', () => {
+            expect(getModerationFlagState(makeActionWithDecision(CONST.MODERATION.MODERATOR_DECISION_PENDING))).toEqual({
+                latestDecision: CONST.MODERATION.MODERATOR_DECISION_PENDING,
+                hasBeenFlagged: false,
+            });
+        });
+
+        it('returns pendingRemove and not flagged', () => {
+            expect(getModerationFlagState(makeActionWithDecision(CONST.MODERATION.MODERATOR_DECISION_PENDING_REMOVE))).toEqual({
+                latestDecision: CONST.MODERATION.MODERATOR_DECISION_PENDING_REMOVE,
+                hasBeenFlagged: false,
+            });
+        });
+
+        it('returns pendingHide and flagged', () => {
+            expect(getModerationFlagState(makeActionWithDecision(CONST.MODERATION.MODERATOR_DECISION_PENDING_HIDE))).toEqual({
+                latestDecision: CONST.MODERATION.MODERATOR_DECISION_PENDING_HIDE,
+                hasBeenFlagged: true,
+            });
+        });
+
+        it('returns hidden and flagged', () => {
+            expect(getModerationFlagState(makeActionWithDecision(CONST.MODERATION.MODERATOR_DECISION_HIDDEN))).toEqual({
+                latestDecision: CONST.MODERATION.MODERATOR_DECISION_HIDDEN,
+                hasBeenFlagged: true,
+            });
         });
     });
 });

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -5173,5 +5173,13 @@ describe('ReportActionsUtils', () => {
                 hasBeenFlagged: true,
             });
         });
+
+        it('returns the safe default for non-ADD_COMMENT actions even when the message carries a flagged decision', () => {
+            const action = {
+                ...makeActionWithDecision(CONST.MODERATION.MODERATOR_DECISION_HIDDEN),
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+            } as ReportAction;
+            expect(getModerationFlagState(action)).toEqual({latestDecision: undefined, hasBeenFlagged: false});
+        });
     });
 });

--- a/tests/unit/WhisperContentMentionContextTest.tsx
+++ b/tests/unit/WhisperContentMentionContextTest.tsx
@@ -98,7 +98,6 @@ describe('Whisper content components provide MentionReportContext so room mentio
                     report={report}
                     originalReport={undefined}
                     isReportArchived={false}
-                    resolveActionableReportMentionWhisper={jest.fn()}
                 />
             </OnyxListItemProvider>,
         );

--- a/tests/utils/LHNTestUtils.tsx
+++ b/tests/utils/LHNTestUtils.tsx
@@ -24,6 +24,9 @@ type MockedReportActionItemSingleProps = {
 
     /** All the data of the action */
     reportAction: ReportAction;
+
+    /** Optional children rendered inside the wrapping View (used to probe styling around children). */
+    children?: ReactElement;
 };
 
 type MockedSidebarLinksProps = {
@@ -330,7 +333,7 @@ function internalRender(component: ReactElement) {
     }
 }
 
-function MockedReportActionItemSingle({report, reportAction}: MockedReportActionItemSingleProps) {
+function MockedReportActionItemSingle({report, reportAction, children}: MockedReportActionItemSingleProps) {
     return (
         <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, EnvironmentProvider, CurrentReportIDContextProvider]}>
             <ReportActionItemSingle
@@ -339,12 +342,14 @@ function MockedReportActionItemSingle({report, reportAction}: MockedReportAction
                 showHeader
                 iouReport={undefined}
                 isHovered={false}
-            />
+            >
+                {children}
+            </ReportActionItemSingle>
         </ComposeProviders>
     );
 }
 
-function getDefaultRenderedReportActionItemSingle(report?: Report, reportAction?: ReportAction) {
+function getDefaultRenderedReportActionItemSingle(report?: Report, reportAction?: ReportAction, children?: ReactElement) {
     const currentReport = report ?? getFakeReport();
     const currentReportAction = reportAction ?? getFakeAdvancedReportAction();
 
@@ -352,7 +357,9 @@ function getDefaultRenderedReportActionItemSingle(report?: Report, reportAction?
         <MockedReportActionItemSingle
             report={currentReport}
             reportAction={currentReportAction}
-        />,
+        >
+            {children}
+        </MockedReportActionItemSingle>,
     );
 }
 

--- a/tests/utils/LHNTestUtils.tsx
+++ b/tests/utils/LHNTestUtils.tsx
@@ -337,7 +337,6 @@ function MockedReportActionItemSingle({report, reportAction}: MockedReportAction
                 action={reportAction}
                 report={report}
                 showHeader
-                hasBeenFlagged={false}
                 iouReport={undefined}
                 isHovered={false}
             />


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

  Three cleanups to PureReportActionItem and its row-level neighbors:

  1. Moderation. `moderationDecision` was wrapper-level useState mirrored from action. Replaced with a pure `getModerationFlagState(action) `helper called inside `ReportActionItemSingle` and
   `ChatMessageContent`. Wrapper state and the prop drilling go away. isHidden stays for the resurrectable `LinkPreviewer` block.
  2. Personal-details subscription. Wide `useOnyx(PERSONAL_DETAILS_LIST)` in `ReportActionItemSingle` replaced by two new gated leaves with narrow selectors: `DelegateOnBehalfOfText` and
  `HumanAgentAssistedByText`. The two gates are mutually exclusive, so subs never double. Dominant rows pay zero.
  3. Prop drilling. `resolveActionableMentionWhisper` / `resolveActionableReportMentionWhisper` / `clearError` / `clearAllRelatedReportActionErrors` / `getTransactionsWithReceipts` are now
  imported directly by their consumers instead of injected via props. `SearchStateContext` consumer moves from `PureReportActionItem` into `ChatMessageContent` (the only user), `getTransactionsWithReceipts` is also short-circuited to whispered rows only.

  No behavior change.
  
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):


Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/89781
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console


### Test 1: Moderation flagged message (Reveal / Hide)

Staging via console (recommended). Open any chat with a recent text message you have sent. Note its `reportID` (from the URL) and the target action's `reportActionID` (visible in React DevTools or in Debug Mode when searching Report details). In the browser console:

```js
const reportID = '2802444100873974';
const reportActionID = '5293260736101972612';

await Onyx.merge(`reportActions_${reportID}`, {
    [reportActionID]: {
        message: [
            {
                type: 'COMMENT',
                text: 'flagged test',
                html: '<comment>flagged test</comment>',
                moderationDecision: {decision: 'hidden'},
            },
        ],
    },
});

```

1. Verify the flagged message is hidden behind the "Reveal message" button.
2. Press "Reveal message".
3. Verify the message content becomes visible and the button text flips to "Hide message".
4. Press "Hide message".
5. Verify the message is hidden again and the button flips back to "Reveal message".

### Test 2: Delegate "on behalf of" rendering

1. Sign in as a user that has a delegate set up, then have the delegate post or perform an action on your behalf in a chat or workspace.
2. Open the report containing that action.
3. Verify the action shows the "on behalf of [account owner display name]" text under the actor row.
4. Verify the displayed name matches the account owner's display name (not the delegate's), and updates if the owner's profile is edited.

### Test 3: Mention whisper invite flow

1. In a workspace chat, @mention a user who is NOT a member of that workspace.
2. Verify the whisper "Heads up, [user] isn't a member of this room." appears, only visible to you.
3. Press "Invite" (or "Invite to submit expense" if shown).
4. Verify the user is invited and the whisper disappears.
5. Repeat the @mention for another non-member, then press "Do not invite".
6. Verify the whisper resolves and disappears.

### Test 4: Mention a non-existent room (report mention whisper)

Two users (A and B) in the same workspace

1. Sign in as User A. In a workspace chat where both A and B participate, type `#a-room-that-does-not-exist` and send.
2. Verify the whisper "Do you want to create #a-room-that-does-not-exist?" appears, only visible to A.
3. Press "Yes".
4. Verify the room is created and the whisper resolves and disappears.
5. As A, click the `#a-room-that-does-not-exist` mention in the chat. Verify it navigates to the new room and the room name is the one A typed.
6. Sign in as User B. Open the same workspace chat where A's mention lives.
7. Verify B sees the message with the room reference rendered as `#Hidden` (since B is not a member of the newly-created room).
8. Sign back in as A. In the same chat, type `#another-non-existent-room` and send.
9. Verify the whisper appears, then press "No".
10. Verify the whisper resolves and disappears, and no new room is created.

### Test 5: Error row renders on a failed action

1. Set the debug failing mode
2. In any chat, send a message.
3. Verify the red error row with a Dismiss button renders under the action.

### Test 6: Search page action rendering

1. Open the Search page and run a query that returns chat actions, for example `type:chat`.
2. Open one of the result rows.
3. Verify each action shows a header line with "in [report name]" linking back to the source report.
4. If any action has an attachment, click the attachment.
5. Verify the attachment opens correctly through

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
Test 1
https://github.com/user-attachments/assets/d917b0a2-cc65-45ba-ad68-b7e7fca41355


Test 2
https://github.com/user-attachments/assets/273603de-5c41-404f-b437-35a90419b6ed


Test 3
https://github.com/user-attachments/assets/eda496f1-aa9f-440c-9542-22a809b1c961


Test 4
https://github.com/user-attachments/assets/e6575465-9ccc-4dcc-82c9-99b479457c33


Test 5
https://github.com/user-attachments/assets/effaca9b-41de-4008-b513-e2712be6bcc1


Test 6
https://github.com/user-attachments/assets/d6b0528f-f4dd-4d82-8aa9-e45ddb0a440c


Test7


</details>