### PR TITLE
Fix back navigation after invite transition links

### DIFF
--- a/src/libs/Navigation/helpers/linkTo/index.ts
+++ b/src/libs/Navigation/helpers/linkTo/index.ts
@@ -27,6 +27,7 @@ const defaultLinkToOptions: LinkToOptions = {
  * Used to distinguish plain tab switches from cross-tab deep navigations.
  */
 const ROOT_TAB_SCREENS = new Set<string>([SCREENS.HOME, SCREENS.INBOX, SCREENS.SEARCH.ROOT, SCREENS.SETTINGS.ROOT, SCREENS.WORKSPACES_LIST]);
+const TRANSIENT_AUTH_SCREENS = new Set<string>([SCREENS.TRANSITION_BETWEEN_APPS, SCREENS.VALIDATE_LOGIN]);
 
 function areNamesAndParamsEqual(currentState: NavigationState<RootNavigatorParamList>, stateFromPath: PartialState<NavigationState<RootNavigatorParamList>>) {
     const currentFocusedRoute = findFocusedRoute(currentState);
@@ -205,11 +206,12 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
         action.type = CONST.NAVIGATION.ACTION_TYPE.PUSH;
     }
 
-    // When something other than TAB_NAVIGATOR is on top of the stack and we're navigating
-    // to TAB_NAVIGATOR, PUSH a new instance above (e.g., above RHP).
+    // When a transient auth screen is on top of the stack, replace it with TAB_NAVIGATOR so
+    // back navigation does not reveal a stale loader after sign-in.
+    // For other stacked routes (e.g., RHP), keep pushing a new TAB_NAVIGATOR above them.
     const currentTopRoute = currentState.routes[currentState.index];
     if (currentTopRoute?.name !== NAVIGATORS.TAB_NAVIGATOR && typedPayload.name === NAVIGATORS.TAB_NAVIGATOR) {
-        (action as {type: string}).type = CONST.NAVIGATION.ACTION_TYPE.PUSH;
+        (action as {type: string}).type = TRANSIENT_AUTH_SCREENS.has(currentTopRoute?.name ?? '') || forceReplace ? CONST.NAVIGATION.ACTION_TYPE.REPLACE : CONST.NAVIGATION.ACTION_TYPE.PUSH;
     }
 
     // Cross-tab navigation to a deep leaf (e.g. Settings → Concierge): PUSH a new TAB_NAVIGATOR so

--- a/tests/navigation/NavigateTests.tsx
+++ b/tests/navigation/NavigateTests.tsx
@@ -20,6 +20,28 @@ jest.mock('@pages/inbox/sidebar/NavigationTabBarAvatar');
 const mockedGetIsNarrowLayout = getIsNarrowLayout as jest.MockedFunction<typeof getIsNarrowLayout>;
 const mockedUseResponsiveLayout = useResponsiveLayout as jest.MockedFunction<typeof useResponsiveLayout>;
 
+const getHomeTabNavigatorRoute = () => ({
+    name: NAVIGATORS.TAB_NAVIGATOR,
+    state: {
+        index: 0,
+        routes: [
+            {name: SCREENS.HOME},
+            {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR},
+            {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR},
+            {name: NAVIGATORS.WORKSPACE_NAVIGATOR},
+        ],
+    },
+});
+
+const getRightModalNavigatorRoute = () => ({
+    name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR,
+    state: {
+        index: 0,
+        routes: [{name: SCREENS.RIGHT_MODAL.SETTINGS}],
+    },
+});
+
 describe('Navigate', () => {
     beforeEach(() => {
         mockedGetIsNarrowLayout.mockReturnValue(true);
@@ -132,6 +154,69 @@ describe('Navigate', () => {
             const settingsSplitAfterGoBack = tabStateAfter?.routes.at(3);
             expect(settingsSplitAfterGoBack?.state?.index).toBe(1);
             expect(settingsSplitAfterGoBack?.state?.routes.at(-1)?.name).toBe(SCREENS.SETTINGS.ABOUT);
+        });
+
+        it.each([SCREENS.TRANSITION_BETWEEN_APPS, SCREENS.VALIDATE_LOGIN])('replaces transient auth route when navigating to a report (%s)', (transientRoute) => {
+            render(
+                <TestNavigationContainer
+                    initialState={{
+                        index: 1,
+                        routes: [getHomeTabNavigatorRoute(), {name: transientRoute}],
+                    }}
+                />,
+            );
+
+            const rootStateBeforeNavigate = navigationRef.current?.getRootState();
+            expect(rootStateBeforeNavigate?.routes.at(-1)?.name).toBe(transientRoute);
+
+            act(() => {
+                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute('1'));
+            });
+
+            const rootStateAfterNavigate = navigationRef.current?.getRootState();
+            const pushedTabState = rootStateAfterNavigate?.routes.at(-1)?.state;
+            const activeTabAfterNavigate = pushedTabState?.routes.at(pushedTabState?.index ?? 0);
+
+            expect(rootStateAfterNavigate?.routes).toHaveLength(2);
+            expect(rootStateAfterNavigate?.routes.map((route) => route.name)).not.toContain(transientRoute);
+            expect(rootStateAfterNavigate?.routes.at(-1)?.name).toBe(NAVIGATORS.TAB_NAVIGATOR);
+            expect(activeTabAfterNavigate?.name).toBe(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR);
+        });
+
+        it('pushes a new tab navigator above a right modal by default', () => {
+            render(
+                <TestNavigationContainer
+                    initialState={{
+                        index: 1,
+                        routes: [getHomeTabNavigatorRoute(), getRightModalNavigatorRoute()],
+                    }}
+                />,
+            );
+
+            act(() => {
+                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute('1'));
+            });
+
+            const rootStateAfterNavigate = navigationRef.current?.getRootState();
+            expect(rootStateAfterNavigate?.routes.map((route) => route.name)).toEqual([NAVIGATORS.TAB_NAVIGATOR, NAVIGATORS.RIGHT_MODAL_NAVIGATOR, NAVIGATORS.TAB_NAVIGATOR]);
+        });
+
+        it('honors forceReplace when navigating from a right modal to a tab route', () => {
+            render(
+                <TestNavigationContainer
+                    initialState={{
+                        index: 1,
+                        routes: [getHomeTabNavigatorRoute(), getRightModalNavigatorRoute()],
+                    }}
+                />,
+            );
+
+            act(() => {
+                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute('1'), {forceReplace: true});
+            });
+
+            const rootStateAfterNavigate = navigationRef.current?.getRootState();
+            expect(rootStateAfterNavigate?.routes.map((route) => route.name)).toEqual([NAVIGATORS.TAB_NAVIGATOR, NAVIGATORS.TAB_NAVIGATOR]);
         });
 
         it('to the page from the different split navigator', () => {

--- a/tests/utils/TestNavigationContainer.tsx
+++ b/tests/utils/TestNavigationContainer.tsx
@@ -210,6 +210,10 @@ function TestNavigationContainer({initialState}: TestNavigationContainerProps) {
                     component={getEmptyComponent()}
                 />
                 <RootStack.Screen
+                    name={SCREENS.TRANSITION_BETWEEN_APPS}
+                    component={getEmptyComponent()}
+                />
+                <RootStack.Screen
                     name={NAVIGATORS.RIGHT_MODAL_NAVIGATOR}
                     component={TestRightModalNavigator}
                 />


### PR DESCRIPTION
## Summary

$ #90140 by replacing transient auth/transition screens when they hand off to a tab route. Previously, `linkTo` always converted non-tab -> `TAB_NAVIGATOR` navigation into `PUSH`, so invite transition routes such as `TRANSITION_BETWEEN_APPS` or `VALIDATE_LOGIN` could remain under the workspace report. Pressing back then exposed the stale full-screen loader instead of returning home.

The change keeps the existing `PUSH` behavior for normal stacked routes like RHP, and preserves explicit `forceReplace` requests. Added navigation coverage for transient auth replacement, default RHP push behavior, and RHP `forceReplace`.

## Tests

- `git diff --check`
- `./node_modules/.bin/prettier --check src/libs/Navigation/helpers/linkTo/index.ts tests/navigation/NavigateTests.tsx tests/utils/TestNavigationContainer.tsx`

Attempted but blocked locally:
- `npm test -- --runInBand tests/navigation/NavigateTests.tsx` initially failed before tests because this sparse worktree lacked installed dependencies/assets; after fallback dependency install and adding `assets/images`, the suite hit a React Navigation ESM loader issue from the no-lock local install.
- `npm run lint -- src/libs/Navigation/helpers/linkTo/index.ts tests/navigation/NavigateTests.tsx tests/utils/TestNavigationContainer.tsx` was blocked by incompatible transient ESLint/Airbnb config versions from the fallback no-lock install.
- `npm run typecheck -- --pretty false` was started but did not complete in a reasonable local window, so I stopped it.
