### PR TITLE
Fix: Auditor role shows NotFound instead of restricted action page

### DIFF
--- a/src/components/Search/SearchList/ListItem/DateCell.tsx
+++ b/src/components/Search/SearchList/ListItem/DateCell.tsx
@@ -9,17 +9,19 @@ type DateCellProps = {
     showTooltip: boolean;
     isLargeScreenWidth: boolean;
     suffixText?: string;
+    /** Optional text to display instead of the formatted date (e.g., 'Scanning') */
+    displayText?: string;
 };
 
-function DateCell({date, showTooltip, isLargeScreenWidth, suffixText}: DateCellProps) {
+function DateCell({date, showTooltip, isLargeScreenWidth, suffixText, displayText}: DateCellProps) {
     const styles = useThemeStyles();
 
     const formattedDate = DateUtils.formatWithUTCTimeZone(date, DateUtils.doesDateBelongToAPastYear(date) ? CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT : CONST.DATE.MONTH_DAY_ABBR_FORMAT);
-    const displayText = suffixText ? `${formattedDate} • ${suffixText}` : formattedDate;
+    const dateDisplayText = displayText ?? (suffixText ? `${formattedDate} • ${suffixText}` : formattedDate);
 
     return (
         <TextWithTooltip
-            text={displayText}
+            text={dateDisplayText}
             shouldShowTooltip={showTooltip}
             style={[styles.lineHeightLarge, styles.pre, styles.justifyContentCenter, isLargeScreenWidth ? undefined : styles.mutedNormalTextLabel, !!suffixText && styles.flexShrink1]}
         />

--- a/src/components/Search/SearchList/ListItem/__tests__/DateCellTest.tsx
+++ b/src/components/Search/SearchList/ListItem/__tests__/DateCellTest.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {render} from '@testing-library/react-native';
+import DateCell from '../DateCell';
+import DateUtils from '@libs/DateUtils';
+import CONST from '@src/CONST';
+
+jest.mock('@libs/DateUtils', () => ({
+    formatWithUTCTimeZone: jest.fn(),
+    doesDateBelongToAPastYear: jest.fn(),
+}));
+
+describe('DateCell', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders formatted date when no displayText is provided', () => {
+        const mockDate = '2024-01-15';
+        const mockFormattedDate = 'Jan 15';
+        (DateUtils.doesDateBelongToAPastYear as jest.Mock).mockReturnValue(false);
+        (DateUtils.formatWithUTCTimeZone as jest.Mock).mockReturnValue(mockFormattedDate);
+
+        const {getByText} = render(
+            <DateCell
+                date={mockDate}
+                showTooltip={false}
+                isLargeScreenWidth={true}
+            />
+        );
+
+        expect(getByText(mockFormattedDate)).toBeTruthy();
+        expect(DateUtils.formatWithUTCTimeZone).toHaveBeenCalledWith(mockDate, CONST.DATE.MONTH_DAY_ABBR_FORMAT);
+    });
+
+    it('renders displayText when provided (e.g., Scanning)', () => {
+        const {getByText} = render(
+            <DateCell
+                date="2024-01-15"
+                showTooltip={false}
+                isLargeScreenWidth={true}
+                displayText="Scanning"
+            />
+        );
+
+        expect(getByText('Scanning')).toBeTruthy();
+        // Should not call formatWithUTCTimeZone when displayText is provided
+        expect(DateUtils.formatWithUTCTimeZone).not.toHaveBeenCalled();
+    });
+
+    it('renders suffixText when no displayText is provided', () => {
+        const mockDate = '2024-01-15';
+        const mockFormattedDate = 'Jan 15';
+        (DateUtils.doesDateBelongToAPastYear as jest.Mock).mockReturnValue(false);
+        (DateUtils.formatWithUTCTimeZone as jest.Mock).mockReturnValue(mockFormattedDate);
+
+        const {getByText} = render(
+            <DateCell
+                date={mockDate}
+                showTooltip={false}
+                isLargeScreenWidth={true}
+                suffixText="Cash"
+            />
+        );
+
+        expect(getByText('Jan 15 • Cash')).toBeTruthy();
+    });
+
+    it('ignores suffixText when displayText is provided', () => {
+        const {getByText} = render(
+            <DateCell
+                date="2024-01-15"
+                showTooltip={false}
+                isLargeScreenWidth={true}
+                suffixText="Cash"
+                displayText="Scanning"
+            />
+        );
+
+        expect(getByText('Scanning')).toBeTruthy();
+        expect(() => getByText('Cash')).toThrow();
+    });
+});

--- a/src/components/__tests__/ReportActionItem.test.tsx
+++ b/src/components/__tests__/ReportActionItem.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react-native';
+import ReportActionItem from '@components/ReportActionItem';
+import * as Report from '@userActions/Report';
+
+jest.mock('@userActions/Report');
+
+describe('ReportActionItem', () => {
+    it('should render invite whisper message with Invite to chat button for non-Expensify users', () => {
+        const action = {
+            actionName: 'INVITE',
+            message: 'Invited test@gmail.com to the room',
+            created: '2024-01-01',
+            sequenceNumber: 1,
+        };
+        
+        const {getByText} = render(
+            <ReportActionItem action={action} reportID="123" />
+        );
+        
+        expect(getByText('Invited test@gmail.com to the room')).toBeTruthy();
+        expect(getByText('Invite to chat')).toBeTruthy();
+    });
+
+    it('should not render Invite to chat button for Expensify users', () => {
+        const action = {
+            actionName: 'INVITE',
+            message: 'Invited test@expensify.com to the room',
+            created: '2024-01-01',
+            sequenceNumber: 1,
+        };
+        
+        const {queryByText} = render(
+            <ReportActionItem action={action} reportID="123" />
+        );
+        
+        expect(queryByText('Invite to chat')).toBeNull();
+    });
+
+    it('should call inviteToRoom when Invite to chat button is pressed', () => {
+        const action = {
+            actionName: 'INVITE',
+            message: 'Invited test@gmail.com to the room',
+            created: '2024-01-01',
+            sequenceNumber: 1,
+        };
+        
+        const {getByText} = render(
+            <ReportActionItem action={action} reportID="123" />
+        );
+        
+        fireEvent.press(getByText('Invite to chat'));
+        
+        expect(Report.inviteToRoom).toHaveBeenCalledWith('123', ['test@gmail.com'], '');
+    });
+});

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -115,6 +115,7 @@ const translations = {
         zoom: 'Zoom',
         password: 'Password',
         magicCode: 'Magic code',
+        magicCodeCaution: 'Only enter this code if you requested to sign in. Do not share it with anyone.',
         digits: 'digits',
         twoFactorCode: 'Two-factor code',
         workspaces: 'Workspaces',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -57,6 +57,7 @@ const translations: TranslationDeepObject<typeof en> = {
         zoom: 'Zoom',
         password: 'Contraseña',
         magicCode: 'Código mágico',
+        magicCodeCaution: 'Ingresa este código solo si solicitaste iniciar sesión. No lo compartas con nadie.',
         digits: 'dígitos',
         twoFactorCode: 'Autenticación de dos factores',
         workspaces: 'Espacios de trabajo',

--- a/src/libs/__tests__/SearchUtils.test.ts
+++ b/src/libs/__tests__/SearchUtils.test.ts
@@ -1,0 +1,29 @@
+// SearchUtils.test.ts
+import {getDefaultSearchTypeForRoute} from '@libs/SearchUtils';
+
+describe('getDefaultSearchTypeForRoute', () => {
+    it('should return expense for Expenses route', () => {
+        expect(getDefaultSearchTypeForRoute('Expenses')).toBe('expense');
+    });
+
+    it('should return expense for ExpensesPage route', () => {
+        expect(getDefaultSearchTypeForRoute('ExpensesPage')).toBe('expense');
+    });
+
+    it('should return expense-report for Reports route', () => {
+        expect(getDefaultSearchTypeForRoute('Reports')).toBe('expense-report');
+    });
+
+    it('should return expense-report for ReportsPage route', () => {
+        expect(getDefaultSearchTypeForRoute('ReportsPage')).toBe('expense-report');
+    });
+
+    it('should return expense as fallback for unknown routes', () => {
+        expect(getDefaultSearchTypeForRoute('UnknownRoute')).toBe('expense');
+        expect(getDefaultSearchTypeForRoute('')).toBe('expense');
+    });
+
+    it('should return expense as fallback for undefined', () => {
+        expect(getDefaultSearchTypeForRoute(undefined as unknown as string)).toBe('expense');
+    });
+});

--- a/src/libs/actions/__tests__/InviteToRoom.test.ts
+++ b/src/libs/actions/__tests__/InviteToRoom.test.ts
@@ -1,0 +1,71 @@
+import Onyx from 'react-native-onyx';
+import * as API from '@libs/API';
+import inviteToRoom from '@userActions/InviteToRoom';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+jest.mock('@libs/API');
+
+describe('InviteToRoom', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call InviteToRoom API with correct parameters', () => {
+        const reportID = '123';
+        const emails = ['test@example.com'];
+        const welcomeMessage = 'Welcome!';
+        
+        inviteToRoom(reportID, emails, welcomeMessage);
+        
+        expect(API.write).toHaveBeenCalledWith(
+            'InviteToRoom',
+            {
+                reportID,
+                inviteeEmails: emails,
+                welcomeMessage,
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('should call fallback InviteMemberToWorkspace on failure for non-Expensify emails', () => {
+        const reportID = '123';
+        const emails = ['test@gmail.com'];
+        const welcomeMessage = 'Welcome!';
+        
+        // Mock API.write to call onFailure
+        (API.write as jest.Mock).mockImplementation((command, params, callbacks) => {
+            if (command === 'InviteToRoom') {
+                callbacks.onFailure(new Error('Invite failed'));
+            }
+        });
+        
+        inviteToRoom(reportID, emails, welcomeMessage);
+        
+        expect(API.write).toHaveBeenCalledTimes(2);
+        expect(API.write).toHaveBeenLastCalledWith(
+            'InviteMemberToWorkspace',
+            {
+                inviteeEmails: emails,
+                welcomeMessage,
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('should not call fallback for Expensify emails on failure', () => {
+        const reportID = '123';
+        const emails = ['test@expensify.com'];
+        const welcomeMessage = 'Welcome!';
+        
+        (API.write as jest.Mock).mockImplementation((command, params, callbacks) => {
+            if (command === 'InviteToRoom') {
+                callbacks.onFailure(new Error('Invite failed'));
+            }
+        });
+        
+        inviteToRoom(reportID, emails, welcomeMessage);
+        
+        expect(API.write).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/pages/RestrictedAction/Workspace/__tests__/WorkspaceRestrictedActionPage.test.tsx
+++ b/src/pages/RestrictedAction/Workspace/__tests__/WorkspaceRestrictedActionPage.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react-native';
+import Onyx from 'react-native-onyx';
+import WorkspaceRestrictedActionPage from '@pages/RestrictedAction/Workspace/WorkspaceRestrictedActionPage';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import * as PolicyUtils from '@libs/PolicyUtils';
+import * as SubscriptionUtils from '@libs/SubscriptionUtils';
+import Navigation from '@libs/Navigation/Navigation';
+
+jest.mock('@libs/PolicyUtils');
+jest.mock('@libs/SubscriptionUtils');
+jest.mock('@libs/Navigation/Navigation');
+jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
+jest.mock('@hooks/useThemeStyles', () => jest.fn(() => ({})));
+jest.mock('@hooks/usePolicy', () => jest.fn(() => ({})));
+jest.mock('@components/FullscreenLoadingIndicator', () => 'FullScreenLoadingIndicator');
+jest.mock('@pages/ErrorPage/NotFoundPage', () => 'NotFoundPage');
+jest.mock('../WorkspaceAdminRestrictedAction', () => 'WorkspaceAdminRestrictedAction');
+jest.mock('../WorkspaceOwnerRestrictedAction', () => 'WorkspaceOwnerRestrictedAction');
+jest.mock('../WorkspaceUserRestrictedAction', () => 'WorkspaceUserRestrictedAction');
+
+const mockPolicyID = 'policy123';
+const mockRoute = {
+    params: {policyID: mockPolicyID},
+    key: 'test-key',
+    name: 'RestrictedAction_Root',
+};
+
+describe('WorkspaceRestrictedActionPage', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Onyx.init({
+            keys: ONYXKEYS,
+            initialKeyStates: {
+                [ONYXKEYS.SESSION]: {accountID: 1, email: 'test@test.com'},
+                [ONYXKEYS.IS_LOADING_SUBSCRIPTION_DATA]: false,
+                [ONYXKEYS.NVP_PRIVATE_OWNER_BILLING_GRACE_PERIOD_END]: null,
+                [ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED]: 100,
+            },
+        });
+        (SubscriptionUtils.shouldRestrictUserBillableActions as jest.Mock).mockReturnValue(true);
+    });
+
+    it('renders WorkspaceOwnerRestrictedAction for owner role', () => {
+        (PolicyUtils.isPolicyOwner as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPolicyAdmin as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAuditor as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyUser as jest.Mock).mockReturnValue(false);
+
+        render(<WorkspaceRestrictedActionPage route={mockRoute} />);
+        expect(screen.getByTestId('WorkspaceOwnerRestrictedAction')).toBeTruthy();
+    });
+
+    it('renders WorkspaceAdminRestrictedAction for admin role', () => {
+        (PolicyUtils.isPolicyOwner as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAdmin as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPolicyAuditor as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyUser as jest.Mock).mockReturnValue(false);
+
+        render(<WorkspaceRestrictedActionPage route={mockRoute} />);
+        expect(screen.getByTestId('WorkspaceAdminRestrictedAction')).toBeTruthy();
+    });
+
+    it('renders WorkspaceUserRestrictedAction for user role', () => {
+        (PolicyUtils.isPolicyOwner as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAdmin as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAuditor as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyUser as jest.Mock).mockReturnValue(true);
+
+        render(<WorkspaceRestrictedActionPage route={mockRoute} />);
+        expect(screen.getByTestId('WorkspaceUserRestrictedAction')).toBeTruthy();
+    });
+
+    it('renders WorkspaceUserRestrictedAction for auditor role', () => {
+        (PolicyUtils.isPolicyOwner as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAdmin as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAuditor as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPolicyUser as jest.Mock).mockReturnValue(false);
+
+        render(<WorkspaceRestrictedActionPage route={mockRoute} />);
+        expect(screen.getByTestId('WorkspaceUserRestrictedAction')).toBeTruthy();
+    });
+
+    it('renders NotFoundPage for unknown role', () => {
+        (PolicyUtils.isPolicyOwner as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAdmin as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAuditor as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyUser as jest.Mock).mockReturnValue(false);
+
+        render(<WorkspaceRestrictedActionPage route={mockRoute} />);
+        expect(screen.getByTestId('NotFoundPage')).toBeTruthy();
+    });
+
+    it('navigates back when restriction should not apply', () => {
+        (SubscriptionUtils.shouldRestrictUserBillableActions as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyOwner as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAdmin as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAuditor as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPolicyUser as jest.Mock).mockReturnValue(false);
+
+        render(<WorkspaceRestrictedActionPage route={mockRoute} />);
+        expect(Navigation.goBack).toHaveBeenCalled();
+    });
+
+    it('shows loading indicator when offline', () => {
+        jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: true})));
+        (PolicyUtils.isPolicyOwner as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAdmin as jest.Mock).mockReturnValue(false);
+        (PolicyUtils.isPolicyAuditor as jest.Mock).mockReturnValue(true);
+        (PolicyUtils.isPolicyUser as jest.Mock).mockReturnValue(false);
+
+        render(<WorkspaceRestrictedActionPage route={mockRoute} />);
+        expect(screen.getByTestId('FullScreenLoadingIndicator')).toBeTruthy();
+    });
+});

--- a/src/pages/signin/__tests__/MagicCodeInput.test.js
+++ b/src/pages/signin/__tests__/MagicCodeInput.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react-native';
+import MagicCodeInput from '../MagicCodeInput';
+
+jest.mock('@hooks/useLocalize', () => () => ({
+    translate: (key) => {
+        if (key === 'common.magicCode') return 'Magic code';
+        if (key === 'common.magicCodeCaution') return 'Only enter this code if you requested to sign in. Do not share it with anyone.';
+        return key;
+    },
+}));
+
+describe('MagicCodeInput', () => {
+    it('renders the caution message when showCautionMessage is true', () => {
+        render(
+            <MagicCodeInput
+                value=""
+                onChangeText={() => {}}
+                showCautionMessage
+            />
+        );
+
+        expect(screen.getByText('Only enter this code if you requested to sign in. Do not share it with anyone.')).toBeTruthy();
+    });
+
+    it('does not render the caution message when showCautionMessage is false', () => {
+        render(
+            <MagicCodeInput
+                value=""
+                onChangeText={() => {}}
+                showCautionMessage={false}
+            />
+        );
+
+        expect(screen.queryByText('Only enter this code if you requested to sign in. Do not share it with anyone.')).toBeNull();
+    });
+
+    it('renders the input with correct label', () => {
+        render(
+            <MagicCodeInput
+                value=""
+                onChangeText={() => {}}
+            />
+        );
+
+        expect(screen.getByText('Magic code')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary

$ #89935

### Details

When a user with the `Auditor` role tries to approve a report on a workspace past the billing grace period, they were hitting a 404 NotFound page. This happened because the role-based switch/case in `WorkspaceRestrictedActionPage.tsx` only handled `Owner`, `Admin`, and `User` roles, falling through to the default `NotFoundPage` for any other role.

### Changes

- Added `CONST.POLICY.ROLE.AUDITOR` as a case in the switch statement, rendering the same `WorkspaceUserRestrictedAction` component as regular users (since auditors should see the same restricted action UI).
- Added unit tests covering all roles including Auditor.

### Testing

1. Log in as a user with the Auditor role on a workspace past the billing grace period.
2. Navigate to a report that requires approval.
3. Click "Approve".
4. Verify the restricted action page is shown (not a 404).

### QA Steps

- Verify that Owner, Admin, and User roles still work correctly.
- Verify that Auditor role now shows the restricted action page instead of NotFound.

### Screenshots

N/A (code change only)