### PR TITLE
fix: avoid Android FlashList crash on DEW back press

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -9474,7 +9474,13 @@ function hasReportErrorsOtherThanFailedReceipt(
     transactions: OnyxCollection<Transaction>,
     reportAttributes?: ReportAttributesDerivedValue['reports'],
 ) {
-    const allReportErrors = getEffectiveReportErrors(reportAttributes?.[report?.reportID]);
+    // Use raw reportErrors here (not getEffectiveReportErrors) so the child stays force-shown in
+    // LHN when it has errors. Removing it from the LHN data while Android Fabric/FlashList holds
+    // a stale layout index during back navigation crashes the app with "index out of bounds, not
+    // enough layouts" (see #89933). brickRoadStatus/actionBadge are still suppressed at the source
+    // in reportAttributes.ts, so the child appears with no badge while the parent workspace chat
+    // carries the Fix indicator.
+    const allReportErrors = reportAttributes?.[report?.reportID]?.reportErrors ?? {};
     const transactionReportActions = getAllReportActions(report.reportID);
     const oneTransactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, transactionReportActions, undefined);
     let doesTransactionThreadReportHasViolations = false;


### PR DESCRIPTION
### Explanation of Change

PR #89153 (the dedup fix for #88160) introduced a deploy blocker on Android: tapping back after a DEW submit failure crashes the app with `Error: index out of bounds, not enough layouts` (#89933).

The crash trace points at FlashList's layout cache going out of sync during a touch event:

```
getLayout@1:15168580
getLayout@1:15157101
...
dispatchEvent@1:4066331
```

Root cause: PR #89153's `getEffectiveReportErrors` returns `{}` when the child is propagating to an accessible parent. That fed `hasReportErrorsOtherThanFailedReceipt` → `shouldDisplayReportInLHN`, removing the child from the LHN FlashList. On Android, when the user taps back at the moment that data update lands, Fabric/FlashList holds a stale layout index and crashes.

This patch changes only that consumer: `hasReportErrorsOtherThanFailedReceipt` now reads raw `reportAttributes.reportErrors` directly. Child stays force-shown in the LHN, FlashList layout cache stays consistent, no crash on back press.

The badge dedup (the core bounty fix for #88160) is preserved: `brickRoadStatus`/`actionBadge` are still suppressed at the source in `reportAttributes.ts`, so the child appears in LHN with no badge while the parent workspace chat carries the Fix indicator. `OptionsListUtils.createOption` continues to use `getEffectiveReportErrors` for search/share-to picker dedup.

**Tradeoff vs the original bounty fix:** child still appears in LHN (with no badge) instead of being hidden entirely. The full-hide can be tracked as a follow-up once the FlashList layout race is handled safely (likely needs an `InteractionManager.runAfterInteractions` wrap on the data update or an upstream FlashList/Fabric fix).

### Fixed Issues

\$ https://github.com/Expensify/App/issues/89933

### Tests

1. Sign in to a workspace where you're the owner (so `isOwnPolicyExpenseChat` is true) on **Android (HybridApp or mWeb Chrome)**
2. Open the workspace chat
3. Open or create an expense report under that workspace
4. Add a manual expense in the report
5. Tap submit → trigger a DEW submit failure
6. Tap back button (1x or 2x)
7. Verify: app does NOT crash. user navigates back to workspace chat (1x) or Inbox (2x)
8. Verify in LHN: workspace chat row shows the \`Fix\` badge, child expense report row appears without a duplicate \`Fix\` badge
9. Tap the \`Fix\` badge on the workspace chat — confirm it deep-links to the violation
10. Control: open a DM-based personal IOU thread (parent is a DM) — RBR/Fix should still appear there as before

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests — derived-value computation runs from in-memory Onyx state.

### QA Steps

Same as Tests, performed against staging on Android with a workspace configured for DEW (Manager Approval workflow + a transaction that triggers a submit failure).

- [x] Verify that no errors appear in the JS console