### PR TITLE
Fix duplicate wallet balance transfer

### DIFF
--- a/src/libs/actions/PaymentMethods.ts
+++ b/src/libs/actions/PaymentMethods.ts
@@ -344,13 +344,21 @@ function transferWalletBalance(paymentMethod: PaymentMethod) {
         [paymentMethodIDKey]: paymentMethod.methodID,
     };
 
-    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.WALLET_TRANSFER>> = [
+    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.WALLET_TRANSFER | typeof ONYXKEYS.USER_WALLET>> = [
         {
             onyxMethod: 'merge',
             key: ONYXKEYS.WALLET_TRANSFER,
             value: {
                 loading: true,
                 errors: null,
+            },
+        },
+        {
+            onyxMethod: 'merge',
+            key: ONYXKEYS.USER_WALLET,
+            value: {
+                currentBalance: 0,
+                availableBalance: 0,
             },
         },
     ];

--- a/tests/actions/PaymentMethodsTest.ts
+++ b/tests/actions/PaymentMethodsTest.ts
@@ -1,0 +1,47 @@
+import Onyx from 'react-native-onyx';
+import * as API from '@libs/API';
+import {transferWalletBalance} from '@libs/actions/PaymentMethods';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {OnyxData} from '@src/types/onyx/Request';
+import type PaymentMethod from '@src/types/onyx/PaymentMethod';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+jest.mock('@libs/API');
+
+const writeSpy = jest.spyOn(API, 'write');
+
+describe('actions/PaymentMethods', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('optimistically clears wallet balance when transferring wallet funds', () => {
+        const paymentMethod: PaymentMethod = {
+            methodID: 1,
+            accountType: CONST.PAYMENT_METHODS.PERSONAL_BANK_ACCOUNT,
+        } as PaymentMethod;
+
+        transferWalletBalance(paymentMethod);
+
+        const [, , onyxData] = writeSpy.mock.calls.at(0) as [unknown, unknown, OnyxData<typeof ONYXKEYS.WALLET_TRANSFER | typeof ONYXKEYS.USER_WALLET>];
+
+        expect(onyxData.optimisticData).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    key: ONYXKEYS.USER_WALLET,
+                    value: expect.objectContaining({
+                        currentBalance: 0,
+                        availableBalance: 0,
+                    }),
+                }),
+            ]),
+        );
+    });
+});


### PR DESCRIPTION
## Summary\nFixes #75982.\n\nWhen transferring the full wallet balance, optimistically clear the wallet balance along with the transfer loading state. This keeps the transfer CTA disabled after submit, including test-wallet scenarios where the backend response may not reduce the balance immediately.\n\n## Tests\n- npx jest tests/actions/PaymentMethodsTest.ts --runInBand --runTestsByPath\n- npx eslint src/libs/actions/PaymentMethods.ts tests/actions/PaymentMethodsTest.ts\n- git diff --check