### PR TITLE
Fix quick action route-selected expense tabs

### DIFF
--- a/src/hooks/useResetIOUType.ts
+++ b/src/hooks/useResetIOUType.ts
@@ -80,7 +80,7 @@ function useResetIOUType({
             Keyboard.dismiss();
         }
 
-        if (transaction?.iouRequestType === newIOUType) {
+        if (transaction?.iouRequestType === newIOUType && transaction?.reportID === reportID) {
             return;
         }
 

--- a/src/libs/Navigation/OnyxTabNavigator.tsx
+++ b/src/libs/Navigation/OnyxTabNavigator.tsx
@@ -24,6 +24,9 @@ type OnyxTabNavigatorProps<TTabName extends string = SelectedTabRequest> = Child
     /** Name of the selected tab */
     defaultSelectedTab?: TTabName;
 
+    /** Initial tab selected by the current route */
+    routeSelectedTab?: TTabName;
+
     /** A function triggered when a tab has been selected */
     onTabSelected?: (newTabName: TTabName) => void;
 
@@ -63,6 +66,16 @@ type OnyxTabNavigatorProps<TTabName extends string = SelectedTabRequest> = Child
     equalWidth?: boolean;
 };
 
+type RouteWithNestedTabState = {
+    params?: unknown;
+    state?: {
+        index?: number;
+        routes?: Array<{
+            name?: unknown;
+        }>;
+    };
+};
+
 const TopTab = createMaterialTopTabNavigator<ParamListBase, string>();
 
 // The TabFocusTrapContext is to collect the focus trap container element of each tab screen.
@@ -87,12 +100,40 @@ const getTabNames = (children: React.ReactNode): string[] => {
     return result;
 };
 
+function getSelectedTabFromRoute(route: RouteWithNestedTabState | undefined, tabNames: string[]): string | undefined {
+    const nestedRoutes = route?.state?.routes;
+    const nestedIndex = typeof route?.state?.index === 'number' ? route.state.index : (nestedRoutes?.length ?? 0) - 1;
+    const selectedTabFromState = nestedRoutes?.at(nestedIndex)?.name;
+    const selectedTabFromParams = route?.params && typeof route.params === 'object' && 'screen' in route.params ? route.params.screen : undefined;
+    const selectedTabFromRoute = typeof selectedTabFromState === 'string' ? selectedTabFromState : selectedTabFromParams;
+
+    if (typeof selectedTabFromRoute !== 'string' || !tabNames.includes(selectedTabFromRoute)) {
+        return undefined;
+    }
+
+    return selectedTabFromRoute;
+}
+
+function getInitialTabName<TTabName extends string>(
+    tabNames: string[],
+    selectedTab: string | undefined,
+    defaultSelectedTab: TTabName | undefined,
+    routeSelectedTab?: TTabName,
+): TTabName | undefined {
+    if (routeSelectedTab && tabNames.includes(routeSelectedTab)) {
+        return routeSelectedTab;
+    }
+
+    return selectedTab && tabNames.includes(selectedTab) ? (selectedTab as TTabName) : defaultSelectedTab;
+}
+
 // This takes all the same props as MaterialTopTabsNavigator: https://reactnavigation.org/docs/material-top-tab-navigator/#props,
 // except ID is now required, and it gets a `selectedTab` from Onyx
 // It also takes 2 more optional callbacks to manage the focus trap container elements of the tab bar and the active tab
 function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
     id,
     defaultSelectedTab,
+    routeSelectedTab,
     tabBar: TabBar,
     children,
     onTabBarFocusTrapContainerElementChanged,
@@ -115,7 +156,7 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
 
     const tabNames = useMemo(() => getTabNames(children), [children]);
 
-    const validInitialTab = selectedTab && tabNames.includes(selectedTab) ? selectedTab : defaultSelectedTab;
+    const validInitialTab = getInitialTabName(tabNames, selectedTab, defaultSelectedTab, routeSelectedTab);
 
     const LazyPlaceholder = useCallback(() => {
         return (
@@ -188,15 +229,17 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
                         const state = event.data.state;
                         const index = state.index;
                         const routeNames = state.routeNames;
-                        if (isFirstMountRef.current) {
+                        const isFirstMount = isFirstMountRef.current;
+                        if (isFirstMount) {
                             onTabSelect?.({index});
                             isFirstMountRef.current = false;
                         }
                         const newSelectedTab = routeNames.at(index);
-                        if (selectedTab === newSelectedTab) {
+                        const shouldNotifyRouteSelectedTabOnMount = isFirstMount && routeSelectedTab === newSelectedTab;
+                        if (selectedTab === newSelectedTab && !shouldNotifyRouteSelectedTabOnMount) {
                             return;
                         }
-                        if (newSelectedTab) {
+                        if (newSelectedTab && selectedTab !== newSelectedTab) {
                             Tab.setSelectedTab<TTabName>(id, newSelectedTab as TTabName);
                         }
                         onTabSelected(newSelectedTab as TTabName);
@@ -256,4 +299,4 @@ function TabScreenWithFocusTrapWrapper({children}: {children?: React.ReactNode})
 
 export default OnyxTabNavigator;
 
-export {TabScreenWithFocusTrapWrapper, TopTab};
+export {getInitialTabName, getSelectedTabFromRoute, TabScreenWithFocusTrapWrapper, TopTab};

--- a/src/libs/actions/IOU/MoneyRequest.ts
+++ b/src/libs/actions/IOU/MoneyRequest.ts
@@ -1040,6 +1040,9 @@ function startDistanceRequest(
         case CONST.IOU.REQUEST_TYPE.DISTANCE_GPS:
             Navigation.navigate(ROUTES.DISTANCE_REQUEST_CREATE_TAB_GPS.getRoute(CONST.IOU.ACTION.CREATE, iouType, CONST.IOU.OPTIMISTIC_TRANSACTION_ID, reportID, backToReport));
             return;
+        case CONST.IOU.REQUEST_TYPE.DISTANCE_ODOMETER:
+            Navigation.navigate(ROUTES.DISTANCE_REQUEST_CREATE_TAB_ODOMETER.getRoute(CONST.IOU.ACTION.CREATE, iouType, CONST.IOU.OPTIMISTIC_TRANSACTION_ID, reportID, backToReport));
+            return;
         default:
             Navigation.navigate(ROUTES.DISTANCE_REQUEST_CREATE.getRoute(CONST.IOU.ACTION.CREATE, iouType, CONST.IOU.OPTIMISTIC_TRANSACTION_ID, reportID, backToReport));
     }

--- a/src/pages/iou/request/DistanceRequestStartPage.tsx
+++ b/src/pages/iou/request/DistanceRequestStartPage.tsx
@@ -12,7 +12,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
-import OnyxTabNavigator, {TabScreenWithFocusTrapWrapper, TopTab} from '@libs/Navigation/OnyxTabNavigator';
+import OnyxTabNavigator, {getSelectedTabFromRoute, TabScreenWithFocusTrapWrapper, TopTab} from '@libs/Navigation/OnyxTabNavigator';
 import {getPayeeName} from '@libs/ReportUtils';
 import {endSpan} from '@libs/telemetry/activeSpans';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
@@ -45,7 +45,7 @@ function DistanceRequestStartPage({
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${getNonEmptyStringOnyxID(route?.params.transactionID)}`);
     const {policy} = usePolicyForTransaction({transaction, reportPolicyID: report?.policyID, action, iouType});
-    const [selectedTab, selectedTabResult] = useOnyx(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.DISTANCE_REQUEST_TYPE}`);
+    const [lastSelectedTab, selectedTabResult] = useOnyx(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.DISTANCE_REQUEST_TYPE}`);
     const [lastDistanceExpenseType] = useOnyx(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE);
     const isLoadingSelectedTab = isLoadingOnyxValue(selectedTabResult);
     const isTrackDistanceExpense = iouType === CONST.IOU.TYPE.TRACK;
@@ -62,13 +62,18 @@ function DistanceRequestStartPage({
         [CONST.IOU.TYPE.CREATE]: translate('iou.trackDistance'),
     };
 
+    const availableTabs = useMemo(() => [CONST.TAB_REQUEST.DISTANCE_MAP, CONST.TAB_REQUEST.DISTANCE_MANUAL, CONST.TAB_REQUEST.DISTANCE_GPS, CONST.TAB_REQUEST.DISTANCE_ODOMETER], []);
+    const selectedTabFromRoute = getSelectedTabFromRoute(route, availableTabs) as SelectedTabRequest | undefined;
+    const selectedTab = selectedTabFromRoute ?? lastSelectedTab;
+    const isStaleTransactionDraft = !!transaction?.reportID && transaction.reportID !== reportID;
+
     const transactionRequestType = useMemo(() => {
-        if (!transaction?.iouRequestType) {
-            return lastDistanceExpenseType ?? selectedTab ?? CONST.IOU.REQUEST_TYPE.DISTANCE_MAP;
+        if (!transaction?.iouRequestType || isStaleTransactionDraft) {
+            return selectedTabFromRoute ?? lastDistanceExpenseType ?? lastSelectedTab ?? CONST.IOU.REQUEST_TYPE.DISTANCE_MAP;
         }
 
         return transaction.iouRequestType;
-    }, [transaction?.iouRequestType, selectedTab, lastDistanceExpenseType]);
+    }, [transaction?.iouRequestType, isStaleTransactionDraft, selectedTabFromRoute, lastDistanceExpenseType, lastSelectedTab]);
 
     const resetIOUTypeIfChanged = useResetIOUType({
         reportID,
@@ -122,6 +127,7 @@ function DistanceRequestStartPage({
                     <OnyxTabNavigator
                         id={CONST.TAB.DISTANCE_REQUEST_TYPE}
                         defaultSelectedTab={defaultSelectedTab}
+                        routeSelectedTab={selectedTabFromRoute}
                         onTabSelected={resetIOUTypeIfChanged}
                         tabBar={TabSelector}
                         onTabBarFocusTrapContainerElementChanged={setTabBarContainerElement}

--- a/src/pages/iou/request/IOURequestStartPage.tsx
+++ b/src/pages/iou/request/IOURequestStartPage.tsx
@@ -17,7 +17,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
-import OnyxTabNavigator, {TabScreenWithFocusTrapWrapper, TopTab} from '@libs/Navigation/OnyxTabNavigator';
+import OnyxTabNavigator, {getSelectedTabFromRoute, TabScreenWithFocusTrapWrapper, TopTab} from '@libs/Navigation/OnyxTabNavigator';
 import {
     getActivePoliciesWithExpenseChatAndPerDiemEnabledAndHasRates,
     getActivePoliciesWithExpenseChatAndTimeEnabled,
@@ -66,8 +66,6 @@ function IOURequestStartPage({
     const [reportDraft] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_DRAFT}${reportID}`);
     const policy = usePolicy(report?.policyID);
     const [lastSelectedTab, selectedTabResult] = useOnyx(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.IOU_REQUEST_TYPE}`);
-    // Derive selectedTab directly instead of using state
-    const selectedTab = lastSelectedTab;
 
     const isLoadingSelectedTab = shouldUseTab ? isLoadingOnyxValue(selectedTabResult) : false;
     const [transaction, transactionResult] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${getNonEmptyStringOnyxID(route?.params.transactionID)}`);
@@ -139,6 +137,8 @@ function IOURequestStartPage({
         }
         return tabs;
     }, [shouldUseTab, iouType, shouldShowPerDiemOption, shouldShowTimeOption]);
+    const selectedTabFromRoute = getSelectedTabFromRoute(route, [...availableTabs]) as SelectedTabRequest | undefined;
+    const selectedTab = selectedTabFromRoute ?? lastSelectedTab;
 
     // A quick-action deeplink (e.g. iOS home-screen "Scan receipt") bypasses startMoneyRequest
     // and leaves the previous flow's draft in place under OPTIMISTIC_TRANSACTION_ID. Detect it
@@ -154,11 +154,14 @@ function IOURequestStartPage({
         }
         // selectedTab must be valid for the currently-rendered tab set; otherwise let
         // OnyxTabNavigator.onTabSelected initialize from the URL (which is authoritative).
-        if (selectedTab && availableTabs.has(selectedTab)) {
-            return selectedTab;
+        if (selectedTabFromRoute) {
+            return selectedTabFromRoute;
+        }
+        if (lastSelectedTab && availableTabs.has(lastSelectedTab)) {
+            return lastSelectedTab;
         }
         return undefined;
-    }, [transaction?.iouRequestType, isStaleTransactionDraft, shouldUseTab, selectedTab, availableTabs]);
+    }, [transaction?.iouRequestType, isStaleTransactionDraft, shouldUseTab, selectedTabFromRoute, lastSelectedTab, availableTabs]);
 
     const resetIOUTypeIfChanged = useResetIOUType({
         reportID,
@@ -233,6 +236,7 @@ function IOURequestStartPage({
                             <OnyxTabNavigator
                                 id={CONST.TAB.IOU_REQUEST_TYPE}
                                 defaultSelectedTab={defaultSelectedTab}
+                                routeSelectedTab={selectedTabFromRoute}
                                 onTabSelected={resetIOUTypeIfChanged}
                                 onTabSelect={onTabSelectFocusHandler}
                                 tabBar={TabSelector}

--- a/tests/actions/IOU/MoneyRequestTest.ts
+++ b/tests/actions/IOU/MoneyRequestTest.ts
@@ -1,7 +1,13 @@
 import type {OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import type {MoneyRequestStepScanParticipantsFlowParams} from '@libs/actions/IOU/MoneyRequest';
-import {createTransaction, getMoneyRequestParticipantOptions, handleMoneyRequestStepDistanceNavigation, handleMoneyRequestStepScanParticipants} from '@libs/actions/IOU/MoneyRequest';
+import {
+    createTransaction,
+    getMoneyRequestParticipantOptions,
+    handleMoneyRequestStepDistanceNavigation,
+    handleMoneyRequestStepScanParticipants,
+    startDistanceRequest,
+} from '@libs/actions/IOU/MoneyRequest';
 import getCurrentPosition from '@libs/getCurrentPosition';
 import {GeolocationErrorCode} from '@libs/getCurrentPosition/getCurrentPosition.types';
 import Navigation from '@libs/Navigation/Navigation';
@@ -1595,6 +1601,23 @@ describe('MoneyRequest', () => {
             };
             const participants = getMoneyRequestParticipantOptions(currentUserAccountID, dmReport, fakePolicy, {}, undefined);
             expect(Array.isArray(participants)).toBe(true);
+        });
+    });
+
+    describe('startDistanceRequest', () => {
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should navigate directly to the odometer distance tab', () => {
+            const reportID = '123';
+            const backToReport = '456';
+
+            startDistanceRequest(CONST.IOU.TYPE.SUBMIT, reportID, [], CONST.IOU.REQUEST_TYPE.DISTANCE_ODOMETER, true, backToReport);
+
+            expect(Navigation.navigate).toHaveBeenCalledWith(
+                ROUTES.DISTANCE_REQUEST_CREATE_TAB_ODOMETER.getRoute(CONST.IOU.ACTION.CREATE, CONST.IOU.TYPE.SUBMIT, CONST.IOU.OPTIMISTIC_TRANSACTION_ID, reportID, backToReport),
+            );
         });
     });
 

--- a/tests/ui/IOURequestStartPageTest.tsx
+++ b/tests/ui/IOURequestStartPageTest.tsx
@@ -86,4 +86,98 @@ describe('IOURequestStartPage', () => {
         });
         expect(iouRequestType).toBe(CONST.IOU.REQUEST_TYPE.MANUAL);
     });
+
+    it('uses the route-selected scan tab when a stale manual tab is persisted', async () => {
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.IOU_REQUEST_TYPE}`, CONST.TAB_REQUEST.MANUAL);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${CONST.IOU.OPTIMISTIC_TRANSACTION_ID}`, {
+                reportID: 'old-report',
+                iouRequestType: CONST.IOU.REQUEST_TYPE.MANUAL,
+            });
+        });
+
+        render(
+            <OnyxListItemProvider>
+                <LocaleContextProvider>
+                    <NavigationContainer>
+                        <IOURequestStartPage
+                            route={
+                                {
+                                    params: {iouType: CONST.IOU.TYPE.SUBMIT, reportID: '1', transactionID: CONST.IOU.OPTIMISTIC_TRANSACTION_ID},
+                                    state: {
+                                        index: 0,
+                                        routes: [{name: CONST.TAB_REQUEST.SCAN}],
+                                    },
+                                } as unknown as PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.CREATE>['route']
+                            }
+                            report={undefined}
+                            reportDraft={undefined}
+                            navigation={{} as PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.CREATE>['navigation']}
+                            defaultSelectedTab={CONST.TAB_REQUEST.MANUAL}
+                        />
+                    </NavigationContainer>
+                </LocaleContextProvider>
+            </OnyxListItemProvider>,
+        );
+
+        await waitForBatchedUpdatesWithAct();
+
+        const iouRequestType = await new Promise<OnyxEntry<IOURequestType>>((resolve) => {
+            const connection = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${CONST.IOU.OPTIMISTIC_TRANSACTION_ID}`,
+                callback: (val) => {
+                    resolve(val?.iouRequestType);
+                    Onyx.disconnect(connection);
+                },
+            });
+        });
+        expect(iouRequestType).toBe(CONST.IOU.REQUEST_TYPE.SCAN);
+    });
+
+    it('rebuilds a stale draft when the route-selected tab matches the stale request type', async () => {
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SELECTED_TAB}${CONST.TAB.IOU_REQUEST_TYPE}`, CONST.TAB_REQUEST.SCAN);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${CONST.IOU.OPTIMISTIC_TRANSACTION_ID}`, {
+                reportID: 'old-report',
+                iouRequestType: CONST.IOU.REQUEST_TYPE.SCAN,
+            });
+        });
+
+        render(
+            <OnyxListItemProvider>
+                <LocaleContextProvider>
+                    <NavigationContainer>
+                        <IOURequestStartPage
+                            route={
+                                {
+                                    params: {iouType: CONST.IOU.TYPE.SUBMIT, reportID: '1', transactionID: CONST.IOU.OPTIMISTIC_TRANSACTION_ID},
+                                    state: {
+                                        index: 0,
+                                        routes: [{name: CONST.TAB_REQUEST.SCAN}],
+                                    },
+                                } as unknown as PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.CREATE>['route']
+                            }
+                            report={undefined}
+                            reportDraft={undefined}
+                            navigation={{} as PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.CREATE>['navigation']}
+                            defaultSelectedTab={CONST.TAB_REQUEST.MANUAL}
+                        />
+                    </NavigationContainer>
+                </LocaleContextProvider>
+            </OnyxListItemProvider>,
+        );
+
+        await waitForBatchedUpdatesWithAct();
+
+        const transactionReportID = await new Promise<OnyxEntry<string>>((resolve) => {
+            const connection = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${CONST.IOU.OPTIMISTIC_TRANSACTION_ID}`,
+                callback: (val) => {
+                    resolve(val?.reportID);
+                    Onyx.disconnect(connection);
+                },
+            });
+        });
+        expect(transactionReportID).toBe('1');
+    });
 });

--- a/tests/unit/OnyxTabNavigatorTest.ts
+++ b/tests/unit/OnyxTabNavigatorTest.ts
@@ -1,0 +1,72 @@
+import {getInitialTabName, getSelectedTabFromRoute} from '@libs/Navigation/OnyxTabNavigator';
+import CONST from '@src/CONST';
+
+jest.mock('react-native-tab-view', () => ({
+    TabView: 'TabView',
+    SceneMap: jest.fn(),
+    TabBar: 'TabBar',
+}));
+
+describe('OnyxTabNavigator', () => {
+    const requestTabs = [CONST.TAB_REQUEST.MANUAL, CONST.TAB_REQUEST.SCAN, CONST.TAB_REQUEST.DISTANCE];
+
+    it('uses the route-selected tab before a stale Onyx selected tab', () => {
+        const routeSelectedTab = getSelectedTabFromRoute(
+            {
+                state: {
+                    index: 0,
+                    routes: [{name: CONST.TAB_REQUEST.SCAN}],
+                },
+            },
+            requestTabs,
+        );
+
+        expect(routeSelectedTab).toBe(CONST.TAB_REQUEST.SCAN);
+        expect(getInitialTabName(requestTabs, CONST.TAB_REQUEST.MANUAL, CONST.TAB_REQUEST.MANUAL, routeSelectedTab)).toBe(CONST.TAB_REQUEST.SCAN);
+    });
+
+    it('uses route params when nested state is not available yet', () => {
+        const routeSelectedTab = getSelectedTabFromRoute(
+            {
+                params: {
+                    screen: CONST.TAB_REQUEST.DISTANCE,
+                },
+            },
+            requestTabs,
+        );
+
+        expect(routeSelectedTab).toBe(CONST.TAB_REQUEST.DISTANCE);
+        expect(getInitialTabName(requestTabs, CONST.TAB_REQUEST.SCAN, CONST.TAB_REQUEST.MANUAL, routeSelectedTab)).toBe(CONST.TAB_REQUEST.DISTANCE);
+    });
+
+    it('supports distance child routes including odometer', () => {
+        const distanceTabs = [CONST.TAB_REQUEST.DISTANCE_MAP, CONST.TAB_REQUEST.DISTANCE_MANUAL, CONST.TAB_REQUEST.DISTANCE_GPS, CONST.TAB_REQUEST.DISTANCE_ODOMETER];
+        const routeSelectedTab = getSelectedTabFromRoute(
+            {
+                state: {
+                    index: 0,
+                    routes: [{name: CONST.TAB_REQUEST.DISTANCE_ODOMETER}],
+                },
+            },
+            distanceTabs,
+        );
+
+        expect(routeSelectedTab).toBe(CONST.TAB_REQUEST.DISTANCE_ODOMETER);
+        expect(getInitialTabName(distanceTabs, CONST.TAB_REQUEST.DISTANCE_MAP, CONST.TAB_REQUEST.DISTANCE_MAP, routeSelectedTab)).toBe(CONST.TAB_REQUEST.DISTANCE_ODOMETER);
+    });
+
+    it('ignores route-selected tabs that are not rendered', () => {
+        const routeSelectedTab = getSelectedTabFromRoute(
+            {
+                state: {
+                    index: 0,
+                    routes: [{name: CONST.TAB_REQUEST.TIME}],
+                },
+            },
+            requestTabs,
+        );
+
+        expect(routeSelectedTab).toBeUndefined();
+        expect(getInitialTabName(requestTabs, CONST.TAB_REQUEST.MANUAL, CONST.TAB_REQUEST.SCAN, routeSelectedTab)).toBe(CONST.TAB_REQUEST.MANUAL);
+    });
+});

--- a/tests/unit/QuickActionNavigationTest.ts
+++ b/tests/unit/QuickActionNavigationTest.ts
@@ -110,6 +110,25 @@ describe('IOU Utils', () => {
             expect(startDistanceRequest).toHaveBeenCalledWith(CONST.IOU.TYPE.SUBMIT, reportID, draftTransactionIDs, CONST.IOU.REQUEST_TYPE.DISTANCE_MANUAL, true, undefined, undefined);
         });
 
+        it('should be navigated to odometer distance Expense depending on lastDistanceExpenseType', () => {
+            const draftTransactionIDs: string[] = [];
+            // When the quick action is REQUEST_DISTANCE with odometer as the last distance type
+            navigateToQuickAction({
+                isValidReport: true,
+                quickAction: {action: CONST.QUICK_ACTIONS.REQUEST_DISTANCE, chatReportID: reportID},
+                selectOption: (onSelected: () => void) => {
+                    onSelected();
+                },
+                targetAccountPersonalDetails: createPersonalDetails(1),
+                lastDistanceExpenseType: CONST.IOU.REQUEST_TYPE.DISTANCE_ODOMETER,
+                currentUserAccountID: CONST.DEFAULT_NUMBER_ID,
+                draftTransactionIDs,
+            });
+
+            // Then we should start odometer distance request flow
+            expect(startDistanceRequest).toHaveBeenCalledWith(CONST.IOU.TYPE.SUBMIT, reportID, draftTransactionIDs, CONST.IOU.REQUEST_TYPE.DISTANCE_ODOMETER, true, undefined, undefined);
+        });
+
         it('should pass draftTransactionIDs with existing drafts to startDistanceRequest for TRACK_DISTANCE', () => {
             // Given draftTransactionIDs with some existing draft IDs
             const draftTransactionIDs = ['123'];


### PR DESCRIPTION
Issue: #76229

## Summary
- Prefer the explicit route-selected tab over a persisted Onyx tab when initializing IOU and distance request start pages.
- Rebuild stale IOU/distance drafts when the request type matches but the report ID changed.
- Route distance odometer quick actions directly to the odometer tab.

## Root Cause
Quick-action routes can include a nested request tab, such as scan receipt or odometer, but the Onyx-backed tab navigator initialized from persisted selected tab state first. If a stale draft had the same request type but belonged to a previous report, the reset hook returned early and the user could land on the wrong create flow after login.

## Tests
- `npm test -- tests/unit/OnyxTabNavigatorTest.ts tests/unit/QuickActionNavigationTest.ts tests/actions/IOU/MoneyRequestTest.ts tests/ui/IOURequestStartPageTest.tsx --runInBand`
- `npx eslint` on the changed files
- `npm run typecheck`
- `git diff --check` on the changed files