### PR TITLE
Improve About page version contrast

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -630,7 +630,7 @@ const staticStyles = (theme: ThemeColors) =>
         },
 
         textVersion: {
-            color: theme.iconColorfulBackground,
+            color: colors.yellow800,
             fontSize: variables.fontSizeNormal,
             lineHeight: variables.lineHeightNormal,
             ...FontUtils.fontFamily.platform.MONOSPACE,


### PR DESCRIPTION
### Explanation of Change
Updated the Settings > About version text to use `colors.yellow800` instead of `theme.iconColorfulBackground`. The About illustration uses `colors.yellow600` as its background, and the darker yellow token matches the approved accessibility direction in the issue thread.

### Fixed Issues
$ https://github.com/Expensify/App/issues/76918
PROPOSAL: https://github.com/Expensify/App/issues/76918#issuecomment-3995324985

### Tests
1. Verified the updated text/background contrast ratio is 5.23:1 for `#401102` on `#D18000`.
2. Ran `git diff --check`.
3. Ran `prettier --experimental-cli --no-cache --check src/styles/index.ts`.

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A. This is a static color token change and does not depend on network state.

### QA Steps
1. Open Settings > About.
2. Verify the app version text at the bottom of the yellow illustration area uses the darker yellow text color.
3. Verify the version text passes contrast against the yellow background.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] If new assets were added or existing ones were modified, I verified that: N/A

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>
