### PR TITLE
[No QA] refactor: drop redundant report and reportID props from OptionRowLHN tree

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRowAlternateText.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRowAlternateText.tsx
@@ -6,24 +6,24 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {containsCustomEmoji as containsCustomEmojiUtils, containsOnlyCustomEmoji} from '@libs/EmojiUtils';
 import FS from '@libs/Fullstory';
+import type {OptionData} from '@libs/ReportUtils';
 import TextWithEmojiFragment from '@pages/inbox/report/comment/TextWithEmojiFragment';
 import CONST from '@src/CONST';
-import type {Report} from '@src/types/onyx';
 
 type OptionMode = ValueOf<typeof CONST.OPTION_MODE>;
 
 type OptionRowAlternateTextProps = {
-    alternateText: string | undefined;
-    report?: Report;
+    optionItem: OptionData;
     viewMode: OptionMode;
     isOptionFocused: boolean;
     style?: StyleProp<TextStyle>;
 };
 
-function OptionRowAlternateText({alternateText, report, viewMode, isOptionFocused, style}: OptionRowAlternateTextProps) {
+function OptionRowAlternateText({optionItem, viewMode, isOptionFocused, style}: OptionRowAlternateTextProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
 
+    const alternateText = optionItem.alternateText;
     if (!alternateText) {
         return null;
     }
@@ -33,7 +33,7 @@ function OptionRowAlternateText({alternateText, report, viewMode, isOptionFocuse
     const alternateTextStyle = isInFocusMode
         ? [textStyle, styles.textLabelSupporting, styles.optionAlternateTextCompact, styles.ml2, style]
         : [textStyle, styles.optionAlternateText, styles.textLabelSupporting, style];
-    const alternateTextFSClass = FS.getChatFSClass(report);
+    const alternateTextFSClass = FS.getChatFSClass(optionItem);
 
     const containsCustomEmojiWithText = containsCustomEmojiUtils(alternateText) && !containsOnlyCustomEmoji(alternateText);
 

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRowAvatar.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRowAvatar.tsx
@@ -1,24 +1,21 @@
 import React from 'react';
 import type {ColorValue, ViewStyle} from 'react-native';
-import type {OnyxEntry} from 'react-native-onyx';
 import LHNAvatar from '@components/LHNOptionsList/LHNAvatar';
 import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import {shouldOptionShowTooltip} from '@libs/OptionsListUtils';
 import {getDelegateAccountIDFromReportAction} from '@libs/ReportActionsUtils';
 import type {OptionData} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
-import type {Report} from '@src/types/onyx';
 
 type OptionRowAvatarProps = {
     optionItem: OptionData;
-    report: OnyxEntry<Report>;
     isInFocusMode: boolean;
     subscriptAvatarBorderColor: ColorValue;
     secondaryAvatarBackgroundColor: ColorValue;
     singleAvatarContainerStyle: ViewStyle[];
 };
 
-function OptionRowAvatarInner({optionItem, report, isInFocusMode, subscriptAvatarBorderColor, secondaryAvatarBackgroundColor, singleAvatarContainerStyle}: OptionRowAvatarProps) {
+function OptionRowAvatarInner({optionItem, isInFocusMode, subscriptAvatarBorderColor, secondaryAvatarBackgroundColor, singleAvatarContainerStyle}: OptionRowAvatarProps) {
     const personalDetails = usePersonalDetails();
 
     const delegateAccountID = getDelegateAccountIDFromReportAction(optionItem?.parentReportAction);
@@ -26,7 +23,7 @@ function OptionRowAvatarInner({optionItem, report, isInFocusMode, subscriptAvata
     // Match the header's delegate avatar logic: when a delegate exists on the
     // parent report action, the header (useReportActionAvatars) shows the
     // delegate's avatar as primary instead of the report owner's.
-    const skipDelegate = report?.type === CONST.REPORT.TYPE.INVOICE || (optionItem?.isTaskReport && !report?.chatReportID);
+    const skipDelegate = optionItem?.type === CONST.REPORT.TYPE.INVOICE || (optionItem?.isTaskReport && !optionItem?.chatReportID);
 
     let icons = optionItem?.icons ?? [];
     if (!skipDelegate && delegateAccountID && personalDetails && icons.length > 0) {
@@ -69,7 +66,7 @@ function OptionRowAvatarInner({optionItem, report, isInFocusMode, subscriptAvata
 
 OptionRowAvatarInner.displayName = 'OptionRowAvatarInner';
 
-function OptionRowAvatar({optionItem, report, isInFocusMode, subscriptAvatarBorderColor, secondaryAvatarBackgroundColor, singleAvatarContainerStyle}: OptionRowAvatarProps) {
+function OptionRowAvatar({optionItem, isInFocusMode, subscriptAvatarBorderColor, secondaryAvatarBackgroundColor, singleAvatarContainerStyle}: OptionRowAvatarProps) {
     // Bail out before subscribing to personal details when the row has no avatar to render.
     if (!optionItem.icons?.length || !optionItem.icons.at(0)) {
         return null;
@@ -77,7 +74,6 @@ function OptionRowAvatar({optionItem, report, isInFocusMode, subscriptAvatarBord
     return (
         <OptionRowAvatarInner
             optionItem={optionItem}
-            report={report}
             isInFocusMode={isInFocusMode}
             subscriptAvatarBorderColor={subscriptAvatarBorderColor}
             secondaryAvatarBackgroundColor={secondaryAvatarBackgroundColor}

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRowLHNCore.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRowLHNCore.tsx
@@ -20,7 +20,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import DateUtils from '@libs/DateUtils';
 import FS from '@libs/Fullstory';
 import {shouldUseBoldText} from '@libs/OptionsListUtils';
-import {isChatUsedForOnboarding as isChatUsedForOnboardingReportUtils, isGroupChat, isOneOnOneChat, isSystemChat} from '@libs/ReportUtils';
+import {isChatUsedForOnboarding as isChatUsedForOnboardingReportUtils, isGroupChat, isSystemChat} from '@libs/ReportUtils';
 import FreeTrial from '@pages/settings/Subscription/FreeTrial';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
@@ -78,7 +78,7 @@ function OptionRowLHN({isOptionFocused = false, onSelectRow = () => {}, optionIt
     const currentSelectedTimezone = currentUserPersonalDetails?.timezone?.selected ?? CONST.DEFAULT_TIME_ZONE.selected;
     const formattedDate = DateUtils.getStatusUntilDate(translate, statusClearAfterDate, optionItem?.timezone?.selected ?? CONST.DEFAULT_TIME_ZONE.selected, currentSelectedTimezone);
     const statusContent = formattedDate ? `${statusText ? `${statusText} ` : ''}(${formattedDate})` : statusText;
-    const isStatusVisible = !!emojiCode && isOneOnOneChat(optionItem);
+    const isStatusVisible = !!emojiCode && !!optionItem.isOneOnOneChat;
 
     const subscriptAvatarBorderColor = isOptionFocused ? focusedBackgroundColor : theme.sidebar;
 

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRowLHNCore.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRowLHNCore.tsx
@@ -25,7 +25,6 @@ import FreeTrial from '@pages/settings/Subscription/FreeTrial';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import DraftIndicator from './OptionRow/DraftIndicator';
 import OptionRowAlternateText from './OptionRowAlternateText';
 import OptionRowAvatar from './OptionRowAvatar';
@@ -34,18 +33,7 @@ import OptionRowInfoBadge from './OptionRowInfoBadge';
 import OptionRowPressable from './OptionRowPressable';
 import OptionRowTooltipLayer from './OptionRowTooltipLayer';
 
-function OptionRowLHN({
-    reportID,
-    report,
-    isOptionFocused = false,
-    onSelectRow = () => {},
-    optionItem,
-    viewMode = 'default',
-    style,
-    onLayout = () => {},
-    hasDraftComment,
-    testID,
-}: OptionRowLHNProps) {
+function OptionRowLHN({isOptionFocused = false, onSelectRow = () => {}, optionItem, viewMode = 'default', style, onLayout = () => {}, hasDraftComment, testID}: OptionRowLHNProps) {
     const {isProduction} = useEnvironment();
     const theme = useTheme();
     const styles = useThemeStyles();
@@ -55,7 +43,7 @@ function OptionRowLHN({
 
     const {onboardingPurpose, onboarding, isScreenFocused} = useLHNTooltipContext();
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
-    const isChatUsedForOnboarding = isChatUsedForOnboardingReportUtils(report, onboarding, conciergeReportID, onboardingPurpose);
+    const isChatUsedForOnboarding = isChatUsedForOnboardingReportUtils(optionItem, onboarding, conciergeReportID, onboardingPurpose);
 
     const {translate} = useLocalize();
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
@@ -90,12 +78,12 @@ function OptionRowLHN({
     const currentSelectedTimezone = currentUserPersonalDetails?.timezone?.selected ?? CONST.DEFAULT_TIME_ZONE.selected;
     const formattedDate = DateUtils.getStatusUntilDate(translate, statusClearAfterDate, optionItem?.timezone?.selected ?? CONST.DEFAULT_TIME_ZONE.selected, currentSelectedTimezone);
     const statusContent = formattedDate ? `${statusText ? `${statusText} ` : ''}(${formattedDate})` : statusText;
-    const isStatusVisible = !!emojiCode && isOneOnOneChat(!isEmptyObject(report) ? report : undefined);
+    const isStatusVisible = !!emojiCode && isOneOnOneChat(optionItem);
 
     const subscriptAvatarBorderColor = isOptionFocused ? focusedBackgroundColor : theme.sidebar;
 
     // This is used to ensure that we display the text exactly as the user entered it when displaying LHN title, instead of parsing their text to HTML.
-    const shouldParseFullTitle = optionItem?.parentReportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat(report);
+    const shouldParseFullTitle = optionItem?.parentReportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat(optionItem);
 
     const accessibilityLabel = [
         `${translate('accessibilityHints.navigatesToChat')} ${optionItem.text}`,
@@ -114,7 +102,6 @@ function OptionRowLHN({
 
     const renderPressableRow = () => (
         <OptionRowPressable
-            reportID={reportID}
             optionItem={optionItem}
             isOptionFocused={isOptionFocused}
             isScreenFocused={isScreenFocused}
@@ -139,7 +126,6 @@ function OptionRowLHN({
                             <View style={[styles.flexRow, styles.alignItemsCenter]}>
                                 <OptionRowAvatar
                                     optionItem={optionItem}
-                                    report={report}
                                     isInFocusMode={isInFocusMode}
                                     subscriptAvatarBorderColor={hovered && !isOptionFocused ? hoveredBackgroundColor : subscriptAvatarBorderColor}
                                     secondaryAvatarBackgroundColor={secondaryAvatarBgColor}
@@ -163,8 +149,8 @@ function OptionRowLHN({
                                                 !!optionItem.isMoneyRequestReport ||
                                                 !!optionItem.isInvoiceReport ||
                                                 !!optionItem.private_isArchived ||
-                                                isGroupChat(report) ||
-                                                isSystemChat(report)
+                                                isGroupChat(optionItem) ||
+                                                isSystemChat(optionItem)
                                             }
                                             testID={testID}
                                         />
@@ -179,8 +165,7 @@ function OptionRowLHN({
                                         )}
                                     </View>
                                     <OptionRowAlternateText
-                                        alternateText={optionItem.alternateText}
-                                        report={report}
+                                        optionItem={optionItem}
                                         viewMode={viewMode}
                                         isOptionFocused={isOptionFocused}
                                         style={style}
@@ -189,7 +174,7 @@ function OptionRowLHN({
                                 {optionItem?.descriptiveText ? (
                                     <View
                                         style={[styles.flexWrap]}
-                                        fsClass={FS.getChatFSClass(report)}
+                                        fsClass={FS.getChatFSClass(optionItem)}
                                     >
                                         <Text style={[styles.textLabel]}>{optionItem.descriptiveText}</Text>
                                     </View>
@@ -232,8 +217,6 @@ function OptionRowLHN({
 
     return (
         <OptionRowTooltipLayer
-            reportID={reportID}
-            report={report}
             optionItem={optionItem}
             renderChildren={renderPressableRow}
         />

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRowLHNData.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRowLHNData.tsx
@@ -38,10 +38,10 @@ function OptionRowLHNData({
     policy,
     invoiceReceiverPolicy,
     viewMode = 'default',
+    reportID,
     ...propsToForward
 }: OptionRowLHNDataProps) {
     const styles = useThemeStyles();
-    const reportID = propsToForward.reportID;
     const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
     const isReportFocused = isOptionFocused && currentReportIDValue === reportID;
     const {translate, localeCompare} = useLocalize();
@@ -197,7 +197,6 @@ function OptionRowLHNData({
             viewMode={viewMode}
             isOptionFocused={isReportFocused}
             optionItem={finalOptionItem}
-            report={fullReport}
             hasDraftComment={hasDraftComment}
         />
     );

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRowPressable.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRowPressable.tsx
@@ -17,7 +17,6 @@ import CONST from '@src/CONST';
 import useLHNRowProductTrainingTooltip from './useLHNRowProductTrainingTooltip';
 
 type OptionRowPressableProps = {
-    reportID: string;
     optionItem: OptionData;
     isOptionFocused: boolean;
     isScreenFocused: boolean;
@@ -31,7 +30,6 @@ type OptionRowPressableProps = {
 };
 
 function OptionRowPressable({
-    reportID,
     optionItem,
     isOptionFocused,
     isScreenFocused,
@@ -44,6 +42,7 @@ function OptionRowPressable({
     children,
 }: OptionRowPressableProps) {
     const {hideProductTrainingTooltip} = useLHNRowProductTrainingTooltip();
+    const reportID = optionItem.reportID;
     const onPress = (event: GestureResponderEvent | KeyboardEvent | undefined) => {
         hideProductTrainingTooltip();
         startSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`, {

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRowTooltipLayer.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRowTooltipLayer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type {OnyxEntry} from 'react-native-onyx';
 import {useLHNTooltipContext} from '@components/LHNOptionsList/LHNTooltipContext';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import {useSession} from '@components/OnyxListItemProvider';
@@ -11,17 +10,10 @@ import type {OptionData} from '@libs/ReportUtils';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Report} from '@src/types/onyx';
 import useLHNRowProductTrainingTooltip from './useLHNRowProductTrainingTooltip';
 
 type OptionRowTooltipLayerProps = {
-    /** Report ID of the row */
-    reportID: string;
-
-    /** Report data of the row, used to determine onboarding eligibility */
-    report: OnyxEntry<Report>;
-
-    /** Option data, used to forward pendingAction and errors to OfflineWithFeedback */
+    /** Option data, drives onboarding eligibility checks and forwards pendingAction/errors to OfflineWithFeedback */
     optionItem: OptionData;
 
     /** Renders the row content. */
@@ -57,15 +49,15 @@ function OptionRowTooltipLayerInner({renderChildren}: OptionRowTooltipLayerInner
 
 OptionRowTooltipLayerInner.displayName = 'OptionRowTooltipLayerInner';
 
-function OptionRowTooltipLayer({reportID, report, optionItem, renderChildren}: OptionRowTooltipLayerProps) {
+function OptionRowTooltipLayer({optionItem, renderChildren}: OptionRowTooltipLayerProps) {
     const {firstReportIDWithGBRorRBR, onboardingPurpose, onboarding} = useLHNTooltipContext();
     const session = useSession();
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
 
-    const shouldShowRBRorGBRTooltip = firstReportIDWithGBRorRBR === reportID;
+    const shouldShowRBRorGBRTooltip = firstReportIDWithGBRorRBR === optionItem.reportID;
     const isOnboardingGuideAssigned = onboardingPurpose === CONST.ONBOARDING_CHOICES.MANAGE_TEAM && !session?.email?.includes('+');
-    const isChatUsedForOnboarding = isChatUsedForOnboardingReportUtils(report, onboarding, conciergeReportID, onboardingPurpose);
-    const shouldShowGetStartedTooltip = isOnboardingGuideAssigned ? isAdminRoom(report) && isChatUsedForOnboarding : isConciergeChatReport(report);
+    const isChatUsedForOnboarding = isChatUsedForOnboardingReportUtils(optionItem, onboarding, conciergeReportID, onboardingPurpose);
+    const shouldShowGetStartedTooltip = isOnboardingGuideAssigned ? isAdminRoom(optionItem) && isChatUsedForOnboarding : isConciergeChatReport(optionItem);
 
     // Skip the inner component (and its heavy hooks) entirely when the row can never show a tooltip.
     const shouldEvaluateTooltip = shouldShowRBRorGBRTooltip || shouldShowGetStartedTooltip;

--- a/src/components/LHNOptionsList/types.ts
+++ b/src/components/LHNOptionsList/types.ts
@@ -76,12 +76,6 @@ type OptionRowLHNDataProps = {
 };
 
 type OptionRowLHNProps = {
-    /** The ID of the report that the option is for */
-    reportID: string;
-
-    /** The report for this option */
-    report?: Report;
-
     /** Whether this option is currently in focus so we can modify its style */
     isOptionFocused?: boolean;
 

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -893,8 +893,11 @@ function getOptionData({
 
     const status = personalDetail?.status ?? '';
 
+    const isOneOnOneChatReport = isOneOnOneChat(report);
+    result.isOneOnOneChat = isOneOnOneChatReport;
+
     // For 1:1 DMs, add the other participant's selected timezone
-    if (isOneOnOneChat(report)) {
+    if (isOneOnOneChatReport) {
         const recipientPersonalDetail = participantPersonalDetailListExcludeCurrentUser.at(0);
         result.timezone = recipientPersonalDetail?.timezone;
     }

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -874,6 +874,7 @@ function getOptionData({
     result.keyForList = String(report.reportID);
     result.hasOutstandingChildRequest = report.hasOutstandingChildRequest;
     result.parentReportID = report.parentReportID;
+    result.parentReportActionID = report.parentReportActionID;
     result.isWaitingOnBankAccount = report.isWaitingOnBankAccount;
     result.notificationPreference = getReportNotificationPreference(report);
     result.isAllowedToComment = canUserPerformWriteActionUtil(report, isReportArchived);

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -861,6 +861,7 @@ function getOptionData({
     result.ownerAccountID = report.ownerAccountID;
     result.managerID = report.managerID;
     result.reportID = report.reportID;
+    result.chatReportID = report.chatReportID;
     result.policyID = report.policyID;
     result.stateNum = report.stateNum;
     result.statusNum = report.statusNum;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Removes redundant `report` and `reportID` props from `OptionRowLHN` and its descendants. `getOptionData` already materializes most of the Report attributes onto `optionItem` (`reportID`, `chatType`, `type`, `policyID`, `parentReportAction`, all boolean flags, etc.), so descendants can rely on `optionItem` alone.

One Report-only field — `chatReportID` — was not previously materialized but is needed by `OptionRowAvatar`'s delegate-skip logic for task reports. Added `result.chatReportID = report.chatReportID;` to `getOptionData` to cover it.

Changes:

- `SidebarUtils.getOptionData`: assign `chatReportID` to result
- `OptionRowAvatar`: drop `report` prop, derive `skipDelegate` from `optionItem.type` and `optionItem.chatReportID`
- `OptionRowTooltipLayer`: drop `report` and `reportID` props, pass `optionItem` to `isAdminRoom` / `isConciergeChatReport` / `isChatUsedForOnboarding`
- `OptionRowPressable`: drop `reportID` prop, read from `optionItem.reportID`
- `OptionRowAlternateText`: take `optionItem` instead of `report`
- `OptionRowLHNCore`: drop `report` and `reportID` from props, switch all util calls to use `optionItem`
- `OptionRowLHNData`: stop forwarding `report` and `reportID` to `OptionRowLHN`
- `types.ts`: drop `reportID` and `report` from `OptionRowLHNProps`

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/89946
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>