### PR TITLE
[50] Fix: hyperlink report names in renamed system messages on mobile

### DIFF
--- a/src/components/ReportActionItem/RenamedAction.tsx
+++ b/src/components/ReportActionItem/RenamedAction.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import RenderHTML from '@components/RenderHTML';
+import useLocalize from '@hooks/useLocalize';
+import {getRenamedActionHTML} from '@libs/ReportActionsUtils';
+import ReportActionItemBasicMessage from '@pages/inbox/report/ReportActionItemBasicMessage';
+import type CONST from '@src/CONST';
+import type {ReportAction} from '@src/types/onyx';
+
+type RenamedActionProps = {
+    /** The renamed action data */
+    action: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.RENAMED>;
+
+    /** Whether the report is an expense report */
+    isExpenseReport: boolean;
+};
+
+function RenamedAction({action, isExpenseReport}: RenamedActionProps) {
+    const {translate} = useLocalize();
+    const htmlContent = `<comment><muted-text>${getRenamedActionHTML(translate, action, isExpenseReport)}</muted-text></comment>`;
+
+    return (
+        <ReportActionItemBasicMessage message="">
+            <RenderHTML html={htmlContent} />
+        </ReportActionItemBasicMessage>
+    );
+}
+
+export default RenamedAction;

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -3854,6 +3854,32 @@ function getRenamedAction(translate: LocalizedTranslate, reportAction: OnyxEntry
     return translate('newRoomPage.renamedRoomAction', originalMessage?.oldName ?? '', originalMessage?.newName ?? '', isExpenseReport, actorName);
 }
 
+function getRenamedActionHTML(
+    translate: LocalizedTranslate,
+    reportAction: OnyxEntry<ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.RENAMED>>,
+    isExpenseReport: boolean,
+    actorName?: string,
+) {
+    const originalMessage = getOriginalMessage(reportAction);
+    const oldName = originalMessage?.oldName ?? '';
+    const newName = originalMessage?.newName ?? '';
+    const reportURL = getReportURLForCurrentContext(reportAction?.reportID);
+
+    if (!newName || !reportURL) {
+        return Str.htmlEncode(getRenamedAction(translate, reportAction, isExpenseReport, actorName));
+    }
+
+    const linkStartMarker = '__renamed_report_link_start__';
+    const linkEndMarker = '__renamed_report_link_end__';
+    const linkedReportName = `${linkStartMarker}${newName}${linkEndMarker}`;
+    const renamedActionMessage = translate('newRoomPage.renamedRoomAction', oldName, linkedReportName, isExpenseReport, actorName);
+
+    return Str.htmlEncode(renamedActionMessage).replace(
+        Str.htmlEncode(linkedReportName),
+        `<a href="${Str.htmlEncode(reportURL)}">${Str.htmlEncode(newName)}</a>`,
+    );
+}
+
 function getAddedApprovalRuleMessage(translate: LocalizedTranslate, reportAction: OnyxEntry<ReportAction>) {
     const {name, approverAccountID, approverEmail, field, approverName} =
         getOriginalMessage(reportAction as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_APPROVER_RULE>) ?? {};
@@ -4563,6 +4589,7 @@ export {
     getMarkedReimbursedMessage,
     getReimbursedMessage,
     getMemberChangeMessageFragment,
+    getRenamedActionHTML,
     getUpdateRoomDescriptionFragment,
     getReportActionMessageFragments,
     getMessageOfOldDotReportAction,

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -22,6 +22,7 @@ import IssueCardMessage from '@components/ReportActionItem/IssueCardMessage';
 import MoneyRequestAction from '@components/ReportActionItem/MoneyRequestAction';
 import MoneyRequestReportPreview from '@components/ReportActionItem/MoneyRequestReportPreview';
 import MovedTransactionAction from '@components/ReportActionItem/MovedTransactionAction';
+import RenamedAction from '@components/ReportActionItem/RenamedAction';
 import TaskAction from '@components/ReportActionItem/TaskAction';
 import TaskPreview from '@components/ReportActionItem/TaskPreview';
 import TripRoomPreview from '@components/ReportActionItem/TripRoomPreview';
@@ -57,7 +58,6 @@ import {
     getIOUReportIDFromReportActionPreview,
     getOriginalMessage,
     getPlaidBalanceFailureMessage,
-    getRenamedAction,
     getReportActionHtml,
     getReportActionMessage,
     getReportActionText,
@@ -803,8 +803,12 @@ function PureReportActionItem({
                 />
             );
         } else if (isRenamedAction(action)) {
-            const message = getRenamedAction(translate, action, isExpenseReport(report));
-            children = <ReportActionItemBasicMessage message={message} />;
+            children = (
+                <RenamedAction
+                    action={action}
+                    isExpenseReport={isExpenseReport(report)}
+                />
+            );
         } else if (isActionOfType(action, CONST.REPORT.ACTIONS.TYPE.INTEGRATION_SYNC_FAILED)) {
             children = (
                 <ReportActionItemBasicMessage message="">


### PR DESCRIPTION
### Fixes
$ [#90422](https://github.com/Expensify/App/issues/90422)

### Details
On mobile, renamed report system messages display the report name as plain text. On web, these names are hyperlinked and clickable.

This PR makes renamed system messages use the HTML render pipeline (RenderHTML + AnchorRenderer) so report names are clickable on all platforms, matching web behavior.

### Changes
- **New:** `src/components/ReportActionItem/RenamedAction.tsx` — renders renamed messages with RenderHTML for clickable links
- **New:** `getRenamedActionHTML()` in `src/libs/ReportActionsUtils.ts` — generates HTML with anchor tags for report names
- **Modified:** `PureReportActionItem.tsx` — uses RenamedAction component instead of plain text

### Testing
1. Rename a report
2. On mobile, verify the new report name appears as a clickable hyperlink
3. Verify the app doesn't crash