### PR TITLE
Fix: Nothing happens after clicking "Update details" for pending bank account

### DIFF
--- a/src/pages/ReimbursementAccount/USD/ConnectBankAccount/components/FinishChatCard.tsx
+++ b/src/pages/ReimbursementAccount/USD/ConnectBankAccount/components/FinishChatCard.tsx
@@ -10,11 +10,13 @@ import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
+import Navigation from '@libs/Navigation/Navigation';
 import WorkspaceResetBankAccountModal from '@pages/workspace/WorkspaceResetBankAccountModal';
 import {goToWithdrawalAccountSetupStep, requestResetBankAccount, setBankAccountSubStep} from '@userActions/BankAccounts';
 import {navigateToConciergeChat} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import type {ReimbursementAccount} from '@src/types/onyx';
 import Enable2FACard from './Enable2FACard';
 
@@ -80,6 +82,13 @@ function FinishChatCard({requiresTwoFactorAuth, reimbursementAccount, setUSDBank
                         setBankAccountSubStep(CONST.BANK_ACCOUNT.SETUP_TYPE.MANUAL).then(() => {
                             setUSDBankAccountStep?.(CONST.BANK_ACCOUNT.STEP.REQUESTOR);
                             goToWithdrawalAccountSetupStep(CONST.BANK_ACCOUNT.STEP.REQUESTOR);
+                            Navigation.navigate(
+                                ROUTES.BANK_ACCOUNT_USD_SETUP.getRoute({
+                                    policyID,
+                                    page: CONST.BANK_ACCOUNT.PAGE_NAMES.REQUESTOR,
+                                    subPage: CONST.BANK_ACCOUNT.PERSONAL_INFO_STEP.SUB_PAGE_NAMES.FULL_NAME,
+                                }),
+                            );
                         });
                     }}
                     outerWrapperStyle={shouldUseNarrowLayout ? styles.mhn5 : styles.mhn8}


### PR DESCRIPTION
### Details
$ #90098

**Cause:**
When the USD Verified Bank Account flow transitioned to URL-based navigation (`USDVerifiedBankAccountFlowPage.tsx`), the `ConnectBankAccount` component no longer received the `setUSDBankAccountStep` prop. As a result, the `FinishChatCard` component failed to trigger a step transition when "Update details" was clicked, because `setUSDBankAccountStep?.(...)` did nothing and `goToWithdrawalAccountSetupStep` only modified Onyx without triggering a route change in the new navigator.

**Fix:**
Updated the `onPress` handler of the "Update details" `MenuItem` to execute an explicit `Navigation.navigate` to `ROUTES.BANK_ACCOUNT_USD_SETUP` with the `REQUESTOR` page and `FULL_NAME` subpage, replacing the legacy Onyx-only transition with the proper URL-based transition.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90098

### Tests
1. Sign in to ND with a validated account
2. Go to Workspace > Workflows > Add bank account
3. Reach the "Let's finish in chat!" pending state
4. Click "Update details"
5. Verify that you are correctly navigated back to the Personal Info step.