### PR TITLE
Skip placeholder report name on cold-cache openReport (fix #88162)

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -1337,7 +1337,9 @@ function openReport(params: OpenReportActionParams) {
     const optimisticReport = reportActionsExist(reportID)
         ? {}
         : {
-              reportName: allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]?.reportName ?? CONST.REPORT.DEFAULT_REPORT_NAME,
+              // Don't fall back to DEFAULT_REPORT_NAME — that flashes "Chat Report" on cold-cache opens (#88162).
+              // The new-report mutation below overwrites this when newReportObject is provided.
+              reportName: allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]?.reportName,
           };
 
     const optimisticData: Array<

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -13,6 +13,7 @@ import useAncestors from '@hooks/useAncestors';
 import markAllMessagesAsRead from '@libs/actions/Report/MarkAllMessageAsRead';
 import {CONCIERGE_RESPONSE_DELAY_MS, resolveSuggestedFollowup} from '@libs/actions/Report/SuggestedFollowup';
 import {getOnboardingMessages} from '@libs/actions/Welcome/OnboardingFlow';
+import * as API from '@libs/API';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import HttpUtils from '@libs/HttpUtils';
 import Navigation from '@libs/Navigation/Navigation';
@@ -7871,6 +7872,46 @@ describe('actions/Report', () => {
             const reportB = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_B}`);
             expect(reportA?.reportName).not.toBe(CONST.REPORT.DEFAULT_REPORT_NAME);
             expect(reportB?.reportName).not.toBe(CONST.REPORT.DEFAULT_REPORT_NAME);
+        });
+
+        // Mutation-test gap: when reportActionsExist returns true (warm cache), the optimistic
+        // payload sent to OpenReport must NOT contain a MERGE for COLLECTION.REPORT/<reportID>.
+        // The current fix at src/libs/actions/Report/index.ts:1337 enforces this by branching
+        // to {} for warm cache and skipping the merge via the `length > 0` guard. Two mutations
+        // would slip past the cold-cache assertions above:
+        //   (a) swapping the cache branches (warm cache writes, cold cache skips) — passes
+        //       cold-cache tests vacuously because nothing is merged.
+        //   (b) loosening the guard to `length >= 0` — adds a no-op MERGE on warm cache.
+        // Both alter the optimisticData payload, so we inspect it directly via API.paginate.
+        it('does not include an optimistic REPORT merge in the OpenReport payload for warm-cache opens (#88162)', async () => {
+            global.fetch = TestHelper.getGlobalFetchMock();
+            const REPORT_ID = '88162-warm-cache';
+
+            // Given: a warm cache — report actions already exist, so reportActionsExist()
+            // returns true and openReport's optimistic-name fallback should be skipped.
+            const action = {...createRandomReportAction(0), reportActionID: 'existing-action'};
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${REPORT_ID}`, {[action.reportActionID]: action});
+            await waitForBatchedUpdates();
+
+            // Spy on API.paginate to capture the OnyxData payload.
+            const apiPaginateSpy = jest.spyOn(API, 'paginate').mockImplementation(() => undefined);
+
+            try {
+                Report.openReport({reportID: REPORT_ID, introSelected: undefined, betas: undefined});
+                await waitForBatchedUpdates();
+
+                // The OpenReport call should have been made.
+                const openReportCall = apiPaginateSpy.mock.calls.find((call) => call.at(1) === WRITE_COMMANDS.OPEN_REPORT);
+                expect(openReportCall).toBeDefined();
+
+                // No entry in optimisticData should target COLLECTION.REPORT/<reportID> on warm cache.
+                const onyxData = openReportCall?.at(3) as {optimisticData?: Array<OnyxUpdate<string>>} | undefined;
+                const optimisticData = onyxData?.optimisticData ?? [];
+                const reportMerges = optimisticData.filter((update) => update.key === `${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`);
+                expect(reportMerges).toHaveLength(0);
+            } finally {
+                apiPaginateSpy.mockRestore();
+            }
         });
     });
 });

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -7814,4 +7814,35 @@ describe('actions/Report', () => {
             expect(result.reportAction.delegateAccountID).toBeUndefined();
         });
     });
+
+    // Repro for https://github.com/Expensify/App/issues/88162 — clicking a multi-transaction
+    // expense report in Search briefly flashes the placeholder "Chat Report" title before the
+    // real (formula-resolved) name resolves. Mechanism: openReport's optimistic merge at
+    // src/libs/actions/Report/index.ts:1340 falls back to CONST.REPORT.DEFAULT_REPORT_NAME
+    // ('Chat Report') when allReports has no entry for reportID (cold cache). Recommended fix
+    // is in src/components/Search/index.tsx multi-tx click handler — seed COLLECTION.REPORT
+    // with the snapshot's report data before navigation so allReports[reportID]?.reportName
+    // is populated by the time openReport's optimistic merge runs.
+    describe('openReport — does not flash "Chat Report" on multi-tx Search click (#88162)', () => {
+        it('should not write reportName="Chat Report" when opening a multi-transaction expense report from cold cache', async () => {
+            global.fetch = TestHelper.getGlobalFetchMock();
+            const REPORT_ID = '88162-multi-tx';
+
+            // Given: a cold cache — no entry in COLLECTION.REPORT, no report actions.
+            // This represents a multi-transaction expense report the user has not opened
+            // before, reachable from Search via a snapshot that already knows its title.
+
+            // When: openReport is called (this happens when SearchMoneyRequestReportPage
+            // mounts after the user clicks the multi-tx item in Search).
+            Report.openReport({reportID: REPORT_ID, introSelected: undefined, betas: undefined});
+            await waitForBatchedUpdates();
+
+            // Then: the optimistic merge should not stamp the placeholder "Chat Report" onto
+            // COLLECTION.REPORT[reportID].reportName. The header should preserve a snapshot's
+            // name (seeded by the Search click handler) or remain unset until the API responds,
+            // but never display the DEFAULT_REPORT_NAME placeholder mid-navigation.
+            const reportValue = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`);
+            expect(reportValue?.reportName).not.toBe(CONST.REPORT.DEFAULT_REPORT_NAME);
+        });
+    });
 });

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -7844,5 +7844,33 @@ describe('actions/Report', () => {
             const reportValue = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`);
             expect(reportValue?.reportName).not.toBe(CONST.REPORT.DEFAULT_REPORT_NAME);
         });
+
+        // Adversarial (state-leak / regression): tapping two distinct multi-tx reports
+        // back-to-back from a cold cache must not leave both reports stamped with the
+        // shared DEFAULT_REPORT_NAME placeholder. Today both calls hit the fallback at
+        // src/libs/actions/Report/index.ts:1340, so the assertion that neither destination
+        // equals "Chat Report" fails. After the fix, each report's name should come from
+        // the upstream (Search snapshot seed or API), not the placeholder.
+        it('does not stamp "Chat Report" on either of two back-to-back cold-cache opens (#88162)', async () => {
+            global.fetch = TestHelper.getGlobalFetchMock();
+            const REPORT_A = '88162-multi-tx-A';
+            const REPORT_B = '88162-multi-tx-B';
+
+            // Given: cold cache for two distinct multi-tx reports (no entries in
+            // COLLECTION.REPORT, no report actions for either).
+
+            // When: a user taps report A, then immediately taps report B from Search —
+            // both pages mount and call openReport before any API responds.
+            Report.openReport({reportID: REPORT_A, introSelected: undefined, betas: undefined});
+            Report.openReport({reportID: REPORT_B, introSelected: undefined, betas: undefined});
+            await waitForBatchedUpdates();
+
+            // Then: neither destination should display the placeholder. If both keys
+            // hold DEFAULT_REPORT_NAME, the user sees "Chat Report" flash on both pages.
+            const reportA = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_A}`);
+            const reportB = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_B}`);
+            expect(reportA?.reportName).not.toBe(CONST.REPORT.DEFAULT_REPORT_NAME);
+            expect(reportB?.reportName).not.toBe(CONST.REPORT.DEFAULT_REPORT_NAME);
+        });
     });
 });


### PR DESCRIPTION
### Explanation of Change

When opening a report whose data isn't yet in the local Onyx cache, `openReport()` was seeding the optimistic update with `CONST.REPORT.DEFAULT_REPORT_NAME` ("Chat Report") as the report name. For reports that resolve to a custom title (via title formula), this caused a visible flash of "Chat Report" before the server response replaced it with the real title.

The fix drops the placeholder fallback — when there's no cached report name, we leave `reportName` undefined in the optimistic payload rather than overwriting any name that other code paths (Search snapshot hydration, etc.) may have already written. The new-report mutation a few lines below still sets `reportName` from `newReportObject` when a fresh report is being created, so that flow is unaffected.

### Fixed Issues
$ https://github.com/Expensify/App/issues/88162
PROPOSAL: N/A

### Tests

1. Sign in with an account that has at least one report under a workspace using a custom report title formula (e.g. `{report:type} - {report:total}`).
2. Open the Reports page (LHN > Reports) and locate that report row — the title column shows the resolved custom title.
3. Click the report row.
4. Verify that the title in the report header / breadcrumb does **not** flash "Chat Report" before resolving — it should either stay on the resolved custom title or appear blank momentarily, then resolve to the custom title.
5. Repeat with the cache cold (hard reload, then click immediately) to make sure the placeholder doesn't appear.
6. Verify no errors appear in the JS console.

### Offline tests

1. While online, complete the steps above so the report is cached locally.
2. Go offline, navigate away, then click the report row again — verify the cached custom title renders immediately without flashing "Chat Report".

### QA Steps

Same as tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods
    - [x] I verified any copy / text that was added to the app is grammatically correct in English
    - [x] I verified proper file naming conventions were followed for any new files or renamed files
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that the file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that a similar style doesn't already exist and the style can't be created with an existing StyleUtils function
- [x] If new assets were added or existing ones were modified, I verified they are optimized and load correctly across all supported platforms
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used
- [x] If the PR modifies the UI or modifies the form input styles, I verified inputs are aligned and added the Design label if relevant
- [x] If a new page is added, I verified it's using the `ScrollView` component
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Reviewed and accepted

- **Codex P2 (`src/libs/actions/Report/index.ts:1337`)** — flagged that the fix is at the generic `openReport()` layer rather than the Search-specific snapshot hydration path, and suggested seeding `COLLECTION.REPORT/<reportID>` with `snapshotReport` in the Search click flow instead. Accepted as-is: dropping the `DEFAULT_REPORT_NAME` placeholder is the correct minimal fix at the actual mutation site, since the placeholder string was never useful — any caller that has the real title (Search snapshots, cached reports, fresh `newReportObject`) still wins, and callers without a title now leave `reportName` undefined rather than briefly clobbering it with "Chat Report". A separate Search-side hydration improvement can be pursued independently if a non-blank initial title is desired for the cold-cache Search flow.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>
</details>

<details>
<summary>Android: mWeb Chrome</summary>
</details>

<details>
<summary>iOS: Native</summary>
</details>

<details>
<summary>iOS: mWeb Safari</summary>
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
</details>
