### PR TITLE
Show 'Scanning' date and sort scanning receipts to top

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -63,7 +63,7 @@ import type {SortableColumnName} from '@libs/ReportUtils';
 import {compareValues, getColumnsToShow, getTableMinWidth, hasFlexColumn, isTransactionAmountTooLong, isTransactionTaxAmountTooLong} from '@libs/SearchUIUtils';
 import {getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import {compareByRBR} from '@libs/TransactionPreviewUtils';
-import {getTransactionPendingAction, isTransactionPendingDelete, shouldShowExpenseBreakdown} from '@libs/TransactionUtils';
+import {getTransactionPendingAction, isScanning, isTransactionPendingDelete, shouldShowExpenseBreakdown} from '@libs/TransactionUtils';
 import shouldShowTransactionYear from '@libs/TransactionUtils/shouldShowTransactionYear';
 import isReportOpenInSuperWideRHP from '@navigation/helpers/isReportOpenInSuperWideRHP';
 import Navigation from '@navigation/Navigation';
@@ -295,6 +295,16 @@ function MoneyRequestReportTransactionList({
 
     const sortedTransactions: TransactionWithOptionalHighlight[] = useMemo(() => {
         return [...transactions].sort((a, b) => {
+            // Scanning receipts always appear at the top regardless of sort direction
+            const aIsScanning = isScanning(a);
+            const bIsScanning = isScanning(b);
+            if (aIsScanning && !bIsScanning) {
+                return -1;
+            }
+            if (!aIsScanning && bIsScanning) {
+                return 1;
+            }
+
             // When on default sort (Date/ASC), prioritize RBR-flagged transactions
             if (isDefaultSort && allTransactionViolations) {
                 const rbrComparison = compareByRBR(

--- a/src/components/Search/SearchList/ListItem/DateCell.tsx
+++ b/src/components/Search/SearchList/ListItem/DateCell.tsx
@@ -9,13 +9,15 @@ type DateCellProps = {
     showTooltip: boolean;
     isLargeScreenWidth: boolean;
     suffixText?: string;
+    textOverride?: string;
 };
 
-function DateCell({date, showTooltip, isLargeScreenWidth, suffixText}: DateCellProps) {
+function DateCell({date, showTooltip, isLargeScreenWidth, suffixText, textOverride}: DateCellProps) {
     const styles = useThemeStyles();
 
     const formattedDate = DateUtils.formatWithUTCTimeZone(date, DateUtils.doesDateBelongToAPastYear(date) ? CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT : CONST.DATE.MONTH_DAY_ABBR_FORMAT);
-    const displayText = suffixText ? `${formattedDate} • ${suffixText}` : formattedDate;
+    const dateText = textOverride ?? formattedDate;
+    const displayText = suffixText ? `${dateText} • ${suffixText}` : dateText;
 
     return (
         <TextWithTooltip

--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -330,6 +330,7 @@ function TransactionItemRow({
                             date={createdAt}
                             showTooltip={shouldShowTooltip}
                             isLargeScreenWidth={!shouldUseNarrowLayout}
+                            textOverride={isScanning(transactionItem) ? translate('iou.receiptStatusTitle') : undefined}
                         />
                     </View>
                 );
@@ -772,6 +773,7 @@ function TransactionItemRow({
                                     showTooltip={shouldShowTooltip}
                                     isLargeScreenWidth={false}
                                     suffixText={categoryForDisplay}
+                                    textOverride={isScanning(transactionItem) ? translate('iou.receiptStatusTitle') : undefined}
                                 />
                                 <TypeCell
                                     transactionItem={transactionItem}

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -3657,6 +3657,31 @@ function getSortedTransactionData(
     sortBy?: SearchColumnType,
     sortOrder?: SortOrder,
 ) {
+    const sorted = sortTransactionsByColumn(data, localeCompare, translate, sortBy, sortOrder);
+
+    // Scanning transactions always appear at the top regardless of sort column or direction
+    return sorted.sort((a, b) => {
+        const aIsScanning = isScanning(a);
+        const bIsScanning = isScanning(b);
+        if (aIsScanning === bIsScanning) {
+            return 0;
+        }
+        return aIsScanning ? -1 : 1;
+    });
+}
+
+/**
+ * @private
+ * Sorts transaction data by the specified column. Called by getSortedTransactionData
+ * before scanning transactions are promoted to the top of the list.
+ */
+function sortTransactionsByColumn(
+    data: TransactionListItemType[],
+    localeCompare: LocaleContextProps['localeCompare'],
+    translate: LocaleContextProps['translate'],
+    sortBy?: SearchColumnType,
+    sortOrder?: SortOrder,
+) {
     if (!sortBy || !sortOrder) {
         return data;
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Details
$ https://github.com/Expensify/App/issues/89966

When a receipt is being SmartScanned, the date column now shows Scanning... instead of the transaction date. Scanning receipts are also sorted to the top of the expense list so users can easily spot which receipts are still processing.

**Changes:**
- `DateCell`: accept optional `textOverride` prop to display arbitrary text instead of the formatted date
- `TransactionItemRow`: pass `textOverride` with the scanning status text when `isScanning(transactionItem)` is true (both wide and narrow layouts)
- `MoneyRequestReportTransactionList`: sort scanning transactions to the top before applying RBR and column-based sort
- `SearchUIUtils`: extract column sort into a helper, then apply scanning priority sort on top

**Testing:**
1. Upload a receipt (photo of any receipt) to create a new expense
2. While SmartScan is processing, check the expenses list — the date column should read Scanning... instead of a date
3. Verify scanning expenses appear at the top of the list regardless of sort column or direction
4. Once scanning completes, verify the date reverts to the actual transaction date and sort order returns to normal
5. Test on web, mWeb, iOS, and Android

**Platforms:**
- [x] Web
- [x] Mobile Web
- [x] iOS
- [x] Android