### PR TITLE
[NoQA] Restore seatbelt entries after revert of #51366

### DIFF
--- a/config/eslint/eslint.seatbelt.tsv
+++ b/config/eslint/eslint.seatbelt.tsv
@@ -226,6 +226,7 @@
 "../../src/hooks/useNewTransactions.ts"	"react-hooks/refs"	2
 "../../src/hooks/useOnboardingFlow.ts"	"@typescript-eslint/no-deprecated/InteractionManager.runAfterInteractions"	1
 "../../src/hooks/useOutstandingBalanceGuard.tsx"	"@typescript-eslint/no-deprecated/ConfirmModal"	1
+"../../src/hooks/usePaginatedReportActions.ts"	"react-hooks/refs"	1
 "../../src/hooks/usePaymentOptions.ts"	"react-hooks/refs"	1
 "../../src/hooks/usePrevious.ts"	"react-hooks/refs"	1
 "../../src/hooks/useProactiveAppReview.ts"	"react-hooks/purity"	1
@@ -522,9 +523,11 @@
 "../../src/pages/inbox/report/ReportActionItemMessageEdit.tsx"	"react-hooks/preserve-manual-memoization"	1
 "../../src/pages/inbox/report/ReportActionItemMessageEdit.tsx"	"react-hooks/refs"	6
 "../../src/pages/inbox/report/ReportActionItemMessageEdit.tsx"	"react-hooks/set-state-in-effect"	1
-"../../src/pages/inbox/report/ReportActionsList.tsx"	"@typescript-eslint/no-deprecated/InteractionManager.runAfterInteractions"	4
-"../../src/pages/inbox/report/ReportActionsList.tsx"	"react-hooks/refs"	5
+"../../src/pages/inbox/report/ReportActionsList.tsx"	"@typescript-eslint/no-deprecated/InteractionManager.runAfterInteractions"	5
+"../../src/pages/inbox/report/ReportActionsList.tsx"	"react-hooks/refs"	7
 "../../src/pages/inbox/report/ReportActionsList.tsx"	"react-hooks/set-state-in-effect"	3
+"../../src/pages/inbox/report/ReportActionsView.tsx"	"react-hooks/globals"	1
+"../../src/pages/inbox/report/ReportActionsView.tsx"	"react-hooks/preserve-manual-memoization"	1
 "../../src/pages/inbox/report/TripSummary.tsx"	"rulesdir/no-default-id-values"	1
 "../../src/pages/inbox/report/UserTypingEventListener.tsx"	"@typescript-eslint/no-deprecated/InteractionManager.runAfterInteractions"	4
 "../../src/pages/inbox/report/shouldUseEmojiPickerSelection/index.website.ts"	"no-restricted-syntax"	1


### PR DESCRIPTION
### Explanation of Change

[PR #90065](https://github.com/Expensify/App/pull/90065) reverted [PR #51366](https://github.com/Expensify/App/pull/51366) (`Open reports at first unread action`). The original PR had brought several `eslint-seatbelt`-tracked rules down to lower counts (or to zero), and the post-merge `Auto-tighten eslint-seatbelt baseline` job ([dd74f007c63](https://github.com/Expensify/App/commit/dd74f007c63)) had ratcheted the baseline accordingly. The straight revert restored the original code (and its violations) but did not restore the corresponding seatbelt entries. Lint has been failing on `main` for every push since 19:14 UTC ([first failing run](https://github.com/Expensify/App/actions/runs/25574605126), [latest failing run at time of writing](https://github.com/Expensify/App/actions/runs/25578904575)).

`eslint-seatbelt` only auto-tightens the baseline, never auto-loosens it (see [`.github/workflows/lint.yml`](https://github.com/Expensify/App/blob/main/.github/workflows/lint.yml)), so the workflow cannot self-heal after a straight revert. This PR adjusts the baseline to match the actual error counts that the revert reintroduced:

| File | Rule | Before | After |
| --- | --- | --- | --- |
| `src/hooks/usePaginatedReportActions.ts` | `react-hooks/refs` | (none) | 1 |
| `src/pages/inbox/report/ReportActionsList.tsx` | `@typescript-eslint/no-deprecated/InteractionManager.runAfterInteractions` | 4 | 5 |
| `src/pages/inbox/report/ReportActionsList.tsx` | `react-hooks/refs` | 5 | 7 |
| `src/pages/inbox/report/ReportActionsView.tsx` | `react-hooks/globals` | (none) | 1 |
| `src/pages/inbox/report/ReportActionsView.tsx` | `react-hooks/preserve-manual-memoization` | (none) | 1 |

Total: 15 entries — exactly matching the `✖ 15 problems (15 errors, 0 warnings)` summary from the failing run. When #51366 is re-rolled, the auto-tighten job will remove these entries again automatically.

This follows the same pattern as [PR #89732](https://github.com/Expensify/App/pull/89732), which fixed an identical situation after a previous revert.

### Fixed Issues

$
PROPOSAL: N/A

### Tests

1. Check out this branch
2. Run `npm run lint` (or just `npx eslint src/hooks/usePaginatedReportActions.ts src/pages/inbox/report/ReportActionsList.tsx src/pages/inbox/report/ReportActionsView.tsx`)
3. Verify lint passes with no errors

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — config-only change.

### QA Steps

N/A — config-only change. CI `lint / ESLint check` going green on `main` after merge is the verification.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — config-only change.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — config-only change.

</details>

<details>
<summary>iOS: Native</summary>

N/A — config-only change.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — config-only change.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — config-only change.

</details>
