### PR TITLE
Fix report lifecycle when moving expense to new report 

### DIFF
--- a/src/libs/actions/Transaction.ts
+++ b/src/libs/actions/Transaction.ts
@@ -844,6 +844,7 @@ type ChangeTransactionsReportProps = {
     accountID: number;
     email: string;
     newReport?: OnyxEntry<Report>;
+    originalReport?: OnyxEntry<Report>;
     policy: OnyxEntry<Policy>;
     reportNextStep?: OnyxEntry<ReportNextStepDeprecated>;
     policyCategories?: OnyxEntry<PolicyCategories>;
@@ -857,6 +858,7 @@ function changeTransactionsReport({
     accountID,
     email,
     newReport,
+    originalReport,
     policy,
     reportNextStep,
     policyCategories,
@@ -1703,6 +1705,10 @@ function changeTransactionsReport({
 
     // 9. Update next steps for all affected reports
     const destinationReportID = reportID === CONST.REPORT.UNREPORTED_REPORT_ID ? (existingSelfDMReportID ?? selfDMReport?.reportID) : reportID;
+    const shouldInheritLifecycleStateFromSource =
+        destinationReportID === newReport?.reportID && !!newReport?.pendingFields?.createReport && originalReport?.stateNum !== undefined && originalReport?.statusNum !== undefined;
+    const inheritedDestinationStateNum = shouldInheritLifecycleStateFromSource ? originalReport.stateNum : undefined;
+    const inheritedDestinationStatusNum = shouldInheritLifecycleStateFromSource ? originalReport.statusNum : undefined;
     const affectedReportIDs = new Set<string>();
 
     for (const reportIDToUpdate of Object.keys(updatedReportTotals)) {
@@ -1731,11 +1737,18 @@ function changeTransactionsReport({
 
         const updatedTotal = updatedReportTotals[affectedReportID] ?? affectedReport.total;
         const updatedTransactionCount = updatedReportTransactionCounts[affectedReportID] ?? affectedReport.transactionCount;
+        const isDestinationReportForInheritance = affectedReportID === destinationReportID && inheritedDestinationStateNum !== undefined && inheritedDestinationStatusNum !== undefined;
         const updatedReport = {
             ...affectedReport,
             total: updatedTotal,
             transactionCount: updatedTransactionCount,
             reportID: affectedReport.reportID ?? affectedReportID,
+            ...(isDestinationReportForInheritance
+                ? {
+                      stateNum: inheritedDestinationStateNum,
+                      statusNum: inheritedDestinationStatusNum,
+                  }
+                : {}),
         };
 
         const predictedNextStatus = updatedReport.statusNum ?? CONST.REPORT.STATUS_NUM.OPEN;
@@ -1817,6 +1830,72 @@ function changeTransactionsReport({
                 pendingFields: failurePendingFields,
             },
         });
+    }
+
+    // Inherit lifecycle state (stateNum/statusNum) from the source report when moving expenses
+    // into a newly-created destination report. This is applied as a dedicated update outside the
+    // nextStep loop so it cannot be silently dropped if the destination report is missing from
+    // affectedReport lookups (e.g. allReports not yet updated from CREATE_APP_REPORT optimistic SET).
+    if (shouldInheritLifecycleStateFromSource && destinationReportID && inheritedDestinationStateNum !== undefined && inheritedDestinationStatusNum !== undefined) {
+        optimisticData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${destinationReportID}`,
+            value: {
+                stateNum: inheritedDestinationStateNum,
+                statusNum: inheritedDestinationStatusNum,
+            },
+        });
+        successData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${destinationReportID}`,
+            value: {
+                stateNum: inheritedDestinationStateNum,
+                statusNum: inheritedDestinationStatusNum,
+            },
+        });
+        failureData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${destinationReportID}`,
+            value: {
+                stateNum: newReport?.stateNum ?? CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: newReport?.statusNum ?? CONST.REPORT.STATUS_NUM.OPEN,
+            },
+        });
+
+        if (newReport?.parentReportID && newReport?.parentReportActionID) {
+            const parentReportAction = getAllReportActions(newReport.parentReportID)?.[newReport.parentReportActionID];
+
+            optimisticData.push({
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${newReport.parentReportID}`,
+                value: {
+                    [newReport.parentReportActionID]: {
+                        childStateNum: inheritedDestinationStateNum,
+                        childStatusNum: inheritedDestinationStatusNum,
+                    },
+                },
+            });
+            successData.push({
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${newReport.parentReportID}`,
+                value: {
+                    [newReport.parentReportActionID]: {
+                        childStateNum: inheritedDestinationStateNum,
+                        childStatusNum: inheritedDestinationStatusNum,
+                    },
+                },
+            });
+            failureData.push({
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${newReport.parentReportID}`,
+                value: {
+                    [newReport.parentReportActionID]: {
+                        childStateNum: parentReportAction?.childStateNum ?? newReport.stateNum ?? CONST.REPORT.STATE_NUM.OPEN,
+                        childStatusNum: parentReportAction?.childStatusNum ?? newReport.statusNum ?? CONST.REPORT.STATUS_NUM.OPEN,
+                    },
+                },
+            });
+        }
     }
 
     const parameters: ChangeTransactionsReportParams = {

--- a/src/pages/NewReportWorkspaceSelectionPage.tsx
+++ b/src/pages/NewReportWorkspaceSelectionPage.tsx
@@ -27,7 +27,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {NewReportWorkspaceSelectionNavigatorParamList} from '@libs/Navigation/types';
 import {getHeaderMessageForNonUserList} from '@libs/OptionsListUtils';
 import {canSubmitPerDiemExpenseFromWorkspace, isPolicyAdmin, shouldShowPolicy} from '@libs/PolicyUtils';
-import {getDefaultWorkspaceAvatar} from '@libs/ReportUtils';
+import {getDefaultWorkspaceAvatar, getReportOrDraftReport} from '@libs/ReportUtils';
 import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
 import {isPerDiemRequest} from '@libs/TransactionUtils';
@@ -104,6 +104,21 @@ function NewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelectionPag
     const createReport = (policyID: string, shouldDismissEmptyReportsConfirmation?: boolean) => {
         const optimisticReport = createNewReport(policyID, shouldDismissEmptyReportsConfirmation);
         const selectedTransactionsKeys = Object.keys(selectedTransactions);
+        const sourceReportIDs = new Set<string>();
+        for (const transactionKey of selectedTransactionsKeys) {
+            const sourceReportID = selectedTransactions[transactionKey]?.reportID;
+            if (sourceReportID && sourceReportID !== CONST.REPORT.UNREPORTED_REPORT_ID) {
+                sourceReportIDs.add(sourceReportID);
+            }
+        }
+        for (const transactionID of selectedTransactionIDs) {
+            const sourceReportID = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`]?.reportID;
+            if (sourceReportID && sourceReportID !== CONST.REPORT.UNREPORTED_REPORT_ID) {
+                sourceReportIDs.add(sourceReportID);
+            }
+        }
+        const originalReportID = sourceReportIDs.size === 1 ? [...sourceReportIDs].at(0) : undefined;
+        const originalReport = getReportOrDraftReport(originalReportID);
 
         if (isMovingExpenses && (!!selectedTransactionsKeys.length || !!selectedTransactionIDs.length)) {
             const reportNextStep = allReportNextSteps?.[`${ONYXKEYS.COLLECTION.NEXT_STEP}${optimisticReport.reportID}`];
@@ -115,6 +130,7 @@ function NewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelectionPag
                     accountID: currentUserPersonalDetails?.accountID ?? CONST.DEFAULT_NUMBER_ID,
                     email: currentUserPersonalDetails?.email ?? '',
                     newReport: optimisticReport,
+                    originalReport,
                     policy: policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyID}`],
                     reportNextStep,
                     policyCategories: undefined,

--- a/src/pages/Search/SearchTransactionsChangeReport.tsx
+++ b/src/pages/Search/SearchTransactionsChangeReport.tsx
@@ -66,6 +66,7 @@ function SearchTransactionsChangeReport() {
         Object.values(selectedTransactions).every((transaction) => transaction.reportID === firstTransactionReportID) && firstTransactionReportID !== CONST.REPORT.UNREPORTED_REPORT_ID
             ? firstTransactionReportID
             : undefined;
+    const originalReport = selectedReportID ? allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${selectedReportID}`] : undefined;
     // Get the policyID from the selected transactions' report to pass to usePolicyForMovingExpenses
     // This ensures the "Create report" button shows the correct workspace instead of the user's default
     const selectedReportPolicyID = selectedReportID ? allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${selectedReportID}`]?.policyID : undefined;
@@ -115,6 +116,7 @@ function SearchTransactionsChangeReport() {
                 accountID: session?.accountID ?? CONST.DEFAULT_NUMBER_ID,
                 email: session?.email ?? '',
                 newReport: optimisticReport,
+                originalReport,
                 policy: policyForMovingExpenses,
                 reportNextStep,
                 policyCategories: allPolicyCategories?.[`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyForMovingExpensesID}`],
@@ -191,6 +193,7 @@ function SearchTransactionsChangeReport() {
             accountID: session?.accountID ?? CONST.DEFAULT_NUMBER_ID,
             email: session?.email ?? '',
             newReport: destinationReport,
+            originalReport,
             policy: allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${item.policyID}`],
             reportNextStep,
             policyCategories: allPolicyCategories?.[`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${item.policyID}`],

--- a/src/pages/iou/request/step/IOURequestEditReport.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReport.tsx
@@ -87,6 +87,7 @@ function IOURequestEditReport({route}: IOURequestEditReportProps) {
                 accountID: session?.accountID ?? CONST.DEFAULT_NUMBER_ID,
                 email: session?.email ?? '',
                 newReport,
+                originalReport: selectedReport,
                 policy: allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${item.policyID}`],
                 reportNextStep,
                 policyCategories: allPolicyCategories?.[`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${item.policyID}`],

--- a/src/pages/iou/request/step/IOURequestStepReport/hooks/useReportSelectionActions.ts
+++ b/src/pages/iou/request/step/IOURequestStepReport/hooks/useReportSelectionActions.ts
@@ -179,6 +179,7 @@ function useReportSelectionActions({
                 );
 
                 if (isEditing) {
+                    const originalReport = transaction.reportID ? allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${transaction.reportID}`] : undefined;
                     const policyTagList = item?.policyID ? allPolicyTags?.[`${ONYXKEYS.COLLECTION.POLICY_TAGS}${item.policyID}`] : {};
                     changeTransactionsReport({
                         transactionIDs: [transaction.transactionID],
@@ -186,6 +187,7 @@ function useReportSelectionActions({
                         accountID: session?.accountID ?? CONST.DEFAULT_NUMBER_ID,
                         email: session?.email ?? '',
                         newReport: report,
+                        originalReport,
                         policy: allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${item.policyID}`],
                         reportNextStep: undefined,
                         policyCategories: allPolicyCategories?.[`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${item.policyID}`],

--- a/src/pages/iou/request/step/IOURequestStepUpgrade.tsx
+++ b/src/pages/iou/request/step/IOURequestStepUpgrade.tsx
@@ -28,7 +28,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {MoneyRequestNavigatorParamList} from '@libs/Navigation/types';
 import {getParticipantsOption} from '@libs/OptionsListUtils';
-import {getPersonalDetailsForAccountID, hasViolations as hasViolationsReportUtils} from '@libs/ReportUtils';
+import {getPersonalDetailsForAccountID, getReportOrDraftReport, hasViolations as hasViolationsReportUtils} from '@libs/ReportUtils';
 import UpgradeConfirmation from '@pages/workspace/upgrade/UpgradeConfirmation';
 import UpgradeIntro from '@pages/workspace/upgrade/UpgradeIntro';
 import {setCustomUnitRateID, setMoneyRequestParticipants} from '@userActions/IOU/MoneyRequest';
@@ -82,6 +82,18 @@ function IOURequestStepUpgrade({
     const {selectedTransactions} = useSearchStateContext();
     const {clearSelectedTransactions} = useSearchActionsContext();
     const selectedTransactionsKeys = useMemo(() => Object.keys(selectedTransactions), [selectedTransactions]);
+    const originalReport = useMemo(() => {
+        const sourceReportIDs = new Set<string>();
+        for (const selectedTransaction of Object.values(selectedTransactions)) {
+            const sourceReportID = selectedTransaction.reportID;
+            if (sourceReportID && sourceReportID !== CONST.REPORT.UNREPORTED_REPORT_ID) {
+                sourceReportIDs.add(sourceReportID);
+            }
+        }
+
+        const originalReportID = sourceReportIDs.size === 1 ? [...sourceReportIDs].at(0) : undefined;
+        return getReportOrDraftReport(originalReportID);
+    }, [selectedTransactions]);
     const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS);
     const [allPolicyCategories] = useOnyx(ONYXKEYS.COLLECTION.POLICY_CATEGORIES);
     const [allReportNextSteps] = useOnyx(ONYXKEYS.COLLECTION.NEXT_STEP);
@@ -145,6 +157,7 @@ function IOURequestStepUpgrade({
                 accountID: session?.accountID ?? CONST.DEFAULT_NUMBER_ID,
                 email: session?.email ?? '',
                 newReport: optimisticReport,
+                originalReport,
                 policy: newPolicy,
                 reportNextStep,
                 policyCategories: allPolicyCategories?.[`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`],
@@ -236,6 +249,7 @@ function IOURequestStepUpgrade({
         session?.accountID,
         session?.email,
         ownerPersonalDetails,
+        originalReport,
         allTransactions,
         betas,
         iouType,

--- a/tests/ui/NewReportWorkspaceSelectionPageTest.tsx
+++ b/tests/ui/NewReportWorkspaceSelectionPageTest.tsx
@@ -10,6 +10,7 @@ import {createNewReport} from '@libs/actions/Report';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import type {NewReportWorkspaceSelectionNavigatorParamList} from '@libs/Navigation/types';
 import NewReportWorkspaceSelectionPage from '@pages/NewReportWorkspaceSelectionPage';
+import {changeTransactionsReport} from '@userActions/Transaction';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
@@ -18,6 +19,26 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 
 jest.mock('@libs/actions/Report', () => ({
     createNewReport: jest.fn(() => ({reportID: 'new-report-id'})),
+}));
+
+jest.mock('@userActions/Transaction', () => ({
+    changeTransactionsReport: jest.fn(),
+}));
+
+const mockChangeTransactionsReport = jest.mocked(changeTransactionsReport);
+
+const mockSelectedTransactions: Record<string, {reportID?: string; transaction?: Transaction}> = {};
+const mockSelectedTransactionIDs: string[] = [];
+
+jest.mock('@components/Search/SearchContext', () => ({
+    useSearchStateContext: () => ({
+        selectedTransactions: mockSelectedTransactions,
+        selectedTransactionIDs: mockSelectedTransactionIDs,
+    }),
+    useSearchActionsContext: () => ({
+        clearSelectedTransactions: jest.fn(),
+        setSelectedTransactions: jest.fn(),
+    }),
 }));
 
 const mockOpenCreateReportConfirmation = jest.fn();
@@ -44,6 +65,8 @@ const EMAIL = 'test@example.com';
 const POLICY_ID = 'policy-1';
 const POLICY_NAME = 'Test Workspace';
 const REPORT_ID = 'report-1';
+const SOURCE_REPORT_ID = 'source-report-1';
+const OTHER_SOURCE_REPORT_ID = 'source-report-2';
 
 const BASE_TODOS: TodosDerivedValue = {
     reportsToSubmit: [],
@@ -55,7 +78,7 @@ const BASE_TODOS: TodosDerivedValue = {
 
 const Stack = createPlatformStackNavigator<NewReportWorkspaceSelectionNavigatorParamList>();
 
-function renderPage() {
+function renderPage(initialParams: {isMovingExpenses?: boolean} = {}) {
     return render(
         <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
             <PortalProvider>
@@ -64,7 +87,7 @@ function renderPage() {
                         <Stack.Screen
                             name={SCREENS.NEW_REPORT_WORKSPACE_SELECTION.ROOT}
                             component={NewReportWorkspaceSelectionPage}
-                            initialParams={{}}
+                            initialParams={initialParams}
                         />
                     </Stack.Navigator>
                 </NavigationContainer>
@@ -113,6 +136,10 @@ describe('NewReportWorkspaceSelectionPage', () => {
         await act(async () => {
             await Onyx.clear();
         });
+        for (const key of Object.keys(mockSelectedTransactions)) {
+            delete mockSelectedTransactions[key];
+        }
+        mockSelectedTransactionIDs.length = 0;
         jest.clearAllMocks();
     });
 
@@ -156,5 +183,91 @@ describe('NewReportWorkspaceSelectionPage', () => {
 
         expect(mockCreateNewReport).toHaveBeenCalled();
         expect(mockOpenCreateReportConfirmation).not.toHaveBeenCalled();
+    });
+
+    it('passes originalReport to changeTransactionsReport when moving expenses from a single source report', async () => {
+        const sourceReport: Partial<Report> = {
+            reportID: SOURCE_REPORT_ID,
+            policyID: POLICY_ID,
+            ownerAccountID: ACCOUNT_ID,
+            type: CONST.REPORT.TYPE.EXPENSE,
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+            total: -100,
+            nonReimbursableTotal: 0,
+            pendingAction: null,
+        };
+        const transaction: Partial<Transaction> = {
+            transactionID: 'txn-1',
+            reportID: SOURCE_REPORT_ID,
+            pendingAction: null,
+        };
+
+        mockSelectedTransactions['txn-1'] = {reportID: SOURCE_REPORT_ID, transaction: transaction as Transaction};
+        mockSelectedTransactionIDs.length = 0;
+        mockSelectedTransactionIDs.push('txn-1');
+
+        await act(async () => {
+            await seedBaseOnyx();
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${SOURCE_REPORT_ID}`, sourceReport);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}txn-1`, transaction);
+            await Onyx.set(ONYXKEYS.DERIVED.TODOS, BASE_TODOS);
+            await Onyx.set(ONYXKEYS.NVP_EMPTY_REPORTS_CONFIRMATION_DISMISSED, true);
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderPage({isMovingExpenses: true});
+        await waitForBatchedUpdatesWithAct();
+
+        fireEvent.press(await screen.findByText(POLICY_NAME));
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockChangeTransactionsReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                originalReport: expect.objectContaining({
+                    reportID: SOURCE_REPORT_ID,
+                    statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+                }),
+            }),
+        );
+    });
+
+    it('does not pass originalReport when moving expenses from multiple source reports', async () => {
+        const transactionOne: Partial<Transaction> = {
+            transactionID: 'txn-1',
+            reportID: SOURCE_REPORT_ID,
+            pendingAction: null,
+        };
+        const transactionTwo: Partial<Transaction> = {
+            transactionID: 'txn-2',
+            reportID: OTHER_SOURCE_REPORT_ID,
+            pendingAction: null,
+        };
+
+        mockSelectedTransactions['txn-1'] = {reportID: SOURCE_REPORT_ID, transaction: transactionOne as Transaction};
+        mockSelectedTransactions['txn-2'] = {reportID: OTHER_SOURCE_REPORT_ID, transaction: transactionTwo as Transaction};
+        mockSelectedTransactionIDs.length = 0;
+        mockSelectedTransactionIDs.push('txn-1', 'txn-2');
+
+        await act(async () => {
+            await seedBaseOnyx();
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}txn-1`, transactionOne);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}txn-2`, transactionTwo);
+            await Onyx.set(ONYXKEYS.DERIVED.TODOS, BASE_TODOS);
+            await Onyx.set(ONYXKEYS.NVP_EMPTY_REPORTS_CONFIRMATION_DISMISSED, true);
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderPage({isMovingExpenses: true});
+        await waitForBatchedUpdatesWithAct();
+
+        fireEvent.press(await screen.findByText(POLICY_NAME));
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockChangeTransactionsReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                originalReport: undefined,
+            }),
+        );
     });
 });

--- a/tests/ui/SearchTransactionsChangeReportTest.tsx
+++ b/tests/ui/SearchTransactionsChangeReportTest.tsx
@@ -1,0 +1,200 @@
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import type {SelectedTransactions} from '@components/Search/types';
+import SearchTransactionsChangeReport from '@pages/Search/SearchTransactionsChangeReport';
+import {changeTransactionsReport} from '@userActions/Transaction';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report, Transaction} from '@src/types/onyx';
+import {createExpenseReport} from '../utils/collections/reports';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('@userActions/Transaction', () => ({
+    changeTransactionsReport: jest.fn(),
+}));
+
+const mockChangeTransactionsReport = jest.mocked(changeTransactionsReport);
+
+jest.mock('@libs/actions/Report', () => ({
+    createNewReport: jest.fn(),
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+    setNavigationActionToMicrotaskQueue: jest.fn((callback: () => void) => callback()),
+}));
+
+jest.mock('@hooks/useConditionalCreateEmptyReportConfirmation', () => () => ({
+    handleCreateReport: jest.fn(),
+}));
+
+jest.mock('@hooks/useHasPerDiemTransactions', () => () => false);
+
+jest.mock('@hooks/usePolicyForMovingExpenses', () => () => ({
+    policyForMovingExpensesID: 'policy-1',
+    shouldSelectPolicy: false,
+}));
+
+let mockSelectedTransactions: SelectedTransactions = {};
+let mockSelectedTransactionIDs: string[] = [];
+
+jest.mock('@components/Search/SearchContext', () => ({
+    useSearchStateContext: () => ({
+        selectedTransactions: mockSelectedTransactions,
+        selectedTransactionIDs: mockSelectedTransactionIDs,
+    }),
+    useSearchActionsContext: () => ({
+        clearSelectedTransactions: jest.fn(),
+    }),
+}));
+
+jest.mock('@components/OnyxListItemProvider', () => ({
+    useSession: () => ({accountID: 1, email: 'test@example.com'}),
+    usePersonalDetails: () => ({}),
+}));
+
+jest.mock('@hooks/usePermissions', () => () => ({
+    isBetaEnabled: () => false,
+}));
+
+type CapturedEditReportCommonProps = {
+    selectReport: (item: {value: string; policyID?: string}) => void;
+};
+
+let capturedProps: CapturedEditReportCommonProps | undefined;
+
+jest.mock('@pages/iou/request/step/IOURequestEditReportCommon', () => {
+    return function MockIOURequestEditReportCommon(props: CapturedEditReportCommonProps) {
+        capturedProps = props;
+        return null;
+    };
+});
+
+const SOURCE_REPORT_ID = 'source-report-1';
+const DESTINATION_REPORT_ID = 'destination-report-1';
+const POLICY_ID = 'policy-1';
+
+describe('SearchTransactionsChangeReport', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        capturedProps = undefined;
+        mockSelectedTransactions = {};
+        mockSelectedTransactionIDs = [];
+        mockChangeTransactionsReport.mockClear();
+        await act(async () => {
+            await Onyx.clear();
+        });
+    });
+
+    it('forwards originalReport when all selected transactions share one source report', async () => {
+        const sourceReport: Report = {
+            ...createExpenseReport(6),
+            reportID: SOURCE_REPORT_ID,
+            policyID: POLICY_ID,
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+            currency: CONST.CURRENCY.USD,
+        };
+        const destinationReport: Report = {
+            ...createExpenseReport(7),
+            reportID: DESTINATION_REPORT_ID,
+            policyID: POLICY_ID,
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            currency: CONST.CURRENCY.USD,
+        };
+        const transaction: Transaction = {
+            transactionID: 'txn-1',
+            reportID: SOURCE_REPORT_ID,
+            amount: -100,
+            currency: CONST.CURRENCY.USD,
+            created: '2023-10-01',
+            modified: '2023-10-01',
+        };
+
+        mockSelectedTransactions = {
+            [transaction.transactionID]: {
+                reportID: SOURCE_REPORT_ID,
+                transaction,
+            },
+        };
+        mockSelectedTransactionIDs = [transaction.transactionID];
+
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.SESSION, {accountID: 1, email: 'test@example.com'});
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${SOURCE_REPORT_ID}`, sourceReport);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${DESTINATION_REPORT_ID}`, destinationReport);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, {id: POLICY_ID, name: 'Policy'});
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        render(<SearchTransactionsChangeReport />);
+        await waitForBatchedUpdatesWithAct();
+
+        act(() => {
+            capturedProps?.selectReport({value: DESTINATION_REPORT_ID, policyID: POLICY_ID});
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockChangeTransactionsReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                newReport: destinationReport,
+                originalReport: sourceReport,
+            }),
+        );
+    });
+
+    it('does not forward originalReport when selected transactions come from different source reports', async () => {
+        const transactionOne: Transaction = {
+            transactionID: 'txn-1',
+            reportID: SOURCE_REPORT_ID,
+            amount: -100,
+            currency: CONST.CURRENCY.USD,
+            created: '2023-10-01',
+            modified: '2023-10-01',
+        };
+        const transactionTwo: Transaction = {
+            transactionID: 'txn-2',
+            reportID: 'other-source-report',
+            amount: -50,
+            currency: CONST.CURRENCY.USD,
+            created: '2023-10-01',
+            modified: '2023-10-01',
+        };
+
+        mockSelectedTransactions = {
+            [transactionOne.transactionID]: {reportID: SOURCE_REPORT_ID, transaction: transactionOne},
+            [transactionTwo.transactionID]: {reportID: 'other-source-report', transaction: transactionTwo},
+        };
+        mockSelectedTransactionIDs = [transactionOne.transactionID, transactionTwo.transactionID];
+
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.SESSION, {accountID: 1, email: 'test@example.com'});
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${DESTINATION_REPORT_ID}`, {
+                ...createExpenseReport(7),
+                reportID: DESTINATION_REPORT_ID,
+                policyID: POLICY_ID,
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        render(<SearchTransactionsChangeReport />);
+        await waitForBatchedUpdatesWithAct();
+
+        act(() => {
+            capturedProps?.selectReport({value: DESTINATION_REPORT_ID, policyID: POLICY_ID});
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockChangeTransactionsReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                originalReport: undefined,
+            }),
+        );
+    });
+});

--- a/tests/ui/SearchTransactionsChangeReportTest.tsx
+++ b/tests/ui/SearchTransactionsChangeReportTest.tsx
@@ -1,13 +1,14 @@
 import {act, render} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
-import type {SelectedTransactions} from '@components/Search/types';
+import type {SelectedTransactionInfo, SelectedTransactions} from '@components/Search/types';
 import SearchTransactionsChangeReport from '@pages/Search/SearchTransactionsChangeReport';
 import {changeTransactionsReport} from '@userActions/Transaction';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report, Transaction} from '@src/types/onyx';
 import {createExpenseReport} from '../utils/collections/reports';
+import createRandomTransaction from '../utils/collections/transaction';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
 
 jest.mock('@userActions/Transaction', () => ({
@@ -76,6 +77,26 @@ const SOURCE_REPORT_ID = 'source-report-1';
 const DESTINATION_REPORT_ID = 'destination-report-1';
 const POLICY_ID = 'policy-1';
 
+function makeSelectedTransaction(overrides: Partial<SelectedTransactionInfo> = {}): SelectedTransactionInfo {
+    return {
+        isSelected: true,
+        canReject: false,
+        canHold: false,
+        canSplit: false,
+        hasBeenSplit: false,
+        canChangeReport: true,
+        isHeld: false,
+        canUnhold: false,
+        action: CONST.SEARCH.ACTION_TYPES.VIEW,
+        reportID: SOURCE_REPORT_ID,
+        policyID: POLICY_ID,
+        amount: -100,
+        currency: CONST.CURRENCY.USD,
+        isFromOneTransactionReport: false,
+        ...overrides,
+    };
+}
+
 describe('SearchTransactionsChangeReport', () => {
     beforeAll(() => {
         Onyx.init({keys: ONYXKEYS});
@@ -109,19 +130,20 @@ describe('SearchTransactionsChangeReport', () => {
             currency: CONST.CURRENCY.USD,
         };
         const transaction: Transaction = {
+            ...createRandomTransaction(1),
             transactionID: 'txn-1',
             reportID: SOURCE_REPORT_ID,
             amount: -100,
             currency: CONST.CURRENCY.USD,
-            created: '2023-10-01',
-            modified: '2023-10-01',
         };
 
         mockSelectedTransactions = {
-            [transaction.transactionID]: {
+            [transaction.transactionID]: makeSelectedTransaction({
                 reportID: SOURCE_REPORT_ID,
                 transaction,
-            },
+                amount: transaction.amount,
+                currency: transaction.currency ?? CONST.CURRENCY.USD,
+            }),
         };
         mockSelectedTransactionIDs = [transaction.transactionID];
 
@@ -151,25 +173,33 @@ describe('SearchTransactionsChangeReport', () => {
 
     it('does not forward originalReport when selected transactions come from different source reports', async () => {
         const transactionOne: Transaction = {
+            ...createRandomTransaction(1),
             transactionID: 'txn-1',
             reportID: SOURCE_REPORT_ID,
             amount: -100,
             currency: CONST.CURRENCY.USD,
-            created: '2023-10-01',
-            modified: '2023-10-01',
         };
         const transactionTwo: Transaction = {
+            ...createRandomTransaction(2),
             transactionID: 'txn-2',
             reportID: 'other-source-report',
             amount: -50,
             currency: CONST.CURRENCY.USD,
-            created: '2023-10-01',
-            modified: '2023-10-01',
         };
 
         mockSelectedTransactions = {
-            [transactionOne.transactionID]: {reportID: SOURCE_REPORT_ID, transaction: transactionOne},
-            [transactionTwo.transactionID]: {reportID: 'other-source-report', transaction: transactionTwo},
+            [transactionOne.transactionID]: makeSelectedTransaction({
+                reportID: SOURCE_REPORT_ID,
+                transaction: transactionOne,
+                amount: transactionOne.amount,
+                currency: transactionOne.currency ?? CONST.CURRENCY.USD,
+            }),
+            [transactionTwo.transactionID]: makeSelectedTransaction({
+                reportID: 'other-source-report',
+                transaction: transactionTwo,
+                amount: transactionTwo.amount,
+                currency: transactionTwo.currency ?? CONST.CURRENCY.USD,
+            }),
         };
         mockSelectedTransactionIDs = [transactionOne.transactionID, transactionTwo.transactionID];
 

--- a/tests/unit/TransactionTest.ts
+++ b/tests/unit/TransactionTest.ts
@@ -1434,7 +1434,8 @@ describe('Transaction', () => {
             await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
             await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_OLD_REPORT_ID}`, submittedSourceReport);
             await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_OLD_REPORT_ID}`, {[oldIOUAction.reportActionID]: oldIOUAction});
-            getAllReportActionsSpy.mockImplementation((reportID?: string) => {
+            getAllReportActionsSpy.mockImplementation((...args: unknown[]) => {
+                const reportID = args.at(0) as string | undefined;
                 if (reportID === PARENT_REPORT_ID) {
                     return {[PARENT_REPORT_ACTION_ID]: parentReportAction};
                 }

--- a/tests/unit/TransactionTest.ts
+++ b/tests/unit/TransactionTest.ts
@@ -113,6 +113,27 @@ describe('Transaction', () => {
     });
 
     describe('changeTransactionsReport', () => {
+        type OnyxWriteEntry = {key: string; value: Record<string, unknown>};
+
+        function isDedicatedLifecycleInheritanceValue(value: Record<string, unknown> | undefined): value is {stateNum: number; statusNum: number} {
+            if (!value) {
+                return false;
+            }
+
+            const keys = Object.keys(value);
+            return keys.length === 2 && 'stateNum' in value && 'statusNum' in value;
+        }
+
+        function findDedicatedLifecycleReportUpdate(updates: OnyxWriteEntry[] | undefined, reportID: string, stateNum: number, statusNum: number) {
+            return updates?.find(
+                (data) =>
+                    data.key === `${ONYXKEYS.COLLECTION.REPORT}${reportID}` &&
+                    isDedicatedLifecycleInheritanceValue(data.value) &&
+                    data.value.stateNum === stateNum &&
+                    data.value.statusNum === statusNum,
+            );
+        }
+
         function createIOUAction(transaction: Transaction, reportID = transaction.reportID, type: ValueOf<typeof CONST.IOU.REPORT_ACTION_TYPE> = CONST.IOU.REPORT_ACTION_TYPE.CREATE) {
             return {
                 reportActionID: rand64(),
@@ -1286,6 +1307,279 @@ describe('Transaction', () => {
             expect(missingTagViolations).toHaveLength(2);
             expect(missingTagViolations.some((violation) => violation.data?.tagName === 'Region')).toBe(true);
             expect(missingTagViolations.some((violation) => violation.data?.tagName === 'City')).toBe(true);
+        });
+
+        it('inherits lifecycle state from originalReport when moving into an optimistic new report', async () => {
+            const mockAPIWrite = jest.spyOn(require('@libs/API'), 'write').mockImplementation(() => Promise.resolve());
+            const FAKE_OPTIMISTIC_NEW_REPORT_ID = '5';
+
+            const transaction = generateTransaction({
+                reportID: FAKE_OLD_REPORT_ID,
+                amount: -100,
+                currency: CONST.CURRENCY.USD,
+            });
+            const oldIOUAction = createIOUAction(transaction);
+            const submittedSourceReport: Report = {
+                ...createExpenseReport(6),
+                reportID: FAKE_OLD_REPORT_ID,
+                ownerAccountID: CURRENT_USER_ID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+                currency: CONST.CURRENCY.USD,
+                total: -100,
+            };
+            const optimisticNewReport: Report = {
+                ...createExpenseReport(7),
+                reportID: FAKE_OPTIMISTIC_NEW_REPORT_ID,
+                ownerAccountID: CURRENT_USER_ID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                currency: CONST.CURRENCY.USD,
+                pendingFields: {
+                    createReport: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
+                },
+            };
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_OLD_REPORT_ID}`, submittedSourceReport);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_OLD_REPORT_ID}`, {[oldIOUAction.reportActionID]: oldIOUAction});
+
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`]: transaction,
+            };
+
+            changeTransactionsReport({
+                transactionIDs: [transaction.transactionID],
+                isASAPSubmitBetaEnabled: false,
+                accountID: CURRENT_USER_ID,
+                email: 'test@example.com',
+                newReport: optimisticNewReport,
+                originalReport: submittedSourceReport,
+                policy: undefined,
+                allTransactions,
+                policyTagList: undefined,
+            });
+            await waitForBatchedUpdates();
+
+            const apiWriteCall = mockAPIWrite.mock.calls.at(0);
+            const optimisticData = (apiWriteCall?.[2] as {optimisticData?: OnyxWriteEntry[]})?.optimisticData;
+            const successData = (apiWriteCall?.[2] as {successData?: OnyxWriteEntry[]})?.successData;
+            const failureData = (apiWriteCall?.[2] as {failureData?: OnyxWriteEntry[]})?.failureData;
+
+            const lifecycleOptimisticUpdate = findDedicatedLifecycleReportUpdate(
+                optimisticData,
+                FAKE_OPTIMISTIC_NEW_REPORT_ID,
+                CONST.REPORT.STATE_NUM.OPEN,
+                CONST.REPORT.STATUS_NUM.SUBMITTED,
+            );
+            const lifecycleSuccessUpdate = findDedicatedLifecycleReportUpdate(successData, FAKE_OPTIMISTIC_NEW_REPORT_ID, CONST.REPORT.STATE_NUM.OPEN, CONST.REPORT.STATUS_NUM.SUBMITTED);
+            const lifecycleFailureUpdate = findDedicatedLifecycleReportUpdate(
+                failureData,
+                FAKE_OPTIMISTIC_NEW_REPORT_ID,
+                optimisticNewReport.stateNum ?? CONST.REPORT.STATE_NUM.OPEN,
+                optimisticNewReport.statusNum ?? CONST.REPORT.STATUS_NUM.OPEN,
+            );
+
+            expect(lifecycleOptimisticUpdate).toBeDefined();
+            expect(lifecycleSuccessUpdate).toBeDefined();
+            expect(lifecycleFailureUpdate).toBeDefined();
+
+            mockAPIWrite.mockRestore();
+        });
+
+        it('inherits parent report preview child lifecycle state when optimistic new report has a parent preview action', async () => {
+            const mockAPIWrite = jest.spyOn(require('@libs/API'), 'write').mockImplementation(() => Promise.resolve());
+            const getAllReportActionsSpy = jest.spyOn(require('@libs/ReportActionsUtils'), 'getAllReportActions');
+            const FAKE_OPTIMISTIC_NEW_REPORT_ID = '5';
+            const PARENT_REPORT_ID = '6';
+            const PARENT_REPORT_ACTION_ID = 'parent-action-1';
+
+            const transaction = generateTransaction({
+                reportID: FAKE_OLD_REPORT_ID,
+                amount: -100,
+                currency: CONST.CURRENCY.USD,
+            });
+            const oldIOUAction = createIOUAction(transaction);
+            const submittedSourceReport: Report = {
+                ...createExpenseReport(6),
+                reportID: FAKE_OLD_REPORT_ID,
+                ownerAccountID: CURRENT_USER_ID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+                currency: CONST.CURRENCY.USD,
+                total: -100,
+            };
+            const optimisticNewReport: Report = {
+                ...createExpenseReport(7),
+                reportID: FAKE_OPTIMISTIC_NEW_REPORT_ID,
+                ownerAccountID: CURRENT_USER_ID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                currency: CONST.CURRENCY.USD,
+                parentReportID: PARENT_REPORT_ID,
+                parentReportActionID: PARENT_REPORT_ACTION_ID,
+                pendingFields: {
+                    createReport: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
+                },
+            };
+            const parentReportAction = {
+                reportActionID: PARENT_REPORT_ACTION_ID,
+                actionName: CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW,
+                actorAccountID: CURRENT_USER_ID,
+                created: DateUtils.getDBTime(),
+                childStateNum: CONST.REPORT.STATE_NUM.OPEN,
+                childStatusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            };
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_OLD_REPORT_ID}`, submittedSourceReport);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_OLD_REPORT_ID}`, {[oldIOUAction.reportActionID]: oldIOUAction});
+            getAllReportActionsSpy.mockImplementation((reportID?: string) => {
+                if (reportID === PARENT_REPORT_ID) {
+                    return {[PARENT_REPORT_ACTION_ID]: parentReportAction};
+                }
+                return {};
+            });
+
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`]: transaction,
+            };
+
+            changeTransactionsReport({
+                transactionIDs: [transaction.transactionID],
+                isASAPSubmitBetaEnabled: false,
+                accountID: CURRENT_USER_ID,
+                email: 'test@example.com',
+                newReport: optimisticNewReport,
+                originalReport: submittedSourceReport,
+                policy: undefined,
+                allTransactions,
+                policyTagList: undefined,
+            });
+            await waitForBatchedUpdates();
+
+            const apiWriteCall = mockAPIWrite.mock.calls.at(0);
+            const optimisticData = (apiWriteCall?.[2] as {optimisticData?: Array<{key: string; value: Record<string, {childStateNum?: number; childStatusNum?: number}>}>})?.optimisticData;
+            const parentPreviewOptimisticUpdate = optimisticData?.find(
+                (data) =>
+                    data.key === `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${PARENT_REPORT_ID}` &&
+                    data.value?.[PARENT_REPORT_ACTION_ID]?.childStateNum === CONST.REPORT.STATE_NUM.OPEN &&
+                    data.value?.[PARENT_REPORT_ACTION_ID]?.childStatusNum === CONST.REPORT.STATUS_NUM.SUBMITTED,
+            );
+
+            expect(parentPreviewOptimisticUpdate).toBeDefined();
+
+            getAllReportActionsSpy.mockRestore();
+            mockAPIWrite.mockRestore();
+        });
+
+        it('does not inherit lifecycle state when originalReport is omitted', async () => {
+            const mockAPIWrite = jest.spyOn(require('@libs/API'), 'write').mockImplementation(() => Promise.resolve());
+            const FAKE_OPTIMISTIC_NEW_REPORT_ID = '5';
+
+            const transaction = generateTransaction({
+                reportID: FAKE_OLD_REPORT_ID,
+            });
+            const oldIOUAction = createIOUAction(transaction);
+            const optimisticNewReport: Report = {
+                ...createExpenseReport(7),
+                reportID: FAKE_OPTIMISTIC_NEW_REPORT_ID,
+                ownerAccountID: CURRENT_USER_ID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                pendingFields: {
+                    createReport: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
+                },
+            };
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_OLD_REPORT_ID}`, {[oldIOUAction.reportActionID]: oldIOUAction});
+
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`]: transaction,
+            };
+
+            changeTransactionsReport({
+                transactionIDs: [transaction.transactionID],
+                isASAPSubmitBetaEnabled: false,
+                accountID: CURRENT_USER_ID,
+                email: 'test@example.com',
+                newReport: optimisticNewReport,
+                policy: undefined,
+                allTransactions,
+                policyTagList: undefined,
+            });
+            await waitForBatchedUpdates();
+
+            const apiWriteCall = mockAPIWrite.mock.calls.at(0);
+            const optimisticData = (apiWriteCall?.[2] as {optimisticData?: OnyxWriteEntry[]})?.optimisticData;
+            const lifecycleOptimisticUpdate = findDedicatedLifecycleReportUpdate(
+                optimisticData,
+                FAKE_OPTIMISTIC_NEW_REPORT_ID,
+                CONST.REPORT.STATE_NUM.OPEN,
+                CONST.REPORT.STATUS_NUM.SUBMITTED,
+            );
+
+            expect(lifecycleOptimisticUpdate).toBeUndefined();
+
+            mockAPIWrite.mockRestore();
+        });
+
+        it('does not inherit lifecycle state when destination report is not an optimistic create', async () => {
+            const mockAPIWrite = jest.spyOn(require('@libs/API'), 'write').mockImplementation(() => Promise.resolve());
+
+            const transaction = generateTransaction({
+                reportID: FAKE_OLD_REPORT_ID,
+                amount: -100,
+                currency: CONST.CURRENCY.USD,
+            });
+            const oldIOUAction = createIOUAction(transaction);
+            const submittedSourceReport: Report = {
+                ...createExpenseReport(6),
+                reportID: FAKE_OLD_REPORT_ID,
+                ownerAccountID: CURRENT_USER_ID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+                currency: CONST.CURRENCY.USD,
+                total: -100,
+            };
+            const existingDestinationReport: Report = {
+                ...createExpenseReport(7),
+                reportID: FAKE_NEW_REPORT_ID,
+                ownerAccountID: CURRENT_USER_ID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                currency: CONST.CURRENCY.USD,
+            };
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${FAKE_OLD_REPORT_ID}`, submittedSourceReport);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_OLD_REPORT_ID}`, {[oldIOUAction.reportActionID]: oldIOUAction});
+
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`]: transaction,
+            };
+
+            changeTransactionsReport({
+                transactionIDs: [transaction.transactionID],
+                isASAPSubmitBetaEnabled: false,
+                accountID: CURRENT_USER_ID,
+                email: 'test@example.com',
+                newReport: existingDestinationReport,
+                originalReport: submittedSourceReport,
+                policy: undefined,
+                allTransactions,
+                policyTagList: undefined,
+            });
+            await waitForBatchedUpdates();
+
+            const apiWriteCall = mockAPIWrite.mock.calls.at(0);
+            const optimisticData = (apiWriteCall?.[2] as {optimisticData?: OnyxWriteEntry[]})?.optimisticData;
+            const lifecycleOptimisticUpdate = findDedicatedLifecycleReportUpdate(optimisticData, FAKE_NEW_REPORT_ID, CONST.REPORT.STATE_NUM.OPEN, CONST.REPORT.STATUS_NUM.SUBMITTED);
+
+            expect(lifecycleOptimisticUpdate).toBeUndefined();
+
+            mockAPIWrite.mockRestore();
         });
 
         it('should auto-select a valid distance rate when moving a distance expense with an invalid P2P rate to a workspace', async () => {

--- a/tests/unit/hooks/useReportSelectionActions.test.ts
+++ b/tests/unit/hooks/useReportSelectionActions.test.ts
@@ -1,0 +1,146 @@
+import {act, renderHook} from '@testing-library/react-native';
+// eslint-disable-next-line no-restricted-imports -- required to stub InteractionManager for synchronous test execution
+import {InteractionManager} from 'react-native';
+import Onyx from 'react-native-onyx';
+import {changeTransactionsReport} from '@libs/actions/Transaction';
+import useReportSelectionActions from '@pages/iou/request/step/IOURequestStepReport/hooks/useReportSelectionActions';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report} from '@src/types/onyx';
+import {createExpenseReport} from '../../utils/collections/reports';
+import createRandomTransaction from '../../utils/collections/transaction';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+
+jest.mock('@libs/actions/Transaction', () => ({
+    changeTransactionsReport: jest.fn(),
+    setTransactionReport: jest.fn(),
+}));
+
+const mockChangeTransactionsReport = jest.mocked(changeTransactionsReport);
+const mockRemoveTransaction = jest.fn();
+
+jest.mock('@libs/actions/IOU', () => ({
+    setCustomUnitID: jest.fn(),
+    setCustomUnitRateID: jest.fn(),
+}));
+
+jest.mock('@libs/actions/IOU/PerDiem', () => ({
+    clearSubrates: jest.fn(),
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+    dismissToSuperWideRHP: jest.fn(),
+    setNavigationActionToMicrotaskQueue: jest.fn((callback: () => void) => callback()),
+}));
+
+jest.mock('@components/Search/SearchContext', () => ({
+    useSearchActionsContext: () => ({
+        removeTransaction: mockRemoveTransaction,
+    }),
+}));
+
+const CURRENT_USER_ID = 1;
+const SOURCE_REPORT_ID = 'source-report-1';
+const DESTINATION_REPORT_ID = 'destination-report-1';
+const TRANSACTION_ID = 'transaction-1';
+const POLICY_ID = 'policy-1';
+
+describe('useReportSelectionActions', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+            initialKeyStates: {
+                [ONYXKEYS.SESSION]: {accountID: CURRENT_USER_ID, email: 'test@example.com'},
+            },
+        });
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        jest.clearAllMocks();
+        jest.spyOn(InteractionManager, 'runAfterInteractions').mockImplementation((callback) => {
+            if (typeof callback === 'function') {
+                callback();
+            }
+            return {cancel: jest.fn()};
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('forwards originalReport and policyTagList when editing and selecting a new report', async () => {
+        const sourceReport: Report = {
+            ...createExpenseReport(6),
+            reportID: SOURCE_REPORT_ID,
+            ownerAccountID: CURRENT_USER_ID,
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+            currency: CONST.CURRENCY.USD,
+        };
+        const destinationReport: Report = {
+            ...createExpenseReport(7),
+            reportID: DESTINATION_REPORT_ID,
+            ownerAccountID: CURRENT_USER_ID,
+            policyID: POLICY_ID,
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            currency: CONST.CURRENCY.USD,
+            pendingFields: {
+                createReport: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
+            },
+        };
+        const transaction = {
+            ...createRandomTransaction(1),
+            transactionID: TRANSACTION_ID,
+            reportID: SOURCE_REPORT_ID,
+        };
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${SOURCE_REPORT_ID}`, sourceReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${DESTINATION_REPORT_ID}`, destinationReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${TRANSACTION_ID}`, transaction);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${POLICY_ID}`, {});
+
+        const handleGoBack = jest.fn();
+        const {result} = renderHook(() =>
+            useReportSelectionActions({
+                transaction,
+                transactions: [transaction],
+                allPolicies: {},
+                perDiemOriginalPolicy: undefined,
+                isPerDiemTransaction: false,
+                isEditing: true,
+                isASAPSubmitBetaEnabled: false,
+                session: {accountID: CURRENT_USER_ID, email: 'test@example.com'},
+                transactionID: TRANSACTION_ID,
+                iouType: CONST.IOU.TYPE.SUBMIT,
+                action: CONST.IOU.ACTION.EDIT,
+                reportIDFromRoute: SOURCE_REPORT_ID,
+                personalPolicyID: undefined,
+                backTo: undefined,
+                handleGoBack,
+            }),
+        );
+
+        act(() => {
+            result.current.handleRegularReportSelection({value: DESTINATION_REPORT_ID, keyForList: DESTINATION_REPORT_ID}, destinationReport);
+        });
+        await waitForBatchedUpdates();
+
+        expect(handleGoBack).toHaveBeenCalled();
+        expect(mockChangeTransactionsReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                newReport: destinationReport,
+                originalReport: expect.objectContaining({
+                    reportID: SOURCE_REPORT_ID,
+                    statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+                }),
+                policyTagList: {},
+            }),
+        );
+        expect(mockRemoveTransaction).toHaveBeenCalledWith(TRANSACTION_ID);
+    });
+});

--- a/tests/unit/hooks/useReportSelectionActions.test.ts
+++ b/tests/unit/hooks/useReportSelectionActions.test.ts
@@ -60,11 +60,18 @@ describe('useReportSelectionActions', () => {
     beforeEach(async () => {
         await Onyx.clear();
         jest.clearAllMocks();
-        jest.spyOn(InteractionManager, 'runAfterInteractions').mockImplementation((callback) => {
-            if (typeof callback === 'function') {
-                callback();
+        jest.spyOn(InteractionManager, 'runAfterInteractions').mockImplementation((task) => {
+            if (typeof task === 'function') {
+                task();
             }
-            return {cancel: jest.fn()};
+            return {
+                then: (onfulfilled?: () => void) => {
+                    onfulfilled?.();
+                    return Promise.resolve();
+                },
+                done: () => undefined,
+                cancel: jest.fn(),
+            };
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

When moving an expense onto a **new** report (e.g. from a **submitted** source report), optimistic / merged report data could show **Draft** instead of preserving the source report’s lifecycle (e.g. **Outstanding**). This PR passes an explicit **`originalReport`** into **`changeTransactionsReport`** so the client can apply the source report’s **`stateNum` / `statusNum`** when the destination is an optimistic newly created report, and keeps lifecycle inheritance logic aligned with that flow. Call sites that know the source report (`IOU` edit/step report flows, search bulk move, new report workspace selection) pass **`originalReport`**. After **`main`** refactored report selection into **`useReportSelectionActions`**, the same **`originalReport`** + **`policyTagList`** arguments are wired through that hook so behavior stays correct with current **`main`**.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/86637
PROPOSAL: https://github.com/Expensify/App/issues/86637#issuecomment-4251426969


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. On an account with a **submitted** expense report, open an expense on that report and use the flow to **move** / **change report** / **create new report** (same entry points you changed: IOU edit report, step report including global create if applicable, search change report, new report workspace selection where relevant).
2. Confirm the **destination** report row / header shows the **expected** lifecycle (not incorrectly stuck on **Draft**) immediately after the move, before a full reload, when the destination is a **new** optimistic report.
3. Repeat moving to an **existing** report and confirm no regression (correct report, no console errors).
4. Smoke-test **remove from report** / personal-policy path from the report step screen: action completes and no regressions around **`changeTransactionsReport`**.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Turn **offline**, perform the same “move expense to **new** report” flow as in Tests.
2. Confirm optimistic UI still shows the **intended** lifecycle state for the new report (not an incorrect **Draft** state attributable to this path) while offline.
3. Go back **online** and confirm the app reconciles without unexpected errors (watch JS console).

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Same as **Tests** and **Offline tests** on staging: submitted source report → move expense to **new** report; verify lifecycle display; then existing report; then remove-from-report smoke where applicable.
2. Confirm no new regressions in **Search** bulk “change report” if that flow is available on staging with the same policy setup.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>





</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/94bd9422-95b8-4a98-9224-daf7289b90d7

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/f18b47ef-7509-4392-91fa-1ae96d49d531



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/ec906ef7-bb8f-43cd-a161-c03aee8cfd21



</details>