### PR TITLE
Fix/search saved tab native highlight

### DIFF
--- a/src/hooks/useSearchTypeMenuSections.ts
+++ b/src/hooks/useSearchTypeMenuSections.ts
@@ -131,7 +131,18 @@ const useSearchTypeMenuSections = (queryParams?: UseSearchTypeMenuSectionsParams
     );
 
     const activeItemIndex = useMemo(() => {
-        const isSavedSearchActive = hash !== undefined && !!savedSearches && Object.keys(savedSearches).some((key) => Number(key) === hash);
+        const isSavedSearchActive =
+            hash !== undefined &&
+            !!savedSearches &&
+            Object.entries(savedSearches).some(([key, item]) => {
+                if (Number(key) !== hash) {
+                    return false;
+                }
+                if (item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE && !isOffline) {
+                    return false;
+                }
+                return true;
+            });
 
         if (isSavedSearchActive) {
             return -1;
@@ -169,7 +180,7 @@ const useSearchTypeMenuSections = (queryParams?: UseSearchTypeMenuSectionsParams
         }
 
         return -1;
-    }, [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type]);
+    }, [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type, isOffline]);
 
     const activeKey = activeItemIndex < 0 ? undefined : typeMenuSections.flatMap((section) => section.menuItems).at(activeItemIndex)?.key;
 

--- a/src/hooks/useSearchTypeMenuSections.ts
+++ b/src/hooks/useSearchTypeMenuSections.ts
@@ -53,6 +53,57 @@ type UseSearchTypeMenuSectionsParams = {
     type?: string;
 };
 
+type GetActiveItemIndexParams = {
+    typeMenuSections: ReturnType<typeof createTypeMenuSections>;
+    savedSearches: OnyxEntry<Record<string, unknown>>;
+    hash?: number;
+    similarSearchHash?: number;
+    sortBy?: string;
+    sortOrder?: string;
+    type?: string;
+};
+
+function getActiveItemIndex({typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type}: GetActiveItemIndexParams): number {
+    const isSavedSearchActive = hash !== undefined && !!savedSearches && Object.keys(savedSearches).some((key) => Number(key) === hash);
+
+    if (isSavedSearchActive) {
+        return -1;
+    }
+
+    let index = 0;
+    for (const section of typeMenuSections) {
+        const found = section.menuItems.findIndex((item) => {
+            if (item.similarSearchHash !== similarSearchHash) {
+                return false;
+            }
+            return doesSearchItemMatchSort(item.key, item.searchQueryJSON?.sortBy, item.searchQueryJSON?.sortOrder, sortBy, sortOrder);
+        });
+        if (found !== -1) {
+            return index + found;
+        }
+        index += section.menuItems.length;
+    }
+
+    // Fallback: if no exact match found, select the generic search key matching the type
+    const typeToGenericKey: Record<string, string> = {
+        [CONST.SEARCH.DATA_TYPES.EXPENSE]: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+        [CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT]: CONST.SEARCH.SEARCH_KEYS.REPORTS,
+    };
+    const fallbackKey = type ? typeToGenericKey[type] : undefined;
+    if (fallbackKey) {
+        let fallbackIndex = 0;
+        for (const section of typeMenuSections) {
+            const found = section.menuItems.findIndex((item) => item.key === fallbackKey);
+            if (found !== -1) {
+                return fallbackIndex + found;
+            }
+            fallbackIndex += section.menuItems.length;
+        }
+    }
+
+    return -1;
+}
+
 /**
  * Get a list of all search groupings, along with their search items. Also returns the
  * currently focused search, based on the hash
@@ -127,51 +178,29 @@ const useSearchTypeMenuSections = (queryParams?: UseSearchTypeMenuSectionsParams
         ],
     );
 
-    const activeItemIndex = useMemo(() => {
-        const isSavedSearchActive = hash !== undefined && !!savedSearches && Object.keys(savedSearches).some((key) => Number(key) === hash);
+    const activeItemIndex = useMemo(
+        () =>
+            getActiveItemIndex({
+                typeMenuSections,
+                savedSearches: savedSearches as OnyxEntry<Record<string, unknown>>,
+                hash,
+                similarSearchHash,
+                sortBy,
+                sortOrder,
+                type,
+            }),
+        [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type],
+    );
 
-        if (isSavedSearchActive) {
-            return -1;
-        }
-
-        let index = 0;
-        for (const section of typeMenuSections) {
-            const found = section.menuItems.findIndex((item) => {
-                if (item.similarSearchHash !== similarSearchHash) {
-                    return false;
-                }
-                return doesSearchItemMatchSort(item.key, item.searchQueryJSON?.sortBy, item.searchQueryJSON?.sortOrder, sortBy, sortOrder);
-            });
-            if (found !== -1) {
-                return index + found;
-            }
-            index += section.menuItems.length;
-        }
-
-        // Fallback: if no exact match found, select the generic search key matching the type
-        const typeToGenericKey: Record<string, string> = {
-            [CONST.SEARCH.DATA_TYPES.EXPENSE]: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
-            [CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT]: CONST.SEARCH.SEARCH_KEYS.REPORTS,
-        };
-        const fallbackKey = type ? typeToGenericKey[type] : undefined;
-        if (fallbackKey) {
-            let fallbackIndex = 0;
-            for (const section of typeMenuSections) {
-                const found = section.menuItems.findIndex((item) => item.key === fallbackKey);
-                if (found !== -1) {
-                    return fallbackIndex + found;
-                }
-                fallbackIndex += section.menuItems.length;
-            }
-        }
-
-        return -1;
-    }, [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type]);
+    const flattenedTypeMenuItems = useMemo(() => typeMenuSections.flatMap((section) => section.menuItems), [typeMenuSections]);
+    const activeItemKey = useMemo(() => flattenedTypeMenuItems.at(activeItemIndex)?.key, [flattenedTypeMenuItems, activeItemIndex]);
 
     return {
         typeMenuSections,
         activeItemIndex,
+        activeItemKey,
     };
 };
 
+export {getActiveItemIndex};
 export default useSearchTypeMenuSections;

--- a/src/hooks/useSearchTypeMenuSections.ts
+++ b/src/hooks/useSearchTypeMenuSections.ts
@@ -61,10 +61,23 @@ type GetActiveItemIndexParams = {
     sortBy?: string;
     sortOrder?: string;
     type?: string;
+    isOffline: boolean;
 };
 
-function getActiveItemIndex({typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type}: GetActiveItemIndexParams): number {
-    const isSavedSearchActive = hash !== undefined && !!savedSearches && Object.keys(savedSearches).some((key) => Number(key) === hash);
+function getActiveItemIndex({typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type, isOffline}: GetActiveItemIndexParams): number {
+    const isSavedSearchActive =
+        hash !== undefined &&
+        !!savedSearches &&
+        Object.entries(savedSearches).some(([key, raw]) => {
+            if (Number(key) !== hash) {
+                return false;
+            }
+            const item = raw as {pendingAction?: string};
+            if (item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE && !isOffline) {
+                return false;
+            }
+            return true;
+        });
 
     if (isSavedSearchActive) {
         return -1;
@@ -188,8 +201,9 @@ const useSearchTypeMenuSections = (queryParams?: UseSearchTypeMenuSectionsParams
                 sortBy,
                 sortOrder,
                 type,
+                isOffline,
             }),
-        [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type],
+        [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type, isOffline],
     );
 
     const flattenedTypeMenuItems = useMemo(() => typeMenuSections.flatMap((section) => section.menuItems), [typeMenuSections]);

--- a/src/pages/Search/SearchPageNarrow/StaticSearchTypeMenu.tsx
+++ b/src/pages/Search/SearchPageNarrow/StaticSearchTypeMenu.tsx
@@ -1,25 +1,26 @@
-import {useSession} from '@components/OnyxListItemProvider';
-import type {SearchQueryJSON} from '@components/Search/types';
-import type {TabSelectorBaseItem} from '@components/TabSelector/types';
-
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
-import useLocalize from '@hooks/useLocalize';
-import useOnyx from '@hooks/useOnyx';
-
-import type {SearchTypeMenuItem} from '@libs/SearchUIUtils';
-import {getSuggestedSearches} from '@libs/SearchUIUtils';
-
-import {SearchTypeMenuNarrowContent} from '@pages/Search/SearchTypeMenuNarrow';
-
-import CONST from '@src/CONST';
-import ONYXKEYS from '@src/ONYXKEYS';
-
 // Static twin of SearchTypeMenuNarrow - used for fast perceived performance.
 // Keep hooks and Onyx subscriptions to an absolute minimum; add new ones only
 // when strictly necessary. UI must stay visually identical to the interactive version.
 import React from 'react';
-
+import {useSession} from '@components/OnyxListItemProvider';
+import type {SearchQueryJSON} from '@components/Search/types';
+import type {TabSelectorBaseItem} from '@components/TabSelector/types';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import type {SearchTypeMenuItem} from '@libs/SearchUIUtils';
+import {getSuggestedSearches} from '@libs/SearchUIUtils';
+import {SearchTypeMenuNarrowContent} from '@pages/Search/SearchTypeMenuNarrow';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import staticPolicyInfoSelector from './staticPolicyInfoSelector';
+
+type SavedSearchMinimal = {
+    name: string;
+    query: string;
+    pendingAction?: string;
+};
 
 function getActiveKey(similarSearchHash: number, hasGroupPolicy: boolean, searches: Record<string, SearchTypeMenuItem>): string {
     const reportsSearch = searches[CONST.SEARCH.SEARCH_KEYS.REPORTS];
@@ -29,10 +30,32 @@ function getActiveKey(similarSearchHash: number, hasGroupPolicy: boolean, search
     return candidates.find((entry) => similarSearchHash === entry.similarSearchHash)?.key ?? reportsSearch.key;
 }
 
+function getActiveSavedSearch(savedSearches: Record<string, SavedSearchMinimal> | undefined, hash: number, isOffline: boolean): {key: string; title: string} | undefined {
+    if (!savedSearches) {
+        return undefined;
+    }
+    const entry = Object.entries(savedSearches).find(([key, item]) => {
+        if (Number(key) !== hash) {
+            return false;
+        }
+        if (item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE && !isOffline) {
+            return false;
+        }
+        return true;
+    });
+    if (!entry) {
+        return undefined;
+    }
+    const [key, item] = entry;
+    return {key, title: item.name || item.query || key};
+}
+
 function StaticSearchTypeMenu({queryJSON}: {queryJSON: SearchQueryJSON}) {
     const {translate} = useLocalize();
-    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Receipt', 'Document', 'Pencil']);
+    const {isOffline} = useNetwork();
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Receipt', 'Document', 'Pencil', 'Bookmark']);
     const [policyInfo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: staticPolicyInfoSelector});
+    const [savedSearches] = useOnyx(ONYXKEYS.SAVED_SEARCHES);
     const hasGroupPolicy = policyInfo?.hasGroupPolicy ?? false;
     const session = useSession();
     const accountID = session?.accountID ?? CONST.DEFAULT_NUMBER_ID;
@@ -51,7 +74,12 @@ function StaticSearchTypeMenu({queryJSON}: {queryJSON: SearchQueryJSON}) {
         tabs.push({key: submitSearch.key, icon: expensifyIcons.Pencil, title: translate(submitSearch.translationPath)});
     }
 
-    const activeKey = getActiveKey(queryJSON.similarSearchHash, hasGroupPolicy, suggestedSearches);
+    const activeSavedSearch = getActiveSavedSearch(savedSearches as Record<string, SavedSearchMinimal> | undefined, queryJSON.hash, isOffline);
+    if (activeSavedSearch) {
+        tabs.push({key: activeSavedSearch.key, icon: expensifyIcons.Bookmark, title: activeSavedSearch.title});
+    }
+
+    const activeKey = activeSavedSearch?.key ?? getActiveKey(queryJSON.similarSearchHash, hasGroupPolicy, suggestedSearches);
 
     return (
         <SearchTypeMenuNarrowContent

--- a/src/pages/Search/SearchPageNarrow/StaticSearchTypeMenu.tsx
+++ b/src/pages/Search/SearchPageNarrow/StaticSearchTypeMenu.tsx
@@ -1,26 +1,29 @@
-// Static twin of SearchTypeMenuNarrow - used for fast perceived performance.
-// Keep hooks and Onyx subscriptions to an absolute minimum; add new ones only
-// when strictly necessary. UI must stay visually identical to the interactive version.
-import React from 'react';
 import {useSession} from '@components/OnyxListItemProvider';
 import type {SearchQueryJSON} from '@components/Search/types';
 import type {TabSelectorBaseItem} from '@components/TabSelector/types';
+
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+
 import type {SearchTypeMenuItem} from '@libs/SearchUIUtils';
 import {getSuggestedSearches} from '@libs/SearchUIUtils';
+
 import {SearchTypeMenuNarrowContent} from '@pages/Search/SearchTypeMenuNarrow';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import staticPolicyInfoSelector from './staticPolicyInfoSelector';
+import type {SaveSearch} from '@src/types/onyx';
 
-type SavedSearchMinimal = {
-    name: string;
-    query: string;
-    pendingAction?: string;
-};
+import type {OnyxEntry} from 'react-native-onyx';
+
+// Static twin of SearchTypeMenuNarrow - used for fast perceived performance.
+// Keep hooks and Onyx subscriptions to an absolute minimum; add new ones only
+// when strictly necessary. UI must stay visually identical to the interactive version.
+import React from 'react';
+
+import staticPolicyInfoSelector from './staticPolicyInfoSelector';
 
 function getActiveKey(similarSearchHash: number, hasGroupPolicy: boolean, searches: Record<string, SearchTypeMenuItem>): string {
     const reportsSearch = searches[CONST.SEARCH.SEARCH_KEYS.REPORTS];
@@ -30,7 +33,7 @@ function getActiveKey(similarSearchHash: number, hasGroupPolicy: boolean, search
     return candidates.find((entry) => similarSearchHash === entry.similarSearchHash)?.key ?? reportsSearch.key;
 }
 
-function getActiveSavedSearch(savedSearches: Record<string, SavedSearchMinimal> | undefined, hash: number, isOffline: boolean): {key: string; title: string} | undefined {
+function getActiveSavedSearch(savedSearches: OnyxEntry<SaveSearch>, hash: number, isOffline: boolean): {key: string; title: string} | undefined {
     if (!savedSearches) {
         return undefined;
     }
@@ -74,7 +77,7 @@ function StaticSearchTypeMenu({queryJSON}: {queryJSON: SearchQueryJSON}) {
         tabs.push({key: submitSearch.key, icon: expensifyIcons.Pencil, title: translate(submitSearch.translationPath)});
     }
 
-    const activeSavedSearch = getActiveSavedSearch(savedSearches as Record<string, SavedSearchMinimal> | undefined, queryJSON.hash, isOffline);
+    const activeSavedSearch = getActiveSavedSearch(savedSearches, queryJSON.hash, isOffline);
     if (activeSavedSearch) {
         tabs.push({key: activeSavedSearch.key, icon: expensifyIcons.Bookmark, title: activeSavedSearch.title});
     }

--- a/src/pages/Search/SearchPageNarrow/StaticSearchTypeMenu.tsx
+++ b/src/pages/Search/SearchPageNarrow/StaticSearchTypeMenu.tsx
@@ -7,6 +7,7 @@ import type {SearchQueryJSON} from '@components/Search/types';
 import type {TabSelectorBaseItem} from '@components/TabSelector/types';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import type {SearchTypeMenuItem} from '@libs/SearchUIUtils';
 import {getSuggestedSearches} from '@libs/SearchUIUtils';
@@ -14,6 +15,12 @@ import {SearchTypeMenuNarrowContent} from '@pages/Search/SearchTypeMenuNarrow';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import staticPolicyInfoSelector from './staticPolicyInfoSelector';
+
+type SavedSearchMinimal = {
+    name: string;
+    query: string;
+    pendingAction?: string;
+};
 
 function getActiveKey(similarSearchHash: number, hasPaidGroupPolicy: boolean, searches: Record<string, SearchTypeMenuItem>): string {
     const reportsSearch = searches[CONST.SEARCH.SEARCH_KEYS.REPORTS];
@@ -23,10 +30,32 @@ function getActiveKey(similarSearchHash: number, hasPaidGroupPolicy: boolean, se
     return candidates.find((entry) => similarSearchHash === entry.similarSearchHash)?.key ?? reportsSearch.key;
 }
 
+function getActiveSavedSearch(savedSearches: Record<string, SavedSearchMinimal> | undefined, hash: number, isOffline: boolean): {key: string; title: string} | undefined {
+    if (!savedSearches) {
+        return undefined;
+    }
+    const entry = Object.entries(savedSearches).find(([key, item]) => {
+        if (Number(key) !== hash) {
+            return false;
+        }
+        if (item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE && !isOffline) {
+            return false;
+        }
+        return true;
+    });
+    if (!entry) {
+        return undefined;
+    }
+    const [key, item] = entry;
+    return {key, title: item.name || item.query || key};
+}
+
 function StaticSearchTypeMenu({queryJSON}: {queryJSON: SearchQueryJSON}) {
     const {translate} = useLocalize();
-    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Receipt', 'Document', 'Pencil']);
+    const {isOffline} = useNetwork();
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Receipt', 'Document', 'Pencil', 'Bookmark']);
     const [policyInfo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: staticPolicyInfoSelector});
+    const [savedSearches] = useOnyx(ONYXKEYS.SAVED_SEARCHES);
     const hasPaidGroupPolicy = policyInfo?.hasPaidGroupPolicy ?? false;
     const session = useSession();
     const accountID = session?.accountID ?? CONST.DEFAULT_NUMBER_ID;
@@ -45,7 +74,12 @@ function StaticSearchTypeMenu({queryJSON}: {queryJSON: SearchQueryJSON}) {
         tabs.push({key: submitSearch.key, icon: expensifyIcons.Pencil, title: translate(submitSearch.translationPath)});
     }
 
-    const activeKey = getActiveKey(queryJSON.similarSearchHash, hasPaidGroupPolicy, suggestedSearches);
+    const activeSavedSearch = getActiveSavedSearch(savedSearches as Record<string, SavedSearchMinimal> | undefined, queryJSON.hash, isOffline);
+    if (activeSavedSearch) {
+        tabs.push({key: activeSavedSearch.key, icon: expensifyIcons.Bookmark, title: activeSavedSearch.title});
+    }
+
+    const activeKey = activeSavedSearch?.key ?? getActiveKey(queryJSON.similarSearchHash, hasPaidGroupPolicy, suggestedSearches);
 
     return (
         <SearchTypeMenuNarrowContent

--- a/src/pages/Search/SearchTypeMenuNarrow.tsx
+++ b/src/pages/Search/SearchTypeMenuNarrow.tsx
@@ -49,7 +49,10 @@ type SearchTypeMenuNarrowContentProps = {
 };
 
 function getNarrowActiveTabKey(activeSavedSearchKey: string, activeItemKey?: string): string {
-    return activeSavedSearchKey || activeItemKey || '';
+    if (activeSavedSearchKey !== '') {
+        return activeSavedSearchKey;
+    }
+    return activeItemKey ?? '';
 }
 
 function SearchTypeMenuNarrowContent({tabs, activeTabKey, onActiveTabPress, onTabPress: onTabPressContent, onLongTabPress, containerRef, children}: SearchTypeMenuNarrowContentProps) {

--- a/src/pages/Search/SearchTypeMenuNarrow.tsx
+++ b/src/pages/Search/SearchTypeMenuNarrow.tsx
@@ -48,6 +48,10 @@ type SearchTypeMenuNarrowContentProps = {
     children?: React.ReactNode;
 };
 
+function getNarrowActiveTabKey(activeSavedSearchKey: string, activeItemKey?: string): string {
+    return activeSavedSearchKey || activeItemKey || '';
+}
+
 function SearchTypeMenuNarrowContent({tabs, activeTabKey, onActiveTabPress, onTabPress: onTabPressContent, onLongTabPress, containerRef, children}: SearchTypeMenuNarrowContentProps) {
     const styles = useThemeStyles();
 
@@ -74,7 +78,8 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
     const navigation = useNavigation();
-    const {typeMenuSections} = useSearchTypeMenuSections();
+    const {hash, similarSearchHash, sortBy, sortOrder, type} = queryJSON ?? {};
+    const {typeMenuSections, activeItemKey} = useSearchTypeMenuSections({hash, similarSearchHash, sortBy, sortOrder, type});
     const personalDetails = usePersonalDetails();
     const feedKeysWithCards = useFeedKeysWithAssignedCards();
     const [restoreFocusType, setRestoreFocusType] = useState<BaseModalProps['restoreFocusType']>();
@@ -132,7 +137,7 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
     const queryMap = new Map<string, {query: string; name?: string}>();
     const tabItems: TabSelectorBaseItem[] = [];
     const savedSearchesPopoverMenuItems: Record<string, PopoverMenuItem[]> = {};
-    let activeKey = '';
+    let activeSavedSearchKey = '';
 
     const savedSearchesTabItems: TabSelectorBaseItem[] = savedSearches
         ? Object.entries(savedSearches)
@@ -149,7 +154,7 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
                   );
 
                   if (Number(key) === queryJSON?.hash) {
-                      activeKey = key;
+                      activeSavedSearchKey = key;
                   }
 
                   return {
@@ -178,12 +183,10 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
                     badgeText,
                 });
                 queryMap.set(item.key, {query: item.searchQuery});
-                if (item.similarSearchHash === queryJSON?.similarSearchHash) {
-                    activeKey = item.key;
-                }
             }
         }
     }
+    const activeKey = getNarrowActiveTabKey(activeSavedSearchKey, activeItemKey);
 
     const popoverMenuItems = savedSearchToModifyKey ? savedSearchesPopoverMenuItems?.[savedSearchToModifyKey] : [];
     const shouldShowSavedSearchPopover = savedSearchToModifyKey && popoverMenuItems.length > 0;
@@ -253,6 +256,6 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
     );
 }
 
-export {SearchTypeMenuNarrowContent};
+export {getNarrowActiveTabKey, SearchTypeMenuNarrowContent};
 export default SearchTypeMenuNarrow;
 export type {SearchTypeMenuNarrowProps};

--- a/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
+++ b/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
@@ -1,0 +1,171 @@
+import {act, render, screen} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import type * as ReactNavigation from '@react-navigation/native';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import useNetwork from '@hooks/useNetwork';
+import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
+import StaticSearchTypeMenu from '@pages/Search/SearchPageNarrow/StaticSearchTypeMenu';
+import SearchTypeMenuNarrow from '@pages/Search/SearchTypeMenuNarrow';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import {translateLocal} from '../../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('@hooks/useTodoCounts', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({counts: {}})),
+}));
+
+jest.mock('@react-navigation/native', () => {
+    const actualNavigation: typeof ReactNavigation = jest.requireActual('@react-navigation/native');
+
+    return {
+        ...actualNavigation,
+        useNavigation: jest.fn(() => ({dispatch: jest.fn()})),
+        useIsFocused: jest.fn(() => true),
+    };
+});
+jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
+
+function Wrapper({children}: {children: React.ReactNode}) {
+    return (
+        <OnyxListItemProvider>
+            <LocaleContextProvider>{children}</LocaleContextProvider>
+        </OnyxListItemProvider>
+    );
+}
+
+describe('Search saved-search tab highlight', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await Onyx.clear();
+        });
+        await waitForBatchedUpdatesWithAct();
+        jest.clearAllMocks();
+    });
+
+    it('keeps saved search selected in static narrow menu when similar hash collides', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <StaticSearchTypeMenu queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByRole('tab', {name: 'My saved search', selected: true})).toBeTruthy();
+    });
+
+    it('keeps saved search selected in interactive narrow menu when similar hash collides', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <SearchTypeMenuNarrow queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByRole('tab', {name: 'My saved search', selected: true})).toBeTruthy();
+    });
+
+    it('does not show pending-delete saved search as selected in static narrow menu while online', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        (useNetwork as jest.Mock).mockReturnValue({isOffline: false});
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <StaticSearchTypeMenu queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByRole('tab', {name: 'My saved search'})).toBeNull();
+    });
+
+    it('highlights built-in tab when saved search is pending delete while online (interactive narrow)', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        (useNetwork as jest.Mock).mockReturnValue({isOffline: false});
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <SearchTypeMenuNarrow queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByRole('tab', {name: 'My saved search'})).toBeNull();
+        expect(screen.getByRole('tab', {name: translateLocal('search.tabs.expenses'), selected: true})).toBeTruthy();
+    });
+});

--- a/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
+++ b/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
@@ -1,15 +1,23 @@
 import {act, render, screen} from '@testing-library/react-native';
-import React from 'react';
-import Onyx from 'react-native-onyx';
-import type * as ReactNavigation from '@react-navigation/native';
+
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
 import useNetwork from '@hooks/useNetwork';
+
 import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
+
 import StaticSearchTypeMenu from '@pages/Search/SearchPageNarrow/StaticSearchTypeMenu';
 import SearchTypeMenuNarrow from '@pages/Search/SearchTypeMenuNarrow';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+
+import type * as ReactNavigation from '@react-navigation/native';
+
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
 import {translateLocal} from '../../utils/TestHelper';
 import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
 
@@ -115,7 +123,7 @@ describe('Search saved-search tab highlight', () => {
             throw new Error('Failed to build saved query JSON');
         }
 
-        (useNetwork as jest.Mock).mockReturnValue({isOffline: false});
+        jest.mocked(useNetwork).mockReturnValue({isOffline: false});
 
         await act(async () => {
             await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
@@ -146,7 +154,7 @@ describe('Search saved-search tab highlight', () => {
             throw new Error('Failed to build saved query JSON');
         }
 
-        (useNetwork as jest.Mock).mockReturnValue({isOffline: false});
+        jest.mocked(useNetwork).mockReturnValue({isOffline: false});
 
         await act(async () => {
             await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {

--- a/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
+++ b/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
@@ -1,0 +1,126 @@
+import {act, render, screen} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
+import StaticSearchTypeMenu from '@pages/Search/SearchPageNarrow/StaticSearchTypeMenu';
+import SearchTypeMenuNarrow from '@pages/Search/SearchTypeMenuNarrow';
+import ONYXKEYS from '@src/ONYXKEYS';
+import CONST from '@src/CONST';
+import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
+import useNetwork from '@hooks/useNetwork';
+
+jest.mock('@react-navigation/native', () => ({
+    useNavigation: jest.fn(() => ({dispatch: jest.fn()})),
+}));
+jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
+
+function Wrapper({children}: {children: React.ReactNode}) {
+    return (
+        <OnyxListItemProvider>
+            <LocaleContextProvider>{children}</LocaleContextProvider>
+        </OnyxListItemProvider>
+    );
+}
+
+describe('Search saved-search tab highlight', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await Onyx.clear();
+        });
+        await waitForBatchedUpdatesWithAct();
+        jest.clearAllMocks();
+    });
+
+    it('keeps saved search selected in static narrow menu when similar hash collides', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <StaticSearchTypeMenu queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByRole('tab', {name: 'My saved search', selected: true})).toBeTruthy();
+    });
+
+    it('keeps saved search selected in interactive narrow menu when similar hash collides', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <SearchTypeMenuNarrow queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByRole('tab', {name: 'My saved search', selected: true})).toBeTruthy();
+    });
+
+    it('does not show pending-delete saved search as selected in static narrow menu while online', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        (useNetwork as jest.Mock).mockReturnValue({isOffline: false});
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <StaticSearchTypeMenu queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByRole('tab', {name: 'My saved search'})).toBeNull();
+    });
+});

--- a/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
+++ b/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
@@ -3,17 +3,23 @@ import React from 'react';
 import Onyx from 'react-native-onyx';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import useNetwork from '@hooks/useNetwork';
 import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
 import StaticSearchTypeMenu from '@pages/Search/SearchPageNarrow/StaticSearchTypeMenu';
 import SearchTypeMenuNarrow from '@pages/Search/SearchTypeMenuNarrow';
-import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
-import useNetwork from '@hooks/useNetwork';
 
-jest.mock('@react-navigation/native', () => ({
-    useNavigation: jest.fn(() => ({dispatch: jest.fn()})),
-}));
+jest.mock('@react-navigation/native', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const actual = jest.requireActual('@react-navigation/native');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...actual,
+        useNavigation: jest.fn(() => ({dispatch: jest.fn()})),
+    };
+});
 jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
 
 function Wrapper({children}: {children: React.ReactNode}) {

--- a/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
+++ b/tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx
@@ -9,6 +9,7 @@ import StaticSearchTypeMenu from '@pages/Search/SearchPageNarrow/StaticSearchTyp
 import SearchTypeMenuNarrow from '@pages/Search/SearchTypeMenuNarrow';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import {translateLocal} from '../../utils/TestHelper';
 import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
 
 jest.mock('@react-navigation/native', () => {
@@ -128,5 +129,37 @@ describe('Search saved-search tab highlight', () => {
         await waitForBatchedUpdatesWithAct();
 
         expect(screen.queryByRole('tab', {name: 'My saved search'})).toBeNull();
+    });
+
+    it('highlights built-in tab when saved search is pending delete while online (interactive narrow)', async () => {
+        const baseQuery = 'type:expense status:all';
+        const savedQueryString = `${baseQuery} sortBy:amount`;
+        const savedQueryJSON = buildSearchQueryJSON(savedQueryString);
+
+        if (!savedQueryJSON) {
+            throw new Error('Failed to build saved query JSON');
+        }
+
+        (useNetwork as jest.Mock).mockReturnValue({isOffline: false});
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SAVED_SEARCHES, {
+                [savedQueryJSON.hash]: {
+                    name: 'My saved search',
+                    query: savedQueryString,
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                },
+            });
+        });
+
+        render(
+            <Wrapper>
+                <SearchTypeMenuNarrow queryJSON={savedQueryJSON} />
+            </Wrapper>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByRole('tab', {name: 'My saved search'})).toBeNull();
+        expect(screen.getByRole('tab', {name: translateLocal('search.tabs.expenses'), selected: true})).toBeTruthy();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The main interactive narrow saved-search highlight path was fixed on main separately (#89112 via `useSearchTypeMenuSections` / `activeTypeMenuKey`). This PR polishes the remaining gaps:

1. **Pending-delete while online:** when a saved search is pending delete, it is hidden from the tab strip, but active-tab logic still treated its `hash` as an active saved search, so no tab was highlighted. We now ignore pending-delete entries (while online) in `useSearchTypeMenuSections` so the matching built-in tab (e.g. Expenses) highlights instead.
2. **Static narrow header:** `StaticSearchTypeMenu` only knew about built-in tabs and `similarSearchHash`, so during the static loading phase a built-in tab could flash as active for a saved search. It now includes the active saved search (when not pending-delete online) and highlights it.
3. **Regression tests:** adds `SearchTypeMenuSavedSearchHighlightTest` for static + interactive narrow menus, including the pending-delete case.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/87769
PROPOSAL: https://github.com/Expensify/App/issues/87769#issuecomment-4282081093

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. On iOS or Android native, open Search and select a saved search whose query differs from a built-in tab only in fields that do not change `similarSearchHash` (e.g. expense search with a custom sort). Confirm the **saved search** tab is highlighted (not Expenses/Reports).
2. Repeat on narrow web (viewport at or below ~800px). Confirm the saved search tab highlights correctly.
3. **Pending-delete (online):** while online, delete a saved search so it is pending delete, then open Search on that query. Confirm the pending-delete saved search is **not** shown as active (and is not in the strip while online), and the matching **built-in** tab (e.g. Expenses) **is** highlighted.
4. **Static header:** open a saved search on a slow network or heavy result set so the static header is visible briefly. Confirm the saved search tab is highlighted during the static phase (not Expenses/Reports as the wrong final highlight).
5. Run `npx jest --runTestsByPath tests/ui/components/SearchTypeMenuSavedSearchHighlightTest.tsx --watchman=false --runInBand` and confirm all tests pass.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. While **online**, mark a saved search for deletion (pending delete) and open Search on native/narrow layout. Confirm the saved search is **not** shown as the active tab and a built-in tab matching the query shape **is** highlighted.
2. Go **offline** with a pending-delete saved search still in Onyx. Confirm interactive narrow still follows existing product rules (pending-delete saved searches remain visible/usable offline, same as before this PR).

### QA Steps
1. On native (iOS/Android) or narrow mWeb (≤ ~800px), open Search and select a saved search that only differs from Expenses/Reports by sort (or similar). Confirm the **saved search** tab is highlighted in the horizontal tab strip.
2. While **online**, delete a saved search (pending delete) and open Search for that query. Confirm the saved search is **not** highlighted as active and the related built-in tab (e.g. Expenses) **is** highlighted.
3. Open a saved search and watch the tab strip while the page loads (static → interactive), ideally on a slow network. Confirm the saved search stays highlighted and you do not end on the wrong built-in tab.
4. Optional regression: Spend → select a saved search → Inbox → Spend again. Confirm the correct tab is still highlighted.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/0cfe6bbf-3e39-4143-ae42-932fee28b1f1



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/d9a5fb65-2526-4db5-b8da-274dd8b583f9


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>