### PR TITLE
fix: jump to existing workspaces tab instead of pushing new one

### DIFF
--- a/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
+++ b/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
@@ -34,37 +34,24 @@ function useRestoreWorkspacesTabOnNavigate() {
         // Priority: live nav state (root level) -> inside TabNavigator -> preserved state -> session storage.
         const rootState = navigationRef.isReady() ? navigationRef.getRootState() : undefined;
         const lastTabNavigatorRoute = rootState?.routes?.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
-        const routeState = (() => {
-            if (!lastTabNavigatorRoute) {
-                return {};
+        const lastWorkspacesTabNavigatorRoute = (() => {
+            if (lastTabNavigatorRoute) {
+                const workspaceNavigatorRoute = getTabState(lastTabNavigatorRoute)?.routes?.find((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
+                const workspaceNavigatorState = workspaceNavigatorRoute?.state ?? (workspaceNavigatorRoute?.key ? getPreservedNavigatorState(workspaceNavigatorRoute.key) : undefined);
+                const lastWorkspaceRoute = workspaceNavigatorState?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
+                if (lastWorkspaceRoute) {
+                    return lastWorkspaceRoute;
+                }
             }
 
-            const workspaceNavigatorRoute = getTabState(lastTabNavigatorRoute)?.routes?.find((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
-            const workspaceNavigatorState = workspaceNavigatorRoute?.state ?? (workspaceNavigatorRoute?.key ? getPreservedNavigatorState(workspaceNavigatorRoute.key) : undefined);
-            const lastWorkspaceRoute = workspaceNavigatorState?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
-
-            if (lastWorkspaceRoute) {
-                const tabState = lastWorkspaceRoute.state ?? (lastWorkspaceRoute.key ? getPreservedNavigatorState(lastWorkspaceRoute.key) : undefined);
-                return {lastWorkspacesTabNavigatorRoute: lastWorkspaceRoute, workspacesTabState: tabState};
-            }
-
-            // Fall back to session storage when no workspace route exists anywhere in the navigation tree.
-            // getStateFromPath returns state rooted at TAB_NAVIGATOR, so we must drill into it first.
+            // Fall back to session storage. Shape mirrors the live nav state: TabNavigator -> WorkspaceNavigator -> WorkspaceSplitNavigator.
             const sessionTabNavigatorRoute = getWorkspacesTabStateFromSessionStorage()?.routes?.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
-            const sessionRoute = getTabState(sessionTabNavigatorRoute)
-                ?.routes?.findLast((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR)
-                ?.state?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
-            if (sessionRoute) {
-                return {lastWorkspacesTabNavigatorRoute: sessionRoute, workspacesTabState: sessionRoute.state};
-            }
-
-            return {};
+            const sessionWorkspaceNavigatorRoute = sessionTabNavigatorRoute?.state?.routes?.find((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
+            return sessionWorkspaceNavigatorRoute?.state?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
         })();
 
-        const {lastWorkspacesTabNavigatorRoute, workspacesTabState} = routeState;
-
         // If the last route was a specific workspace or domain, extract its ID from params
-        const params = workspacesTabState?.routes?.at(0)?.params as
+        const params = lastWorkspacesTabNavigatorRoute?.state?.routes?.at(0)?.params as
             | WorkspaceSplitNavigatorParamList[typeof SCREENS.WORKSPACE.INITIAL]
             | DomainSplitNavigatorParamList[typeof SCREENS.DOMAIN.INITIAL];
         const paramsPolicyID = params && 'policyID' in params ? params.policyID : undefined;

--- a/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
+++ b/src/hooks/useRestoreWorkspacesTabOnNavigate.ts
@@ -1,5 +1,5 @@
 import {getPreservedNavigatorState} from '@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState';
-import {isFullScreenName, isWorkspaceNavigatorRouteName} from '@libs/Navigation/helpers/isNavigatorName';
+import {isWorkspaceNavigatorRouteName} from '@libs/Navigation/helpers/isNavigatorName';
 import {getWorkspacesTabStateFromSessionStorage} from '@libs/Navigation/helpers/lastVisitedTabPathUtils';
 import navigateToWorkspacesPage from '@libs/Navigation/helpers/navigateToWorkspacesPage';
 import {getTabState} from '@libs/Navigation/helpers/tabNavigatorUtils';
@@ -33,29 +33,19 @@ function useRestoreWorkspacesTabOnNavigate() {
         // Find the last route the user had open in the Workspaces tab (workspace, domain, or list).
         // Priority: live nav state (root level) -> inside TabNavigator -> preserved state -> session storage.
         const rootState = navigationRef.isReady() ? navigationRef.getRootState() : undefined;
+        const lastTabNavigatorRoute = rootState?.routes?.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
         const routeState = (() => {
-            const topmostFullScreenRoute = rootState?.routes?.findLast((route) => isFullScreenName(route.name));
-            if (!topmostFullScreenRoute) {
+            if (!lastTabNavigatorRoute) {
                 return {};
             }
 
-            // Multiple TAB_NAVIGATOR instances can coexist in the root stack — when navigation from
-            // inside an RHP targets a tab, linkTo PUSHes a fresh TabNavigator above the modal, and that
-            // new instance's WORKSPACE_NAVIGATOR slot starts empty. Older instances kept alive by
-            // ensureTabNavigatorRoutes still hold the previous workspace state, so flatten every
-            // workspace route from every TabNavigator in stack order and take the most recent one.
-            const lastWorkspaceRoute = (rootState?.routes ?? [])
-                .filter((route) => route.name === NAVIGATORS.TAB_NAVIGATOR)
-                .flatMap((tabNavigatorRoute) => {
-                    const workspaceNavigatorRoute = getTabState(tabNavigatorRoute)?.routes?.find((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
-                    const workspaceNavigatorState = workspaceNavigatorRoute?.state ?? (workspaceNavigatorRoute?.key ? getPreservedNavigatorState(workspaceNavigatorRoute.key) : undefined);
-                    return workspaceNavigatorState?.routes?.filter((route) => isWorkspaceNavigatorRouteName(route.name)) ?? [];
-                })
-                .at(-1);
+            const workspaceNavigatorRoute = getTabState(lastTabNavigatorRoute)?.routes?.find((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
+            const workspaceNavigatorState = workspaceNavigatorRoute?.state ?? (workspaceNavigatorRoute?.key ? getPreservedNavigatorState(workspaceNavigatorRoute.key) : undefined);
+            const lastWorkspaceRoute = workspaceNavigatorState?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
 
             if (lastWorkspaceRoute) {
                 const tabState = lastWorkspaceRoute.state ?? (lastWorkspaceRoute.key ? getPreservedNavigatorState(lastWorkspaceRoute.key) : undefined);
-                return {lastWorkspacesTabNavigatorRoute: lastWorkspaceRoute, workspacesTabState: tabState, topmostFullScreenRoute};
+                return {lastWorkspacesTabNavigatorRoute: lastWorkspaceRoute, workspacesTabState: tabState};
             }
 
             // Fall back to session storage when no workspace route exists anywhere in the navigation tree.
@@ -65,13 +55,13 @@ function useRestoreWorkspacesTabOnNavigate() {
                 ?.routes?.findLast((route) => route.name === NAVIGATORS.WORKSPACE_NAVIGATOR)
                 ?.state?.routes?.findLast((route) => isWorkspaceNavigatorRouteName(route.name));
             if (sessionRoute) {
-                return {lastWorkspacesTabNavigatorRoute: sessionRoute, workspacesTabState: sessionRoute.state, topmostFullScreenRoute};
+                return {lastWorkspacesTabNavigatorRoute: sessionRoute, workspacesTabState: sessionRoute.state};
             }
 
-            return {topmostFullScreenRoute};
+            return {};
         })();
 
-        const {lastWorkspacesTabNavigatorRoute, workspacesTabState, topmostFullScreenRoute} = routeState;
+        const {lastWorkspacesTabNavigatorRoute, workspacesTabState} = routeState;
 
         // If the last route was a specific workspace or domain, extract its ID from params
         const params = workspacesTabState?.routes?.at(0)?.params as
@@ -94,8 +84,7 @@ function useRestoreWorkspacesTabOnNavigate() {
             policy: lastViewedPolicy,
             domain: lastViewedDomain,
             lastWorkspacesTabNavigatorRoute,
-            topmostFullScreenRoute,
-            workspacesTabState,
+            lastTabNavigatorRoute,
         });
     };
 }

--- a/src/libs/Navigation/AppNavigator/createWorkspaceNavigator/WorkspaceRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createWorkspaceNavigator/WorkspaceRouter.ts
@@ -1,16 +1,48 @@
-import type {RouterConfigOptions} from '@react-navigation/native';
+import type {ParamListBase, PartialState, RouterConfigOptions, StackNavigationState} from '@react-navigation/native';
 import {StackRouter} from '@react-navigation/native';
+import {getWorkspacesTabStateFromSessionStorage} from '@libs/Navigation/helpers/lastVisitedTabPathUtils';
 import {getPreservedNavigatorState} from '@navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState';
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
 import type WorkspaceNavigatorRouterOptions from './types';
+
+/**
+ * Builds the WorkspaceNavigator initial state from the saved Workspaces-tab path in sessionStorage —
+ * the routes the user had open in the tab before navigating away. Prepends WORKSPACES_LIST when the
+ * saved path didn't include it so the back-stack works (swipe back from a workspace returns to the list).
+ * Returns `undefined` on native (no sessionStorage), when nothing is saved, or when the parsed
+ * state has no WORKSPACE_NAVIGATOR slot.
+ */
+function buildWorkspaceInitialStateFromSessionStorage(): PartialState<StackNavigationState<ParamListBase>> | undefined {
+    const sessionState = getWorkspacesTabStateFromSessionStorage();
+    const restoredState = sessionState?.routes?.find((r) => r.name === NAVIGATORS.TAB_NAVIGATOR)?.state?.routes?.find((r) => r.name === NAVIGATORS.WORKSPACE_NAVIGATOR)?.state as
+        | PartialState<StackNavigationState<ParamListBase>>
+        | undefined;
+    if (!restoredState?.routes?.length) {
+        return undefined;
+    }
+    if (restoredState.routes.some((r) => r.name === SCREENS.WORKSPACES_LIST)) {
+        return restoredState;
+    }
+    const routes = [{name: SCREENS.WORKSPACES_LIST}, ...restoredState.routes];
+    return {routes, index: routes.length - 1};
+}
 
 function WorkspaceRouter(options: WorkspaceNavigatorRouterOptions) {
     const stackRouter = StackRouter(options);
 
     return {
         ...stackRouter,
-        getInitialState({routeNames, routeParamList, routeGetIdList}: RouterConfigOptions) {
+        getInitialState(configOptions: RouterConfigOptions) {
             const preservedState = getPreservedNavigatorState(options.parentRoute.key);
-            return preservedState ?? stackRouter.getInitialState({routeNames, routeParamList, routeGetIdList});
+            if (preservedState) {
+                return preservedState;
+            }
+            const sessionState = buildWorkspaceInitialStateFromSessionStorage();
+            if (sessionState) {
+                return stackRouter.getRehydratedState(sessionState, configOptions);
+            }
+            return stackRouter.getInitialState(configOptions);
         },
     };
 }

--- a/src/libs/Navigation/NavigationRoot.tsx
+++ b/src/libs/Navigation/NavigationRoot.tsx
@@ -80,10 +80,17 @@ function parseAndLogRoute(state: NavigationState) {
     const lastRoute = state.routes.at(-1);
     const activeTabName = getActiveTabName(lastRoute);
 
-    if (activeTabName === NAVIGATORS.WORKSPACE_NAVIGATOR) {
-        saveWorkspacesTabPathToSessionStorage(currentPath);
-    } else if (activeTabName === NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR) {
-        saveSettingsTabPathToSessionStorage(currentPath);
+    // Skip saving when the focused route is the navigator itself (no nested screen yet), e.g. during
+    // the intermediate state right after `TabActions.jumpTo(WORKSPACE_NAVIGATOR)` and before the
+    // navigator mounts. The path collapses to `/` in that moment and would clobber the real path
+    // that WorkspaceRouter.getInitialState needs to read.
+    const isFocusedOnEmptyNavigator = focusedRoute?.name === activeTabName;
+    if (!isFocusedOnEmptyNavigator) {
+        if (activeTabName === NAVIGATORS.WORKSPACE_NAVIGATOR) {
+            saveWorkspacesTabPathToSessionStorage(currentPath);
+        } else if (activeTabName === NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR) {
+            saveSettingsTabPathToSessionStorage(currentPath);
+        }
     }
 
     // Fullstory Page navigation tracking

--- a/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
+++ b/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
@@ -1,28 +1,24 @@
-import {findFocusedRoute, StackActions} from '@react-navigation/native';
 import type {NavigationState, PartialState} from '@react-navigation/native';
+import {findFocusedRoute, StackActions, TabActions} from '@react-navigation/native';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
-import {getPreservedNavigatorState} from '@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
+// eslint-disable-next-line no-restricted-imports
+import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import {isPendingDeletePolicy, shouldShowPolicy as shouldShowPolicyUtil} from '@libs/PolicyUtils';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ROUTES from '@src/ROUTES';
-import type {Route} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Domain, Policy} from '@src/types/onyx';
 import getActiveTabName from './getActiveTabName';
-import getPathFromState from './getPathFromState';
-import {getTabState} from './tabNavigatorUtils';
 
 type RouteType = NavigationState['routes'][number] | PartialState<NavigationState>['routes'][number];
 
-/**
- * Wraps a leaf navigation state in successive ancestor navigators (outermost first).
- * Used to reconstruct the linking-config hierarchy that `getPathFromState` walks when
- * resolving a state subtree to a URL.
- */
-function wrapStateInNavigators(state: PartialState<NavigationState>, navigators: readonly string[]): PartialState<NavigationState> {
-    return navigators.reduceRight<PartialState<NavigationState>>((acc, name) => ({routes: [{name, state: acc}], index: 0}), state);
+function jumpToWorkspacesTab(tabNavStateKey: string) {
+    navigationRef.dispatch({
+        ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+        target: tabNavStateKey,
+    });
 }
 
 type Params = {
@@ -31,60 +27,33 @@ type Params = {
     policy?: Policy;
     domain?: Domain;
     lastWorkspacesTabNavigatorRoute?: RouteType;
-    topmostFullScreenRoute?: RouteType;
-    /**
-     * The full WorkspaceSplitNavigator inner state captured by the hook.
-     * Wrapped in a synthetic outer node and fed to `getPathFromState` to reconstruct
-     * the deep URL the user was on (e.g. `/workspaces/POLICY_ID/workflows`). Navigating
-     * via that URL goes through `getStateFromPath` which produces a fully-formed
-     * navigation state — bypassing custom router actions that don't seed nested state
-     * when pushing a fresh TabNavigator on top of an existing fullscreen stack.
-     */
-    workspacesTabState?: NavigationState | PartialState<NavigationState>;
+    lastTabNavigatorRoute?: RouteType;
 };
 
-const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, policy, domain, lastWorkspacesTabNavigatorRoute, topmostFullScreenRoute, workspacesTabState}: Params) => {
+const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, policy, domain, lastWorkspacesTabNavigatorRoute, lastTabNavigatorRoute}: Params) => {
     const rootState = navigationRef.getRootState();
     const focusedRoute = rootState ? findFocusedRoute(rootState) : undefined;
     const isOnWorkspacesList = focusedRoute?.name === SCREENS.WORKSPACES_LIST;
 
-    if (!topmostFullScreenRoute || isOnWorkspacesList) {
+    if (!lastTabNavigatorRoute || isOnWorkspacesList) {
         // Not in a main workspace navigation context or the workspaces list page is already displayed, so do nothing.
         return;
-    }
-
-    // Pop to the older TAB_NAVIGATOR holding the workspace state. Target the root stack
-    // explicitly so POP bypasses SearchFullscreenNavigator's PUSH_PARAMS interceptor.
-    // https://github.com/Expensify/App/issues/89009
-    if (rootState) {
-        const topRootIndex = rootState.index ?? rootState.routes.length - 1;
-        const olderTabIdx = rootState.routes.findLastIndex((route, idx) => {
-            if (idx >= topRootIndex || route.name !== NAVIGATORS.TAB_NAVIGATOR) {
-                return false;
-            }
-            const tabState = getTabState(route as Parameters<typeof getTabState>[0]);
-            const focusedTab = tabState?.routes?.at(tabState.index ?? 0);
-            if (focusedTab?.name !== NAVIGATORS.WORKSPACE_NAVIGATOR) {
-                return false;
-            }
-            const wsState = focusedTab.state ?? (focusedTab.key ? getPreservedNavigatorState(focusedTab.key) : undefined);
-            return !!wsState?.routes?.length;
-        });
-        if (olderTabIdx !== -1) {
-            navigationRef.dispatch({...StackActions.pop(topRootIndex - olderTabIdx), target: rootState.key});
-            return;
-        }
     }
 
     // Check if user is already on a workspace or domain inside WORKSPACE_NAVIGATOR (within TabNavigator)
     const isWorkspaceOrDomainOnTop =
         lastWorkspacesTabNavigatorRoute?.name === NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR || lastWorkspacesTabNavigatorRoute?.name === NAVIGATORS.DOMAIN_SPLIT_NAVIGATOR;
-    const activeTabName = topmostFullScreenRoute.name === NAVIGATORS.TAB_NAVIGATOR ? getActiveTabName(topmostFullScreenRoute as Parameters<typeof getActiveTabName>[0]) : undefined;
+    const activeTabName = getActiveTabName(lastTabNavigatorRoute as Parameters<typeof getActiveTabName>[0]);
     if (activeTabName === NAVIGATORS.WORKSPACE_NAVIGATOR && isWorkspaceOrDomainOnTop) {
         // Already inside a workspace or domain: go back to the list.
         Navigation.goBack(ROUTES.WORKSPACES_LIST.route);
         return;
     }
+
+    // Restore WORKSPACE_SPLIT_NAVIGATOR / DOMAIN_SPLIT_NAVIGATOR by jumping to the WORKSPACE_NAVIGATOR
+    // tab in-place. URL-based navigation would go through `getStateFromPath` and push a brand-new
+    // TAB_NAVIGATOR on top of the existing one, which is wasteful.
+    const existingTabNavStateKey = (lastTabNavigatorRoute.state as NavigationState | undefined)?.key;
 
     interceptAnonymousUser(() => {
         // No workspace found in nav state: go to list.
@@ -104,34 +73,26 @@ const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, poli
                 return;
             }
 
-            if (policy?.id) {
-                // Synthesize a URL from the captured WorkspaceSplitNavigator inner state and navigate
-                // to it. URL-based navigation goes through `getStateFromPath`, which produces a fully
-                // formed nested state and reliably handles pushing a fresh TabNavigator on top of an
-                // existing fullscreen stack. The state has to be wrapped with its full ancestor chain
-                // (TAB_NAVIGATOR > WORKSPACE_NAVIGATOR > WORKSPACE_SPLIT_NAVIGATOR) so `getPathFromState`
-                // can match the linking-config hierarchy and produce a real URL like
-                // `/workspaces/POLICY_ID/workflows`; otherwise the resolver falls back to navigator
-                // names as path segments and the result hits 404. Narrow layouts skip the deep-restore
-                // and go to the workspace's initial page (mirrors mobile behavior).
-                const wrappedState =
-                    !shouldUseNarrowLayout && workspacesTabState
-                        ? wrapStateInNavigators(workspacesTabState as PartialState<NavigationState>, [
-                              NAVIGATORS.TAB_NAVIGATOR,
-                              NAVIGATORS.WORKSPACE_NAVIGATOR,
-                              NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
-                          ])
-                        : undefined;
-                const targetPath = (wrappedState ? getPathFromState(wrappedState) : ROUTES.WORKSPACE_INITIAL.getRoute(policy.id)) as Route;
-                Navigation.navigate(targetPath);
+            if (policy?.id && existingTabNavStateKey) {
+                const focusedWorkspaceSplitRouteName = lastWorkspacesTabNavigatorRoute.state ? findFocusedRoute(lastWorkspacesTabNavigatorRoute.state)?.name : undefined;
+                const isOnWorkspaceInitial = focusedWorkspaceSplitRouteName === SCREENS.WORKSPACE.INITIAL;
+                if (shouldUseNarrowLayout && lastWorkspacesTabNavigatorRoute.state?.key && !isOnWorkspaceInitial) {
+                    // On narrow layout, pop the workspace split to WorkspaceInitialPage while the tab is
+                    // still hidden, then jump to the tab. Resetting first prevents any sub-page from
+                    // flashing before WorkspaceInitialPage appears.
+                    navigationRef.dispatch({...StackActions.popToTop(), target: lastWorkspacesTabNavigatorRoute.state.key});
+                    TransitionTracker.runAfterTransitions({callback: () => jumpToWorkspacesTab(existingTabNavStateKey), waitForUpcomingTransition: true});
+                    return;
+                }
+                jumpToWorkspacesTab(existingTabNavStateKey);
+                return;
             }
-            return;
         }
 
         // Domain route found: try to restore last domain screen.
         if (lastWorkspacesTabNavigatorRoute.name === NAVIGATORS.DOMAIN_SPLIT_NAVIGATOR) {
-            if (domain?.accountID !== undefined) {
-                Navigation.navigate(ROUTES.DOMAIN_INITIAL.getRoute(domain.accountID));
+            if (domain?.accountID && existingTabNavStateKey) {
+                jumpToWorkspacesTab(existingTabNavStateKey);
                 return;
             }
         }

--- a/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
+++ b/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
@@ -11,6 +11,7 @@ import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Domain, Policy} from '@src/types/onyx';
 import getActiveTabName from './getActiveTabName';
+import {saveWorkspacesTabPathToSessionStorage} from './lastVisitedTabPathUtils';
 
 type RouteType = NavigationState['routes'][number] | PartialState<NavigationState>['routes'][number];
 
@@ -52,12 +53,19 @@ const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, poli
 
     // Restore WORKSPACE_SPLIT_NAVIGATOR / DOMAIN_SPLIT_NAVIGATOR by jumping to the WORKSPACE_NAVIGATOR
     // tab in-place. URL-based navigation would go through `getStateFromPath` and push a brand-new
-    // TAB_NAVIGATOR on top of the existing one, which is wasteful.
+    // TAB_NAVIGATOR on top of the existing one, which is wasteful. On cold start the slot has no
+    // nested state yet; jumping focuses it and WorkspaceRouter.getInitialState reads the last-visited
+    // sub-page from sessionStorage so the user still lands on it.
     const existingTabNavStateKey = (lastTabNavigatorRoute.state as NavigationState | undefined)?.key;
 
     interceptAnonymousUser(() => {
-        // No workspace found in nav state: go to list.
+        // Cold start: no nested state yet. Jump to the Workspaces tab and let WorkspaceRouter.getInitialState
+        // restore the last-visited sub-page (or fall back to WORKSPACES_LIST when there's nothing saved).
         if (!lastWorkspacesTabNavigatorRoute) {
+            if (existingTabNavStateKey) {
+                jumpToWorkspacesTab(existingTabNavStateKey);
+                return;
+            }
             Navigation.navigate(ROUTES.WORKSPACES_LIST.route);
             return;
         }
@@ -76,13 +84,19 @@ const navigateToWorkspacesPage = ({currentUserLogin, shouldUseNarrowLayout, poli
             if (policy?.id && existingTabNavStateKey) {
                 const focusedWorkspaceSplitRouteName = lastWorkspacesTabNavigatorRoute.state ? findFocusedRoute(lastWorkspacesTabNavigatorRoute.state)?.name : undefined;
                 const isOnWorkspaceInitial = focusedWorkspaceSplitRouteName === SCREENS.WORKSPACE.INITIAL;
-                if (shouldUseNarrowLayout && lastWorkspacesTabNavigatorRoute.state?.key && !isOnWorkspaceInitial) {
-                    // On narrow layout, pop the workspace split to WorkspaceInitialPage while the tab is
-                    // still hidden, then jump to the tab. Resetting first prevents any sub-page from
-                    // flashing before WorkspaceInitialPage appears.
-                    navigationRef.dispatch({...StackActions.popToTop(), target: lastWorkspacesTabNavigatorRoute.state.key});
-                    TransitionTracker.runAfterTransitions({callback: () => jumpToWorkspacesTab(existingTabNavStateKey), waitForUpcomingTransition: true});
-                    return;
+                if (shouldUseNarrowLayout && !isOnWorkspaceInitial) {
+                    if (lastWorkspacesTabNavigatorRoute.state?.key) {
+                        // Live state: pop the workspace split to WorkspaceInitialPage while the tab is
+                        // still hidden, then jump to the tab. Resetting first prevents any sub-page from
+                        // flashing before WorkspaceInitialPage appears.
+                        navigationRef.dispatch({...StackActions.popToTop(), target: lastWorkspacesTabNavigatorRoute.state.key});
+                        TransitionTracker.runAfterTransitions({callback: () => jumpToWorkspacesTab(existingTabNavStateKey), waitForUpcomingTransition: true});
+                        return;
+                    }
+                    // Session-storage state: the WorkspaceSplitNavigator isn't mounted yet, so we can't
+                    // dispatch popToTop. Overwrite the saved path with the workspace-initial URL so
+                    // WorkspaceRouter/SplitRouter rehydrate to just WORKSPACE_INITIAL when they mount.
+                    saveWorkspacesTabPathToSessionStorage(ROUTES.WORKSPACE_INITIAL.getRoute(policy.id));
                 }
                 jumpToWorkspacesTab(existingTabNavStateKey);
                 return;

--- a/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
+++ b/src/libs/Navigation/helpers/navigateToWorkspacesPage.ts
@@ -3,7 +3,7 @@ import {findFocusedRoute, StackActions, TabActions} from '@react-navigation/nati
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
-// eslint-disable-next-line no-restricted-imports
+// eslint-disable-next-line no-restricted-imports -- TransitionTracker is needed here to sequence the tab jump after the popToTop transition completes, so WorkspaceInitialPage appears before the tab becomes visible.
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import {isPendingDeletePolicy, shouldShowPolicy as shouldShowPolicyUtil} from '@libs/PolicyUtils';
 import NAVIGATORS from '@src/NAVIGATORS';

--- a/src/pages/workspace/AccessOrNotFoundWrapper.tsx
+++ b/src/pages/workspace/AccessOrNotFoundWrapper.tsx
@@ -180,7 +180,7 @@ function AccessOrNotFoundWrapper({
     }, true);
 
     const isPolicyNotAccessible = !isPolicyAccessible(policy, login);
-    const shouldShowNotFoundPage = (!isMoneyRequest && !isFromGlobalCreate && isPolicyNotAccessible) || !isPageAccessible || shouldBeBlocked;
+    const shouldShowNotFoundPage = isFocused && ((!isMoneyRequest && !isFromGlobalCreate && isPolicyNotAccessible) || !isPageAccessible || shouldBeBlocked);
     // We only update the feature state if it isn't pending.
     // This is because the feature state changes several times during the creation of a workspace, while we are waiting for a response from the backend.
     // Without this, we can be unexpectedly navigated to the More Features page.
@@ -212,7 +212,6 @@ function AccessOrNotFoundWrapper({
         };
         return <FullscreenLoadingIndicator reasonAttributes={reasonAttributes} />;
     }
-
     if (shouldShowNotFoundPage) {
         return (
             <PageNotFoundFallback

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -190,7 +190,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
     const prevIsPendingDelete = isPendingDeletePolicy(prevPolicy);
     // While the policy is being fetched (e.g., right after joinAccessiblePolicy), the role is not yet populated,
     // so checkIfShouldShowPolicy returns false. Suppress NotFound during this loading window.
-    const shouldShowNotFoundPage = !shouldShowPolicy && !policy?.isLoading && (!isPendingDelete || prevIsPendingDelete);
+    const shouldShowNotFoundPage = isFocused && !shouldShowPolicy && !policy?.isLoading && (!isPendingDelete || prevIsPendingDelete);
     const fetchPolicyData = () => {
         if (policyDraft?.id || !isFocused) {
             return;

--- a/src/pages/workspace/WorkspacePageWithSections.tsx
+++ b/src/pages/workspace/WorkspacePageWithSections.tsx
@@ -165,7 +165,14 @@ function WorkspacePageWithSections({
     const shouldShowPolicy = useMemo(() => shouldShowPolicyUtil(policy, false, currentUserLogin), [policy, currentUserLogin]);
     const isPendingDelete = isPendingDeletePolicy(policy);
     const prevIsPendingDelete = isPendingDeletePolicy(prevPolicy);
+
     const shouldShow = useMemo(() => {
+        // Don't trigger the not-found view while the screen is in the background — prevents unexpected
+        // navigation when the workspace is deleted from another device while this screen is unfocused.
+        if (!isFocused) {
+            return false;
+        }
+
         // If the policy object doesn't exist or contains only error data, we shouldn't display it.
         if (((isEmptyObject(policy) || (Object.keys(policy).length === 1 && !isEmptyObject(policy.errors))) && isEmptyObject(policyDraft)) || shouldShowNotFoundPage) {
             return true;
@@ -174,7 +181,7 @@ function WorkspacePageWithSections({
         // We check isPendingDelete and prevIsPendingDelete to prevent the NotFound view from showing right after we delete the workspace
         return (!isEmptyObject(policy) && !canEditWorkspaceSettings(policy) && !shouldShowNonAdmin) || (!shouldShowPolicy && !(isPendingDelete && !prevIsPendingDelete));
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [policy, shouldShowNonAdmin, shouldShowPolicy]);
+    }, [isFocused, policy, shouldShowNonAdmin, shouldShowPolicy]);
 
     const handleOnBackButtonPress = () => {
         if (shouldShow) {

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardDetailsPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardDetailsPage.tsx
@@ -327,7 +327,7 @@ function WorkspaceExpensifyCardDetailsPage({route}: WorkspaceExpensifyCardDetail
                         title={translate('workspace.common.viewTransactions')}
                         style={styles.mt3}
                         onPress={() => {
-                            Navigation.navigate(
+                            Navigation.revealRouteBeforeDismissingModal(
                                 ROUTES.SEARCH_ROOT.getRoute({
                                     query: buildCannedSearchQuery({
                                         type: CONST.SEARCH.DATA_TYPES.EXPENSE,

--- a/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
+++ b/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
@@ -2,7 +2,7 @@ import {StackActions, TabActions} from '@react-navigation/native';
 import {renderHook} from '@testing-library/react-native';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
-// eslint-disable-next-line no-restricted-imports
+// eslint-disable-next-line no-restricted-imports -- TransitionTracker is mocked here to assert the tab-jump sequencing after popToTop in navigateToWorkspacesPage.
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';

--- a/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
+++ b/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
@@ -14,10 +14,6 @@ jest.mock('@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigat
     getPreservedNavigatorState: jest.fn(() => undefined),
 }));
 
-jest.mock('@libs/Navigation/helpers/lastVisitedTabPathUtils', () => ({
-    getWorkspacesTabStateFromSessionStorage: jest.fn(() => undefined),
-}));
-
 const mockResponsiveLayout = jest.fn(() => ({shouldUseNarrowLayout: false}));
 jest.mock('@hooks/useResponsiveLayout', () => () => mockResponsiveLayout());
 
@@ -80,8 +76,6 @@ const useRestoreWorkspacesTabOnNavigate = (require('@hooks/useRestoreWorkspacesT
 
 const PolicyUtils = require('@libs/PolicyUtils') as {shouldShowPolicy: jest.Mock; isPendingDeletePolicy: jest.Mock};
 
-const lastVisitedTabPathUtils = require('@libs/Navigation/helpers/lastVisitedTabPathUtils') as {getWorkspacesTabStateFromSessionStorage: jest.Mock};
-
 function setupOnyxForPolicy() {
     mockUseOnyx.mockImplementation((key: unknown) => {
         if (key === ONYXKEYS.COLLECTION.POLICY) {
@@ -126,7 +120,6 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         jest.clearAllMocks();
         mockUseOnyx.mockReturnValue([undefined]);
         mockResponsiveLayout.mockReturnValue({shouldUseNarrowLayout: false});
-        lastVisitedTabPathUtils.getWorkspacesTabStateFromSessionStorage.mockReturnValue(undefined);
         PolicyUtils.shouldShowPolicy.mockReturnValue(true);
         PolicyUtils.isPendingDeletePolicy.mockReturnValue(false);
         mockedGetRootState.mockReturnValue({routes: []});
@@ -220,10 +213,11 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
 
     // Inverted contract for the topmost-only behavior: the consumer restores via TabActions.jumpTo
     // against the topmost TAB_NAVIGATOR's state key, so workspace state held by older TAB_NAVIGATOR
-    // instances kept alive by ensureTabNavigatorRoutes is intentionally ignored. With an empty topmost
-    // workspace slot and empty session storage, the hook must fall back to the workspaces list rather
-    // than reach back into the older instance — guards against a regression to flat-walking all tabs.
-    it('falls back to the workspaces list when the topmost TabNavigator workspace slot is empty', () => {
+    // instances kept alive by ensureTabNavigatorRoutes is intentionally ignored — guards against a
+    // regression to flat-walking all tabs. With an empty topmost workspace slot the hook still jumps
+    // to the topmost tab (rather than pushing a new TAB_NAVIGATOR via Navigation.navigate); cold-start
+    // hydration is then handled by WorkspaceRouter.getInitialState from sessionStorage.
+    it('jumps to the topmost TabNavigator even when its workspace slot is empty', () => {
         setupOnyxForPolicy();
         mockedGetRootState.mockReturnValue({
             routes: [
@@ -269,8 +263,11 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACES_LIST.route);
-        expect(mockedDispatch).not.toHaveBeenCalled();
+        expect(mockedDispatch).toHaveBeenCalledWith({
+            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+            target: TAB_NAV_STATE_KEY,
+        });
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
     // On narrow layouts (mobile), the consumer pops the workspace split to its initial page
@@ -302,57 +299,6 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         expect(mockedDispatch).toHaveBeenNthCalledWith(1, {...StackActions.popToTop(), target: WORKSPACE_SPLIT_STATE_KEY});
         expect(mockedDispatch).toHaveBeenNthCalledWith(2, {...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR), target: TAB_NAV_STATE_KEY});
         expect(TransitionTracker.runAfterTransitions).toHaveBeenCalledWith(expect.objectContaining({waitForUpcomingTransition: true}));
-        expect(Navigation.navigate).not.toHaveBeenCalled();
-    });
-
-    // Cold-start path: when no workspace route exists anywhere in the live nav tree, fall back to the
-    // sessionStorage-persisted state so a fresh page-load still restores the user's last workspace sub-page.
-    it('hydrates from sessionStorage when the live navigation tree has no workspace route', () => {
-        setupOnyxForPolicy();
-        mockedGetRootState.mockReturnValue({
-            routes: [
-                {
-                    name: NAVIGATORS.TAB_NAVIGATOR,
-                    state: {key: TAB_NAV_STATE_KEY, index: 0, routes: [{name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}]},
-                },
-            ],
-        });
-        lastVisitedTabPathUtils.getWorkspacesTabStateFromSessionStorage.mockReturnValue({
-            routes: [
-                {
-                    name: NAVIGATORS.TAB_NAVIGATOR,
-                    state: {
-                        routes: [
-                            {
-                                name: NAVIGATORS.WORKSPACE_NAVIGATOR,
-                                state: {
-                                    routes: [
-                                        {
-                                            name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
-                                            state: {
-                                                index: 1,
-                                                routes: [
-                                                    {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
-                                                    {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
-                                                ],
-                                            },
-                                        },
-                                    ],
-                                },
-                            },
-                        ],
-                    },
-                },
-            ],
-        });
-
-        const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
-        result.current();
-
-        expect(mockedDispatch).toHaveBeenCalledWith({
-            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
-            target: TAB_NAV_STATE_KEY,
-        });
         expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
+++ b/tests/unit/hooks/useRestoreWorkspacesTabOnNavigate.test.ts
@@ -1,7 +1,9 @@
+import {StackActions, TabActions} from '@react-navigation/native';
 import {renderHook} from '@testing-library/react-native';
-import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
+// eslint-disable-next-line no-restricted-imports
+import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -35,7 +37,10 @@ jest.mock('@libs/Navigation/navigationRef', () => ({
 jest.mock('@react-navigation/native', () => ({
     findFocusedRoute: jest.fn(() => ({name: 'some-screen'})),
     StackActions: {
-        pop: jest.fn((count: number) => ({type: 'POP', payload: {count}})),
+        popToTop: jest.fn(() => ({type: 'POP_TO_TOP'})),
+    },
+    TabActions: {
+        jumpTo: jest.fn((name: string) => ({type: 'JUMP_TO', payload: {name}})),
     },
 }));
 
@@ -44,9 +49,16 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     goBack: jest.fn(),
 }));
 
-jest.mock('@libs/Navigation/helpers/getPathFromState', () => ({
+jest.mock('@libs/Navigation/TransitionTracker', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: {
+        runAfterTransitions: jest.fn(({callback}: {callback: () => void}) => {
+            callback();
+            return {cancel: () => {}};
+        }),
+        startTransition: jest.fn(),
+        endTransition: jest.fn(),
+    },
 }));
 
 jest.mock('@libs/PolicyUtils', () => ({
@@ -58,7 +70,7 @@ const fakePolicyID = 'ABCD1234';
 const mockPolicy = {...createRandomPolicy(0), id: fakePolicyID};
 const fakeDomainAccountID = 4242;
 const mockDomain = {accountID: fakeDomainAccountID, validated: true, email: 'admin@example.com'};
-const mockedGetPathFromState = getPathFromState as jest.MockedFunction<typeof getPathFromState>;
+const TAB_NAV_STATE_KEY = 'tab-nav-1';
 /* eslint-disable @typescript-eslint/unbound-method -- jest.fn() mocks don't rely on `this` binding */
 const mockedGetRootState = navigationRef.getRootState as unknown as jest.Mock<{routes: unknown[]} | undefined>;
 const mockedDispatch = jest.mocked(navigationRef.dispatch);
@@ -94,6 +106,7 @@ function buildStateWithUserOnDifferentTab(workspaceRoutes: unknown[]) {
             {
                 name: NAVIGATORS.TAB_NAVIGATOR,
                 state: {
+                    key: TAB_NAV_STATE_KEY,
                     index: 0,
                     routes: [
                         {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
@@ -116,14 +129,11 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         lastVisitedTabPathUtils.getWorkspacesTabStateFromSessionStorage.mockReturnValue(undefined);
         PolicyUtils.shouldShowPolicy.mockReturnValue(true);
         PolicyUtils.isPendingDeletePolicy.mockReturnValue(false);
-        mockedGetPathFromState.mockReset();
         mockedGetRootState.mockReturnValue({routes: []});
     });
 
     it('restores to the last visited workspace when re-entering the Workspaces tab', () => {
         setupOnyxForPolicy();
-        const restoredPath = `/workspaces/${fakePolicyID}` as const;
-        mockedGetPathFromState.mockReturnValue(restoredPath);
         mockedGetRootState.mockReturnValue(
             buildStateWithUserOnDifferentTab([
                 {
@@ -136,7 +146,11 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
+        expect(mockedDispatch).toHaveBeenCalledWith({
+            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+            target: TAB_NAV_STATE_KEY,
+        });
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
     it('falls back to the workspaces list when no workspace was previously visited', () => {
@@ -174,12 +188,11 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACES_LIST.route);
     });
 
-    // Regression: clicking the Workspaces tab from any other tab should land the user on the *exact* sub-page
-    // they had open inside the workspace (e.g. Workflows), not the workspace's initial page.
-    it('preserves the focused workspace sub-page (Workflows) when restoring on a wide layout', () => {
+    // Regression: clicking the Workspaces tab from any other tab should restore the user's last
+    // workspace sub-page via an in-place TabActions.jumpTo against the topmost TAB_NAVIGATOR,
+    // not by pushing a fresh TAB_NAVIGATOR through Navigation.navigate.
+    it('jumps to the existing WORKSPACE_NAVIGATOR tab when restoring on a wide layout', () => {
         setupOnyxForPolicy();
-        const restoredPath = `/workspaces/${fakePolicyID}/workflows` as const;
-        mockedGetPathFromState.mockReturnValue(restoredPath);
         mockedGetRootState.mockReturnValue(
             buildStateWithUserOnDifferentTab([
                 {
@@ -198,17 +211,23 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
+        expect(mockedDispatch).toHaveBeenCalledWith({
+            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+            target: TAB_NAV_STATE_KEY,
+        });
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
-    // Regression for the original bug (#89106): when an RHP-driven navigation pushes a fresh TabNavigator above
-    // the modal, the new TabNavigator's WORKSPACE_NAVIGATOR is empty. The hook must reach into the *older*
-    // TabNavigator instance still alive in the root stack to recover the user's last workspace sub-page.
-    it('reads workspace state from an older TabNavigator instance when the topmost one is empty', () => {
+    // Inverted contract for the topmost-only behavior: the consumer restores via TabActions.jumpTo
+    // against the topmost TAB_NAVIGATOR's state key, so workspace state held by older TAB_NAVIGATOR
+    // instances kept alive by ensureTabNavigatorRoutes is intentionally ignored. With an empty topmost
+    // workspace slot and empty session storage, the hook must fall back to the workspaces list rather
+    // than reach back into the older instance — guards against a regression to flat-walking all tabs.
+    it('falls back to the workspaces list when the topmost TabNavigator workspace slot is empty', () => {
         setupOnyxForPolicy();
         mockedGetRootState.mockReturnValue({
             routes: [
-                // Older TabNavigator: still holds the workspace state with WORKFLOWS focused.
+                // Older TabNavigator with workspace state. Should be ignored.
                 {
                     name: NAVIGATORS.TAB_NAVIGATOR,
                     state: {
@@ -235,10 +254,11 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
                         ],
                     },
                 },
-                // Newer TabNavigator pushed above the modal: WORKSPACE_NAVIGATOR is empty.
+                // Topmost TabNavigator with empty WORKSPACE_NAVIGATOR.
                 {
                     name: NAVIGATORS.TAB_NAVIGATOR,
                     state: {
+                        key: TAB_NAV_STATE_KEY,
                         index: 0,
                         routes: [{name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}, {name: NAVIGATORS.WORKSPACE_NAVIGATOR}],
                     },
@@ -249,22 +269,23 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        // The older TabNavigator is reached via StackActions.pop (popping the newer empty one off the root stack),
-        // not via a fresh Navigation.navigate. Verify dispatch was called with a POP action.
-        expect(mockedDispatch).toHaveBeenCalledWith(expect.objectContaining({type: 'POP'}));
-        expect(Navigation.navigate).not.toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACES_LIST.route);
+        expect(mockedDispatch).not.toHaveBeenCalled();
     });
 
-    // On narrow layouts (mobile), the URL-based restore is skipped: we always land on the workspace's
-    // initial page so the user can navigate inward via the side-list — matches mobile UX and the docs.
-    it('falls back to the workspace initial page on narrow layouts even when a sub-page is focused', () => {
+    // On narrow layouts (mobile), the consumer pops the workspace split to its initial page
+    // *before* jumping to the tab to prevent a sub-page from flashing in. We assert both dispatches
+    // fire in order. TransitionTracker is mocked to invoke its callback synchronously.
+    it('pops the workspace split to its initial page, then jumps to the tab, on narrow layouts', () => {
         mockResponsiveLayout.mockReturnValue({shouldUseNarrowLayout: true});
         setupOnyxForPolicy();
+        const WORKSPACE_SPLIT_STATE_KEY = 'workspace-split-1';
         mockedGetRootState.mockReturnValue(
             buildStateWithUserOnDifferentTab([
                 {
                     name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
                     state: {
+                        key: WORKSPACE_SPLIT_STATE_KEY,
                         index: 1,
                         routes: [
                             {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
@@ -278,21 +299,21 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        expect(mockedGetPathFromState).not.toHaveBeenCalled();
-        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_INITIAL.getRoute(fakePolicyID));
+        expect(mockedDispatch).toHaveBeenNthCalledWith(1, {...StackActions.popToTop(), target: WORKSPACE_SPLIT_STATE_KEY});
+        expect(mockedDispatch).toHaveBeenNthCalledWith(2, {...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR), target: TAB_NAV_STATE_KEY});
+        expect(TransitionTracker.runAfterTransitions).toHaveBeenCalledWith(expect.objectContaining({waitForUpcomingTransition: true}));
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
     // Cold-start path: when no workspace route exists anywhere in the live nav tree, fall back to the
     // sessionStorage-persisted state so a fresh page-load still restores the user's last workspace sub-page.
     it('hydrates from sessionStorage when the live navigation tree has no workspace route', () => {
         setupOnyxForPolicy();
-        const restoredPath = `/workspaces/${fakePolicyID}/workflows` as const;
-        mockedGetPathFromState.mockReturnValue(restoredPath);
         mockedGetRootState.mockReturnValue({
             routes: [
                 {
                     name: NAVIGATORS.TAB_NAVIGATOR,
-                    state: {index: 0, routes: [{name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}]},
+                    state: {key: TAB_NAV_STATE_KEY, index: 0, routes: [{name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}]},
                 },
             ],
         });
@@ -328,12 +349,17 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
+        expect(mockedDispatch).toHaveBeenCalledWith({
+            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+            target: TAB_NAV_STATE_KEY,
+        });
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
-    // Domain restore: when the last workspace-tab route is a DOMAIN_SPLIT_NAVIGATOR with a domainAccountID,
-    // resolve the matching Domain via useOnyx(ONYXKEYS.COLLECTION.DOMAIN) and navigate to the domain page.
-    it('restores to the last visited domain when re-entering the Workspaces tab', () => {
+    // Domain restore: when the last workspace-tab route is a DOMAIN_SPLIT_NAVIGATOR with an
+    // accessible accountID, jump to the existing WORKSPACE_NAVIGATOR tab so the preserved
+    // DOMAIN_SPLIT_NAVIGATOR state is shown without pushing a new TAB_NAVIGATOR.
+    it('jumps to the existing WORKSPACE_NAVIGATOR tab when restoring a domain', () => {
         setupOnyxForDomain();
         mockedGetRootState.mockReturnValue(
             buildStateWithUserOnDifferentTab([
@@ -347,7 +373,11 @@ describe('useRestoreWorkspacesTabOnNavigate', () => {
         const {result} = renderHook(() => useRestoreWorkspacesTabOnNavigate());
         result.current();
 
-        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.DOMAIN_INITIAL.getRoute(fakeDomainAccountID));
+        expect(mockedDispatch).toHaveBeenCalledWith({
+            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+            target: TAB_NAV_STATE_KEY,
+        });
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
     // If the last route was a domain but it's no longer present in the Onyx domain collection

--- a/tests/unit/navigateToWorkspacesPageTest.ts
+++ b/tests/unit/navigateToWorkspacesPageTest.ts
@@ -1,28 +1,46 @@
+import type {NavigationState, PartialState} from '@react-navigation/native';
+import {StackActions, TabActions} from '@react-navigation/native';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
-import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
 import navigateToWorkspacesPage from '@libs/Navigation/helpers/navigateToWorkspacesPage';
 import Navigation from '@libs/Navigation/Navigation';
+import navigationRef from '@libs/Navigation/navigationRef';
+// eslint-disable-next-line no-restricted-imports
+import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import * as PolicyUtils from '@libs/PolicyUtils';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
+import type {Domain} from '@src/types/onyx';
 import createRandomPolicy from '../utils/collections/policies';
 
 jest.mock('@libs/Navigation/navigationRef');
 jest.mock('@libs/Navigation/Navigation');
-jest.mock('@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState');
+jest.mock('@libs/Navigation/TransitionTracker', () => ({
+    __esModule: true,
+    default: {
+        runAfterTransitions: jest.fn(({callback}: {callback: () => void}) => {
+            callback();
+            return {cancel: () => {}};
+        }),
+        startTransition: jest.fn(),
+        endTransition: jest.fn(),
+    },
+}));
 jest.mock('@libs/PolicyUtils');
 jest.mock('@libs/interceptAnonymousUser');
-jest.mock('@libs/Navigation/helpers/getPathFromState', () => ({
-    __esModule: true,
-    default: jest.fn(),
-}));
 
-const mockedGetPathFromState = getPathFromState as jest.MockedFunction<typeof getPathFromState>;
+// eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mocks don't rely on `this` binding
+const mockedDispatch = jest.mocked(navigationRef.dispatch);
 
 const fakePolicyID = '344559B2CCF2B6C1';
 const mockPolicy = {...createRandomPolicy(0), id: fakePolicyID};
 const baseParams = {currentUserLogin: 'test@example.com', shouldUseNarrowLayout: false, policy: mockPolicy};
+
+const TAB_NAV_STATE_KEY = 'tab-nav-key-123';
+const tabNavigatorRoute = {
+    name: NAVIGATORS.TAB_NAVIGATOR,
+    state: {key: TAB_NAV_STATE_KEY} as PartialState<NavigationState>,
+};
 
 describe('navigateToWorkspacesPage', () => {
     beforeEach(() => {
@@ -34,10 +52,11 @@ describe('navigateToWorkspacesPage', () => {
             callback();
         });
     }
+
     it('calls goBack if WORKSPACE_NAVIGATOR is topmost and a split navigator is inside', () => {
         navigateToWorkspacesPage({
             ...baseParams,
-            topmostFullScreenRoute: {
+            lastTabNavigatorRoute: {
                 name: NAVIGATORS.TAB_NAVIGATOR,
                 state: {
                     index: 4,
@@ -48,7 +67,7 @@ describe('navigateToWorkspacesPage', () => {
                         {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR},
                         {name: NAVIGATORS.WORKSPACE_NAVIGATOR},
                     ],
-                },
+                } as PartialState<NavigationState>,
             },
             lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR},
         });
@@ -59,95 +78,114 @@ describe('navigateToWorkspacesPage', () => {
         mockIntercept();
         navigateToWorkspacesPage({
             ...baseParams,
-            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            lastTabNavigatorRoute: {name: NAVIGATORS.TAB_NAVIGATOR},
             lastWorkspacesTabNavigatorRoute: undefined,
         });
 
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACES_LIST.route);
     });
 
-    it('navigates to the workspace initial URL when no workspacesTabState is provided', () => {
+    it('dispatches jumpTo WORKSPACE_NAVIGATOR when a TAB_NAVIGATOR is already on top (workspace, wide layout)', () => {
         (PolicyUtils.shouldShowPolicy as jest.Mock).mockReturnValue(true);
         (PolicyUtils.isPendingDeletePolicy as jest.Mock).mockReturnValue(false);
-
         mockIntercept();
+
         navigateToWorkspacesPage({
             ...baseParams,
-            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
-            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, key: 'someKey'},
+            lastTabNavigatorRoute: tabNavigatorRoute,
+            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR},
         });
 
-        expect(mockedGetPathFromState).not.toHaveBeenCalled();
-        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_INITIAL.getRoute(fakePolicyID));
+        expect(mockedDispatch).toHaveBeenCalledWith({
+            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+            target: TAB_NAV_STATE_KEY,
+        });
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
-    it('navigates to the URL produced by getPathFromState when workspacesTabState is provided on wide layouts', () => {
+    it('pops workspace split to root then jumps to tab on narrow layout when a sub-page is focused (no flicker)', () => {
         (PolicyUtils.shouldShowPolicy as jest.Mock).mockReturnValue(true);
         (PolicyUtils.isPendingDeletePolicy as jest.Mock).mockReturnValue(false);
-        const restoredPath = `/workspaces/${fakePolicyID}/workflows` as const;
-        mockedGetPathFromState.mockReturnValue(restoredPath);
-
         mockIntercept();
-        const workspacesTabState = {
-            index: 1,
-            routes: [
-                {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
-                {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
-            ],
-        };
-        navigateToWorkspacesPage({
-            ...baseParams,
-            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
-            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, key: 'someKey'},
-            workspacesTabState,
-        });
 
-        // Wrapped with the full TAB_NAVIGATOR > WORKSPACE_NAVIGATOR > WORKSPACE_SPLIT_NAVIGATOR ancestor chain
-        // so getPathFromState can match the linking-config hierarchy.
-        expect(mockedGetPathFromState).toHaveBeenCalledWith({
-            routes: [
-                {
-                    name: NAVIGATORS.TAB_NAVIGATOR,
-                    state: {
-                        routes: [
-                            {
-                                name: NAVIGATORS.WORKSPACE_NAVIGATOR,
-                                state: {
-                                    routes: [{name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, state: workspacesTabState}],
-                                    index: 0,
-                                },
-                            },
-                        ],
-                        index: 0,
-                    },
-                },
-            ],
-            index: 0,
-        });
-        expect(Navigation.navigate).toHaveBeenCalledWith(restoredPath);
-    });
+        const WORKSPACE_SPLIT_STATE_KEY = 'workspace-split-state-key-456';
 
-    it('falls back to the workspace initial URL on narrow layouts even when workspacesTabState is provided', () => {
-        (PolicyUtils.shouldShowPolicy as jest.Mock).mockReturnValue(true);
-        (PolicyUtils.isPendingDeletePolicy as jest.Mock).mockReturnValue(false);
-
-        mockIntercept();
         navigateToWorkspacesPage({
             ...baseParams,
             shouldUseNarrowLayout: true,
-            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
-            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR, key: 'someKey'},
-            workspacesTabState: {
-                index: 1,
-                routes: [
-                    {name: SCREENS.WORKSPACE.INITIAL, params: {policyID: fakePolicyID}},
-                    {name: SCREENS.WORKSPACE.WORKFLOWS, params: {policyID: fakePolicyID}},
-                ],
+            lastTabNavigatorRoute: tabNavigatorRoute,
+            lastWorkspacesTabNavigatorRoute: {
+                name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                state: {
+                    key: WORKSPACE_SPLIT_STATE_KEY,
+                    index: 1,
+                    routes: [{name: SCREENS.WORKSPACE.INITIAL}, {name: SCREENS.WORKSPACE.MEMBERS}],
+                } as PartialState<NavigationState>,
             },
         });
 
-        expect(mockedGetPathFromState).not.toHaveBeenCalled();
-        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_INITIAL.getRoute(fakePolicyID));
+        expect(mockedDispatch).toHaveBeenNthCalledWith(1, {...StackActions.popToTop(), target: WORKSPACE_SPLIT_STATE_KEY});
+        expect(mockedDispatch).toHaveBeenNthCalledWith(2, {...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR), target: TAB_NAV_STATE_KEY});
+        expect(TransitionTracker.runAfterTransitions).toHaveBeenCalledWith(expect.objectContaining({waitForUpcomingTransition: true}));
+        expect(Navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('skips popToTop on narrow layout when WorkspaceInitialPage is already focused', () => {
+        (PolicyUtils.shouldShowPolicy as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPendingDeletePolicy as jest.Mock).mockReturnValue(false);
+        mockIntercept();
+
+        const WORKSPACE_SPLIT_STATE_KEY = 'workspace-split-state-key-789';
+
+        navigateToWorkspacesPage({
+            ...baseParams,
+            shouldUseNarrowLayout: true,
+            lastTabNavigatorRoute: tabNavigatorRoute,
+            lastWorkspacesTabNavigatorRoute: {
+                name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                state: {
+                    key: WORKSPACE_SPLIT_STATE_KEY,
+                    index: 0,
+                    routes: [{name: SCREENS.WORKSPACE.INITIAL}],
+                } as PartialState<NavigationState>,
+            },
+        });
+
+        expect(mockedDispatch).toHaveBeenCalledTimes(1);
+        expect(mockedDispatch).toHaveBeenCalledWith({...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR), target: TAB_NAV_STATE_KEY});
+        expect(TransitionTracker.runAfterTransitions).not.toHaveBeenCalled();
+    });
+
+    it('dispatches jumpTo WORKSPACE_NAVIGATOR when a TAB_NAVIGATOR is already on top (domain)', () => {
+        mockIntercept();
+
+        navigateToWorkspacesPage({
+            ...baseParams,
+            domain: {accountID: 123} as unknown as Domain,
+            lastTabNavigatorRoute: tabNavigatorRoute,
+            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.DOMAIN_SPLIT_NAVIGATOR},
+        });
+
+        expect(mockedDispatch).toHaveBeenCalledWith({
+            ...TabActions.jumpTo(NAVIGATORS.WORKSPACE_NAVIGATOR),
+            target: TAB_NAV_STATE_KEY,
+        });
+        expect(Navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates to WORKSPACES_LIST for domain when the TAB_NAVIGATOR has no usable state key', () => {
+        mockIntercept();
+
+        navigateToWorkspacesPage({
+            ...baseParams,
+            domain: {accountID: 123} as unknown as Domain,
+            // TAB_NAVIGATOR present but with no state (so no existingTabNavStateKey to jump to).
+            lastTabNavigatorRoute: {name: NAVIGATORS.TAB_NAVIGATOR},
+            lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.DOMAIN_SPLIT_NAVIGATOR},
+        });
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACES_LIST.route);
+        expect(mockedDispatch).not.toHaveBeenCalled();
     });
 
     it('navigates to WORKSPACES_LIST if policy is pending delete', () => {
@@ -157,7 +195,7 @@ describe('navigateToWorkspacesPage', () => {
         mockIntercept();
         navigateToWorkspacesPage({
             ...baseParams,
-            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            lastTabNavigatorRoute: {name: NAVIGATORS.TAB_NAVIGATOR},
             lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR},
         });
 
@@ -171,7 +209,7 @@ describe('navigateToWorkspacesPage', () => {
         mockIntercept();
         navigateToWorkspacesPage({
             ...baseParams,
-            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            lastTabNavigatorRoute: {name: NAVIGATORS.TAB_NAVIGATOR},
             lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR},
         });
 
@@ -183,7 +221,7 @@ describe('navigateToWorkspacesPage', () => {
         navigateToWorkspacesPage({
             ...baseParams,
             policy: undefined,
-            topmostFullScreenRoute: {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            lastTabNavigatorRoute: {name: NAVIGATORS.TAB_NAVIGATOR},
             lastWorkspacesTabNavigatorRoute: {name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR},
         });
 

--- a/tests/unit/navigateToWorkspacesPageTest.ts
+++ b/tests/unit/navigateToWorkspacesPageTest.ts
@@ -4,7 +4,7 @@ import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import navigateToWorkspacesPage from '@libs/Navigation/helpers/navigateToWorkspacesPage';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
-// eslint-disable-next-line no-restricted-imports
+// eslint-disable-next-line no-restricted-imports -- TransitionTracker is mocked here to assert the tab-jump sequencing after popToTop in navigateToWorkspacesPage.
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import * as PolicyUtils from '@libs/PolicyUtils';
 import NAVIGATORS from '@src/NAVIGATORS';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Fixes two navigation bugs in workspace/domain tab handling:

1. `WorkspacePageWithSections` and `WorkspaceInitialPage`: `shouldShow` / `shouldShowNotFoundPage` now gates on `isFocused`, preventing the not-found view from activating while the screen is rendered in the background (e.g. workspace deleted from another device while the user is on a different screen).
2. `navigateToWorkspacesPage`: domain tab navigation now reuses the existing `TAB_NAVIGATOR` via `TabActions.jumpTo` (same as workspace), instead of calling `Navigation.navigate` which pushed a redundant new `TAB_NAVIGATOR` on top of the stack.



https://github.com/user-attachments/assets/2d0736b4-8a19-4bbe-82bf-dfd70c2bc602

### Fixed Issues
$ https://github.com/Expensify/App/issues/88978
PROPOSAL:


### Tests

1. Open a workspace settings page, then navigate to a different screen (e.g. search) so the workspace screen is in the background.
2. From another device/session, delete that workspace.
3. Return to the workspace screen on the first device.
4. Verify that the not-found view appears only after returning focus to the workspace screen, not while it was in the background, and that the navigation stack is not disrupted.

---

1. Open a domain page (via the Workspaces tab).
2. Navigate away from the Workspaces tab (e.g. switch to Search tab).
3. Tap the Workspaces tab button again to navigate back.
4. Verify that the existing domain screen is restored in-place without pushing a new `TAB_NAVIGATOR` onto the stack (no duplicate navigator, back button behaves correctly).

---

1. Open a workspace settings page, navigate away, then tap the Workspaces tab button.
2. Verify the workspace screen is restored to the exact page the user was on (same as before this change).

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — changes are navigation-only and do not involve API calls or Onyx writes.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
