### PR TITLE
docs: add contributor note to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -219,3 +219,5 @@ Video demo available [here 🧵](https://expensify.slack.com/archives/C02NK2DQWU
 This site is hosted on Cloudflare pages. Whenever code is merged to main, the github action `deployExpensifyHelp` will run.
 
 It will generate routes.yml using the script `createDocsRoutes`, build the Jekyll site housed in the `/docs` directory and deploy it straight to production. The help site is publicly discoverable at https://help.expensify.com/
+
+> Note: This documentation is maintained by the Expensify team and external contributors.


### PR DESCRIPTION
Small documentation improvement - added a note acknowledging external contributors to the Help site README. This aligns with Expensify's commitment to open source collaboration.