### PR TITLE
fix: allow moving expenses on reopened forwarded reports

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11477,13 +11477,16 @@ function isReportOutstanding(
         !isExpenseReport(iouReport) ||
         iouReport?.stateNum === undefined ||
         iouReport?.statusNum === undefined ||
-        iouReport?.policyID !== policyID ||
-        hasForwardedAction(iouReport.reportID)
+        iouReport?.policyID !== policyID
     ) {
         return false;
     }
     const reportNameValuePair = reportNameValuePairs?.[`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${iouReport.reportID}`];
     if (isArchivedReport(reportNameValuePair)) {
+        return false;
+    }
+    const isOpen = iouReport.stateNum === CONST.REPORT.STATE_NUM.OPEN && iouReport.statusNum === CONST.REPORT.STATUS_NUM.OPEN;
+    if (!isOpen && hasForwardedAction(iouReport.reportID)) {
         return false;
     }
     const currentRoute = navigationRef.getCurrentRoute();

--- a/tests/unit/canEditFieldOfMoneyRequestTest.ts
+++ b/tests/unit/canEditFieldOfMoneyRequestTest.ts
@@ -340,6 +340,32 @@ describe('canEditFieldOfMoneyRequest', () => {
                 // Then they should be able to move the expense since there are multiple outstanding expense reports
                 expect(canEditReportField).toBe(false);
             });
+
+            it('should return true when a forwarded expense report is rejected back to open state', async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${IOUReportID}`, {
+                    ...expenseReport,
+                    stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                    statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                });
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${IOUReportID}`, {
+                    1: {
+                        ...createRandomReportAction(1),
+                        actionName: CONST.REPORT.ACTIONS.TYPE.FORWARDED,
+                    },
+                });
+                await waitForBatchedUpdates();
+
+                const outstandingReportsByPolicyID = await OnyxUtils.get(ONYXKEYS.DERIVED.OUTSTANDING_REPORTS_BY_POLICY_ID);
+
+                const canEditReportField = canEditFieldOfMoneyRequest({
+                    reportAction,
+                    fieldToEdit: CONST.EDIT_REQUEST_FIELD.REPORT,
+                    outstandingReportsByPolicyID,
+                    transaction: moneyRequestTransaction,
+                });
+
+                expect(canEditReportField).toBe(true);
+            });
         });
 
         describe('Policy has Dynamic External Workflow', () => {


### PR DESCRIPTION
### Details
This updates the outstanding-report check so a report that has been rejected back to Draft/Open is still treated as movable even if an earlier approval cycle left a historical FORWARDED action in the report actions.

### Fixed Issues
$ 89624
PROPOSAL: N/A

### Tests
1. Added a unit regression covering an open expense report with a historical FORWARDED action.
2. Ran formatting and TS syntax transform checks on the changed files.

### Offline tests
- npx prettier@3.3.3 --check ReportUtils.ts canEditFieldOfMoneyRequestTest.ts
- npx esbuild@0.23.1 ReportUtils.ts --format=esm --outfile=/tmp/expensify-reportutils.js
- npx esbuild@0.23.1 canEditFieldOfMoneyRequestTest.ts --format=esm --outfile=/tmp/expensify-test.js