### PR TITLE
fixed manual distance tab blockers

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -6300,6 +6300,7 @@ const CONST = {
         RECEIPT_TAB_ID: 'ReceiptTab',
         IOU_REQUEST_TYPE: 'iouRequestType',
         DISTANCE_REQUEST_TYPE: 'distanceRequestType',
+        DISTANCE_EDIT_TYPE: 'distanceEditType',
         SPLIT_EXPENSE_TAB_TYPE: 'splitExpenseTabType',
         SPLIT: {
             AMOUNT: 'amount',

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -118,7 +118,13 @@ function ReportActionItemImage({
     const isMapDistanceRequest = !!transaction && isDistanceRequest(transaction) && !isManualDistanceRequest(transaction);
     const hasPendingWaypoints = transaction && isFetchingWaypointsFromServer(transaction);
     const hasErrors = !isEmptyObject(transaction?.errors) || !isEmptyObject(transaction?.errorFields?.route) || !isEmptyObject(transaction?.errorFields?.waypoints);
-    const showMapAsImage = isMapDistanceRequest && (hasErrors || hasPendingWaypoints);
+    // After a distance/rate edit the BE regenerates the receipt and invalidates the prior URL, but
+    // the local `receipt.source` only refreshes when the Pusher push arrives. Render `ConfirmedRoute`
+    // (which draws the map from `routes.coordinates`, independent of the URL) while any of these
+    // edits are pending so the thumbnail doesn't briefly try to load the now-404'd URL.
+    const pf = transaction?.pendingFields as Record<string, unknown> | undefined;
+    const hasPendingReceiptRegeneration = !!pf && (!!pf.distance || !!pf.merchant || !!pf.customUnitRateID);
+    const showMapAsImage = isMapDistanceRequest && (hasErrors || !!hasPendingWaypoints || hasPendingReceiptRegeneration);
 
     if (showMapAsImage) {
         return (

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1501,6 +1501,7 @@ const translations = {
             genericSmartscanFailureMessage: 'Transaction is missing fields',
             duplicateWaypointsErrorMessage: 'Please remove duplicate waypoints',
             atLeastTwoDifferentWaypoints: 'Please enter at least two different addresses',
+            fixWaypointsOnMapTab: 'Please add at least two valid waypoints on the Map tab before saving',
             splitExpenseMultipleParticipantsErrorMessage: 'An expense cannot be split between a workspace and other members. Please update your selection.',
             invalidMerchant: 'Please enter a valid merchant',
             atLeastOneAttendee: 'At least one attendee must be selected',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1501,7 +1501,6 @@ const translations = {
             genericSmartscanFailureMessage: 'Transaction is missing fields',
             duplicateWaypointsErrorMessage: 'Please remove duplicate waypoints',
             atLeastTwoDifferentWaypoints: 'Please enter at least two different addresses',
-            fixWaypointsOnMapTab: 'Please add at least two valid waypoints on the Map tab before saving',
             splitExpenseMultipleParticipantsErrorMessage: 'An expense cannot be split between a workspace and other members. Please update your selection.',
             invalidMerchant: 'Please enter a valid merchant',
             atLeastOneAttendee: 'At least one attendee must be selected',

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4589,7 +4589,6 @@ function getTransactionDetails(
     }
 
     const report = getReportOrDraftReport(transaction?.reportID, undefined, 'report' in transaction ? transaction.report : undefined);
-    const isManualDistanceRequest = isManualDistanceRequestTransactionUtils(transaction);
     const isFromExpenseReport = (!isEmptyObject(report) && isExpenseReport(report)) || isPaidGroupPolicyPolicyUtils(policy);
 
     return {
@@ -4616,7 +4615,7 @@ function getTransactionDetails(
         convertedAmount: getConvertedAmount(transaction, isFromExpenseReport, transaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID, allowNegativeAmount, disableOppositeConversion),
         postedDate: getFormattedPostedDate(transaction),
         transactionID: transaction.transactionID,
-        ...(isManualDistanceRequest && {distance: transaction.comment?.customUnit?.quantity ?? undefined}),
+        ...(isDistanceRequest(transaction) && {distance: transaction.comment?.customUnit?.quantity ?? undefined}),
     };
 }
 

--- a/src/libs/TransactionUtils/getDistanceInMeters.ts
+++ b/src/libs/TransactionUtils/getDistanceInMeters.ts
@@ -5,16 +5,19 @@ import type {Unit} from '@src/types/onyx/Policy';
 // Get the distance in meters from the transaction.
 // This function is placed in a separate file to avoid circular dependencies.
 function getDistanceInMeters(transaction: OnyxInputOrEntry<Transaction>, unit: Unit | undefined) {
+    // If the request is completed, transaction.routes is cleared and comment.customUnit.quantity holds the new distance in the selected unit.
+    // We need to convert it from the selected distance unit to meters.
+    // This check takes priority because after a manual distance edit, routes.route0.distance may still
+    // hold a stale route-calculated value while quantity reflects the user's intended distance.
+    if (transaction?.comment?.customUnit?.quantity && unit) {
+        return DistanceRequestUtils.convertToDistanceInMeters(transaction.comment.customUnit.quantity, unit);
+    }
+
     // If we are creating a new distance request, the distance is available in routes.route0.distance and it's already in meters.
     if (transaction?.routes?.route0?.distance) {
         return transaction.routes.route0.distance;
     }
 
-    // If the request is completed, transaction.routes is cleared and comment.customUnit.quantity holds the new distance in the selected unit.
-    // We need to convert it from the selected distance unit to meters.
-    if (transaction?.comment?.customUnit?.quantity && unit) {
-        return DistanceRequestUtils.convertToDistanceInMeters(transaction.comment.customUnit.quantity, unit);
-    }
     return 0;
 }
 

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -895,6 +895,14 @@ function getUpdatedTransaction({
         const updatedMileageRate = DistanceRequestUtils.getRate({transaction: updatedTransaction, policy, useTransactionDistanceUnit: false});
         const {unit, rate} = updatedMileageRate;
 
+        // Sync the stored distanceUnit to the policy's current unit. The user's input on the Manual
+        // tab is already in this unit; without writing it back, the optimistic state carries a stale
+        // unit (e.g. "miles" when the workspace switched to km) and the display stays wrong until the
+        // BE response — which never lands offline.
+        if (unit) {
+            lodashSet(updatedTransaction, 'comment.customUnit.distanceUnit', unit);
+        }
+
         const distanceInMeters = getDistanceInMeters(updatedTransaction, unit);
         let amount = DistanceRequestUtils.getDistanceRequestAmount(distanceInMeters, unit, rate ?? 0);
         amount = isFromExpenseReport || isUnReportedExpense ? -amount : amount;

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -191,6 +191,17 @@ function hasGPSWaypoints(transaction: OnyxEntry<Transaction>) {
     return !!waypoint?.keyForList?.startsWith('gps');
 }
 
+/**
+ * Compare two waypoint collections by their addresses only (ignoring coordinates/names), which is
+ * the meaningful signal for "did the user change the route?". Numeric fields like lat/lng can drift
+ * due to rounding in transaction backups, so they're excluded.
+ */
+function haveWaypointAddressesChanged(oldWaypoints: WaypointCollection | undefined, newWaypoints: WaypointCollection | undefined): boolean {
+    const toAddresses = (collection: WaypointCollection | undefined) =>
+        Object.fromEntries(Object.entries(collection ?? {}).map(([key, waypoint]) => [key, waypoint && 'address' in waypoint ? waypoint.address : undefined]));
+    return !deepEqual(toAddresses(oldWaypoints), toAddresses(newWaypoints));
+}
+
 function isMapDistanceRequest(transaction: OnyxEntry<Transaction>): boolean {
     // This is used during the expense creation flow before the transaction has been saved to the server
     if (transaction && Object.hasOwn(transaction, 'iouRequestType')) {
@@ -719,16 +730,22 @@ function getUpdatedTransaction({
         }
         shouldStopSmartscan = true;
 
-        if (!transactionChanges.routes?.route0?.geometry?.coordinates) {
+        // A manual-distance edit re-sends unchanged waypoints; when they truly didn't change, leave
+        // `amount`/`modifiedAmount` to the sibling `distance` branch instead of zeroing them here.
+        const waypointsActuallyChanged = !deepEqual(transactionChanges.waypoints, transaction?.comment?.waypoints);
+
+        if (waypointsActuallyChanged && !transactionChanges.routes?.route0?.geometry?.coordinates) {
             // The waypoints were changed, but there is no route – it is pending from the BE and we should mark the fields as pending
             updatedTransaction.amount = CONST.IOU.DEFAULT_AMOUNT;
             updatedTransaction.modifiedAmount = CONST.IOU.DEFAULT_AMOUNT;
             updatedTransaction.modifiedMerchant = translateLocal('iou.fieldPending');
-        } else {
+        } else if (transactionChanges.routes?.route0?.geometry?.coordinates) {
             const mileageRate = DistanceRequestUtils.getRate({transaction: updatedTransaction, policy});
             const {unit, rate} = mileageRate;
 
-            const distanceInMeters = getDistanceInMeters(transaction, unit);
+            // Use route distance directly since waypoints changed and the route was recalculated.
+            // getDistanceInMeters prefers quantity which may hold a stale manually-edited value.
+            const distanceInMeters = transactionChanges.routes?.route0?.distance ?? getDistanceInMeters(transaction, unit);
             const amount = DistanceRequestUtils.getDistanceRequestAmount(distanceInMeters, unit, rate ?? 0);
             const updatedAmount = isFromExpenseReport || isUnReportedExpense ? -amount : amount;
             const updatedMerchant = DistanceRequestUtils.getDistanceMerchant(
@@ -746,6 +763,13 @@ function getUpdatedTransaction({
             updatedTransaction.amount = updatedAmount;
             updatedTransaction.modifiedAmount = updatedAmount;
             updatedTransaction.modifiedMerchant = updatedMerchant;
+
+            // Sync `customUnit.quantity` to the new route distance. Without this the prior manual
+            // quantity (set when the user edited distance manually before changing waypoints) would
+            // linger and drive `getDistanceInMeters`, since that helper prefers quantity over routes.
+            if (unit) {
+                lodashSet(updatedTransaction, 'comment.customUnit.quantity', roundToTwoDecimalPlaces(DistanceRequestUtils.convertDistanceUnit(distanceInMeters, unit)));
+            }
         }
     }
 
@@ -861,8 +885,11 @@ function getUpdatedTransaction({
 
     if (Object.hasOwn(transactionChanges, 'distance') && typeof transactionChanges.distance === 'number') {
         const distance = roundToTwoDecimalPlaces(transactionChanges.distance ?? 0);
+        // Capture before mutating quantity below; needed by the fallback amount computation.
+        const previousDistanceInMeters = getDistanceInMeters(transaction, transaction?.comment?.customUnit?.distanceUnit);
 
         lodashSet(updatedTransaction, 'comment.customUnit.quantity', distance);
+        lodashSet(updatedTransaction, 'routes.route0.distance', null);
         shouldStopSmartscan = true;
 
         const updatedMileageRate = DistanceRequestUtils.getRate({transaction: updatedTransaction, policy, useTransactionDistanceUnit: false});
@@ -884,9 +911,20 @@ function getUpdatedTransaction({
             isManualDistanceRequest(transaction),
         );
 
-        updatedTransaction.modifiedAmount = amount;
-        updatedTransaction.modifiedMerchant = updatedMerchant;
-        updatedTransaction.modifiedCurrency = updatedCurrency;
+        // No locally resolvable rate (e.g. track expense without policy loaded) → scale the previous
+        // amount by the distance ratio so the optimistic value isn't 0. `modifiedAmount` is `""` for
+        // unedited transactions, so coerce via Number() and fall through to `amount`.
+        const previousAmount = Number(transaction?.modifiedAmount) || transaction?.amount || 0;
+        const useFallback = !rate && !!previousDistanceInMeters && !!previousAmount && !!distanceInMeters;
+        if (useFallback) {
+            updatedTransaction.modifiedAmount = Math.round(previousAmount * (distanceInMeters / previousDistanceInMeters));
+            updatedTransaction.modifiedMerchant = updatedMerchant;
+            // Leave currency alone — without a resolvable rate we don't know the target currency.
+        } else {
+            updatedTransaction.modifiedAmount = amount;
+            updatedTransaction.modifiedMerchant = updatedMerchant;
+            updatedTransaction.modifiedCurrency = updatedCurrency;
+        }
     }
 
     if (Object.hasOwn(transactionChanges, 'odometerStart') && typeof transactionChanges.odometerStart === 'number') {
@@ -2881,6 +2919,7 @@ export {
     isReceiptBeingScanned,
     didReceiptScanSucceed,
     getValidWaypoints,
+    haveWaypointAddressesChanged,
     isDistanceRequest,
     isMapDistanceRequest,
     isGPSDistanceRequest,

--- a/src/libs/actions/IOU/UpdateMoneyRequest.ts
+++ b/src/libs/actions/IOU/UpdateMoneyRequest.ts
@@ -988,15 +988,22 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
             .map((key) => [key, CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE]),
     );
     // Flag `merchant` as pending on any edit that causes the BE to regenerate the receipt
-    // (waypoints / distance / rate). `merchant` isn't in `transactionChanges`, so the success-data
-    // merge won't clear it via `clearedPendingFields` — it persists through the gap between API ack
-    // and the Pusher push that delivers the new `receipt.source`. The Pusher push then clears all
-    // pendingFields atomically together with the new URL, eliminating the broken-image flash.
-    // It also drives the Distance row's offline-feedback strikethrough for pure distance edits.
-    if ('waypoints' in transactionChanges || 'distance' in transactionChanges || 'customUnitRateID' in transactionChanges) {
+    // (waypoints / distance / rate). It bridges the gap between API ack and the Pusher push that
+    // delivers the new `receipt.source`, keeping `ReportActionItemImage` on `ConfirmedRoute` so the
+    // stale receipt URL doesn't briefly render. It also drives the Distance row's offline-feedback
+    // strikethrough for pure distance edits.
+    const shouldFlagMerchantPending = 'waypoints' in transactionChanges || 'distance' in transactionChanges || 'customUnitRateID' in transactionChanges;
+    if (shouldFlagMerchantPending) {
         pendingFields.merchant = CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE;
     }
     const clearedPendingFields = getClearedPendingFields(transactionChanges);
+    // `getClearedPendingFields` only clears `merchant` for distance edits, so when we artificially
+    // flag it for waypoint/rate edits we must also clear it here. Otherwise the flag persists past
+    // API ack if the Pusher receipt push is missed/delayed (e.g. flaky subscription, incognito),
+    // leaving the receipt frame stuck on `ConfirmedRoute` instead of switching to the new image.
+    if (shouldFlagMerchantPending) {
+        clearedPendingFields.merchant = null;
+    }
     const errorFields = Object.fromEntries(Object.keys(pendingFields).map((key) => [key, getMicroSecondOnyxErrorWithTranslationKey('iou.error.genericEditFailureMessage')]));
 
     const isTransactionOnHold = isOnHold(transaction);

--- a/src/libs/actions/IOU/UpdateMoneyRequest.ts
+++ b/src/libs/actions/IOU/UpdateMoneyRequest.ts
@@ -28,6 +28,7 @@ import {
     getClearedPendingFields,
     getMerchant,
     getUpdatedTransaction,
+    haveWaypointAddressesChanged,
     isDistanceRequest as isDistanceRequestTransactionUtils,
     isFetchingWaypointsFromServer,
     isOnHold,
@@ -522,7 +523,10 @@ function updateMoneyRequestDistance({
         // Don't sanitize waypoints here - keep all fields for Onyx optimistic data (e.g., keyForList)
         // Sanitization happens when building API params
         ...(waypoints && {waypoints}),
-        routes,
+        // Only include routes when the caller explicitly provided them. Including `routes: undefined`
+        // would make the optimistic merge wipe the existing route, briefly blanking the map thumbnail
+        // and report preview before the server response restores it.
+        ...(routes !== undefined && {routes}),
         ...(distance && {distance}),
         ...(odometerStart !== undefined && {odometerStart}),
         ...(odometerEnd !== undefined && {odometerEnd}),
@@ -967,20 +971,46 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
         >
     > = [];
 
-    // Step 1: Set any "pending fields" (ones updated while the user was offline) to have error messages in the failureData
-    const pendingFields: OnyxTypes.Transaction['pendingFields'] = Object.fromEntries(Object.keys(transactionChanges).map((key) => [key, CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE]));
+    // Step 1: Get the transaction being updated
+    const transaction = getAllTransactions()?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
+
+    // The manual-distance submit path always sends waypoints to keep the BE in sync, even when the user
+    // only edited the distance number. Detect whether the addresses actually changed so we can skip the
+    // optimistic side effects (pending field, route clearing, render-path swap to interactive map) that
+    // would otherwise make the parent map briefly disappear on a pure distance edit.
+    const hasWaypointAddressesChanged = 'waypoints' in transactionChanges && haveWaypointAddressesChanged(transaction?.comment?.waypoints, transactionChanges.waypoints);
+    const shouldSuppressWaypointsAsPending = 'waypoints' in transactionChanges && !hasWaypointAddressesChanged;
+
+    // Step 2: Set any "pending fields" (ones updated while the user was offline) to have error messages in the failureData
+    const pendingFields: OnyxTypes.Transaction['pendingFields'] = Object.fromEntries(
+        Object.keys(transactionChanges)
+            .filter((key) => !(shouldSuppressWaypointsAsPending && key === 'waypoints'))
+            .map((key) => [key, CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE]),
+    );
+    // Flag `merchant` as pending on any edit that causes the BE to regenerate the receipt
+    // (waypoints / distance / rate). `merchant` isn't in `transactionChanges`, so the success-data
+    // merge won't clear it via `clearedPendingFields` — it persists through the gap between API ack
+    // and the Pusher push that delivers the new `receipt.source`. The Pusher push then clears all
+    // pendingFields atomically together with the new URL, eliminating the broken-image flash.
+    // It also drives the Distance row's offline-feedback strikethrough for pure distance edits.
+    if ('waypoints' in transactionChanges || 'distance' in transactionChanges || 'customUnitRateID' in transactionChanges) {
+        pendingFields.merchant = CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE;
+    }
     const clearedPendingFields = getClearedPendingFields(transactionChanges);
     const errorFields = Object.fromEntries(Object.keys(pendingFields).map((key) => [key, getMicroSecondOnyxErrorWithTranslationKey('iou.error.genericEditFailureMessage')]));
 
-    // Step 2: Get all the collections being updated
-    const transaction = getAllTransactions()?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-
     const isTransactionOnHold = isOnHold(transaction);
     const isFromExpenseReport = isExpenseReport(iouReport) || isInvoiceReportReportUtils(iouReport);
+    // Drop the waypoints from the changes fed to getUpdatedTransaction when they didn't actually change,
+    // so we skip the waypoints branch that flips isLoading and clobbers amount/merchant before being
+    // re-overridden by the distance branch.
+    const transactionChangesForOptimisticMerge: TransactionChanges = shouldSuppressWaypointsAsPending
+        ? Object.fromEntries(Object.entries(transactionChanges).filter(([key]) => key !== 'waypoints'))
+        : transactionChanges;
     const updatedTransaction: OnyxEntry<OnyxTypes.Transaction> = transaction
         ? getUpdatedTransaction({
               transaction,
-              transactionChanges,
+              transactionChanges: transactionChangesForOptimisticMerge,
               isFromExpenseReport,
               isSplitTransaction,
               policy,
@@ -994,6 +1024,12 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
     }
 
     const dataToIncludeInParams: Partial<TransactionDetails> = Object.fromEntries(Object.entries(transactionDetails ?? {}).filter(([key]) => key in transactionChanges));
+
+    // Preserve the caller's full-precision distance so the server doesn't fire `increasedDistance`
+    // when the rounded display value drifts above the exact route distance.
+    if ('distance' in transactionChanges && typeof transactionChanges.distance === 'number') {
+        dataToIncludeInParams.distance = transactionChanges.distance;
+    }
 
     const apiParams: UpdateMoneyRequestParams = {
         ...dataToIncludeInParams,
@@ -1009,6 +1045,9 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
     // For split transactions, the merchant and amount are already computed in transactionChanges,
     // so we can build a valid optimistic MODIFIED_EXPENSE even when waypoints are pending.
     const hasSplitDistanceMessageFields = !!isSplitTransaction && hasModifiedMerchant && hasModifiedAmount;
+    // When distance is provided alongside waypoints (route was already calculated), we have valid
+    // merchant/amount data to build the optimistic report action instead of waiting for the server.
+    const hasDistanceWithWaypoints = hasPendingWaypoints && 'distance' in transactionChanges;
     if (transaction && updatedTransaction && (hasPendingWaypoints || hasModifiedDistanceRate)) {
         // Delete the draft transaction when editing waypoints when the server responds successfully and there are no errors
         successData.push({
@@ -1044,7 +1083,11 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
     const updatedReportAction = shouldBuildOptimisticModifiedExpenseReportAction
         ? buildOptimisticModifiedExpenseReportAction(transactionThreadReport, transaction, transactionChanges, isFromExpenseReport, policy, updatedTransaction, allowNegative)
         : null;
-    if ((!hasPendingWaypoints || hasSplitDistanceMessageFields) && !(hasModifiedDistanceRate && isFetchingWaypointsFromServer(transaction)) && updatedReportAction) {
+    if (
+        (!hasPendingWaypoints || hasSplitDistanceMessageFields || hasDistanceWithWaypoints) &&
+        !(hasModifiedDistanceRate && isFetchingWaypointsFromServer(transaction)) &&
+        updatedReportAction
+    ) {
         apiParams.reportActionID = updatedReportAction.reportActionID;
 
         optimisticData.push({
@@ -1256,7 +1299,14 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
         apiParams.attendees = JSON.stringify(apiParams?.attendees);
     }
 
-    // Clear out the error fields and loading states on success
+    // Clear out the error fields and loading states on success.
+    // Only clear `routes` when waypoints/rate changed (the server will push a fresh route via Pusher).
+    // For pure distance edits the route is unchanged, and clearing it would make the map briefly disappear.
+    // When the caller already supplied a valid optimistic route (waypoint edit with route pre-fetched
+    // locally), keep it so the receipt thumbnail and ConfirmedRoute don't flicker between success and
+    // the Pusher route push.
+    const hasValidOptimisticRoute = !!transactionChanges.routes?.route0?.geometry?.coordinates?.length;
+    const shouldClearRoutes = (hasWaypointAddressesChanged || hasModifiedDistanceRate) && !hasValidOptimisticRoute;
     successData.push({
         onyxMethod: Onyx.METHOD.MERGE,
         key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`,
@@ -1264,7 +1314,7 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
             pendingFields: clearedPendingFields,
             isLoading: false,
             errorFields: null,
-            routes: null,
+            ...(shouldClearRoutes && {routes: null}),
         },
     });
 
@@ -1333,9 +1383,13 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
         if (hasPendingWaypoints) {
             optimisticViolations = optimisticViolations.filter((violation) => violation.name !== CONST.VIOLATIONS.NO_ROUTE);
         }
-        if (hasModifiedDistanceRate || hasModifiedDistance) {
+        if (hasModifiedDistanceRate || hasModifiedDistance || hasPendingWaypoints) {
+            // Clear stale distance-related violations while the server reprocesses.
+            // The server will re-evaluate and re-add any that legitimately apply.
             optimisticViolations = optimisticViolations.filter(
-                (violation) => !(violation.name === CONST.VIOLATIONS.MODIFIED_AMOUNT && violation.data?.type === CONST.MODIFIED_AMOUNT_VIOLATION_DATA.DISTANCE),
+                (violation) =>
+                    !(violation.name === CONST.VIOLATIONS.MODIFIED_AMOUNT && violation.data?.type === CONST.MODIFIED_AMOUNT_VIOLATION_DATA.DISTANCE) &&
+                    violation.name !== CONST.VIOLATIONS.INCREASED_DISTANCE,
             );
         }
 

--- a/src/libs/actions/TransactionEdit.ts
+++ b/src/libs/actions/TransactionEdit.ts
@@ -39,7 +39,9 @@ function createBackupTransaction(transaction: OnyxEntry<Transaction>, isDraft: b
         key: `${ONYXKEYS.COLLECTION.TRANSACTION_BACKUP}${transaction.transactionID}`,
         callback: (transactionBackup) => {
             Onyx.disconnect(conn);
-            if (transactionBackup) {
+            // Treat a backup missing `transactionID` as corrupted (a partial route-fetch shape can
+            // leak in via Pusher) and overwrite it instead of restoring from it.
+            if (transactionBackup?.transactionID) {
                 // If the transactionBackup exists it means we haven't properly restored original value on unmount
                 // such as on page refresh, so we will just restore the transaction from the transactionBackup here.
                 Onyx.set(`${isDraft ? ONYXKEYS.COLLECTION.TRANSACTION_DRAFT : ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transactionBackup);

--- a/src/pages/iou/request/step/DistanceManualTabContent.tsx
+++ b/src/pages/iou/request/step/DistanceManualTabContent.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import type {TextInput} from 'react-native';
+import Button from '@components/Button';
+import NumberWithSymbolForm from '@components/NumberWithSymbolForm';
+import type {NumberWithSymbolFormRef} from '@components/NumberWithSymbolForm';
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+import useAutoFocusInput from '@hooks/useAutoFocusInput';
+import useLocalize from '@hooks/useLocalize';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {canUseTouchScreen} from '@libs/DeviceCapabilities';
+import variables from '@styles/variables';
+import CONST from '@src/CONST';
+import type {Unit} from '@src/types/onyx/Policy';
+
+type DistanceManualTabContentProps = {
+    currentDistance: number | undefined;
+    distanceUnit: Unit;
+    onSubmit: () => void;
+    manualFormError: string;
+    onInputChange: () => void;
+    manualTextInputRef: React.RefObject<BaseTextInputRef | null>;
+    manualNumberFormRef: React.RefObject<NumberWithSymbolFormRef | null>;
+};
+
+function DistanceManualTabContent({currentDistance, distanceUnit, onSubmit, manualFormError, onInputChange, manualTextInputRef, manualNumberFormRef}: DistanceManualTabContentProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const {isExtraSmallScreenHeight} = useResponsiveLayout();
+    const {inputCallbackRef} = useAutoFocusInput();
+
+    const setInputRef = (ref: BaseTextInputRef | null) => {
+        // eslint-disable-next-line no-param-reassign
+        manualTextInputRef.current = ref;
+        inputCallbackRef(ref as unknown as TextInput | null);
+    };
+
+    return (
+        <NumberWithSymbolForm
+            ref={setInputRef}
+            numberFormRef={manualNumberFormRef}
+            value={currentDistance?.toString()}
+            shouldUseDynamicFontSize
+            onInputChange={onInputChange}
+            decimals={CONST.DISTANCE_DECIMAL_PLACES}
+            symbol={distanceUnit}
+            symbolPosition={CONST.TEXT_INPUT_SYMBOL_POSITION.SUFFIX}
+            isSymbolPressable={false}
+            symbolTextStyle={styles.textSupporting}
+            style={styles.iouAmountTextInput}
+            containerStyle={styles.iouAmountTextInputContainer}
+            autoGrowExtraSpace={variables.w80}
+            touchableInputWrapperStyle={styles.heightUndefined}
+            errorText={manualFormError}
+            accessibilityLabel={`${translate('common.distance')} (${translate(`common.${distanceUnit}`)})`}
+            footer={
+                <Button
+                    success
+                    allowBubble={false}
+                    pressOnEnter
+                    medium={isExtraSmallScreenHeight}
+                    large={!isExtraSmallScreenHeight}
+                    style={[styles.w100, canUseTouchScreen() ? styles.mt5 : styles.mt0]}
+                    onPress={onSubmit}
+                    text={translate('common.save')}
+                    testID="next-button"
+                    sentryLabel={CONST.SENTRY_LABEL.IOU_REQUEST_STEP.DISTANCE_MANUAL_NEXT_BUTTON}
+                />
+            }
+        />
+    );
+}
+
+DistanceManualTabContent.displayName = 'DistanceManualTabContent';
+
+export default DistanceManualTabContent;

--- a/src/pages/iou/request/step/DistanceManualTabContent.tsx
+++ b/src/pages/iou/request/step/DistanceManualTabContent.tsx
@@ -30,7 +30,7 @@ function DistanceManualTabContent({currentDistance, distanceUnit, onSubmit, manu
     const {inputCallbackRef} = useAutoFocusInput();
 
     const setInputRef = (ref: BaseTextInputRef | null) => {
-        // eslint-disable-next-line no-param-reassign
+        // eslint-disable-next-line no-param-reassign -- Assign to ref's .current which is a safe mutation, not a true parameter reassignment
         manualTextInputRef.current = ref;
         inputCallbackRef(ref as unknown as TextInput | null);
     };

--- a/src/pages/iou/request/step/DistanceMapTabContent.tsx
+++ b/src/pages/iou/request/step/DistanceMapTabContent.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import {View} from 'react-native';
+// eslint-disable-next-line no-restricted-imports
+import type {ScrollView as RNScrollView} from 'react-native';
+import type {RenderItemParams} from 'react-native-draggable-flatlist/lib/typescript/types';
+import type {OnyxEntry} from 'react-native-onyx';
+import Button from '@components/Button';
+import DistanceRequestFooter from '@components/DistanceRequest/DistanceRequestFooter';
+import DotIndicatorMessage from '@components/DotIndicatorMessage';
+import DraggableList from '@components/DraggableList';
+import useIsInLandscapeMode from '@hooks/useIsInLandscapeMode';
+import useThemeStyles from '@hooks/useThemeStyles';
+import CONST from '@src/CONST';
+import type {Policy} from '@src/types/onyx';
+import type {Errors} from '@src/types/onyx/OnyxCommon';
+import type Transaction from '@src/types/onyx/Transaction';
+import type {WaypointCollection} from '@src/types/onyx/Transaction';
+
+type ErrorState = {
+    shouldShowAtLeastTwoDifferentWaypointsError: boolean;
+    atLeastTwoDifferentWaypointsError: boolean;
+    duplicateWaypointsError: boolean;
+    hasRouteError: boolean;
+    getError: () => Errors;
+};
+
+type LoadingState = {
+    isOffline: boolean;
+    isLoadingRoute: boolean;
+    shouldFetchRoute: boolean;
+    isLoading: boolean;
+};
+
+type DistanceMapTabContentProps = {
+    waypointItems: string[];
+    waypoints: WaypointCollection;
+    extractKey: (key: string) => string;
+    updateWaypoints: (data: {data: string[]}) => void;
+    scrollViewRef: React.RefObject<RNScrollView | null>;
+    renderItem: (params: RenderItemParams<string>) => React.JSX.Element;
+    navigateToWaypointEditPage: (index: number) => void;
+    transaction: OnyxEntry<Transaction>;
+    policy: OnyxEntry<Policy>;
+    submitWaypoints: () => void;
+    buttonText: string;
+    errorState: ErrorState;
+    loadingState: LoadingState;
+};
+
+function DistanceMapTabContent({
+    waypointItems,
+    waypoints,
+    extractKey,
+    updateWaypoints,
+    scrollViewRef,
+    renderItem,
+    navigateToWaypointEditPage,
+    transaction,
+    policy,
+    submitWaypoints,
+    buttonText,
+    errorState,
+    loadingState,
+}: DistanceMapTabContentProps) {
+    const styles = useThemeStyles();
+    const isInLandscapeMode = useIsInLandscapeMode();
+
+    const {shouldShowAtLeastTwoDifferentWaypointsError, atLeastTwoDifferentWaypointsError, duplicateWaypointsError, hasRouteError, getError} = errorState;
+    const {isOffline, isLoadingRoute, shouldFetchRoute, isLoading} = loadingState;
+    const hasError = (shouldShowAtLeastTwoDifferentWaypointsError && atLeastTwoDifferentWaypointsError) || duplicateWaypointsError || hasRouteError;
+
+    return (
+        <View style={[styles.flex1, isInLandscapeMode && styles.flexRow]}>
+            {isInLandscapeMode && (
+                <View style={styles.flex1}>
+                    <DistanceRequestFooter
+                        waypoints={waypoints}
+                        navigateToWaypointEditPage={navigateToWaypointEditPage}
+                        transaction={transaction}
+                        policy={policy}
+                        mapContainerStyle={{minHeight: undefined}}
+                    />
+                </View>
+            )}
+            <View style={[styles.flex1, isInLandscapeMode && styles.pl2]}>
+                <DraggableList
+                    data={waypointItems}
+                    keyExtractor={extractKey}
+                    onDragEnd={updateWaypoints}
+                    ref={scrollViewRef}
+                    renderItem={renderItem}
+                    ListFooterComponent={
+                        !isInLandscapeMode ? (
+                            <DistanceRequestFooter
+                                waypoints={waypoints}
+                                navigateToWaypointEditPage={navigateToWaypointEditPage}
+                                transaction={transaction}
+                                policy={policy}
+                            />
+                        ) : undefined
+                    }
+                />
+                <View style={[styles.w100, styles.pt2]}>
+                    {/* Show error message if there is route error or there are less than 2 routes and user has tried submitting */}
+                    {hasError && (
+                        <DotIndicatorMessage
+                            style={[styles.mh4, styles.mv3]}
+                            messages={getError()}
+                            type="error"
+                        />
+                    )}
+                    <Button
+                        success
+                        allowBubble
+                        pressOnEnter
+                        large
+                        style={[styles.w100, styles.mb5, styles.ph5, styles.flexShrink0]}
+                        onPress={submitWaypoints}
+                        text={buttonText}
+                        isLoading={!isOffline && (isLoadingRoute || shouldFetchRoute || isLoading)}
+                        sentryLabel={CONST.SENTRY_LABEL.IOU_REQUEST_STEP.DISTANCE_MAP_NEXT_BUTTON}
+                    />
+                </View>
+            </View>
+        </View>
+    );
+}
+
+DistanceMapTabContent.displayName = 'DistanceMapTabContent';
+
+export default DistanceMapTabContent;

--- a/src/pages/iou/request/step/IOURequestStepDistance.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistance.tsx
@@ -1,21 +1,18 @@
 import {deepEqual} from 'fast-equals';
 import isEmpty from 'lodash/isEmpty';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {View} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import type {ScrollView as RNScrollView} from 'react-native';
 import type {RenderItemParams} from 'react-native-draggable-flatlist/lib/typescript/types';
 import type {OnyxEntry} from 'react-native-onyx';
-import Button from '@components/Button';
-import DistanceRequestFooter from '@components/DistanceRequest/DistanceRequestFooter';
 import DistanceRequestRenderItem from '@components/DistanceRequest/DistanceRequestRenderItem';
-import DotIndicatorMessage from '@components/DotIndicatorMessage';
-import DraggableList from '@components/DraggableList';
+import type {NumberWithSymbolFormRef} from '@components/NumberWithSymbolForm';
+import TabSelector from '@components/TabSelector/TabSelector';
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 import withCurrentUserPersonalDetails from '@components/withCurrentUserPersonalDetails';
 import type {WithCurrentUserPersonalDetailsProps} from '@components/withCurrentUserPersonalDetails';
 import useDefaultExpensePolicy from '@hooks/useDefaultExpensePolicy';
 import useFetchRoute from '@hooks/useFetchRoute';
-import useIsInLandscapeMode from '@hooks/useIsInLandscapeMode';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -28,9 +25,8 @@ import useReportAttributes from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useSelfDMReport from '@hooks/useSelfDMReport';
 import useShowNotFoundPageInIOUStep from '@hooks/useShowNotFoundPageInIOUStep';
-import useThemeStyles from '@hooks/useThemeStyles';
 import useWaypointItems from '@hooks/useWaypointItems';
-import {setMoneyRequestAmount} from '@libs/actions/IOU';
+import {setMoneyRequestAmount, setMoneyRequestDistance} from '@libs/actions/IOU';
 import {handleMoneyRequestStepDistanceNavigation} from '@libs/actions/IOU/MoneyRequest';
 import {setDraftSplitTransaction, setSplitShares} from '@libs/actions/IOU/Split';
 import {updateMoneyRequestDistance} from '@libs/actions/IOU/UpdateMoneyRequest';
@@ -44,8 +40,10 @@ import {getLatestErrorField} from '@libs/ErrorUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {shouldUseTransactionDraft} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import OnyxTabNavigator, {TabScreenWithFocusTrapWrapper, TopTab} from '@libs/Navigation/OnyxTabNavigator';
+import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import {isPolicyExpenseChat as isPolicyExpenseChatUtil} from '@libs/ReportUtils';
-import {getDistanceInMeters, getRateID, getRequestType, hasRoute, isCustomUnitRateIDForP2P, isWaypointNullIsland} from '@libs/TransactionUtils';
+import {getDistanceInMeters, getRateID, getRequestType, hasRoute, haveWaypointAddressesChanged, isCustomUnitRateIDForP2P, isWaypointNullIsland} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
 import type {IOUType} from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -59,6 +57,8 @@ import type {Waypoint, WaypointCollection} from '@src/types/onyx/Transaction';
 import type Transaction from '@src/types/onyx/Transaction';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type TransactionStateType from '@src/types/utils/TransactionStateType';
+import DistanceManualTabContent from './DistanceManualTabContent';
+import DistanceMapTabContent from './DistanceMapTabContent';
 import StepScreenWrapper from './StepScreenWrapper';
 import withFullTransactionOrNotFound from './withFullTransactionOrNotFound';
 import type {WithWritableReportOrNotFoundProps} from './withWritableReportOrNotFound';
@@ -78,8 +78,6 @@ function IOURequestStepDistance({
     transaction,
     currentUserPersonalDetails,
 }: IOURequestStepDistanceProps) {
-    const styles = useThemeStyles();
-    const isInLandscapeMode = useIsInLandscapeMode();
     const {isOffline} = useNetwork();
     const {translate} = useLocalize();
     const {isBetaEnabled} = usePermissions();
@@ -181,6 +179,48 @@ function IOURequestStepDistance({
 
     const isASAPSubmitBetaEnabled = isBetaEnabled(CONST.BETAS.ASAP_SUBMIT);
 
+    // Manual distance editing state
+    const manualNumberFormRef = useRef<NumberWithSymbolFormRef | null>(null);
+    const manualTextInputRef = useRef<BaseTextInputRef | null>(null);
+    const [manualFormError, setManualFormError] = useState<string>('');
+
+    const mileageRate = DistanceRequestUtils.getRate({
+        transaction: currentTransaction,
+        policy,
+        useTransactionDistanceUnit: false,
+    });
+    const distanceUnit = mileageRate.unit;
+    const distanceRate = mileageRate.rate ?? 0;
+    const currentTransactionDistanceUnit = currentTransaction?.comment?.customUnit?.distanceUnit;
+    const distanceInMeters = getDistanceInMeters(currentTransaction, currentTransactionDistanceUnit ?? distanceUnit);
+    const currentDistance = useMemo(
+        () => (distanceInMeters > 0 ? roundToTwoDecimalPlaces(DistanceRequestUtils.convertDistanceUnit(distanceInMeters, distanceUnit)) : undefined),
+        [distanceInMeters, distanceUnit],
+    );
+
+    // Track whether the user has started editing on the manual tab to prevent route updates
+    // from overwriting in-progress manual input.
+    const isManuallyEditing = useRef(false);
+
+    // Push the route distance into the manual tab input only on a real waypoint-driven recalculation
+    // (a non-null → different non-null transition). Skip the initial null → value transition, which
+    // is the post-save re-fetch, so we don't overwrite a saved manual quantity with the route distance.
+    const routeDistance = currentTransaction?.routes?.route0?.distance;
+    const lastSyncedRouteDistance = useRef<number | null | undefined>(routeDistance);
+    useEffect(() => {
+        if (routeDistance == null || !distanceUnit || isManuallyEditing.current) {
+            lastSyncedRouteDistance.current = routeDistance;
+            return;
+        }
+        if (lastSyncedRouteDistance.current == null || lastSyncedRouteDistance.current === routeDistance) {
+            lastSyncedRouteDistance.current = routeDistance;
+            return;
+        }
+        const routeDistanceInUnit = roundToTwoDecimalPlaces(DistanceRequestUtils.convertDistanceUnit(routeDistance, distanceUnit));
+        manualNumberFormRef.current?.updateNumber(routeDistanceInUnit.toString());
+        lastSyncedRouteDistance.current = routeDistance;
+    }, [routeDistance, distanceUnit]);
+
     // Sets `amount` and `split` share data before moving to the next step to avoid briefly showing `0.00` as the split share for participants
     const setDistanceRequestData = useCallback(
         (participants: Participant[]) => {
@@ -188,15 +228,15 @@ function IOURequestStepDistance({
             const isPolicyExpenseChat = participants?.some((participant) => participant.isPolicyExpenseChat);
             const policyCurrency = policy?.outputCurrency ?? personalPolicy?.outputCurrency ?? CONST.CURRENCY.USD;
 
-            const mileageRates = DistanceRequestUtils.getMileageRates(policy);
+            const policyMileageRates = DistanceRequestUtils.getMileageRates(policy);
             const defaultMileageRate = DistanceRequestUtils.getDefaultMileageRate(policy);
-            const mileageRate: MileageRate | undefined = isCustomUnitRateIDForP2P(transaction)
+            const selectedMileageRate: MileageRate | undefined = isCustomUnitRateIDForP2P(transaction)
                 ? DistanceRequestUtils.getRateForP2P(policyCurrency, transaction)
-                : (customUnitRateID && mileageRates?.[customUnitRateID]) || defaultMileageRate;
+                : (customUnitRateID && policyMileageRates?.[customUnitRateID]) || defaultMileageRate;
 
-            const {unit, rate} = mileageRate ?? {};
+            const {unit, rate} = selectedMileageRate ?? {};
             const distance = getDistanceInMeters(transaction, unit);
-            const currency = mileageRate?.currency ?? policyCurrency;
+            const currency = selectedMileageRate?.currency ?? policyCurrency;
             const amount = DistanceRequestUtils.getDistanceRequestAmount(distance, unit ?? CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES, rate ?? 0);
             setMoneyRequestAmount(transactionID, amount, currency);
 
@@ -289,6 +329,10 @@ function IOURequestStepDistance({
         Navigation.goBack(backTo);
     }, [backTo]);
 
+    const navigateBackAfterSave = useCallback(() => {
+        Navigation.closeRHPFlow();
+    }, []);
+
     /**
      * Takes the user to the page for editing a specific waypoint
      * @param index of the waypoint to edit
@@ -299,11 +343,15 @@ function IOURequestStepDistance({
             if (isEditingSplit) {
                 iouWaypointType = CONST.IOU.TYPE.SPLIT_EXPENSE;
             }
-            Navigation.navigate(
-                ROUTES.MONEY_REQUEST_STEP_WAYPOINT.getRoute(action, iouWaypointType, transactionID, report?.reportID ?? reportID, index.toString(), Navigation.getActiveRoute()),
-            );
+            // Construct the backTo URL explicitly to match the stack entry created when we navigated
+            // to this distance edit page. Using Navigation.getActiveRoute() would return a URL with
+            // the OnyxTabNavigator's tab suffix (e.g. "/distance-map") which doesn't match the stack
+            // entry — causing Navigation.goBack() to REPLACE instead of POP and creating a duplicate
+            // distance page entry in the stack.
+            const waypointBackTo = ROUTES.MONEY_REQUEST_STEP_DISTANCE.getRoute(action, iouType, transactionID, report?.reportID ?? reportID, backTo);
+            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_WAYPOINT.getRoute(action, iouWaypointType, transactionID, report?.reportID ?? reportID, index.toString(), waypointBackTo));
         },
-        [action, transactionID, report?.reportID, reportID, isEditingSplit],
+        [action, iouType, transactionID, report?.reportID, reportID, backTo, isEditingSplit],
     );
 
     const navigateToNextStep = useCallback(() => {
@@ -383,7 +431,7 @@ function IOURequestStepDistance({
         conciergeReportID,
     ]);
 
-    const getError = () => {
+    const getError = useCallback(() => {
         // Get route error if available else show the invalid number of waypoints error.
         if (hasRouteError) {
             return getLatestErrorField(currentTransaction, 'route');
@@ -398,7 +446,7 @@ function IOURequestStepDistance({
             return {atLeastTwoDifferentWaypointsError: translate('iou.error.atLeastTwoDifferentWaypoints')} as Errors;
         }
         return {};
-    };
+    }, [hasRouteError, currentTransaction, isWaypointsNullIslandError, translate, duplicateWaypointsError, atLeastTwoDifferentWaypointsError]);
 
     type DataParams = {
         data: string[];
@@ -453,18 +501,16 @@ function IOURequestStepDistance({
                     {waypoints: currentTransaction?.comment?.waypoints, routes: currentTransaction?.routes},
                     policy,
                 );
-                navigateBack();
+                navigateBackAfterSave();
                 return;
             }
 
             // If nothing was changed, simply go to transaction thread
             // We compare only addresses because numbers are rounded while backup
-            const oldWaypoints = transactionBackup?.comment?.waypoints ?? {};
-            const oldAddresses = Object.fromEntries(Object.entries(oldWaypoints).map(([key, waypoint]) => [key, 'address' in waypoint ? waypoint.address : {}]));
-            const addresses = Object.fromEntries(Object.entries(waypoints).map(([key, waypoint]) => [key, 'address' in waypoint ? waypoint.address : {}]));
             const hasRouteChanged = !deepEqual(transactionBackup?.routes, transaction?.routes);
-            if (deepEqual(oldAddresses, addresses)) {
-                navigateBack();
+            if (!haveWaypointAddressesChanged(transactionBackup?.comment?.waypoints, waypoints)) {
+                transactionWasSaved.current = true;
+                navigateBackAfterSave();
                 return;
             }
             if (transaction?.transactionID && report?.reportID) {
@@ -486,7 +532,10 @@ function IOURequestStepDistance({
                 });
             }
             transactionWasSaved.current = true;
-            navigateBack();
+            // Remove the backup eagerly so the parent report view reads the optimistic transaction
+            // immediately, instead of the stale backup, while the API request is still in flight.
+            removeBackupTransaction(transaction?.transactionID);
+            navigateBackAfterSave();
             return;
         }
 
@@ -500,13 +549,13 @@ function IOURequestStepDistance({
         isLoading,
         isCreatingNewRequest,
         navigateToNextStep,
+        navigateBackAfterSave,
         isEditingSplit,
         originalSplitTransactionDraft,
         transactionBackup,
         waypoints,
         transaction,
         report,
-        navigateBack,
         currentTransaction?.comment?.waypoints,
         currentTransaction?.routes,
         policy,
@@ -518,6 +567,91 @@ function IOURequestStepDistance({
         currentUserEmailParam,
         isASAPSubmitBetaEnabled,
         parentReportNextStep,
+    ]);
+
+    const submitManualDistance = useCallback(() => {
+        isManuallyEditing.current = false;
+        const value = manualNumberFormRef.current?.getNumber() ?? '';
+        if (!value.length || parseFloat(value) <= 0) {
+            setManualFormError(translate('iou.error.invalidDistance'));
+            return;
+        }
+        if (!DistanceRequestUtils.isDistanceAmountWithinLimit(parseFloat(value), distanceRate)) {
+            setManualFormError(translate('iou.error.distanceAmountTooLargeReduceDistance'));
+            return;
+        }
+
+        const distanceAsFloat = roundToTwoDecimalPlaces(parseFloat(value));
+
+        if (isEditingSplit && transaction) {
+            setMoneyRequestDistance(transactionID, distanceAsFloat, shouldUseTransactionDraft(action, iouType), distanceUnit);
+            setDraftSplitTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID, splitDraftTransaction, {distance: distanceAsFloat}, policy);
+            navigateBackAfterSave();
+            return;
+        }
+
+        const transactionDistanceUnit = currentTransaction?.comment?.customUnit?.distanceUnit;
+        const isDistanceChanged = currentDistance !== distanceAsFloat;
+        const isDistanceUnitChanged = transactionDistanceUnit && transactionDistanceUnit !== distanceUnit;
+
+        // Check if waypoints were edited on the map tab before the user switched to manual.
+        // If so, we must still send the update even if the distance value itself didn't change.
+        const haveWaypointsChanged = haveWaypointAddressesChanged(transactionBackup?.comment?.waypoints, waypoints);
+
+        if (!isDistanceChanged && !isDistanceUnitChanged && !haveWaypointsChanged) {
+            transactionWasSaved.current = true;
+            navigateBackAfterSave();
+            return;
+        }
+
+        const hasRouteChanged = haveWaypointsChanged && !deepEqual(transactionBackup?.routes, transaction?.routes);
+        updateMoneyRequestDistance({
+            transaction,
+            transactionThreadReport: report,
+            parentReport,
+            waypoints,
+            distance: distanceAsFloat,
+            ...(hasRouteChanged ? {routes: transaction?.routes} : {}),
+            transactionBackup,
+            policy,
+            policyTagList: policyTags,
+            policyCategories,
+            currentUserAccountIDParam,
+            currentUserEmailParam,
+            isASAPSubmitBetaEnabled,
+            parentReportNextStep,
+            recentWaypoints,
+        });
+        transactionWasSaved.current = true;
+        // Remove the backup eagerly so the parent report view reads the optimistic transaction
+        // immediately, instead of the stale backup, while the API request is still in flight.
+        removeBackupTransaction(transaction?.transactionID);
+        navigateBackAfterSave();
+    }, [
+        translate,
+        distanceRate,
+        transactionID,
+        action,
+        iouType,
+        distanceUnit,
+        isEditingSplit,
+        transaction,
+        currentTransaction?.comment?.customUnit?.distanceUnit,
+        splitDraftTransaction,
+        policy,
+        navigateBackAfterSave,
+        currentDistance,
+        waypoints,
+        transactionBackup,
+        report,
+        parentReport,
+        policyTags,
+        policyCategories,
+        currentUserAccountIDParam,
+        currentUserEmailParam,
+        isASAPSubmitBetaEnabled,
+        parentReportNextStep,
+        recentWaypoints,
     ]);
 
     const renderItem = useCallback(
@@ -535,67 +669,105 @@ function IOURequestStepDistance({
         [isLoadingRoute, navigateToWaypointEditPage, waypoints, getWaypointKey],
     );
 
+    const handleManualInputChange = useCallback(() => {
+        isManuallyEditing.current = true;
+        if (!manualFormError) {
+            return;
+        }
+        setManualFormError('');
+    }, [manualFormError]);
+
+    const errorState = useMemo(
+        () => ({shouldShowAtLeastTwoDifferentWaypointsError, atLeastTwoDifferentWaypointsError, duplicateWaypointsError, hasRouteError, getError}),
+        [shouldShowAtLeastTwoDifferentWaypointsError, atLeastTwoDifferentWaypointsError, duplicateWaypointsError, hasRouteError, getError],
+    );
+
+    const loadingState = useMemo(() => ({isOffline, isLoadingRoute, shouldFetchRoute, isLoading}), [isOffline, isLoadingRoute, shouldFetchRoute, isLoading]);
+
+    const renderMapTab = useCallback(
+        () => (
+            <TabScreenWithFocusTrapWrapper>
+                <DistanceMapTabContent
+                    waypointItems={waypointItems}
+                    waypoints={waypoints}
+                    extractKey={extractKey}
+                    updateWaypoints={updateWaypoints}
+                    scrollViewRef={scrollViewRef}
+                    renderItem={renderItem}
+                    navigateToWaypointEditPage={navigateToWaypointEditPage}
+                    transaction={transaction}
+                    policy={policy}
+                    submitWaypoints={submitWaypoints}
+                    buttonText={buttonText}
+                    errorState={errorState}
+                    loadingState={loadingState}
+                />
+            </TabScreenWithFocusTrapWrapper>
+        ),
+        [waypointItems, waypoints, extractKey, updateWaypoints, renderItem, navigateToWaypointEditPage, transaction, policy, submitWaypoints, buttonText, errorState, loadingState],
+    );
+
+    const renderManualTab = useCallback(
+        () => (
+            <TabScreenWithFocusTrapWrapper>
+                <DistanceManualTabContent
+                    currentDistance={currentDistance}
+                    distanceUnit={distanceUnit}
+                    onSubmit={submitManualDistance}
+                    manualFormError={manualFormError}
+                    onInputChange={handleManualInputChange}
+                    manualTextInputRef={manualTextInputRef}
+                    manualNumberFormRef={manualNumberFormRef}
+                />
+            </TabScreenWithFocusTrapWrapper>
+        ),
+        [currentDistance, distanceUnit, submitManualDistance, manualFormError, handleManualInputChange],
+    );
+
+    if (isEditing) {
+        return (
+            <StepScreenWrapper
+                headerTitle={translate('common.distance')}
+                onBackButtonPress={navigateBack}
+                testID="IOURequestStepDistance"
+                shouldShowNotFoundPage={!currentTransaction?.comment?.waypoints || shouldShowNotFoundPage}
+                shouldShowWrapper
+            >
+                <OnyxTabNavigator
+                    id={CONST.TAB.DISTANCE_EDIT_TYPE}
+                    defaultSelectedTab={CONST.TAB_REQUEST.DISTANCE_MAP}
+                    tabBar={TabSelector}
+                >
+                    <TopTab.Screen name={CONST.TAB_REQUEST.DISTANCE_MAP}>{renderMapTab}</TopTab.Screen>
+                    <TopTab.Screen name={CONST.TAB_REQUEST.DISTANCE_MANUAL}>{renderManualTab}</TopTab.Screen>
+                </OnyxTabNavigator>
+            </StepScreenWrapper>
+        );
+    }
+
     return (
         <StepScreenWrapper
             headerTitle={translate('common.distance')}
             onBackButtonPress={navigateBack}
             testID="IOURequestStepDistance"
-            shouldShowNotFoundPage={(isEditing && !currentTransaction?.comment?.waypoints) || shouldShowNotFoundPage}
+            shouldShowNotFoundPage={shouldShowNotFoundPage}
             shouldShowWrapper={!isCreatingNewRequest}
         >
-            <View style={[styles.flex1, isInLandscapeMode && styles.flexRow]}>
-                {isInLandscapeMode && (
-                    <View style={styles.flex1}>
-                        <DistanceRequestFooter
-                            waypoints={waypoints}
-                            navigateToWaypointEditPage={navigateToWaypointEditPage}
-                            transaction={transaction}
-                            policy={policy}
-                            mapContainerStyle={{minHeight: undefined}}
-                        />
-                    </View>
-                )}
-                <View style={[styles.flex1, isInLandscapeMode && styles.pl2]}>
-                    <DraggableList
-                        data={waypointItems}
-                        keyExtractor={extractKey}
-                        onDragEnd={updateWaypoints}
-                        ref={scrollViewRef}
-                        renderItem={renderItem}
-                        ListFooterComponent={
-                            !isInLandscapeMode ? (
-                                <DistanceRequestFooter
-                                    waypoints={waypoints}
-                                    navigateToWaypointEditPage={navigateToWaypointEditPage}
-                                    transaction={transaction}
-                                    policy={policy}
-                                />
-                            ) : undefined
-                        }
-                    />
-                    <View style={[styles.w100, styles.pt2]}>
-                        {/* Show error message if there is route error or there are less than 2 routes and user has tried submitting, */}
-                        {((shouldShowAtLeastTwoDifferentWaypointsError && atLeastTwoDifferentWaypointsError) || duplicateWaypointsError || hasRouteError) && (
-                            <DotIndicatorMessage
-                                style={[styles.mh4, styles.mv3]}
-                                messages={getError()}
-                                type="error"
-                            />
-                        )}
-                        <Button
-                            success
-                            allowBubble
-                            pressOnEnter
-                            large
-                            style={[styles.w100, styles.mb5, styles.ph5, styles.flexShrink0]}
-                            onPress={submitWaypoints}
-                            text={buttonText}
-                            isLoading={!isOffline && (isLoadingRoute || shouldFetchRoute || isLoading)}
-                            sentryLabel={CONST.SENTRY_LABEL.IOU_REQUEST_STEP.DISTANCE_NEXT_BUTTON}
-                        />
-                    </View>
-                </View>
-            </View>
+            <DistanceMapTabContent
+                waypointItems={waypointItems}
+                waypoints={waypoints}
+                extractKey={extractKey}
+                updateWaypoints={updateWaypoints}
+                scrollViewRef={scrollViewRef}
+                renderItem={renderItem}
+                navigateToWaypointEditPage={navigateToWaypointEditPage}
+                transaction={transaction}
+                policy={policy}
+                submitWaypoints={submitWaypoints}
+                buttonText={buttonText}
+                errorState={errorState}
+                loadingState={loadingState}
+            />
         </StepScreenWrapper>
     );
 }

--- a/src/pages/iou/request/step/IOURequestStepDistance.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistance.tsx
@@ -588,12 +588,10 @@ function IOURequestStepDistance({
         // For a map-based distance edit, require valid waypoints even when saving from the Manual tab.
         // Without this, clearing waypoints on the Map tab and then saving on Manual would persist a
         // half-broken transaction and surface "Please select a valid waypoint" only post-save. Surface
-        // the error inline on the Manual tab pointing the user back to the Map tab — the existing
-        // address-based copy ("at least two different addresses") would be confusing here since the
-        // Manual tab has no address inputs.
+        // the existing waypoint error inline on the Manual tab so the user sees it immediately.
         const wasOriginallyMapDistance = !isEmpty(transactionBackup?.comment?.waypoints);
         if (wasOriginallyMapDistance && (duplicateWaypointsError || atLeastTwoDifferentWaypointsError || hasRouteError)) {
-            setManualFormError(translate('iou.error.fixWaypointsOnMapTab'));
+            setManualFormError(translate('iou.error.atLeastTwoDifferentWaypoints'));
             return;
         }
 

--- a/src/pages/iou/request/step/IOURequestStepDistance.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistance.tsx
@@ -192,7 +192,13 @@ function IOURequestStepDistance({
     const distanceUnit = mileageRate.unit;
     const distanceRate = mileageRate.rate ?? 0;
     const currentTransactionDistanceUnit = currentTransaction?.comment?.customUnit?.distanceUnit;
-    const distanceInMeters = getDistanceInMeters(currentTransaction, currentTransactionDistanceUnit ?? distanceUnit);
+    const currentDistanceInMeters = getDistanceInMeters(currentTransaction, currentTransactionDistanceUnit ?? distanceUnit);
+    // While a new route is in flight (the user added/edited a waypoint on the Map tab), `saveWaypoint`
+    // clears `customUnit.quantity` and `routes.route0.distance` to null, so `getDistanceInMeters` returns
+    // 0. Fall back to the pre-edit `transactionBackup` distance so switching to the Manual tab keeps
+    // showing the previous value instead of "0 mi" until the BE returns the new route.
+    const distanceInMeters =
+        currentDistanceInMeters > 0 ? currentDistanceInMeters : getDistanceInMeters(transactionBackup, transactionBackup?.comment?.customUnit?.distanceUnit ?? distanceUnit);
     const currentDistance = useMemo(
         () => (distanceInMeters > 0 ? roundToTwoDecimalPlaces(DistanceRequestUtils.convertDistanceUnit(distanceInMeters, distanceUnit)) : undefined),
         [distanceInMeters, distanceUnit],
@@ -330,8 +336,15 @@ function IOURequestStepDistance({
     }, [backTo]);
 
     const navigateBackAfterSave = useCallback(() => {
+        // When editing an individual split, the previous RHP screen is the edit-split page the user
+        // wants to return to — `closeRHPFlow` would tear it down too. Use `goBack` so the RHP stays
+        // open at the edit-split page.
+        if (isEditingSplit) {
+            Navigation.goBack(backTo);
+            return;
+        }
         Navigation.closeRHPFlow();
-    }, []);
+    }, [isEditingSplit, backTo]);
 
     /**
      * Takes the user to the page for editing a specific waypoint
@@ -571,6 +584,19 @@ function IOURequestStepDistance({
 
     const submitManualDistance = useCallback(() => {
         isManuallyEditing.current = false;
+
+        // For a map-based distance edit, require valid waypoints even when saving from the Manual tab.
+        // Without this, clearing waypoints on the Map tab and then saving on Manual would persist a
+        // half-broken transaction and surface "Please select a valid waypoint" only post-save. Surface
+        // the error inline on the Manual tab pointing the user back to the Map tab — the existing
+        // address-based copy ("at least two different addresses") would be confusing here since the
+        // Manual tab has no address inputs.
+        const wasOriginallyMapDistance = !isEmpty(transactionBackup?.comment?.waypoints);
+        if (wasOriginallyMapDistance && (duplicateWaypointsError || atLeastTwoDifferentWaypointsError || hasRouteError)) {
+            setManualFormError(translate('iou.error.fixWaypointsOnMapTab'));
+            return;
+        }
+
         const value = manualNumberFormRef.current?.getNumber() ?? '';
         if (!value.length || parseFloat(value) <= 0) {
             setManualFormError(translate('iou.error.invalidDistance'));
@@ -652,6 +678,9 @@ function IOURequestStepDistance({
         isASAPSubmitBetaEnabled,
         parentReportNextStep,
         recentWaypoints,
+        duplicateWaypointsError,
+        atLeastTwoDifferentWaypointsError,
+        hasRouteError,
     ]);
 
     const renderItem = useCallback(

--- a/src/pages/iou/request/step/IOURequestStepDistanceMap.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceMap.tsx
@@ -1,21 +1,15 @@
 import {deepEqual} from 'fast-equals';
 import isEmpty from 'lodash/isEmpty';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {View} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import type {ScrollView as RNScrollView} from 'react-native';
 import type {RenderItemParams} from 'react-native-draggable-flatlist/lib/typescript/types';
 import type {OnyxEntry} from 'react-native-onyx';
-import Button from '@components/Button';
-import DistanceRequestFooter from '@components/DistanceRequest/DistanceRequestFooter';
 import DistanceRequestRenderItem from '@components/DistanceRequest/DistanceRequestRenderItem';
-import DotIndicatorMessage from '@components/DotIndicatorMessage';
-import DraggableList from '@components/DraggableList';
 import withCurrentUserPersonalDetails from '@components/withCurrentUserPersonalDetails';
 import type {WithCurrentUserPersonalDetailsProps} from '@components/withCurrentUserPersonalDetails';
 import useDefaultExpensePolicy from '@hooks/useDefaultExpensePolicy';
 import useFetchRoute from '@hooks/useFetchRoute';
-import useIsInLandscapeMode from '@hooks/useIsInLandscapeMode';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -28,7 +22,6 @@ import useReportAttributes from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useSelfDMReport from '@hooks/useSelfDMReport';
 import useShowNotFoundPageInIOUStep from '@hooks/useShowNotFoundPageInIOUStep';
-import useThemeStyles from '@hooks/useThemeStyles';
 import useWaypointItems from '@hooks/useWaypointItems';
 import {setMoneyRequestAmount} from '@libs/actions/IOU';
 import {handleMoneyRequestStepDistanceNavigation} from '@libs/actions/IOU/MoneyRequest';
@@ -45,7 +38,7 @@ import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {shouldUseTransactionDraft} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {isPolicyExpenseChat as isPolicyExpenseChatUtil} from '@libs/ReportUtils';
-import {getDistanceInMeters, getRateID, getRequestType, hasRoute, isCustomUnitRateIDForP2P, isWaypointNullIsland} from '@libs/TransactionUtils';
+import {getDistanceInMeters, getRateID, getRequestType, hasRoute, haveWaypointAddressesChanged, isCustomUnitRateIDForP2P, isWaypointNullIsland} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -58,6 +51,7 @@ import type {Waypoint, WaypointCollection} from '@src/types/onyx/Transaction';
 import type Transaction from '@src/types/onyx/Transaction';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type TransactionStateType from '@src/types/utils/TransactionStateType';
+import DistanceMapTabContent from './DistanceMapTabContent';
 import StepScreenWrapper from './StepScreenWrapper';
 import withFullTransactionOrNotFound from './withFullTransactionOrNotFound';
 import type {WithWritableReportOrNotFoundProps} from './withWritableReportOrNotFound';
@@ -77,8 +71,6 @@ function IOURequestStepDistanceMap({
     transaction,
     currentUserPersonalDetails,
 }: IOURequestStepDistanceMapProps) {
-    const styles = useThemeStyles();
-    const isInLandscapeMode = useIsInLandscapeMode();
     const {isOffline} = useNetwork();
     const {translate} = useLocalize();
     const {isBetaEnabled} = usePermissions();
@@ -375,7 +367,7 @@ function IOURequestStepDistanceMap({
         conciergeReportID,
     ]);
 
-    const getError = () => {
+    const getError = useCallback(() => {
         // Get route error if available else show the invalid number of waypoints error.
         if (hasRouteError) {
             return getLatestErrorField(currentTransaction, 'route');
@@ -390,7 +382,7 @@ function IOURequestStepDistanceMap({
             return {atLeastTwoDifferentWaypointsError: translate('iou.error.atLeastTwoDifferentWaypoints')} as Errors;
         }
         return {};
-    };
+    }, [hasRouteError, isWaypointsNullIslandError, duplicateWaypointsError, atLeastTwoDifferentWaypointsError, currentTransaction, translate]);
 
     type DataParams = {
         data: string[];
@@ -446,11 +438,8 @@ function IOURequestStepDistanceMap({
 
             // If nothing was changed, simply go to transaction thread
             // We compare only addresses because numbers are rounded while backup
-            const oldWaypoints = transactionBackup?.comment?.waypoints ?? {};
-            const oldAddresses = Object.fromEntries(Object.entries(oldWaypoints).map(([key, waypoint]) => [key, 'address' in waypoint ? waypoint.address : {}]));
-            const addresses = Object.fromEntries(Object.entries(waypoints).map(([key, waypoint]) => [key, 'address' in waypoint ? waypoint.address : {}]));
             const hasRouteChanged = !deepEqual(transactionBackup?.routes, transaction?.routes);
-            if (deepEqual(oldAddresses, addresses)) {
+            if (!haveWaypointAddressesChanged(transactionBackup?.comment?.waypoints, waypoints)) {
                 navigateBack();
                 return;
             }
@@ -525,6 +514,13 @@ function IOURequestStepDistanceMap({
         [isLoadingRoute, navigateToWaypointEditPage, waypoints, getWaypointKey],
     );
 
+    const errorState = useMemo(
+        () => ({shouldShowAtLeastTwoDifferentWaypointsError, atLeastTwoDifferentWaypointsError, duplicateWaypointsError, hasRouteError, getError}),
+        [shouldShowAtLeastTwoDifferentWaypointsError, atLeastTwoDifferentWaypointsError, duplicateWaypointsError, hasRouteError, getError],
+    );
+
+    const loadingState = useMemo(() => ({isOffline, isLoadingRoute, shouldFetchRoute, isLoading}), [isOffline, isLoadingRoute, shouldFetchRoute, isLoading]);
+
     return (
         <StepScreenWrapper
             headerTitle={translate('common.distance')}
@@ -533,59 +529,21 @@ function IOURequestStepDistanceMap({
             shouldShowNotFoundPage={(isEditing && !currentTransaction?.comment?.waypoints) || shouldShowNotFoundPage}
             shouldShowWrapper={!isCreatingNewRequest}
         >
-            <View style={[styles.flex1, isInLandscapeMode && styles.flexRow]}>
-                {isInLandscapeMode && (
-                    <View style={styles.flex1}>
-                        <DistanceRequestFooter
-                            waypoints={waypoints}
-                            navigateToWaypointEditPage={navigateToWaypointEditPage}
-                            transaction={transaction}
-                            policy={policy}
-                            mapContainerStyle={{minHeight: undefined}}
-                        />
-                    </View>
-                )}
-                <View style={[styles.flex1, isInLandscapeMode && styles.pl2]}>
-                    <DraggableList
-                        data={waypointItems}
-                        keyExtractor={extractKey}
-                        onDragEnd={updateWaypoints}
-                        ref={scrollViewRef}
-                        renderItem={renderItem}
-                        ListFooterComponent={
-                            !isInLandscapeMode ? (
-                                <DistanceRequestFooter
-                                    waypoints={waypoints}
-                                    navigateToWaypointEditPage={navigateToWaypointEditPage}
-                                    transaction={transaction}
-                                    policy={policy}
-                                />
-                            ) : undefined
-                        }
-                    />
-                    <View style={[styles.w100, styles.pt2]}>
-                        {/* Show error message if there is route error or there are less than 2 routes and user has tried submitting, */}
-                        {((shouldShowAtLeastTwoDifferentWaypointsError && atLeastTwoDifferentWaypointsError) || duplicateWaypointsError || hasRouteError) && (
-                            <DotIndicatorMessage
-                                style={[styles.mh4, styles.mv3]}
-                                messages={getError()}
-                                type="error"
-                            />
-                        )}
-                        <Button
-                            success
-                            allowBubble
-                            pressOnEnter
-                            large
-                            style={[styles.w100, styles.mb5, styles.ph5, styles.flexShrink0]}
-                            onPress={submitWaypoints}
-                            text={buttonText}
-                            isLoading={!isOffline && (isLoadingRoute || shouldFetchRoute || isLoading)}
-                            sentryLabel={CONST.SENTRY_LABEL.IOU_REQUEST_STEP.DISTANCE_MAP_NEXT_BUTTON}
-                        />
-                    </View>
-                </View>
-            </View>
+            <DistanceMapTabContent
+                waypointItems={waypointItems}
+                waypoints={waypoints}
+                extractKey={extractKey}
+                updateWaypoints={updateWaypoints}
+                scrollViewRef={scrollViewRef}
+                renderItem={renderItem}
+                navigateToWaypointEditPage={navigateToWaypointEditPage}
+                transaction={transaction}
+                policy={policy}
+                submitWaypoints={submitWaypoints}
+                buttonText={buttonText}
+                errorState={errorState}
+                loadingState={loadingState}
+            />
         </StepScreenWrapper>
     );
 }

--- a/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
+++ b/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
@@ -33,6 +33,7 @@ import {
     getRateID,
     getTaxValue,
     getValidWaypoints,
+    isDistanceRequest as isDistanceRequestTransactionUtils,
     isGPSDistanceRequest as isGPSDistanceRequestTransactionUtils,
     isManualDistanceRequest as isManualDistanceRequestTransactionUtils,
 } from '@libs/TransactionUtils';
@@ -313,7 +314,16 @@ function useExpenseSubmission(params: UseExpenseSubmissionParams) {
                 action,
                 transactionParams: {
                     amount: itemAmount,
-                    distance: isManualDistanceRequest && typeof item.comment?.customUnit?.quantity === 'number' ? roundToTwoDecimalPlaces(item.comment.customUnit.quantity) : undefined,
+                    // Pass the stored quantity for any distance request so that a manually-edited distance
+                    // on a map-based expense survives `convertTrackedExpenseToRequest`. Without this, BE
+                    // would recompute the distance from waypoints and drop the user's edit. Check the
+                    // per-item transaction (not the page-level `isDistanceRequest` prop) because in
+                    // submit-from-self-DM flows the page-level transaction can be a draft optimistic one
+                    // that hasn't yet inherited the distance custom unit.
+                    distance:
+                        isDistanceRequestTransactionUtils(item) && typeof item.comment?.customUnit?.quantity === 'number'
+                            ? roundToTwoDecimalPlaces(item.comment.customUnit.quantity)
+                            : undefined,
                     attendees: item.comment?.attendees,
                     currency: itemCurrency,
                     created: item.created,

--- a/tests/ui/IOURequestStepDistanceTest.tsx
+++ b/tests/ui/IOURequestStepDistanceTest.tsx
@@ -2,7 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import {act, render, screen} from '@testing-library/react-native';
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {act, fireEvent, render, screen} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersonalDetailsProvider';
@@ -60,6 +61,10 @@ jest.mock('@libs/actions/IOU', () => {
     };
 });
 
+jest.mock('@libs/actions/IOU/UpdateMoneyRequest', () => ({
+    updateMoneyRequestDistance: jest.fn(),
+}));
+
 jest.mock('@libs/actions/IOU/MoneyRequest', () => ({
     handleMoneyRequestStepDistanceNavigation: jest.fn(),
 }));
@@ -85,6 +90,22 @@ jest.mock('@libs/actions/TransactionEdit', () => ({
 jest.mock('@components/ProductTrainingContext', () => ({
     useProductTrainingContext: () => [false],
 }));
+
+jest.mock('@libs/Navigation/OnyxTabNavigator', () => {
+    const React2 = require('react');
+    const OnyxTabNavigator = ({children}: {children: React.ReactNode}) => React2.createElement(React2.Fragment, null, children);
+    const TopTab = {
+        Screen: ({children}: {children: () => React.ReactNode}) => React2.createElement(React2.Fragment, null, typeof children === 'function' ? children() : children),
+    };
+    const TabScreenWithFocusTrapWrapper = ({children}: {children: React.ReactNode}) => React2.createElement(React2.Fragment, null, children);
+    return {
+        __esModule: true,
+        default: OnyxTabNavigator,
+        TopTab,
+        TabScreenWithFocusTrapWrapper,
+    };
+});
+jest.mock('@hooks/useShowNotFoundPageInIOUStep', () => () => false);
 jest.mock('@src/hooks/useResponsiveLayout');
 
 jest.mock('@libs/Navigation/navigationRef', () => ({
@@ -167,7 +188,7 @@ function createTestReport(): Report {
     };
 }
 
-function createDistanceTransaction(): Transaction {
+function createDistanceTransaction(overrides?: Partial<Transaction>): Transaction {
     const transaction = createRandomTransaction(1);
     return {
         ...transaction,
@@ -180,8 +201,41 @@ function createDistanceTransaction(): Transaction {
                 waypoint0: {address: '123 Main St', lat: 40.7128, lng: -74.006, keyForList: 'start_waypoint'},
                 waypoint1: {address: '456 Oak Ave', lat: 40.7589, lng: -73.9851, keyForList: 'stop_waypoint'},
             },
+            customUnit: {
+                customUnitID: 'test-unit-id',
+                customUnitRateID: 'test-rate-id',
+                name: 'Distance',
+                distanceUnit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES,
+                quantity: 100,
+            },
+            ...overrides?.comment,
         },
+        ...overrides,
     };
+}
+
+function renderEditMode() {
+    return render(
+        <OnyxListItemProvider>
+            <CurrentUserPersonalDetailsProvider>
+                <IOURequestStepDistance
+                    route={{
+                        key: 'Money_Request_Step_Distance-test',
+                        name: SCREENS.MONEY_REQUEST.STEP_DISTANCE,
+                        params: {
+                            action: CONST.IOU.ACTION.EDIT as never,
+                            iouType: CONST.IOU.TYPE.SUBMIT,
+                            reportID: REPORT_ID,
+                            transactionID: TRANSACTION_ID,
+                            backTo: undefined as never,
+                        },
+                    }}
+                    // @ts-expect-error minimal navigation for test
+                    navigation={undefined}
+                />
+            </CurrentUserPersonalDetailsProvider>
+        </OnyxListItemProvider>,
+    );
 }
 
 describe('IOURequestStepDistance - draft transactions coverage', () => {
@@ -278,5 +332,125 @@ describe('IOURequestStepDistance - draft transactions coverage', () => {
 
         // Component rendered with multiple draft transaction IDs available
         expect(screen.getByAccessibilityHint(/123 Main St/)).toBeTruthy();
+    });
+});
+
+describe('IOURequestStepDistance - submitManualDistance', () => {
+    const {updateMoneyRequestDistance} = jest.requireMock<{updateMoneyRequestDistance: jest.Mock}>('@libs/actions/IOU/UpdateMoneyRequest');
+
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+            evictableKeys: [ONYXKEYS.COLLECTION.REPORT_ACTIONS],
+        });
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('should show validation error for empty distance input', async () => {
+        await signInWithTestUser(ACCOUNT_ID, ACCOUNT_LOGIN);
+        const transaction = createDistanceTransaction();
+        const report = createTestReport();
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${TRANSACTION_ID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${TRANSACTION_ID}`, null);
+            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
+        });
+
+        renderEditMode();
+        await waitForBatchedUpdatesWithAct();
+
+        // The Save button from the manual tab should be visible (mock renders both tabs)
+        const saveButtons = screen.getAllByText('common.save');
+        expect(saveButtons.length).toBeGreaterThan(0);
+
+        // Press Save without changing the value — the form starts with the current distance
+        // so we need to clear it first to test empty validation
+        const distanceInput = screen.getAllByLabelText(/common\.distance/).at(0)!;
+        fireEvent.changeText(distanceInput, '');
+
+        fireEvent.press(saveButtons.at(0)!);
+
+        // updateMoneyRequestDistance should NOT have been called
+        expect(updateMoneyRequestDistance).not.toHaveBeenCalled();
+    });
+
+    it('should render manual distance input with current distance in edit mode', async () => {
+        await signInWithTestUser(ACCOUNT_ID, ACCOUNT_LOGIN);
+        const transaction = createDistanceTransaction();
+        const report = createTestReport();
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${TRANSACTION_ID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${TRANSACTION_ID}`, null);
+            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
+        });
+
+        renderEditMode();
+        await waitForBatchedUpdatesWithAct();
+
+        // The manual distance input should display the current quantity value
+        const distanceInputs = screen.getAllByLabelText(/common\.distance/);
+        expect(distanceInputs.length).toBeGreaterThan(0);
+
+        // Save button should be visible
+        const saveButtons = screen.getAllByText('common.save');
+        expect(saveButtons.length).toBeGreaterThan(0);
+    });
+
+    it('should not call updateMoneyRequestDistance when Save is pressed without valid changes', async () => {
+        await signInWithTestUser(ACCOUNT_ID, ACCOUNT_LOGIN);
+        const transaction = createDistanceTransaction();
+        const report = createTestReport();
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${TRANSACTION_ID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${TRANSACTION_ID}`, null);
+            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
+        });
+
+        renderEditMode();
+        await waitForBatchedUpdatesWithAct();
+
+        // Press Save — the distance value has not been changed via the number pad
+        const saveButtons = screen.getAllByText('common.save');
+        fireEvent.press(saveButtons.at(0)!);
+
+        // updateMoneyRequestDistance should not be called (either validation blocks or no-change early return)
+        expect(updateMoneyRequestDistance).not.toHaveBeenCalled();
+    });
+
+    it('should render both Map and Manual tabs with correct content in edit mode', async () => {
+        await signInWithTestUser(ACCOUNT_ID, ACCOUNT_LOGIN);
+        const transaction = createDistanceTransaction();
+        const report = createTestReport();
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${TRANSACTION_ID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${TRANSACTION_ID}`, null);
+            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
+        });
+
+        renderEditMode();
+        await waitForBatchedUpdatesWithAct();
+
+        // Map tab content: waypoint addresses should be visible
+        expect(screen.getByAccessibilityHint(/123 Main St/)).toBeTruthy();
+        expect(screen.getByAccessibilityHint(/456 Oak Ave/)).toBeTruthy();
+
+        // Manual tab content: distance input and Save button should be present
+        const distanceInputs = screen.getAllByLabelText(/common\.distance/);
+        expect(distanceInputs.length).toBeGreaterThan(0);
+        const saveButtons = screen.getAllByText('common.save');
+        expect(saveButtons.length).toBeGreaterThan(0);
     });
 });

--- a/tests/ui/components/IOURequestStepDistanceTest.tsx
+++ b/tests/ui/components/IOURequestStepDistanceTest.tsx
@@ -56,6 +56,20 @@ jest.mock('@libs/EmojiTrie', () => ({
 jest.mock('@components/ProductTrainingContext', () => ({
     useProductTrainingContext: () => [false],
 }));
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
+jest.mock('@libs/Navigation/OnyxTabNavigator', () => {
+    const ReactMock = require('react');
+    return {
+        __esModule: true,
+        default: ({children}: {children: React.ReactNode}) => ReactMock.createElement(ReactMock.Fragment, null, children),
+        TopTab: {
+            Screen: ({children}: {children: () => React.ReactNode}) => ReactMock.createElement(ReactMock.Fragment, null, typeof children === 'function' ? children() : children),
+        },
+        TabScreenWithFocusTrapWrapper: ({children}: {children: React.ReactNode}) => ReactMock.createElement(ReactMock.Fragment, null, children),
+    };
+});
+
 jest.mock('@src/hooks/useResponsiveLayout');
 
 jest.mock('@libs/Navigation/navigationRef', () => ({


### PR DESCRIPTION
👋 @francoisl - please don’t revert this PR. We’ll assess any blockers raised by QA on staging. If there are any showstoppers, we’ll get [this PR](https://github.com/Expensify/App/pull/89976) CP’d to staging to hide the manual tab temporarily if needs be.
___
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/83781

Regression tests:
https://github.com/Expensify/App/issues/89841
https://github.com/Expensify/App/issues/89842
https://github.com/Expensify/App/issues/89843
https://github.com/Expensify/App/issues/89844
https://github.com/Expensify/App/issues/89847
https://github.com/Expensify/App/issues/89849
PROPOSAL: https://github.com/Expensify/App/issues/83781#issuecomment-3976357287


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

https://github.com/Expensify/App/issues/89841:
1. Go to workspace chat.
2. Create a distance expense.
3. Open the expense.
4. Click Distance.
5. Add a new waypoint and save it.
- Verify new map receipt will be generated after editing distance.

https://github.com/Expensify/App/issues/89842:
1. Go to workspace chat.
2. Create a distance expense.
3. Open the expense.
4. Click Distance.
5. Add a new waypoint.
6. Go to Manual tab.
- Verify Manual tab will show the new distance.

https://github.com/Expensify/App/issues/89843: 
1. Go to workspace chat.
2. Create a distance expense.
3. Open the expense.
4. Click More > Split.
5. Open any split.
6. Click Distance > Manual tab (or Map tab).
7. Edit distance and save it.
- Verify RHP will return to edit split page.

https://github.com/Expensify/App/issues/89844: 
1. Go to workspace chat.
2. Create a distance expense.
3. Open the expense.
4. Click Distance.
5. Clear the waypoints.
6. Go to Manual tab.
7. Enter distance and save it.
- Verify you see Please enter at least two different addresses and cannot save

https://github.com/Expensify/App/issues/89847:
1. Go to workspace chat.
2. Create a map distance expense.
3. Open the expense.
4. Click Distance.
5. Go to Manual tab.
6. Edit the distance and save it.
7. Click Report field > Remove from report.
8. Go to self DM.
9. Open the distance expense.
10. Click on the header > Submit it to someone.
11. Select workspace chat.
  → Confirm page shows the edited distance from Step 7.
12. Click Create expense.
13. Open the expense.
- Verify the edited distance will persist after submitting the distance expense from self DM.

https://github.com/Expensify/App/issues/89849:
1. Go to workspace chat.
2. Create a distance expense.
3. Go to workspace settings > DIstance rates.
4. Click Settings > Unit.
5. Select a different unit.
6. Open distance expense in Step 3.
7. Go offline.
8. Click Distance > Go to Manual tab.
9. Click Save.
- Verify distance field will show the converted distance with new unit.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
The same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details> 