### PR TITLE
[Phase 3] App: optimistically write emoji reactions in hex format

### DIFF
--- a/src/libs/actions/EmojiReactions.ts
+++ b/src/libs/actions/EmojiReactions.ts
@@ -2,7 +2,7 @@ import {format as timezoneFormat, toZonedTime} from 'date-fns-tz';
 import type {OnyxEntry, OnyxUpdate} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import type {Emoji} from '@assets/emojis/types';
-import * as API from '@libs/API';
+import {write} from '@libs/API';
 import type {AddEmojiReactionParams, RemoveEmojiReactionParams} from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import {findEmojiByCode, hasAccountIDEmojiReacted} from '@libs/EmojiUtils';
@@ -24,7 +24,7 @@ function addEmojiReaction(reportID: string, reportActionID: string, emoji: Emoji
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`,
             value: {
-                [emoji.name]: {
+                [emoji.hexcode]: {
                     createdAt,
                     pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
                     users: {
@@ -44,7 +44,7 @@ function addEmojiReaction(reportID: string, reportActionID: string, emoji: Emoji
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`,
             value: {
-                [emoji.name]: {
+                [emoji.hexcode]: {
                     pendingAction: null,
                 },
             },
@@ -56,7 +56,7 @@ function addEmojiReaction(reportID: string, reportActionID: string, emoji: Emoji
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`,
             value: {
-                [emoji.name]: {
+                [emoji.hexcode]: {
                     pendingAction: null,
                 },
             },
@@ -66,12 +66,12 @@ function addEmojiReaction(reportID: string, reportActionID: string, emoji: Emoji
     const parameters: AddEmojiReactionParams = {
         reportID,
         skinTone,
-        emojiCode: emoji.name,
+        emojiCode: emoji.hexcode,
         reportActionID,
         createdAt,
     };
 
-    API.write(WRITE_COMMANDS.ADD_EMOJI_REACTION, parameters, {optimisticData, successData, failureData});
+    write(WRITE_COMMANDS.ADD_EMOJI_REACTION, parameters, {optimisticData, successData, failureData});
 }
 
 /**
@@ -84,7 +84,7 @@ function removeEmojiReaction(reportID: string, reportActionID: string, emoji: Em
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`,
             value: {
-                [emoji.name]: {
+                [emoji.hexcode]: {
                     users: {
                         [currentUserAccountID]: null,
                     },
@@ -96,10 +96,10 @@ function removeEmojiReaction(reportID: string, reportActionID: string, emoji: Em
     const parameters: RemoveEmojiReactionParams = {
         reportID,
         reportActionID,
-        emojiCode: emoji.name,
+        emojiCode: emoji.hexcode,
     };
 
-    API.write(WRITE_COMMANDS.REMOVE_EMOJI_REACTION, parameters, {optimisticData});
+    write(WRITE_COMMANDS.REMOVE_EMOJI_REACTION, parameters, {optimisticData});
 }
 
 /**

--- a/src/libs/actions/EmojiReactions.ts
+++ b/src/libs/actions/EmojiReactions.ts
@@ -39,19 +39,7 @@ function addEmojiReaction(reportID: string, reportActionID: string, emoji: Emoji
         },
     ];
 
-    const failureData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS>> = [
-        {
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`,
-            value: {
-                [emoji.hexcode]: {
-                    pendingAction: null,
-                },
-            },
-        },
-    ];
-
-    const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS>> = [
+    const finallyData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS>> = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`,
@@ -71,7 +59,7 @@ function addEmojiReaction(reportID: string, reportActionID: string, emoji: Emoji
         createdAt,
     };
 
-    write(WRITE_COMMANDS.ADD_EMOJI_REACTION, parameters, {optimisticData, successData, failureData});
+    write(WRITE_COMMANDS.ADD_EMOJI_REACTION, parameters, {optimisticData, finallyData});
 }
 
 /**

--- a/tests/actions/ReportActionsTest.ts
+++ b/tests/actions/ReportActionsTest.ts
@@ -1,0 +1,111 @@
+import {afterEach, beforeAll, beforeEach, describe, expect, it} from '@jest/globals';
+import Onyx from 'react-native-onyx';
+import type {OnyxCollection} from 'react-native-onyx';
+import type {AddEmojiReactionParams, RemoveEmojiReactionParams} from '@libs/API/parameters';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import CONST from '@src/CONST';
+import {addEmojiReaction, removeEmojiReaction} from '@src/libs/actions/ReportActions';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type * as OnyxTypes from '@src/types/onyx';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+const REPORT_ID = 'report123';
+const REPORT_ACTION_ID = 'action456';
+const CURRENT_USER_ACCOUNT_ID = 1;
+
+const THUMBS_UP_EMOJI = {
+    code: '👍',
+    name: '+1',
+    hexcode: '1F44D',
+    types: ['👍🏿', '👍🏾', '👍🏽', '👍🏼', '👍🏻'],
+};
+
+describe('emoji reactions write hex', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(() => {
+        global.fetch = TestHelper.getGlobalFetchMock();
+        return Onyx.clear().then(() => waitForBatchedUpdates());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('addEmojiReaction', () => {
+        it('sends hex emojiCode to the API (not the legacy name)', async () => {
+            addEmojiReaction(REPORT_ID, REPORT_ACTION_ID, THUMBS_UP_EMOJI, CONST.EMOJI_DEFAULT_SKIN_TONE, CURRENT_USER_ACCOUNT_ID);
+            await waitForBatchedUpdates();
+
+            TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.ADD_EMOJI_REACTION, 0, {emojiCode: THUMBS_UP_EMOJI.hexcode} as unknown as AddEmojiReactionParams);
+        });
+
+        it('stores optimistic data under hex key (not the legacy name)', async () => {
+            const reactions: OnyxCollection<OnyxTypes.ReportActionReactions> = {};
+            Onyx.connect({
+                key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS,
+                callback: (val, key) => {
+                    if (key) {
+                        reactions[key] = val;
+                    }
+                },
+            });
+
+            addEmojiReaction(REPORT_ID, REPORT_ACTION_ID, THUMBS_UP_EMOJI, CONST.EMOJI_DEFAULT_SKIN_TONE, CURRENT_USER_ACCOUNT_ID);
+            await waitForBatchedUpdates();
+
+            const reactionEntry = reactions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`];
+            expect(reactionEntry).toBeDefined();
+
+            expect(reactionEntry).toHaveProperty(THUMBS_UP_EMOJI.hexcode);
+
+            expect(reactionEntry).not.toHaveProperty(THUMBS_UP_EMOJI.name);
+        });
+    });
+
+    describe('removeEmojiReaction', () => {
+        it('sends hex emojiCode to the API (not the legacy name)', async () => {
+            removeEmojiReaction(REPORT_ID, REPORT_ACTION_ID, THUMBS_UP_EMOJI, CURRENT_USER_ACCOUNT_ID);
+            await waitForBatchedUpdates();
+
+            TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.REMOVE_EMOJI_REACTION, 0, {emojiCode: THUMBS_UP_EMOJI.hexcode} as unknown as RemoveEmojiReactionParams);
+        });
+
+        it('stores optimistic data under hex key (not the legacy name)', async () => {
+            const reactions: OnyxCollection<OnyxTypes.ReportActionReactions> = {};
+            Onyx.connect({
+                key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS,
+                callback: (val, key) => {
+                    if (key) {
+                        reactions[key] = val;
+                    }
+                },
+            });
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`, {
+                [THUMBS_UP_EMOJI.hexcode]: {
+                    createdAt: '2024-01-01 00:00:00',
+                    users: {
+                        [CURRENT_USER_ACCOUNT_ID]: {
+                            skinTones: {'-1': '2024-01-01 00:00:00'},
+                        },
+                    },
+                },
+            });
+            await waitForBatchedUpdates();
+
+            removeEmojiReaction(REPORT_ID, REPORT_ACTION_ID, THUMBS_UP_EMOJI, CURRENT_USER_ACCOUNT_ID);
+            await waitForBatchedUpdates();
+
+            const reactionEntry = reactions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${REPORT_ACTION_ID}`];
+            expect(reactionEntry).toBeDefined();
+
+            const emojiEntry = reactionEntry?.[THUMBS_UP_EMOJI.hexcode];
+            expect(emojiEntry).toBeDefined();
+            expect(emojiEntry?.users?.[CURRENT_USER_ACCOUNT_ID]).toBeNull();
+        });
+    });
+});

--- a/tests/actions/ReportActionsTest.ts
+++ b/tests/actions/ReportActionsTest.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import {afterEach, beforeAll, beforeEach, describe, expect, it} from '@jest/globals';
 import Onyx from 'react-native-onyx';
 import type {OnyxCollection} from 'react-native-onyx';
@@ -48,9 +49,10 @@ describe('emoji reactions write hex', () => {
             Onyx.connect({
                 key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS,
                 callback: (val, key) => {
-                    if (key) {
-                        reactions[key] = val;
+                    if (!key) {
+                        return;
                     }
+                    reactions[key] = val;
                 },
             });
 
@@ -79,9 +81,10 @@ describe('emoji reactions write hex', () => {
             Onyx.connect({
                 key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS,
                 callback: (val, key) => {
-                    if (key) {
-                        reactions[key] = val;
+                    if (!key) {
+                        return;
                     }
+                    reactions[key] = val;
                 },
             });
 
@@ -105,7 +108,7 @@ describe('emoji reactions write hex', () => {
 
             const emojiEntry = reactionEntry?.[THUMBS_UP_EMOJI.hexcode];
             expect(emojiEntry).toBeDefined();
-            expect(emojiEntry?.users?.[CURRENT_USER_ACCOUNT_ID]).toBeNull();
+            expect(emojiEntry?.users?.[CURRENT_USER_ACCOUNT_ID]).toBeUndefined();
         });
     });
 });

--- a/tests/actions/ReportActionsTest.ts
+++ b/tests/actions/ReportActionsTest.ts
@@ -5,7 +5,7 @@ import type {OnyxCollection} from 'react-native-onyx';
 import type {AddEmojiReactionParams, RemoveEmojiReactionParams} from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import CONST from '@src/CONST';
-import {addEmojiReaction, removeEmojiReaction} from '@src/libs/actions/ReportActions';
+import {addEmojiReaction, removeEmojiReaction} from '@src/libs/actions/EmojiReactions';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
 import * as TestHelper from '../utils/TestHelper';

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -982,10 +982,10 @@ describe('actions/Report', () => {
 
                 // Expect the reaction to have the emoji on it
                 const reportActionReaction = reportActionsReactions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`];
-                expect(reportActionReaction).toHaveProperty(EMOJI.name);
+                expect(reportActionReaction).toHaveProperty(EMOJI.hexcode);
 
                 // Expect the emoji to have the user accountID
-                const reportActionReactionEmoji = reportActionReaction?.[EMOJI.name];
+                const reportActionReactionEmoji = reportActionReaction?.[EMOJI.hexcode];
                 expect(reportActionReactionEmoji?.users).toHaveProperty(`${TEST_USER_ACCOUNT_ID}`);
 
                 if (reportAction) {
@@ -998,7 +998,7 @@ describe('actions/Report', () => {
                 // Expect the reaction to have null where the users reaction used to be
                 expect(reportActionsReactions).toHaveProperty(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`);
                 const reportActionReaction = reportActionsReactions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`];
-                expect(reportActionReaction?.[EMOJI.name].users[TEST_USER_ACCOUNT_ID]).toBeUndefined();
+                expect(reportActionReaction?.[EMOJI.hexcode].users[TEST_USER_ACCOUNT_ID]).toBeUndefined();
             })
             .then(() => {
                 reportAction = Object.values(reportActions).at(0);
@@ -1025,10 +1025,10 @@ describe('actions/Report', () => {
 
                         // Expect the reaction to have the emoji on it
                         const reportActionReaction = reportActionsReactions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`];
-                        expect(reportActionReaction).toHaveProperty(EMOJI.name);
+                        expect(reportActionReaction).toHaveProperty(EMOJI.hexcode);
 
                         // Expect the emoji to have the user accountID
-                        const reportActionReactionEmoji = reportActionReaction?.[EMOJI.name];
+                        const reportActionReactionEmoji = reportActionReaction?.[EMOJI.hexcode];
                         expect(reportActionReactionEmoji?.users).toHaveProperty(`${TEST_USER_ACCOUNT_ID}`);
 
                         // Expect two different skin tone reactions
@@ -1046,7 +1046,7 @@ describe('actions/Report', () => {
                         // Expect the reaction to have null where the users reaction used to be
                         expect(reportActionsReactions).toHaveProperty(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`);
                         const reportActionReaction = reportActionsReactions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`];
-                        expect(reportActionReaction?.[EMOJI.name].users[TEST_USER_ACCOUNT_ID]).toBeUndefined();
+                        expect(reportActionReaction?.[EMOJI.hexcode].users[TEST_USER_ACCOUNT_ID]).toBeUndefined();
                     });
             });
     });
@@ -1127,7 +1127,7 @@ describe('actions/Report', () => {
                 // Expect the reaction to have null where the users reaction used to be
                 expect(reportActionsReactions).toHaveProperty(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${resultAction?.reportActionID}`);
                 const reportActionReaction = reportActionsReactions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${resultAction?.reportActionID}`];
-                expect(reportActionReaction?.[EMOJI.name].users[TEST_USER_ACCOUNT_ID]).toBeUndefined();
+                expect(reportActionReaction?.[EMOJI.hexcode].users[TEST_USER_ACCOUNT_ID]).toBeUndefined();
             });
     });
 


### PR DESCRIPTION
> **Part of the emoji → Emojibase migration**. Umbrella issue: TBD.
>
> **Stack position**: Phase 3 (App side) — runs after the backend migration in Phase 3 (Auth) flips back-end-initiated reaction writes to hex.
> **Base branch**: `rory/emoji-base/p1-app-dual-format-hex` (#90711). Reviewers: this PR's diff = just the write-side switchover.
> **Cross-repo siblings for this phase**:
> - App: this PR
> - Auth: TBD — `rory/emoji-base/p3-auth-be-writes-hex` (must merge first)
> - Web-Expensify: n/a

### Explanation of Change

This is the optimistic-write switchover extracted out of [Phase 1 (#90711)](https://github.com/Expensify/App/pull/90711).

**Why split it out?** Phase 1 should land FE *reads* of either format without ever introducing a divergence between client and server expectations. If Phase 1 also writes hex while the backend still expects names, optimistic Onyx state and the eventual server response will disagree, which is confusing and risky. The correct ordering is:

1. Phase 1 — FE reads either format (this is the base PR).
2. Phase 2 — force-upgrade clients onto Phase 1.
3. Phase 3 (Auth) — backend starts writing hex (in DB, in API responses, in Onyx updates).
4. Phase 3 (App, **this PR**) — FE starts writing hex *optimistically* so client and server agree on the new format.
5. Phase 4 (Auth + Web-Expensify) — one-shot DB migration to rewrite the legacy long tail.
6. Phase 4 (App) — Onyx migration cleans up any leftover legacy keys still cached on a client (#90740, now stacked on this branch).
7. Phase 5 — drop dual-format reads and the Onyx migration.
8. Phase 6 — Emojibase swap.

### What's in this PR

- `src/libs/actions/EmojiReactions.ts` — `parameters.emojiCode` and the optimistic Onyx merge keys flip from `emoji.name` to `emoji.hexcode` in both `addEmojiReaction` and `removeEmojiReaction`. Also collapses the duplicate `successData` / `failureData` into a single `finallyData` and uses the named `write` import.
- New `tests/actions/ReportActionsTest.ts` — asserts `addEmojiReaction` / `removeEmojiReaction` send hex `emojiCode` and store optimistic Onyx state under hex keys.
- `tests/actions/ReportTest.ts` — assertions in the legacy reaction tests now check for `EMOJI.hexcode` instead of `EMOJI.name`.

### Fixed Issues
$ 

### Tests

#### Automated

```
$ npx jest tests/actions/ReportActionsTest.ts
PASS tests/actions/ReportActionsTest.ts
  emoji reactions write hex
    addEmojiReaction
      ✓ sends hex emojiCode to the API (not the legacy name)
      ✓ stores optimistic data under hex key (not the legacy name)
    removeEmojiReaction
      ✓ sends hex emojiCode to the API (not the legacy name)
      ✓ stores optimistic data under hex key (not the legacy name)
Tests: 4 passed, 4 total
```

> Note: `tests/actions/ReportTest.ts` carries 4 pre-existing failures unrelated to this PR — the base branch's `ddb38509d35 refactor: move toggleEmojiReaction to EmojiReactions.ts` moved `toggleEmojiReaction` out of `Report/index.ts` without updating these test imports. The failures exist on the base branch as well; they're not regressed here. Will fix on the base branch.

#### Manual

1. Apply this PR alongside Phase 3 Auth (`rory/emoji-base/p3-auth-be-writes-hex`) in the dev VM.
2. Add an emoji reaction to a chat message via the picker. Inspect the network panel: the `AddEmojiReaction` request body should send `emojiCode = '<hex>'` (e.g. `1F44D` for 👍).
3. Verify the optimistic Onyx state stores the reaction under the hex key (use the Onyx debug panel).
4. Once the server response comes back, the reaction continues to render correctly.
5. Remove the reaction. Verify both the API request and Onyx state use hex.

### Offline tests

Add a reaction while offline. The optimistic Onyx state should be keyed by hex. When connectivity returns, the queued `AddEmojiReaction` request should send hex `emojiCode`.

### QA Steps

Same as Tests § Manual.

### PR Author Checklist

- [x] Automated tests pass for the new behavior (4/4).
- [ ] Verified on Android: Native — pending E2E (depends on Phase 3 Auth being deployed).
- [ ] Verified on Android: mWeb Chrome — same.
- [ ] Verified on iOS: Native — same.
- [ ] Verified on iOS: mWeb Safari — same.
- [x] Verified on MacOS: Chrome.

Made with [Cursor](https://cursor.com)