### PR TITLE
Fix icon and badge alignment in Spend left-hand navigation bar

### DIFF
--- a/src/pages/Search/SearchTypeMenuAccordion.tsx
+++ b/src/pages/Search/SearchTypeMenuAccordion.tsx
@@ -92,7 +92,7 @@ function SearchTypeMenuAccordion({title, isExpanded, badgeText, children, onSect
         <View>
             <PressableWithoutFeedback
                 onPress={onSectionHeaderPress}
-                style={[styles.flexRow, styles.p2, styles.gap2, styles.alignItemsCenter, styles.br2]}
+                style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.br2, {paddingLeft: 8, paddingRight: 12, paddingVertical: 8}]}
                 role={CONST.ROLE.BUTTON}
                 accessibilityLabel={title}
                 sentryLabel={CONST.SENTRY_LABEL.ACCORDION_SECTION.TOGGLE}

--- a/src/pages/Search/SearchTypeMenuItem.tsx
+++ b/src/pages/Search/SearchTypeMenuItem.tsx
@@ -54,7 +54,7 @@ function SearchTypeMenuItem({title, icon, badgeText, focused = false, onPress}: 
             {({hovered, pressed}) => (
                 <>
                     {icon != null && (
-                        <View style={[styles.popoverMenuIcon, styles.wAuto]}>
+                        <View style={[styles.lhnMenuIcon]}>
                             <Icon
                                 src={icon}
                                 width={variables.iconSizeNormal}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1849,6 +1849,12 @@ const staticStyles = (theme: ThemeColors) =>
             alignItems: 'center',
         },
 
+        lhnMenuIcon: {
+            width: 28,
+            justifyContent: 'center',
+            alignItems: 'center',
+        },
+
         popoverIconCircle: {
             backgroundColor: theme.buttonDefaultBG,
             borderRadius: variables.buttonBorderRadius,
@@ -5644,12 +5650,14 @@ const staticStyles = (theme: ThemeColors) =>
         todoBadge: {
             alignItems: 'center',
             justifyContent: 'center',
+            width: 28,
         },
 
         searchSectionBadge: {
             alignItems: 'center',
             justifyContent: 'center',
             height: 16,
+            width: 28,
         },
 
         stickToBottom: {
@@ -6420,7 +6428,8 @@ const dynamicStyles = (theme: ThemeColors) =>
 
         sectionMenuItem: (shouldUseNarrowLayout: boolean) => ({
             borderRadius: 8,
-            paddingHorizontal: 16,
+            paddingLeft: 16,
+            paddingRight: 12,
             paddingVertical: shouldUseNarrowLayout ? 8 : 4,
             height: shouldUseNarrowLayout ? variables.sectionMenuItemHeight : variables.sectionMenuItemHeightCompact,
             alignItems: 'center',


### PR DESCRIPTION
$ #90643

The Spend LHN sidebar had misaligned icons and inconsistent badge widths. This was noticeable when icons didn't sit in a consistent horizontal position and badge counters had varying widths.

**Changes:**

- Added `lhnMenuIcon` style (28px fixed-width, centered) specifically for Spend LHN icon containers — avoids touching the broader `popoverMenuIcon` used elsewhere
- `sectionMenuItem`: replaced `paddingHorizontal: 16` with `paddingLeft: 16, paddingRight: 12` to give 12px on the right
- `todoBadge` and `searchSectionBadge`: added `width: 28` to align badge counters within the same bounding box as icons
- `SearchTypeMenuAccordion` accordion header: removed `styles.p2` (8px all sides) and replaced with explicit `paddingLeft: 8, paddingRight: 12, paddingVertical: 8` to match the 12px right padding spec

**Platforms tested conceptually against design spec:**
- All items get 12px right padding
- Icon wrappers and badge elements are within a 28px fixed bounding box, centered