### PR TITLE
Part 4: Remove Onyx.connect() for ONYXKEYS.COLLECTION.REPORT_ACTIONS in shareTrackedExpense path

### DIFF
--- a/src/libs/actions/IOU/TrackExpense.ts
+++ b/src/libs/actions/IOU/TrackExpense.ts
@@ -2372,9 +2372,6 @@ function trackExpense(params: CreateTrackExpenseParams) {
         isDraftPolicy,
         action,
         // Strip reportActionsList from retryParams to keep the serialized error JSON small.
-        // The retry path doesn't need a fresh list: SHARE retries are practically impossible (the receipt is already
-        // uploaded with the original Track Expense), and even if one did fire, the chat unarchive in
-        // createPolicyExpenseChats still runs unconditionally. See https://github.com/Expensify/App/issues/66578.
         reportActionsList: undefined,
         participantParams: {
             participant,

--- a/src/libs/actions/IOU/TrackExpense.ts
+++ b/src/libs/actions/IOU/TrackExpense.ts
@@ -2163,7 +2163,16 @@ function categorizeTrackedExpense(trackedExpenseParams: TrackedExpenseParams) {
 }
 
 function shareTrackedExpense(trackedExpenseParams: TrackedExpenseParams) {
-    const {onyxData: trackedExpenseOnyxData, reportInformation, transactionParams, policyParams, createdWorkspaceParams, accountantParams, currentUserAccountID} = trackedExpenseParams;
+    const {
+        onyxData: trackedExpenseOnyxData,
+        reportInformation,
+        transactionParams,
+        policyParams,
+        createdWorkspaceParams,
+        accountantParams,
+        currentUserAccountID,
+        reportActionsList,
+    } = trackedExpenseParams;
 
     const policyID = policyParams?.policyID;
     const chatReportID = reportInformation?.chatReportID;
@@ -2231,6 +2240,9 @@ function shareTrackedExpense(trackedExpenseParams: TrackedExpenseParams) {
             CONST.POLICY.ROLE.ADMIN,
             formatPhoneNumber,
             currentUserAccountID,
+            undefined,
+            undefined,
+            reportActionsList,
         );
         onyxData.optimisticData?.push(...addAccountantToWorkspaceOptimisticData);
         onyxData.successData?.push(...addAccountantToWorkspaceSuccessData);
@@ -2312,6 +2324,7 @@ function trackExpense(params: CreateTrackExpenseParams) {
         isSelfTourViewed,
         defaultWorkspaceName,
         previousOdometerDraft,
+        reportActionsList,
     } = params;
     const {participant, payeeAccountID, payeeEmail} = participantParams;
     const {policy, policyCategories, policyTagList} = policyData;
@@ -2358,6 +2371,11 @@ function trackExpense(params: CreateTrackExpenseParams) {
         report,
         isDraftPolicy,
         action,
+        // Strip reportActionsList from retryParams to keep the serialized error JSON small.
+        // The retry path doesn't need a fresh list: SHARE retries are practically impossible (the receipt is already
+        // uploaded with the original Track Expense), and even if one did fire, the chat unarchive in
+        // createPolicyExpenseChats still runs unconditionally. See https://github.com/Expensify/App/issues/66578.
+        reportActionsList: undefined,
         participantParams: {
             participant,
             payeeAccountID,
@@ -2597,6 +2615,7 @@ function trackExpense(params: CreateTrackExpenseParams) {
                 accountantParams,
                 currentUserAccountID: currentUserAccountIDParam,
                 currentUserEmail: currentUserEmailParam,
+                reportActionsList,
             };
             shareTrackedExpense(trackedExpenseParams);
             break;

--- a/src/libs/actions/IOU/types/CreateTrackExpenseParams.ts
+++ b/src/libs/actions/IOU/types/CreateTrackExpenseParams.ts
@@ -1,4 +1,4 @@
-import type {OnyxEntry} from 'react-native-onyx';
+import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import type {IOUAction} from '@src/CONST';
 import type * as OnyxTypes from '@src/types/onyx';
 import type {Accountant} from '@src/types/onyx/IOU';
@@ -34,6 +34,8 @@ type CreateTrackExpenseParams = {
     isSelfTourViewed: boolean;
     defaultWorkspaceName?: string;
     previousOdometerDraft?: OnyxEntry<OnyxTypes.OdometerDraft>;
+    // TODO: Remove optional (?) once all callers are updated in follow-up PRs of https://github.com/Expensify/App/issues/66578
+    reportActionsList?: OnyxCollection<OnyxTypes.ReportActions>;
 };
 
 export type {CreateTrackExpenseParams, TrackExpenseAccountantParams};

--- a/src/libs/actions/IOU/types/TrackedExpenseParams.ts
+++ b/src/libs/actions/IOU/types/TrackedExpenseParams.ts
@@ -1,4 +1,4 @@
-import type {OnyxEntry} from 'react-native-onyx';
+import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import type {CreateWorkspaceParams} from '@libs/API/parameters';
 import type {BuildPolicyDataKeys} from '@userActions/Policy/Policy';
 import type ONYXKEYS from '@src/ONYXKEYS';
@@ -66,6 +66,8 @@ type TrackedExpenseParams = {
     accountantParams?: TrackExpenseAccountantParams;
     currentUserAccountID: number;
     currentUserEmail?: string;
+    // TODO: Remove optional (?) once all callers are updated in follow-up PRs of https://github.com/Expensify/App/issues/66578
+    reportActionsList?: OnyxCollection<OnyxTypes.ReportActions>;
 };
 
 export type {TrackedExpenseParams, TrackedExpensePolicyParams, TrackedExpenseTransactionParams, TrackedExpenseReportInformation, BuildOnyxDataForTrackExpenseKeys};

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -3054,6 +3054,7 @@ function buildPolicyData(options: BuildPolicyDataOptions): OnyxData<BuildPolicyD
             policyID,
             {[adminParticipant.login]: adminParticipant.accountID ?? CONST.DEFAULT_NUMBER_ID},
             currentUserAccountIDParam,
+            // reportActionsList is intentionally undefined. See https://github.com/Expensify/App/pull/88312#issuecomment-4286942084
             undefined,
             hasOutstandingChildRequest,
         );

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -7665,8 +7665,7 @@ function changeReportPolicyAndInviteSubmitter({
     formatPhoneNumber: LocaleContextProps['formatPhoneNumber'];
     isReportLastVisibleArchived: boolean | undefined;
     reportNextStep: OnyxEntry<ReportNextStepDeprecated>;
-    // TODO: Remove optional (?) once all callers are updated in follow-up PRs of https://github.com/Expensify/App/issues/66578
-    reportActionsList?: OnyxCollection<ReportActions>;
+    reportActionsList: OnyxCollection<ReportActions>;
 }) {
     if (!report.reportID || !policy?.id || report.policyID === policy.id || !isExpenseReport(report) || !report.ownerAccountID) {
         return;

--- a/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
+++ b/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
@@ -3,6 +3,7 @@ import {hasSeenTourSelector} from '@selectors/Onboarding';
 import {useEffect, useRef, useState} from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import useActivePolicy from '@hooks/useActivePolicy';
+import useAllPolicyExpenseChatReportActions from '@hooks/useAllPolicyExpenseChatReportActions';
 import useLastWorkspaceNumber from '@hooks/useLastWorkspaceNumber';
 import useLocalize from '@hooks/useLocalize';
 import useOnboardingTaskInformation from '@hooks/useOnboardingTaskInformation';
@@ -183,6 +184,7 @@ function useExpenseSubmission(params: UseExpenseSubmissionParams) {
     const [recentlyUsedDestinations] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_DESTINATIONS}${policyID}`);
     const lastWorkspaceNumber = useLastWorkspaceNumber();
     const activePolicy = useActivePolicy();
+    const policyExpenseChatReportActions = useAllPolicyExpenseChatReportActions();
 
     // Reports
     const [selfDMReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${findSelfDMReportID()}`);
@@ -536,6 +538,7 @@ function useExpenseSubmission(params: UseExpenseSubmissionParams) {
                 isSelfTourViewed,
                 defaultWorkspaceName: generateDefaultWorkspaceName(email, lastWorkspaceNumber, translate),
                 previousOdometerDraft: odometerDraft,
+                reportActionsList: policyExpenseChatReportActions,
             });
         }
     }

--- a/tests/actions/IOUTest/TrackExpenseTest.ts
+++ b/tests/actions/IOUTest/TrackExpenseTest.ts
@@ -908,6 +908,173 @@ describe('actions/IOU/TrackExpense', () => {
             expect(announceChat?.writeCapability).toBe(CONST.REPORT.WRITE_CAPABILITIES.ADMINS);
         });
 
+        it('share with accountant not archived existing expense report via the explicit reportActionsList param (not the deprecated onyx fallback)', async () => {
+            // Given a policy without the accountant + an existing (orphaned) archived expense chat for the accountant + an archived nested expense report.
+            // The REPORT_PREVIEW action that links the chat to the expense report is supplied via the explicit reportActionsList,
+            // not seeded into ONYXKEYS.COLLECTION.REPORT_ACTIONS. Proves the explicit param wins over the deprecatedAllReportActions Onyx fallback.
+            const accountant: Required<Accountant> = {login: VIT_EMAIL, accountID: VIT_ACCOUNT_ID};
+            const policy: Policy = {...createRandomPolicy(1), id: 'ABC', employeeList: {}};
+            const selfDMReport: Report = {
+                ...createRandomReport(1, CONST.REPORT.CHAT_TYPE.SELF_DM),
+                reportID: '10',
+            };
+            const ownPolicyExpenseChat: Report = {
+                ...createRandomReport(1, CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT),
+                reportID: '123',
+                policyID: policy.id,
+                type: CONST.REPORT.TYPE.CHAT,
+                isOwnPolicyExpenseChat: true,
+            };
+            // Orphaned policy expense chat for the accountant: the accountant was removed from the workspace but the chat still exists.
+            const accountantExpenseChatID = '777';
+            const accountantExpenseChat: Report = {
+                ...createRandomReport(2, CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT),
+                reportID: accountantExpenseChatID,
+                policyID: policy.id,
+                ownerAccountID: accountant.accountID,
+                type: CONST.REPORT.TYPE.CHAT,
+            };
+            const archivedExpenseReportID = '888';
+            const transaction: Transaction = {...createRandomTransaction(1), transactionID: '555'};
+
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${ownPolicyExpenseChat.reportID}`, ownPolicyExpenseChat);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${accountantExpenseChat.reportID}`, accountantExpenseChat);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${accountantExpenseChatID}`, {private_isArchived: DateUtils.getDBTime()});
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${archivedExpenseReportID}`, {private_isArchived: DateUtils.getDBTime()});
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${transaction.transactionID}`, transaction);
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {[accountant.accountID]: accountant});
+
+            // Build the REPORT_PREVIEW action OUTSIDE Onyx and pass it explicitly.
+            // If the implementation falls back to deprecatedAllReportActions (Onyx) instead of using this explicit param,
+            // the unarchive failure-data entry will not be generated and the assertion below will fail.
+            const reportPreviewAction: ReportAction = {
+                reportActionID: 'preview-1',
+                actionName: CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW,
+                childReportID: archivedExpenseReportID,
+                created: DateUtils.getDBTime(),
+                message: [],
+            } as unknown as ReportAction;
+            const explicitReportActionsList = {
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${accountantExpenseChatID}`]: {
+                    [reportPreviewAction.reportActionID]: reportPreviewAction,
+                },
+            };
+
+            const recentWaypoints = (await getOnyxValue(ONYXKEYS.NVP_RECENT_WAYPOINTS)) ?? [];
+
+            // Create the tracked expense first
+            trackExpense({
+                report: selfDMReport,
+                isDraftPolicy: true,
+                action: CONST.IOU.ACTION.CREATE,
+                participantParams: {
+                    payeeEmail: RORY_EMAIL,
+                    payeeAccountID: RORY_ACCOUNT_ID,
+                    participant: {accountID: RORY_ACCOUNT_ID},
+                },
+                transactionParams: {
+                    amount: transaction.amount,
+                    currency: transaction.currency,
+                    created: format(new Date(), CONST.DATE.FNS_FORMAT_STRING),
+                    merchant: transaction.merchant,
+                    billable: false,
+                },
+                isASAPSubmitBetaEnabled: false,
+                currentUserAccountIDParam: RORY_ACCOUNT_ID,
+                currentUserEmailParam: RORY_EMAIL,
+                introSelected: undefined,
+                quickAction: undefined,
+                recentWaypoints,
+                betas: [CONST.BETAS.ALL],
+                draftTransactionIDs: [transaction.transactionID],
+                isSelfTourViewed: false,
+            });
+            await waitForBatchedUpdates();
+
+            const selfDMReportActionsOnyx = await new Promise<OnyxEntry<ReportActions>>((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReport.reportID}`,
+                    waitForCollectionCallback: false,
+                    callback: (value) => {
+                        Onyx.disconnect(connection);
+                        resolve(value);
+                    },
+                });
+            });
+
+            const linkedTrackedExpenseReportAction = Object.values(selfDMReportActionsOnyx ?? {}).find((reportAction) => isMoneyRequestAction(reportAction));
+            const reportActionableTrackExpense = Object.values(selfDMReportActionsOnyx ?? {}).find((reportAction) => isActionableTrackExpense(reportAction));
+
+            mockFetch?.pause?.();
+
+            // When sharing the tracked expense with the accountant, passing the explicit reportActionsList
+            trackExpense({
+                report: ownPolicyExpenseChat,
+                isDraftPolicy: false,
+                action: CONST.IOU.ACTION.SHARE,
+                participantParams: {
+                    payeeEmail: RORY_EMAIL,
+                    payeeAccountID: RORY_ACCOUNT_ID,
+                    participant: {reportID: ownPolicyExpenseChat.reportID, isPolicyExpenseChat: true},
+                },
+                policyParams: {
+                    policy,
+                },
+                transactionParams: {
+                    amount: transaction.amount,
+                    currency: transaction.currency,
+                    created: format(new Date(), CONST.DATE.FNS_FORMAT_STRING),
+                    merchant: transaction.merchant,
+                    billable: false,
+                    actionableWhisperReportActionID: reportActionableTrackExpense?.reportActionID,
+                    linkedTrackedExpenseReportAction,
+                    linkedTrackedExpenseReportID: selfDMReport.reportID,
+                },
+                accountantParams: {
+                    accountant,
+                },
+                reportActionsList: explicitReportActionsList,
+                isASAPSubmitBetaEnabled: false,
+                currentUserAccountIDParam: RORY_ACCOUNT_ID,
+                currentUserEmailParam: RORY_EMAIL,
+                introSelected: undefined,
+                quickAction: undefined,
+                recentWaypoints,
+                betas: [CONST.BETAS.ALL],
+                draftTransactionIDs: [],
+                isSelfTourViewed: false,
+            });
+            await waitForBatchedUpdates();
+
+            // Then the orphaned accountant expense chat AND the nested expense report should both be optimistically not archived
+            const accountantChatNvpAfter = await new Promise<OnyxEntry<{private_isArchived?: string | null}>>((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${accountantExpenseChatID}`,
+                    waitForCollectionCallback: false,
+                    callback: (value) => {
+                        Onyx.disconnect(connection);
+                        resolve(value);
+                    },
+                });
+            });
+            const expenseReportNvpAfter = await new Promise<OnyxEntry<{private_isArchived?: string | null}>>((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${archivedExpenseReportID}`,
+                    waitForCollectionCallback: false,
+                    callback: (value) => {
+                        Onyx.disconnect(connection);
+                        resolve(value);
+                    },
+                });
+            });
+
+            await mockFetch?.resume?.();
+
+            expect(accountantChatNvpAfter?.private_isArchived).toBeFalsy();
+            expect(expenseReportNvpAfter?.private_isArchived).toBeFalsy();
+        });
+
         /**
          * Creates default trackExpense parameters - only override what's needed for each test
          */

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3424,6 +3424,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: undefined,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 
@@ -3511,6 +3512,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: false,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 
@@ -3553,6 +3555,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: undefined,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 
@@ -3581,6 +3584,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: undefined,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 
@@ -3608,6 +3612,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: undefined,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 
@@ -3635,6 +3640,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: undefined,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 
@@ -3664,6 +3670,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: undefined,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 
@@ -3714,6 +3721,7 @@ describe('actions/Report', () => {
                 formatPhoneNumber: TestHelper.formatPhoneNumber,
                 isReportLastVisibleArchived: false,
                 reportNextStep: undefined,
+                reportActionsList: {},
             });
             await waitForBatchedUpdates();
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR is part of deprecating the module-scoped `Onyx.connect()` cache `deprecatedAllReportActions` in `src/libs/actions/Policy/Policy.ts`. `deprecatedAllReportActions` is read inside `createPolicyExpenseChats` (Policy.ts:1612) when the `if (oldChat)` branch is entered. Callers should supply an explicit `reportActionsList` (from the `useAllPolicyExpenseChatReportActions()` hook) instead of relying on the module-scoped fallback.

After PR #88312 the last remaining live caller path that still relied on the Onyx fallback was `shareTrackedExpense` (deferred at the time to keep that PR small). This PR threads `reportActionsList` through that path.

#### Threading

Chain: UI/hook → `trackExpense` → SHARE branch → `shareTrackedExpense` → `buildAddMembersToWorkspaceOnyxData` → `createPolicyExpenseChats`.

**Changes:**
- Added `reportActionsList?: OnyxCollection<OnyxTypes.ReportActions>` to both `TrackedExpenseParams` and `CreateTrackExpenseParams` (each with a `// TODO: Remove optional (?)` comment pointing at #66578).
- `shareTrackedExpense` (`TrackExpense.ts`) now destructures `reportActionsList` from `trackedExpenseParams` and forwards it to `buildAddMembersToWorkspaceOnyxData`.
- `trackExpense` (`TrackExpense.ts`) now forwards `reportActionsList` to the SHARE-branch `TrackedExpenseParams` it constructs (the CATEGORIZE branch does not call `createPolicyExpenseChats`, so it does not need it).
- The only UI caller that actually reaches the SHARE branch — `useExpenseSubmission.ts` — now calls `useAllPolicyExpenseChatReportActions()` and passes the result through to `trackExpense`. Other `trackExpense` callers do not pass `action: SHARE` and never reach `shareTrackedExpense`, so they were not touched.
- **Retry path:** the receipt-upload retry handler deserializes `retryParams` from a stored JSON string, so any `reportActionsList` baked into the original call would be stale at retry time. `DotIndicatorMessage` now calls `useAllPolicyExpenseChatReportActions()` and passes it down through `handleRetryPress` (both `.ts` and `.android.ts`) into `handleFileRetry`, which overwrites `trackExpenseParams.reportActionsList` with the fresh value before invoking `TrackExpense.trackExpense(...)`.
- Added a comment at the `buildPolicyData` → `createPolicyExpenseChats` call (Policy.ts:3019) explaining that the `undefined` `reportActionsList` argument is intentional dead code: `buildPolicyData` always uses a fresh `policyID` (`generatePolicyID()`), so the `if (oldChat)` branch — the sole reader of `reportActionsList` — is never entered. The only caller that passes `adminParticipant` (`IOURequestStepUpgrade.tsx`) also passes `policyID: undefined`, confirming the path is dead.
- Added a unit test (`TrackExpenseTest.ts`) that:
  - Seeds an orphaned archived policy expense chat for the accountant + an archived nested expense report.
  - Builds a `REPORT_PREVIEW` action **outside Onyx** and supplies it via the explicit `reportActionsList`.
  - Calls `trackExpense` with `action: SHARE` and asserts both NVPs end up `private_isArchived` falsy — proving the explicit param wins over the deprecated `Onyx.connect()` fallback (which would not contain the preview action).

**Deferred to the follow-up PR of #66578:**
- Once this lands, every live caller of `createPolicyExpenseChats` / `buildAddMembersToWorkspaceOnyxData` supplies `reportActionsList`. The final cleanup PR will make the parameter required, delete the `?? deprecatedAllReportActions` fallback inside `createPolicyExpenseChats`, remove the `Onyx.connect()` block + `deprecatedAllReportActions` variable in `Policy.ts`, drop the `// TODO: Remove optional (?)` markers, and decrement the allowable `Onyx.connect` ESLint warning count in `package.json`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/66578
PROPOSAL:


### Tests

1. Track an expense
2. Verify that the flow is working well 

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A - This is a refactoring change that does not affect offline behavior.

### QA Steps
1. Track an expense
2. Verify that the flow is working well 
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/2c0f3f81-beab-4a84-ac81-792b3d178356


