### PR TITLE
Navigate to report thread in RHP when viewing a report in a right docked modal

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
@@ -147,6 +147,8 @@ function MoneyRequestReportNavigationContent({reportID, shouldDisplayNarrowVersi
         });
         Navigation.setParams({
             reportID: reportId,
+            reportActionID: undefined,
+            referrer: undefined,
         });
     };
 

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
@@ -125,7 +125,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
             backTo = params?.backTo ?? backTo;
         }
         const nextThreadReportID = nextParentReportAction?.childReportID;
-        const navigationParams = {reportID: nextThreadReportID, backTo};
+        const navigationParams = {reportID: nextThreadReportID, reportActionID: undefined, backTo};
 
         if (nextThreadReportID) {
             markReportIDAsExpense(nextThreadReportID);
@@ -161,7 +161,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
             backTo = params?.backTo ?? backTo;
         }
         const prevThreadReportID = prevParentReportAction?.childReportID;
-        const navigationParams = {reportID: prevThreadReportID, backTo};
+        const navigationParams = {reportID: prevThreadReportID, reportActionID: undefined, backTo};
 
         if (prevThreadReportID) {
             markReportIDAsExpense(prevThreadReportID);

--- a/src/components/ParentNavigationSubtitle.tsx
+++ b/src/components/ParentNavigationSubtitle.tsx
@@ -186,14 +186,12 @@ function ParentNavigationSubtitle({
             // avoid stacking RHPs by going back to the search report if it's already there
             const previousRoute = currentFocusedNavigator?.state?.routes.at(-2);
 
-            if (previousRoute?.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT && lastRoute?.name === SCREENS.RIGHT_MODAL.EXPENSE_REPORT) {
-                if (previousRoute.params && 'reportID' in previousRoute.params) {
-                    const reportIDFromParams = previousRoute.params.reportID;
+            if (previousRoute?.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT && previousRoute.params && 'reportID' in previousRoute.params) {
+                const reportIDFromParams = previousRoute.params.reportID;
 
-                    if (reportIDFromParams === parentReportID) {
-                        Navigation.goBack();
-                        return;
-                    }
+                if (reportIDFromParams === parentReportID) {
+                    Navigation.goBack();
+                    return;
                 }
             }
 
@@ -212,6 +210,14 @@ function ParentNavigationSubtitle({
                     Navigation.dismissModal();
                     return;
                 }
+            }
+
+            // Stay in the Search tab when the parent link is tapped from a SEARCH_REPORT RHP
+            // and the parent isn't already in the stack — otherwise the REPORT_WITH_ID fallback
+            // would yank the user to Inbox.
+            if (isReportInRHP) {
+                Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: parentReportID, reportActionID: isVisibleAction ? parentReportActionID : undefined}));
+                return;
             }
         }
 

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -105,7 +105,7 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
     const containerRef = useRef(null);
     const isExecutingRef = useRef<boolean>(false);
     const screenOptions = useRHPScreenOptions();
-    const {superWideRHPRouteKeys, shouldRenderTertiaryOverlay} = useWideRHPState();
+    const {superWideRHPRouteKeys, wideRHPRouteKeys, shouldRenderTertiaryOverlay} = useWideRHPState();
     const {clearWideRHPKeys, syncRHPKeys} = useWideRHPActions();
     const {windowWidth} = useWindowDimensions();
     const modalStackScreenOptions = useModalStackScreenOptions();
@@ -130,7 +130,7 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
 
     // Animation should be disabled when we open the wide rhp from the narrow one.
     // When the wide rhp page is opened as first one, it will be animated with the entire RightModalNavigator.
-    const animationEnabledOnSearchReport = superWideRHPRouteKeys.length > 0 || isSmallScreenWidth;
+    const animationEnabledOnSearchReport = superWideRHPRouteKeys.length > 0 || wideRHPRouteKeys.length > 0 || isSmallScreenWidth;
 
     const animatedWidth = expandedRHPProgress.interpolate({
         inputRange: [0, 1, 2],

--- a/src/libs/Navigation/helpers/getTopmostFullScreenRoute.ts
+++ b/src/libs/Navigation/helpers/getTopmostFullScreenRoute.ts
@@ -1,0 +1,24 @@
+import {navigationRef} from '@libs/Navigation/Navigation';
+import type {NavigationRoute, RootNavigatorParamList, State} from '@libs/Navigation/types';
+import NAVIGATORS from '@src/NAVIGATORS';
+
+/**
+ * Returns the active tab route of the topmost TAB_NAVIGATOR in the root navigation state.
+ * Use this to determine which full-screen tab (Search, Inbox, etc.) is currently focused.
+ */
+function getTopmostFullScreenRoute(): NavigationRoute | undefined {
+    const rootState = navigationRef.getRootState() as State<RootNavigatorParamList>;
+
+    if (!rootState) {
+        return undefined;
+    }
+
+    const topmostTabNavigatorRoute = rootState.routes.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
+    if (!topmostTabNavigatorRoute?.state) {
+        return undefined;
+    }
+    const index = topmostTabNavigatorRoute.state.index ?? 0;
+    return topmostTabNavigatorRoute.state.routes?.at(index);
+}
+
+export default getTopmostFullScreenRoute;

--- a/src/libs/Navigation/helpers/isReportTopmostSplitNavigator.ts
+++ b/src/libs/Navigation/helpers/isReportTopmostSplitNavigator.ts
@@ -1,18 +1,12 @@
-import {navigationRef} from '@libs/Navigation/Navigation';
-import type {RootNavigatorParamList, State} from '@libs/Navigation/types';
 import NAVIGATORS from '@src/NAVIGATORS';
-import getActiveTabName from './getActiveTabName';
-import {isFullScreenName} from './isNavigatorName';
+import getTopmostFullScreenRoute from './getTopmostFullScreenRoute';
 
 const isReportTopmostSplitNavigator = (): boolean => {
-    const rootState = navigationRef.getRootState() as State<RootNavigatorParamList>;
-
-    if (!rootState) {
+    const topmostFullScreenRoute = getTopmostFullScreenRoute();
+    if (!topmostFullScreenRoute) {
         return false;
     }
-
-    const topmostFullScreenRoute = rootState.routes.findLast((route) => isFullScreenName(route.name));
-    return getActiveTabName(topmostFullScreenRoute) === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR;
+    return topmostFullScreenRoute.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR;
 };
 
 export default isReportTopmostSplitNavigator;

--- a/src/libs/Navigation/helpers/isSearchTopmostFullScreenRoute.ts
+++ b/src/libs/Navigation/helpers/isSearchTopmostFullScreenRoute.ts
@@ -1,18 +1,12 @@
-import {navigationRef} from '@libs/Navigation/Navigation';
-import type {RootNavigatorParamList, State} from '@libs/Navigation/types';
 import NAVIGATORS from '@src/NAVIGATORS';
-import getActiveTabName from './getActiveTabName';
-import {isFullScreenName} from './isNavigatorName';
+import getTopmostFullScreenRoute from './getTopmostFullScreenRoute';
 
 const isSearchTopmostFullScreenRoute = (): boolean => {
-    const rootState = navigationRef.getRootState() as State<RootNavigatorParamList>;
-
-    if (!rootState) {
+    const topmostFullScreenRoute = getTopmostFullScreenRoute();
+    if (!topmostFullScreenRoute) {
         return false;
     }
-
-    const topmostFullScreenRoute = rootState.routes.findLast((route) => isFullScreenName(route.name));
-    return getActiveTabName(topmostFullScreenRoute) === NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR;
+    return topmostFullScreenRoute.name === NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR;
 };
 
 export default isSearchTopmostFullScreenRoute;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -10248,6 +10248,19 @@ function navigateToLinkedReportAction(
     visibleReportActionsData?: VisibleReportActionsDerivedValue,
 ) {
     if (isInNarrowPaneModal) {
+        const rootState = navigationRef.current?.getRootState();
+        const topmostRHP = rootState?.routes.findLast((route) => route.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR);
+        const rhpState = topmostRHP?.state;
+        const rhpIndex = rhpState?.index ?? (rhpState?.routes.length ? rhpState.routes.length - 1 : -1);
+        const routeBelow = rhpIndex > 0 ? rhpState?.routes.at(rhpIndex - 1) : undefined;
+        const routeBelowParams = routeBelow?.params as {reportID?: string} | undefined;
+
+        if (routeBelow?.key && routeBelowParams?.reportID === ancestor.report.reportID) {
+            Navigation.setParams({reportActionID: ancestor.reportAction.reportActionID}, routeBelow.key, rhpState?.key);
+            Navigation.goBack();
+            return;
+        }
+
         Navigation.navigate(
             ROUTES.SEARCH_REPORT.getRoute({
                 reportID: ancestor.report.reportID,

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -75,6 +75,7 @@ import Log from '@libs/Log';
 import {isEmailPublicDomain} from '@libs/LoginUtils';
 import {getMovedReportID} from '@libs/ModifiedExpenseMessage';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
+import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import type {LinkToOptions} from '@libs/Navigation/helpers/linkTo/types';
 import Navigation from '@libs/Navigation/Navigation';
 import enhanceParameters from '@libs/Network/enhanceParameters';
@@ -2440,7 +2441,11 @@ function navigateToAndOpenChildReport(
 ) {
     const report = childReport ?? createChildReport(childReport, parentReportAction, parentReport, currentUserAccountID, introSelected, betas, isSelfTourViewed, personalDetails);
 
-    Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report.reportID, undefined, undefined, Navigation.getActiveRoute()));
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: report.reportID, backTo: Navigation.getActiveRoute()}));
+    } else {
+        Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report.reportID, undefined, undefined, Navigation.getActiveRoute()));
+    }
 }
 
 /**
@@ -2533,7 +2538,11 @@ function explain(
     // Check if explanation thread report already exists
     const report = childReport ?? createChildReport(childReport, reportAction, originalReport, currentUserAccountID, introSelected, betas, isSelfTourViewed);
 
-    Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report.reportID, undefined, undefined, Navigation.getActiveRoute()));
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: report.reportID, backTo: Navigation.getActiveRoute()}));
+    } else {
+        Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report.reportID, undefined, undefined, Navigation.getActiveRoute()));
+    }
     // Schedule adding the explanation comment on the next animation frame
     // so it runs immediately after navigation completes.
     requestAnimationFrame(() => {

--- a/src/pages/inbox/HeaderView.tsx
+++ b/src/pages/inbox/HeaderView.tsx
@@ -105,6 +105,7 @@ function HeaderView({onNavigationMenuButtonClicked, reportID}: HeaderViewProps) 
     const {isSmallScreenWidth, shouldUseNarrowLayout, isInLandscapeMode} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
     const route = useRoute();
+    const openParentReportInCurrentTab = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
     const [parentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(report?.parentReportID) ?? getNonEmptyStringOnyxID(report?.reportID)}`);
     const [grandParentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(parentReport?.parentReportID)}`);
     const grandParentReportAction = useParentReportAction(parentReport);
@@ -346,6 +347,7 @@ function HeaderView({onNavigationMenuButtonClicked, reportID}: HeaderViewProps) 
                                                 parentReportID={parentNavigationReport?.parentReportID}
                                                 parentReportActionID={isParentOneTransactionThread ? undefined : parentNavigationReport?.parentReportActionID}
                                                 pressableStyles={[styles.alignSelfStart, styles.mw100]}
+                                                openParentReportInCurrentTab={openParentReportInCurrentTab}
                                                 humanAgentAccountID={humanAgentAccountID}
                                                 humanAgentName={humanAgentName}
                                             />

--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
@@ -310,9 +310,9 @@ function ComposerWithSuggestions({
 
     const commentRef = useRef(initialText);
 
-    const {superWideRHPRouteKeys} = useWideRHPState();
-    // When SearchReport is stacked above another RHP, delay autofocus until after the transition completes to avoid animation jank
-    const shouldDelayAutoFocus = superWideRHPRouteKeys.length > 0 && route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+    const {superWideRHPRouteKeys, wideRHPRouteKeys} = useWideRHPState();
+    // When SearchReport is stacked above another RHP (wide or super-wide), delay autofocus until after the transition completes to avoid animation jank
+    const shouldDelayAutoFocus = (superWideRHPRouteKeys.length > 0 || wideRHPRouteKeys.length > 0) && route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
     const shouldDelayAutoFocusRef = useRef(shouldDelayAutoFocus);
     shouldDelayAutoFocusRef.current = shouldDelayAutoFocus;
 

--- a/tests/unit/Navigation/getTopmostFullScreenRouteTest.ts
+++ b/tests/unit/Navigation/getTopmostFullScreenRouteTest.ts
@@ -1,0 +1,93 @@
+import getTopmostFullScreenRoute from '@libs/Navigation/helpers/getTopmostFullScreenRoute';
+import NAVIGATORS from '@src/NAVIGATORS';
+
+const mockGetRootState = jest.fn();
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigationRef: {
+        getRootState: () => mockGetRootState() as unknown,
+    },
+}));
+
+describe('getTopmostFullScreenRoute', () => {
+    beforeEach(() => {
+        mockGetRootState.mockReset();
+    });
+
+    it('returns undefined when there is no root state', () => {
+        mockGetRootState.mockReturnValue(undefined);
+        expect(getTopmostFullScreenRoute()).toBeUndefined();
+    });
+
+    it('returns undefined when there is no TAB_NAVIGATOR route in the root state', () => {
+        mockGetRootState.mockReturnValue({
+            routes: [{name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR}, {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR}],
+        });
+        expect(getTopmostFullScreenRoute()).toBeUndefined();
+    });
+
+    it('returns undefined when the TAB_NAVIGATOR has no nested state yet', () => {
+        mockGetRootState.mockReturnValue({
+            routes: [{name: NAVIGATORS.TAB_NAVIGATOR}],
+        });
+        expect(getTopmostFullScreenRoute()).toBeUndefined();
+    });
+
+    it('returns the focused tab route based on state.index', () => {
+        const reportsRoute = {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR};
+        const searchRoute = {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR};
+        mockGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 1,
+                        routes: [reportsRoute, searchRoute],
+                    },
+                },
+            ],
+        });
+        expect(getTopmostFullScreenRoute()).toBe(searchRoute);
+    });
+
+    it('falls back to the first child route when state.index is missing', () => {
+        const reportsRoute = {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR};
+        const searchRoute = {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR};
+        mockGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        routes: [reportsRoute, searchRoute],
+                    },
+                },
+            ],
+        });
+        expect(getTopmostFullScreenRoute()).toBe(reportsRoute);
+    });
+
+    it('returns the focused tab of the topmost TAB_NAVIGATOR when multiple exist', () => {
+        const oldFocused = {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR};
+        const newFocused = {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR};
+        mockGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 0,
+                        routes: [oldFocused],
+                    },
+                },
+                {name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR},
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 0,
+                        routes: [newFocused],
+                    },
+                },
+            ],
+        });
+        expect(getTopmostFullScreenRoute()).toBe(newFocused);
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Continues #88527 (reverted by deploy blocker #90180): keeps the user in Search when opening report threads from the RHP. Clears stale `reportActionID`/`referrer` params on next/previous arrow navigation in `MoneyRequestReportView` — this is the deploy-blocker fix. Adds a shared `getTopmostFullScreenRoute` helper and routes child reports / explanations through `SEARCH_REPORT` when Search is the active tab.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90180
PROPOSAL:

The previous PR (#88527) was reverted because of deploy blocker https://github.com/Expensify/App/issues/90180. That regression is fixed in this PR — see `MoneyRequestReportNavigation.tsx`, where the arrow navigation now resets `reportActionID` and `referrer` so the next/previous expense no longer loads the "Not Here" page.

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. Reproduce the deploy blocker (#90180):
    1. Sign in and go to a workspace chat.
    2. Create two expenses on the same report.
    3. Go to **Spend > Reports** and open the report.
    4. Open one of the expenses.
    5. Send a message in the transaction thread.
    6. Right-click the message > **Reply in thread**.
    7. Click the parent message link in the thread header to return to the transaction.
    8. Click the next/previous arrow on the transaction.
    9. Verify that the next/previous expense loads correctly and the **Not Here** page does **not** appear.
2. Open report thread from a SearchReport RHP and stay in the Search tab:
    1. Go to **Search** and open any expense report from the results (the report opens in the RHP).
    2. Open a transaction thread inside that report.
    3. Tap the parent report name in the thread header.
    4. Verify that the parent report opens inside the Search RHP (URL stays under `/search/...`) and the app does **not** switch to the Inbox tab.
3. Verify pop-instead-of-push when navigating to a linked report action:
    1. From Search, open an expense report (SearchMoneyRequestReport in the RHP).
    2. Open a transaction thread (a SearchReport gets pushed on top).
    3. Inside the thread, tap the parent report name in the header to navigate back to the parent report.
    4. Verify the navigation feels like a pop (no stacked SearchReport screen below) and the underlying route shows the updated context for the parent reportAction.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as **Tests** — perform the steps with the network connection turned off after the report data has loaded. Verify the same navigation behaviour and that no "Not Here" page is shown for already-loaded reports.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/53f25a7e-078e-4236-8117-2cd38aadf0c6


</details>
