### PR TITLE
fix: show restricted action page for workspace Auditor role instead of NotFound

### DIFF
--- a/src/pages/RestrictedAction/Workspace/WorkspaceRestrictedActionPage.tsx
+++ b/src/pages/RestrictedAction/Workspace/WorkspaceRestrictedActionPage.tsx
@@ -8,7 +8,7 @@ import {openSubscriptionPage} from '@libs/actions/Subscription';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {RestrictedActionParamList} from '@libs/Navigation/types';
-import {isPolicyAdmin, isPolicyOwner, isPolicyUser} from '@libs/PolicyUtils';
+import {isPolicyAdmin, isPolicyAuditor, isPolicyOwner, isPolicyUser} from '@libs/PolicyUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
@@ -92,8 +92,8 @@ function WorkspaceRestrictedActionPage({
         return <WorkspaceAdminRestrictedAction policyID={policyID} />;
     }
 
-    // Workspace User
-    if (isPolicyUser(policy, session?.email)) {
+    // Workspace User or Auditor
+    if (isPolicyUser(policy, session?.email) || isPolicyAuditor(policy, session?.email)) {
         return <WorkspaceUserRestrictedAction policyID={policyID} />;
     }
 


### PR DESCRIPTION
### Explanation of Change

`WorkspaceRestrictedActionPage` dispatches to one of three role-specific views (Owner / Admin / User). Users with the **Auditor** role matched none of these conditions and fell through to `NotFoundPage`, producing a confusing 404 error when they attempted to approve reports on a billing-restricted workspace.

`isPolicyAuditor` was already exported from `PolicyUtils` — it simply was never referenced in this page. Auditors have the same relationship to billing restrictions as regular users: they cannot resolve the billing issue themselves and need to contact their admin. This PR wires `isPolicyAuditor` into the existing `isPolicyUser` condition so both roles render `WorkspaceUserRestrictedAction`.

Only `WorkspaceRestrictedActionPage.tsx` is modified (import + one condition). No new components, no translation changes, no data-layer changes.

### Fixed Issues
$ https://github.com/Expensify/App/issues/89935
PROPOSAL:

### Tests

1. Sign in as a workspace **Auditor** on a workspace where the owner is past their billing grace period.
2. Attempt to approve a report — this triggers navigation to the restricted action screen.
3. **Before fix:** NotFound (404) page is shown.
4. **After fix:** The standard user restricted action page appears with the message "Actions are currently restricted" and a "Chat with your admin" button.
5. Verify a workspace **User** still sees the same restricted action page (no regression).
6. Verify a workspace **Admin** still sees the admin-specific restricted action page (no regression).
7. Verify a workspace **Owner** still sees the owner-specific restricted action page (no regression).
8. Verify that no errors appear in the JS console.

### Offline tests

The restricted action page loads from cached Onyx data. When offline:
1. Navigate to the restricted action page as an Auditor.
2. Verify the correct user-variant restricted action page is shown — the offline guard in the component skips the API fetch, but the role-dispatch logic is unaffected.

### QA Steps

Same as Tests above. Reproduce on staging:
1. Create a workspace, invite a user and grant them the **Auditor** role.
2. Let the workspace owner's account fall into billing grace period (or use a staging account already in grace period).
3. As the Auditor, attempt an action that triggers the restricted action page.
4. Confirm the user-variant restricted action page is shown (not 404).

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the translation method
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods
    - [x] I verified any copy / text that was added to the app is grammatically correct in English.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files.
    - [x] I verified the JSDocs style guidelines were followed
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY (the PR does not include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
