### PR TITLE
fix(onboarding): restore prod CompleteGuidedSetup payload on join to break the join-workspace loop (#89684)

### DIFF
--- a/src/libs/navigateAfterOnboarding.ts
+++ b/src/libs/navigateAfterOnboarding.ts
@@ -140,7 +140,6 @@ function navigateToSubmitWorkspaceAfterOnboarding(policyID?: string, isSmallScre
     }
 
     setOnboardingRHPVariant(CONST.ONBOARDING_RHP_VARIANT.RHP_ADMINS_ROOM);
-    Navigation.navigate(ROUTES.WORKSPACES_LIST.route);
     Navigation.navigate(ROUTES.WORKSPACE_CATEGORIES.getRoute(policyID));
     SidePanelActions.openSidePanel(!isSmallScreenWidth);
 }

--- a/src/libs/navigateAfterOnboarding.ts
+++ b/src/libs/navigateAfterOnboarding.ts
@@ -141,10 +141,8 @@ function navigateToSubmitWorkspaceAfterOnboarding(policyID?: string, isSmallScre
 
     setOnboardingRHPVariant(CONST.ONBOARDING_RHP_VARIANT.RHP_ADMINS_ROOM);
     Navigation.navigate(ROUTES.WORKSPACES_LIST.route);
-    Navigation.setNavigationActionToMicrotaskQueue(() => {
-        Navigation.navigate(ROUTES.WORKSPACE_CATEGORIES.getRoute(policyID));
-        SidePanelActions.openSidePanel(!isSmallScreenWidth);
-    });
+    Navigation.navigate(ROUTES.WORKSPACE_CATEGORIES.getRoute(policyID));
+    SidePanelActions.openSidePanel(!isSmallScreenWidth);
 }
 
 function navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue(policyID?: string, isSmallScreenWidth = false) {

--- a/src/pages/OnboardingWorkspaces/BaseOnboardingWorkspaces.tsx
+++ b/src/pages/OnboardingWorkspaces/BaseOnboardingWorkspaces.tsx
@@ -91,13 +91,11 @@ function BaseOnboardingWorkspaces({route, shouldUseNativeStyles}: BaseOnboarding
             askToJoinPolicy(policy.policyID);
         }
 
-        const engagementChoice = shouldUseSubmitFlow ? CONST.ONBOARDING_CHOICES.EMPLOYER : CONST.ONBOARDING_CHOICES.LOOKING_AROUND;
         completeOnboarding({
-            engagementChoice,
-            onboardingMessage: onboardingMessages[engagementChoice],
+            engagementChoice: CONST.ONBOARDING_CHOICES.LOOKING_AROUND,
+            onboardingMessage: onboardingMessages[CONST.ONBOARDING_CHOICES.LOOKING_AROUND],
             firstName: onboardingPersonalDetails?.firstName ?? '',
             lastName: onboardingPersonalDetails?.lastName ?? '',
-            onboardingPolicyID: shouldUseSubmitFlow && policy.automaticJoiningEnabled ? policy.policyID : undefined,
             companySize: onboardingCompanySize,
             introSelected,
             isSelfTourViewed,

--- a/src/pages/OnboardingWorkspaces/BaseOnboardingWorkspaces.tsx
+++ b/src/pages/OnboardingWorkspaces/BaseOnboardingWorkspaces.tsx
@@ -78,12 +78,8 @@ function BaseOnboardingWorkspaces({route, shouldUseNativeStyles}: BaseOnboarding
     const onboardingStep = useOnboardingStepCounter(SCREENS.ONBOARDING.WORKSPACES);
 
     const handleJoinWorkspace = (policy: JoinablePolicy) => {
-        // Only mirror the EMPLOYER ("Get paid back by my employer") + Submit-2026 onboarding flow
-        // when the user actually picked EMPLOYER, or when no Purpose was selected (private-domain
-        // users who reach this screen without going through the Purpose step). Users on the Submit
-        // beta who picked a different Purpose (e.g. MANAGE_TEAM) must not be re-routed through
-        // the Submit flow.
-        const shouldUseSubmitFlow = canUseSubmit2026 && (!onboardingPurposeSelected || onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.EMPLOYER);
+        const isJoiningSubmitPolicy = policy.policyType === CONST.POLICY.TYPE.SUBMIT;
+        const shouldUseSubmitFlow = canUseSubmit2026 && policy.automaticJoiningEnabled && isJoiningSubmitPolicy;
 
         if (policy.automaticJoiningEnabled) {
             joinAccessiblePolicy(policy.policyID);
@@ -104,7 +100,7 @@ function BaseOnboardingWorkspaces({route, shouldUseNativeStyles}: BaseOnboarding
         setOnboardingAdminsChatReportID();
         setOnboardingPolicyID(policy.policyID);
 
-        if (shouldUseSubmitFlow && policy.automaticJoiningEnabled) {
+        if (shouldUseSubmitFlow) {
             navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue(policy.policyID, isSmallScreenWidth);
             return;
         }

--- a/src/types/onyx/JoinablePolicies.ts
+++ b/src/types/onyx/JoinablePolicies.ts
@@ -1,3 +1,6 @@
+import type {ValueOf} from 'type-fest';
+import type CONST from '@src/CONST';
+
 /** Model of Joinable Policy */
 type JoinablePolicy = {
     /** Policy id of the workspace */
@@ -10,8 +13,10 @@ type JoinablePolicy = {
     employeeCount: number;
     /** If the user has already requested access, and is currently awaiting decision */
     hasPendingAccess: boolean;
-    /** Weather the user needs an approval to join the workspace or not */
+    /** Whether the user needs an approval to join the workspace or not */
     automaticJoiningEnabled: boolean;
+    /** Policy type returned by the backend (`team` | `corporate` | `submit2026` | ...). */
+    policyType?: ValueOf<typeof CONST.POLICY.TYPE>;
 };
 
 /** Model of Joinable Policies */

--- a/tests/ui/WorkspaceOnboarding.tsx
+++ b/tests/ui/WorkspaceOnboarding.tsx
@@ -294,6 +294,7 @@ describe('OnboardingWorkspaces Page', () => {
                     employeeCount: 4,
                     hasPendingAccess: false,
                     automaticJoiningEnabled: true,
+                    policyType: CONST.POLICY.TYPE.SUBMIT,
                 },
             });
         });
@@ -315,10 +316,11 @@ describe('OnboardingWorkspaces Page', () => {
             expect(mockCompleteOnboarding).toHaveBeenCalledWith(
                 expect.objectContaining({
                     engagementChoice: CONST.ONBOARDING_CHOICES.LOOKING_AROUND,
-                    onboardingPolicyID: undefined,
                 }),
             );
         });
+        const lastCompleteOnboardingArgs = mockCompleteOnboarding.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
+        expect(lastCompleteOnboardingArgs).not.toHaveProperty('onboardingPolicyID');
 
         await waitFor(() => {
             expect(onyxSetSpy).toHaveBeenCalledWith(ONYXKEYS.NVP_ONBOARDING_RHP_VARIANT, CONST.ONBOARDING_RHP_VARIANT.RHP_ADMINS_ROOM);

--- a/tests/ui/WorkspaceOnboarding.tsx
+++ b/tests/ui/WorkspaceOnboarding.tsx
@@ -270,7 +270,7 @@ describe('OnboardingWorkspaces Page', () => {
         await waitForBatchedUpdatesWithAct();
     });
 
-    it('should complete onboarding with the joined Submit workspace policyID and open Categories in the admins room', async () => {
+    it('should complete onboarding without passing the joined workspace policyID and open Categories in the admins room', async () => {
         jest.spyOn(Navigation, 'dismissModal').mockImplementation(() => {});
         jest.spyOn(Navigation, 'setNavigationActionToMicrotaskQueue').mockImplementation((callback: () => void) => callback());
 
@@ -314,8 +314,8 @@ describe('OnboardingWorkspaces Page', () => {
         await waitFor(() => {
             expect(mockCompleteOnboarding).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    engagementChoice: CONST.ONBOARDING_CHOICES.EMPLOYER,
-                    onboardingPolicyID: 'submit-policy-id',
+                    engagementChoice: CONST.ONBOARDING_CHOICES.LOOKING_AROUND,
+                    onboardingPolicyID: undefined,
                 }),
             );
         });

--- a/tests/unit/libs/navigateAfterOnboarding.test.ts
+++ b/tests/unit/libs/navigateAfterOnboarding.test.ts
@@ -1,0 +1,50 @@
+import {navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue} from '@libs/navigateAfterOnboarding';
+import Navigation from '@libs/Navigation/Navigation';
+import ROUTES from '@src/ROUTES';
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    default: {
+        dismissModal: jest.fn(),
+        navigate: jest.fn(),
+        setNavigationActionToMicrotaskQueue: jest.fn((callback: () => void) => callback()),
+    },
+}));
+
+jest.mock('@libs/actions/SidePanel', () => ({
+    __esModule: true,
+    default: {openSidePanel: jest.fn()},
+}));
+
+jest.mock('@libs/actions/Welcome', () => ({
+    setOnboardingRHPVariant: jest.fn(),
+}));
+
+jest.mock('@libs/actions/Modal', () => ({
+    setDisableDismissOnEscape: jest.fn(),
+}));
+
+const navigationMock = Navigation as jest.Mocked<typeof Navigation>;
+
+describe('navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('navigates to HOME when policyID is missing', () => {
+        navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue(undefined);
+
+        expect(navigationMock.dismissModal).toHaveBeenCalledTimes(1);
+        expect(navigationMock.navigate).toHaveBeenCalledTimes(1);
+        expect(navigationMock.navigate).toHaveBeenCalledWith(ROUTES.HOME);
+    });
+
+    it('pushes WorkspacesList then Categories when policyID is provided', () => {
+        navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue('test-policy-id');
+
+        expect(navigationMock.dismissModal).toHaveBeenCalledTimes(1);
+        expect(navigationMock.navigate).toHaveBeenCalledTimes(2);
+        expect(navigationMock.navigate).toHaveBeenNthCalledWith(1, ROUTES.WORKSPACES_LIST.route);
+        expect(navigationMock.navigate).toHaveBeenNthCalledWith(2, ROUTES.WORKSPACE_CATEGORIES.getRoute('test-policy-id'));
+    });
+});

--- a/tests/unit/libs/navigateAfterOnboarding.test.ts
+++ b/tests/unit/libs/navigateAfterOnboarding.test.ts
@@ -39,12 +39,11 @@ describe('navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue', () => {
         expect(navigationMock.navigate).toHaveBeenCalledWith(ROUTES.HOME);
     });
 
-    it('pushes WorkspacesList then Categories when policyID is provided', () => {
+    it('navigates to Workspace Categories when policyID is provided', () => {
         navigateToSubmitWorkspaceAfterOnboardingWithMicrotaskQueue('test-policy-id');
 
         expect(navigationMock.dismissModal).toHaveBeenCalledTimes(1);
-        expect(navigationMock.navigate).toHaveBeenCalledTimes(2);
-        expect(navigationMock.navigate).toHaveBeenNthCalledWith(1, ROUTES.WORKSPACES_LIST.route);
-        expect(navigationMock.navigate).toHaveBeenNthCalledWith(2, ROUTES.WORKSPACE_CATEGORIES.getRoute('test-policy-id'));
+        expect(navigationMock.navigate).toHaveBeenCalledTimes(1);
+        expect(navigationMock.navigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_CATEGORIES.getRoute('test-policy-id'));
     });
 });


### PR DESCRIPTION
### Explanation of Change

`handleJoinWorkspace` now gates the Submit-specific landing UX on the joined policy's `policyType` (newly surfaced on `JoinablePolicy`) instead of just the user's beta + purpose. Submit joins still land on Workspace > Categories with the `#admins` side panel; non-Submit joins fall through to the regular post-onboarding flow, fixing the join-loop where SUBMIT_2026-beta users joining a Team/Corporate workspace got `401` on `CompleteGuidedSetup` and were trapped back on **Join a workspace**.

### Fixed Issues

$ https://github.com/Expensify/App/issues/89684
PROPOSAL: n/a 
### Tests

#### Test 1 — Joining a Submit workspace

1. Enable the `SUBMIT_2026` beta locally.
2. Sign in with a brand-new test account on a private domain that has the beta enabled (e.g. a `ruutukf.com` address from temp-mail.io)  
3. Complete personal details, skip the magic-code → click **Get paid back by my employer**.
4. On the **Join a workspace** screen, click **Join now** on a workspace whose `policyType` is `submit2026`.
5. Verify you land on **Workspace > Categories** with the `#admins` side panel open (wide screens)
 
#### Test 2 — Joining a normal (Team / Corporate) workspace

1. Same setup as Test 1 (SUBMIT_2026 beta enabled, brand-new private-domain account).
2. On the **Join a workspace** screen, click **Join now** on a workspace whose `policyType` is `team` or `corporate`.
3. Verify you land on the regular post-onboarding destination (admins room or last-accessed report) — **not** Workspace > Categories.
 
- [X] Verify that no errors appear in the JS console

### Offline tests

same as tests 

### QA Steps

same as tests 

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

 

https://github.com/user-attachments/assets/c0b03dfb-0d98-46cd-a00d-eb77c9d3c23c

https://github.com/user-attachments/assets/17a8dd4f-4134-4dc6-a4ee-64c53afecf3d


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/7112cbdc-7bae-4811-879b-8f70be913bdb

https://github.com/user-attachments/assets/c0e83c59-4ae8-4f07-afa7-817335d763bf


 
</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/e76de3bf-e69f-4dd6-8b46-477671b04b3b


 
https://github.com/user-attachments/assets/1a801e4b-c37f-4b7c-8871-bc46bd07973b




</details>

<details>
<summary>iOS: mWeb Safari</summary>

 

https://github.com/user-attachments/assets/8a8b11d0-22c0-4ca6-afcf-2197e43a49c3


https://github.com/user-attachments/assets/b05ddfd7-53e1-4f52-9753-dc048155c1fb


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


 

https://github.com/user-attachments/assets/8cb1afbe-bd45-4236-8fd2-924a66f7cdf8

https://github.com/user-attachments/assets/403fdff4-d451-4c60-a417-e930eaf47a15



</details>










