### PR TITLE
Allow proactive Sage Intacct credential rotation

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -2330,7 +2330,13 @@ const ROUTES = {
     },
     POLICY_ACCOUNTING: {
         route: 'workspaces/:policyID/accounting',
-        getRoute: (policyID: string | undefined, newConnectionName?: ConnectionName, integrationToDisconnect?: ConnectionName, shouldDisconnectIntegrationBeforeConnecting?: boolean) => {
+        getRoute: (
+            policyID: string | undefined,
+            newConnectionName?: ConnectionName,
+            integrationToDisconnect?: ConnectionName,
+            shouldDisconnectIntegrationBeforeConnecting?: boolean,
+            entryPoint?: string,
+        ) => {
             if (!policyID) {
                 Log.warn('Invalid policyID is used to build the POLICY_ACCOUNTING route');
             }
@@ -2343,6 +2349,9 @@ const ROUTES = {
                 }
                 if (shouldDisconnectIntegrationBeforeConnecting !== undefined) {
                     queryParams += `&shouldDisconnectIntegrationBeforeConnecting=${shouldDisconnectIntegrationBeforeConnecting}`;
+                }
+                if (entryPoint) {
+                    queryParams += `&entryPoint=${entryPoint}`;
                 }
             }
             return `workspaces/${policyID}/accounting${queryParams}` as const;

--- a/src/components/ConnectToSageIntacctFlow/index.tsx
+++ b/src/components/ConnectToSageIntacctFlow/index.tsx
@@ -7,14 +7,17 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 
+type ConnectToSageIntacctFlowEntryPoint = 'credentials';
+
 type ConnectToSageIntacctFlowProps = {
     policyID: string;
+    entryPoint?: ConnectToSageIntacctFlowEntryPoint;
 };
 
-function ConnectToSageIntacctFlow({policyID}: ConnectToSageIntacctFlowProps) {
+function ConnectToSageIntacctFlow({policyID, entryPoint}: ConnectToSageIntacctFlowProps) {
     const hasReusablePoliciesConnectedToSageIntacct = useHasReusablePoliciesConnectedTo(CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT, policyID);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
-    const shouldGoToEnterCredentials = isAuthenticationError(policy, CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT);
+    const shouldGoToEnterCredentials = entryPoint === 'credentials' || isAuthenticationError(policy, CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT);
 
     useEffect(() => {
         if (shouldGoToEnterCredentials) {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -6188,6 +6188,7 @@ _Für ausführlichere Anweisungen [besuchen Sie unsere Hilfeseite](${CONST.NETSU
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `Sind Sie sicher, dass Sie ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'diese Buchhaltungsintegration'} verbinden möchten? Dadurch werden alle bestehenden Buchhaltungsverbindungen entfernt.`,
             enterCredentials: 'Gib deine Anmeldedaten ein',
+            updateCredentials: 'Anmeldedaten aktualisieren',
             claimOffer: {
                 badgeText: 'Angebot verfügbar!',
                 xero: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6156,6 +6156,7 @@ const translations = {
             advanced: 'Advanced',
             other: 'Other',
             syncNow: 'Sync now',
+            updateCredentials: 'Update credentials',
             disconnect: 'Disconnect',
             reinstall: 'Reinstall connector',
             disconnectTitle: ({connectionName}: OptionalParam<ConnectionNameParams> = {}) => {

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -5985,6 +5985,7 @@ ${amount} para ${merchant} - ${date}`,
             connectPrompt: ({connectionName}) =>
                 `¿Estás seguro de que quieres conectar a ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'esta integración contable'}? Esto eliminará cualquier conexión contable existente.`,
             enterCredentials: 'Ingresa tus credenciales',
+            updateCredentials: 'Actualizar credenciales',
             claimOffer: {
                 badgeText: '¡Oferta disponible!',
                 xero: {

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -6209,6 +6209,7 @@ _Pour des instructions plus détaillées, [visitez notre site d’aide](${CONST.
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `Voulez-vous vraiment connecter ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'cette intégration comptable'} ? Cette action supprimera toutes les connexions comptables existantes.`,
             enterCredentials: 'Saisissez vos identifiants',
+            updateCredentials: 'Mettre à jour les identifiants',
             claimOffer: {
                 badgeText: 'Offre disponible !',
                 xero: {

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -6178,6 +6178,7 @@ _Per istruzioni più dettagliate, [visita il nostro sito di assistenza](${CONST.
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `Sei sicuro di voler collegare ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'questa integrazione contabile'}? Questo rimuoverà tutte le connessioni contabili esistenti.`,
             enterCredentials: 'Inserisci le tue credenziali',
+            updateCredentials: 'Aggiorna credenziali',
             claimOffer: {
                 badgeText: 'Offerta disponibile!',
                 xero: {

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -6107,6 +6107,7 @@ _詳しい手順については、[ヘルプサイトをご覧ください](${CO
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'この会計連携'} を接続してもよろしいですか？これにより、既存の会計連携はすべて削除されます。`,
             enterCredentials: '認証情報を入力してください',
+            updateCredentials: '認証情報を更新',
             claimOffer: {
                 badgeText: 'オファーをご利用いただけます！',
                 xero: {

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -6156,6 +6156,7 @@ _Voor meer gedetailleerde instructies, [bezoek onze help-site](${CONST.NETSUITE_
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `Weet je zeker dat je ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'deze boekhoudkoppeling'} wilt koppelen? Hierdoor worden alle bestaande boekhoudkundige koppelingen verwijderd.`,
             enterCredentials: 'Voer je inloggegevens in',
+            updateCredentials: 'Inloggegevens bijwerken',
             claimOffer: {
                 badgeText: 'Aanbieding beschikbaar!',
                 xero: {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6150,6 +6150,7 @@ _Aby uzyskać bardziej szczegółowe instrukcje, [odwiedź naszą stronę pomocy
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `Czy na pewno chcesz połączyć ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'ta integracja księgowa'}? Spowoduje to usunięcie wszystkich istniejących połączeń księgowych.`,
             enterCredentials: 'Wprowadź swoje dane logowania',
+            updateCredentials: 'Zaktualizuj dane logowania',
             claimOffer: {
                 badgeText: 'Oferta dostępna!',
                 xero: {

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -6157,6 +6157,7 @@ _Para instruções mais detalhadas, [visite nossa central de ajuda](${CONST.NETS
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `Tem certeza de que deseja conectar ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? 'esta integração contábil'}? Isso removerá quaisquer conexões contábeis existentes.`,
             enterCredentials: 'Insira suas credenciais',
+            updateCredentials: 'Atualizar credenciais',
             claimOffer: {
                 badgeText: 'Oferta disponível!',
                 xero: {

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -6004,6 +6004,7 @@ _如需更详细的说明，请[访问我们的帮助网站](${CONST.NETSUITE_IM
             connectPrompt: ({connectionName}: ConnectionNameParams) =>
                 `确定要连接 ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName] ?? '此会计集成'} 吗？这将删除所有现有的会计连接。`,
             enterCredentials: '请输入您的凭证',
+            updateCredentials: '更新凭证',
             claimOffer: {
                 badgeText: '优惠可用！',
                 xero: {

--- a/src/pages/workspace/accounting/AccountingContext/index.tsx
+++ b/src/pages/workspace/accounting/AccountingContext/index.tsx
@@ -50,6 +50,7 @@ function AccountingContextProvider({children, policy}: AccountingContextProvider
                 newActiveIntegration.shouldDisconnectIntegrationBeforeConnecting,
                 undefined,
                 accountingIcons,
+                newActiveIntegration.entryPoint,
             );
             const workspaceUpgradeNavigationDetails = accountingIntegrationData?.workspaceUpgradeNavigationDetails;
             if (workspaceUpgradeNavigationDetails && !isControlPolicy(policy)) {
@@ -110,6 +111,7 @@ function AccountingContextProvider({children, policy}: AccountingContextProvider
             undefined,
             undefined,
             accountingIcons,
+            activeIntegration.entryPoint,
         )?.setupConnectionFlow;
     };
 

--- a/src/pages/workspace/accounting/AccountingContext/types.ts
+++ b/src/pages/workspace/accounting/AccountingContext/types.ts
@@ -2,10 +2,13 @@ import type {RefObject} from 'react';
 import type {View} from 'react-native';
 import type {ConnectionName} from '@src/types/onyx/Policy';
 
+type ActiveIntegrationEntryPoint = 'credentials';
+
 type ActiveIntegration = {
     name: ConnectionName;
     shouldDisconnectIntegrationBeforeConnecting?: boolean;
     integrationToDisconnect?: ConnectionName;
+    entryPoint?: ActiveIntegrationEntryPoint;
 };
 
 type ActiveIntegrationState = ActiveIntegration & {key: number};
@@ -19,4 +22,4 @@ type AccountingActionsContextType = {
     startIntegrationFlow: (activeIntegration: ActiveIntegration) => void;
 };
 
-export type {ActiveIntegration, ActiveIntegrationState, AccountingStateContextType, AccountingActionsContextType};
+export type {ActiveIntegration, ActiveIntegrationEntryPoint, ActiveIntegrationState, AccountingStateContextType, AccountingActionsContextType};

--- a/src/pages/workspace/accounting/PolicyAccountingPage.tsx
+++ b/src/pages/workspace/accounting/PolicyAccountingPage.tsx
@@ -62,6 +62,7 @@ import ROUTES from '@src/ROUTES';
 import type {ConnectionName} from '@src/types/onyx/Policy';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import {AccountingContextProvider, useAccountingActions, useAccountingState} from './AccountingContext';
+import type {ActiveIntegrationEntryPoint} from './AccountingContext/types';
 import type {MenuItemData, PolicyAccountingPageProps} from './types';
 import {getAccountingIntegrationData, getSynchronizationErrorMessage} from './utils';
 
@@ -69,6 +70,7 @@ type RouteParams = {
     newConnectionName?: ConnectionName;
     integrationToDisconnect?: ConnectionName;
     shouldDisconnectIntegrationBeforeConnecting?: boolean;
+    entryPoint?: string;
 };
 
 function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
@@ -96,6 +98,7 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
     const newConnectionName = params?.newConnectionName;
     const integrationToDisconnect = params?.integrationToDisconnect;
     const shouldDisconnectIntegrationBeforeConnecting = params?.shouldDisconnectIntegrationBeforeConnecting;
+    const entryPoint: ActiveIntegrationEntryPoint | undefined = params?.entryPoint === 'credentials' ? params.entryPoint : undefined;
     const policyID = policy?.id;
     const workspaceAccountID = useWorkspaceAccountID(policyID);
     const allCardSettings = useExpensifyCardFeeds(policyID);
@@ -110,7 +113,10 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
     const hasAccountingConnection = hasAccountingConnections(policy);
     const synchronizationError = connectedIntegration && getSynchronizationErrorMessage(policy, connectedIntegration, isSyncInProgress, translate, styles);
 
-    const shouldShowEnterCredentials = connectedIntegration && !!synchronizationError && isAuthenticationError(policy, connectedIntegration);
+    const isSageIntacctConnection = connectedIntegration === CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT;
+    const hasAuthenticationError = !!connectedIntegration && !!synchronizationError && isAuthenticationError(policy, connectedIntegration);
+    const shouldShowEnterCredentials = hasAuthenticationError || isSageIntacctConnection;
+    const shouldShowSyncNow = !!connectedIntegration && (!hasAuthenticationError || isSageIntacctConnection);
 
     // Get the last successful date of the integration. Then, if `connectionSyncProgress` is the same integration displayed and the state is 'jobDone', get the more recent update time of the two.
     const successfulDate = getIntegrationLastSuccessfulDate(
@@ -145,21 +151,34 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
                 ? [
                       {
                           icon: icons.Key,
-                          text: translate('workspace.accounting.enterCredentials'),
-                          onSelected: () => startIntegrationFlow({name: connectedIntegration}),
+                          text: translate(
+                              isSageIntacctConnection ? 'workspace.accounting.updateCredentials' : 'workspace.accounting.enterCredentials',
+                          ),
+                          onSelected: () => {
+                              if (!connectedIntegration) {
+                                  return;
+                              }
+                              startIntegrationFlow({
+                                  name: connectedIntegration,
+                                  entryPoint: isSageIntacctConnection ? 'credentials' : undefined,
+                              });
+                          },
                           shouldCallAfterModalHide: true,
                           disabled: isOffline,
                           iconRight: icons.NewWindow,
                       },
                   ]
-                : [
+                : []),
+            ...(shouldShowSyncNow
+                ? [
                       {
                           icon: icons.Sync,
                           text: translate('workspace.accounting.syncNow'),
                           onSelected: () => syncConnection(policy, connectedIntegration),
                           disabled: isOffline,
                       },
-                  ]),
+                  ]
+                : []),
             {
                 icon: icons.Trashcan,
                 text: translate('workspace.accounting.disconnect'),
@@ -173,8 +192,11 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
             icons.Key,
             icons.Sync,
             icons.Trashcan,
+            hasAuthenticationError,
+            isSageIntacctConnection,
             shouldShowEnterCredentials,
             shouldShowReinstallConnectorMenuItem,
+            shouldShowSyncNow,
             translate,
             isOffline,
             policy,
@@ -193,8 +215,9 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
                 name: newConnectionName,
                 integrationToDisconnect,
                 shouldDisconnectIntegrationBeforeConnecting,
+                entryPoint,
             });
-        }, [newConnectionName, integrationToDisconnect, shouldDisconnectIntegrationBeforeConnecting, policy, startIntegrationFlow]),
+        }, [newConnectionName, integrationToDisconnect, shouldDisconnectIntegrationBeforeConnecting, entryPoint, policy, startIntegrationFlow]),
     );
 
     useEffect(() => {

--- a/src/pages/workspace/accounting/utils.tsx
+++ b/src/pages/workspace/accounting/utils.tsx
@@ -39,6 +39,7 @@ import {
 } from './netsuite/utils';
 import getQuickbooksDesktopSetupEntryRoute from './qbd/utils';
 import type {AccountingIntegration} from './types';
+import type {ActiveIntegrationEntryPoint} from './AccountingContext/types';
 
 function getAccountingIntegrationData(
     connectionName: PolicyConnectionName,
@@ -51,6 +52,7 @@ function getAccountingIntegrationData(
     shouldDisconnectIntegrationBeforeConnecting?: boolean,
     canUseNetSuiteUSATax?: boolean,
     expensifyIcons?: Record<'IntacctSquare' | 'QBOSquare' | 'XeroSquare' | 'NetSuiteSquare' | 'QBDSquare', IconAsset>,
+    entryPoint?: ActiveIntegrationEntryPoint,
 ): AccountingIntegration | undefined {
     const basePath = ROUTES.POLICY_ACCOUNTING.getRoute(policyID);
     const qboConfig = policy?.connections?.quickbooksOnline?.config;
@@ -58,7 +60,10 @@ function getAccountingIntegrationData(
     const netsuiteSelectedSubsidiary = (policy?.connections?.netsuite?.options?.data?.subsidiaryList ?? []).find((subsidiary) => subsidiary.internalID === netsuiteConfig?.subsidiaryID);
     const getBackToAfterWorkspaceUpgradeRouteForIntacct = () => {
         if (integrationToDisconnect) {
-            return ROUTES.POLICY_ACCOUNTING.getRoute(policyID, connectionName, integrationToDisconnect, shouldDisconnectIntegrationBeforeConnecting);
+            return ROUTES.POLICY_ACCOUNTING.getRoute(policyID, connectionName, integrationToDisconnect, shouldDisconnectIntegrationBeforeConnecting, entryPoint);
+        }
+        if (entryPoint) {
+            return ROUTES.POLICY_ACCOUNTING.getRoute(policyID, connectionName, undefined, undefined, entryPoint);
         }
         if (existingConnections.sageIntacct) {
             return ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_EXISTING_CONNECTIONS.getRoute(policyID);
@@ -235,6 +240,7 @@ function getAccountingIntegrationData(
                     <ConnectToSageIntacctFlow
                         policyID={policyID}
                         key={key}
+                        entryPoint={entryPoint}
                     />
                 ),
                 onImportPagePress: () => Navigation.navigate(ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_IMPORT.getRoute(policyID)),

--- a/tests/unit/components/ConnectToSageIntacctFlowTest.tsx
+++ b/tests/unit/components/ConnectToSageIntacctFlowTest.tsx
@@ -1,0 +1,80 @@
+import {render} from '@testing-library/react-native';
+import React from 'react';
+import ConnectToSageIntacctFlow from '@components/ConnectToSageIntacctFlow';
+import useHasReusablePoliciesConnectedTo from '@hooks/useHasReusablePoliciesConnectedTo';
+import useOnyx from '@hooks/useOnyx';
+import Navigation from '@libs/Navigation/Navigation';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
+
+jest.mock('@hooks/useHasReusablePoliciesConnectedTo');
+jest.mock('@hooks/useOnyx');
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+}));
+
+const mockedUseHasReusablePoliciesConnectedTo = jest.mocked(useHasReusablePoliciesConnectedTo);
+const mockedUseOnyx = jest.mocked(useOnyx);
+const mockedNavigate = jest.mocked(Navigation.navigate);
+
+const getUseOnyxResult = (value: unknown) => [value] as unknown as ReturnType<typeof useOnyx>;
+
+describe('ConnectToSageIntacctFlow', () => {
+    const policyID = '123';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedUseHasReusablePoliciesConnectedTo.mockReturnValue(false);
+        mockedUseOnyx.mockImplementation((key) => {
+            if (key === `${ONYXKEYS.COLLECTION.POLICY}${policyID}`) {
+                return getUseOnyxResult({});
+            }
+            return getUseOnyxResult(undefined);
+        });
+    });
+
+    it('routes proactive credential updates directly to the credential form', () => {
+        mockedUseHasReusablePoliciesConnectedTo.mockReturnValue(true);
+
+        render(
+            <ConnectToSageIntacctFlow
+                policyID={policyID}
+                entryPoint="credentials"
+            />,
+        );
+
+        expect(mockedNavigate).toHaveBeenCalledWith(ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_ENTER_CREDENTIALS.getRoute(policyID));
+    });
+
+    it('routes authentication errors to the credential form', () => {
+        mockedUseOnyx.mockReturnValue(getUseOnyxResult(
+            {
+                connections: {
+                    intacct: {
+                        lastSync: {
+                            isAuthenticationError: true,
+                        },
+                    },
+                },
+            },
+        ));
+
+        render(<ConnectToSageIntacctFlow policyID={policyID} />);
+
+        expect(mockedNavigate).toHaveBeenCalledWith(ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_ENTER_CREDENTIALS.getRoute(policyID));
+    });
+
+    it('routes to prerequisites when no reusable Sage Intacct workspace exists', () => {
+        render(<ConnectToSageIntacctFlow policyID={policyID} />);
+
+        expect(mockedNavigate).toHaveBeenCalledWith(`${ROUTES.POLICY_ACCOUNTING.getRoute(policyID)}/${DYNAMIC_ROUTES.SAGE_INTACCT_PREREQUISITES.path}`);
+    });
+
+    it('routes to reusable connections when eligible Sage Intacct workspaces exist', () => {
+        mockedUseHasReusablePoliciesConnectedTo.mockReturnValue(true);
+
+        render(<ConnectToSageIntacctFlow policyID={policyID} />);
+
+        expect(mockedNavigate).toHaveBeenCalledWith(ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_EXISTING_CONNECTIONS.getRoute(policyID));
+    });
+});


### PR DESCRIPTION
### Details
- Always show Update credentials for connected Sage Intacct workspaces.
- Keep Sync now available alongside Update credentials for Sage Intacct.
- Route the credential entry through startIntegrationFlow so AccountingContext workspace-upgrade gating remains intact.
- Preserve existing default Sage setup routing and non-Sage credential behavior.

### Fixed Issues
$ #90281

### Tests
- [x] git diff --check
- [x] git diff --cached --check
- [x] git diff --check HEAD^ HEAD
- [ ] npm test -- --runInBand tests/unit/components/ConnectToSageIntacctFlowTest.tsx (not run locally: jest not installed)
- [ ] npm run typecheck -- --pretty false (not run locally: tsc not installed)
- [ ] npm run typecheck-tsgo (not run locally: tsgo not installed)
- [ ] npm run lint-changed (not run locally: sandbox could not open .git/FETCH_HEAD)