### PR TITLE
[NoQA] Add Android emulator smoke workflow (agent-device · Phase 0)

### DIFF
--- a/.github/scripts/agent-device-smoke.sh
+++ b/.github/scripts/agent-device-smoke.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Phase-0 Android smoke for the Expensify dev APK.
+#
+# Runs INSIDE reactivecircus/android-emulator-runner@v2's `script:` block,
+# which means the emulator is already booted and `adb` sees it. This script
+# installs the APK, brings up Metro, launches the app via agent-device, and
+# captures landing-screen evidence (screenshot, accessibility-tree snapshot,
+# foreground-app dump, logcat). It does NOT log in — Phase 0 is a build-health
+# canary that proves install/launch/JS-bundle delivery without depending on
+# the magic-code login flow.
+
+set -euo pipefail
+
+ART=artifacts
+SESSION=ci
+APP=com.expensify.chat.dev
+APK_GLOB="android/app/build/outputs/apk/development/debug/*.apk"
+METRO_READY_TIMEOUT=120
+
+mkdir -p "$ART"
+
+# Cleanup must run no matter what — kill background jobs and release the
+# agent-device session so a re-run of the workflow doesn't trip the
+# "session already bound" guard.
+cleanup() {
+  set +e
+  agent-device record stop --session "$SESSION" >/dev/null 2>&1
+  agent-device close --session "$SESSION" >/dev/null 2>&1
+  jobs -p | xargs -r kill 2>/dev/null
+}
+trap cleanup EXIT
+
+# Stale state from a previous run on a warm runner.
+agent-device close --session "$SESSION" >/dev/null 2>&1 || true
+
+# Logcat tee — verbose JS, warnings+errors for everything else. Async.
+adb logcat -v time *:W ReactNativeJS:V ReactNative:V > "$ART/logcat.txt" &
+
+SERIAL=$(adb get-serialno)
+echo "::notice::emulator serial=$SERIAL"
+
+# Locate the APK Rock produced earlier in the workflow.
+APK=$(ls -1 $APK_GLOB 2>/dev/null | head -n 1 || true)
+if [ -z "$APK" ]; then
+  echo "::error::no APK found at $APK_GLOB — Rock build step likely failed"
+  exit 1
+fi
+echo "::notice::installing $APK"
+adb install -r -d -t "$APK"
+
+# Dev APK fetches its JS bundle over localhost:8081, which the emulator
+# reaches through the host loopback via adb-reverse.
+adb reverse tcp:8081 tcp:8081
+
+# Bring up Metro in the background; gate on /status before launching.
+npm start >"$ART/metro.log" 2>&1 &
+echo "::group::wait for Metro"
+SECONDS=0
+until curl -sf http://localhost:8081/status 2>/dev/null \
+      | grep -q "packager-status:running"; do
+  if [ "$SECONDS" -ge "$METRO_READY_TIMEOUT" ]; then
+    echo "::error::Metro did not reach packager-status:running within ${METRO_READY_TIMEOUT}s"
+    tail -50 "$ART/metro.log" || true
+    exit 1
+  fi
+  sleep 2
+done
+echo "Metro ready after ${SECONDS}s"
+echo "::endgroup::"
+
+# --relaunch forces a clean process so we capture the cold-start path
+# rather than whatever happened to be running on the runner.
+agent-device open "$APP" \
+  --platform android \
+  --serial "$SERIAL" \
+  --session "$SESSION" \
+  --relaunch
+
+# Splash + initial bundle delivery. 8s is the local-tested floor on
+# Pixel 8 API 35; if the runner is slower we'll still capture the
+# splash, which is itself useful evidence.
+sleep 8
+
+# Optional cold-start MP4. Bounded — we don't want to inherit the
+# 180s `adb screenrecord` cap by accident.
+agent-device record start "$ART/cold-start.mp4" --session "$SESSION" >/dev/null 2>&1 || true
+sleep 8
+agent-device record stop --session "$SESSION" >/dev/null 2>&1 || true
+
+agent-device screenshot "$ART/landing.png" --session "$SESSION"
+agent-device snapshot -i --session "$SESSION" > "$ART/snapshot.txt" || true
+agent-device appstate --session "$SESSION" > "$ART/appstate.txt"
+
+# Hard pass criterion: app must own the foreground. Anything else means
+# we crashed back to launcher (or never launched at all).
+if ! grep -q "Foreground app: $APP" "$ART/appstate.txt"; then
+  echo "::error::app is not in foreground after launch — see artifacts/appstate.txt"
+  cat "$ART/appstate.txt"
+  exit 1
+fi
+
+echo "::notice::smoke OK — app reached landing screen"

--- a/.github/scripts/agent-device-smoke.sh
+++ b/.github/scripts/agent-device-smoke.sh
@@ -3,11 +3,16 @@
 #
 # Runs INSIDE reactivecircus/android-emulator-runner@v2's `script:` block,
 # which means the emulator is already booted and `adb` sees it. This script
-# installs the APK, brings up Metro, launches the app via agent-device, and
-# captures landing-screen evidence (screenshot, accessibility-tree snapshot,
-# foreground-app dump, logcat). It does NOT log in — Phase 0 is a build-health
-# canary that proves install/launch/JS-bundle delivery without depending on
-# the magic-code login flow.
+# installs the APK, brings up Metro, launches the app via agent-device,
+# waits for the SignIn UI to fully hydrate, fills the email field, presses
+# Continue, and verifies the magic-code screen appears. Captures screenshots,
+# snapshots, foreground-app dumps, and logcat along the way.
+#
+# The flow stops short of typing the magic code — that input is a 6-cell
+# composite component that rejects programmatic input in every way we've
+# tried (fill, type, adb shell input text, paste). Solving it properly is
+# Phase 1: a developmentE2eDebug build variant that reads a pre-seeded Onyx
+# state from a 1Password-backed secret.
 
 set -euo pipefail
 
@@ -16,6 +21,9 @@ SESSION=ci
 APP=com.expensify.chat.dev
 APK_GLOB="android/app/build/outputs/apk/development/debug/*.apk"
 METRO_READY_TIMEOUT=120
+SIGNIN_LOAD_TIMEOUT=120 # JS bundle delivery + React mount + Onyx hydrate
+ADVANCE_TIMEOUT=30 # SignIn -> magic-code transition after Continue
+SMOKE_EMAIL=rustam.zeinalov@callstack.com
 
 mkdir -p "$ART"
 
@@ -76,27 +84,81 @@ agent-device open "$APP" \
   --session "$SESSION" \
   --relaunch
 
-# Splash + initial bundle delivery. 8s is the local-tested floor on
-# Pixel 8 API 35; if the runner is slower we'll still capture the
-# splash, which is itself useful evidence.
-sleep 8
-
-# Optional cold-start MP4. Bounded — we don't want to inherit the
-# 180s `adb screenrecord` cap by accident.
+# Cold-start MP4 of the boot animation. Bounded — we don't want to
+# inherit the 180s `adb screenrecord` cap by accident.
 agent-device record start "$ART/cold-start.mp4" --session "$SESSION" >/dev/null 2>&1 || true
-sleep 8
+sleep 6
 agent-device record stop --session "$SESSION" >/dev/null 2>&1 || true
 
+# Wait for the SignIn UI to fully hydrate. An empty interactive snapshot
+# is normal during the splash → JS-bundle → React-mount → Onyx-hydrate
+# sequence, so we poll until the email text-field appears. A bare sleep
+# bites on slower runners (the previous fork-test run captured the
+# splash because 8s wasn't enough for first-bundle delivery).
+PROBE="$ART/.probe.txt"
+echo "::group::wait for SignIn UI"
+SECONDS=0
+while [ "$SECONDS" -lt "$SIGNIN_LOAD_TIMEOUT" ]; do
+  agent-device snapshot -i --session "$SESSION" > "$PROBE" 2>/dev/null || true
+  if grep -q '\[text-field\] "Phone or email' "$PROBE"; then
+    echo "SignIn email field detected after ${SECONDS}s"
+    cp "$PROBE" "$ART/snapshot-signin.txt"
+    break
+  fi
+  sleep 4
+done
+echo "::endgroup::"
+
+# Capture state at SignIn (or at timeout, for debugging).
 agent-device screenshot "$ART/landing.png" --session "$SESSION"
-agent-device snapshot -i --session "$SESSION" > "$ART/snapshot.txt" || true
 agent-device appstate --session "$SESSION" > "$ART/appstate.txt"
 
-# Hard pass criterion: app must own the foreground. Anything else means
-# we crashed back to launcher (or never launched at all).
+if [ "$SECONDS" -ge "$SIGNIN_LOAD_TIMEOUT" ]; then
+  echo "::error::SignIn email field never appeared (timeout ${SIGNIN_LOAD_TIMEOUT}s)"
+  exit 1
+fi
+
+# Hard pass criterion: app must own the foreground.
 if ! grep -q "Foreground app: $APP" "$ART/appstate.txt"; then
   echo "::error::app is not in foreground after launch — see artifacts/appstate.txt"
   cat "$ART/appstate.txt"
   exit 1
 fi
 
-echo "::notice::smoke OK — app reached landing screen"
+# Drive the email-submit interaction. Selector by label rather than @ref:
+# refs renumber per snapshot and the field's label is stable.
+echo "::group::fill email + press Continue"
+agent-device fill 'label="Phone or email"' "$SMOKE_EMAIL" --session "$SESSION"
+agent-device screenshot "$ART/email-filled.png" --session "$SESSION"
+# `--first` is unsupported on `press` (warning is benign — the action
+# still resolves selector ambiguity to the on-screen instance).
+agent-device press 'label="Continue"' --session "$SESSION" 2>&1 \
+  | grep -vE '^Warning:' || true
+echo "::endgroup::"
+
+# Wait for advance to magic-code screen. Detection: the new field has
+# label "Magic code, 6 digits" and React identifier "validateCode".
+echo "::group::wait for magic-code screen"
+SECONDS=0
+while [ "$SECONDS" -lt "$ADVANCE_TIMEOUT" ]; do
+  agent-device snapshot -i --session "$SESSION" > "$PROBE" 2>/dev/null || true
+  if grep -qE 'Magic code|validateCode' "$PROBE"; then
+    echo "magic-code screen detected after ${SECONDS}s"
+    cp "$PROBE" "$ART/snapshot-magic-code.txt"
+    break
+  fi
+  sleep 3
+done
+echo "::endgroup::"
+
+# Capture post-Continue state regardless of pass/fail.
+agent-device screenshot "$ART/post-continue.png" --session "$SESSION"
+agent-device snapshot -i --session "$SESSION" > "$ART/snapshot.txt" 2>/dev/null || true
+
+if [ "$SECONDS" -ge "$ADVANCE_TIMEOUT" ]; then
+  echo "::error::magic-code screen did not appear after pressing Continue"
+  exit 1
+fi
+
+rm -f "$PROBE"
+echo "::notice::smoke OK — email submitted, magic-code screen reached"

--- a/.github/scripts/agent-device-smoke.sh
+++ b/.github/scripts/agent-device-smoke.sh
@@ -21,8 +21,11 @@ SESSION=ci
 APP=com.expensify.chat.dev
 APK_GLOB="android/app/build/outputs/apk/development/debug/*.apk"
 METRO_READY_TIMEOUT=120
-SIGNIN_LOAD_TIMEOUT=120 # JS bundle delivery + React mount + Onyx hydrate
-ADVANCE_TIMEOUT=30 # SignIn -> magic-code transition after Continue
+SIGNIN_LOAD_TIMEOUT=300 # JS bundle delivery + React mount + Onyx hydrate
+                        # 120s was enough on a 4-core runner but free
+                        # 2-core ubuntu-latest is much slower; first
+                        # bundle delivery alone can take 2-3 min.
+ADVANCE_TIMEOUT=60      # SignIn -> magic-code transition after Continue
 SMOKE_EMAIL=rustam.zeinalov@callstack.com
 
 mkdir -p "$ART"

--- a/.github/scripts/agent-device-smoke.sh
+++ b/.github/scripts/agent-device-smoke.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
-# Phase-0 Android smoke for the Expensify dev APK.
-#
-# Runs INSIDE reactivecircus/android-emulator-runner@v2's `script:` block,
-# which means the emulator is already booted and `adb` sees it. This script
-# installs the APK, brings up Metro, launches the app via agent-device,
-# waits for the SignIn UI to fully hydrate, fills the email field, presses
-# Continue, and verifies the magic-code screen appears. Captures screenshots,
-# snapshots, foreground-app dumps, and logcat along the way.
-#
-# The flow stops short of typing the magic code — that input is a 6-cell
-# composite component that rejects programmatic input in every way we've
-# tried (fill, type, adb shell input text, paste). Solving it properly is
-# Phase 1: a developmentE2eDebug build variant that reads a pre-seeded Onyx
-# state from a 1Password-backed secret.
+: <<'COMMENT'
+Phase-0 Android smoke for the Expensify dev APK.
+
+Runs INSIDE reactivecircus/android-emulator-runner@v2's `script:` block,
+which means the emulator is already booted and `adb` sees it. This script
+installs the APK, brings up Metro, launches the app via agent-device,
+waits for the SignIn UI to fully hydrate, fills the email field, presses
+Continue, and verifies the magic-code screen appears. Captures screenshots,
+snapshots, foreground-app dumps, and logcat along the way.
+
+The flow stops short of typing the magic code — that input is a 6-cell
+composite component that rejects programmatic input in every way we've
+tried (fill, type, adb shell input text, paste). Solving it properly is
+Phase 1: a developmentE2eDebug build variant that reads a pre-seeded Onyx
+state from a 1Password-backed secret.
+COMMENT
 
 set -euo pipefail
 
@@ -22,17 +24,21 @@ APP=com.expensify.chat.dev
 APK_GLOB="android/app/build/outputs/apk/development/debug/*.apk"
 METRO_READY_TIMEOUT=120
 SIGNIN_LOAD_TIMEOUT=360 # JS bundle delivery + React mount + Onyx hydrate.
-                        # Free 2-core ubuntu-latest is much slower than
-                        # local Pixel 8 — observed ~290s on a real run,
-                        # so 360 gives ~70s safety margin.
+                        : <<'COMMENT'
+                        Free 2-core ubuntu-latest is much slower than
+                        local Pixel 8 — observed ~290s on a real run,
+                        so 360 gives ~70s safety margin.
+                        COMMENT
 ADVANCE_TIMEOUT=60      # SignIn -> magic-code transition after Continue
 SMOKE_EMAIL=rustam.zeinalov@callstack.com
 
 mkdir -p "$ART"
 
-# Cleanup must run no matter what — kill background jobs and release the
-# agent-device session so a re-run of the workflow doesn't trip the
-# "session already bound" guard.
+: <<'COMMENT'
+Cleanup must run no matter what — kill background jobs and release the
+agent-device session so a re-run of the workflow doesn't trip the
+"session already bound" guard.
+COMMENT
 cleanup() {
   set +e
   agent-device record stop --session "$SESSION" >/dev/null 2>&1
@@ -59,8 +65,10 @@ fi
 echo "::notice::installing $APK"
 adb install -r -d -t "$APK"
 
-# Dev APK fetches its JS bundle over localhost:8081, which the emulator
-# reaches through the host loopback via adb-reverse.
+: <<'COMMENT'
+Dev APK fetches its JS bundle over localhost:8081, which the emulator
+reaches through the host loopback via adb-reverse.
+COMMENT
 adb reverse tcp:8081 tcp:8081
 
 # Bring up Metro in the background; gate on /status before launching.
@@ -79,25 +87,31 @@ done
 echo "Metro ready after ${SECONDS}s"
 echo "::endgroup::"
 
-# --relaunch forces a clean process so we capture the cold-start path
-# rather than whatever happened to be running on the runner.
+: <<'COMMENT'
+--relaunch forces a clean process so we capture the cold-start path
+rather than whatever happened to be running on the runner.
+COMMENT
 agent-device open "$APP" \
   --platform android \
   --serial "$SERIAL" \
   --session "$SESSION" \
   --relaunch
 
-# Cold-start MP4 of the boot animation. Bounded — we don't want to
-# inherit the 180s `adb screenrecord` cap by accident.
+: <<'COMMENT'
+Cold-start MP4 of the boot animation. Bounded — we don't want to
+inherit the 180s `adb screenrecord` cap by accident.
+COMMENT
 agent-device record start "$ART/cold-start.mp4" --session "$SESSION" >/dev/null 2>&1 || true
 sleep 6
 agent-device record stop --session "$SESSION" >/dev/null 2>&1 || true
 
-# Wait for the SignIn UI to fully hydrate. An empty interactive snapshot
-# is normal during the splash → JS-bundle → React-mount → Onyx-hydrate
-# sequence, so we poll until the email text-field appears. A bare sleep
-# bites on slower runners (the previous fork-test run captured the
-# splash because 8s wasn't enough for first-bundle delivery).
+: <<'COMMENT'
+Wait for the SignIn UI to fully hydrate. An empty interactive snapshot
+is normal during the splash → JS-bundle → React-mount → Onyx-hydrate
+sequence, so we poll until the email text-field appears. A bare sleep
+bites on slower runners (the previous fork-test run captured the
+splash because 8s wasn't enough for first-bundle delivery).
+COMMENT
 PROBE="$ART/.probe.txt"
 echo "::group::wait for SignIn UI"
 SECONDS=0
@@ -128,14 +142,16 @@ if ! grep -q "Foreground app: $APP" "$ART/appstate.txt"; then
   exit 1
 fi
 
-# Drive the email-submit interaction.
-#
-# Use @ref discovered from the snapshot above rather than a label= selector.
-# The Android label is "Phone or email," (with a trailing comma) where the
-# iOS label has no comma; agent-device's selector form does exact-match,
-# so the cross-platform-friendly path is to parse the ref out of the
-# snapshot we already captured and act on it directly. Refs are stable
-# inside the same session as long as we don't re-snapshot between.
+: <<'COMMENT'
+Drive the email-submit interaction.
+
+Use @ref discovered from the snapshot above rather than a label= selector.
+The Android label is "Phone or email," (with a trailing comma) where the
+iOS label has no comma; agent-device's selector form does exact-match,
+so the cross-platform-friendly path is to parse the ref out of the
+snapshot we already captured and act on it directly. Refs are stable
+inside the same session as long as we don't re-snapshot between.
+COMMENT
 EMAIL_REF=$(grep -oE '@e[0-9]+ \[text-field\] "Phone or email' "$ART/snapshot-signin.txt" \
             | head -1 | grep -oE '@e[0-9]+')
 CONTINUE_REF=$(grep -oE '@e[0-9]+ \[button\] "Continue"' "$ART/snapshot-signin.txt" \
@@ -154,8 +170,10 @@ agent-device screenshot "$ART/email-filled.png" --session "$SESSION"
 agent-device press "$CONTINUE_REF" --session "$SESSION"
 echo "::endgroup::"
 
-# Wait for advance to magic-code screen. Detection: the new field has
-# label "Magic code, 6 digits" and React identifier "validateCode".
+: <<'COMMENT'
+Wait for advance to magic-code screen. Detection: the new field has
+label "Magic code, 6 digits" and React identifier "validateCode".
+COMMENT
 echo "::group::wait for magic-code screen"
 SECONDS=0
 while [ "$SECONDS" -lt "$ADVANCE_TIMEOUT" ]; do

--- a/.github/scripts/agent-device-smoke.sh
+++ b/.github/scripts/agent-device-smoke.sh
@@ -21,10 +21,10 @@ SESSION=ci
 APP=com.expensify.chat.dev
 APK_GLOB="android/app/build/outputs/apk/development/debug/*.apk"
 METRO_READY_TIMEOUT=120
-SIGNIN_LOAD_TIMEOUT=300 # JS bundle delivery + React mount + Onyx hydrate
-                        # 120s was enough on a 4-core runner but free
-                        # 2-core ubuntu-latest is much slower; first
-                        # bundle delivery alone can take 2-3 min.
+SIGNIN_LOAD_TIMEOUT=360 # JS bundle delivery + React mount + Onyx hydrate.
+                        # Free 2-core ubuntu-latest is much slower than
+                        # local Pixel 8 — observed ~290s on a real run,
+                        # so 360 gives ~70s safety margin.
 ADVANCE_TIMEOUT=60      # SignIn -> magic-code transition after Continue
 SMOKE_EMAIL=rustam.zeinalov@callstack.com
 
@@ -128,15 +128,30 @@ if ! grep -q "Foreground app: $APP" "$ART/appstate.txt"; then
   exit 1
 fi
 
-# Drive the email-submit interaction. Selector by label rather than @ref:
-# refs renumber per snapshot and the field's label is stable.
-echo "::group::fill email + press Continue"
-agent-device fill 'label="Phone or email"' "$SMOKE_EMAIL" --session "$SESSION"
+# Drive the email-submit interaction.
+#
+# Use @ref discovered from the snapshot above rather than a label= selector.
+# The Android label is "Phone or email," (with a trailing comma) where the
+# iOS label has no comma; agent-device's selector form does exact-match,
+# so the cross-platform-friendly path is to parse the ref out of the
+# snapshot we already captured and act on it directly. Refs are stable
+# inside the same session as long as we don't re-snapshot between.
+EMAIL_REF=$(grep -oE '@e[0-9]+ \[text-field\] "Phone or email' "$ART/snapshot-signin.txt" \
+            | head -1 | grep -oE '@e[0-9]+')
+CONTINUE_REF=$(grep -oE '@e[0-9]+ \[button\] "Continue"' "$ART/snapshot-signin.txt" \
+              | head -1 | grep -oE '@e[0-9]+')
+
+if [ -z "$EMAIL_REF" ] || [ -z "$CONTINUE_REF" ]; then
+  echo "::error::could not parse email/continue refs from snapshot-signin.txt"
+  echo "--- snapshot-signin.txt: ---"
+  cat "$ART/snapshot-signin.txt"
+  exit 1
+fi
+
+echo "::group::fill email ($EMAIL_REF) + press Continue ($CONTINUE_REF)"
+agent-device fill "$EMAIL_REF" "$SMOKE_EMAIL" --session "$SESSION"
 agent-device screenshot "$ART/email-filled.png" --session "$SESSION"
-# `--first` is unsupported on `press` (warning is benign — the action
-# still resolves selector ambiguity to the on-screen instance).
-agent-device press 'label="Continue"' --session "$SESSION" 2>&1 \
-  | grep -vE '^Warning:' || true
+agent-device press "$CONTINUE_REF" --session "$SESSION"
 echo "::endgroup::"
 
 # Wait for advance to magic-code screen. Detection: the new field has

--- a/.github/workflows/smokeAndroid.yml
+++ b/.github/workflows/smokeAndroid.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 35
     env:
-      AGENT_DEVICE_VERSION: "0.14.7"
+      AGENT_DEVICE_VERSION: "0.15.2"
 
     steps:
       - name: Checkout

--- a/.github/workflows/smokeAndroid.yml
+++ b/.github/workflows/smokeAndroid.yml
@@ -1,0 +1,154 @@
+name: Android Smoke (agent-device · Phase 0)
+
+# Phase-0 build-health canary: proves the developmentDebug APK installs,
+# launches, and reaches a known JS-rendered screen on a fresh emulator.
+# Does NOT log in or run a tab tour — see contributingGuides for Phase 1
+# follow-up which adds an Onyx-seed login bypass.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
+    paths-ignore:
+      - docs/**
+      - help/**
+      - .github/**
+      - contributingGuides/**
+      - tests/**
+      - '**.md'
+      - '**.sh'
+  workflow_dispatch:
+
+# Newer pushes to the same PR cancel older smoke runs; protects the runner
+# pool from PR-churn pile-ups.
+concurrency:
+  group: smoke-android-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Android emulator smoke
+    if: ${{ github.actor != 'OSBotify' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 35
+    env:
+      AGENT_DEVICE_VERSION: '0.14.7'
+
+    steps:
+      - name: Checkout
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          submodules: true
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Verify KVM / fix permissions if needed
+        run: |
+          if ! ls -la /dev/kvm 2>/dev/null; then
+            echo "::error::No /dev/kvm on this runner — emulator will fall back to TCG and the job will time out"
+            exit 1
+          fi
+          if [ ! -w /dev/kvm ]; then
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+              | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+          fi
+
+      - name: Setup Java
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+        with:
+          IS_HYBRID_BUILD: 'false'
+
+      - name: Install agent-device CLI
+        # Pin — never @latest. A breaking selector/flag change in a
+        # downstream release would silently flip this canary into a
+        # confidence-eroding flake source.
+        run: npm install -g "agent-device@${AGENT_DEVICE_VERSION}"
+
+      - name: Configure AWS credentials (Rock S3 cache)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Configure MapBox SDK
+        # Required because the JS bundle imports @rnmapbox/maps and Metro
+        # serves the bundle from this checkout — the gradle path is gated
+        # by the same token via the existing setup script.
+        run: ./scripts/setup-mapbox-sdk.sh ${{ secrets.MAPBOX_SDK_DOWNLOAD_TOKEN }}
+
+      - name: Build / fetch developmentDebug APK via Rock
+        # If fingerprint matches main, pulls the prebuilt APK from S3 in
+        # ~30s. If it misses (e.g. native deps shifted on this branch),
+        # Rock falls back to a local Gradle build — slower but still
+        # produces the same APK at the path the smoke script expects.
+        env:
+          STANDALONE_NEW_DOT: 'true'
+        run: npx rock build:android --variant developmentDebug
+
+      - name: AVD cache
+        # adbkey* must be cached too — without them adb regenerates keys
+        # and the device shows up as unauthorized with no UI to accept
+        # the prompt. Cache key includes a v1 salt + a hash of this
+        # workflow so editing the file invalidates stale snapshots.
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+            ~/.android/adbkey
+            ~/.android/adbkey.pub
+          key: avd-pixel8-api35-x86_64-v1-${{ hashFiles('.github/workflows/smokeAndroid.yml') }}
+
+      - name: Prime AVD snapshot (cache miss only)
+        # First-run cost. Subsequent runs hit the cache and skip this
+        # step entirely. The script must wait for sys.boot_completed —
+        # exiting too early snapshots a half-booted system and the
+        # cached snapshot is unusable.
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_8
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: false
+          script: |
+            adb wait-for-device
+            until [ -n "$(adb shell getprop sys.boot_completed | tr -d '\r')" ]; do sleep 2; done
+            echo "AVD primed"
+
+      - name: Run smoke
+        # -no-snapshot-save preserves the cached cold-boot snapshot
+        # (otherwise this run would overwrite it with whatever post-test
+        # state we ended up in).
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_8
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: bash .github/scripts/agent-device-smoke.sh
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: smoke-android-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/smokeAndroid.yml
+++ b/.github/workflows/smokeAndroid.yml
@@ -15,8 +15,8 @@ on:
       - .github/**
       - contributingGuides/**
       - tests/**
-      - '**.md'
-      - '**.sh'
+      - "**.md"
+      - "**.sh"
   workflow_dispatch:
 
 # Newer pushes to the same PR cancel older smoke runs; protects the runner
@@ -32,7 +32,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 35
     env:
-      AGENT_DEVICE_VERSION: '0.14.7'
+      AGENT_DEVICE_VERSION: "0.14.7"
 
     steps:
       - name: Checkout
@@ -59,12 +59,12 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
         with:
-          IS_HYBRID_BUILD: 'false'
+          IS_HYBRID_BUILD: "false"
 
       - name: Install agent-device CLI
         # Pin — never @latest. A breaking selector/flag change in a
@@ -85,13 +85,24 @@ jobs:
         # by the same token via the existing setup script.
         run: ./scripts/setup-mapbox-sdk.sh ${{ secrets.MAPBOX_SDK_DOWNLOAD_TOKEN }}
 
+      - name: Install Android CMake 3.30.5 (Hermes pins this exact version)
+        # Defensive: if the Rock S3 fingerprint misses and Rock falls
+        # back to a local Gradle build, hermes-engine's
+        # configureCMakeRelease[x86_64] task fails with [CXX1300] when
+        # CMake 3.30.5 isn't on the runner. Install before Rock so we
+        # surface the real fingerprint-drift signal rather than a
+        # confusing CMake-not-found error.
+        run: |
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null 2>&1 || true
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "cmake;3.30.5" 2>&1 | tail -5
+
       - name: Build / fetch developmentDebug APK via Rock
         # If fingerprint matches main, pulls the prebuilt APK from S3 in
         # ~30s. If it misses (e.g. native deps shifted on this branch),
         # Rock falls back to a local Gradle build — slower but still
         # produces the same APK at the path the smoke script expects.
         env:
-          STANDALONE_NEW_DOT: 'true'
+          STANDALONE_NEW_DOT: "true"
         run: npx rock build:android --variant developmentDebug
 
       - name: AVD cache


### PR DESCRIPTION
### Explanation of Change

Adds a Phase-0 build-health canary that runs on every PR + on manual dispatch:

1. Pulls the `developmentDebug` APK from Rock's S3 cache (`npx rock build:android --variant developmentDebug`) — falls back to a local Gradle build if the fingerprint misses.
2. Boots a Pixel 8 / API 35 / `google_apis` / x86_64 emulator on `blacksmith-4vcpu-ubuntu-2404` via [`reactivecircus/android-emulator-runner@v2`](https://github.com/marketplace/actions/android-emulator-runner) with the standard two-stage AVD-cache pattern.
3. Inside the emulator's `script:` block, the new `.github/scripts/agent-device-smoke.sh`:
   - tees `adb logcat` into `artifacts/logcat.txt`
   - `adb install`s the APK and `adb reverse tcp:8081 tcp:8081`
   - brings up Metro and gates on `/status` reaching `packager-status:running`
   - launches via `agent-device open … --relaunch` (pinned to `agent-device@0.14.7`)
   - captures a screenshot, accessibility-tree snapshot, foreground-app dump, and a short cold-start MP4
   - **fails the run if the app is not in the foreground after launch** (catches install-but-immediate-crash regressions).
4. Uploads `artifacts/` with `if: always()` so failures are debuggable.

Phase 0 explicitly **does not** log in or run a tab tour — the magic-code 6-cell input rejects all programmatic input we tested locally (`agent-device fill`, `adb shell input text`, paste). The full tab-tour smoke is deferred to a separate Phase 1 change which would add a build-variant + Onyx-state seed delivery + 1Password rotation. This PR is the workflow harness only.

### Cost guards
- `concurrency.cancel-in-progress` keyed by ref: newer pushes to the same PR cancel older smoke runs
- `timeout-minutes: 35` — hard ceiling
- `paths-ignore` for `docs/**`, `help/**`, `.github/**`, `contributingGuides/**`, `tests/**`, `**.md`, `**.sh` (matches `reassurePerformanceTests.yml`)
- `if: github.actor != 'OSBotify'` (matches `reassurePerformanceTests.yml`)

### Required secrets
All already used by other workflows in this repo: `OS_BOTIFY_TOKEN`, `MAPBOX_SDK_DOWNLOAD_TOKEN`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.

### Fixed Issues

$
PROPOSAL:

_No tracking issue exists for this work yet — opening as a draft so it can be discussed before going through formal Bug Zero / proposal flow. Happy to move it to ready-for-review and link an issue once direction is confirmed._

### Tests

This PR introduces a CI workflow only — no runtime app code changes. Verification is exercising the workflow itself.

1. From this branch, run **Actions → Android Smoke (agent-device · Phase 0) → Run workflow** (`workflow_dispatch`).
2. Confirm the run lands on `blacksmith-4vcpu-ubuntu-2404`.
3. Confirm the **Verify KVM** step succeeds (`/dev/kvm` exists and is writable).
4. Confirm the **Build / fetch developmentDebug APK via Rock** step logs `Downloaded cached build from S3 (…)` and that an APK lands at `android/app/build/outputs/apk/development/debug/*.apk`.
5. First run only: confirm **Prime AVD snapshot** completes in ≤ 5 min (cache miss path); subsequent runs hit the AVD cache and skip this step.
6. Confirm the **Run smoke** step writes:
   - `artifacts/landing.png` showing the Expensify SignIn screen
   - `artifacts/snapshot.txt` containing an accessibility tree with refs like `@e<n> [text-field] \"Phone or email\" [editable]`
   - `artifacts/appstate.txt` containing `Foreground app: com.expensify.chat.dev`
   - `artifacts/logcat.txt` (non-empty)
   - `artifacts/cold-start.mp4` (≥ 1 KB)
7. Confirm the artifact `smoke-android-<run_id>-<run_attempt>` uploads successfully (visible in the run summary).
8. Open a no-op PR (e.g. a whitespace change in `src/`) and confirm the workflow auto-fires.
9. Push a follow-up commit to the same PR before the run completes; confirm `cancel-in-progress` cancels the prior run.

Failure-mode probe (optional):
- Toggle `emulator-options: -accel off` to force the boot to fail; confirm `timeout-minutes` kicks in and the **Upload artifacts** step still runs (`if: always()`).

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this PR adds CI infrastructure only. No app runtime is changed.

### QA Steps

N/A — files under `.github/` are not shipped to staging or production.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the \`### Fixed Issues\` section above

  _No tracking issue exists yet; opened as a draft to discuss direction first._
- [ ] I wrote clear testing steps that cover the changes made in this PR
  - [ ] I added steps for local testing in the \`Tests\` section
  - [ ] I added steps for the expected offline behavior in the \`Offline steps\` section
  - [ ] I added steps for Staging and/or Production testing in the \`QA steps\` section
  - [ ] I added steps to cover failure scenarios
- [ ] I included screenshots or videos for tests on all platforms — N/A, CI workflow change only
- [ ] I ran the tests on **all platforms** — N/A, CI workflow change only:
  - [ ] Android: Native — N/A
  - [ ] Android: mWeb Chrome — N/A
  - [ ] iOS: Native — N/A
  - [ ] iOS: mWeb Safari — N/A
  - [ ] MacOS: Chrome / Safari — N/A
- [x] I verified there are no console errors
- [x] I followed proper code patterns
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes — N/A
- [x] I verified all code is DRY
- [x] I verified any variables that can be defined as constants are
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — CI workflow change only. The workflow itself produces `landing.png` + `cold-start.mp4` artifacts that demonstrate end-to-end behavior; those will be attached after the first successful run from this branch.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A — Phase 0 is Android only (see Phase 1 plan in the workflow file's header comment).

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>