### PR TITLE
[CP Staging] Revert "Refactor ReanimatedModal/index.tsx to follow Rules of React and compile with React Compiler" (#90358)

### DIFF
--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -106,6 +106,7 @@ function ReanimatedModal({
     useEffect(
         () => () => {
             if (handleRef.current) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 InteractionManager.clearInteractionHandle(handleRef.current);
             }
             if (transitionHandleRef.current) {
@@ -122,11 +123,14 @@ function ReanimatedModal({
 
     useEffect(() => {
         if (isVisible && !isContainerOpen && !isTransitioning) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             handleRef.current = InteractionManager.createInteractionHandle();
             transitionHandleRef.current = TransitionTracker.startTransition();
             onModalWillShow();
 
+            // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsVisibleState(true);
+            // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsTransitioning(true);
         } else if (!isVisible && isContainerOpen && !isTransitioning) {
             handleRef.current = InteractionManager.createInteractionHandle();
@@ -134,7 +138,9 @@ function ReanimatedModal({
             onModalWillHide();
 
             blurActiveElement();
+            // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsVisibleState(false);
+            // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsTransitioning(true);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -148,6 +154,7 @@ function ReanimatedModal({
         setIsTransitioning(false);
         setIsContainerOpen(true);
         if (handleRef.current) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             InteractionManager.clearInteractionHandle(handleRef.current);
         }
         if (transitionHandleRef.current) {

--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -1,5 +1,5 @@
 import noop from 'lodash/noop';
-import React, {useEffect, useEffectEvent, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {NativeEventSubscription, ViewStyle} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import {BackHandler, InteractionManager, Modal, StyleSheet, View} from 'react-native';
@@ -55,64 +55,37 @@ function ReanimatedModal({
     shouldReturnFocus,
     ...props
 }: ReanimatedModalProps) {
+    const [isVisibleState, setIsVisibleState] = useState(isVisible);
     const [isContainerOpen, setIsContainerOpen] = useState(false);
+    const [isTransitioning, setIsTransitioning] = useState(false);
     const {windowWidth, windowHeight} = useWindowDimensions();
-    const styles = useThemeStyles();
 
     const backHandlerListener = useRef<NativeEventSubscription | null>(null);
     const handleRef = useRef<number | undefined>(undefined);
     const transitionHandleRef = useRef<TransitionHandle | null>(null);
 
-    const isTransitioning = isVisible !== isContainerOpen;
-    const backdropStyle: ViewStyle = {width: windowWidth, height: windowHeight, backgroundColor: backdropColor};
-    const modalStyle = {zIndex: StyleSheet.flatten(style)?.zIndex};
+    const styles = useThemeStyles();
 
-    const onBackButtonPressHandler = () => {
+    const onBackButtonPressHandler = useCallback(() => {
         if (shouldIgnoreBackHandlerDuringTransition && isTransitioning) {
             return false;
         }
-        if (isVisible) {
+        if (isVisibleState) {
             onBackButtonPress();
             return true;
         }
         return false;
-    };
+    }, [isVisibleState, onBackButtonPress, isTransitioning, shouldIgnoreBackHandlerDuringTransition]);
 
-    const handleEscape = (e: KeyboardEvent) => {
-        if (e.key !== 'Escape' || onBackButtonPressHandler() !== true) {
-            return;
-        }
-        e.stopImmediatePropagation();
-    };
-
-    const clearTransitionHandles = () => {
-        if (handleRef.current) {
-            InteractionManager.clearInteractionHandle(handleRef.current);
-            handleRef.current = undefined;
-        }
-        if (transitionHandleRef.current) {
-            TransitionTracker.endTransition(transitionHandleRef.current);
-            transitionHandleRef.current = null;
-        }
-    };
-
-    const onOpenCallBack = () => {
-        setIsContainerOpen(true);
-        clearTransitionHandles();
-        onModalShow();
-    };
-
-    const onCloseCallBack = () => {
-        setIsContainerOpen(false);
-        clearTransitionHandles();
-
-        // Because on Android, the Modal's onDismiss callback does not work reliably. There's a reported issue at:
-        // https://stackoverflow.com/questions/58937956/react-native-modal-ondismiss-not-invoked
-        // Therefore, we manually call onModalHide() here for Android.
-        if (getPlatform() === CONST.PLATFORM.ANDROID) {
-            onModalHide();
-        }
-    };
+    const handleEscape = useCallback(
+        (e: KeyboardEvent) => {
+            if (e.key !== 'Escape' || onBackButtonPressHandler() !== true) {
+                return;
+            }
+            e.stopImmediatePropagation();
+        },
+        [onBackButtonPressHandler],
+    );
 
     useEffect(() => {
         if (getPlatform() === CONST.PLATFORM.WEB) {
@@ -130,29 +103,82 @@ function ReanimatedModal({
         };
     }, [handleEscape, onBackButtonPressHandler]);
 
+    useEffect(
+        () => () => {
+            if (handleRef.current) {
+                InteractionManager.clearInteractionHandle(handleRef.current);
+            }
+            if (transitionHandleRef.current) {
+                TransitionTracker.endTransition(transitionHandleRef.current);
+                transitionHandleRef.current = null;
+            }
+
+            setIsVisibleState(false);
+            setIsContainerOpen(false);
+        },
+
+        [],
+    );
+
     useEffect(() => {
-        if (isTransitioning) {
+        if (isVisible && !isContainerOpen && !isTransitioning) {
             handleRef.current = InteractionManager.createInteractionHandle();
             transitionHandleRef.current = TransitionTracker.startTransition();
-        }
-
-        return () => {
-            clearTransitionHandles();
-        };
-    }, [isTransitioning]);
-
-    const fireTransitionCallbacks = useEffectEvent(() => {
-        if (isVisible && !isContainerOpen) {
             onModalWillShow();
-        } else if (!isVisible && isContainerOpen) {
-            onModalWillHide();
-            blurActiveElement();
-        }
-    });
 
-    useEffect(() => {
-        fireTransitionCallbacks();
-    }, [isVisible, isContainerOpen]);
+            setIsVisibleState(true);
+            setIsTransitioning(true);
+        } else if (!isVisible && isContainerOpen && !isTransitioning) {
+            handleRef.current = InteractionManager.createInteractionHandle();
+            transitionHandleRef.current = TransitionTracker.startTransition();
+            onModalWillHide();
+
+            blurActiveElement();
+            setIsVisibleState(false);
+            setIsTransitioning(true);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isVisible, isContainerOpen, isTransitioning]);
+
+    const backdropStyle: ViewStyle = useMemo(() => {
+        return {width: windowWidth, height: windowHeight, backgroundColor: backdropColor};
+    }, [windowWidth, windowHeight, backdropColor]);
+
+    const onOpenCallBack = useCallback(() => {
+        setIsTransitioning(false);
+        setIsContainerOpen(true);
+        if (handleRef.current) {
+            InteractionManager.clearInteractionHandle(handleRef.current);
+        }
+        if (transitionHandleRef.current) {
+            TransitionTracker.endTransition(transitionHandleRef.current);
+            transitionHandleRef.current = null;
+        }
+        onModalShow();
+    }, [onModalShow]);
+
+    const onCloseCallBack = useCallback(() => {
+        setIsTransitioning(false);
+        setIsContainerOpen(false);
+        if (handleRef.current) {
+            InteractionManager.clearInteractionHandle(handleRef.current);
+        }
+        if (transitionHandleRef.current) {
+            TransitionTracker.endTransition(transitionHandleRef.current);
+            transitionHandleRef.current = null;
+        }
+
+        // Because on Android, the Modal's onDismiss callback does not work reliably. There's a reported issue at:
+        // https://stackoverflow.com/questions/58937956/react-native-modal-ondismiss-not-invoked
+        // Therefore, we manually call onModalHide() here for Android.
+        if (getPlatform() === CONST.PLATFORM.ANDROID) {
+            onModalHide();
+        }
+    }, [onModalHide]);
+
+    const modalStyle = useMemo(() => {
+        return {zIndex: StyleSheet.flatten(style)?.zIndex};
+    }, [style]);
 
     const containerView = (
         <Container
@@ -186,7 +212,7 @@ function ReanimatedModal({
         />
     );
 
-    if (!coverScreen && isVisible) {
+    if (!coverScreen && isVisibleState) {
         return (
             <View
                 pointerEvents="box-none"
@@ -197,8 +223,8 @@ function ReanimatedModal({
             </View>
         );
     }
-    const isBackdropMounted = isVisible || (isTransitioning && getPlatform() === CONST.PLATFORM.WEB);
-    const modalVisibility = isVisible || isTransitioning;
+    const isBackdropMounted = isVisibleState || ((isTransitioning || isContainerOpen !== isVisibleState) && getPlatform() === CONST.PLATFORM.WEB);
+    const modalVisibility = isVisibleState || isTransitioning || isContainerOpen !== isVisibleState;
     return (
         <LayoutAnimationConfig skipExiting={getPlatform() !== CONST.PLATFORM.WEB}>
             <Modal
@@ -225,7 +251,7 @@ function ReanimatedModal({
                         pointerEvents="box-none"
                         style={[style, {margin: 0}]}
                     >
-                        {isVisible && containerView}
+                        {isVisibleState && containerView}
                     </KeyboardAvoidingView>
                 ) : (
                     <FocusTrapForModal
@@ -234,7 +260,7 @@ function ReanimatedModal({
                         shouldReturnFocus={shouldReturnFocus ?? !shouldEnableNewFocusManagement}
                         shouldPreventScroll={shouldPreventScrollOnFocus}
                     >
-                        {isVisible && containerView}
+                        {isVisibleState && containerView}
                     </FocusTrapForModal>
                 )}
             </Modal>

--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -130,7 +130,6 @@ function ReanimatedModal({
 
             // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsVisibleState(true);
-            // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsTransitioning(true);
         } else if (!isVisible && isContainerOpen && !isTransitioning) {
             handleRef.current = InteractionManager.createInteractionHandle();
@@ -138,9 +137,7 @@ function ReanimatedModal({
             onModalWillHide();
 
             blurActiveElement();
-            // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsVisibleState(false);
-            // eslint-disable-next-line react-hooks/set-state-in-effect
             setIsTransitioning(true);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Explanation of Change

Reverts the merge commit `0348dd515ec` (PR #90358).

PR #90358 refactored `ReanimatedModal/index.tsx` to eliminate `isVisibleState` and derive `isTransitioning` directly. The refactor introduced a regression: the modal content is now removed from the React tree in the **same render** that `isVisible` becomes `false`. This causes a window — between React's commit and Reanimated's exit-animation interception — where the transparent `Modal` wrapper is still mounted but has no children, exposing the underlying UI through it.

The original code avoided this by using `isVisibleState` (a state variable initialized from `isVisible`) whose update was deferred to a `useEffect`. This guaranteed the content stayed mounted for the first render after `isVisible → false`, giving Reanimated's dummy-clone mechanism time to intercept the unmount and start the exit animation before any visible frame was painted with an empty modal.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90510
$ https://github.com/Expensify/App/issues/90438
$ https://github.com/Expensify/App/issues/90463
$ https://github.com/Expensify/App/issues/90442
$ https://github.com/Expensify/App/issues/90527
$ https://github.com/Expensify/App/issues/90450

### Tests

1. Open any modal (bottom sheet, right-hand panel, popover) in the app
2. Verify the modal opens and closes with correct animations on all platforms
3. Verify the back button / Escape key dismisses the modal correctly
4. Verify backdrop tap dismisses the modal
5. Verify no errors appear in the JS console

### Offline tests

Not applicable — modal open/close behavior is not network-dependent.

### QA Steps

**#90510 — Search RHP close flash (web):**
1. Open staging.new.expensify.com, navigate to Inbox
2. Click the search icon (top right) to open the Search RHP
3. Close it by clicking outside or pressing ESC
4. Verify the RHP dismisses cleanly with no brief flash of chats on top of the screen

**#90438 — Distance RHP animates correctly after changing distance rate:**
5. Go to Workspace Settings > Distance Rates
6. Tap Settings > Unit and select a different rate
7. Verify the RHP animates in and out correctly (no freeze or missing animation)

**#90442 — Delete actions work immediately after closing a modal (Android):**
8. Open any expense report and tap More > Delete > Delete
9. Verify the delete confirmation modal appears without delay and the expense is removed
10. Repeat for other delete flows: saved search, category, tag, distance rate — all should respond immediately

**#90463 — Import spreadsheet modal appears after dismissing an upgrade modal (Android):**
11. Go to Workspace Settings > Tags, enable tags, add one
12. Tap More > Import spreadsheet > Multi-level of tags > Upgrade > Got it Thanks
13. Tap Switch Tag Levels
14. Verify the Import spreadsheet modal appears correctly with a Choose file button

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>