### PR TITLE
Fix Distance expense - Undefault distance rate is not displayed when duplicate wp offline

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -303,16 +303,27 @@ function cloneCustomUnitWithNewIDs(unit: CustomUnit, newCustomUnitID: string, ne
         // The server-side DUPLICATE_POLICY assigns newDefaultRateID to the source's default rate.
         // Mirror getDefaultMileageRate's selection (enabled rates, sorted by index with
         // CONST.DEFAULT_NUMBER_ID for missing indexes) so the optimistic clone aligns with the
-        // rate the expense flow will later treat as default. Other source rates get fresh server
-        // IDs, so we drop them from the optimistic state to avoid stale duplicates.
+        // rate the expense flow will later treat as default. Non-default rates keep their source
+        // IDs so they remain visible offline; successData clears them after the API succeeds so
+        // the server response can repopulate with fresh server IDs without leaving duplicates.
         const defaultRate = Object.values(unit.rates)
             .filter((rate) => rate.enabled !== false)
             .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
             .at(0);
+        const rates: Record<string, Rate> = {};
+        for (const rate of Object.values(unit.rates)) {
+            if (rate.customUnitRateID === defaultRate?.customUnitRateID) {
+                continue;
+            }
+            rates[rate.customUnitRateID] = rate;
+        }
+        if (defaultRate) {
+            rates[newDefaultRateID] = {...defaultRate, customUnitRateID: newDefaultRateID};
+        }
         return {
             ...unit,
             customUnitID: newCustomUnitID,
-            rates: defaultRate ? {[newDefaultRateID]: {...defaultRate, customUnitRateID: newDefaultRateID}} : {},
+            rates,
         };
     }
 

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -316,14 +316,10 @@ function getDefaultDistanceRate(rates: Record<string, Rate> | undefined): Rate |
 
 function cloneCustomUnitWithNewIDs(unit: CustomUnit, newCustomUnitID: string, newDefaultRateID?: string): CustomUnit {
     if (newDefaultRateID) {
-        // The server-side DUPLICATE_POLICY assigns newDefaultRateID to the source's default rate
-        // and preserves the source's rate IDs for non-default rates in the duplicated workspace.
-        // Mirror that here: rebind the default to newDefaultRateID, and keep non-default rates with
-        // their source IDs so they remain visible offline and merge cleanly with the server response
-        // (same keys, no optimistic-vs-server duplicates). Iteration order is preserved from the
-        // source (default's key swapped in place) so getDefaultMileageRate's stable sort still picks
-        // the original default when other rates have a missing index (which would otherwise tie at
-        // CONST.DEFAULT_NUMBER_ID).
+        // Mirror DUPLICATE_POLICY: rebind the source default to newDefaultRateID, keep other rates
+        // under their source IDs (the server preserves them). Preserve source iteration order so
+        // getDefaultMileageRate's stable sort still picks the original default when rates tie on
+        // index (e.g. a rate with no index falls back to CONST.DEFAULT_NUMBER_ID).
         const defaultRate = getDefaultDistanceRate(unit.rates);
         const rates: Record<string, Rate> = {};
         for (const rate of Object.values(unit.rates)) {

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -298,21 +298,31 @@ function hasEligibleActiveAdminFromWorkspaces(policies: OnyxCollection<Policy> |
     return false;
 }
 
+/**
+ * Pick the rate that the expense flow will treat as default for a distance custom unit's rates
+ * dictionary: filter enabled rates, sort by `index` (treating missing index as CONST.DEFAULT_NUMBER_ID),
+ * and take the first. Mirrors `getDefaultMileageRate`'s selection so optimistic state stays aligned
+ * with the rate the expense flow later picks.
+ */
+function getDefaultDistanceRate(rates: Record<string, Rate> | undefined): Rate | undefined {
+    if (!rates) {
+        return undefined;
+    }
+    return Object.values(rates)
+        .filter((rate) => rate.enabled !== false)
+        .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
+        .at(0);
+}
+
 function cloneCustomUnitWithNewIDs(unit: CustomUnit, newCustomUnitID: string, newDefaultRateID?: string): CustomUnit {
     if (newDefaultRateID) {
         // The server-side DUPLICATE_POLICY assigns newDefaultRateID to the source's default rate.
-        // Mirror getDefaultMileageRate's selection (enabled rates, sorted by index with
-        // CONST.DEFAULT_NUMBER_ID for missing indexes) so the optimistic clone aligns with the
-        // rate the expense flow will later treat as default. Non-default rates keep their source
-        // IDs so they remain visible offline; successData clears them after the API succeeds so
-        // the server response can repopulate with fresh server IDs without leaving duplicates.
-        // Iteration order is preserved from the source (default's key swapped in place) so
-        // getDefaultMileageRate's stable sort still picks the original default when other rates
-        // have a missing index (which would otherwise tie at CONST.DEFAULT_NUMBER_ID).
-        const defaultRate = Object.values(unit.rates)
-            .filter((rate) => rate.enabled !== false)
-            .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
-            .at(0);
+        // Non-default rates keep their source IDs so they remain visible offline; successData clears
+        // them after the API succeeds so the server response can repopulate with fresh server IDs
+        // without leaving duplicates. Iteration order is preserved from the source (default's key
+        // swapped in place) so getDefaultMileageRate's stable sort still picks the original default
+        // when other rates have a missing index (which would otherwise tie at CONST.DEFAULT_NUMBER_ID).
+        const defaultRate = getDefaultDistanceRate(unit.rates);
         const rates: Record<string, Rate> = {};
         for (const rate of Object.values(unit.rates)) {
             if (rate.customUnitRateID === defaultRate?.customUnitRateID) {
@@ -2280,6 +2290,7 @@ export {
     getManagerAccountID,
     isPreferredExporter,
     getCustomUnitsForDuplication,
+    getDefaultDistanceRate,
     getCountOfRequiredTagLists,
     getActiveEmployeeWorkspaces,
     getPolicyRole,

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -316,12 +316,14 @@ function getDefaultDistanceRate(rates: Record<string, Rate> | undefined): Rate |
 
 function cloneCustomUnitWithNewIDs(unit: CustomUnit, newCustomUnitID: string, newDefaultRateID?: string): CustomUnit {
     if (newDefaultRateID) {
-        // The server-side DUPLICATE_POLICY assigns newDefaultRateID to the source's default rate.
-        // Non-default rates keep their source IDs so they remain visible offline; successData clears
-        // them after the API succeeds so the server response can repopulate with fresh server IDs
-        // without leaving duplicates. Iteration order is preserved from the source (default's key
-        // swapped in place) so getDefaultMileageRate's stable sort still picks the original default
-        // when other rates have a missing index (which would otherwise tie at CONST.DEFAULT_NUMBER_ID).
+        // The server-side DUPLICATE_POLICY assigns newDefaultRateID to the source's default rate
+        // and preserves the source's rate IDs for non-default rates in the duplicated workspace.
+        // Mirror that here: rebind the default to newDefaultRateID, and keep non-default rates with
+        // their source IDs so they remain visible offline and merge cleanly with the server response
+        // (same keys, no optimistic-vs-server duplicates). Iteration order is preserved from the
+        // source (default's key swapped in place) so getDefaultMileageRate's stable sort still picks
+        // the original default when other rates have a missing index (which would otherwise tie at
+        // CONST.DEFAULT_NUMBER_ID).
         const defaultRate = getDefaultDistanceRate(unit.rates);
         const rates: Record<string, Rate> = {};
         for (const rate of Object.values(unit.rates)) {

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -306,6 +306,9 @@ function cloneCustomUnitWithNewIDs(unit: CustomUnit, newCustomUnitID: string, ne
         // rate the expense flow will later treat as default. Non-default rates keep their source
         // IDs so they remain visible offline; successData clears them after the API succeeds so
         // the server response can repopulate with fresh server IDs without leaving duplicates.
+        // Iteration order is preserved from the source (default's key swapped in place) so
+        // getDefaultMileageRate's stable sort still picks the original default when other rates
+        // have a missing index (which would otherwise tie at CONST.DEFAULT_NUMBER_ID).
         const defaultRate = Object.values(unit.rates)
             .filter((rate) => rate.enabled !== false)
             .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
@@ -313,12 +316,10 @@ function cloneCustomUnitWithNewIDs(unit: CustomUnit, newCustomUnitID: string, ne
         const rates: Record<string, Rate> = {};
         for (const rate of Object.values(unit.rates)) {
             if (rate.customUnitRateID === defaultRate?.customUnitRateID) {
-                continue;
+                rates[newDefaultRateID] = {...rate, customUnitRateID: newDefaultRateID};
+            } else {
+                rates[rate.customUnitRateID] = rate;
             }
-            rates[rate.customUnitRateID] = rate;
-        }
-        if (defaultRate) {
-            rates[newDefaultRateID] = {...defaultRate, customUnitRateID: newDefaultRateID};
         }
         return {
             ...unit,

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -90,7 +90,14 @@ import Permissions from '@libs/Permissions';
 import * as PersonalDetailsUtils from '@libs/PersonalDetailsUtils';
 import * as PhoneNumber from '@libs/PhoneNumber';
 import * as PolicyUtils from '@libs/PolicyUtils';
-import {getCustomUnitsForDuplication, getMemberAccountIDsForWorkspace, goBackWhenEnableFeature, isControlPolicy, navigateToExpensifyCardPage} from '@libs/PolicyUtils';
+import {
+    getCustomUnitsForDuplication,
+    getDefaultDistanceRate,
+    getMemberAccountIDsForWorkspace,
+    goBackWhenEnableFeature,
+    isControlPolicy,
+    navigateToExpensifyCardPage,
+} from '@libs/PolicyUtils';
 import * as ReportUtils from '@libs/ReportUtils';
 import {hasValidModifiedAmount} from '@libs/TransactionUtils';
 import type {Feature} from '@pages/OnboardingInterestedFeatures/types';
@@ -3236,16 +3243,13 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
     const {customUnitID: distanceCustomUnitID, customUnitRateID} = buildOptimisticDistanceRateCustomUnits(outputCurrency);
     const perDiemCustomUnitID = generateCustomUnitID();
 
-    // Source non-default distance rate IDs — kept in optimistic data so they're visible offline,
-    // then nulled in successData so the server's Pusher response can repopulate with fresh server
-    // IDs without leaving optimistic-vs-server duplicates.
-    const sourceDistanceUnit = Object.values(policy?.customUnits ?? {}).find((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE);
-    const sourceDistanceDefaultRate = sourceDistanceUnit
-        ? Object.values(sourceDistanceUnit.rates)
-              .filter((rate) => rate.enabled !== false)
-              .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
-              .at(0)
-        : undefined;
+    // Source non-default distance rate IDs — kept in optimistic data (by cloneCustomUnitWithNewIDs)
+    // so they're visible offline, then nulled in successData so the server's Pusher response can
+    // repopulate with fresh server IDs without leaving optimistic-vs-server duplicates. Only
+    // computed when the user actually selected distance rates for duplication; otherwise no
+    // optimistic distance unit was created and there's nothing to clean up.
+    const sourceDistanceUnit = parts?.distance ? Object.values(policy?.customUnits ?? {}).find((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE) : undefined;
+    const sourceDistanceDefaultRate = getDefaultDistanceRate(sourceDistanceUnit?.rates);
     const sourceNonDefaultDistanceRateIDs = sourceDistanceUnit
         ? Object.values(sourceDistanceUnit.rates)
               .filter((rate) => rate.customUnitRateID !== sourceDistanceDefaultRate?.customUnitRateID)

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -3236,6 +3236,22 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
     const {customUnitID: distanceCustomUnitID, customUnitRateID} = buildOptimisticDistanceRateCustomUnits(outputCurrency);
     const perDiemCustomUnitID = generateCustomUnitID();
 
+    // Source non-default distance rate IDs — kept in optimistic data so they're visible offline,
+    // then nulled in successData so the server's Pusher response can repopulate with fresh server
+    // IDs without leaving optimistic-vs-server duplicates.
+    const sourceDistanceUnit = Object.values(policy?.customUnits ?? {}).find((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE);
+    const sourceDistanceDefaultRate = sourceDistanceUnit
+        ? Object.values(sourceDistanceUnit.rates)
+              .filter((rate) => rate.enabled !== false)
+              .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
+              .at(0)
+        : undefined;
+    const sourceNonDefaultDistanceRateIDs = sourceDistanceUnit
+        ? Object.values(sourceDistanceUnit.rates)
+              .filter((rate) => rate.customUnitRateID !== sourceDistanceDefaultRate?.customUnitRateID)
+              .map((rate) => rate.customUnitRateID)
+        : [];
+
     const optimisticAnnounceChat = ReportUtils.buildOptimisticAnnounceChat(targetPolicyID, [...policyMemberAccountIDs], currentUserAccountID);
     const announceRoomChat = optimisticAnnounceChat.announceChatData;
 
@@ -3351,6 +3367,13 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
                     type: null,
                     areReportFieldsEnabled: null,
                 },
+                ...(sourceNonDefaultDistanceRateIDs.length > 0 && {
+                    customUnits: {
+                        [distanceCustomUnitID]: {
+                            rates: Object.fromEntries(sourceNonDefaultDistanceRateIDs.map((id) => [id, null])),
+                        },
+                    },
+                }),
             },
         },
         {

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -90,14 +90,7 @@ import Permissions from '@libs/Permissions';
 import * as PersonalDetailsUtils from '@libs/PersonalDetailsUtils';
 import * as PhoneNumber from '@libs/PhoneNumber';
 import * as PolicyUtils from '@libs/PolicyUtils';
-import {
-    getCustomUnitsForDuplication,
-    getDefaultDistanceRate,
-    getMemberAccountIDsForWorkspace,
-    goBackWhenEnableFeature,
-    isControlPolicy,
-    navigateToExpensifyCardPage,
-} from '@libs/PolicyUtils';
+import {getCustomUnitsForDuplication, getMemberAccountIDsForWorkspace, goBackWhenEnableFeature, isControlPolicy, navigateToExpensifyCardPage} from '@libs/PolicyUtils';
 import * as ReportUtils from '@libs/ReportUtils';
 import {hasValidModifiedAmount} from '@libs/TransactionUtils';
 import type {Feature} from '@pages/OnboardingInterestedFeatures/types';
@@ -3243,19 +3236,6 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
     const {customUnitID: distanceCustomUnitID, customUnitRateID} = buildOptimisticDistanceRateCustomUnits(outputCurrency);
     const perDiemCustomUnitID = generateCustomUnitID();
 
-    // Source non-default distance rate IDs — kept in optimistic data (by cloneCustomUnitWithNewIDs)
-    // so they're visible offline, then nulled in successData so the server's Pusher response can
-    // repopulate with fresh server IDs without leaving optimistic-vs-server duplicates. Only
-    // computed when the user actually selected distance rates for duplication; otherwise no
-    // optimistic distance unit was created and there's nothing to clean up.
-    const sourceDistanceUnit = parts?.distance ? Object.values(policy?.customUnits ?? {}).find((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE) : undefined;
-    const sourceDistanceDefaultRate = getDefaultDistanceRate(sourceDistanceUnit?.rates);
-    const sourceNonDefaultDistanceRateIDs = sourceDistanceUnit
-        ? Object.values(sourceDistanceUnit.rates)
-              .filter((rate) => rate.customUnitRateID !== sourceDistanceDefaultRate?.customUnitRateID)
-              .map((rate) => rate.customUnitRateID)
-        : [];
-
     const optimisticAnnounceChat = ReportUtils.buildOptimisticAnnounceChat(targetPolicyID, [...policyMemberAccountIDs], currentUserAccountID);
     const announceRoomChat = optimisticAnnounceChat.announceChatData;
 
@@ -3371,13 +3351,6 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
                     type: null,
                     areReportFieldsEnabled: null,
                 },
-                ...(sourceNonDefaultDistanceRateIDs.length > 0 && {
-                    customUnits: {
-                        [distanceCustomUnitID]: {
-                            rates: Object.fromEntries(sourceNonDefaultDistanceRateIDs.map((id) => [id, null])),
-                        },
-                    },
-                }),
             },
         },
         {

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -866,102 +866,12 @@ describe('actions/Policy', () => {
             }
             expect(distanceUnit.rates[defaultRateID]).toBe(defaultRate);
 
-            // Resume the mocked fetch so successData fires and clears the optimistic source rate IDs.
-            // After success, only the rebound default remains until a Pusher response (not mocked here)
-            // would repopulate the rates with fresh server IDs.
+            // Resume the mocked fetch so the API call resolves; the duplicated workspace's optimistic
+            // rates remain visible until a Pusher response (not mocked here) repopulates them with
+            // the server's rate set. We rely on the server preserving the source's non-default rate
+            // IDs in the duplicate, so the optimistic state and the eventual server state line up.
             await mockFetch.resume?.();
             await waitForBatchedUpdates();
-
-            const duplicateAfterSuccess: OnyxEntry<PolicyType> = await new Promise((resolve) => {
-                const connection = Onyx.connect({
-                    key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-                    callback: (workspace) => {
-                        Onyx.disconnect(connection);
-                        resolve(workspace);
-                    },
-                });
-            });
-
-            const distanceUnitAfter = Object.values(duplicateAfterSuccess?.customUnits ?? {}).find((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE);
-            if (!distanceUnitAfter) {
-                throw new Error('Expected duplicated distance unit to still exist after success');
-            }
-            const ratesAfter = Object.entries(distanceUnitAfter.rates).filter(([, rate]) => rate !== null);
-            expect(ratesAfter).toHaveLength(1);
-            expect(ratesAfter.at(0)?.[1]?.name).toBe('Default Rate');
-        });
-
-        it('duplicate workspace without distance rates does not write any customUnits cleanup for the source distance rates', async () => {
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
-
-            const sourceDistanceUnitID = 'srcDistUnitB';
-            const sourceExtraRateID = 'srcExtraRateB';
-            const fakePolicy: PolicyType = {
-                ...createRandomPolicy(20, CONST.POLICY.TYPE.TEAM),
-                customUnits: {
-                    [sourceDistanceUnitID]: {
-                        customUnitID: sourceDistanceUnitID,
-                        name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
-                        enabled: true,
-                        attributes: {unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
-                        rates: {
-                            srcDefaultRateB: {customUnitRateID: 'srcDefaultRateB', name: 'Default Rate', rate: 72.5, currency: 'USD', enabled: true, index: 0},
-                            [sourceExtraRateID]: {customUnitRateID: sourceExtraRateID, name: 'Extra Rate', rate: 100, currency: 'USD', enabled: true, index: 1},
-                        },
-                    },
-                },
-            };
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
-            await waitForBatchedUpdates();
-
-            const policyID = Policy.generatePolicyID();
-            const options = {
-                currentUserAccountID: ESH_ACCOUNT_ID,
-                currentUserEmail: ESH_EMAIL,
-                policyName: 'No Distance Duplicate',
-                policyID: fakePolicy.id,
-                targetPolicyID: policyID,
-                welcomeNote: 'Join my policy',
-                parts: {
-                    people: false,
-                    reports: false,
-                    connections: false,
-                    categories: false,
-                    tags: false,
-                    taxes: false,
-                    perDiem: false,
-                    reimbursements: false,
-                    expenses: false,
-                    distance: false,
-                    invoices: false,
-                    exportLayouts: false,
-                },
-                localCurrency: 'USD',
-            };
-
-            Policy.duplicateWorkspace(fakePolicy, options);
-            await waitForBatchedUpdates();
-
-            const duplicatePolicy: OnyxEntry<PolicyType> = await new Promise((resolve) => {
-                const connection = Onyx.connect({
-                    key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-                    callback: (workspace) => {
-                        Onyx.disconnect(connection);
-                        resolve(workspace);
-                    },
-                });
-            });
-
-            // The duplicate should not have any distance custom unit because parts.distance is false.
-            // In particular, it should not contain a partial/orphan distance unit consisting only of
-            // nulled-out source rate IDs (which would be the regression the gating prevents).
-            const distanceUnits = Object.values(duplicatePolicy?.customUnits ?? {}).filter((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE);
-            expect(distanceUnits).toHaveLength(0);
-            // The source's extra rate ID must not appear anywhere in the duplicate's customUnits as
-            // a stale "null" entry from successData cleanup.
-            for (const unit of Object.values(duplicatePolicy?.customUnits ?? {})) {
-                expect(Object.keys(unit.rates ?? {})).not.toContain(sourceExtraRateID);
-            }
         });
 
         it('creates a new workspace with BASIC approval mode if the introSelected is MANAGE_TEAM', async () => {

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -773,6 +773,197 @@ describe('actions/Policy', () => {
             expect(messages?.at(0)?.text).toBe(callerEmail);
         });
 
+        it('duplicate workspace with distance rates clones all source rates in optimistic data with the default rebound to the API-known rate ID', async () => {
+            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+
+            const sourceDistanceUnitID = 'srcDistUnit';
+            const sourceDefaultRateID = 'srcDefaultRate';
+            const sourceExtraRateID = 'srcExtraRate';
+            const fakePolicy: PolicyType = {
+                ...createRandomPolicy(19, CONST.POLICY.TYPE.TEAM),
+                customUnits: {
+                    [sourceDistanceUnitID]: {
+                        customUnitID: sourceDistanceUnitID,
+                        name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
+                        enabled: true,
+                        attributes: {unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
+                        rates: {
+                            [sourceDefaultRateID]: {customUnitRateID: sourceDefaultRateID, name: 'Default Rate', rate: 72.5, currency: 'USD', enabled: true, index: 0},
+                            [sourceExtraRateID]: {customUnitRateID: sourceExtraRateID, name: 'Extra Rate', rate: 100, currency: 'USD', enabled: true, index: 1},
+                        },
+                    },
+                },
+            };
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
+            await waitForBatchedUpdates();
+
+            const policyID = Policy.generatePolicyID();
+            const options = {
+                currentUserAccountID: ESH_ACCOUNT_ID,
+                currentUserEmail: ESH_EMAIL,
+                policyName: 'Distance Rates Duplicate',
+                policyID: fakePolicy.id,
+                targetPolicyID: policyID,
+                welcomeNote: 'Join my policy',
+                parts: {
+                    people: false,
+                    reports: false,
+                    connections: false,
+                    categories: false,
+                    tags: false,
+                    taxes: false,
+                    perDiem: false,
+                    reimbursements: false,
+                    expenses: false,
+                    distance: true,
+                    invoices: false,
+                    exportLayouts: false,
+                },
+                localCurrency: 'USD',
+            };
+
+            // Pause the API call so successData (which clears the optimistic source rate IDs) does not
+            // run yet — this lets us inspect the optimistic state the user sees offline.
+            mockFetch.pause();
+            Policy.duplicateWorkspace(fakePolicy, options);
+            await waitForBatchedUpdates();
+
+            const duplicatePolicy: OnyxEntry<PolicyType> = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                    callback: (workspace) => {
+                        Onyx.disconnect(connection);
+                        resolve(workspace);
+                    },
+                });
+            });
+
+            expect(duplicatePolicy?.areDistanceRatesEnabled).toBe(true);
+            const distanceUnit = Object.values(duplicatePolicy?.customUnits ?? {}).find((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE);
+            if (!distanceUnit) {
+                throw new Error('Expected duplicated distance unit');
+            }
+            // The duplicated unit's customUnitID should differ from the source's (fresh ID).
+            expect(distanceUnit.customUnitID).not.toBe(sourceDistanceUnitID);
+            // Both rates should be present in optimistic data: the extra rate keeps its source ID,
+            // and the default is rebound to a fresh API-known customUnitRateID.
+            const rateKeys = Object.keys(distanceUnit.rates);
+            expect(rateKeys).toContain(sourceExtraRateID);
+            expect(rateKeys).not.toContain(sourceDefaultRateID);
+            expect(rateKeys).toHaveLength(2);
+            // The Default Rate should be the one picked by getDefaultDistanceRate (lowest enabled index).
+            const defaultRate = Object.values(distanceUnit.rates)
+                .filter((rate) => rate.enabled !== false)
+                .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
+                .at(0);
+            expect(defaultRate?.name).toBe('Default Rate');
+            expect(defaultRate?.rate).toBe(72.5);
+            // The default rate's customUnitRateID matches its dictionary key (rebound).
+            expect(defaultRate?.customUnitRateID).not.toBe(sourceDefaultRateID);
+            const defaultRateID = defaultRate?.customUnitRateID;
+            if (!defaultRateID) {
+                throw new Error('Expected default rate to have a customUnitRateID');
+            }
+            expect(distanceUnit.rates[defaultRateID]).toBe(defaultRate);
+
+            // Resume the mocked fetch so successData fires and clears the optimistic source rate IDs.
+            // After success, only the rebound default remains until a Pusher response (not mocked here)
+            // would repopulate the rates with fresh server IDs.
+            await mockFetch.resume?.();
+            await waitForBatchedUpdates();
+
+            const duplicateAfterSuccess: OnyxEntry<PolicyType> = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                    callback: (workspace) => {
+                        Onyx.disconnect(connection);
+                        resolve(workspace);
+                    },
+                });
+            });
+
+            const distanceUnitAfter = Object.values(duplicateAfterSuccess?.customUnits ?? {}).find((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE);
+            if (!distanceUnitAfter) {
+                throw new Error('Expected duplicated distance unit to still exist after success');
+            }
+            const ratesAfter = Object.entries(distanceUnitAfter.rates).filter(([, rate]) => rate !== null);
+            expect(ratesAfter).toHaveLength(1);
+            expect(ratesAfter.at(0)?.[1]?.name).toBe('Default Rate');
+        });
+
+        it('duplicate workspace without distance rates does not write any customUnits cleanup for the source distance rates', async () => {
+            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+
+            const sourceDistanceUnitID = 'srcDistUnitB';
+            const sourceExtraRateID = 'srcExtraRateB';
+            const fakePolicy: PolicyType = {
+                ...createRandomPolicy(20, CONST.POLICY.TYPE.TEAM),
+                customUnits: {
+                    [sourceDistanceUnitID]: {
+                        customUnitID: sourceDistanceUnitID,
+                        name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
+                        enabled: true,
+                        attributes: {unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
+                        rates: {
+                            srcDefaultRateB: {customUnitRateID: 'srcDefaultRateB', name: 'Default Rate', rate: 72.5, currency: 'USD', enabled: true, index: 0},
+                            [sourceExtraRateID]: {customUnitRateID: sourceExtraRateID, name: 'Extra Rate', rate: 100, currency: 'USD', enabled: true, index: 1},
+                        },
+                    },
+                },
+            };
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
+            await waitForBatchedUpdates();
+
+            const policyID = Policy.generatePolicyID();
+            const options = {
+                currentUserAccountID: ESH_ACCOUNT_ID,
+                currentUserEmail: ESH_EMAIL,
+                policyName: 'No Distance Duplicate',
+                policyID: fakePolicy.id,
+                targetPolicyID: policyID,
+                welcomeNote: 'Join my policy',
+                parts: {
+                    people: false,
+                    reports: false,
+                    connections: false,
+                    categories: false,
+                    tags: false,
+                    taxes: false,
+                    perDiem: false,
+                    reimbursements: false,
+                    expenses: false,
+                    distance: false,
+                    invoices: false,
+                    exportLayouts: false,
+                },
+                localCurrency: 'USD',
+            };
+
+            Policy.duplicateWorkspace(fakePolicy, options);
+            await waitForBatchedUpdates();
+
+            const duplicatePolicy: OnyxEntry<PolicyType> = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                    callback: (workspace) => {
+                        Onyx.disconnect(connection);
+                        resolve(workspace);
+                    },
+                });
+            });
+
+            // The duplicate should not have any distance custom unit because parts.distance is false.
+            // In particular, it should not contain a partial/orphan distance unit consisting only of
+            // nulled-out source rate IDs (which would be the regression the gating prevents).
+            const distanceUnits = Object.values(duplicatePolicy?.customUnits ?? {}).filter((unit) => unit.name === CONST.CUSTOM_UNITS.NAME_DISTANCE);
+            expect(distanceUnits).toHaveLength(0);
+            // The source's extra rate ID must not appear anywhere in the duplicate's customUnits as
+            // a stale "null" entry from successData cleanup.
+            for (const unit of Object.values(duplicatePolicy?.customUnits ?? {})) {
+                expect(Object.keys(unit.rates ?? {})).not.toContain(sourceExtraRateID);
+            }
+        });
+
         it('creates a new workspace with BASIC approval mode if the introSelected is MANAGE_TEAM', async () => {
             const policyID = Policy.generatePolicyID();
             // When a new workspace is created with introSelected set to MANAGE_TEAM

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -352,7 +352,7 @@ describe('PolicyUtils', () => {
             ).toBeUndefined();
         });
 
-        it('clones the source default rate (lowest enabled index) under the API-known customUnitRateID', () => {
+        it('rebinds the default rate to the API-known customUnitRateID and keeps non-default rates with their source IDs', () => {
             const distanceUnitWithMultipleRates = {
                 customUnitID: 'srcDist',
                 name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
@@ -377,13 +377,14 @@ describe('PolicyUtils', () => {
                     ...distanceUnitWithMultipleRates,
                     customUnitID: 'newDist',
                     rates: {
+                        rateB: {customUnitRateID: 'rateB', name: 'New Rate 1', rate: 100, currency: 'USD', enabled: true, index: 1, attributes: {taxRateExternalID: 'tax_other'}},
                         newRate: {customUnitRateID: 'newRate', name: 'Default Rate', rate: 70, currency: 'USD', enabled: true, index: 0, attributes: {taxRateExternalID: 'tax_default'}},
                     },
                 },
             });
         });
 
-        it('drops all rates when no enabled rate exists', () => {
+        it('keeps source rates with their source IDs when no enabled rate exists', () => {
             const distanceUnitAllDisabled = {
                 customUnitID: 'srcDist',
                 name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
@@ -402,7 +403,9 @@ describe('PolicyUtils', () => {
                 perDiemCustomUnitID: 'newPerDiem',
                 customUnitRateID: 'newRate',
             });
-            expect(result?.newDist.rates).toEqual({});
+            expect(result?.newDist.rates).toEqual({
+                rateA: {customUnitRateID: 'rateA', name: 'Disabled', rate: 50, currency: 'USD', enabled: false, index: 0},
+            });
         });
 
         it('treats missing index as 0 when picking the default rate', () => {
@@ -426,6 +429,7 @@ describe('PolicyUtils', () => {
                 customUnitRateID: 'newRate',
             });
             expect(result?.newDist.rates).toEqual({
+                rateB: {customUnitRateID: 'rateB', name: 'Indexed Rate', rate: 100, currency: 'USD', enabled: true, index: 1},
                 newRate: {customUnitRateID: 'newRate', name: 'No-Index Rate', rate: 70, currency: 'USD', enabled: true},
             });
         });

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -433,6 +433,51 @@ describe('PolicyUtils', () => {
                 newRate: {customUnitRateID: 'newRate', name: 'No-Index Rate', rate: 70, currency: 'USD', enabled: true},
             });
         });
+
+        it('preserves source iteration order so getDefaultMileageRate still picks the original default when a non-default rate has a missing index', () => {
+            // Source has 3 rates: Default (index 0), Indexed (index 1), and No-Index (no index field).
+            // No-Index ties with Default at the index-0 sort key after `?? CONST.DEFAULT_NUMBER_ID`.
+            // The optimistic clone must keep the source's iteration order so JavaScript's stable
+            // sort still places Default before No-Index — otherwise getDefaultMileageRate would
+            // pick whichever tied rate appeared first in iteration order, swapping the default.
+            const sourceUnit = {
+                customUnitID: 'srcDist',
+                name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
+                enabled: true,
+                attributes: {unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
+                rates: {
+                    rateA: {customUnitRateID: 'rateA', name: 'Default Rate', rate: 72.5, currency: 'USD', enabled: true, index: 0},
+                    rateB: {customUnitRateID: 'rateB', name: 'Indexed Rate', rate: 100, currency: 'USD', enabled: true, index: 1},
+                    rateC: {customUnitRateID: 'rateC', name: 'No-Index Rate', rate: 200, currency: 'USD', enabled: true},
+                },
+            };
+            const policyWithTiedIndex: Policy = {
+                ...createRandomPolicy(0),
+                customUnits: {[sourceUnit.customUnitID]: sourceUnit},
+            };
+            const result = getCustomUnitsForDuplication(policyWithTiedIndex, true, false, {
+                distanceCustomUnitID: 'newDist',
+                perDiemCustomUnitID: 'newPerDiem',
+                customUnitRateID: 'newRate',
+            });
+
+            const cloned = result?.newDist;
+            if (!cloned) {
+                throw new Error('Expected cloned distance unit');
+            }
+            // Iteration order: the rebound default should still be first, before the No-Index rate.
+            const orderedKeys = Object.keys(cloned.rates);
+            expect(orderedKeys).toEqual(['newRate', 'rateB', 'rateC']);
+
+            // Sanity-check that getDefaultMileageRate's selection (enabled, sorted by index ?? 0,
+            // first) lands on the rebound default and not on No-Index Rate.
+            const pickedDefault = Object.values(cloned.rates)
+                .filter((rate) => rate.enabled !== false)
+                .sort((a, b) => (a.index ?? CONST.DEFAULT_NUMBER_ID) - (b.index ?? CONST.DEFAULT_NUMBER_ID))
+                .at(0);
+            expect(pickedDefault?.customUnitRateID).toBe('newRate');
+            expect(pickedDefault?.name).toBe('Default Rate');
+        });
     });
     describe('getRateDisplayValue', () => {
         it('should return an empty string for NaN', () => {


### PR DESCRIPTION
### Explanation of Change
PR #89448 (which $ [#86116](https://github.com/Expensify/App/issues/86116) — the "Unexpected error" when creating a distance expense in a duplicated workspace) introduced a regression: the optimistic data for a duplicated workspace dropped all non-default distance rates, expecting the server's Pusher response to repopulate them. That works online, but **offline the server response never arrives**, leaving the duplicated workspace's `Distance rates` page showing only the default rate (deploy blocker [#89865](https://github.com/Expensify/App/issues/89865)).

This PR restores the non-default rates in the optimistic clone so they're visible offline, while keeping #86116's fix intact:

1. `cloneCustomUnitWithNewIDs` (`PolicyUtils.ts`) — now includes all source distance rates in the optimistic clone. The default rate is still rebound to the API-known `customUnitRateID` (so `getDefaultMileageRate` aligns with what the server creates); non-default rates keep their source IDs so they remain visible until the server response merges in.
2. `buildDuplicatePolicyData` (`Policy.ts`) — the existing successData merge for the duplicated policy now also nulls the source non-default rate IDs. When the API resolves, the optimistic source IDs are cleared so the server's Pusher response can repopulate the rates dict with fresh server IDs without leaving optimistic-vs-server duplicates.

### Fixed Issues
$ https://github.com/Expensify/App/issues/89865
PROPOSAL: N/A — deploy blocker fix authored by the same contributor (#89448 author)

### Tests
1. Sign in to a fresh account.
2. Create a workspace (`Workspace 1`).
3. Open `Workspace 1` → `More features` → toggle `Distance rates` on.
4. Open `Distance rates` and tap `Add rate`. Enter `1.00` as the rate amount and tap `Save`. The page now shows two rates: `Default Rate ($0.725 / mile)` and `New Rate ($1.00 / mile)`.
5. Navigate back to `Workspaces` (the workspaces list).
6. Go offline (toggle airplane mode, or in dev tools throttle to Offline).
7. From the workspaces list, tap the three-dot menu on `Workspace 1` → `Duplicate workspace`.
8. Accept the default name (`Workspace 1 (Duplicate)`) and tap `Next`. On the `Select features to copy` page, ensure `Distance rates` is checked (it should already be) and tap `Continue`.
9. Tap the duplicated workspace (`Workspace 1 (Duplicate)`) to open it, then open its `Distance rates` page.
10. **Expected:** the duplicated workspace's `Distance rates` page shows BOTH rates — `Default Rate ($0.725 / mile)` and `New Rate ($1.00 / mile)` — even while offline.
11. Bring the network back online and wait for the optimistic state to sync. Verify the `Distance rates` page still shows exactly two rates (no duplicate / no flicker / no extra rate).
12. Verify that no errors appear in the JS console.

### Offline tests
The Tests above already cover the offline scenario (steps 6-10). Additionally:
1. Repeat the Tests above with the network kept offline indefinitely after step 6. The duplicated workspace's `Distance rates` page should continue to show both rates without ever flickering or losing the non-default rate.
2. Bring the network back online (step 11). The rates should remain stable — both visible, no duplicates added by the server response merge.

### QA Steps
Same as Tests.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/ef5bf32f-d6ff-45d8-b7c5-3305ad8e20b5


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/758b9e3f-33fa-4d18-9f38-49646eebc5a3


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/e9bec2d3-0d27-4fa9-aa4b-a69cd6b325cc


</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/307c4160-a0ef-4f57-bafe-f254ba00b12b


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/41518581-ba70-4555-a9f3-7a22a5689026


</details>