### PR TITLE
[No QA] Notify Slack when staging/production deploys are cancelled

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -58,7 +58,7 @@ jobs:
               channel: '#deployer',
               attachments: [{
                 color: 'warning',
-                text: `⚠️ ${{ inputs.TARGET == 'production' && 'Production' || 'Staging' }} <${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL }}|deploy> cancelled`
+                text: `⚠️ ${{ inputs.TARGET == 'production' && 'Production' || 'Staging' }} <${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL }}|deploy> cancelled by new cherry-pick`
               }]
             }
         env:

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -37,6 +37,34 @@ jobs:
   validate:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
+      - name: Check for in-progress deploy on target branch
+        id: checkInProgressDeploy
+        run: |
+          # Is a deploy currently running on the target branch? If so, this CP will supersede it.
+          DEPLOY_RUN_URL=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/deploy.yml/runs?branch=${{ inputs.TARGET }}&per_page=5" \
+            --jq '.workflow_runs[] | select(.status != "completed") | .html_url' | head -n 1)
+          echo "DEPLOY_RUN_URL=$DEPLOY_RUN_URL" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Warn that previous deploy will be superseded
+        if: ${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL != '' }}
+        uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#deployer',
+              attachments: [{
+                color: 'warning',
+                text: `⚠️ Current ${{ inputs.TARGET == 'production' && 'Production' || 'Staging' }} deploy <${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL }}|workflow> will be replaced by new cherry pick`
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
       - name: Validate pull request URL
         if: ${{ inputs.PULL_REQUEST_URL != '' }}
         run: |

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -254,7 +254,6 @@ jobs:
               }]
             }
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Find deploy workflow run

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -58,7 +58,7 @@ jobs:
               channel: '#deployer',
               attachments: [{
                 color: 'warning',
-                text: `⚠️ Current ${{ inputs.TARGET == 'production' && 'Production' || 'Staging' }} deploy <${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL }}|workflow> will be replaced by new cherry pick`
+                text: `⚠️ ${{ inputs.TARGET == 'production' && 'Production' || 'Staging' }} <${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL }}|deploy> cancelled`
               }]
             }
         env:

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -37,34 +37,6 @@ jobs:
   validate:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - name: Check for in-progress deploy on target branch
-        id: checkInProgressDeploy
-        run: |
-          # Is a deploy currently running on the target branch? If so, this CP will supersede it.
-          DEPLOY_RUN_URL=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/deploy.yml/runs?branch=${{ inputs.TARGET }}&per_page=5" \
-            --jq '.workflow_runs[] | select(.status != "completed") | .html_url' | head -n 1)
-          echo "DEPLOY_RUN_URL=$DEPLOY_RUN_URL" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Warn that previous deploy will be superseded
-        if: ${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL != '' }}
-        uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e
-        with:
-          status: custom
-          custom_payload: |
-            {
-              channel: '#deployer',
-              attachments: [{
-                color: 'warning',
-                text: `⚠️ ${{ inputs.TARGET == 'production' && 'Production' || 'Staging' }} <${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL }}|deploy> cancelled by new cherry-pick`
-              }]
-            }
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
       - name: Validate pull request URL
         if: ${{ inputs.PULL_REQUEST_URL != '' }}
         run: |
@@ -104,6 +76,17 @@ jobs:
     needs: createNewVersion
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
+      - name: Check for in-progress deploy on target branch
+        id: checkInProgressDeploy
+        run: |
+          # Capture in-progress deploy URL before we push. The actual Slack post is gated on a successful target-branch push.
+          DEPLOY_RUN_URL=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/deploy.yml/runs?branch=${{ inputs.TARGET }}&per_page=5" \
+            --jq '.workflow_runs[] | select(.status != "completed") | .html_url' | head -n 1)
+          echo "DEPLOY_RUN_URL=$DEPLOY_RUN_URL" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
       - name: Extract PR information
         # Note: this step is only skipped when there's no PULL_REQUEST_URL, which is only ever be the case when we're CPing just a version bump.
         if: ${{ inputs.PULL_REQUEST_URL != '' }}
@@ -256,6 +239,23 @@ jobs:
             # Push E/App changes
             git push origin ${{ inputs.TARGET }}
           fi
+
+      - name: Warn that previous deploy was superseded
+        if: ${{ steps.cherryPick.outputs.HAS_CONFLICTS != 'true' && steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL != '' }}
+        uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#deployer',
+              attachments: [{
+                color: 'warning',
+                text: `⚠️ ${{ inputs.TARGET == 'production' && 'Production' || 'Staging' }} <${{ steps.checkInProgressDeploy.outputs.DEPLOY_RUN_URL }}|deploy> cancelled by new cherry-pick`
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Find deploy workflow run
         # Also runs for version-bump-only CPs where HAS_CONFLICTS is unset

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -649,6 +649,43 @@ jobs:
         with:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
+  postSlackMessageOnCancellation:
+    name: Post a Slack message when the deploy is cancelled manually
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: ${{ cancelled() }}
+    needs: [androidBuild, androidUploadGooglePlay, androidSubmit, iosBuild, iosUploadTestflight, iosSubmit, webBuild, webDeploy]
+    steps:
+      - name: Check whether a newer deploy run exists
+        id: check
+        run: |
+          # If a newer run exists, the cherry-pick workflow already announced this. Skip to avoid double-posting.
+          LATEST=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/deploy.yml/runs?branch=${{ github.ref_name }}&per_page=1" \
+            --jq '.workflow_runs[0].id')
+          if [ "$LATEST" != "${{ github.run_id }}" ]; then
+            echo "SKIP=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Post Slack message on manual cancellation
+        if: ${{ steps.check.outputs.SKIP != 'true' }}
+        # v3
+        uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#deployer',
+              attachments: [{
+                color: 'warning',
+                text: `⚠️ ${{ github.ref == 'refs/heads/production' && 'Production' || 'Staging' }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|deploy> cancelled manually`
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
   checkDeploymentSuccess:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -683,7 +683,6 @@ jobs:
               }]
             }
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   checkDeploymentSuccess:


### PR DESCRIPTION
### Explanation of Change
Adds two new Slack notifications to `#deployer` so cancellation of a staging/production deploy is no longer silent:

1. **`cherryPick.yml`** — when a CP starts and detects an in-progress `deploy.yml` run on the target branch, post a warning that this CP will cancel it. Fires *before* the cancellation actually happens, so it lands between the two CP "started" messages in the Slack channel.

2. **`deploy.yml`** — adds a `postSlackMessageOnCancellation` job (`if: cancelled()`) that posts a manual-cancel notification. Includes a check that suppresses the message when a newer deploy run exists, so the supersede case (already announced by `cherryPick.yml`) doesn't double-post.

Color: yellow `warning` for both.

### Fixed Issues
$ N/A — internal CI/CD improvement, no GitHub issue

### Tests

We'll test it live

### Offline tests
N/A

### QA Steps

We'll test it live internally

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
