### PR TITLE
Fix card issued action visibility after reactions

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -205,7 +205,13 @@ function isDeletedAction(reportAction: OnyxInputOrEntry<ReportAction | Optimisti
     if (
         reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENT_DIRECTOR_INFORMATION_REQUIRED ||
         reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED_REPORT_FOR_UNAPPROVED_TRANSACTIONS ||
-        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REASSIGN_APPROVER
+        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REASSIGN_APPROVER ||
+        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED ||
+        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL ||
+        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CARD_MISSING_ADDRESS ||
+        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CARD_ASSIGNED ||
+        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CARD_REPLACED_VIRTUAL ||
+        reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CARD_REPLACED
     ) {
         return false;
     }

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -1701,6 +1701,22 @@ describe('ReportActionsUtils', () => {
             expect(ReportActionsUtils.isDeletedAction(reportAction)).toBe(false);
         });
 
+        it('should return false for card issued actions with empty message array', () => {
+            const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL> = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL,
+                reportActionID: 'virtual-card-action-123',
+                actorAccountID: 123,
+                created: '2024-01-01',
+                message: [],
+                originalMessage: {
+                    assigneeAccountID: 456,
+                    cardID: 789,
+                },
+            };
+
+            expect(ReportActionsUtils.isDeletedAction(reportAction)).toBe(false);
+        });
+
         it('should return false for CARDFROZEN action with a backend-provided message fragment', () => {
             const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.CARD_FROZEN> = {
                 actionName: CONST.REPORT.ACTIONS.TYPE.CARD_FROZEN,
@@ -1971,6 +1987,23 @@ describe('ReportActionsUtils', () => {
             };
 
             // Then the action should be visible
+            const actual = ReportActionsUtils.shouldReportActionBeVisible(reportAction, reportAction.reportActionID, true);
+            expect(actual).toBe(true);
+        });
+
+        it('should return true for card issued actions with empty message array', () => {
+            const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL> = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL,
+                reportActionID: 'virtual-card-action-123',
+                actorAccountID: 123,
+                created: '2024-01-01',
+                message: [],
+                originalMessage: {
+                    assigneeAccountID: 456,
+                    cardID: 789,
+                },
+            };
+
             const actual = ReportActionsUtils.shouldReportActionBeVisible(reportAction, reportAction.reportActionID, true);
             expect(actual).toBe(true);
         });


### PR DESCRIPTION
### Details
This fixes card-issued system report actions being treated as deleted when they have an intentionally empty `message` array.

Card-issued actions render from `originalMessage` via the card issued message path, so `message: []` is valid data for these system actions. After adding an emoji reaction, visibility can be recomputed and `isDeletedAction()` currently classifies the action as a legacy deleted comment, hiding it from the chat.

### Fixed Issues
$ #89140

### Tests
- Added regression coverage for `isDeletedAction()` with a `CARD_ISSUED_VIRTUAL` action and empty `message` array.
- Added regression coverage for `shouldReportActionBeVisible()` to keep that same action visible.

I could not run the full local Jest suite from this Windows checkout because the repository contains route documentation paths with `:` that cannot be checked out on Windows. The change is covered by the targeted unit tests added in this PR.