### PR TITLE
[No QA] Add Save for later odometer details to Distance Expenses help docs

### DIFF
--- a/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
@@ -74,7 +74,7 @@ To create an expense using your vehicle's odometer readings:
 4. Enter the **End reading** from your odometer after the trip.
    - The total distance is calculated automatically as you type.
 5. (Optional) Select the image icon next to each reading to attach a photo of your odometer.
-6. (Optional) To finish creating the expense later, select **Save for later** to keep the expense in progress on your device. Reopen it after your trip to enter the end reading.
+6. (Optional) To finish creating the expense later, select **Save for later** to keep the expense in progress on your device. After your trip, return to **➕ Create** > **Track distance** > **Odometer** to resume the saved expense and enter the end reading.
 7. Select **Next**.
 8. On the confirmation screen, review and confirm:
    - Distance
@@ -168,7 +168,7 @@ Yes. When you add two odometer images to a distance expense, they will be merged
 
 ## Can I save an odometer expense for later?
 
-Yes. Enter your start reading before the trip, then select **Save for later**. After the trip, reopen the expense to enter the end reading.
+Yes. Enter your start reading before the trip, then select **Save for later**. After the trip, return to **➕ Create** > **Track distance** > **Odometer** to resume the saved expense and enter the end reading.
 
 ## Can I have multiple incomplete odometer expenses at the same time?
 

--- a/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
@@ -1,7 +1,7 @@
 ---
 title: Distance Expenses
 description: Learn how to create a Distance expense using GPS tracking, map-based routes, manual entry, or odometer readings, and how the reimbursement rate is determined in New Expensify.
-keywords: [New Expensify, distance expense, mileage reimbursement, create expense, distance rate, workspace rate, map route, reimbursement rate, manual mileage, manual distance, global create, track distance, GPS, GPS tracking, start GPS, track route, track mileage, mileage tracking, calculate mileage reimbursement, mileage rate, odometer, odometer reading, odometer image, odometer mileage, odometer distance, start reading, end reading]
+keywords: [New Expensify, distance expense, mileage reimbursement, create expense, distance rate, workspace rate, map route, reimbursement rate, manual mileage, manual distance, global create, track distance, GPS, GPS tracking, start GPS, track route, track mileage, mileage tracking, calculate mileage reimbursement, mileage rate, odometer, odometer reading, odometer image, odometer mileage, odometer distance, start reading, end reading, save for later, in-progress odometer, incomplete odometer]
 internalScope: Audience is all members. Covers creating Distance expenses using GPS tracking, map-based routes, manual entry, and odometer readings, plus how reimbursement rates are applied. Does not cover configuring Workspace distance rates in detail or broader report submission workflows.
 ---
 
@@ -74,14 +74,15 @@ To create an expense using your vehicle's odometer readings:
 4. Enter the **End reading** from your odometer after the trip.
    - The total distance is calculated automatically as you type.
 5. (Optional) Select the image icon next to each reading to attach a photo of your odometer.
-6. Select **Next**.
-7. On the confirmation screen, review and confirm:
+6. (Optional) If you only have your start reading, select **Save for later** to keep the expense in progress on your device. Reopen it after your trip to enter the end reading.
+7. Select **Next**.
+8. On the confirmation screen, review and confirm:
    - Distance
    - Amount
    - Rate
    - Date
    - (Optional) Add a description, category, or tag.
-8. Select **Create expense**.
+9. Select **Create expense**.
 
 Once a Distance expense is created, it can be submitted on a report. To learn how to add expenses to a report, see [Create and Submit Reports](/articles/new-expensify/reports-and-expenses/Create-and-Submit-Reports).
 
@@ -164,4 +165,12 @@ Yes. Manual readings are required, but you have the option to attach images of t
 ## Can I add two odometer images to a distance expense?
 
 Yes. When you add two odometer images to a distance expense, they will be merged into a single image for easy viewing.
+
+## Can I save an odometer expense for later?
+
+Yes! Enter a reading at the beginning of your trip and you can save the expense until the end. Or simply take a photo and attach them both once the trip is complete.
+
+## Can I have multiple incomplete odometer expenses at the same time?
+
+Only one in-progress odometer expense can be saved to your device at a time.
 

--- a/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
@@ -74,7 +74,7 @@ To create an expense using your vehicle's odometer readings:
 4. Enter the **End reading** from your odometer after the trip.
    - The total distance is calculated automatically as you type.
 5. (Optional) Select the image icon next to each reading to attach a photo of your odometer.
-6. (Optional) If you only have your start reading, select **Save for later** to keep the expense in progress on your device. Reopen it after your trip to enter the end reading.
+6. (Optional) To finish creating the expense later, select **Save for later** to keep the expense in progress on your device. Reopen it after your trip to enter the end reading.
 7. Select **Next**.
 8. On the confirmation screen, review and confirm:
    - Distance

--- a/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
@@ -168,7 +168,7 @@ Yes. When you add two odometer images to a distance expense, they will be merged
 
 ## Can I save an odometer expense for later?
 
-Yes! Enter your start reading before the trip, then select **Save for later** to keep the expense on your device. Reopen it after your trip to add your end reading and create the expense.
+Yes. Enter your start reading before the trip, then select **Save for later**. After the trip, reopen the expense to enter the end reading.
 
 ## Can I have multiple incomplete odometer expenses at the same time?
 

--- a/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Distance-Expenses.md
@@ -168,7 +168,7 @@ Yes. When you add two odometer images to a distance expense, they will be merged
 
 ## Can I save an odometer expense for later?
 
-Yes! Enter a reading at the beginning of your trip and you can save the expense until the end. Or simply take a photo and attach them both once the trip is complete.
+Yes! Enter your start reading before the trip, then select **Save for later** to keep the expense on your device. Reopen it after your trip to add your end reading and create the expense.
 
 ## Can I have multiple incomplete odometer expenses at the same time?
 


### PR DESCRIPTION
### Explanation of Change

With the launch of Odometer project phase 2, we need to add updates the Distance Expenses help site page with information about the Save for later feature for odometer expenses:

- Adds a Save for later step to the Odometer creation flow
- Adds two new FAQs covering saving an odometer expense for later and the single-in-progress limit

- [Design Doc plan](https://docs.google.com/document/d/1Z103dY4guA07UUw3sTP1o0IKvFxXZJ1HAB1EwUeEyaA/edit?tab=t.0#bookmark=id.i8yjh2q2axhr)

Follow up to [#86366](https://github.com/Expensify/App/pull/86366).

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/571644

### Tests
- N/A — documentation-only change

### Offline tests
N/A

### QA Steps
N/A

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
