### PR TITLE
Fix New Expensify wallet links opening externally

### DIFF
--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -171,7 +171,6 @@ function getInternalExpensifyPath(href: string) {
 }
 
 function openLink(href: string, environmentURL: string, isAttachment = false) {
-    const hasSameOrigin = Url.hasSameExpensifyOrigin(href, environmentURL);
     const hasExpensifyOrigin = Url.hasSameExpensifyOrigin(href, CONFIG.EXPENSIFY.EXPENSIFY_URL) || Url.hasSameExpensifyOrigin(href, CONFIG.EXPENSIFY.STAGING_API_ROOT);
     const internalNewExpensifyPath = getInternalNewExpensifyPath(href);
     const internalExpensifyPath = getInternalExpensifyPath(href);
@@ -201,7 +200,7 @@ function openLink(href: string, environmentURL: string, isAttachment = false) {
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
-    if (internalNewExpensifyPath && hasSameOrigin) {
+    if (internalNewExpensifyPath) {
         if (isAnonymousUser() && !canAnonymousUserAccessRoute(internalNewExpensifyPath)) {
             signOutAndRedirectToSignIn();
             return;

--- a/tests/actions/LinkTest.ts
+++ b/tests/actions/LinkTest.ts
@@ -1,0 +1,32 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import Navigation from '@libs/Navigation/Navigation';
+import navigationRef from '@libs/Navigation/navigationRef';
+import {openLink} from '@libs/actions/Link';
+
+jest.mock('@libs/getIsNarrowLayout', () => jest.fn(() => true));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+    closeRHPFlow: jest.fn(),
+}));
+
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    getRootState: jest.fn(() => ({routes: [{name: 'Root'}]})),
+}));
+
+describe('Link.openLink', () => {
+    const mockNavigate = Navigation.navigate as jest.MockedFunction<typeof Navigation.navigate>;
+    const mockGetRootState = navigationRef.getRootState as jest.MockedFunction<typeof navigationRef.getRootState>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetRootState.mockReturnValue({routes: [{name: 'Root'}]} as unknown as ReturnType<typeof navigationRef.getRootState>);
+    });
+
+    it('navigates New Expensify links in-app even when environment differs', () => {
+        openLink('https://new.expensify.com/settings/wallet', 'https://staging.new.expensify.com');
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('settings/wallet');
+    });
+});


### PR DESCRIPTION
$ #90729.

### What
- Treat `new.expensify.com` / `staging.new.expensify.com` links as in-app routes even when the link origin differs from the current `environmentURL`.

### Why
- On mobile, Concierge messages can contain production links like `https://new.expensify.com/settings/wallet`.
- When running a staging build, `openLink()` previously required a same-origin match with `environmentURL`, so the link fell through to external navigation.

### Testing
- `npm test -- tests/actions/LinkTest.ts`