### PR TITLE
fix(tests): resolve flaky fetch count assertions in MiddlewareTest

### DIFF
--- a/tests/unit/MiddlewareTest.ts
+++ b/tests/unit/MiddlewareTest.ts
@@ -144,6 +144,12 @@ describe('Middleware', () => {
             }));
 
             SequentialQueue.unpause();
+            // Wait for the first request to complete and for Onyx to process the preexistingReportID
+            // update before the second request is dispatched. A single waitForNetworkPromises() call
+            // is not enough because the middleware re-queues the second request after the Onyx update
+            // resolves, which happens in a subsequent microtask/batch cycle.
+            await waitForNetworkPromises();
+            await waitForBatchedUpdates();
             await waitForNetworkPromises();
 
             expect(global.fetch).toHaveBeenCalledTimes(2);
@@ -338,7 +344,11 @@ describe('Middleware', () => {
                 }));
 
             SequentialQueue.unpause();
+            // Both requests are sequential; we need to wait for all network activity to settle,
+            // including the second fetch triggered after Onyx processes preexistingReportID.
+            await waitForNetworkPromises();
             await waitForBatchedUpdates();
+            await waitForNetworkPromises();
 
             expect(global.fetch).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
/claim #90660

## Problem

Two tests in `tests/unit/MiddlewareTest.ts` were intermittently failing on:

```
expect(global.fetch).toHaveBeenCalledTimes(2)
```

Failures confirmed in CI run [#33684](https://github.com/Expensify/App/actions/runs/25858979390/attempts/1) — attempt 1 failed, attempt 2 passed, classic timing flake.

## Root Cause

The `HandleUnusedOptimisticID` middleware intercepts the first request's response, reads `preexistingReportID` out of the Onyx update, then patches the second request's data before it fires. This chain runs across multiple async cycles:

1. First fetch resolves
2. Onyx processes the merge (1 batch cycle)
3. Middleware reacts to Onyx change, updates queued request (another batch cycle)
4. Second fetch fires

`waitForNetworkPromises()` only covers 2 batch cycles (it's `waitForBatchedUpdates().then(waitForBatchedUpdates)`). That's enough for step 2 but not steps 3 and 4. On loaded CI runners, the assertion fires before step 4 completes.

The 'OpenReport to a chat' test had the same issue but used only `waitForBatchedUpdates()` — even less robust.

## Fix

Add an extra `waitForBatchedUpdates()` + `waitForNetworkPromises()` pass after the initial wait to fully drain the async queue before asserting on call counts.

No logic changes — the tests were conceptually correct, just not waiting long enough.
