### PR TITLE
Fix Concierge show history button for older pages

### DIFF
--- a/src/hooks/useConciergeSidePanelReportActions.ts
+++ b/src/hooks/useConciergeSidePanelReportActions.ts
@@ -67,8 +67,9 @@ function useConciergeSidePanelReportActions({
         if (!isConciergeSidePanel || !hadUserMessageAtSessionStart || !sessionStartTime) {
             return false;
         }
-        return visibleReportActions.some((action) => !isCreatedAction(action) && action.created < sessionStartTime);
-    }, [isConciergeSidePanel, visibleReportActions, sessionStartTime, hadUserMessageAtSessionStart]);
+        // Prior messages may be on older pages that have not been loaded yet.
+        return hasOlderActions || visibleReportActions.some((action) => !isCreatedAction(action) && action.created < sessionStartTime);
+    }, [isConciergeSidePanel, visibleReportActions, sessionStartTime, hadUserMessageAtSessionStart, hasOlderActions]);
 
     const showConciergeSidePanelWelcome = isConciergeSidePanel && hadUserMessageAtSessionStart && !hasUserSentMessage && !showFullHistory;
     const showConciergeGreeting = isConciergeSidePanel && hadUserMessageAtSessionStart && !showFullHistory;

--- a/tests/unit/useConciergeSidePanelReportActionsTest.ts
+++ b/tests/unit/useConciergeSidePanelReportActionsTest.ts
@@ -1,0 +1,109 @@
+import {act, renderHook} from '@testing-library/react-native';
+import useConciergeSidePanelReportActions from '@hooks/useConciergeSidePanelReportActions';
+import CONST from '@src/CONST';
+import type * as OnyxTypes from '@src/types/onyx';
+
+const REPORT_ID = '1';
+const CURRENT_USER_ACCOUNT_ID = 123;
+const SESSION_START_TIME = '2026-05-12 10:00:00.000';
+
+const createdAction = {
+    reportActionID: 'created',
+    reportID: REPORT_ID,
+    actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
+    actorAccountID: CURRENT_USER_ACCOUNT_ID,
+    created: '2026-05-10 10:00:00.000',
+} as OnyxTypes.ReportAction;
+
+const previousUserAction = {
+    reportActionID: 'previous-user-message',
+    reportID: REPORT_ID,
+    actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+    actorAccountID: CURRENT_USER_ACCOUNT_ID,
+    created: '2026-05-11 10:00:00.000',
+} as OnyxTypes.ReportAction;
+
+const currentSessionUserAction = {
+    reportActionID: 'current-session-user-message',
+    reportID: REPORT_ID,
+    actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+    actorAccountID: CURRENT_USER_ACCOUNT_ID,
+    created: '2026-05-12 10:01:00.000',
+} as OnyxTypes.ReportAction;
+
+const defaultParams = {
+    report: {
+        reportID: REPORT_ID,
+        lastReadTime: '2026-05-12 09:59:00.000',
+    } as OnyxTypes.Report,
+    reportActions: [createdAction],
+    visibleReportActions: [createdAction],
+    isConciergeSidePanel: true,
+    hasUserSentMessage: false,
+    hasOlderActions: false,
+    sessionStartTime: SESSION_START_TIME,
+    currentUserAccountID: CURRENT_USER_ACCOUNT_ID,
+    greetingText: 'How can I help?',
+    loadOlderChats: jest.fn(),
+};
+
+describe('useConciergeSidePanelReportActions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows previous message affordance when prior Concierge history is on older pages', () => {
+        const {result} = renderHook(() =>
+            useConciergeSidePanelReportActions({
+                ...defaultParams,
+                hasOlderActions: true,
+            }),
+        );
+
+        expect(result.current.hasPreviousMessages).toBe(true);
+    });
+
+    it('loads older Concierge messages when showing previous messages', () => {
+        const loadOlderChats = jest.fn();
+        const {result} = renderHook(() =>
+            useConciergeSidePanelReportActions({
+                ...defaultParams,
+                hasOlderActions: true,
+                loadOlderChats,
+            }),
+        );
+
+        act(() => {
+            result.current.handleShowPreviousMessages();
+        });
+
+        expect(loadOlderChats).toHaveBeenCalledWith(true);
+        expect(result.current.showFullHistory).toBe(true);
+    });
+
+    it('shows previous message affordance when prior Concierge history is already loaded', () => {
+        const {result} = renderHook(() =>
+            useConciergeSidePanelReportActions({
+                ...defaultParams,
+                reportActions: [createdAction, previousUserAction, currentSessionUserAction],
+                visibleReportActions: [createdAction, previousUserAction, currentSessionUserAction],
+                hasUserSentMessage: true,
+            }),
+        );
+
+        expect(result.current.hasPreviousMessages).toBe(true);
+    });
+
+    it('does not show previous message affordance without prior Concierge history', () => {
+        const {result} = renderHook(() =>
+            useConciergeSidePanelReportActions({
+                ...defaultParams,
+                reportActions: [createdAction, currentSessionUserAction],
+                visibleReportActions: [createdAction, currentSessionUserAction],
+                hasUserSentMessage: true,
+            }),
+        );
+
+        expect(result.current.hasPreviousMessages).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
$ #89571.

The Concierge side panel already treats `hasOlderActions` as evidence that the user has prior Concierge history, but the `hasPreviousMessages` value used by the "Show history" button only checked messages that were already loaded. This keeps the button visible when prior history exists on older pages that have not been loaded yet.

## Tests
- `npx prettier --write src/hooks/useConciergeSidePanelReportActions.ts tests/unit/useConciergeSidePanelReportActionsTest.ts`
- `npx eslint src/hooks/useConciergeSidePanelReportActions.ts tests/unit/useConciergeSidePanelReportActionsTest.ts`
- `npx jest --runTestsByPath tests/unit/useConciergeSidePanelReportActionsTest.ts tests/unit/ShowPreviousMessagesButtonTest.tsx --runInBand --verbose`
- `npm run react-compiler-compliance-check check-changed`

## Notes
- `npm run typecheck-tsgo` currently fails on pre-existing Map/GPS typing errors in `src/components/MapView/utils.ts` and `src/libs/migrations/ConvertGpsPointsTo2DArray.ts`, unrelated to this change.