### PR TITLE
Fix Android GPS crash when reopening app with invalid tracking state

### DIFF
--- a/src/components/GPSTripStateChecker/index.native.tsx
+++ b/src/components/GPSTripStateChecker/index.native.tsx
@@ -5,7 +5,7 @@ import ConfirmModal from '@components/ConfirmModal';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import {getGpsPoints, stopGpsTrip} from '@libs/GPSDraftDetailsUtils';
+import {getGpsPoints, getTotalGpsTripPoints, stopGpsTrip} from '@libs/GPSDraftDetailsUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {generateReportID} from '@libs/ReportUtils';
 import {BACKGROUND_LOCATION_TASK_OPTIONS, BACKGROUND_LOCATION_TRACKING_TASK_NAME} from '@pages/iou/request/step/IOURequestStepDistanceGPS/const';
@@ -32,18 +32,27 @@ function GPSTripStateChecker() {
 
     useEffect(() => {
         async function handleGpsTripInProgressOnAppRestart() {
-            await checkAndCleanGpsNotification();
-            const gpsTrip = await OnyxUtils.get(ONYXKEYS.GPS_DRAFT_DETAILS);
+            try {
+                await checkAndCleanGpsNotification();
+                const gpsTrip = await OnyxUtils.get(ONYXKEYS.GPS_DRAFT_DETAILS);
 
-            if (!gpsTrip?.isTracking) {
-                return;
+                if (!gpsTrip?.isTracking) {
+                    return;
+                }
+
+                if (getTotalGpsTripPoints(gpsTrip) === 0) {
+                    console.warn('[GPS distance request] Invalid GPS trip state on restart (no points), resetting');
+                    await stopGpsTrip(isOffline, getGpsPoints(gpsTrip), true);
+                    return;
+                }
+
+                setShowContinueTripModal(true);
+            } catch (error) {
+                console.error('[GPS distance request] Failed to handle GPS trip on app restart', error);
             }
-
-            setShowContinueTripModal(true);
         }
 
         handleGpsTripInProgressOnAppRestart();
-        checkAndCleanGpsNotification();
 
         return () => {
             hasStartedLocationUpdatesAsync(BACKGROUND_LOCATION_TRACKING_TASK_NAME).then((isRunning) => {
@@ -63,6 +72,12 @@ function GPSTripStateChecker() {
     const continueGpsTrip = async () => {
         const isBackgroundTaskRunning = await hasStartedLocationUpdatesAsync(BACKGROUND_LOCATION_TRACKING_TASK_NAME);
 
+        if (getTotalGpsTripPoints(gpsDraftDetails) === 0) {
+            console.warn('[GPS distance request] Cannot continue trip with no GPS points');
+            await stopGpsTrip(isOffline, getGpsPoints(gpsDraftDetails), true);
+            return;
+        }
+
         const unit = gpsDraftDetails?.unit;
 
         if (isBackgroundTaskRunning) {
@@ -76,6 +91,7 @@ function GPSTripStateChecker() {
             await startLocationUpdatesAsync(BACKGROUND_LOCATION_TRACKING_TASK_NAME, BACKGROUND_LOCATION_TASK_OPTIONS);
         } catch (error) {
             console.error('[GPS distance request] Failed to restart location tracking', error);
+            await stopGpsTrip(isOffline, getGpsPoints(gpsDraftDetails), true);
             return;
         }
 


### PR DESCRIPTION
## Summary

$ #88700

This PR prevents the Android crash that occurs when reopening the app after discarding GPS tracking twice and starting tracking again.

## Root Cause

After discarding GPS tracking twice, the `GPS_DRAFT_DETAILS` Onyx state can become invalid:

```ts
{
  isTracking: true,
  gpsPoints: [] // or [[]]
}
```

When the app reopens, `GPSTripStateChecker` attempts to restore/continue the GPS trip with no valid GPS points, which can crash the native location tracking flow.

## Changes

In `src/components/GPSTripStateChecker/index.native.tsx`:

1. Add validation in `handleGpsTripInProgressOnAppRestart()` before showing the continue trip modal
2. Add validation in `continueGpsTrip()` before calling `startLocationUpdatesAsync()`
3. Reset invalid GPS tracking state with `stopGpsTrip(..., true)`
4. Add error handling around restart state recovery
5. Remove duplicate `checkAndCleanGpsNotification()` call

## Test Plan

> Note: I do not currently have an Android 13 device to verify the exact repro locally. The fix is based on code flow analysis and defensive validation of the invalid state.

Expected manual verification steps:

1. Open Android app
2. Start GPS tracking
3. Kill app and reopen
4. Stop GPS tracking and discard
5. Repeat steps 2-4 once more
6. Start GPS tracking again
7. Kill app while GPS trip is in progress
8. Reopen app
9. Verify the app does not crash and invalid GPS state is reset cleanly

## Checklist

- [x] Code follows existing GPS tracking patterns
- [x] Defensive validation prevents invalid state restoration
- [x] Error path resets GPS state instead of crashing
- [ ] Android device repro verification pending maintainer/tester confirmation