### PR TITLE
Set JEKYLL_ENV for help site deploys

### DIFF
--- a/.github/workflows/deployExpensifyHelp.yml
+++ b/.github/workflows/deployExpensifyHelp.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Build Jekyll site
         run: bundle exec jekyll build --source ./ --destination ./_site
         working-directory: ./docs
+        env:
+          JEKYLL_ENV: production
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca

--- a/.github/workflows/deployNewHelp.yml
+++ b/.github/workflows/deployNewHelp.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Build Jekyll site
         run: bundle exec jekyll build --source ./ --destination ./_site
         working-directory: ./help  # Ensure Jekyll is building the site in /help
+        env:
+          JEKYLL_ENV: production
 
       # This will copy the contents of /help/_site to Cloudflare.  The pages-action will
       # evaluate the current branch to determine into which CF environment to deploy:


### PR DESCRIPTION
## Summary

$ #89309 by setting `JEKYLL_ENV=production` for both Jekyll help-site deploy build steps. This makes `docs/_includes/CONST.html` resolve `MAIN_SITE_URL` to `https://new.expensify.com`, so the generated Concierge link points to `https://new.expensify.com/concierge` instead of the dev host.

This implements the approved workflow-only fix after the bot implementation was blocked by missing `workflow` token scope.

## Tests

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .github/workflows/deployExpensifyHelp.yml .github/workflows/deployNewHelp.yml`\n\nFull Jekyll deploy was not run locally; this is a workflow environment configuration change.