### PR TITLE
Fix invoice business bank account payments

### DIFF
--- a/src/hooks/usePaymentOptions.ts
+++ b/src/hooks/usePaymentOptions.ts
@@ -17,6 +17,7 @@ import Navigation from '@navigation/Navigation';
 import {isCurrencySupportedForGlobalReimbursement} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import type {AccountData, BankAccountList, FundList, LastPaymentMethod} from '@src/types/onyx';
 import {getEmptyObject, isEmptyObject} from '@src/types/utils/EmptyObject';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
@@ -100,6 +101,7 @@ function usePaymentOptions({
     const isLoadingLastPaymentMethod = isLoadingOnyxValue(lastPaymentMethodResult);
     const [bankAccountList = getEmptyObject<BankAccountList>()] = useOnyx(ONYXKEYS.BANK_ACCOUNT_LIST);
     const [fundList = getEmptyObject<FundList>()] = useOnyx(ONYXKEYS.FUND_LIST);
+    const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     const {isBetaEnabled} = usePermissions();
     const isPayInvoiceViaExpensifyBetaEnabled = isBetaEnabled(CONST.BETAS.PAY_INVOICE_VIA_EXPENSIFY);
     const lastPaymentMethodRef = useRef(lastPaymentMethod);
@@ -191,14 +193,18 @@ function usePaymentOptions({
                     }));
             };
 
-            const addBankAccountItem = {
+            const getAddBankAccountItem = (payAsBusiness: boolean) => ({
                 text: translate('bankAccount.addBankAccount'),
                 icon: icons.Bank,
                 onSelected: () => {
-                    const bankAccountRoute = getBankAccountRoute(chatReport);
+                    const businessBankAccountPolicyID = activePolicyID ?? policyID;
+                    const bankAccountRoute =
+                        payAsBusiness && businessBankAccountPolicyID && businessBankAccountPolicyID !== CONST.POLICY.ID_FAKE
+                            ? ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({policyID: businessBankAccountPolicyID, backTo: Navigation.getActiveRoute()})
+                            : getBankAccountRoute(chatReport);
                     Navigation.navigate(bankAccountRoute);
                 },
-            };
+            });
 
             if (isIndividualInvoiceRoomUtil(chatReport)) {
                 buttonOptions.push({
@@ -214,7 +220,7 @@ function usePaymentOptions({
                             value: CONST.IOU.PAYMENT_TYPE.ELSEWHERE,
                             onSelected: () => onPress({paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE}),
                         },
-                        ...(showPayViaExpensifyOptions ? [addBankAccountItem] : []),
+                        ...(showPayViaExpensifyOptions ? [getAddBankAccountItem(false)] : []),
                     ],
                 });
             }
@@ -226,7 +232,7 @@ function usePaymentOptions({
                 backButtonText: translate('iou.business'),
                 subMenuItems: [
                     ...(showPayViaExpensifyOptions ? getPaymentSubItems(true) : []),
-                    ...(showPayViaExpensifyOptions ? [addBankAccountItem] : []),
+                    ...(showPayViaExpensifyOptions ? [getAddBankAccountItem(true)] : []),
                     {
                         text: translate('iou.payElsewhere', ''),
                         icon: icons.Cash,
@@ -265,6 +271,8 @@ function usePaymentOptions({
         onPress,
         onlyShowPayElsewhere,
         icons,
+        policyID,
+        activePolicyID,
     ]);
 
     return paymentButtonOptions;

--- a/src/libs/actions/IOU/PayMoneyRequest.ts
+++ b/src/libs/actions/IOU/PayMoneyRequest.ts
@@ -857,7 +857,7 @@ function payInvoice({
         payAsBusiness,
     };
 
-    if (paymentMethod === CONST.PAYMENT_METHODS.PERSONAL_BANK_ACCOUNT) {
+    if (paymentMethod === CONST.PAYMENT_METHODS.PERSONAL_BANK_ACCOUNT || paymentMethod === CONST.PAYMENT_METHODS.BUSINESS_BANK_ACCOUNT) {
         params.bankAccountID = methodID;
     }
 

--- a/tests/actions/IOUTest/PayMoneyRequestTest.ts
+++ b/tests/actions/IOUTest/PayMoneyRequestTest.ts
@@ -3,11 +3,13 @@ import Onyx from 'react-native-onyx';
 import type {OnyxEntry, OnyxInputValue} from 'react-native-onyx';
 import * as Hold from '@libs/actions/IOU/Hold';
 import {putOnHold} from '@libs/actions/IOU/Hold';
-import {cancelPayment, completePaymentOnboarding, payMoneyRequest} from '@libs/actions/IOU/PayMoneyRequest';
+import {cancelPayment, completePaymentOnboarding, payInvoice, payMoneyRequest} from '@libs/actions/IOU/PayMoneyRequest';
 import {requestMoney} from '@libs/actions/IOU/TrackExpense';
 import initOnyxDerivedValues from '@libs/actions/OnyxDerived';
 import {createWorkspace, generatePolicyID} from '@libs/actions/Policy/Policy';
 import {notifyNewAction} from '@libs/actions/Report';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
 import type * as PolicyUtils from '@libs/PolicyUtils';
 import {getOriginalMessage, getReportActionHtml, getReportActionText, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import * as ReportUtils from '@libs/ReportUtils';
@@ -120,6 +122,65 @@ describe('actions/IOU/PayMoneyRequest', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+    });
+
+    describe('payInvoice', () => {
+        it('passes the selected business bank account ID to PayInvoice', () => {
+            const bankAccountID = 123;
+            const policyID = 'policyID';
+            const chatReport = {
+                reportID: '1',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.INVOICE,
+                policyID,
+                invoiceReceiver: {
+                    type: CONST.REPORT.INVOICE_RECEIVER_TYPE.INDIVIDUAL,
+                },
+            } as Report;
+            const invoiceReport = {
+                reportID: '2',
+                chatReportID: chatReport.reportID,
+                type: CONST.REPORT.TYPE.INVOICE,
+                ownerAccountID: CARLOS_ACCOUNT_ID,
+                total: 10000,
+                currency: CONST.CURRENCY.USD,
+                policyID,
+            } as Report;
+            const activePolicy = {
+                ...createRandomPolicy(0, CONST.POLICY.TYPE.TEAM),
+                id: policyID,
+                role: CONST.POLICY.ROLE.ADMIN,
+                ownerAccountID: RORY_ACCOUNT_ID,
+            } as Policy;
+            const writeSpy = jest.spyOn(API, 'write').mockImplementation();
+
+            payInvoice({
+                paymentMethodType: CONST.IOU.PAYMENT_TYPE.VBBA,
+                chatReport,
+                invoiceReport,
+                introSelected: undefined,
+                invoiceReportCurrentNextStepDeprecated: undefined,
+                currentUserAccountIDParam: RORY_ACCOUNT_ID,
+                currentUserEmailParam: RORY_EMAIL,
+                payAsBusiness: true,
+                methodID: bankAccountID,
+                paymentMethod: CONST.PAYMENT_METHODS.BUSINESS_BANK_ACCOUNT,
+                activePolicy,
+                betas: [],
+                isSelfTourViewed: false,
+                defaultWorkspaceName: 'Workspace',
+            });
+
+            expect(writeSpy).toHaveBeenCalledWith(
+                WRITE_COMMANDS.PAY_INVOICE,
+                expect.objectContaining({
+                    bankAccountID,
+                    paymentMethodType: CONST.IOU.PAYMENT_TYPE.VBBA,
+                    payAsBusiness: true,
+                }),
+                expect.any(Object),
+            );
+        });
     });
 
     describe('payMoneyRequestElsewhere', () => {

--- a/tests/unit/hooks/usePaymentOptions.test.ts
+++ b/tests/unit/hooks/usePaymentOptions.test.ts
@@ -1,0 +1,76 @@
+import {renderHook} from '@testing-library/react-native';
+import Navigation from '@navigation/Navigation';
+import CONST from '@src/CONST';
+import usePaymentOptions from '@src/hooks/usePaymentOptions';
+import ROUTES from '@src/ROUTES';
+import type {Report} from '@src/types/onyx';
+
+const mockChatReportID = '1';
+const mockActivePolicyID = 'activePolicyID';
+
+const mockChatReport = {
+    reportID: mockChatReportID,
+    type: CONST.REPORT.TYPE.CHAT,
+    chatType: CONST.REPORT.CHAT_TYPE.INVOICE,
+    invoiceReceiver: {
+        type: CONST.REPORT.INVOICE_RECEIVER_TYPE.INDIVIDUAL,
+    },
+} as Report;
+
+jest.mock('@src/hooks/useCurrentUserPersonalDetails', () => jest.fn(() => ({accountID: 1})));
+jest.mock('@src/hooks/useLazyAsset', () => ({
+    useMemoizedLazyExpensifyIcons: () => ({
+        Bank: 'bank',
+        Building: 'building',
+        Cash: 'cash',
+        CheckCircle: 'check-circle',
+        ThumbsUp: 'thumbs-up',
+        User: 'user',
+        Wallet: 'wallet',
+    }),
+}));
+jest.mock('@src/hooks/useLocalize', () => jest.fn(() => ({translate: (key: string) => key})));
+jest.mock('@src/hooks/usePermissions', () => jest.fn(() => ({isBetaEnabled: () => true})));
+jest.mock('@src/hooks/usePolicy', () => jest.fn(() => undefined));
+jest.mock('@src/hooks/useThemeStyles', () => jest.fn(() => ({})));
+jest.mock('@src/hooks/useOnyx', () => {
+    const mockOnyxKeys = jest.requireActual('@src/ONYXKEYS').default;
+    return jest.fn((key: string) => {
+        if (key === `${mockOnyxKeys.COLLECTION.REPORT}${mockChatReportID}`) {
+            return [mockChatReport, {status: 'loaded'}];
+        }
+        if (key === mockOnyxKeys.NVP_ACTIVE_POLICY_ID) {
+            return [mockActivePolicyID, {status: 'loaded'}];
+        }
+        return [undefined, {status: 'loaded'}];
+    });
+});
+jest.mock('@navigation/Navigation', () => ({
+    getActiveRoute: jest.fn(() => 'invoice/report'),
+    navigate: jest.fn(),
+}));
+
+describe('usePaymentOptions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('routes invoice business add-bank-account to the active workspace bank account flow', () => {
+        const {result} = renderHook(() =>
+            usePaymentOptions({
+                chatReportID: mockChatReportID,
+                currency: CONST.CURRENCY.USD,
+                iouReport: {type: CONST.REPORT.TYPE.INVOICE} as Report,
+                onPress: jest.fn(),
+                policyID: CONST.POLICY.ID_FAKE,
+            }),
+        );
+
+        const businessOption = result.current.find((option) => option.text === 'iou.settleBusiness');
+        const addBankAccountOption = businessOption?.subMenuItems?.find((option) => option.text === 'bankAccount.addBankAccount');
+
+        addBankAccountOption?.onSelected?.();
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({policyID: mockActivePolicyID, backTo: 'invoice/report'}));
+    });
+});


### PR DESCRIPTION
## Summary
- Fix invoice business-bank-account payments to send `bankAccountID` to `PayInvoice`.
- Route invoice business **Add bank account** to the active workspace bank-account setup flow, while keeping personal invoice **Add bank account** on the existing personal route.
- Add regression coverage for selected business bank account payment and business add-bank-account routing.

$ #88464

## Test Plan
- `npx prettier --write src/hooks/usePaymentOptions.ts src/libs/actions/IOU/PayMoneyRequest.ts tests/unit/hooks/usePaymentOptions.test.ts tests/actions/IOUTest/PayMoneyRequestTest.ts`
- `npm run test -- tests/actions/IOUTest/PayMoneyRequestTest.ts --runInBand -t "passes the selected business bank account ID"`
- `npm run test -- tests/unit/hooks/usePaymentOptions.test.ts --runInBand`

## Notes
- A broader combined Jest command over both touched test files timed out locally without failure output, so the targeted regression commands above are the completed verification.
- `npm run typecheck-tsgo` still reports unrelated pre-existing GPS/map typing errors outside this change; the introduced PayMoneyRequest typing error found during review was fixed before submission.
