### PR TITLE
Rollback failed distance type preference updates

### DIFF
--- a/src/libs/actions/IOU/Split.ts
+++ b/src/libs/actions/IOU/Split.ts
@@ -61,7 +61,7 @@ import {removeDraftTransaction} from '@userActions/TransactionEdit';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
-import type {Attendee, Participant, Split} from '@src/types/onyx/IOU';
+import type {Attendee, DistanceExpenseType, Participant, Split} from '@src/types/onyx/IOU';
 import type RecentlyUsedTags from '@src/types/onyx/RecentlyUsedTags';
 import type {OnyxData} from '@src/types/onyx/Request';
 import type {Receipt, ReceiptSource, SplitShares, TransactionChanges, WaypointCollection} from '@src/types/onyx/Transaction';
@@ -135,6 +135,14 @@ type CreateDistanceRequestInformation = {
     shouldDeferAutoSubmit?: boolean;
     previousOdometerDraft?: OnyxEntry<OnyxTypes.OdometerDraft>;
 };
+
+let lastDistanceExpenseType: OnyxEntry<DistanceExpenseType>;
+Onyx.connect({
+    key: ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE,
+    callback: (value) => {
+        lastDistanceExpenseType = value;
+    },
+});
 
 type CreateSplitsTransactionParams = Omit<BaseTransactionParams, 'customUnitRateID'> & {
     splitShares: SplitShares;
@@ -2002,6 +2010,11 @@ function createDistanceRequest(distanceRequestInformation: CreateDistanceRequest
                 onyxMethod: Onyx.METHOD.SET,
                 key: ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE,
                 value: transaction.iouRequestType,
+            });
+            onyxData?.failureData?.push({
+                onyxMethod: Onyx.METHOD.SET,
+                key: ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE,
+                value: lastDistanceExpenseType ?? null,
             });
         }
 

--- a/src/libs/actions/IOU/TrackExpense.ts
+++ b/src/libs/actions/IOU/TrackExpense.ts
@@ -97,7 +97,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import type * as OnyxTypes from '@src/types/onyx';
-import type {Attendee, Participant} from '@src/types/onyx/IOU';
+import type {Attendee, DistanceExpenseType, Participant} from '@src/types/onyx/IOU';
 import type {QuickActionName} from '@src/types/onyx/QuickAction';
 import type ReportAction from '@src/types/onyx/ReportAction';
 import type {OnyxData} from '@src/types/onyx/Request';
@@ -136,6 +136,14 @@ type TrackExpenseInformation = {
     optimisticReportActionID: string | undefined;
     onyxData: OnyxData<BuildOnyxDataForTrackExpenseKeys | BuildPolicyDataKeys | typeof ONYXKEYS.SELF_DM_REPORT_ID>;
 };
+
+let lastDistanceExpenseType: OnyxEntry<DistanceExpenseType>;
+Onyx.connect({
+    key: ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE,
+    callback: (value) => {
+        lastDistanceExpenseType = value;
+    },
+});
 
 type GetTrackExpenseInformationTransactionParams = {
     comment: string;
@@ -2444,6 +2452,11 @@ function trackExpense(params: CreateTrackExpenseParams) {
             onyxMethod: Onyx.METHOD.SET,
             key: ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE,
             value: transaction?.iouRequestType,
+        });
+        onyxData?.failureData?.push({
+            onyxMethod: Onyx.METHOD.SET,
+            key: ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE,
+            value: lastDistanceExpenseType ?? null,
         });
     }
 

--- a/tests/actions/IOUTest/SplitTest.ts
+++ b/tests/actions/IOUTest/SplitTest.ts
@@ -6876,6 +6876,30 @@ describe('createDistanceRequest', () => {
         await waitForBatchedUpdates();
     });
 
+    it('rolls back last distance expense type when the distance request fails', async () => {
+        const testReport = createRandomReport(1, undefined);
+        const existingTransaction: Transaction = {
+            ...createRandomTransaction(1),
+            iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_MANUAL,
+        };
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${testReport.reportID}`, testReport);
+        await Onyx.set(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE, CONST.IOU.REQUEST_TYPE.DISTANCE_MAP);
+        await waitForBatchedUpdates();
+
+        mockFetch?.fail?.();
+
+        const recentWaypoints = (await getOnyxValue(ONYXKEYS.NVP_RECENT_WAYPOINTS)) ?? [];
+        createDistanceRequest({
+            ...getDefaultDistanceRequestParams(testReport, {amount: 500, comment: 'Failed distance request'}, recentWaypoints),
+            existingTransaction,
+        });
+        await waitForBatchedUpdates();
+
+        expect(await getOnyxValue(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE)).toBe(CONST.IOU.REQUEST_TYPE.DISTANCE_MAP);
+
+        mockFetch?.succeed?.();
+    });
+
     it('creates billable distance request when billable flag is set', async () => {
         const policyID = 'billablePolicy';
         const fakePolicy = {...createRandomPolicy(1), id: policyID, disabledFields: {defaultBillable: false}};

--- a/tests/actions/IOUTest/TrackExpenseTest.ts
+++ b/tests/actions/IOUTest/TrackExpenseTest.ts
@@ -1391,6 +1391,33 @@ describe('actions/IOU/TrackExpense', () => {
             mockFetch?.succeed?.();
         });
 
+        it('should roll back last distance expense type when a tracked distance request fails', async () => {
+            const selfDMReport: Report = {
+                ...createRandomReport(1, CONST.REPORT.CHAT_TYPE.SELF_DM),
+                reportID: 'selfDM-distance-failure',
+            };
+            const existingTransaction: Transaction = {
+                ...createRandomTransaction(1),
+                iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_MANUAL,
+            };
+
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${selfDMReport.reportID}`, selfDMReport);
+            await Onyx.set(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE, CONST.IOU.REQUEST_TYPE.DISTANCE_MAP);
+            await waitForBatchedUpdates();
+
+            mockFetch?.fail?.();
+
+            trackExpense({
+                ...getDefaultTrackExpenseParams(selfDMReport, {amount: 5000, distance: 1200, merchant: 'Failed Distance'}),
+                existingTransaction,
+            });
+            await waitForBatchedUpdates();
+
+            expect(await getOnyxValue(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE)).toBe(CONST.IOU.REQUEST_TYPE.DISTANCE_MAP);
+
+            mockFetch?.succeed?.();
+        });
+
         it('should handle category and tag together correctly', async () => {
             // Given a selfDM report with category and tag
             const selfDMReport: Report = {


### PR DESCRIPTION
## Summary

$ #89701 by adding matching `failureData` for the optimistic `NVP_LAST_DISTANCE_EXPENSE_TYPE` writes in both distance expense writers. When a distance expense API write fails, Onyx now restores the previous last-used distance type instead of keeping the failed attempt as the default for the next Track distance flow.

The fix keeps the existing optimistic happy-path behavior and mirrors the rollback pattern already used nearby for recent waypoints and odometer draft data. Regression coverage was added for both `trackExpense` and `createDistanceRequest`.

## Tests

- `git diff --check`
- `./node_modules/.bin/prettier --check src/libs/actions/IOU/TrackExpense.ts src/libs/actions/IOU/Split.ts tests/actions/IOUTest/TrackExpenseTest.ts tests/actions/IOUTest/SplitTest.ts`

Attempted but blocked locally:
- `npm test -- --runInBand tests/actions/IOUTest/TrackExpenseTest.ts tests/actions/IOUTest/SplitTest.ts` failed before tests due the existing `TextEncoder` setup ordering issue in this fallback local install.
- Retried Jest with a temporary `TextEncoder` setup file; it then failed before tests on React Navigation ESM loading from the no-lock fallback dependency install.
- `./node_modules/.bin/tsc --noEmit --pretty false --project tsconfig.json --incremental false --skipLibCheck` was started but did not complete in a reasonable local window, so I stopped it.
