### PR TITLE
Fix quick-action deeplinks selecting stale tabs

### DIFF
--- a/src/libs/Navigation/OnyxTabNavigator.tsx
+++ b/src/libs/Navigation/OnyxTabNavigator.tsx
@@ -24,6 +24,9 @@ type OnyxTabNavigatorProps<TTabName extends string = SelectedTabRequest> = Child
     /** Name of the selected tab */
     defaultSelectedTab?: TTabName;
 
+    /** Tab to prefer over the stored Onyx tab, usually from a nested route in a deeplink. */
+    selectedTabOverride?: TTabName;
+
     /** A function triggered when a tab has been selected */
     onTabSelected?: (newTabName: TTabName) => void;
 
@@ -93,6 +96,7 @@ const getTabNames = (children: React.ReactNode): string[] => {
 function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
     id,
     defaultSelectedTab,
+    selectedTabOverride,
     tabBar: TabBar,
     children,
     onTabBarFocusTrapContainerElementChanged,
@@ -115,7 +119,9 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
 
     const tabNames = useMemo(() => getTabNames(children), [children]);
 
-    const validInitialTab = selectedTab && tabNames.includes(selectedTab) ? selectedTab : defaultSelectedTab;
+    const validInitialTabFromOverride = selectedTabOverride && tabNames.includes(selectedTabOverride) ? selectedTabOverride : undefined;
+    const validInitialTabFromOnyx = selectedTab && tabNames.includes(selectedTab) ? selectedTab : undefined;
+    const validInitialTab = validInitialTabFromOverride ?? validInitialTabFromOnyx ?? defaultSelectedTab;
 
     const LazyPlaceholder = useCallback(() => {
         return (

--- a/src/pages/iou/request/DistanceRequestStartPage.tsx
+++ b/src/pages/iou/request/DistanceRequestStartPage.tsx
@@ -49,8 +49,8 @@ function DistanceRequestStartPage({
     const [lastDistanceExpenseType] = useOnyx(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE);
     const isLoadingSelectedTab = isLoadingOnyxValue(selectedTabResult);
     const isTrackDistanceExpense = iouType === CONST.IOU.TYPE.TRACK;
-    const routeWithState: typeof route & {state?: {index?: number; routes: Array<{name: SelectedTabRequest}>}} = route;
-    const routeSelectedTab = routeWithState.state?.routes.at(routeWithState.state.index ?? 0)?.name;
+    const routeWithTabState: typeof route & {state?: {index?: number; routes: Array<{name: SelectedTabRequest}>}; params: typeof route.params & {screen?: SelectedTabRequest}} = route;
+    const routeSelectedTab = routeWithTabState.state?.routes.at(routeWithTabState.state.index ?? 0)?.name ?? routeWithTabState.params.screen;
     const distanceTabs = useMemo(
         () => new Set<SelectedTabRequest>([CONST.TAB_REQUEST.DISTANCE_MAP, CONST.TAB_REQUEST.DISTANCE_MANUAL, CONST.TAB_REQUEST.DISTANCE_GPS, CONST.TAB_REQUEST.DISTANCE_ODOMETER]),
         [],

--- a/src/pages/iou/request/DistanceRequestStartPage.tsx
+++ b/src/pages/iou/request/DistanceRequestStartPage.tsx
@@ -49,6 +49,13 @@ function DistanceRequestStartPage({
     const [lastDistanceExpenseType] = useOnyx(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE);
     const isLoadingSelectedTab = isLoadingOnyxValue(selectedTabResult);
     const isTrackDistanceExpense = iouType === CONST.IOU.TYPE.TRACK;
+    const routeWithState: typeof route & {state?: {index?: number; routes: Array<{name: SelectedTabRequest}>}} = route;
+    const routeSelectedTab = routeWithState.state?.routes.at(routeWithState.state.index ?? 0)?.name;
+    const distanceTabs = useMemo(
+        () => new Set<SelectedTabRequest>([CONST.TAB_REQUEST.DISTANCE_MAP, CONST.TAB_REQUEST.DISTANCE_MANUAL, CONST.TAB_REQUEST.DISTANCE_GPS, CONST.TAB_REQUEST.DISTANCE_ODOMETER]),
+        [],
+    );
+    const selectedTabOverride = routeSelectedTab && distanceTabs.has(routeSelectedTab) ? routeSelectedTab : undefined;
 
     const tabTitles = {
         [CONST.IOU.TYPE.REQUEST]: translate('iou.trackDistance'),
@@ -122,6 +129,7 @@ function DistanceRequestStartPage({
                     <OnyxTabNavigator
                         id={CONST.TAB.DISTANCE_REQUEST_TYPE}
                         defaultSelectedTab={defaultSelectedTab}
+                        selectedTabOverride={selectedTabOverride}
                         onTabSelected={resetIOUTypeIfChanged}
                         tabBar={TabSelector}
                         onTabBarFocusTrapContainerElementChanged={setTabBarContainerElement}

--- a/src/pages/iou/request/IOURequestStartPage.tsx
+++ b/src/pages/iou/request/IOURequestStartPage.tsx
@@ -139,8 +139,8 @@ function IOURequestStartPage({
         }
         return tabs;
     }, [shouldUseTab, iouType, shouldShowPerDiemOption, shouldShowTimeOption]);
-    const routeWithState: typeof route & {state?: {index?: number; routes: Array<{name: SelectedTabRequest}>}} = route;
-    const routeSelectedTab = routeWithState.state?.routes.at(routeWithState.state.index ?? 0)?.name;
+    const routeWithTabState: typeof route & {state?: {index?: number; routes: Array<{name: SelectedTabRequest}>}; params: typeof route.params & {screen?: SelectedTabRequest}} = route;
+    const routeSelectedTab = routeWithTabState.state?.routes.at(routeWithTabState.state.index ?? 0)?.name ?? routeWithTabState.params.screen;
     const selectedTabOverride = routeSelectedTab && availableTabs.has(routeSelectedTab) ? routeSelectedTab : undefined;
 
     // A quick-action deeplink (e.g. iOS home-screen "Scan receipt") bypasses startMoneyRequest

--- a/src/pages/iou/request/IOURequestStartPage.tsx
+++ b/src/pages/iou/request/IOURequestStartPage.tsx
@@ -139,6 +139,9 @@ function IOURequestStartPage({
         }
         return tabs;
     }, [shouldUseTab, iouType, shouldShowPerDiemOption, shouldShowTimeOption]);
+    const routeWithState: typeof route & {state?: {index?: number; routes: Array<{name: SelectedTabRequest}>}} = route;
+    const routeSelectedTab = routeWithState.state?.routes.at(routeWithState.state.index ?? 0)?.name;
+    const selectedTabOverride = routeSelectedTab && availableTabs.has(routeSelectedTab) ? routeSelectedTab : undefined;
 
     // A quick-action deeplink (e.g. iOS home-screen "Scan receipt") bypasses startMoneyRequest
     // and leaves the previous flow's draft in place under OPTIMISTIC_TRANSACTION_ID. Detect it
@@ -233,6 +236,7 @@ function IOURequestStartPage({
                             <OnyxTabNavigator
                                 id={CONST.TAB.IOU_REQUEST_TYPE}
                                 defaultSelectedTab={defaultSelectedTab}
+                                selectedTabOverride={selectedTabOverride}
                                 onTabSelected={resetIOUTypeIfChanged}
                                 onTabSelect={onTabSelectFocusHandler}
                                 tabBar={TabSelector}

--- a/tests/ui/IOURequestStartPageTest.tsx
+++ b/tests/ui/IOURequestStartPageTest.tsx
@@ -86,4 +86,46 @@ describe('IOURequestStartPage', () => {
         });
         expect(iouRequestType).toBe(CONST.IOU.REQUEST_TYPE.MANUAL);
     });
+
+    it('uses the nested route screen over a stale selected tab', async () => {
+        // Given the previous selected tab is MANUAL
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.IOU_REQUEST_TYPE}`, CONST.TAB_REQUEST.MANUAL);
+        });
+
+        // When the page is mounted from a nested route to the scan tab
+        render(
+            <OnyxListItemProvider>
+                <LocaleContextProvider>
+                    <NavigationContainer>
+                        <IOURequestStartPage
+                            route={
+                                {params: {iouType: CONST.IOU.TYPE.SUBMIT, reportID: '1', transactionID: '', screen: CONST.TAB_REQUEST.SCAN}} as unknown as PlatformStackScreenProps<
+                                    MoneyRequestNavigatorParamList,
+                                    typeof SCREENS.MONEY_REQUEST.CREATE
+                                >['route']
+                            }
+                            report={undefined}
+                            reportDraft={undefined}
+                            navigation={{} as PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.CREATE>['navigation']}
+                            defaultSelectedTab={CONST.TAB_REQUEST.MANUAL}
+                        />
+                    </NavigationContainer>
+                </LocaleContextProvider>
+            </OnyxListItemProvider>,
+        );
+
+        await waitForBatchedUpdatesWithAct();
+
+        const iouRequestType = await new Promise<OnyxEntry<IOURequestType>>((resolve) => {
+            const connection = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${CONST.IOU.OPTIMISTIC_TRANSACTION_ID}`,
+                callback: (val) => {
+                    resolve(val?.iouRequestType);
+                    Onyx.disconnect(connection);
+                },
+            });
+        });
+        expect(iouRequestType).toBe(CONST.IOU.REQUEST_TYPE.SCAN);
+    });
 });

--- a/tests/unit/OnyxTabNavigatorTest.tsx
+++ b/tests/unit/OnyxTabNavigatorTest.tsx
@@ -1,0 +1,80 @@
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import OnyxTabNavigator, {TopTab} from '@libs/Navigation/OnyxTabNavigator';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+type MockNavigatorProps = {
+    children?: React.ReactNode;
+    initialRouteName?: string;
+};
+
+const mockNavigatorProps = jest.fn<void, [MockNavigatorProps]>();
+
+jest.mock('@react-navigation/material-top-tabs', () => ({
+    createMaterialTopTabNavigator: () => {
+        const ReactMock = jest.requireActual<typeof React>('react');
+        return {
+            Navigator: ({children, initialRouteName}: MockNavigatorProps) => {
+                mockNavigatorProps({children, initialRouteName});
+                return ReactMock.createElement(ReactMock.Fragment, null, children);
+            },
+            Screen: ({children}: {children?: React.ReactNode | (() => React.ReactNode)}) =>
+                ReactMock.createElement(ReactMock.Fragment, null, typeof children === 'function' ? children() : children),
+        };
+    },
+}));
+
+jest.mock('@hooks/useThemeStyles', () => () => ({
+    fullScreenLoading: {},
+    h100: {},
+    w100: {},
+}));
+
+describe('OnyxTabNavigator', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await act(async () => Onyx.clear());
+    });
+
+    function renderNavigator(selectedTabOverride?: string) {
+        render(
+            <OnyxListItemProvider>
+                <OnyxTabNavigator
+                    id={CONST.TAB.IOU_REQUEST_TYPE}
+                    defaultSelectedTab={CONST.TAB_REQUEST.SCAN}
+                    selectedTabOverride={selectedTabOverride}
+                    tabBar={() => null}
+                >
+                    <TopTab.Screen name={CONST.TAB_REQUEST.MANUAL}>{() => null}</TopTab.Screen>
+                    <TopTab.Screen name={CONST.TAB_REQUEST.SCAN}>{() => null}</TopTab.Screen>
+                </OnyxTabNavigator>
+            </OnyxListItemProvider>,
+        );
+    }
+
+    it('prefers an explicit tab override over a stale selected tab from Onyx', async () => {
+        await act(async () => Onyx.set(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.IOU_REQUEST_TYPE}`, CONST.TAB_REQUEST.MANUAL));
+
+        renderNavigator(CONST.TAB_REQUEST.SCAN);
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockNavigatorProps.mock.calls.at(-1)?.[0].initialRouteName).toBe(CONST.TAB_REQUEST.SCAN);
+    });
+
+    it('falls back to the selected tab from Onyx when the route has no tab state', async () => {
+        await act(async () => Onyx.set(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.IOU_REQUEST_TYPE}`, CONST.TAB_REQUEST.MANUAL));
+
+        renderNavigator();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockNavigatorProps.mock.calls.at(-1)?.[0].initialRouteName).toBe(CONST.TAB_REQUEST.MANUAL);
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes quick-action deeplinks so the tab encoded in the route wins over a stale persisted Onyx tab.
- Applies the same route-selected tab override to money request and distance request start pages, covering scan/manual and distance quick-action entry points.
- Handles both mounted nested route state and initial `params.screen` nested navigation.
- Adds focused unit/UI coverage for the tab override behavior.

$ #76229

## Test plan
- npx -p node@20.20.0 -p npm@10.8.2 npx eslint src/libs/Navigation/OnyxTabNavigator.tsx src/pages/iou/request/IOURequestStartPage.tsx src/pages/iou/request/DistanceRequestStartPage.tsx tests/unit/OnyxTabNavigatorTest.tsx tests/ui/IOURequestStartPageTest.tsx
- npx -p node@20.20.0 -p npm@10.8.2 npm test -- tests/unit/OnyxTabNavigatorTest.tsx tests/ui/IOURequestStartPageTest.tsx --runInBand
- npx -p node@20.20.0 -p npm@10.8.2 npm run typecheck -- --pretty false