### PR TITLE
Fix Xero 2FA modal not navigating after disconnecting other accountin…

### DIFF
--- a/src/components/ConnectToXeroFlow/index.native.tsx
+++ b/src/components/ConnectToXeroFlow/index.native.tsx
@@ -10,7 +10,6 @@ import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getXeroSetupLink} from '@libs/actions/connections/Xero';
-import {close} from '@libs/actions/Modal';
 import getUAForWebView from '@libs/getUAForWebView';
 import Navigation from '@libs/Navigation/Navigation';
 import CONST from '@src/CONST';
@@ -55,20 +54,18 @@ function ConnectToXeroFlow({policyID}: ConnectToXeroFlowProps) {
                 <RequireTwoFactorAuthenticationModal
                     onSubmit={() => {
                         setIsRequire2FAModalOpen(false);
-                        close(() => {
-                            const backTo = ROUTES.POLICY_ACCOUNTING.getRoute(policyID);
-                            const validatedUserForwardTo = getXeroSetupLink(policyID);
-                            if (isUserValidated) {
-                                Navigation.navigate(ROUTES.SETTINGS_2FA_ROOT.getRoute(backTo, validatedUserForwardTo));
-                                return;
-                            }
-                            Navigation.navigate(
-                                ROUTES.SETTINGS_2FA_VERIFY_ACCOUNT.getRoute({
-                                    backTo,
-                                    forwardTo: ROUTES.SETTINGS_2FA_ROOT.getRoute(backTo, validatedUserForwardTo),
-                                }),
-                            );
-                        });
+                        const backTo = ROUTES.POLICY_ACCOUNTING.getRoute(policyID);
+                        const validatedUserForwardTo = getXeroSetupLink(policyID);
+                        if (isUserValidated) {
+                            Navigation.navigate(ROUTES.SETTINGS_2FA_ROOT.getRoute(backTo, validatedUserForwardTo));
+                            return;
+                        }
+                        Navigation.navigate(
+                            ROUTES.SETTINGS_2FA_VERIFY_ACCOUNT.getRoute({
+                                backTo,
+                                forwardTo: ROUTES.SETTINGS_2FA_ROOT.getRoute(backTo, validatedUserForwardTo),
+                            }),
+                        );
                     }}
                     onCancel={() => setIsRequire2FAModalOpen(false)}
                     isVisible={isRequire2FAModalOpen}


### PR DESCRIPTION
### Explanation of Change
On iOS, when a workspace was already connected to another accounting integration (e.g., Sage Intacct) and the user tried to connect Xero, tapping **Enable two-factor authentication** did not navigate to the 2FA setup page — the navigation only happened after the user pressed the back button.

The `RequireTwoFactorAuthenticationModal`'s `onSubmit` handler wrapped the navigation inside `Modal.close(callback)`. `close()` stores its callback and only runs it later when `onModalDidClose()` fires from `BaseModal.hideModal()`, which on iOS is triggered by RN Modal's `onDismiss` event.

This flow is unique because an `AccountingConnectionConfirmationModal` (the "disconnect existing integration?" prompt) is shown first and unmounts right before the 2FA modal mounts. On iOS, the unmounting confirmation modal's `onDismiss` event is misattributed to the freshly mounted 2FA modal, causing `hideModal()` to fire prematurely as a no-op (no callback queued yet). Later, when the user taps **Enable 2FA**, `close()` stores the navigation callback and calls `closeTop()`, but `onDismiss` never fires again, so the navigation callback never runs.

The fix removes the `close()` wrapper in `src/components/ConnectToXeroFlow/index.native.tsx` and navigates directly after `setIsRequire2FAModalOpen(false)`. The modal still closes on its own via `isVisible` becoming false, and navigation does not need to wait for the close animation. This matches how the other accounting integrations (QBO, NetSuite, Sage Intacct) handle this navigation.

### Fixed Issues
$ https://github.com/Expensify/App/issues/79494
PROPOSAL: https://github.com/Expensify/App/issues/79494#issuecomment-3745184877

### Tests
Precondition: the workspace is already connected to another accounting integration (e.g., Sage Intacct).

1. Launch the Expensify app on iOS.
2. Go to workspace **Settings > Accounting**.
3. Tap **Other**.
4. Tap **Connect** next to Xero.
5. Proceed past the prompt to disconnect the existing integration.
6. Tap **Enable two-factor authentication**.
7. Verify the 2FA setup page opens immediately, without needing to press the back button.
8. Disconnect Xero and repeat from a workspace with no other integration connected — the Xero connection flow should still work normally (WebView opens for Xero login).

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests.

### QA Steps
Precondition: the workspace is already connected to another accounting integration (e.g., Sage Intacct).

1. Launch the Expensify app on iOS.
2. Go to workspace **Settings > Accounting**.
3. Tap **Other**.
4. Tap **Connect** next to Xero.
5. Proceed past the prompt to disconnect the existing integration.
6. Tap **Enable two-factor authentication**.
7. Verify the 2FA setup page opens immediately (no back-button workaround required).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f4a42cf7-c566-4ede-8ac9-a075a3a31ba1


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/72923e35-521e-4548-ac17-9ee70e035102


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>