### PR TITLE
Follow up improvements for inline code blocks on iOS

### DIFF
--- a/patches/react-native/details.md
+++ b/patches/react-native/details.md
@@ -264,3 +264,10 @@
 - Reason: Fixes an Android-specific issue (reproducible on certain Samsung models) where `onPress` events do not trigger for `Pressable` components when used inside a `Tooltip`. The root cause is that in the new architecture, `Pressability.measure()` reads stale layout information from the shadow tree instead of the actual native view hierarchy. This patch introduces a new `measureAsyncOnUI` method that measures the view asynchronously using the native layout hierarchy on the UI thread, bypassing stale shadow tree data.
 - Upstream PR/issue: [facebook/react-native#51835](https://github.com/facebook/react-native/pull/51835)
 - E/App issue: [#59953](https://github.com/Expensify/App/issues/59953)
+
+### [react-native+0.83.1+036+rounded-inline-code-background.patch](react-native+0.83.1+036+rounded-inline-code-background.patch)
+
+- Reason: Draws inline code block background with rounded corners on iOS when `borderTopLeftRadius` is set.
+- Upstream PR/issue: 🛑
+- E/App issue: https://github.com/Expensify/App/issues/57556
+- PR introducing patch: https://github.com/Expensify/App/pull/79815

--- a/patches/react-native/react-native+0.83.1+036+rounded-inline-code-background.patch
+++ b/patches/react-native/react-native+0.83.1+036+rounded-inline-code-background.patch
@@ -1,0 +1,155 @@
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp b/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+index 9cf89bf..845f6c1 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
++++ b/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+@@ -25,6 +25,9 @@ void TextAttributes::apply(TextAttributes textAttributes) {
+   backgroundColor = textAttributes.backgroundColor
+       ? textAttributes.backgroundColor
+       : backgroundColor;
++  borderTopLeftRadius = !std::isnan(textAttributes.borderTopLeftRadius)
++      ? textAttributes.borderTopLeftRadius
++      : borderTopLeftRadius;
+   opacity =
+       !std::isnan(textAttributes.opacity) ? textAttributes.opacity : opacity;
+ 
+@@ -171,6 +174,7 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
+       floatEquality(fontSizeMultiplier, rhs.fontSizeMultiplier) &&
+       floatEquality(letterSpacing, rhs.letterSpacing) &&
+       floatEquality(lineHeight, rhs.lineHeight) &&
++      floatEquality(borderTopLeftRadius, rhs.borderTopLeftRadius) &&
+       floatEquality(textShadowRadius, rhs.textShadowRadius);
+ }
+ 
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h b/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+index b664524..dce4e3b 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
++++ b/node_modules/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+@@ -41,6 +41,7 @@ class TextAttributes : public DebugStringConvertible {
+   // Color
+   SharedColor foregroundColor{};
+   SharedColor backgroundColor{};
++  Float borderTopLeftRadius{std::numeric_limits<Float>::quiet_NaN()};
+   Float opacity{std::numeric_limits<Float>::quiet_NaN()};
+ 
+   // Font
+@@ -112,6 +113,7 @@ struct hash<facebook::react::TextAttributes> {
+     return facebook::react::hash_combine(
+         textAttributes.foregroundColor,
+         textAttributes.backgroundColor,
++        textAttributes.borderTopLeftRadius,
+         textAttributes.opacity,
+         textAttributes.fontFamily,
+         textAttributes.fontSize,
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp b/node_modules/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+index f20cd3c..8a9cedc 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
++++ b/node_modules/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+@@ -222,6 +222,12 @@ static TextAttributes convertRawProp(
+       "backgroundColor",
+       sourceTextAttributes.backgroundColor,
+       defaultTextAttributes.backgroundColor);
++  textAttributes.borderTopLeftRadius = convertRawProp(
++      context,
++      rawProps,
++      "borderTopLeftRadius",
++      sourceTextAttributes.borderTopLeftRadius,
++      defaultTextAttributes.borderTopLeftRadius);
+ 
+   return textAttributes;
+ }
+@@ -334,6 +340,8 @@ void BaseTextProps::setProp(
+         defaults, value, textAttributes, opacity, "opacity");
+     REBUILD_FIELD_SWITCH_CASE(
+         defaults, value, textAttributes, backgroundColor, "backgroundColor");
++    REBUILD_FIELD_SWITCH_CASE(
++        defaults, value, textAttributes, borderTopLeftRadius, "borderTopLeftRadius");
+   }
+ }
+ 
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+index dac572b..87cc9f0 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
++++ b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+@@ -18,6 +18,7 @@ NSString *const RCTAttributedStringEventEmitterKey = @"EventEmitter";
+ 
+ // String representation of either `role` or `accessibilityRole`
+ NSString *const RCTTextAttributesAccessibilityRoleAttributeName = @"AccessibilityRole";
++NSString *const RCTTextBackgroundBorderRadiusAttributeName = @"TextBackgroundBorderRadius";
+ 
+ /*
+  * Creates `NSTextAttributes` from given `facebook::react::TextAttributes`
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+index 520a24c..452a0fe 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
++++ b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+@@ -179,7 +179,12 @@ inline static CGFloat RCTEffectiveFontSizeMultiplierFromTextAttributes(const Tex
+   }
+ 
+   if (textAttributes.backgroundColor || !isnan(textAttributes.opacity)) {
+-    attributes[NSBackgroundColorAttributeName] = RCTEffectiveBackgroundColorFromTextAttributes(textAttributes);
++    UIColor *bgColor = RCTEffectiveBackgroundColorFromTextAttributes(textAttributes) ?: [UIColor clearColor];
++    if (!isnan(textAttributes.borderTopLeftRadius) && textAttributes.borderTopLeftRadius > 0) {
++      attributes[RCTTextBackgroundBorderRadiusAttributeName] = @[@(textAttributes.borderTopLeftRadius), bgColor];
++    } else {
++      attributes[NSBackgroundColorAttributeName] = bgColor;
++    }
+   }
+ 
+   // Kerning
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+index ef50487..df9290f 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
++++ b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+@@ -17,6 +17,8 @@
+ 
+ using namespace facebook::react;
+ 
++static const CGFloat inlineCodeBackgroundTopInset = 3;
++
+ @implementation RCTTextLayoutManager {
+   SimpleThreadSafeCache<AttributedString, std::shared_ptr<void>, 256> _cache;
+ }
+@@ -86,6 +88,43 @@ - (void)drawAttributedString:(AttributedString)attributedString
+ 
+   NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
+ 
++  NSRange characterRange = [layoutManager characterRangeForGlyphRange:glyphRange actualGlyphRange:NULL];
++  [textStorage enumerateAttribute:RCTTextBackgroundBorderRadiusAttributeName
++                          inRange:characterRange
++                          options:0
++                       usingBlock:^(NSArray *value, NSRange range, BOOL *stop) {
++                         if (!value) {
++                           return;
++                         }
++                         CGFloat radius = [value[0] floatValue];
++                         UIColor *color = value[1];
++                         NSRange rangeGlyphRange = [layoutManager glyphRangeForCharacterRange:range actualCharacterRange:NULL];
++                         NSMutableArray<NSValue *> *rects = [NSMutableArray array];
++                         [layoutManager enumerateEnclosingRectsForGlyphRange:rangeGlyphRange
++                                                     withinSelectedGlyphRange:rangeGlyphRange
++                                                              inTextContainer:textContainer
++                                                                   usingBlock:^(CGRect enclosingRect, BOOL *anotherStop) {
++                             [rects addObject:[NSValue valueWithCGRect:enclosingRect]];
++                         }];
++                         NSUInteger count = rects.count;
++                         for (NSUInteger i = 0; i < count; i++) {
++                             CGRect rect = UIEdgeInsetsInsetRect(
++                                 CGRectOffset([rects[i] CGRectValue], frame.origin.x, frame.origin.y),
++                                 UIEdgeInsetsMake(inlineCodeBackgroundTopInset, 0, 0, 0));
++                             UIRectCorner corners = 0;
++                             if (count == 1) {
++                                 corners = UIRectCornerAllCorners;
++                             } else if (i == 0) {
++                                 corners = UIRectCornerTopLeft | UIRectCornerBottomLeft;
++                             } else if (i == count - 1) {
++                                 corners = UIRectCornerTopRight | UIRectCornerBottomRight;
++                             }
++                             UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:rect byRoundingCorners:corners cornerRadii:CGSizeMake(radius, radius)];
++                             [color setFill];
++                             [path fill];
++                         }
++                       }];
++
+   [self processTruncatedAttributedText:textStorage textContainer:textContainer layoutManager:layoutManager];
+ 
+   [layoutManager drawBackgroundForGlyphRange:glyphRange atPoint:frame.origin];


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This implements step 1 on iOS of [the 3-step incremental approach](https://github.com/Expensify/App/issues/57556#issuecomment-3669366235):

> 1. Add rounded corners like 'expense-report' below (if we can only get this far, it's already an improvement)
> 
> <img width="390" height="80" alt="Image" src="https://github.com/user-attachments/assets/b232c88e-715f-4608-9aa7-a5831b54ceba" />
> <p></p>
> 
> 2. Add paddings like the 'Outstanding' badge below (this would be even better)
> 
> <img width="390" height="68" alt="Image" src="https://github.com/user-attachments/assets/5bf6ce82-461c-4796-9d17-4add3d8e78e8" />
> <p></p>
> 
> 3. Add borders to match the web inline code block below (ideal)
> 
> <img width="390" height="55" alt="Image" src="https://github.com/user-attachments/assets/0548956f-1593-4b62-ad8a-309558b94bd8" />
> <p></p>


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/57556
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Note: This change only affects iOS Native.

1. Open any chat.
2. Send a message containing inline code blocks.
3. Verify that the inline code blocks are displayed with rounded corners on iOS.

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native (N/A)</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome (N/A)</summary>

<!-- add screenshots or videos here -->

</details>

<details open>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-06 at 16 38 02" src="https://github.com/user-attachments/assets/146a3866-5b20-4bdd-935e-1bed054decec" />

</details>

<details>
<summary>iOS: mWeb Safari (N/A)</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari (N/A)</summary>

<!-- add screenshots or videos here -->

</details>