### PR TITLE
fix: avoid QBO fallback link for Intacct export history

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -2741,6 +2741,11 @@ function getExportIntegrationActionFragments(translate: LocalizedTranslate, repo
                     // The first three characters in a Salesforce ID is the expense type
                     url = nonReimbursableUrls.at(0)?.substring(0, SALESFORCE_EXPENSES_URL_PREFIX.length + 3) ?? '';
                     break;
+                case CONST.EXPORT_LABELS.INTACCT:
+                case CONST.EXPORT_LABELS.SAGE_INTACCT:
+                    // Intacct exports store IDs instead of browsable URLs.
+                    url = '';
+                    break;
                 default:
                     url = QBO_EXPENSES_URL;
             }

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -5339,4 +5339,42 @@ describe('ReportActionsUtils', () => {
             expect(getModerationFlagState(action)).toEqual({latestDecision: undefined, hasBeenFlagged: false});
         });
     });
+
+    describe('getExportIntegrationActionFragments', () => {
+        function buildExportedToIntegrationAction(label: string): ReportAction {
+            return {
+                ...createRandomReportAction(0),
+                actionName: CONST.REPORT.ACTIONS.TYPE.EXPORTED_TO_INTEGRATION,
+                reportID: '12345',
+                created: '2026-05-13 00:00:00',
+                originalMessage: {
+                    label,
+                    markedManually: false,
+                    automaticAction: false,
+                    nonReimbursableUrls: ['id-1', 'id-2'],
+                },
+            } as ReportAction;
+        }
+
+        it('does not generate a non-reimbursable URL for Intacct exports', () => {
+            const action = buildExportedToIntegrationAction(CONST.EXPORT_LABELS.INTACCT);
+            const fragments = ReportActionsUtils.getExportIntegrationActionFragments(translateLocal, action);
+
+            expect(fragments.at(2)?.url).toBe('');
+        });
+
+        it('does not generate a non-reimbursable URL for Sage Intacct exports', () => {
+            const action = buildExportedToIntegrationAction(CONST.EXPORT_LABELS.SAGE_INTACCT);
+            const fragments = ReportActionsUtils.getExportIntegrationActionFragments(translateLocal, action);
+
+            expect(fragments.at(2)?.url).toBe('');
+        });
+
+        it('keeps the existing QBO non-reimbursable URL for QBO exports', () => {
+            const action = buildExportedToIntegrationAction(CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY.quickbooksOnline);
+            const fragments = ReportActionsUtils.getExportIntegrationActionFragments(translateLocal, action);
+
+            expect(fragments.at(2)?.url).toBe('https://qbo.intuit.com/app/expenses');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- fix NewDot export history link generation for multi-entry non-reimbursable Intacct exports
- handle both server labels (`Intacct`) and friendly labels (`Sage Intacct`)
- keep existing behavior for other integrations, including QBO

## Root cause
In `getExportIntegrationActionFragments`, the multi-entry non-reimbursable branch falls through to `default` and assigns `QBO_EXPENSES_URL` when no case matches the integration label. Intacct labels were not handled in this switch, so Intacct IDs were incorrectly linked to QBO.

## Changes
- added explicit switch cases for:
  - `CONST.EXPORT_LABELS.INTACCT`
  - `CONST.EXPORT_LABELS.SAGE_INTACCT`
- these cases now return an empty link URL (`''`) because Intacct exports store IDs, not browsable URLs
- added unit coverage in `tests/unit/ReportActionsUtilsTest.ts` for:
  - `Intacct` multi-entry non-reimbursable exports => no URL
  - `Sage Intacct` multi-entry non-reimbursable exports => no URL
  - QBO multi-entry non-reimbursable exports => still uses `QBO_EXPENSES_URL`

$ #90386

## Test notes
- Could not run tests in this environment because dependency install failed with `ENOSPC` (disk full) while linking `node_modules`.
- Added focused unit tests for CI validation.
