### PR TITLE
Increase spacing between FAB icon and title

### DIFF
--- a/src/pages/inbox/sidebar/FABPopoverContent/FABFocusableMenuItem.tsx
+++ b/src/pages/inbox/sidebar/FABPopoverContent/FABFocusableMenuItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import FocusableMenuItem from '@components/FocusableMenuItem';
 import type {MenuItemProps} from '@components/MenuItem';
 import CONST from '@src/CONST';
+import useThemeStyles from '@hooks/useThemeStyles';
 import useFABMenuItem from './useFABMenuItem';
 
 type FABFocusableMenuItemProps = Omit<MenuItemProps, 'focused' | 'onFocus' | 'wrapperStyle' | 'shouldCheckActionAllowedOnPress' | 'role' | 'onPress'> & {
@@ -11,18 +12,22 @@ type FABFocusableMenuItemProps = Omit<MenuItemProps, 'focused' | 'onFocus' | 'wr
     shouldCallAfterModalHide?: boolean;
 };
 
-function FABFocusableMenuItem({itemId, isVisible = true, onPress, shouldCallAfterModalHide, ...props}: FABFocusableMenuItemProps) {
+function FABFocusableMenuItem({itemId, isVisible = true, onPress, shouldCallAfterModalHide, iconStyles, ...props}: FABFocusableMenuItemProps) {
     const {itemIndex, isFocused, wrapperStyle, setFocusedIndex, onItemPress} = useFABMenuItem(itemId, isVisible);
+    const styles = useThemeStyles();
 
     if (!isVisible) {
         return null;
     }
+
+    const mergedIconStyles = [styles.mr3, ...(Array.isArray(iconStyles) ? iconStyles : [iconStyles])].filter(Boolean);
 
     return (
         <FocusableMenuItem
             // FABFocusableMenuItemProps is a strict subset of MenuItemProps — spreading forwards all remaining props safely
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...(props as MenuItemProps)}
+            iconStyles={mergedIconStyles}
             focused={isFocused}
             onFocus={() => setFocusedIndex(itemIndex)}
             wrapperStyle={wrapperStyle}

--- a/tests/unit/FABFocusableMenuItem.test.tsx
+++ b/tests/unit/FABFocusableMenuItem.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {render} from '@testing-library/react-native';
+import FABFocusableMenuItem from '@pages/inbox/sidebar/FABPopoverContent/FABFocusableMenuItem';
+
+const mockFocusableMenuItem = jest.fn(() => null);
+jest.mock('@components/FocusableMenuItem', () => (props: unknown) => mockFocusableMenuItem(props));
+
+jest.mock('@hooks/useThemeStyles', () => ({
+    __esModule: true,
+    default: () => ({mr3: {marginRight: 12}}),
+}));
+
+jest.mock('@pages/inbox/sidebar/FABPopoverContent/useFABMenuItem', () => ({
+    __esModule: true,
+    default: () => ({
+        itemIndex: 0,
+        isFocused: false,
+        wrapperStyle: {},
+        setFocusedIndex: jest.fn(),
+        onItemPress: jest.fn(),
+    }),
+}));
+
+describe('FABFocusableMenuItem', () => {
+    beforeEach(() => {
+        mockFocusableMenuItem.mockClear();
+    });
+
+    it('adds right margin to the icon container', () => {
+        render(
+            <FABFocusableMenuItem
+                itemId="new-workspace"
+                icon={'MockIcon' as never}
+                title="New workspace"
+            />,
+        );
+
+        expect(mockFocusableMenuItem).toHaveBeenCalled();
+        const props = mockFocusableMenuItem.mock.calls[0][0] as {iconStyles?: unknown};
+        expect(Array.isArray(props.iconStyles)).toBe(true);
+        expect((props.iconStyles as unknown[])[0]).toEqual({marginRight: 12});
+    });
+});


### PR DESCRIPTION
Addresses a FAB popover spacing issue.

Changes:
- Add right margin to FAB popover menu item icon container (`FABFocusableMenuItem`) so icons have consistent breathing room from their titles.
- Add unit test covering the added margin.

Tested:
- `npm test -- tests/unit/FABFocusableMenuItem.test.tsx`