### PR TITLE
Fix greyed-out dates in bulk-edit date picker

### DIFF
--- a/src/pages/Search/SearchEditMultiple/SearchEditMultipleDatePage.tsx
+++ b/src/pages/Search/SearchEditMultiple/SearchEditMultipleDatePage.tsx
@@ -66,7 +66,6 @@ function SearchEditMultipleDatePage() {
                         autoFocus
                         defaultValue={currentDate}
                         maxDate={CONST.CALENDAR_PICKER.MAX_DATE}
-                        minDate={CONST.CALENDAR_PICKER.MIN_DATE}
                     />
                 </View>
             </FormProvider>


### PR DESCRIPTION
Historical dates (pre-2006) were disabled in the multi-expense date editor because `SearchEditMultipleDatePage` was passing `minDate={CONST.CALENDAR_PICKER.MIN_DATE}` (today − 20 years) to the `DatePicker`. The single-expense date picker never sets `minDate` and lets users pick any date within the last 100 years.

PR #89221 removed this same override from `IOURequestStepDate`, `IOURequestStepTime`, and `SplitExpenseCreateDateRangePage` — this file was missed in that pass.

Removing the prop lets `DatePicker` fall back to its built-in 100-year default, matching the single-expense flow exactly.

$ #90697