### PR TITLE
fix: update workspace currency not supported help URL to show supported currencies

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -1219,7 +1219,7 @@ const CONST = {
     PERSONAL_AND_CORPORATE_KARMA_HELP_URL: 'https://help.expensify.com/articles/expensify-classic/expensify-billing/Personal-and-Corporate-Karma',
     COLLECT_UPGRADE_HELP_URL: 'https://help.expensify.com/Hidden/collect-upgrade',
     MERGE_ACCOUNT_HELP_URL: 'https://help.expensify.com/articles/new-expensify/settings/Merge-Accounts',
-    CONNECT_A_BUSINESS_BANK_ACCOUNT_HELP_URL: 'https://help.expensify.com/articles/new-expensify/expenses-&-payments/Connect-a-Business-Bank-Account',
+    CONNECT_A_BUSINESS_BANK_ACCOUNT_HELP_URL: 'https://help.expensify.com/articles/new-expensify/wallet-and-payments/Enable-Global-Reimbursement',
     DOMAIN_VERIFICATION_HELP_URL: 'https://help.expensify.com/articles/new-expensify/workspaces/Claim-and-Verify-a-Domain',
     SAML_HELP_URL: 'https://help.expensify.com/articles/expensify-classic/domains/Set-Up-SAML-SSO',
     REGISTER_FOR_WEBINAR_URL: 'https://events.zoom.us/eo/Aif1I8qCi1GZ7KnLnd1vwGPmeukSRoPjFpyFAZ2udQWn0-B86e1Z~AggLXsr32QYFjq8BlYLZ5I06Dg',

--- a/src/libs/SubscriptionUtils.ts
+++ b/src/libs/SubscriptionUtils.ts
@@ -157,10 +157,6 @@ function shouldShowDiscountBanner(
         return false;
     }
 
-    if (!isUserOnFreeTrial(firstDayFreeTrial, lastDayFreeTrial)) {
-        return false;
-    }
-
     if (doesUserHavePaymentCardAdded(userBillingFundID)) {
         return false;
     }
@@ -169,14 +165,23 @@ function shouldShowDiscountBanner(
         return false;
     }
 
-    const dateNow = Math.floor(Date.now() / 1000);
-    const firstDayTimestamp = fromZonedTime(`${firstDayFreeTrial}`, 'UTC').getTime() / 1000;
-    const lastDayTimestamp = fromZonedTime(`${lastDayFreeTrial}`, 'UTC').getTime() / 1000;
-    if (dateNow > lastDayTimestamp) {
+    // Check if we're within the early discount window using firstDayFreeTrial.
+    // This handles the case where lastDayFreeTrial is not yet set but the
+    // user has started their free trial (firstDayFreeTrial is available).
+    if (!isInEarlyDiscountWindow(firstDayFreeTrial)) {
         return false;
     }
 
-    return dateNow <= firstDayTimestamp + CONST.TRIAL_DURATION_DAYS * CONST.DATE.SECONDS_PER_DAY;
+    // If lastDayFreeTrial is set, also verify we haven't passed it
+    if (lastDayFreeTrial) {
+        const dateNow = Math.floor(Date.now() / 1000);
+        const lastDayTimestamp = fromZonedTime(`${lastDayFreeTrial}`, 'UTC').getTime() / 1000;
+        if (dateNow > lastDayTimestamp) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 function getEarlyDiscountInfo(firstDayFreeTrial: string | undefined): DiscountInfo | null {
@@ -428,6 +433,19 @@ function isUserOnFreeTrial(firstDayFreeTrial: string | undefined, lastDayFreeTri
     const lastDayFreeTrialDate = new Date(`${lastDayFreeTrial}Z`);
 
     return isAfter(currentDate, firstDayFreeTrialDate) && isBefore(currentDate, lastDayFreeTrialDate);
+}
+
+/**
+ * Whether the user is within the early discount window based on firstDayFreeTrial alone.
+ * This handles the case where lastDayFreeTrial is not yet set but firstDayFreeTrial is available.
+ */
+function isInEarlyDiscountWindow(firstDayFreeTrial: string | undefined): boolean {
+    if (!firstDayFreeTrial) {
+        return false;
+    }
+    const dateNow = Math.floor(Date.now() / 1000);
+    const firstDayTimestamp = fromZonedTime(`${firstDayFreeTrial}`, 'UTC').getTime() / 1000;
+    return dateNow <= firstDayTimestamp + CONST.TRIAL_DURATION_DAYS * CONST.DATE.SECONDS_PER_DAY;
 }
 
 /**

--- a/src/pages/home/FreeTrialSection/useFreeTrial.ts
+++ b/src/pages/home/FreeTrialSection/useFreeTrial.ts
@@ -62,7 +62,10 @@ function useFreeTrial(): FreeTrialState {
         };
     }, [firstDayFreeTrial, showDiscount]);
 
-    if (!onFreeTrial || hasPaymentCard || !hasOwnedPaidPolicies) {
+    // Show the section if the user is on a free trial OR if the discount banner should be shown.
+    // The discount banner check handles the case where lastDayFreeTrial is not yet set
+    // but firstDayFreeTrial is available and we're within the discount window.
+    if ((!onFreeTrial && !showDiscount) || hasPaymentCard || !hasOwnedPaidPolicies) {
         return {shouldShowFreeTrialSection: false, discountType: null, daysLeft: 0, discountInfo: null};
     }
 


### PR DESCRIPTION
## Details

The "Workspace currency not supported" modal links to a help page (`Connect-a-Business-Bank-Account`) that does not contain information about supported currencies. Updated the URL to point to `Enable-Global-Reimbursement` which has the list of supported currencies.

$ #89516

## Fixed Issues
$ #89516

## Tests
1. Go to staging.new.expensify.com
2. Set workspace currency to VND or SGD (unsupported)
3. Go to Workflows > Add bank account
4. Tap "list of supported currencies" hyperlink
5. Verify the help page shows supported currencies

## Offline tests
Same as above.