### PR TITLE
[No QA] Make deploy workflow manually dispatchable

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -356,6 +356,8 @@ jobs:
 
           Note that you **must** test this PR, and both the author and reviewer checklist should be completed, just as if you were merging the PR to main.
 
+          **Important:** This PR should ideally be merged by a member of the [mobile-deployers](https://github.com/orgs/Expensify/teams/mobile-deployers) team. If it is merged by someone who is not a deployer, the staging deploy triggered by the merge will fail and will need to be manually re-triggered (not just retried) via the [deploy workflow](https://github.com/${{ github.repository }}/actions/workflows/deploy.yml).
+
           _Pro-tip:_ If this PR appears to have conflicts against the _${{ inputs.TARGET }}_ base, it means that the version on ${{ inputs.TARGET }} has been updated. The easiest thing to do if you see this is to close the PR and re-run the CP.
 
           $AUTHOR_CHECKLIST

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -356,7 +356,8 @@ jobs:
 
           Note that you **must** test this PR, and both the author and reviewer checklist should be completed, just as if you were merging the PR to main.
 
-          **Important:** This PR should ideally be merged by a member of the [mobile-deployers](https://github.com/orgs/Expensify/teams/mobile-deployers) team. If it is merged by someone who is not a deployer, the staging deploy triggered by the merge will fail and will need to be manually re-triggered (not just retried) via the [deploy workflow](https://github.com/${{ github.repository }}/actions/workflows/deploy.yml).
+          > [!IMPORTANT]
+          > This PR should ideally be merged by a member of the [mobile-deployers](https://github.com/orgs/Expensify/teams/mobile-deployers) team. If it is merged by someone who is not a deployer, the staging deploy triggered by the merge will fail and will need to be manually re-triggered (not just retried) via the [deploy workflow](https://github.com/${{ github.repository }}/actions/workflows/deploy.yml).
 
           _Pro-tip:_ If this PR appears to have conflicts against the _${{ inputs.TARGET }}_ base, it means that the version on ${{ inputs.TARGET }} has been updated. The easiest thing to do if you see this is to close the PR and re-run the CP.
 

--- a/.github/workflows/createDeployChecklist.yml
+++ b/.github/workflows/createDeployChecklist.yml
@@ -2,6 +2,11 @@ name: Create or update deploy checklist
 
 on:
   workflow_call:
+    inputs:
+      REF:
+        description: 'Git ref (branch, tag, or SHA) to check out. Defaults to the caller commit SHA.'
+        type: string
+        required: false
   workflow_dispatch:
 
 jobs:
@@ -11,6 +16,8 @@ jobs:
       - name: Checkout
         # v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.REF || github.sha }}
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,18 +134,27 @@ jobs:
                 const currentTag = process.env.DEPLOY_TAG;
                 const isStaging = currentTag.endsWith('-staging');
 
-                const { data: tags } = await github.rest.repos.listTags({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    per_page: 20,
-                });
-
-                // Find the most recent prior tag on the same branch (staging or production)
-                // to bound the commit range and avoid false positives from prior cherry-picks.
-                const prevTag = tags.find((t) => {
-                    if (t.name === currentTag) return false;
-                    return isStaging ? t.name.endsWith('-staging') : !t.name.endsWith('-staging');
-                });
+                // Paginate tags (max 100 per page) until we find the most recent prior tag
+                // on the same branch. A single page of 20 isn't enough: a production deploy
+                // that follows many staging releases may have the last production tag beyond
+                // the first page, causing prevTag to be undefined and falling back to HEAD only.
+                let prevTag = null;
+                for (let page = 1; !prevTag; page++) {
+                    const { data: tags } = await github.rest.repos.listTags({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        per_page: 100,
+                        page,
+                    });
+                    if (tags.length === 0) break;
+                    // Find the most recent prior tag on the same branch (staging or production)
+                    // to bound the commit range and avoid false positives from prior cherry-picks.
+                    prevTag = tags.find((t) => {
+                        if (t.name === currentTag) return false;
+                        return isStaging ? t.name.endsWith('-staging') : !t.name.endsWith('-staging');
+                    });
+                    if (tags.length < 100) break;
+                }
 
                 if (prevTag) {
                     const { data: comparison } = await github.rest.repos.compareCommits({

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           HEAD_COMMIT_SHA: ${{ steps.getDeploySHA.outputs.SHA }}
+          DEPLOY_TAG: ${{ steps.getTagName.outputs.TAG }}
         with:
           script: |
             let commitMessages;
@@ -116,27 +117,45 @@ jobs:
                 commitMessages = context.payload.commits.map((commit) => commit.message);
             } else {
                 // workflow_dispatch: payload has no commits array.
-                // For a conflict-resolution cherry-pick, GitHub creates a merge commit at HEAD whose first
-                // parent is the branch before the merge. The cherry-picked commit (which carries the
-                // "(cherry-picked to ... by ...)" marker) sits under the merge commit, not at HEAD itself.
-                // We therefore compare the first parent against HEAD to get all commits that were merged in.
+                // We must inspect the full commit range since the previous deploy, not just HEAD.
+                // Two cases where HEAD alone misses the marker:
+                //   1. Linear push: Mobile-Expensify cherry-picks amend the marker onto the
+                //      version-bump commit, then push a final unmarked submodule-update commit on top.
+                //   2. Merge commit: a conflict-resolution PR creates a merge commit at HEAD; the
+                //      cherry-picked commit with the marker is an inner commit, not HEAD itself.
+                // compareCommits(prevTag, HEAD) follows all parents and covers both cases.
                 const headSha = process.env.HEAD_COMMIT_SHA;
-                const { data: headCommit } = await github.rest.git.getCommit({
+                const currentTag = process.env.DEPLOY_TAG;
+                const isStaging = currentTag.endsWith('-staging');
+
+                const { data: tags } = await github.rest.repos.listTags({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    commit_sha: headSha,
+                    per_page: 20,
                 });
-                if (headCommit.parents.length > 1) {
-                    // Merge commit: get all commits between first parent and HEAD
+
+                // Find the most recent prior tag on the same branch (staging or production)
+                // to bound the commit range and avoid false positives from prior cherry-picks.
+                const prevTag = tags.find((t) => {
+                    if (t.name === currentTag) return false;
+                    return isStaging ? t.name.endsWith('-staging') : !t.name.endsWith('-staging');
+                });
+
+                if (prevTag) {
                     const { data: comparison } = await github.rest.repos.compareCommits({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
-                        base: headCommit.parents[0].sha,
+                        base: prevTag.commit.sha,
                         head: headSha,
                     });
-                    commitMessages = [headCommit.message, ...comparison.commits.map((c) => c.commit.message)];
+                    commitMessages = comparison.commits.map((c) => c.commit.message);
                 } else {
-                    // Linear commit: only check this commit's message
+                    // No previous tag found: fall back to HEAD only
+                    const { data: headCommit } = await github.rest.git.getCommit({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        commit_sha: headSha,
+                    });
                     commitMessages = [headCommit.message];
                 }
             }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         # v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ inputs.ENVIRONMENT || github.ref }}
+          ref: ${{ inputs.ENVIRONMENT || github.sha }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
           submodules: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,22 @@ name: Deploy code to staging or production
 on:
   push:
     branches: [staging, production]
+  workflow_dispatch:
+    inputs:
+      ENVIRONMENT:
+        description: 'Environment to deploy'
+        required: true
+        type: choice
+        options: [staging, production]
 
 env:
   IS_APP_REPO: ${{ github.repository == 'Expensify/App' }}
+  # For push triggers, fall back to deriving environment from the branch name.
+  # For workflow_dispatch, use the explicit input.
+  DEPLOY_ENV: ${{ inputs.ENVIRONMENT || (github.ref == 'refs/heads/production' && 'production' || 'staging') }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.ENVIRONMENT || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,10 +27,11 @@ jobs:
     outputs:
       APP_VERSION: ${{ steps.getAppVersion.outputs.VERSION }}
       TAG: ${{ steps.getTagName.outputs.TAG }}
+      DEPLOY_SHA: ${{ steps.getDeploySHA.outputs.SHA }}
       # Is this deploy for a cherry-pick?
       IS_CHERRY_PICK: ${{ steps.isCherryPick.outputs.IS_CHERRY_PICK }}
       # Should we build native apps? (only on staging or cherry-pick, not production)
-      SHOULD_BUILD_NATIVE: ${{ github.ref == 'refs/heads/staging' || fromJSON(steps.isCherryPick.outputs.IS_CHERRY_PICK) }}
+      SHOULD_BUILD_NATIVE: ${{ env.DEPLOY_ENV == 'staging' || fromJSON(steps.isCherryPick.outputs.IS_CHERRY_PICK) }}
       VERSION_CODE: ${{ steps.getAndroidVersion.outputs.VERSION_CODE }}
       IOS_VERSION: ${{ steps.getIOSVersion.outputs.IOS_VERSION }}
     steps:
@@ -28,8 +39,13 @@ jobs:
         # v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          ref: ${{ inputs.ENVIRONMENT || github.ref }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
           submodules: true
+
+      - name: Get deploy SHA
+        id: getDeploySHA
+        run: echo "SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Validate actor
         id: validateActor
@@ -52,7 +68,7 @@ jobs:
 
       - name: Get tag
         id: getTagName
-        run: echo "TAG=${{ github.ref == 'refs/heads/production' && steps.getAppVersion.outputs.VERSION || format('{0}-staging', steps.getAppVersion.outputs.VERSION) }}" >> "$GITHUB_OUTPUT"
+        run: echo "TAG=${{ env.DEPLOY_ENV == 'production' && steps.getAppVersion.outputs.VERSION || format('{0}-staging', steps.getAppVersion.outputs.VERSION) }}" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
         run: |
@@ -69,7 +85,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            const commitMessages = context.payload.commits.map((commit) => commit.message);
+            const commitMessages = (context.payload.commits || []).map((commit) => commit.message);
             const isCherryPick = commitMessages.some((message) => /.*\(cherry-picked to .* by .*\)$/.test(message));
             console.log('Is cherry pick?', isCherryPick);
             core.setOutput(
@@ -89,7 +105,7 @@ jobs:
   deployChecklist:
     name: Create or update deploy checklist
     uses: ./.github/workflows/createDeployChecklist.yml
-    if: ${{ github.ref == 'refs/heads/staging' }}
+    if: ${{ env.DEPLOY_ENV == 'staging' }}
     needs: prep
     secrets: inherit
 
@@ -99,7 +115,7 @@ jobs:
     if: ${{ fromJSON(needs.prep.outputs.SHOULD_BUILD_NATIVE) }}
     uses: ./.github/workflows/buildAndroid.yml
     with:
-      ref: ${{ github.sha }}
+      ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
       variant: Release
     secrets: inherit
 
@@ -112,6 +128,8 @@ jobs:
       - name: Checkout
         # v6
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
 
       - name: Download Android build artifact
         # v7
@@ -160,11 +178,13 @@ jobs:
     name: Submit Android for production rollout
     needs: [prep, androidBuild, androidUploadGooglePlay]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/production' && needs.androidBuild.result != 'failure' && needs.androidUploadGooglePlay.result != 'failure' }}
+    if: ${{ always() && !cancelled() && env.DEPLOY_ENV == 'production' && needs.androidBuild.result != 'failure' && needs.androidUploadGooglePlay.result != 'failure' }}
     steps:
       - name: Checkout
         # v6
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
 
       - name: Setup Ruby
         # v1.229.0
@@ -258,7 +278,7 @@ jobs:
     name: Upload Android to Applause
     needs: [prep, androidBuild]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: ${{ github.repository == 'Expensify/App' && github.ref == 'refs/heads/staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
+    if: ${{ github.repository == 'Expensify/App' && env.DEPLOY_ENV == 'staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
     continue-on-error: true
     steps:
       - name: Download Android APK artifact
@@ -308,7 +328,7 @@ jobs:
     if: ${{ fromJSON(needs.prep.outputs.SHOULD_BUILD_NATIVE) }}
     uses: ./.github/workflows/buildIOS.yml
     with:
-      ref: ${{ github.sha }}
+      ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
       variant: Release
     secrets: inherit
 
@@ -324,6 +344,7 @@ jobs:
         # v6
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
+          ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
           submodules: true
 
@@ -396,13 +417,15 @@ jobs:
     name: Submit iOS for production rollout
     needs: [prep, iosBuild, iosUploadTestflight]
     runs-on: blacksmith-12vcpu-macos-latest
-    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/production' && needs.iosBuild.result != 'failure' && needs.iosUploadTestflight.result != 'failure' }}
+    if: ${{ always() && !cancelled() && env.DEPLOY_ENV == 'production' && needs.iosBuild.result != 'failure' && needs.iosUploadTestflight.result != 'failure' }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     steps:
       - name: Checkout
         # v6
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
 
       - name: Setup Ruby
         # v1.229.0
@@ -488,7 +511,7 @@ jobs:
     name: Upload iOS to Applause
     needs: [prep, iosBuild]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: ${{ github.repository == 'Expensify/App' && github.ref == 'refs/heads/staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
+    if: ${{ github.repository == 'Expensify/App' && env.DEPLOY_ENV == 'staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
     continue-on-error: true
     steps:
       - name: Download iOS build artifact
@@ -537,8 +560,8 @@ jobs:
     needs: [prep]
     uses: ./.github/workflows/buildWeb.yml
     with:
-      ref: ${{ github.sha }}
-      environment: ${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }}
+      ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
+      environment: ${{ env.DEPLOY_ENV }}
     secrets: inherit
 
   webDeploy:
@@ -551,7 +574,7 @@ jobs:
         # v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
 
       - name: Download web build artifact
         # v7
@@ -588,21 +611,21 @@ jobs:
           aws s3 cp --acl public-read --content-type 'application/json' --metadata-directive REPLACE ${{ env.S3_BUCKET }}/.well-known/apple-app-site-association ${{ env.S3_BUCKET }}/.well-known/apple-app-site-association
           aws s3 cp --acl public-read --content-type 'application/json' --metadata-directive REPLACE ${{ env.S3_BUCKET }}/.well-known/apple-app-site-association ${{ env.S3_BUCKET }}/apple-app-site-association
         env:
-          S3_BUCKET: s3://${{ github.ref == 'refs/heads/staging' && 'staging-' || '' }}${{ vars.PRODUCTION_S3_BUCKET }}
+          S3_BUCKET: s3://${{ env.DEPLOY_ENV == 'staging' && 'staging-' || '' }}${{ vars.PRODUCTION_S3_BUCKET }}
 
       - name: Purge Cloudflare cache
         run: |
           /home/runner/.local/bin/cli4 --verbose --delete hosts=["$HOST"] /zones/:9ee042e6cfc7fd45e74aa7d2f78d617b/purge_cache
         env:
           CF_API_KEY: ${{ secrets.CLOUDFLARE_TOKEN }}
-          HOST: ${{ github.ref == 'refs/heads/production' && vars.WEB_PRODUCTION_HOST || vars.WEB_STAGING_HOST }}
+          HOST: ${{ env.DEPLOY_ENV == 'production' && vars.WEB_PRODUCTION_HOST || vars.WEB_STAGING_HOST }}
 
       - name: Verify deploy
         run: |
           APP_VERSION=$(jq -r .version < package.json)
           ./.github/scripts/verifyDeploy.sh "$HOST" "$APP_VERSION"
         env:
-          HOST: ${{ github.ref == 'refs/heads/production' && vars.WEB_PRODUCTION_HOST || vars.WEB_STAGING_HOST }}
+          HOST: ${{ env.DEPLOY_ENV == 'production' && vars.WEB_PRODUCTION_HOST || vars.WEB_STAGING_HOST }}
 
   buildStorybook:
     name: Build storybook docs
@@ -614,14 +637,14 @@ jobs:
         # v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
 
       - name: Build storybook docs
         run: |
-          if [ "${{ github.ref }}" == "refs/heads/production" ]; then
+          if [ "${{ env.DEPLOY_ENV }}" == "production" ]; then
             npm run storybook-build
           else
             npm run storybook-build-staging
@@ -679,7 +702,7 @@ jobs:
               channel: '#deployer',
               attachments: [{
                 color: 'warning',
-                text: `⚠️ ${{ github.ref == 'refs/heads/production' && 'Production' || 'Staging' }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|deploy> cancelled manually`
+                text: `⚠️ ${{ env.DEPLOY_ENV == 'production' && 'Production' || 'Staging' }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|deploy> cancelled manually`
               }]
             }
         env:
@@ -702,7 +725,7 @@ jobs:
         run: |
           # Android: use submit result for production, upload result for staging.
           # On production cherry-picks, propagate build/upload failures that caused submit to be skipped.
-          if [ "${{ github.ref }}" == "refs/heads/production" ]; then
+          if [ "${{ env.DEPLOY_ENV }}" == "production" ]; then
             if [ "${{ needs.androidBuild.result }}" == "failure" ] || [ "${{ needs.androidUploadGooglePlay.result }}" == "failure" ]; then
               echo "ANDROID_RESULT=failure" >> "$GITHUB_OUTPUT"
             else
@@ -716,7 +739,7 @@ jobs:
 
           # iOS: use submit result for production, upload result for staging.
           # On production cherry-picks, propagate build/upload failures that caused submit to be skipped.
-          if [ "${{ github.ref }}" == "refs/heads/production" ]; then
+          if [ "${{ env.DEPLOY_ENV }}" == "production" ]; then
             if [ "${{ needs.iosBuild.result }}" == "failure" ] || [ "${{ needs.iosUploadTestflight.result }}" == "failure" ]; then
               echo "IOS_RESULT=failure" >> "$GITHUB_OUTPUT"
             else
@@ -786,13 +809,13 @@ jobs:
             echo "Release ${{ needs.prep.outputs.TAG }} does not exist, creating it now."
             readonly CREATE_MAX_RETRIES=5
             for ((i = 0; i <= CREATE_MAX_RETRIES; i++)); do
-              if gh release create "${{ needs.prep.outputs.TAG }}" ${{ github.ref == 'refs/heads/staging' && '--prerelease' || '' }} \
+              if gh release create "${{ needs.prep.outputs.TAG }}" ${{ env.DEPLOY_ENV == 'staging' && '--prerelease' || '' }} \
                 --repo "${{ github.repository }}" \
                 --title "${{ needs.prep.outputs.TAG }}" \
-                ${{ github.ref == 'refs/heads/production' && format('--notes-start-tag {0}', steps.get_last_prod_version.outputs.LAST_PROD_VERSION) || '' }} \
+                ${{ env.DEPLOY_ENV == 'production' && format('--notes-start-tag {0}', steps.get_last_prod_version.outputs.LAST_PROD_VERSION) || '' }} \
                 --generate-notes \
                 --verify-tag \
-                --target "${{ github.ref }}"; then
+                --target "${{ env.DEPLOY_ENV }}"; then
                 break
               fi
               if [[ $i -lt $CREATE_MAX_RETRIES ]]; then
@@ -865,7 +888,7 @@ jobs:
               attachments: [{
                 color: "#DB4545",
                 pretext: `<!subteam^S4TJJ3PSL>`,
-                text: `💥 NewDot ${{ github.ref == 'refs/heads/staging' && 'staging' || 'production' }} deploy failed. 💥`,
+                text: `💥 NewDot ${{ env.DEPLOY_ENV }} deploy failed. 💥`,
               }]
             }
         env:
@@ -882,7 +905,7 @@ jobs:
   #   2. CP that version bump to staging
   cherryPickExtraVersionBump:
     needs: [prep, checkDeploymentSuccess]
-    if: ${{ always() && fromJSON(needs.checkDeploymentSuccess.outputs.IS_AT_LEAST_ONE_PLATFORM_DEPLOYED) && github.ref == 'refs/heads/production' && fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
+    if: ${{ always() && fromJSON(needs.checkDeploymentSuccess.outputs.IS_AT_LEAST_ONE_PLATFORM_DEPLOYED) && env.DEPLOY_ENV == 'production' && fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
     uses: ./.github/workflows/cherryPick.yml
     secrets: inherit
     with:
@@ -905,7 +928,7 @@ jobs:
               channel: '#announce',
               attachments: [{
                 color: 'good',
-                text: `🎉️ Successfully deployed ${process.env.AS_REPO} <https://github.com/Expensify/App/releases/tag/${{ needs.prep.outputs.TAG }}|${{ needs.prep.outputs.TAG }}> to ${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }} 🎉️`,
+                text: `🎉️ Successfully deployed ${process.env.AS_REPO} <https://github.com/Expensify/App/releases/tag/${{ needs.prep.outputs.TAG }}|${{ needs.prep.outputs.TAG }}> to ${{ env.DEPLOY_ENV }} 🎉️`,
               }]
             }
         env:
@@ -922,7 +945,7 @@ jobs:
               channel: '#deployer',
               attachments: [{
                 color: 'good',
-                text: `🎉️ Successfully deployed ${process.env.AS_REPO} <https://github.com/Expensify/App/releases/tag/${{ needs.prep.outputs.TAG }}|${{ needs.prep.outputs.TAG }}> to ${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }} 🎉️`,
+                text: `🎉️ Successfully deployed ${process.env.AS_REPO} <https://github.com/Expensify/App/releases/tag/${{ needs.prep.outputs.TAG }}|${{ needs.prep.outputs.TAG }}> to ${{ env.DEPLOY_ENV }} 🎉️`,
               }]
             }
         env:
@@ -932,7 +955,7 @@ jobs:
       - name: 'Announces a production deploy in the #expensify-open-source Slack room'
         # v3
         uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e
-        if: ${{ github.ref == 'refs/heads/production' }}
+        if: ${{ env.DEPLOY_ENV == 'production' }}
         with:
           status: custom
           custom_payload: |
@@ -954,7 +977,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prep.outputs.APP_VERSION }}
-      env: ${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }}
+      env: ${{ env.DEPLOY_ENV }}
       android: ${{ needs.checkDeploymentSuccess.outputs.ANDROID_RESULT }}
       ios: ${{ needs.checkDeploymentSuccess.outputs.IOS_RESULT }}
       web: ${{ needs.checkDeploymentSuccess.outputs.WEB_RESULT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,11 +75,31 @@ jobs:
 
       - name: Create and push tag
         run: |
-          git tag ${{ steps.getTagName.outputs.TAG }}
-          git push origin --tags
+          # Idempotent tag creation: if the tag already exists at HEAD (e.g. a prior deploy
+          # attempt tagged successfully before failing later), skip creation so that a manual
+          # re-trigger of the workflow doesn't abort in prep. If the tag exists but points
+          # to a different commit, fail loudly to avoid deploying the wrong code.
+          create_tag_idempotent() {
+            local tag="$1"
+            local head_sha
+            head_sha=$(git rev-parse HEAD)
+            if git tag "$tag" 2>/dev/null; then
+              git push origin --tags
+            else
+              git fetch origin "refs/tags/$tag:refs/tags/$tag" 2>/dev/null || true
+              local existing_sha
+              existing_sha=$(git rev-parse "refs/tags/$tag" 2>/dev/null || echo "unknown")
+              if [ "$existing_sha" = "$head_sha" ]; then
+                echo "Tag $tag already exists at $head_sha, skipping creation."
+              else
+                echo "ERROR: Tag $tag exists at $existing_sha, expected $head_sha"
+                exit 1
+              fi
+            fi
+          }
+          create_tag_idempotent ${{ steps.getTagName.outputs.TAG }}
           cd Mobile-Expensify
-          git tag ${{ steps.getTagName.outputs.TAG }}
-          git push origin --tags
+          create_tag_idempotent ${{ steps.getTagName.outputs.TAG }}
 
         # We use JS here instead of bash/jq because inlining potentially large json into a bash command is non-trivial.
         # JS is better at handling JSON: https://stackoverflow.com/questions/72953526/github-actions-how-to-pass-tojson-result-to-shell-commands

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,9 +86,23 @@ jobs:
       - name: Check if this deploy was triggered by a cherry-pick
         id: isCherryPick
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          HEAD_COMMIT_SHA: ${{ steps.getDeploySHA.outputs.SHA }}
         with:
           script: |
-            const commitMessages = (context.payload.commits || []).map((commit) => commit.message);
+            let commitMessages;
+            if (context.payload.commits) {
+                // push trigger: commits are in the payload
+                commitMessages = context.payload.commits.map((commit) => commit.message);
+            } else {
+                // workflow_dispatch: payload has no commits array, so fetch the HEAD commit message directly
+                const { data: commit } = await github.rest.git.getCommit({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    commit_sha: process.env.HEAD_COMMIT_SHA,
+                });
+                commitMessages = [commit.message];
+            }
             const isCherryPick = commitMessages.some((message) => /.*\(cherry-picked to .* by .*\)$/.test(message));
             console.log('Is cherry pick?', isCherryPick);
             core.setOutput(

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,16 +92,33 @@ jobs:
           script: |
             let commitMessages;
             if (context.payload.commits) {
-                // push trigger: commits are in the payload
+                // push trigger: all pushed commits are in the payload
                 commitMessages = context.payload.commits.map((commit) => commit.message);
             } else {
-                // workflow_dispatch: payload has no commits array, so fetch the HEAD commit message directly
-                const { data: commit } = await github.rest.git.getCommit({
+                // workflow_dispatch: payload has no commits array.
+                // For a conflict-resolution cherry-pick, GitHub creates a merge commit at HEAD whose first
+                // parent is the branch before the merge. The cherry-picked commit (which carries the
+                // "(cherry-picked to ... by ...)" marker) sits under the merge commit, not at HEAD itself.
+                // We therefore compare the first parent against HEAD to get all commits that were merged in.
+                const headSha = process.env.HEAD_COMMIT_SHA;
+                const { data: headCommit } = await github.rest.git.getCommit({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    commit_sha: process.env.HEAD_COMMIT_SHA,
+                    commit_sha: headSha,
                 });
-                commitMessages = [commit.message];
+                if (headCommit.parents.length > 1) {
+                    // Merge commit: get all commits between first parent and HEAD
+                    const { data: comparison } = await github.rest.repos.compareCommits({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        base: headCommit.parents[0].sha,
+                        head: headSha,
+                    });
+                    commitMessages = [headCommit.message, ...comparison.commits.map((c) => c.commit.message)];
+                } else {
+                    // Linear commit: only check this commit's message
+                    commitMessages = [headCommit.message];
+                }
             }
             const isCherryPick = commitMessages.some((message) => /.*\(cherry-picked to .* by .*\)$/.test(message));
             console.log('Is cherry pick?', isCherryPick);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
       APP_VERSION: ${{ steps.getAppVersion.outputs.VERSION }}
       TAG: ${{ steps.getTagName.outputs.TAG }}
       DEPLOY_SHA: ${{ steps.getDeploySHA.outputs.SHA }}
+      DEPLOY_ENV: ${{ steps.getDeploySHA.outputs.DEPLOY_ENV }}
       # Is this deploy for a cherry-pick?
       IS_CHERRY_PICK: ${{ steps.isCherryPick.outputs.IS_CHERRY_PICK }}
       # Should we build native apps? (only on staging or cherry-pick, not production)
@@ -43,9 +44,11 @@ jobs:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
           submodules: true
 
-      - name: Get deploy SHA
+      - name: Get deploy SHA and environment
         id: getDeploySHA
-        run: echo "SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "DEPLOY_ENV=${{ env.DEPLOY_ENV }}" >> "$GITHUB_OUTPUT"
 
       - name: Validate actor
         id: validateActor
@@ -105,7 +108,7 @@ jobs:
   deployChecklist:
     name: Create or update deploy checklist
     uses: ./.github/workflows/createDeployChecklist.yml
-    if: ${{ env.DEPLOY_ENV == 'staging' }}
+    if: ${{ needs.prep.outputs.DEPLOY_ENV == 'staging' }}
     needs: prep
     secrets: inherit
 
@@ -178,7 +181,7 @@ jobs:
     name: Submit Android for production rollout
     needs: [prep, androidBuild, androidUploadGooglePlay]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: ${{ always() && !cancelled() && env.DEPLOY_ENV == 'production' && needs.androidBuild.result != 'failure' && needs.androidUploadGooglePlay.result != 'failure' }}
+    if: ${{ always() && !cancelled() && needs.prep.outputs.DEPLOY_ENV == 'production' && needs.androidBuild.result != 'failure' && needs.androidUploadGooglePlay.result != 'failure' }}
     steps:
       - name: Checkout
         # v6
@@ -278,7 +281,7 @@ jobs:
     name: Upload Android to Applause
     needs: [prep, androidBuild]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: ${{ github.repository == 'Expensify/App' && env.DEPLOY_ENV == 'staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
+    if: ${{ github.repository == 'Expensify/App' && needs.prep.outputs.DEPLOY_ENV == 'staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
     continue-on-error: true
     steps:
       - name: Download Android APK artifact
@@ -417,7 +420,7 @@ jobs:
     name: Submit iOS for production rollout
     needs: [prep, iosBuild, iosUploadTestflight]
     runs-on: blacksmith-12vcpu-macos-latest
-    if: ${{ always() && !cancelled() && env.DEPLOY_ENV == 'production' && needs.iosBuild.result != 'failure' && needs.iosUploadTestflight.result != 'failure' }}
+    if: ${{ always() && !cancelled() && needs.prep.outputs.DEPLOY_ENV == 'production' && needs.iosBuild.result != 'failure' && needs.iosUploadTestflight.result != 'failure' }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     steps:
@@ -511,7 +514,7 @@ jobs:
     name: Upload iOS to Applause
     needs: [prep, iosBuild]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: ${{ github.repository == 'Expensify/App' && env.DEPLOY_ENV == 'staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
+    if: ${{ github.repository == 'Expensify/App' && needs.prep.outputs.DEPLOY_ENV == 'staging' && !fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
     continue-on-error: true
     steps:
       - name: Download iOS build artifact
@@ -561,7 +564,7 @@ jobs:
     uses: ./.github/workflows/buildWeb.yml
     with:
       ref: ${{ needs.prep.outputs.DEPLOY_SHA }}
-      environment: ${{ env.DEPLOY_ENV }}
+      environment: ${{ needs.prep.outputs.DEPLOY_ENV }}
     secrets: inherit
 
   webDeploy:
@@ -905,7 +908,7 @@ jobs:
   #   2. CP that version bump to staging
   cherryPickExtraVersionBump:
     needs: [prep, checkDeploymentSuccess]
-    if: ${{ always() && fromJSON(needs.checkDeploymentSuccess.outputs.IS_AT_LEAST_ONE_PLATFORM_DEPLOYED) && env.DEPLOY_ENV == 'production' && fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
+    if: ${{ always() && fromJSON(needs.checkDeploymentSuccess.outputs.IS_AT_LEAST_ONE_PLATFORM_DEPLOYED) && needs.prep.outputs.DEPLOY_ENV == 'production' && fromJSON(needs.prep.outputs.IS_CHERRY_PICK) }}
     uses: ./.github/workflows/cherryPick.yml
     secrets: inherit
     with:
@@ -977,7 +980,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prep.outputs.APP_VERSION }}
-      env: ${{ env.DEPLOY_ENV }}
+      env: ${{ needs.prep.outputs.DEPLOY_ENV }}
       android: ${{ needs.checkDeploymentSuccess.outputs.ANDROID_RESULT }}
       ios: ${{ needs.checkDeploymentSuccess.outputs.IOS_RESULT }}
       web: ${{ needs.checkDeploymentSuccess.outputs.WEB_RESULT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ env:
   DEPLOY_ENV: ${{ inputs.ENVIRONMENT || (github.ref == 'refs/heads/production' && 'production' || 'staging') }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ENVIRONMENT || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.ENVIRONMENT || (github.ref == 'refs/heads/production' && 'production' || 'staging') }}
   cancel-in-progress: true
 
 jobs:
@@ -124,6 +124,8 @@ jobs:
     uses: ./.github/workflows/createDeployChecklist.yml
     if: ${{ needs.prep.outputs.DEPLOY_ENV == 'staging' }}
     needs: prep
+    with:
+      REF: ${{ needs.prep.outputs.DEPLOY_SHA }}
     secrets: inherit
 
   androidBuild:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,18 +83,24 @@ jobs:
             local tag="$1"
             local head_sha
             head_sha=$(git rev-parse HEAD)
-            if git tag "$tag" 2>/dev/null; then
-              git push origin --tags
-            else
-              git fetch origin "refs/tags/$tag:refs/tags/$tag" 2>/dev/null || true
+            # Fetch the tag from remote before checking locally. actions/checkout uses
+            # fetch-depth=1 and fetch-tags=false by default, so a previously pushed tag
+            # won't be present in the workspace. Without this fetch, git tag "$tag" would
+            # succeed locally and then git push would fail because the tag already exists
+            # on the remote, causing the idempotent path below to be unreachable.
+            git fetch origin "refs/tags/$tag:refs/tags/$tag" 2>/dev/null || true
+            if git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
               local existing_sha
-              existing_sha=$(git rev-parse "refs/tags/$tag" 2>/dev/null || echo "unknown")
+              existing_sha=$(git rev-parse "refs/tags/$tag")
               if [ "$existing_sha" = "$head_sha" ]; then
                 echo "Tag $tag already exists at $head_sha, skipping creation."
               else
                 echo "ERROR: Tag $tag exists at $existing_sha, expected $head_sha"
                 exit 1
               fi
+            else
+              git tag "$tag"
+              git push origin --tags
             fi
           }
           create_tag_idempotent ${{ steps.getTagName.outputs.TAG }}


### PR DESCRIPTION
### Explanation of Change
Adds a `workflow_dispatch` trigger to `deploy.yml` so that deployers can manually re-trigger a staging or production deploy from the GitHub Actions UI without needing to push a new commit to the branch.

The workflow accepts an `ENVIRONMENT` input (`staging` or `production`). When dispatched manually, it checks out the branch corresponding to that environment and runs the deploy from that branch as normal.

Also updates cherry-pick conflict PR descriptions to note that the PR should ideally be merged by a deployer; if merged by a non-deployer, the deploy will fail and must be manually re-triggered (not just retried).

### Fixed Issues
$ https://github.com/Expensify/App/issues/89934

### Tests
None.

- [x] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
