### PR TITLE
Hide attachment download button until image loads

### DIFF
--- a/src/pages/media/AttachmentModalScreen/AttachmentModalBaseContent/AttachmentStateContextProvider.tsx
+++ b/src/pages/media/AttachmentModalScreen/AttachmentModalBaseContent/AttachmentStateContextProvider.tsx
@@ -47,7 +47,7 @@ function AttachmentStateContextProvider({children}: Props) {
         setAttachmentLoadedState({});
     }, []);
 
-    const isAttachmentLoaded = useCallback((key: AttachmentSource) => attachmentLoaded?.[convertSourceToString(key)] !== false, [attachmentLoaded]);
+    const isAttachmentLoaded = useCallback((key: AttachmentSource) => attachmentLoaded?.[convertSourceToString(key)] === true, [attachmentLoaded]);
     const value = useMemo(() => ({setAttachmentLoaded, clearAttachmentLoaded, isAttachmentLoaded}), [setAttachmentLoaded, clearAttachmentLoaded, isAttachmentLoaded]);
     return <AttachmentStateContext.Provider value={value}>{children}</AttachmentStateContext.Provider>;
 }

--- a/tests/unit/AttachmentStateContextProviderTest.tsx
+++ b/tests/unit/AttachmentStateContextProviderTest.tsx
@@ -1,0 +1,56 @@
+import {render} from '@testing-library/react-native';
+import React, {useContext, useEffect} from 'react';
+import type {AttachmentSource} from '@components/Attachments/types';
+import AttachmentStateContextProvider, {AttachmentStateContext} from '@pages/media/AttachmentModalScreen/AttachmentModalBaseContent/AttachmentStateContextProvider';
+
+type TestConsumerProps = {
+    source: AttachmentSource;
+    onLoadedState: (isLoaded: boolean) => void;
+    loadedStateToSet?: boolean;
+};
+
+function TestConsumer({source, onLoadedState, loadedStateToSet}: TestConsumerProps) {
+    const {isAttachmentLoaded, setAttachmentLoaded} = useContext(AttachmentStateContext);
+
+    useEffect(() => {
+        if (loadedStateToSet === undefined) {
+            return;
+        }
+        setAttachmentLoaded(source, loadedStateToSet);
+    }, [loadedStateToSet, setAttachmentLoaded, source]);
+
+    useEffect(() => {
+        onLoadedState(isAttachmentLoaded(source));
+    }, [isAttachmentLoaded, onLoadedState, source]);
+
+    return null;
+}
+
+describe('AttachmentStateContextProvider', () => {
+    it('treats unknown attachments as not loaded until they explicitly load', () => {
+        const source = 'https://invalid-url/image.jpg';
+        const onLoadedState = jest.fn();
+        const {rerender} = render(
+            <AttachmentStateContextProvider>
+                <TestConsumer
+                    source={source}
+                    onLoadedState={onLoadedState}
+                />
+            </AttachmentStateContextProvider>,
+        );
+
+        expect(onLoadedState).toHaveBeenLastCalledWith(false);
+
+        rerender(
+            <AttachmentStateContextProvider>
+                <TestConsumer
+                    source={source}
+                    onLoadedState={onLoadedState}
+                    loadedStateToSet
+                />
+            </AttachmentStateContextProvider>,
+        );
+
+        expect(onLoadedState).toHaveBeenLastCalledWith(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Treat unknown attachment sources as not loaded instead of loaded.
- Prevents the attachment modal download button from appearing before an image successfully loads, including broken image URLs.
- Adds unit coverage for the attachment loaded-state context.

$ #90322

## Test plan
- npx -p node@20.20.0 -p npm@10.8.2 npx eslint src/pages/media/AttachmentModalScreen/AttachmentModalBaseContent/AttachmentStateContextProvider.tsx tests/unit/AttachmentStateContextProviderTest.tsx
- npx -p node@20.20.0 -p npm@10.8.2 npm test -- tests/unit/AttachmentStateContextProviderTest.tsx --runInBand
- npx -p node@20.20.0 -p npm@10.8.2 npm run typecheck -- --pretty false


Made with [Cursor](https://cursor.com)