### PR TITLE
Show 'Scanning' date and sort scanning receipts to top of expenses list

### DIFF
--- a/src/components/Search/SearchList/ListItem/DateCell.tsx
+++ b/src/components/Search/SearchList/ListItem/DateCell.tsx
@@ -9,13 +9,15 @@ type DateCellProps = {
     showTooltip: boolean;
     isLargeScreenWidth: boolean;
     suffixText?: string;
+    /** Optional text to display instead of the formatted date (e.g., 'Scanning') */
+    displayText?: string;
 };
 
-function DateCell({date, showTooltip, isLargeScreenWidth, suffixText}: DateCellProps) {
+function DateCell({date, showTooltip, isLargeScreenWidth, suffixText, displayText: displayTextOverride}: DateCellProps) {
     const styles = useThemeStyles();
 
     const formattedDate = DateUtils.formatWithUTCTimeZone(date, DateUtils.doesDateBelongToAPastYear(date) ? CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT : CONST.DATE.MONTH_DAY_ABBR_FORMAT);
-    const displayText = suffixText ? `${formattedDate} • ${suffixText}` : formattedDate;
+    const displayText = displayTextOverride ?? (suffixText ? `${formattedDate} • ${suffixText}` : formattedDate);
 
     return (
         <TextWithTooltip

--- a/src/components/Search/SearchList/ListItem/__tests__/DateCellTest.tsx
+++ b/src/components/Search/SearchList/ListItem/__tests__/DateCellTest.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {render} from '@testing-library/react-native';
+import DateCell from '../DateCell';
+
+describe('DateCell', () => {
+    it('renders formatted date when no displayText is provided', () => {
+        const {getByText} = render(
+            <DateCell
+                date="2024-01-15"
+                showTooltip={false}
+                isLargeScreenWidth
+            />,
+        );
+        expect(getByText('Jan 15, 2024')).toBeTruthy();
+    });
+
+    it('renders displayText when provided', () => {
+        const {getByText} = render(
+            <DateCell
+                date="2024-01-15"
+                showTooltip={false}
+                isLargeScreenWidth
+                displayText="Scanning"
+            />,
+        );
+        expect(getByText('Scanning')).toBeTruthy();
+    });
+
+    it('renders formatted date with suffix when no displayText is provided', () => {
+        const {getByText} = render(
+            <DateCell
+                date="2024-01-15"
+                showTooltip={false}
+                isLargeScreenWidth
+                suffixText="Cash"
+            />,
+        );
+        expect(getByText('Jan 15, 2024 • Cash')).toBeTruthy();
+    });
+
+    it('renders displayText even when suffixText is provided', () => {
+        const {getByText} = render(
+            <DateCell
+                date="2024-01-15"
+                showTooltip={false}
+                isLargeScreenWidth
+                suffixText="Cash"
+                displayText="Scanning"
+            />,
+        );
+        expect(getByText('Scanning')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary

$ #89966

### Changes

1. **DateCell.tsx**: Added optional `displayText` prop to allow overriding the formatted date with custom text (e.g., 'Scanning')
2. **TransactionItemRow/index.tsx**: Pass `translate('iou.receiptStatusTitle')` as `displayText` to DateCell when the transaction is scanning, in both wide and narrow layouts
3. **SearchUIUtils.ts**: Added scanning-priority sort logic in `getSortedTransactionData` to push scanning receipts to the top of the list
4. **MoneyRequestReportTransactionList.tsx**: Added the same scanning-priority sort logic for report-level transaction lists

### Testing

- Scanning receipts now show 'Scanning' instead of the date
- Scanning receipts appear at the top of the expenses list
- After SmartScan completes, the receipt reverts to normal date display and normal sort position
- Existing sort behavior is preserved for non-scanning receipts

### Screenshots

N/A - UI change is consistent with existing merchant column pattern