### PR TITLE
[$250] fix: Align Spend LHN icon and badge spacing

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1839,7 +1839,7 @@ const staticStyles = (theme: ThemeColors) =>
         },
 
         popoverMenuIcon: {
-            width: variables.componentSizeNormal,
+            width: 28,
             justifyContent: 'center',
             alignItems: 'center',
         },
@@ -5635,11 +5635,13 @@ const staticStyles = (theme: ThemeColors) =>
 
         todoBadge: {
             alignItems: 'center',
+            width: 28,
             justifyContent: 'center',
         },
 
         searchSectionBadge: {
             alignItems: 'center',
+            width: 28,
             justifyContent: 'center',
             height: 16,
         },
@@ -6415,6 +6417,7 @@ const dynamicStyles = (theme: ThemeColors) =>
             paddingHorizontal: 16,
             paddingVertical: shouldUseNarrowLayout ? 8 : 4,
             height: shouldUseNarrowLayout ? variables.sectionMenuItemHeight : variables.sectionMenuItemHeightCompact,
+            paddingRight: 12,
             alignItems: 'center',
         }),
 


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/90643

### Explanation of Change
Aligns the Spend left-hand navigation icon and badge spacing to match the design spec: 28px fixed-width icon wrapper, 12px right padding on row items.

### Changes
1. **popoverMenuIcon**: width from 40 → 28px
2. **todoBadge**: added width: 28
3. **searchSectionBadge**: added width: 28
4. **sectionMenuItem**: added paddingRight: 12 (keeps paddingLeft: 16)

### Tests
- Verify icons in Spend LHN are vertically aligned with consistent spacing
- Verify badge counters have consistent width across items
- Verify no regression in other popover menu icons

### Screenshots
N/A — CSS-only change

<!-- mahlon optimized -->