### PR TITLE
Fix flaky HandleUnusedOptimisticID tests - fetch call count race condition

### DIFF
--- a/tests/unit/MiddlewareTest.ts
+++ b/tests/unit/MiddlewareTest.ts
@@ -144,6 +144,10 @@ describe('Middleware', () => {
             }));
 
             SequentialQueue.unpause();
+            // Two rounds of network promises are needed: the first round lets the initial
+            // OpenReport fetch resolve and Onyx process the preexistingReportID update;
+            // the second round lets the queued AddComment request fire with the updated reportID.
+            await waitForNetworkPromises();
             await waitForNetworkPromises();
 
             expect(global.fetch).toHaveBeenCalledTimes(2);
@@ -338,7 +342,10 @@ describe('Middleware', () => {
                 }));
 
             SequentialQueue.unpause();
-            await waitForBatchedUpdates();
+            // waitForNetworkPromises twice: first round resolves the OpenReport fetch and lets
+            // Onyx apply the preexistingReportID, second round fires the follow-up OpenReport request.
+            await waitForNetworkPromises();
+            await waitForNetworkPromises();
 
             expect(global.fetch).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
$ #90660

The two flaky assertions in `HandleUnusedOptimisticID` tests both fail on:
```
expect(global.fetch).toHaveBeenCalledTimes(2)
```

**Root cause:** Both tests push two requests to SequentialQueue — but the second request only fires *after* Onyx processes the first response (which sets `preexistingReportID`). The middleware then rewrites the pending request with the new ID before it fires.

`waitForNetworkPromises()` is defined as `waitForBatchedUpdates().then(waitForBatchedUpdates)` — that's 2 Onyx update cycles. But we need:
1. First `waitForNetworkPromises()`: resolves the initial fetch + lets Onyx apply the `preexistingReportID` update
2. Second `waitForNetworkPromises()`: waits for the middleware to rewrite + fire the second queued request

A single call races against the Onyx update cycle, so the second fetch call sometimes hasn't happened yet when the assertion runs.

**Fix:** Await `waitForNetworkPromises()` twice at the two affected assertion sites. No production code changes — test timing only.

I have read the CLA Document and I hereby sign the CLA