### PR TITLE
Handle report duplication so opening Relationship Manager chat works properly

### DIFF
--- a/src/libs/actions/RequestConflictUtils.ts
+++ b/src/libs/actions/RequestConflictUtils.ts
@@ -85,6 +85,21 @@ function resolveOpenReportDuplicationConflictAction<TKey extends OnyxKey>(persis
                 };
             }
 
+            // The queued request carries the participants needed to create the optimistic chat on the
+            // server (e.g. from navigateToAndOpenReportWithAccountIDs). A follow-up OpenReport fired by
+            // ReportFetchHandler when the screen mounts has no participants. Replacing would drop the
+            // accountIDList, leaving the server with no way to resolve the optimistic reportID — Auth
+            // returns NIL reportSummary and PHP throws "Report not found" (da7984df).
+            const queuedHasParticipants = !!(request.data?.emailList ?? request.data?.accountIDList);
+            const newHasParticipants = !!(parameters.emailList ?? parameters.accountIDList);
+            if (queuedHasParticipants && !newHasParticipants) {
+                return {
+                    conflictAction: {
+                        type: 'noAction',
+                    },
+                };
+            }
+
             // In other cases it's safe to replace the previous request with the new one
             return {
                 conflictAction: {

--- a/src/libs/actions/RequestConflictUtils.ts
+++ b/src/libs/actions/RequestConflictUtils.ts
@@ -1,12 +1,23 @@
-import type {OnyxKey, OnyxUpdate} from 'react-native-onyx';
+import type { OnyxKey, OnyxUpdate } from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
-import type {TupleToUnion} from 'type-fest';
-import type {DetachReceiptParams, OpenReportParams, UpdateCommentParams} from '@libs/API/parameters';
-import {WRITE_COMMANDS} from '@libs/API/types';
-import type {ApiRequestCommandParameters} from '@libs/API/types';
+import type { TupleToUnion } from 'type-fest';
+import type { DetachReceiptParams, OpenReportParams, UpdateCommentParams } from '@libs/API/parameters';
+import { WRITE_COMMANDS } from '@libs/API/types';
+import type { ApiRequestCommandParameters } from '@libs/API/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type OnyxRequest from '@src/types/onyx/Request';
-import type {AnyRequest, ConflictActionData} from '@src/types/onyx/Request';
+import type { AnyRequest, ConflictActionData } from '@src/types/onyx/Request';
+
+
+
+
+
+
+
+
+
+
+
 
 type AnyRequestMatcher = (request: AnyRequest) => boolean;
 
@@ -90,8 +101,10 @@ function resolveOpenReportDuplicationConflictAction<TKey extends OnyxKey>(persis
             // ReportFetchHandler when the screen mounts has no participants. Replacing would drop the
             // accountIDList, leaving the server with no way to resolve the optimistic reportID — Auth
             // returns NIL reportSummary and PHP throws "Report not found" (da7984df).
-            const queuedHasParticipants = !!(request.data?.emailList ?? request.data?.accountIDList);
-            const newHasParticipants = !!(parameters.emailList ?? parameters.accountIDList);
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            const queuedHasParticipants = !!(request.data?.emailList || request.data?.accountIDList);
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            const newHasParticipants = !!(parameters.emailList || parameters.accountIDList);
             if (queuedHasParticipants && !newHasParticipants) {
                 return {
                     conflictAction: {

--- a/src/libs/actions/RequestConflictUtils.ts
+++ b/src/libs/actions/RequestConflictUtils.ts
@@ -1,23 +1,12 @@
-import type { OnyxKey, OnyxUpdate } from 'react-native-onyx';
+import type {OnyxKey, OnyxUpdate} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
-import type { TupleToUnion } from 'type-fest';
-import type { DetachReceiptParams, OpenReportParams, UpdateCommentParams } from '@libs/API/parameters';
-import { WRITE_COMMANDS } from '@libs/API/types';
-import type { ApiRequestCommandParameters } from '@libs/API/types';
+import type {TupleToUnion} from 'type-fest';
+import type {DetachReceiptParams, OpenReportParams, UpdateCommentParams} from '@libs/API/parameters';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import type {ApiRequestCommandParameters} from '@libs/API/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type OnyxRequest from '@src/types/onyx/Request';
-import type { AnyRequest, ConflictActionData } from '@src/types/onyx/Request';
-
-
-
-
-
-
-
-
-
-
-
+import type {AnyRequest, ConflictActionData} from '@src/types/onyx/Request';
 
 type AnyRequestMatcher = (request: AnyRequest) => boolean;
 

--- a/tests/unit/RequestConflictUtilsTest.ts
+++ b/tests/unit/RequestConflictUtilsTest.ts
@@ -6,6 +6,7 @@ import {
     resolveDuplicationConflictAction,
     resolveEditCommentWithNewAddCommentRequest,
     resolveEnableFeatureConflicts,
+    resolveOpenReportDuplicationConflictAction,
 } from '@libs/actions/RequestConflictUtils';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import type {WriteCommand} from '@libs/API/types';
@@ -160,6 +161,44 @@ describe('RequestConflictUtils', () => {
                 indices: [0],
                 pushNewRequest: false,
             },
+        });
+    });
+
+    describe('resolveOpenReportDuplicationConflictAction', () => {
+        it('returns push when no matching OpenReport for the reportID exists in the queue', () => {
+            const persistedRequests = [{command: 'OpenApp'}, {command: WRITE_COMMANDS.OPEN_REPORT, data: {reportID: '2'}}];
+            const result = resolveOpenReportDuplicationConflictAction(persistedRequests, {reportID: '1'} as never);
+            expect(result).toEqual({conflictAction: {type: 'push'}});
+        });
+
+        it('returns noAction when the queued OpenReport carries guidedSetupData', () => {
+            const persistedRequests = [{command: WRITE_COMMANDS.OPEN_REPORT, data: {reportID: '1', guidedSetupData: '[{}]'}}];
+            const result = resolveOpenReportDuplicationConflictAction(persistedRequests, {reportID: '1'} as never);
+            expect(result).toEqual({conflictAction: {type: 'noAction'}});
+        });
+
+        it('returns noAction when the queued request carries accountIDList but the new one has no participants', () => {
+            const persistedRequests = [{command: WRITE_COMMANDS.OPEN_REPORT, data: {reportID: '1', accountIDList: '10,20'}}];
+            const result = resolveOpenReportDuplicationConflictAction(persistedRequests, {reportID: '1'} as never);
+            expect(result).toEqual({conflictAction: {type: 'noAction'}});
+        });
+
+        it('replaces when the new request also carries an accountIDList', () => {
+            const persistedRequests = [{command: WRITE_COMMANDS.OPEN_REPORT, data: {reportID: '1', accountIDList: '10,20'}}];
+            const result = resolveOpenReportDuplicationConflictAction(persistedRequests, {reportID: '1', accountIDList: '10,20'} as never);
+            expect(result).toEqual({conflictAction: {type: 'replace', index: 0}});
+        });
+
+        it('replaces when neither queued nor new request has participants', () => {
+            const persistedRequests = [{command: 'OpenApp'}, {command: WRITE_COMMANDS.OPEN_REPORT, data: {reportID: '1'}}];
+            const result = resolveOpenReportDuplicationConflictAction(persistedRequests, {reportID: '1'} as never);
+            expect(result).toEqual({conflictAction: {type: 'replace', index: 1}});
+        });
+
+        it('replaces when the queued request has no participants but the new request does', () => {
+            const persistedRequests = [{command: WRITE_COMMANDS.OPEN_REPORT, data: {reportID: '1'}}];
+            const result = resolveOpenReportDuplicationConflictAction(persistedRequests, {reportID: '1', accountIDList: '10,20'} as never);
+            expect(result).toEqual({conflictAction: {type: 'replace', index: 0}});
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The `resolveOpenReportDuplicationConflictAction` resolver in `src/libs/actions/RequestConflictUtils.ts` was treating any queued `OpenReport` with the same `reportID` and `emailList` as a duplicate to replace, without considering `accountIDList`. When the user opened the assigned RM/PM/guide chat from the Help page, `navigateToAndOpenReportWithAccountIDs` queued an `OpenReport` carrying the account manager's `accountIDList`, and the subsequent screen-mount call from `ReportFetchHandler` (no participants) was matched as a duplicate and overwrote it — stripping the participants. Auth then took the `loginList.empty() && !doesReportExist` early-return path, returning a NIL reportSummary, which PHP surfaced as 403 "Report not found", flipping the optimistic report's `errorFields.notFound` so the chat rendered greyed-out. The fix adds a guard: if the queued request already carries participants (`emailList` or `accountIDList`) and the incoming one doesn't, return `noAction` and keep the original request intact so the server still gets the data it needs to resolve the optimistic chat.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/89928
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
This bug only happened when online

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Open the RM chat, note the reportID
3. Go to Settings → Help
3. Paste the following into the browser console (replace REPORTID with the ID from step 1):
```
// 1. Open the database
const request = indexedDB.open("OnyxDB", 1);

request.onsuccess = (event) => {
  const db = event.target.result;

  // 2. Start a transaction in 'readwrite' mode
  const transaction = db.transaction(["keyvaluepairs"], "readwrite");
  const store = transaction.objectStore("keyvaluepairs");

  // 3. Request deletion of the key
  const deleteRequest = store.delete("report_REPORTID");

  deleteRequest.onsuccess = () => {
    console.log("Key deleted successfully");
  };

  deleteRequest.onerror = (err) => {
    console.error("Error deleting key:", err);
  };
};
```
4. Throttle network requests to 3G in the Developer Tools Network tab
5. Click the account manager

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>