### PR TITLE
[Payment due @rojiphil] Disable Chronos timer header button while OpenReport is in flight

### DIFF
--- a/src/components/ChronosTimerHeaderButton.tsx
+++ b/src/components/ChronosTimerHeaderButton.tsx
@@ -56,8 +56,7 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
     });
     const {isOffline} = useNetwork();
 
-    // Keep the button usable while offline so queued start/stop comments are sent on reconnect,
-    // even though the optimistic OpenReport request leaves isLoadingInitialReportActions=true.
+    // Keep the button usable while offline so queued start/stop comments are sent on reconnect.
     // The button should be disabled if the OpenReport request is in progress, so that the state of the button (wither it says "start" or "stop") will reflect the most recent data coming from the server.
     // There is still a possible bug where if you are offline, the button could reflect the wrong state. However, there is really no way to fix this without breaking the offline experience.
     const shouldDisableButton = !!isLoadingInitialReportActions && !isOffline;

--- a/src/components/ChronosTimerHeaderButton.tsx
+++ b/src/components/ChronosTimerHeaderButton.tsx
@@ -6,6 +6,7 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useDelegateAccountID from '@hooks/useDelegateAccountID';
 import useIsInSidePanel from '@hooks/useIsInSidePanel';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -53,6 +54,11 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
     const [isLoadingInitialReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${report.reportID}`, {
         selector: isLoadingInitialReportActionsSelector,
     });
+    const {isOffline} = useNetwork();
+
+    // Keep the button usable while offline so queued start/stop comments are sent on reconnect,
+    // even though the optimistic OpenReport request leaves isLoadingInitialReportActions=true.
+    const shouldDisableButton = !!isLoadingInitialReportActions && !isOffline;
 
     const ancestors = useAncestors(report);
     const isInSidePanel = useIsInSidePanel();
@@ -94,7 +100,7 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
         <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentEnd]}>
             <ButtonWithDropdownMenu<ChronosAction>
                 success={!isTimerRunning}
-                isDisabled={!!isLoadingInitialReportActions}
+                isDisabled={shouldDisableButton}
                 onPress={() => {
                     callFunctionIfActionIsAllowed(sendCommentToChronos)();
                 }}

--- a/src/components/ChronosTimerHeaderButton.tsx
+++ b/src/components/ChronosTimerHeaderButton.tsx
@@ -58,6 +58,8 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
 
     // Keep the button usable while offline so queued start/stop comments are sent on reconnect,
     // even though the optimistic OpenReport request leaves isLoadingInitialReportActions=true.
+    // The button should be disabled if the OpenReport request is in progress, so that the state of the button (wither it says "start" or "stop") will reflect the most recent data coming from the server.
+    // There is still a possible bug where if you are offline, the button could reflect the wrong state. However, there is really no way to fix this without breaking the offline experience.
     const shouldDisableButton = !!isLoadingInitialReportActions && !isOffline;
 
     const ancestors = useAncestors(report);

--- a/src/components/ChronosTimerHeaderButton.tsx
+++ b/src/components/ChronosTimerHeaderButton.tsx
@@ -18,6 +18,7 @@ import {callFunctionIfActionIsAllowed} from '@userActions/Session';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
+import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
 import type * as OnyxTypes from '@src/types/onyx';
 import type {ReportActions} from '@src/types/onyx/ReportAction';
 import ButtonWithDropdownMenu from './ButtonWithDropdownMenu';
@@ -48,6 +49,10 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
         },
         [canPerformWriteAction, visibleReportActionsData, report.reportID, currentUserAccountID],
     );
+
+    const [isLoadingInitialReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${report.reportID}`, {
+        selector: isLoadingInitialReportActionsSelector,
+    });
 
     const ancestors = useAncestors(report);
     const isInSidePanel = useIsInSidePanel();
@@ -89,6 +94,7 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
         <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentEnd]}>
             <ButtonWithDropdownMenu<ChronosAction>
                 success={!isTimerRunning}
+                isDisabled={!!isLoadingInitialReportActions}
                 onPress={() => {
                     callFunctionIfActionIsAllowed(sendCommentToChronos)();
                 }}

--- a/src/components/ChronosTimerHeaderButton.tsx
+++ b/src/components/ChronosTimerHeaderButton.tsx
@@ -57,7 +57,7 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
     const {isOffline} = useNetwork();
 
     // Keep the button usable while offline so queued start/stop comments are sent on reconnect.
-    // The button should be disabled if the OpenReport request is in progress, so that the state of the button (wither it says "start" or "stop") will reflect the most recent data coming from the server.
+    // The button should be disabled if the OpenReport request is in progress, so that the state of the button (whether it says "start" or "stop") will reflect the most recent data coming from the server.
     // There is still a possible bug where if you are offline, the button could reflect the wrong state. However, there is really no way to fix this without breaking the offline experience.
     const shouldDisableButton = !!isLoadingInitialReportActions && !isOffline;
 

--- a/src/components/ChronosTimerHeaderButton.tsx
+++ b/src/components/ChronosTimerHeaderButton.tsx
@@ -83,12 +83,24 @@ function ChronosTimerHeaderButton({report}: ChronosTimerHeaderButtonProps) {
         {
             value: 'timer' as const,
             text: translate(isTimerRunning ? 'chronos.stopTimer' : 'chronos.startTimer'),
-            onSelected: () => callFunctionIfActionIsAllowed(sendCommentToChronos)(),
+            disabled: shouldDisableButton,
+            onSelected: () => {
+                if (shouldDisableButton) {
+                    return;
+                }
+                callFunctionIfActionIsAllowed(sendCommentToChronos)();
+            },
         },
         {
             value: 'scheduleOOO' as const,
             text: translate('chronos.scheduleOOO'),
-            onSelected: () => Navigation.navigate(ROUTES.CHRONOS_SCHEDULE_OOO.getRoute(report.reportID)),
+            disabled: shouldDisableButton,
+            onSelected: () => {
+                if (shouldDisableButton) {
+                    return;
+                }
+                Navigation.navigate(ROUTES.CHRONOS_SCHEDULE_OOO.getRoute(report.reportID));
+            },
             shouldUpdateSelectedIndex: false,
         },
     ];

--- a/tests/ui/ChronosTimerHeaderButton.test.tsx
+++ b/tests/ui/ChronosTimerHeaderButton.test.tsx
@@ -8,6 +8,7 @@ import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import type {PopoverMenuItem, PopoverMenuProps} from '@components/PopoverMenu';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
@@ -170,6 +171,30 @@ describe('ChronosTimerHeaderButton', () => {
                 text: CONST.CHRONOS.TIMER_COMMAND.START,
             }),
         );
+    });
+
+    it('should disable the button while the OpenReport API is in progress', async () => {
+        // Given the OpenReport API is in flight for this report (RAM-only loading state set)
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${TEST_REPORT_ID}`, {
+            isLoadingInitialReportActions: true,
+        });
+
+        // When ChronosTimerHeaderButton is rendered
+        renderComponent();
+        await waitForBatchedUpdates();
+
+        // Then every rendered button reports a disabled accessibility state
+        const buttons = screen.getAllByRole('button');
+        expect(buttons.length).toBeGreaterThan(0);
+        buttons.forEach((btn) => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            expect(btn.props.accessibilityState?.disabled).toBe(true);
+        });
+
+        // And pressing the main "Start Timer" button does not trigger addComment
+        fireEvent.press(screen.getByText('Start Timer'));
+        await waitForBatchedUpdates();
+        expect(mockAddComment).not.toHaveBeenCalled();
     });
 
     it('should navigate to Schedule OOO when the option is selected from the dropdown menu', async () => {

--- a/tests/ui/ChronosTimerHeaderButton.test.tsx
+++ b/tests/ui/ChronosTimerHeaderButton.test.tsx
@@ -193,10 +193,10 @@ describe('ChronosTimerHeaderButton', () => {
         // Then every rendered button reports a disabled accessibility state
         const buttons = screen.getAllByRole('button');
         expect(buttons.length).toBeGreaterThan(0);
-        buttons.forEach((btn) => {
+        for (const btn of buttons) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- React test instance `.props` is typed as `unknown`; we read the rendered accessibilityState directly here
             expect(btn.props.accessibilityState?.disabled).toBe(true);
-        });
+        }
 
         // And pressing the main "Start Timer" button does not trigger addComment
         fireEvent.press(screen.getByText('Start Timer'));
@@ -228,6 +228,30 @@ describe('ChronosTimerHeaderButton', () => {
         expect(mockAddComment).not.toHaveBeenCalled();
     });
 
+    it('should not navigate to Schedule OOO from an already-open dropdown when OpenReport flips to in-progress', async () => {
+        // Given the report is already loaded and the dropdown menu is open with the Schedule OOO option visible
+        renderComponent();
+        await waitForBatchedUpdates();
+        fireEvent.press(getDropdownArrowButton());
+        await waitForBatchedUpdates();
+        await waitFor(() => {
+            expect(screen.getByTestId('PopoverMenuItem-Schedule OOO')).toBeOnTheScreen();
+        });
+
+        // When a background OpenReport for the same report kicks off
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${TEST_REPORT_ID}`, {
+            isLoadingInitialReportActions: true,
+        });
+        await waitForBatchedUpdates();
+
+        // And the user selects the (already-visible) Schedule OOO item from the popover
+        fireEvent.press(screen.getByTestId('PopoverMenuItem-Schedule OOO'));
+        await waitForBatchedUpdates();
+
+        // Then Navigation.navigate is not called because the option is gated by the in-flight OpenReport
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
     it('should keep the button enabled while offline so queued start/stop comments are sent on reconnect', async () => {
         // Given the OpenReport API is optimistically in flight for this report
         // (its optimisticData sets isLoadingInitialReportActions=true)
@@ -246,10 +270,10 @@ describe('ChronosTimerHeaderButton', () => {
         // Then no rendered button is marked disabled via accessibility state
         const buttons = screen.getAllByRole('button');
         expect(buttons.length).toBeGreaterThan(0);
-        buttons.forEach((btn) => {
+        for (const btn of buttons) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- React test instance `.props` is typed as `unknown`; we read the rendered accessibilityState directly here
             expect(btn.props.accessibilityState?.disabled).not.toBe(true);
-        });
+        }
 
         // And pressing the main "Start Timer" button still queues the start timer command
         fireEvent.press(screen.getByText('Start Timer'));

--- a/tests/ui/ChronosTimerHeaderButton.test.tsx
+++ b/tests/ui/ChronosTimerHeaderButton.test.tsx
@@ -194,7 +194,7 @@ describe('ChronosTimerHeaderButton', () => {
         const buttons = screen.getAllByRole('button');
         expect(buttons.length).toBeGreaterThan(0);
         buttons.forEach((btn) => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- React test instance `.props` is typed as `unknown`; we read the rendered accessibilityState directly here
             expect(btn.props.accessibilityState?.disabled).toBe(true);
         });
 
@@ -247,7 +247,7 @@ describe('ChronosTimerHeaderButton', () => {
         const buttons = screen.getAllByRole('button');
         expect(buttons.length).toBeGreaterThan(0);
         buttons.forEach((btn) => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- React test instance `.props` is typed as `unknown`; we read the rendered accessibilityState directly here
             expect(btn.props.accessibilityState?.disabled).not.toBe(true);
         });
 

--- a/tests/ui/ChronosTimerHeaderButton.test.tsx
+++ b/tests/ui/ChronosTimerHeaderButton.test.tsx
@@ -204,6 +204,30 @@ describe('ChronosTimerHeaderButton', () => {
         expect(mockAddComment).not.toHaveBeenCalled();
     });
 
+    it('should not send a start timer command from an already-open dropdown when OpenReport flips to in-progress', async () => {
+        // Given the report is already loaded and the dropdown menu is open with the Start Timer option visible
+        renderComponent();
+        await waitForBatchedUpdates();
+        fireEvent.press(getDropdownArrowButton());
+        await waitForBatchedUpdates();
+        await waitFor(() => {
+            expect(screen.getByTestId('PopoverMenuItem-Start Timer')).toBeOnTheScreen();
+        });
+
+        // When a background OpenReport for the same report kicks off (e.g. from a remount of the report list)
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${TEST_REPORT_ID}`, {
+            isLoadingInitialReportActions: true,
+        });
+        await waitForBatchedUpdates();
+
+        // And the user selects the (already-visible) Start Timer item from the popover
+        fireEvent.press(screen.getByTestId('PopoverMenuItem-Start Timer'));
+        await waitForBatchedUpdates();
+
+        // Then addComment is not called because the option is gated by the in-flight OpenReport
+        expect(mockAddComment).not.toHaveBeenCalled();
+    });
+
     it('should keep the button enabled while offline so queued start/stop comments are sent on reconnect', async () => {
         // Given the OpenReport API is optimistically in flight for this report
         // (its optimisticData sets isLoadingInitialReportActions=true)

--- a/tests/ui/ChronosTimerHeaderButton.test.tsx
+++ b/tests/ui/ChronosTimerHeaderButton.test.tsx
@@ -50,6 +50,12 @@ jest.mock('@hooks/useIsInSidePanel', () => ({
     default: () => false,
 }));
 
+const mockUseNetwork = jest.fn(() => ({isOffline: false}));
+jest.mock('@hooks/useNetwork', () => ({
+    __esModule: true,
+    default: () => mockUseNetwork(),
+}));
+
 jest.mock('@hooks/useReportIsArchived', () => ({
     __esModule: true,
     default: () => false,
@@ -128,6 +134,7 @@ describe('ChronosTimerHeaderButton', () => {
         await Onyx.clear();
         await waitForBatchedUpdates();
         jest.clearAllMocks();
+        mockUseNetwork.mockReturnValue({isOffline: false});
     });
 
     it('should send a start timer command when the main button is pressed', async () => {
@@ -195,6 +202,41 @@ describe('ChronosTimerHeaderButton', () => {
         fireEvent.press(screen.getByText('Start Timer'));
         await waitForBatchedUpdates();
         expect(mockAddComment).not.toHaveBeenCalled();
+    });
+
+    it('should keep the button enabled while offline so queued start/stop comments are sent on reconnect', async () => {
+        // Given the OpenReport API is optimistically in flight for this report
+        // (its optimisticData sets isLoadingInitialReportActions=true)
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${TEST_REPORT_ID}`, {
+            isLoadingInitialReportActions: true,
+        });
+
+        // And the app is offline (so the OpenReport request is queued and isLoadingInitialReportActions
+        // would stay true until reconnect)
+        mockUseNetwork.mockReturnValue({isOffline: true});
+
+        // When ChronosTimerHeaderButton is rendered
+        renderComponent();
+        await waitForBatchedUpdates();
+
+        // Then no rendered button is marked disabled via accessibility state
+        const buttons = screen.getAllByRole('button');
+        expect(buttons.length).toBeGreaterThan(0);
+        buttons.forEach((btn) => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            expect(btn.props.accessibilityState?.disabled).not.toBe(true);
+        });
+
+        // And pressing the main "Start Timer" button still queues the start timer command
+        fireEvent.press(screen.getByText('Start Timer'));
+        await waitForBatchedUpdates();
+        expect(mockAddComment).toHaveBeenCalledTimes(1);
+        expect(mockAddComment).toHaveBeenCalledWith(
+            expect.objectContaining({
+                report: mockReport,
+                text: CONST.CHRONOS.TIMER_COMMAND.START,
+            }),
+        );
     });
 
     it('should navigate to Schedule OOO when the option is selected from the dropdown menu', async () => {


### PR DESCRIPTION
### Explanation of Change
- Disables the start/stop dropdown button when `OpenReport` is in process (but not when the app is offline). This should prevent stale report actions from giving the start/stop timer an incorrect state.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/633688

### Tests
1. Sign into NewDot
2. Open the Chronos chat
3. Verify the start/stop dropdown button in the report header is disabled while the report data is loading. You can see this easily if you switch back and forth between two chats
4. Once the button is enabled, verify it still works like normal

### Offline tests
1. Go offline
2. Visit the chronos chat
3. Verify the start/stop button is not disabled and you can use it
4. Go online
5. Verify whatever start/stop command you sent in step 3 goes through

### QA Steps
Same as Tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/7a9a0cd9-82be-4998-b96c-0ad373a7df08



</details>

Made with [Cursor](https://cursor.com)