### PR TITLE
perf(search): stabilize columns reference

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -25,6 +25,7 @@ import usePrevious from '@hooks/usePrevious';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSearchHighlightAndScroll from '@hooks/useSearchHighlightAndScroll';
 import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
+import useStableArrayReference from '@hooks/useStableArrayReference';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {turnOffMobileSelectionMode, turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import {saveLastSearchParams} from '@libs/actions/ReportNavigation';
@@ -78,7 +79,6 @@ import type {OutstandingReportsByPolicyIDDerivedValue, Report, SaveSearch, Trans
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import type SearchResults from '@src/types/onyx/SearchResults';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
-import arraysEqual from '@src/utils/arraysEqual';
 import SearchChartView from './SearchChartView';
 import SearchChartWrapper from './SearchChartWrapper';
 import {useSearchActionsContext, useSearchStateContext} from './SearchContext';
@@ -118,6 +118,8 @@ const OPTIMISTIC_TRACKING_TIMEOUT_MS = 10_000;
 const OPTIMISTIC_ROLLBACK_GRACE_MS = OPTIMISTIC_TRACKING_TIMEOUT_MS * 0.3;
 
 const hashToString = (queryHash?: number) => (queryHash || queryHash === 0 ? String(queryHash) : undefined);
+
+const EMPTY_COLUMNS: SearchColumnType[] = [];
 
 function mapTransactionItemToSelectedEntry(
     item: TransactionListItemType,
@@ -1268,12 +1270,17 @@ function Search({
 
     const shouldUseStrictDefaultExpenseColumns = currentSearchKey === CONST.SEARCH.SEARCH_KEYS.EXPENSES && isDefaultExpensesQuery(queryJSON);
 
-    const currentColumns = useMemo(() => {
+    const computedColumns = useMemo(() => {
         if (!searchResults?.data) {
-            return [];
+            return EMPTY_COLUMNS;
         }
         return getColumnsToShow({currentAccountID: accountID, data: searchResults?.data, visibleColumns, type: searchDataType, groupBy: validGroupBy, shouldUseStrictDefaultExpenseColumns});
     }, [accountID, searchResults?.data, searchDataType, visibleColumns, validGroupBy, shouldUseStrictDefaultExpenseColumns]);
+
+    // getColumnsToShow allocates a fresh array on every call; preserve the previous reference
+    // when contents are equal so downstream consumers don't re-render on Onyx snapshot churn
+    // (e.g. opening a report bumps searchResults.data) that doesn't actually change the columns.
+    const currentColumns = useStableArrayReference(computedColumns);
 
     const opacity = useSharedValue(1);
     const animatedStyle = useAnimatedStyle(() => ({
@@ -1281,12 +1288,12 @@ function Search({
     }));
 
     const previousColumns = usePrevious(currentColumns);
-    const [columnsToShow, setColumnsToShow] = useState<SearchColumnType[]>([]);
+    const [columnsToShow, setColumnsToShow] = useState<SearchColumnType[]>(EMPTY_COLUMNS);
 
     // If columns have changed, trigger an animation before settings columnsToShow to prevent
     // new columns appearing before the fade out animation happens
     useEffect(() => {
-        if ((previousColumns && currentColumns && arraysEqual(previousColumns, currentColumns)) || offset === 0 || isSmallScreenWidth) {
+        if (previousColumns === currentColumns || offset === 0 || isSmallScreenWidth) {
             setColumnsToShow(currentColumns);
             return;
         }

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -79,6 +79,7 @@ import type {OutstandingReportsByPolicyIDDerivedValue, Report, SaveSearch, Trans
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import type SearchResults from '@src/types/onyx/SearchResults';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import getEmptyArray from '@src/types/utils/getEmptyArray';
 import SearchChartView from './SearchChartView';
 import SearchChartWrapper from './SearchChartWrapper';
 import {useSearchActionsContext, useSearchStateContext} from './SearchContext';
@@ -118,8 +119,6 @@ const OPTIMISTIC_TRACKING_TIMEOUT_MS = 10_000;
 const OPTIMISTIC_ROLLBACK_GRACE_MS = OPTIMISTIC_TRACKING_TIMEOUT_MS * 0.3;
 
 const hashToString = (queryHash?: number) => (queryHash || queryHash === 0 ? String(queryHash) : undefined);
-
-const EMPTY_COLUMNS: SearchColumnType[] = [];
 
 function mapTransactionItemToSelectedEntry(
     item: TransactionListItemType,
@@ -1272,7 +1271,7 @@ function Search({
 
     const computedColumns = useMemo(() => {
         if (!searchResults?.data) {
-            return EMPTY_COLUMNS;
+            return getEmptyArray<SearchColumnType>();
         }
         return getColumnsToShow({currentAccountID: accountID, data: searchResults?.data, visibleColumns, type: searchDataType, groupBy: validGroupBy, shouldUseStrictDefaultExpenseColumns});
     }, [accountID, searchResults?.data, searchDataType, visibleColumns, validGroupBy, shouldUseStrictDefaultExpenseColumns]);
@@ -1288,7 +1287,7 @@ function Search({
     }));
 
     const previousColumns = usePrevious(currentColumns);
-    const [columnsToShow, setColumnsToShow] = useState<SearchColumnType[]>(EMPTY_COLUMNS);
+    const [columnsToShow, setColumnsToShow] = useState<SearchColumnType[]>(getEmptyArray);
 
     // If columns have changed, trigger an animation before settings columnsToShow to prevent
     // new columns appearing before the fade out animation happens

--- a/src/hooks/useStableArrayReference.ts
+++ b/src/hooks/useStableArrayReference.ts
@@ -1,0 +1,26 @@
+import {useState} from 'react';
+import arraysEqual from '@src/utils/arraysEqual';
+
+/**
+ * Preserves the previous array reference when its contents are equal.
+ *
+ * Useful for absorbing fresh array allocations from pure derivation utilities
+ * (e.g. functions returning `.filter(...)`/`.map(...)` results) so downstream
+ * consumers don't re-render on identity churn that doesn't reflect a real change.
+ *
+ * Uses the "storing information from previous renders" pattern documented at
+ * https://react.dev/reference/react/useState#storing-information-from-previous-renders
+ * — the equality check bounds the re-render loop to a single extra pass.
+ */
+function useStableArrayReference<T>(value: T[]): T[] {
+    const [stable, setStable] = useState<T[]>(value);
+    const isEqual = arraysEqual(stable, value);
+
+    if (!isEqual) {
+        setStable(value);
+    }
+    
+    return isEqual ? stable : value;
+}
+
+export default useStableArrayReference;

--- a/src/hooks/useStableArrayReference.ts
+++ b/src/hooks/useStableArrayReference.ts
@@ -19,7 +19,7 @@ function useStableArrayReference<T>(value: T[]): T[] {
     if (!isEqual) {
         setStable(value);
     }
-    
+
     return isEqual ? stable : value;
 }
 

--- a/tests/unit/hooks/useStableArrayReference.test.ts
+++ b/tests/unit/hooks/useStableArrayReference.test.ts
@@ -1,0 +1,95 @@
+import {renderHook} from '@testing-library/react-native';
+import useStableArrayReference from '@hooks/useStableArrayReference';
+
+describe('useStableArrayReference', () => {
+    it('returns the input array on the first render', () => {
+        const input = [1, 2, 3];
+        const {result} = renderHook(({value}: {value: number[]}) => useStableArrayReference(value), {initialProps: {value: input}});
+
+        expect(result.current).toBe(input);
+    });
+
+    it('preserves the previous reference when contents are equal but the array is new', () => {
+        const initial = [1, 2, 3];
+        const {result, rerender} = renderHook(({value}: {value: number[]}) => useStableArrayReference(value), {initialProps: {value: initial}});
+        const firstReference = result.current;
+
+        rerender({value: [1, 2, 3]});
+
+        expect(result.current).toBe(firstReference);
+    });
+
+    it('returns the new reference when contents change', () => {
+        const initial = [1, 2, 3];
+        const next = [1, 2, 4];
+        const {result, rerender} = renderHook(({value}: {value: number[]}) => useStableArrayReference(value), {initialProps: {value: initial}});
+
+        rerender({value: next});
+
+        expect(result.current).toBe(next);
+    });
+
+    it('returns the new reference when array length changes', () => {
+        const initial = [1, 2, 3];
+        const longer = [1, 2, 3, 4];
+        const {result, rerender} = renderHook(({value}: {value: number[]}) => useStableArrayReference(value), {initialProps: {value: initial}});
+
+        rerender({value: longer});
+
+        expect(result.current).toBe(longer);
+    });
+
+    it('keeps the same reference across multiple content-equal renders', () => {
+        const initial = ['a', 'b'];
+        const {result, rerender} = renderHook(({value}: {value: string[]}) => useStableArrayReference(value), {initialProps: {value: initial}});
+        const firstReference = result.current;
+
+        rerender({value: ['a', 'b']});
+        rerender({value: ['a', 'b']});
+        rerender({value: ['a', 'b']});
+
+        expect(result.current).toBe(firstReference);
+    });
+
+    it('stabilizes on the new reference after a content change, then preserves it', () => {
+        const initial = [1, 2];
+        const changed = [1, 2, 3];
+        const {result, rerender} = renderHook(({value}: {value: number[]}) => useStableArrayReference(value), {initialProps: {value: initial}});
+
+        rerender({value: changed});
+        const referenceAfterChange = result.current;
+
+        rerender({value: [1, 2, 3]});
+        expect(result.current).toBe(referenceAfterChange);
+    });
+
+    it('handles transitions involving empty arrays', () => {
+        const initial: number[] = [];
+        const {result, rerender} = renderHook(({value}: {value: number[]}) => useStableArrayReference(value), {initialProps: {value: initial}});
+        const firstReference = result.current;
+
+        rerender({value: []});
+        expect(result.current).toBe(firstReference);
+
+        const populated = [1];
+        rerender({value: populated});
+        expect(result.current).toBe(populated);
+
+        rerender({value: []});
+        expect(result.current).not.toBe(firstReference);
+        expect(result.current).toEqual([]);
+    });
+
+    it('treats element identity as the equality check (object refs matter)', () => {
+        const objectA = {id: 1};
+        const objectB = {id: 1};
+        const initial = [objectA];
+        const {result, rerender} = renderHook(({value}: {value: Array<{id: number}>}) => useStableArrayReference(value), {initialProps: {value: initial}});
+        const firstReference = result.current;
+
+        rerender({value: [objectB]});
+
+        expect(result.current).not.toBe(firstReference);
+        expect(result.current.at(0)).toBe(objectB);
+    });
+});


### PR DESCRIPTION


### Explanation of Change

Opening a report from Search causes SearchList and all rows to re-render unnecessarily.

One of the issues is that `getColumnsToShow` always returned a new array reference, even when the contents were identical. When report-related Onyx updates changed `searchResults.data` by reference, `currentColumns` also got a new reference, which triggered downstream re-renders.

The fix adds `useStableArrayReference` hook to preserve array references when contents are unchanged. It replaces previous `useMemo` and `arraysEqual` logic in Search.

### Fixed Issues

$ https://github.com/Expensify/App/issues/90432
PROPOSAL:




### Tests

1. Open Spends tab
2. Go to Expenses
3. Press "Date"
4. Verify sort type changed
5. Press "Display" -> "Edit columns"
6. Hide any column and save
7. Verify column disappeared

- [x] Verify that no errors appear in the JS console

### Offline tests


N/A

### QA Steps


Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari

https://github.com/user-attachments/assets/d9869df7-3129-44b2-94d8-be7b4969f346




