### PR TITLE
Fix navigation to new workspace

### DIFF
--- a/src/libs/Navigation/AppNavigator/KeyboardShortcutsHandler/EscapeHandler.tsx
+++ b/src/libs/Navigation/AppNavigator/KeyboardShortcutsHandler/EscapeHandler.tsx
@@ -1,31 +1,43 @@
-import {StackActions} from '@react-navigation/native';
+import {CommonActions, StackActions} from '@react-navigation/native';
 import {useEffect} from 'react';
 import {useWideRHPState} from '@components/WideRHPContextProvider';
 import useOnyx from '@hooks/useOnyx';
 import KeyboardShortcut from '@libs/KeyboardShortcut';
+import getActiveTabName from '@libs/Navigation/helpers/getActiveTabName';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
+import type {NavigationRoute} from '@libs/Navigation/types';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 /**
  * Pops the active WorkspaceSplitNavigator or DomainSplitNavigator when Escape is pressed inside WorkspaceNavigator.
- * If it is the only remaining route in WorkspaceNavigator, the entire WorkspaceNavigator is popped from the root stack instead.
+ * If it is the only remaining route in WorkspaceNavigator, the TabNavigator is asked to go back instead,
+ * which — thanks to `backBehavior="fullHistory"` — returns the user to the previously focused tab.
  */
 function handleEscapeKeyInWorkspaceNavigator() {
     const rootState = navigationRef.getRootState();
-    const lastRootRoute = rootState?.routes.at(-1);
-    const lastWorkspaceRoute = lastRootRoute?.state?.routes.at(-1);
-
-    const isSplitNavigator = lastWorkspaceRoute?.name === NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR || lastWorkspaceRoute?.name === NAVIGATORS.DOMAIN_SPLIT_NAVIGATOR;
-
-    if (!rootState || !lastRootRoute?.state || !isSplitNavigator) {
+    const tabNavigatorRoute = rootState?.routes.at(-1);
+    if (tabNavigatorRoute?.name !== NAVIGATORS.TAB_NAVIGATOR || !tabNavigatorRoute.state) {
         return;
     }
 
-    const isOnlyRouteInWorkspaceNavigator = lastRootRoute.state.routes.length === 1;
-    const target = isOnlyRouteInWorkspaceNavigator ? rootState.key : lastRootRoute.state.key;
-    navigationRef.dispatch({...StackActions.pop(), target});
+    const tabIndex = tabNavigatorRoute.state.index ?? 0;
+    const workspaceTabRoute = tabNavigatorRoute.state.routes.at(tabIndex);
+    if (workspaceTabRoute?.name !== NAVIGATORS.WORKSPACE_NAVIGATOR || !workspaceTabRoute.state) {
+        return;
+    }
+
+    const lastWorkspaceRoute = workspaceTabRoute.state.routes.at(-1);
+    const isSplitNavigator = lastWorkspaceRoute?.name === NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR || lastWorkspaceRoute?.name === NAVIGATORS.DOMAIN_SPLIT_NAVIGATOR;
+    if (!isSplitNavigator) {
+        return;
+    }
+
+    const isOnlyRouteInWorkspaceNavigator = workspaceTabRoute.state.routes.length === 1;
+    const target = isOnlyRouteInWorkspaceNavigator ? tabNavigatorRoute.state.key : workspaceTabRoute.state.key;
+    const action = isOnlyRouteInWorkspaceNavigator ? CommonActions.goBack() : StackActions.pop();
+    navigationRef.dispatch({...action, target});
 }
 
 function EscapeHandler() {
@@ -61,7 +73,10 @@ function EscapeHandler() {
                     return;
                 }
 
-                if (navigationRef.getRootState()?.routes.at(-1)?.name === NAVIGATORS.WORKSPACE_NAVIGATOR) {
+                const topmostRootRoute = navigationRef.getRootState()?.routes.at(-1);
+                const isFocusedOnWorkspaceTab =
+                    topmostRootRoute?.name === NAVIGATORS.TAB_NAVIGATOR && getActiveTabName(topmostRootRoute as NavigationRoute) === NAVIGATORS.WORKSPACE_NAVIGATOR;
+                if (isFocusedOnWorkspaceTab) {
                     handleEscapeKeyInWorkspaceNavigator();
                     return;
                 }

--- a/src/libs/Navigation/helpers/pushNewlyCreatedWorkspaceUnderActiveModal.ts
+++ b/src/libs/Navigation/helpers/pushNewlyCreatedWorkspaceUnderActiveModal.ts
@@ -1,0 +1,42 @@
+import {CommonActions} from '@react-navigation/native';
+import navigationRef from '@libs/Navigation/navigationRef';
+import NAVIGATORS from '@src/NAVIGATORS';
+import type SCREENS from '@src/SCREENS';
+
+type WorkspaceTargetScreen = typeof SCREENS.WORKSPACE.PROFILE | typeof SCREENS.WORKSPACE.INITIAL;
+
+/**
+ * Pushes a freshly created workspace's split navigator into TAB_NAVIGATOR / WORKSPACE_NAVIGATOR
+ * while an RHP is still on top of the root stack. The dispatch is targeted at the TAB_NAVIGATOR's
+ * state key, so the RHP stays in place; once the caller dismisses it, the modal animation reveals
+ * the new workspace page directly instead of briefly exposing WORKSPACES_LIST underneath.
+ *
+ * `initial: false` matters when WORKSPACE_NAVIGATOR has never been mounted (e.g. workspace created
+ * from Inbox/Reports): it tells the stack router not to seed the stack with WORKSPACES_LIST before
+ * pushing WORKSPACE_SPLIT_NAVIGATOR.
+ */
+function pushNewlyCreatedWorkspaceUnderActiveModal(targetScreen: WorkspaceTargetScreen, policyID: string) {
+    const rootState = navigationRef.getRootState();
+    const tabRoute = rootState?.routes.findLast((r) => r.name === NAVIGATORS.TAB_NAVIGATOR);
+    const tabStateKey = tabRoute?.state?.key;
+    if (!tabStateKey) {
+        return;
+    }
+
+    navigationRef.dispatch({
+        ...CommonActions.navigate({
+            name: NAVIGATORS.WORKSPACE_NAVIGATOR,
+            params: {
+                initial: false,
+                screen: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                params: {
+                    screen: targetScreen,
+                    params: {policyID},
+                },
+            },
+        }),
+        target: tabStateKey,
+    });
+}
+
+export default pushNewlyCreatedWorkspaceUnderActiveModal;

--- a/src/pages/workspace/WorkspaceConfirmationPage.tsx
+++ b/src/pages/workspace/WorkspaceConfirmationPage.tsx
@@ -12,10 +12,12 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {createWorkspaceWithPolicyDraftAndNavigateToIt} from '@libs/actions/App';
 import {generatePolicyID} from '@libs/actions/Policy/Policy';
 import getCurrentUrl from '@libs/Navigation/currentUrl';
+import pushNewlyCreatedWorkspaceUnderActiveModal from '@libs/Navigation/helpers/pushNewlyCreatedWorkspaceUnderActiveModal';
 import {isSubscriptionTypeOfInvoicing} from '@libs/SubscriptionUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
 import type {LastPaymentMethodType} from '@src/types/onyx';
 
 function WorkspaceConfirmationPage() {
@@ -40,6 +42,11 @@ function WorkspaceConfirmationPage() {
         const shouldShowSuccessPage = isDifferentOwner && !params.makeMeAdmin;
         const workspaceRoute = isSmallScreenWidth ? ROUTES.WORKSPACE_INITIAL.getRoute(policyID) : ROUTES.WORKSPACE_OVERVIEW.getRoute(policyID);
         const routeToNavigate = shouldShowSuccessPage ? ROUTES.WORKSPACE_CONFIRMATION_SUCCESS : workspaceRoute;
+        if (!shouldShowSuccessPage) {
+            // Mount the new workspace under this RHP so the dismiss animation reveals it instead of flashing WORKSPACES_LIST.
+            const targetScreen = isSmallScreenWidth ? SCREENS.WORKSPACE.INITIAL : SCREENS.WORKSPACE.PROFILE;
+            pushNewlyCreatedWorkspaceUnderActiveModal(targetScreen, policyID);
+        }
         createWorkspaceWithPolicyDraftAndNavigateToIt({
             introSelected,
             policyOwnerEmail: params.owner,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Creating a new workspace now lands directly on its details page instead of routing through the workspaces list. Escape handling in the workspace tab is updated to work with the tab-nested `WORKSPACE_NAVIGATOR`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88932
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the Workspaces tab and make sure you're on the workspaces list.
2. Start the Create workspace flow and proceed to the confirmation page.
3. Confirm the new workspace.
4. Expected: you land directly on the new workspace's details page — the workspaces list does not appear in between.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/1dcc095f-9cde-4837-abf5-d8c3ca40ada9


</details>
