### PR TITLE
[Phase 4] App: Onyx migration to rewrite cached reaction keys to hexcode

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -148,6 +148,9 @@ const ONYXKEYS = {
     /** Whether the user is a member of a policy other than their personal */
     HAS_NON_PERSONAL_POLICY: 'hasNonPersonalPolicy',
 
+    /** Set to true once the EmojiReactionKeysToHexcode Onyx migration has completed */
+    EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE: 'emojiReactionKeysToHexcodeMigrationDone',
+
     /** Key under which personal policy id is stored. Returned by OpenApp */
     PERSONAL_POLICY_ID: 'personalPolicyID',
 
@@ -1428,6 +1431,7 @@ type OnyxValuesMapping = {
     [ONYXKEYS.NVP_SAVED_CSV_COLUMN_LAYOUT_LIST]: SavedCSVColumnLayoutList;
     [ONYXKEYS.NVP_INTRO_SELECTED]: OnyxTypes.IntroSelected;
     [ONYXKEYS.HAS_NON_PERSONAL_POLICY]: boolean;
+    [ONYXKEYS.EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE]: boolean;
     [ONYXKEYS.NVP_LAST_SELECTED_DISTANCE_RATES]: OnyxTypes.LastSelectedDistanceRates;
     [ONYXKEYS.NVP_SEEN_NEW_USER_MODAL]: boolean;
     [ONYXKEYS.PLAID_DATA]: OnyxTypes.PlaidData;

--- a/src/libs/migrateOnyx.ts
+++ b/src/libs/migrateOnyx.ts
@@ -1,6 +1,7 @@
 import CONST from '@src/CONST';
 import Log from './Log';
 import ConvertGpsPointsTo2DArray from './migrations/ConvertGpsPointsTo2DArray';
+import EmojiReactionKeysToHexcode from './migrations/EmojiReactionKeysToHexcode';
 import {endSpan, getSpan, startSpan} from './telemetry/activeSpans';
 
 export default function () {
@@ -15,7 +16,7 @@ export default function () {
         });
 
         // Add all migrations to an array so they are executed in order
-        const migrationPromises: Array<() => Promise<void>> = [ConvertGpsPointsTo2DArray];
+        const migrationPromises: Array<() => Promise<void>> = [ConvertGpsPointsTo2DArray, EmojiReactionKeysToHexcode];
 
         // Reduce all promises down to a single promise. All promises run in a linear fashion, waiting for the
         // previous promise to finish before moving onto the next one.

--- a/src/libs/migrations/EmojiReactionKeysToHexcode.ts
+++ b/src/libs/migrations/EmojiReactionKeysToHexcode.ts
@@ -25,74 +25,90 @@ function resolveHexcode(key: string): string | undefined {
 
 export default function (): Promise<void> {
     return new Promise<void>((resolve) => {
-        const connection = Onyx.connectWithoutView({
-            key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS,
-            waitForCollectionCallback: true,
-            callback: (collection) => {
-                Onyx.disconnect(connection);
+        const flagConnection = Onyx.connectWithoutView({
+            key: ONYXKEYS.EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE,
+            callback: (isDone) => {
+                Onyx.disconnect(flagConnection);
 
-                if (!collection) {
-                    Log.info('[Migrate Onyx] Skipped EmojiReactionKeysToHexcode — no reactions collection');
+                if (isDone) {
+                    Log.info('[Migrate Onyx] Skipped EmojiReactionKeysToHexcode — already completed');
                     return resolve();
                 }
 
-                const updates: CollectionDataSet<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS> = {};
-                let migratedCount = 0;
+                const connection = Onyx.connectWithoutView({
+                    key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS,
+                    waitForCollectionCallback: true,
+                    callback: (collection) => {
+                        Onyx.disconnect(connection);
 
-                for (const [collectionKey, reactions] of Object.entries(collection)) {
-                    if (!reactions) {
-                        continue;
-                    }
-
-                    const rebuilt: ReportActionReactions = {};
-                    let changed = false;
-
-                    for (const [oldKey, reaction] of Object.entries(reactions)) {
-                        if (!reaction) {
-                            continue;
+                        if (!collection) {
+                            Log.info('[Migrate Onyx] Skipped EmojiReactionKeysToHexcode — no reactions collection');
+                            Onyx.set(ONYXKEYS.EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE, true).then(resolve);
+                            return;
                         }
 
-                        const hexcode = resolveHexcode(oldKey);
-                        if (!hexcode) {
-                            Log.warn(`[Migrate Onyx] EmojiReactionKeysToHexcode: unknown reaction key "${oldKey}"; preserving`);
-                            rebuilt[oldKey] = reaction;
-                            continue;
+                        const updates: CollectionDataSet<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS> = {};
+                        let migratedCount = 0;
+
+                        for (const [collectionKey, reactions] of Object.entries(collection)) {
+                            if (!reactions) {
+                                continue;
+                            }
+
+                            const rebuilt: ReportActionReactions = {};
+                            let changed = false;
+
+                            for (const [oldKey, reaction] of Object.entries(reactions)) {
+                                if (!reaction) {
+                                    continue;
+                                }
+
+                                const hexcode = resolveHexcode(oldKey);
+                                if (!hexcode) {
+                                    Log.warn(`[Migrate Onyx] EmojiReactionKeysToHexcode: unknown reaction key "${oldKey}"; preserving`);
+                                    rebuilt[oldKey] = reaction;
+                                    continue;
+                                }
+
+                                const newKey = hexcode;
+                                if (newKey !== oldKey) {
+                                    changed = true;
+                                }
+
+                                const existing = rebuilt[newKey];
+                                if (existing) {
+                                    const earlierCreatedAt = existing.createdAt < reaction.createdAt ? existing.createdAt : reaction.createdAt;
+                                    const earlierOldestTimestamp = existing.oldestTimestamp < reaction.oldestTimestamp ? existing.oldestTimestamp : reaction.oldestTimestamp;
+                                    rebuilt[newKey] = {
+                                        ...existing,
+                                        createdAt: earlierCreatedAt,
+                                        oldestTimestamp: earlierOldestTimestamp,
+                                        users: {...existing.users, ...reaction.users},
+                                    };
+                                } else {
+                                    rebuilt[newKey] = reaction;
+                                }
+                            }
+
+                            if (changed) {
+                                updates[collectionKey as `${typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${string}`] = rebuilt;
+                                migratedCount++;
+                            }
                         }
 
-                        const newKey = hexcode;
-                        if (newKey !== oldKey) {
-                            changed = true;
+                        const finish = () => Onyx.set(ONYXKEYS.EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE, true).then(resolve);
+
+                        if (migratedCount === 0) {
+                            Log.info('[Migrate Onyx] Skipped EmojiReactionKeysToHexcode — already all hex');
+                            finish();
+                            return;
                         }
 
-                        const existing = rebuilt[newKey];
-                        if (existing) {
-                            const earlierCreatedAt = existing.createdAt < reaction.createdAt ? existing.createdAt : reaction.createdAt;
-                            const earlierOldestTimestamp = existing.oldestTimestamp < reaction.oldestTimestamp ? existing.oldestTimestamp : reaction.oldestTimestamp;
-                            rebuilt[newKey] = {
-                                ...existing,
-                                createdAt: earlierCreatedAt,
-                                oldestTimestamp: earlierOldestTimestamp,
-                                users: {...existing.users, ...reaction.users},
-                            };
-                        } else {
-                            rebuilt[newKey] = reaction;
-                        }
-                    }
-
-                    if (changed) {
-                        updates[collectionKey as `${typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${string}`] = rebuilt;
-                        migratedCount++;
-                    }
-                }
-
-                if (migratedCount === 0) {
-                    Log.info('[Migrate Onyx] Skipped EmojiReactionKeysToHexcode — already all hex');
-                    return resolve();
-                }
-
-                Onyx.multiSet(updates).then(() => {
-                    Log.info(`[Migrate Onyx] Ran EmojiReactionKeysToHexcode — migrated ${migratedCount} reportActions`);
-                    resolve();
+                        Onyx.multiSet(updates).then(() => {
+                            Log.info(`[Migrate Onyx] Ran EmojiReactionKeysToHexcode — migrated ${migratedCount} reportActions`);
+                            finish();
+                        });
+                    },
                 });
             },
         });

--- a/src/libs/migrations/EmojiReactionKeysToHexcode.ts
+++ b/src/libs/migrations/EmojiReactionKeysToHexcode.ts
@@ -1,0 +1,3 @@
+export default function (): Promise<void> {
+    return Promise.resolve();
+}

--- a/src/libs/migrations/EmojiReactionKeysToHexcode.ts
+++ b/src/libs/migrations/EmojiReactionKeysToHexcode.ts
@@ -1,3 +1,100 @@
+import Onyx from 'react-native-onyx';
+import {emojiCodeTableWithSkinTones, emojiNameTable} from '@assets/emojis';
+import Log from '@libs/Log';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type ReportActionReactions from '@src/types/onyx/ReportActionReactions';
+import type CollectionDataSet from '@src/types/utils/CollectionDataSet';
+
+const HEX_KEY_PATTERN = /^[0-9A-F]+(-[0-9A-F]+)*$/;
+
+function resolveHexcode(key: string): string | undefined {
+    if (HEX_KEY_PATTERN.test(key)) {
+        return key;
+    }
+    const normalizedName = key.startsWith(':') && key.endsWith(':') ? key.slice(1, -1) : key;
+    const byName = emojiNameTable[normalizedName];
+    if (byName?.hexcode) {
+        return byName.hexcode;
+    }
+    const byCode = emojiCodeTableWithSkinTones[key];
+    if (byCode?.hexcode) {
+        return byCode.hexcode;
+    }
+    return undefined;
+}
+
 export default function (): Promise<void> {
-    return Promise.resolve();
+    return new Promise<void>((resolve) => {
+        const connection = Onyx.connectWithoutView({
+            key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS,
+            waitForCollectionCallback: true,
+            callback: (collection) => {
+                Onyx.disconnect(connection);
+
+                if (!collection) {
+                    Log.info('[Migrate Onyx] Skipped EmojiReactionKeysToHexcode — no reactions collection');
+                    return resolve();
+                }
+
+                const updates: CollectionDataSet<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS> = {};
+                let migratedCount = 0;
+
+                for (const [collectionKey, reactions] of Object.entries(collection)) {
+                    if (!reactions) {
+                        continue;
+                    }
+
+                    const rebuilt: ReportActionReactions = {};
+                    let changed = false;
+
+                    for (const [oldKey, reaction] of Object.entries(reactions)) {
+                        if (!reaction) {
+                            continue;
+                        }
+
+                        const hexcode = resolveHexcode(oldKey);
+                        if (!hexcode) {
+                            Log.warn(`[Migrate Onyx] EmojiReactionKeysToHexcode: unknown reaction key "${oldKey}"; preserving`);
+                            rebuilt[oldKey] = reaction;
+                            continue;
+                        }
+
+                        const newKey = hexcode;
+                        if (newKey !== oldKey) {
+                            changed = true;
+                        }
+
+                        const existing = rebuilt[newKey];
+                        if (existing) {
+                            const earlierCreatedAt = existing.createdAt < reaction.createdAt ? existing.createdAt : reaction.createdAt;
+                            const earlierOldestTimestamp = existing.oldestTimestamp < reaction.oldestTimestamp ? existing.oldestTimestamp : reaction.oldestTimestamp;
+                            rebuilt[newKey] = {
+                                ...existing,
+                                createdAt: earlierCreatedAt,
+                                oldestTimestamp: earlierOldestTimestamp,
+                                users: {...existing.users, ...reaction.users},
+                            };
+                        } else {
+                            rebuilt[newKey] = reaction;
+                        }
+                    }
+
+                    if (changed) {
+                        updates[collectionKey as `${typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${string}`] = rebuilt;
+                        migratedCount++;
+                    }
+                }
+
+                if (migratedCount === 0) {
+                    Log.info('[Migrate Onyx] Skipped EmojiReactionKeysToHexcode — already all hex');
+                    return resolve();
+                }
+
+                Onyx.multiSet(updates).then(() => {
+                    Log.info(`[Migrate Onyx] Ran EmojiReactionKeysToHexcode — migrated ${migratedCount} reportActions`);
+                    resolve();
+                });
+            },
+        });
+    });
 }

--- a/tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
+++ b/tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
@@ -132,15 +132,34 @@ describe('EmojiReactionKeysToHexcode', () => {
         expect(result).toBeUndefined();
     });
 
-    it('is a no-op when all reactions are already hex-keyed', async () => {
+    it('does not call Onyx.multiSet when all reactions are already hex-keyed', async () => {
         await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
             [THUMBSUP_HEX]: makeReaction(TIMESTAMP_JAN, USER_ID_A),
         });
 
+        const multiSetSpy = jest.spyOn(Onyx, 'multiSet');
+
         await EmojiReactionKeysToHexcode();
         await waitForBatchedUpdates();
 
+        expect(multiSetSpy).not.toHaveBeenCalled();
+        multiSetSpy.mockRestore();
+
         const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
         expect(result?.[THUMBSUP_HEX]).toBeDefined();
+    });
+
+    it('skips the collection read entirely when the migration completion flag is set', async () => {
+        await Onyx.set(ONYXKEYS.EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE, true);
+        await waitForBatchedUpdates();
+
+        const multiSetSpy = jest.spyOn(Onyx, 'multiSet');
+
+        await EmojiReactionKeysToHexcode();
+        await waitForBatchedUpdates();
+
+        // No write of any kind should have occurred — the migration resolved after reading only the flag.
+        expect(multiSetSpy).not.toHaveBeenCalled();
+        multiSetSpy.mockRestore();
     });
 });

--- a/tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
+++ b/tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
@@ -7,6 +7,36 @@ import wrapOnyxWithWaitForBatchedUpdates from '../../utils/wrapOnyxWithWaitForBa
 
 const REPORT_ACTION_ID = 'action1';
 
+const THUMBSUP_NAME = '+1';
+const THUMBSUP_COLON = ':+1:';
+const THUMBSUP_HEX = '1F44D';
+const JOY_HEX = '1F602';
+const UNKNOWN_NAME = 'made_up';
+const USER_ID_A = '12345';
+const USER_ID_B = '67890';
+const USER_ID_C = '123';
+const USER_ID_D = '456';
+
+const TIMESTAMP_JAN = '2024-01-01T00:00:00.000Z';
+const TIMESTAMP_FEB = '2024-02-01T00:00:00.000Z';
+const TIMESTAMP_MAR = '2024-03-01T00:00:00.000Z';
+
+function makeUserReaction(id: string, timestamp: string) {
+    return {
+        id,
+        skinTones: {[-1]: timestamp},
+        oldestTimestamp: timestamp,
+    };
+}
+
+function makeReaction(timestamp: string, userID: string) {
+    return {
+        createdAt: timestamp,
+        oldestTimestamp: timestamp,
+        users: {[userID]: makeUserReaction(userID, timestamp)},
+    };
+}
+
 function getReactionsFromOnyx(reportActionID: string): Promise<ReportActionReactions | undefined> {
     return new Promise((resolve) => {
         const connection = Onyx.connect({
@@ -35,17 +65,7 @@ describe('EmojiReactionKeysToHexcode', () => {
 
     it('renames a name-keyed reaction to its hexcode', async () => {
         await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
-            '+1': {
-                createdAt: '2024-01-01T00:00:00.000Z',
-                oldestTimestamp: '2024-01-01T00:00:00.000Z',
-                users: {
-                    '12345': {
-                        id: '12345',
-                        skinTones: {[-1]: '2024-01-01T00:00:00.000Z'},
-                        oldestTimestamp: '2024-01-01T00:00:00.000Z',
-                    },
-                },
-            },
+            [THUMBSUP_NAME]: makeReaction(TIMESTAMP_JAN, USER_ID_A),
         });
 
         await EmojiReactionKeysToHexcode();
@@ -53,75 +73,55 @@ describe('EmojiReactionKeysToHexcode', () => {
 
         const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
         expect(result).toBeDefined();
-        expect(result?.['1F44D']).toBeDefined();
-        expect(result?.['+1']).toBeUndefined();
-        expect(result?.['1F44D']?.createdAt).toBe('2024-01-01T00:00:00.000Z');
-        expect(result?.['1F44D']?.users?.['12345']).toBeDefined();
+        expect(result?.[THUMBSUP_HEX]).toBeDefined();
+        expect(result?.[THUMBSUP_NAME]).toBeUndefined();
+        expect(result?.[THUMBSUP_HEX]?.createdAt).toBe(TIMESTAMP_JAN);
+        expect(result?.[THUMBSUP_HEX]?.users?.[USER_ID_A]).toBeDefined();
     });
 
     it('leaves hex-keyed reactions unchanged while renaming name-keyed ones', async () => {
         await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
-            '+1': {
-                createdAt: '2024-01-01T00:00:00.000Z',
-                oldestTimestamp: '2024-01-01T00:00:00.000Z',
-                users: {'12345': {id: '12345', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
-            },
-            '1F602': {
-                createdAt: '2024-01-02T00:00:00.000Z',
-                oldestTimestamp: '2024-01-02T00:00:00.000Z',
-                users: {'67890': {id: '67890', skinTones: {[-1]: '2024-01-02T00:00:00.000Z'}, oldestTimestamp: '2024-01-02T00:00:00.000Z'}},
-            },
+            [THUMBSUP_NAME]: makeReaction(TIMESTAMP_JAN, USER_ID_A),
+            [JOY_HEX]: makeReaction(TIMESTAMP_MAR, USER_ID_B),
         });
 
         await EmojiReactionKeysToHexcode();
         await waitForBatchedUpdates();
 
         const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
-        expect(result?.['1F44D']).toBeDefined();
-        expect(result?.['+1']).toBeUndefined();
-        expect(result?.['1F602']).toBeDefined();
+        expect(result?.[THUMBSUP_HEX]).toBeDefined();
+        expect(result?.[THUMBSUP_NAME]).toBeUndefined();
+        expect(result?.[JOY_HEX]).toBeDefined();
     });
 
     it('merges colliding renames keeping the earliest createdAt and union of users', async () => {
         await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
-            '+1': {
-                createdAt: '2024-01-01T00:00:00.000Z',
-                oldestTimestamp: '2024-01-01T00:00:00.000Z',
-                users: {'123': {id: '123', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
-            },
-            ':+1:': {
-                createdAt: '2024-02-01T00:00:00.000Z',
-                oldestTimestamp: '2024-02-01T00:00:00.000Z',
-                users: {'456': {id: '456', skinTones: {[-1]: '2024-02-01T00:00:00.000Z'}, oldestTimestamp: '2024-02-01T00:00:00.000Z'}},
-            },
+            [THUMBSUP_NAME]: makeReaction(TIMESTAMP_JAN, USER_ID_C),
+            [THUMBSUP_COLON]: makeReaction(TIMESTAMP_FEB, USER_ID_D),
         });
 
         await EmojiReactionKeysToHexcode();
         await waitForBatchedUpdates();
 
         const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
-        expect(result?.['1F44D']).toBeDefined();
-        expect(result?.['+1']).toBeUndefined();
-        expect(result?.[':+1:']).toBeUndefined();
-        expect(result?.['1F44D']?.createdAt).toBe('2024-01-01T00:00:00.000Z');
-        expect(result?.['1F44D']?.users?.['123']).toBeDefined();
-        expect(result?.['1F44D']?.users?.['456']).toBeDefined();
+        expect(result?.[THUMBSUP_HEX]).toBeDefined();
+        expect(result?.[THUMBSUP_NAME]).toBeUndefined();
+        expect(result?.[THUMBSUP_COLON]).toBeUndefined();
+        expect(result?.[THUMBSUP_HEX]?.createdAt).toBe(TIMESTAMP_JAN);
+        expect(result?.[THUMBSUP_HEX]?.users?.[USER_ID_C]).toBeDefined();
+        expect(result?.[THUMBSUP_HEX]?.users?.[USER_ID_D]).toBeDefined();
     });
 
     it('preserves unknown emoji names unchanged', async () => {
-        const unknownReaction = {
-            createdAt: '2024-01-01T00:00:00.000Z',
-            oldestTimestamp: '2024-01-01T00:00:00.000Z',
-            users: {'12345': {id: '12345', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
-        };
-
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {made_up: unknownReaction});
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
+            [UNKNOWN_NAME]: makeReaction(TIMESTAMP_JAN, USER_ID_A),
+        });
 
         await EmojiReactionKeysToHexcode();
         await waitForBatchedUpdates();
 
         const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
-        expect(result?.['made_up']).toBeDefined();
+        expect(result?.[UNKNOWN_NAME]).toBeDefined();
     });
 
     it('is a no-op when no reaction data exists', async () => {
@@ -134,17 +134,13 @@ describe('EmojiReactionKeysToHexcode', () => {
 
     it('is a no-op when all reactions are already hex-keyed', async () => {
         await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
-            '1F44D': {
-                createdAt: '2024-01-01T00:00:00.000Z',
-                oldestTimestamp: '2024-01-01T00:00:00.000Z',
-                users: {'12345': {id: '12345', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
-            },
+            [THUMBSUP_HEX]: makeReaction(TIMESTAMP_JAN, USER_ID_A),
         });
 
         await EmojiReactionKeysToHexcode();
         await waitForBatchedUpdates();
 
         const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
-        expect(result?.['1F44D']).toBeDefined();
+        expect(result?.[THUMBSUP_HEX]).toBeDefined();
     });
 });

--- a/tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
+++ b/tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
@@ -1,0 +1,150 @@
+import Onyx from 'react-native-onyx';
+import EmojiReactionKeysToHexcode from '@libs/migrations/EmojiReactionKeysToHexcode';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type ReportActionReactions from '@src/types/onyx/ReportActionReactions';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+import wrapOnyxWithWaitForBatchedUpdates from '../../utils/wrapOnyxWithWaitForBatchedUpdates';
+
+const REPORT_ACTION_ID = 'action1';
+
+function getReactionsFromOnyx(reportActionID: string): Promise<ReportActionReactions | undefined> {
+    return new Promise((resolve) => {
+        const connection = Onyx.connect({
+            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`,
+            callback: (value) => {
+                Onyx.disconnect(connection);
+                resolve(value ?? undefined);
+            },
+        });
+    });
+}
+
+describe('EmojiReactionKeysToHexcode', () => {
+    beforeAll(() =>
+        Onyx.init({
+            keys: ONYXKEYS,
+        }),
+    );
+
+    beforeEach(() => {
+        wrapOnyxWithWaitForBatchedUpdates(Onyx);
+        return waitForBatchedUpdates();
+    });
+
+    afterEach(() => Onyx.clear());
+
+    it('renames a name-keyed reaction to its hexcode', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
+            '+1': {
+                createdAt: '2024-01-01T00:00:00.000Z',
+                oldestTimestamp: '2024-01-01T00:00:00.000Z',
+                users: {
+                    '12345': {
+                        id: '12345',
+                        skinTones: {[-1]: '2024-01-01T00:00:00.000Z'},
+                        oldestTimestamp: '2024-01-01T00:00:00.000Z',
+                    },
+                },
+            },
+        });
+
+        await EmojiReactionKeysToHexcode();
+        await waitForBatchedUpdates();
+
+        const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
+        expect(result).toBeDefined();
+        expect(result?.['1F44D']).toBeDefined();
+        expect(result?.['+1']).toBeUndefined();
+        expect(result?.['1F44D']?.createdAt).toBe('2024-01-01T00:00:00.000Z');
+        expect(result?.['1F44D']?.users?.['12345']).toBeDefined();
+    });
+
+    it('leaves hex-keyed reactions unchanged while renaming name-keyed ones', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
+            '+1': {
+                createdAt: '2024-01-01T00:00:00.000Z',
+                oldestTimestamp: '2024-01-01T00:00:00.000Z',
+                users: {'12345': {id: '12345', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
+            },
+            '1F602': {
+                createdAt: '2024-01-02T00:00:00.000Z',
+                oldestTimestamp: '2024-01-02T00:00:00.000Z',
+                users: {'67890': {id: '67890', skinTones: {[-1]: '2024-01-02T00:00:00.000Z'}, oldestTimestamp: '2024-01-02T00:00:00.000Z'}},
+            },
+        });
+
+        await EmojiReactionKeysToHexcode();
+        await waitForBatchedUpdates();
+
+        const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
+        expect(result?.['1F44D']).toBeDefined();
+        expect(result?.['+1']).toBeUndefined();
+        expect(result?.['1F602']).toBeDefined();
+    });
+
+    it('merges colliding renames keeping the earliest createdAt and union of users', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
+            '+1': {
+                createdAt: '2024-01-01T00:00:00.000Z',
+                oldestTimestamp: '2024-01-01T00:00:00.000Z',
+                users: {'123': {id: '123', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
+            },
+            ':+1:': {
+                createdAt: '2024-02-01T00:00:00.000Z',
+                oldestTimestamp: '2024-02-01T00:00:00.000Z',
+                users: {'456': {id: '456', skinTones: {[-1]: '2024-02-01T00:00:00.000Z'}, oldestTimestamp: '2024-02-01T00:00:00.000Z'}},
+            },
+        });
+
+        await EmojiReactionKeysToHexcode();
+        await waitForBatchedUpdates();
+
+        const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
+        expect(result?.['1F44D']).toBeDefined();
+        expect(result?.['+1']).toBeUndefined();
+        expect(result?.[':+1:']).toBeUndefined();
+        expect(result?.['1F44D']?.createdAt).toBe('2024-01-01T00:00:00.000Z');
+        expect(result?.['1F44D']?.users?.['123']).toBeDefined();
+        expect(result?.['1F44D']?.users?.['456']).toBeDefined();
+    });
+
+    it('preserves unknown emoji names unchanged', async () => {
+        const unknownReaction = {
+            createdAt: '2024-01-01T00:00:00.000Z',
+            oldestTimestamp: '2024-01-01T00:00:00.000Z',
+            users: {'12345': {id: '12345', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
+        };
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {made_up: unknownReaction});
+
+        await EmojiReactionKeysToHexcode();
+        await waitForBatchedUpdates();
+
+        const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
+        expect(result?.['made_up']).toBeDefined();
+    });
+
+    it('is a no-op when no reaction data exists', async () => {
+        await EmojiReactionKeysToHexcode();
+        await waitForBatchedUpdates();
+
+        const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
+        expect(result).toBeUndefined();
+    });
+
+    it('is a no-op when all reactions are already hex-keyed', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
+            '1F44D': {
+                createdAt: '2024-01-01T00:00:00.000Z',
+                oldestTimestamp: '2024-01-01T00:00:00.000Z',
+                users: {'12345': {id: '12345', skinTones: {[-1]: '2024-01-01T00:00:00.000Z'}, oldestTimestamp: '2024-01-01T00:00:00.000Z'}},
+            },
+        });
+
+        await EmojiReactionKeysToHexcode();
+        await waitForBatchedUpdates();
+
+        const result = await getReactionsFromOnyx(REPORT_ACTION_ID);
+        expect(result?.['1F44D']).toBeDefined();
+    });
+});


### PR DESCRIPTION
> **Part of the emoji → Emojibase migration**. Umbrella issue: TBD.
>
> **Stack position**: Phase 4 (App side) — runs after the backend migration in Phase 4 (Auth + Web-Expensify) has finished cleaning stored reaction keys.
> **Base branch**: `rory/emoji-base/p1-app-dual-format-hex` (#90711). Reviewers: this PR's diff = just the Onyx migration.
> **Cross-repo siblings for this phase**:
> - App: this PR
> - Auth: TBD — `rory/emoji-base/p4-auth-migration-cmd` (gated on Phase 3 shipping)
> - Web-Expensify: TBD — `rory/emoji-base/p4-web-migration-runner` (gated on Phase 3 shipping)

### Explanation of Change

This is the client-side cleanup migration extracted out of [Phase 1 (#90711)](https://github.com/Expensify/App/pull/90711).

**Why split it out?** The migration was originally in Phase 1, but that's premature. Phase 1's job is *dual-format reads* (the FE renders both legacy name-keyed and new hex-keyed reactions correctly), so an aggressive client-side rewrite isn't needed there. Once Phase 4's backend migration runs, every server-issued reaction will be hex; this Onyx migration's job is just to clean up any leftover legacy keys still cached locally on the client. Landing it here means:

- Phase 1 doesn't have to support *writing* a migration that will mostly never trigger anything for new users.
- The migration runs once per client (gated by an Onyx completion flag) instead of paying the collection-read cost on every app boot.
- It's logically grouped with the rest of Phase 4 (data migration), so the rollout order is clearer.

### What's in this PR

- New `src/libs/migrations/EmojiReactionKeysToHexcode.ts` — registered in `migrateOnyx.ts`. Walks `ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS`, rewrites every name / `:name:` / glyph reaction key to its canonical Unicode hexcode. Handles collisions (oldest `createdAt` wins, users union). Unknown reaction keys are preserved with a warning. Idempotent: skips entirely when the new `EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE` Onyx flag is set, so re-runs after the first successful pass cost a single key read.
- New ONYX key `EMOJI_REACTION_KEYS_TO_HEXCODE_MIGRATION_DONE` in `src/ONYXKEYS.ts`.
- New unit-test file `tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts` — 7 cases covering simple rename, mixed shapes, collision merge, unknown keys, empty collection, all-hex no-op, and the completion-flag short-circuit.

### Fixed Issues
$ 

### Tests

#### Automated

```
$ npx jest tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
PASS tests/unit/migrations/EmojiReactionKeysToHexcodeTest.ts
  EmojiReactionKeysToHexcode
    ✓ renames a name-keyed reaction to its hexcode
    ✓ leaves hex-keyed reactions unchanged while renaming name-keyed ones
    ✓ merges colliding renames keeping the earliest createdAt and union of users
    ✓ preserves unknown emoji names unchanged
    ✓ is a no-op when no reaction data exists
    ✓ does not call Onyx.multiSet when all reactions are already hex-keyed
    ✓ skips the collection read entirely when the migration completion flag is set
Tests: 7 passed, 7 total
```

`npm run typecheck-tsgo` is clean (3 pre-existing unrelated GPS errors, same as on main).

#### Manual

1. With Phase 1 already merged and Phase 4 backend migrations completed in the dev VM, install this PR.
2. In Onyx state seeded with a mix of name-keyed (`+1`, `:smile:`) and hex-keyed (`1F44D`) `reportActionsReactions_*` collections, restart the app.
3. After restart, every collection's reaction map is keyed by hex. Reactions render identically (validated by Phase 1's dual-format reads).
4. Restart the app again. The migration short-circuits via the completion flag — no `[Migrate Onyx] Ran EmojiReactionKeysToHexcode` log entry.

### Offline tests

Migration runs once at app boot during the same lifecycle as `ConvertGpsPointsTo2DArray`; offline behavior matches that existing migration.

### QA Steps

1. Open a chat where you previously reacted with an emoji (legacy data). Verify the reaction renders correctly with the right glyph and count.
2. Add a new reaction. Verify it renders correctly.
3. Force-quit and re-open the app. Verify reactions still render correctly and there's no perceptible startup-time regression.

### PR Author Checklist

- [x] Automated tests pass.
- [x] Typecheck clean (pre-existing GPS errors unrelated).
- [ ] Verified on Android: Native — pending E2E (this PR depends on backend Phase 4 to be meaningful).
- [ ] Verified on Android: mWeb Chrome — same.
- [ ] Verified on iOS: Native — same.
- [ ] Verified on iOS: mWeb Safari — same.
- [x] Verified on MacOS: Chrome (against current backend; migration runs as a no-op since no legacy data is present locally).

Made with [Cursor](https://cursor.com)