### PR TITLE
Fix stale Top merchants content after From filter

### DIFF
--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -1980,20 +1980,33 @@ function buildFilterQueryWithSortDefaults(
     previousState: {view?: string; groupBy?: string},
     currentQueryOptions: {sortBy?: string; sortOrder?: string},
 ): string | undefined {
+    const shouldShowPersonalExpensesFromGroupedInsight =
+        previousState.view === CONST.SEARCH.VIEW.PIE &&
+        previousState.groupBy === CONST.SEARCH.GROUP_BY.MERCHANT &&
+        filterValues.groupBy === CONST.SEARCH.GROUP_BY.MERCHANT &&
+        Array.isArray(filterValues[CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM]) &&
+        filterValues[CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM].length > 0;
+    const normalizedFilterValues = shouldShowPersonalExpensesFromGroupedInsight
+        ? {
+              ...filterValues,
+              groupBy: undefined,
+              view: CONST.SEARCH.VIEW.TABLE,
+          }
+        : filterValues;
     const resetSort = shouldResetSort({
-        newGroupBy: filterValues.groupBy,
+        newGroupBy: normalizedFilterValues.groupBy,
         oldGroupBy: previousState.groupBy,
     });
 
     const resetSortForViewChange =
         !resetSort &&
         shouldResetSortForViewChange({
-            newView: filterValues.view,
+            newView: normalizedFilterValues.view,
             oldView: previousState.view,
-            groupBy: filterValues.groupBy,
+            groupBy: normalizedFilterValues.groupBy,
         });
 
-    const queryString = buildQueryStringFromFilterFormValues(filterValues, {
+    const queryString = buildQueryStringFromFilterFormValues(normalizedFilterValues, {
         sortBy: resetSort || resetSortForViewChange ? undefined : currentQueryOptions.sortBy,
         sortOrder: resetSort || resetSortForViewChange ? undefined : currentQueryOptions.sortOrder,
     });

--- a/tests/unit/Search/SearchQueryUtilsTest.ts
+++ b/tests/unit/Search/SearchQueryUtilsTest.ts
@@ -1844,6 +1844,29 @@ describe('SearchQueryUtils', () => {
             expect(result).toContain('sortOrder:desc');
         });
 
+        test('from filter on grouped chart insight returns to expenses table', () => {
+            const result = buildFilterQueryWithSortDefaults(
+                {type: CONST.SEARCH.DATA_TYPES.EXPENSE, groupBy: CONST.SEARCH.GROUP_BY.MERCHANT, view: CONST.SEARCH.VIEW.PIE, from: ['12345']},
+                {view: CONST.SEARCH.VIEW.PIE, groupBy: CONST.SEARCH.GROUP_BY.MERCHANT},
+                {sortBy: CONST.SEARCH.TABLE_COLUMNS.GROUP_TOTAL, sortOrder: CONST.SEARCH.SORT_ORDER.DESC},
+            );
+            const queryJSON = buildSearchQueryJSON(result ?? '');
+
+            expect(queryJSON?.type).toBe(CONST.SEARCH.DATA_TYPES.EXPENSE);
+            expect(queryJSON?.groupBy).toBeUndefined();
+            expect(queryJSON?.view).toBe(CONST.SEARCH.VIEW.TABLE);
+            expect(queryJSON?.sortBy).toBe(CONST.SEARCH.TABLE_COLUMNS.DATE);
+            expect(queryJSON?.sortOrder).toBe(CONST.SEARCH.SORT_ORDER.DESC);
+            expect(queryJSON?.flatFilters).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        key: CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM,
+                        filters: expect.arrayContaining([expect.objectContaining({value: '12345'})]),
+                    }),
+                ]),
+            );
+        });
+
         test('view switches between table and bar/pie preserve sort for non-time groupBy', () => {
             // Bar → Table
             let result = buildFilterQueryWithSortDefaults(


### PR DESCRIPTION
### Explanation of Change
Fixes the stale Top merchants content after applying a `From` filter from the Spend > Top merchants chart.

When the user filters the Top merchants pie chart by `From`, the navigation switches to the Expenses tab, but the query still carries the merchant grouping/chart view. This normalizes that specific Top merchants query back to the table view while preserving the selected `From` filter, so the Expenses tab renders the filtered expense list instead of stale grouped chart content.

### Fixed Issues
$ 89811
PROPOSAL: N/A

### Tests
- [x] Added unit coverage for applying a `From` filter from the Top merchants pie chart.
- [x] Verified the branch diff only changes `src/libs/SearchQueryUtils.ts` and `tests/unit/Search/SearchQueryUtilsTest.ts`.
- [x] Ran `git diff --check -- src/libs/SearchQueryUtils.ts tests/unit/Search/SearchQueryUtilsTest.ts`.
- [ ] Ran targeted Jest locally. It could not complete in this Windows partial checkout because Jest setup reached an existing module transform/setup failure before executing the test; CI should run the full repo environment.

### Offline tests
Same as above.

### QA Steps
1. Go to Reports > Spend > Top merchants.
2. Open filters.
3. Set `From` to the current user.
4. Press Search.
5. Verify the app navigates to Expenses and shows the filtered expense table, not stale Top merchants chart content.

### PR Author Checklist
- [x] I linked the correct issue.
- [x] I kept the change scoped to the Top merchants grouped chart flow.
- [x] I added regression coverage for the search query normalization.
- [x] I reviewed the changed files and avoided unrelated formatting churn.