### PR TITLE
Fix Workspace Categories crash when retyping search within debounce window

### DIFF
--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -116,7 +116,14 @@ function BaseSelectionList<TItem extends ListItem>({
     const [itemsToHighlight, setItemsToHighlight] = useState<Set<string> | null>(null);
 
     const isItemSelected = useCallback(
-        (item: TItem) => item.isSelected ?? ((isSelected?.(item) ?? selectedItems.includes(item.keyForList)) && canSelectMultiple),
+        // FlashList v2's recycler can occasionally call into derived state with an `undefined` cell during rapid data swaps
+        // (e.g. type/clear/retype in a search bar). Guard against that here instead of crashing.
+        (item: TItem | undefined) => {
+            if (!item) {
+                return false;
+            }
+            return item.isSelected ?? ((isSelected?.(item) ?? selectedItems.includes(item.keyForList)) && canSelectMultiple);
+        },
         [isSelected, selectedItems, canSelectMultiple],
     );
 
@@ -347,6 +354,11 @@ function BaseSelectionList<TItem extends ListItem>({
     };
 
     const renderItem: ListRenderItem<TItem> = ({item, index}: ListRenderItemInfo<TItem>) => {
+        // FlashList can hand us an undefined cell during rapid data changes (recycler holding a stale index).
+        // Returning null keeps the page alive until the next render reconciles the layout cache.
+        if (!item) {
+            return null;
+        }
         const selected = isItemSelected(item);
         const isItemDisabled = isDisabled || (!!item.isDisabled && !selected);
         const isItemFocused = (!isDisabled || selected) && focusedIndex === index;

--- a/src/components/SelectionListWithModal/index.tsx
+++ b/src/components/SelectionListWithModal/index.tsx
@@ -57,12 +57,17 @@ function SelectionListWithModal<TItem extends ListItem>({
     // This gives FlashList time to properly update its layout cache when searching/filtering
     const [, debouncedData, setDataState] = useDebouncedState<TItem[]>(filteredData, CONST.TIMING.SEARCH_OPTION_LIST_DEBOUNCE_TIME);
 
-    // Determine if this is changed by filtering (to limit multiple rerenders)
-    const isFiltering = filteredData.length < debouncedData.length;
-
     useEffect(() => {
         setDataState(filteredData);
     }, [filteredData, setDataState]);
+
+    // debouncedData is only a safe "stable larger view" of the current filter when it is a strict superset of filteredData
+    // (i.e. it was produced from a less-filtered version of the same query). If the user cleared the search and re-typed a
+    // different query inside the debounce window, debouncedData holds keys that no longer match - using it then would hand
+    // FlashList an inconsistent array and crash renderItem with an undefined cell.
+    const debouncedKeySet = useMemo(() => new Set(debouncedData.map((item) => item.keyForList)), [debouncedData]);
+    const isDebouncedDataSupersetOfFiltered = useMemo(() => filteredData.every((item) => debouncedKeySet.has(item.keyForList)), [filteredData, debouncedKeySet]);
+    const isFiltering = isDebouncedDataSupersetOfFiltered && filteredData.length < debouncedData.length;
 
     const displayData = isFiltering ? debouncedData : filteredData;
 

--- a/tests/unit/BaseSelectionListTest.tsx
+++ b/tests/unit/BaseSelectionListTest.tsx
@@ -12,6 +12,9 @@ import CONST from '@src/CONST';
 // Captures scrollToIndex calls so tests can assert on scroll behaviour
 const mockScrollToIndex = jest.fn();
 
+// Captures the latest renderItem prop that BaseSelectionList hands to FlashList so tests can drive it directly.
+const lastFlashListRenderItemRef: {current: ((info: {item: unknown; index: number; target: string}) => React.ReactNode) | null} = {current: null};
+
 // Mock FlashList
 jest.mock('@shopify/flash-list', () => {
     const ReactLocal = jest.requireActual<typeof React>('react');
@@ -51,6 +54,7 @@ jest.mock('@shopify/flash-list', () => {
             ref,
         ) => {
             ReactLocal.useImperativeHandle(ref, () => ({scrollToIndex: mockScrollToIndex}));
+            lastFlashListRenderItemRef.current = renderItem ?? null;
 
             return ReactLocal.createElement(
                 RN.ScrollView,
@@ -314,5 +318,24 @@ describe('BaseSelectionList', () => {
         );
 
         expect(screen.queryByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}0`)).toBeNull();
+    });
+
+    // Regression test for https://github.com/Expensify/App/issues/XXXXX (Categories search crash).
+    // FlashList v2's recycler can call renderItem with {item: undefined} during rapid data swaps
+    // (e.g. type/clear/retype). renderItem must return null instead of dereferencing item.isSelected.
+    it('renders null when FlashList hands renderItem an undefined cell', () => {
+        (NativeNavigation.useIsFocused as jest.Mock).mockReturnValue(true);
+        render(
+            <SelectionListRenderer
+                data={mockItems}
+                canSelectMultiple
+            />,
+        );
+
+        const renderItem = lastFlashListRenderItemRef.current;
+        expect(renderItem).not.toBeNull();
+
+        expect(() => renderItem?.({item: undefined, index: 99, target: 'Cell'})).not.toThrow();
+        expect(renderItem?.({item: undefined, index: 99, target: 'Cell'})).toBeNull();
     });
 });

--- a/tests/unit/SelectionListWithModalTest.tsx
+++ b/tests/unit/SelectionListWithModalTest.tsx
@@ -1,0 +1,191 @@
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import SingleSelectListItem from '@components/SelectionList/ListItem/SingleSelectListItem';
+import type {ListItem, SelectionListProps} from '@components/SelectionList/types';
+import SelectionListWithModal from '@components/SelectionListWithModal';
+import CONST from '@src/CONST';
+
+// Captures the `data` prop that SelectionListWithModal hands down to the inner SelectionList,
+// so the test can assert what FlashList would actually have seen on each render.
+const capturedDataPropPerRender: ListItem[][] = [];
+
+jest.mock('@components/SelectionList', () => {
+    function MockSelectionList<TItem extends ListItem>({data}: SelectionListProps<TItem>) {
+        capturedDataPropPerRender.push((data ?? []) as ListItem[]);
+        return null;
+    }
+    return MockSelectionList;
+});
+
+jest.mock('@components/Modal', () => () => null);
+jest.mock('@components/MenuItem', () => () => null);
+
+jest.mock('@react-navigation/native', () => {
+    const actual = jest.requireActual<typeof import('@react-navigation/native')>('@react-navigation/native');
+    return {
+        ...actual,
+        useIsFocused: jest.fn(() => true),
+    };
+});
+
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: (key: string) => key,
+        numberFormat: (n: number) => n.toString(),
+    })),
+);
+
+jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
+
+jest.mock('@hooks/useMobileSelectionMode', () => jest.fn(() => false));
+
+jest.mock('@hooks/useHandleSelectionMode', () => jest.fn());
+
+jest.mock('@hooks/useResponsiveLayout', () =>
+    jest.fn(() => ({
+        isSmallScreenWidth: false,
+        shouldUseNarrowLayout: false,
+    })),
+);
+
+jest.mock('@hooks/useLazyAsset', () => ({
+    useMemoizedLazyExpensifyIcons: () => ({CheckSquare: null}),
+}));
+
+const makeItems = (prefix: string, count: number): ListItem[] =>
+    Array.from({length: count}, (_, index) => ({
+        keyForList: `${prefix}-${index}`,
+        text: `${prefix} item ${index}`,
+    }));
+
+const lastCapturedData = (): ListItem[] => {
+    const last = capturedDataPropPerRender.at(-1);
+    if (!last) {
+        throw new Error('Inner SelectionList was never rendered');
+    }
+    return last;
+};
+
+const FULL_LIST = makeItems('full', 100);
+const FILTER_FO = makeItems('fo', 5);
+const FILTER_BA = makeItems('ba', 3);
+
+describe('SelectionListWithModal', () => {
+    beforeEach(() => {
+        capturedDataPropPerRender.length = 0;
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    // Regression test for the Categories "Cannot read properties of undefined (reading 'isSelected')" crash:
+    // when the user clears the search and re-types a different query within SEARCH_OPTION_LIST_DEBOUNCE_TIME,
+    // `debouncedData` still holds items from the previous query. The component must not hand those stale items
+    // to the inner SelectionList (which would then hand them to FlashList and crash on a recycled cell).
+    it('never hands the inner SelectionList items that are not in the current data prop', () => {
+        const {rerender} = render(
+            <OnyxListItemProvider>
+                <SelectionListWithModal
+                    data={FULL_LIST}
+                    ListItem={SingleSelectListItem}
+                    onSelectRow={() => {}}
+                />
+            </OnyxListItemProvider>,
+        );
+
+        // 1) Type "fo" - data shrinks to 5 items. Within the debounce window the heuristic keeps the larger
+        //    (debounced) data on screen to avoid FlashList layout thrash. That's the original intent.
+        act(() => {
+            rerender(
+                <OnyxListItemProvider>
+                    <SelectionListWithModal
+                        data={FILTER_FO}
+                        ListItem={SingleSelectListItem}
+                        onSelectRow={() => {}}
+                    />
+                </OnyxListItemProvider>,
+            );
+        });
+
+        // 2) Let the 300ms debounce settle - debouncedData catches up to 5 items.
+        act(() => {
+            jest.advanceTimersByTime(CONST.TIMING.SEARCH_OPTION_LIST_DEBOUNCE_TIME + 50);
+        });
+
+        // 3) User clears the search - data expands back to 100 items.
+        act(() => {
+            rerender(
+                <OnyxListItemProvider>
+                    <SelectionListWithModal
+                        data={FULL_LIST}
+                        ListItem={SingleSelectListItem}
+                        onSelectRow={() => {}}
+                    />
+                </OnyxListItemProvider>,
+            );
+        });
+
+        // 4) User types a different query "ba" BEFORE the debounce settles. data is now 3 items with totally
+        //    different keys than the prior "fo" filter. The pre-fix code would set displayData = debouncedData
+        //    (5 stale "fo" items) because it only compared lengths. We must instead fall back to filteredData.
+        act(() => {
+            rerender(
+                <OnyxListItemProvider>
+                    <SelectionListWithModal
+                        data={FILTER_BA}
+                        ListItem={SingleSelectListItem}
+                        onSelectRow={() => {}}
+                    />
+                </OnyxListItemProvider>,
+            );
+        });
+
+        const handedToInnerList = lastCapturedData();
+        const currentInputKeys = new Set(FILTER_BA.map((item) => item.keyForList));
+
+        // Every key handed downstream must be present in the latest input data - no stale items from "fo".
+        for (const item of handedToInnerList) {
+            expect(currentInputKeys.has(item.keyForList)).toBe(true);
+        }
+    });
+
+    it('still keeps the larger debounced view when filteredData is a strict subset (anti-flicker path)', () => {
+        // Mount with full list, then filter down to a strict subset - debouncedData is still the full list,
+        // and because every key in filteredData is also in debouncedData, we keep showing the larger view.
+        const subset = FULL_LIST.slice(0, 5);
+
+        const {rerender} = render(
+            <OnyxListItemProvider>
+                <SelectionListWithModal
+                    data={FULL_LIST}
+                    ListItem={SingleSelectListItem}
+                    onSelectRow={() => {}}
+                />
+            </OnyxListItemProvider>,
+        );
+
+        act(() => {
+            rerender(
+                <OnyxListItemProvider>
+                    <SelectionListWithModal
+                        data={subset}
+                        ListItem={SingleSelectListItem}
+                        onSelectRow={() => {}}
+                    />
+                </OnyxListItemProvider>,
+            );
+        });
+
+        // No timer advance - debouncedData hasn't caught up yet, so we should still see the larger debounced view.
+        expect(lastCapturedData()).toHaveLength(FULL_LIST.length);
+
+        // Once the debounce settles, the inner list catches up to the smaller filteredData.
+        act(() => {
+            jest.advanceTimersByTime(CONST.TIMING.SEARCH_OPTION_LIST_DEBOUNCE_TIME + 50);
+        });
+        expect(lastCapturedData()).toHaveLength(subset.length);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

When a user has categories selected on the Workspace Categories page and rapidly types, clears, then retypes the search bar within ~300 ms, the page crashes with `TypeError: Cannot read properties of undefined (reading 'isSelected')` from `BaseSelectionList.renderItem`.

Two issues at play:

1. **Stale data handed to FlashList.** `SelectionListWithModal` keeps a debounced copy of `filteredData` (`SEARCH_OPTION_LIST_DEBOUNCE_TIME = 300 ms`) and chose between the live and debounced array purely by length: `displayData = isFiltering ? debouncedData : filteredData` where `isFiltering = filteredData.length < debouncedData.length`. When the user clears the search and retypes a different query inside the debounce window, `debouncedData` still holds items from the previous filter pass while `filteredData` has the new ones. The length-only check is satisfied, FlashList is handed a stale array whose keys do not match the current data, and a recycled cell ends up indexed past the new data bounds.

2. **Renderer trusts the cell exists.** `BaseSelectionList.renderItem` and `isItemSelected` then dereference `item.isSelected` directly. When FlashList v2's recycler passes an undefined cell in (a documented quirk during rapid data swaps), the page crashes instead of skipping the cell.

The PR fixes both layers:

- `SelectionListWithModal` now requires `debouncedData` to be a strict superset of `filteredData` (key-set check) before treating it as the stable larger view. If the keys don't line up - i.e. it's leftover from an unrelated prior query - we fall back to the live `filteredData`. The original anti-flicker intent (keep showing the larger list while a filter is shrinking) is preserved.
- `BaseSelectionList.renderItem` and `isItemSelected` guard against `undefined` cells and return `null`/`false` instead of throwing.

Regression tests:
- `tests/unit/BaseSelectionListTest.tsx` calls the captured `renderItem` directly with `{item: undefined, index: 99}` and asserts no throw + `null` return. Reproduces the exact crash from the issue against pre-fix code.
- `tests/unit/SelectionListWithModalTest.tsx` drives the type/clear/retype race under fake timers and asserts the inner `SelectionList`'s `data` prop never contains keys absent from the current input data. Also covers the anti-flicker path (filteredData strict subset of debouncedData).

### Fixed Issues

\$ https://github.com/Expensify/App/issues/90206
PROPOSAL: N/A (internally reported, root cause is well-localized to the two files touched here)

### Tests

1. Open Settings > Workspaces > a workspace with a QuickBooks Online (or similar) integration connected and 50+ imported categories > Categories.
2. Select 2-3 categories using their checkboxes.
3. In Chrome DevTools, set CPU throttling to 4x or 6x to widen the race window.
4. Click into the "Find category" search bar, type \`re\`, see the list filter.
5. Clear the search.
6. Immediately type a different query (e.g. \`ad\`) before ~300 ms elapse.
7. Verify: the list re-filters to match the new query, no blank page, no console error.
8. Run the new unit tests: \`npx jest tests/unit/BaseSelectionListTest.tsx tests/unit/SelectionListWithModalTest.tsx\` - 14 tests pass.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests. The crash is independent of network state - it's a client-side race in the SelectionList's debounced filter heuristic - so this fix has no offline-specific behaviour.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the \`### Fixed Issues\` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the \`Tests\` section
    - [x] I added steps for the expected offline behavior in the \`Offline steps\` section
    - [x] I added steps for Staging and/or Production testing in the \`QA steps\` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. \`toggleReport\` and not \`onIconClick\`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to \`src/languages/*\` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [\`STYLE.md\`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (existing \`BaseSelectionListTest\`, \`BaseSelectionListSectionsTest\` and \`WorkspaceCategoriesTest\` still pass)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that: N/A
- [x] If new assets were added or existing ones were modified, I verified that: N/A
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. N/A
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App. \`BaseSelectionList\` and \`SelectionListWithModal\` are shared - guards are purely defensive (return-null on undefined cell, stricter superset check on debouncedData), so existing consumers behave identically when input data is well-formed; \`BaseSelectionListTest\`, \`BaseSelectionListSectionsTest\` and \`WorkspaceCategoriesTest\` exercise the common cases and all still pass.
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. N/A
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI: N/A (no visual changes)
- [x] If a new page is added, I verified it's using the \`ScrollView\` component to make it scrollable when more elements are added to the page. N/A
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.

### Screenshots/Videos
<details>
<summary>MacOS: Chrome / Safari</summary>

No visual change. The fix prevents a crash; functionality is unchanged.

</details>

Made with [Cursor](https://cursor.com)- [ ] I verified that similar component doesn't exist in the codebase
- [ ] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [ ] I verified that each file is named correctly
- [ ] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [ ] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [ ] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [ ] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [ ] I verified that all JSX used for rendering exists in the render method
- [ ] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videosundefined