### PR TITLE
Fix flaky MiddlewareTest assertions after HandleUnusedOptimisticID rewrites queued request

### DIFF
--- a/tests/unit/MiddlewareTest.ts
+++ b/tests/unit/MiddlewareTest.ts
@@ -145,6 +145,9 @@ describe('Middleware', () => {
 
             SequentialQueue.unpause();
             await waitForNetworkPromises();
+            // The middleware rewrites the second request after processing the first response,
+            // which requires an additional flush to ensure the requeued fetch has completed.
+            await waitForNetworkPromises();
 
             expect(global.fetch).toHaveBeenCalledTimes(2);
             expect(global.fetch).toHaveBeenLastCalledWith('https://www.expensify.com.dev/api/AddComment?', expect.anything());
@@ -339,6 +342,9 @@ describe('Middleware', () => {
 
             SequentialQueue.unpause();
             await waitForBatchedUpdates();
+            // The middleware rewrites the second request after processing the first response.
+            // Wait for network promises to ensure the re-queued fetch has resolved.
+            await waitForNetworkPromises();
 
             expect(global.fetch).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
$ #90660

## Root cause

When `HandleUnusedOptimisticID` detects a `preexistingReportID` in the first response, it rewrites the subsequent pending request and re-enqueues it. This rewrite path goes through an async `Onyx.merge` call before the second fetch fires. A single `waitForNetworkPromises()` / `waitForBatchedUpdates()` resolves before that second round-trip completes, so the `toHaveBeenCalledTimes(2)` assertion occasionally runs when only 1 fetch has happened — the classic timing flap.

## Fix

Add a second `waitForNetworkPromises()` after the initial flush in the two affected tests. This mirrors the standard multi-round-trip pattern used elsewhere in the test suite and ensures the requeued fetch has fully settled before the assertion runs.

The teardown worker leak reported in the issue is a downstream symptom of the same open promise — the extra flush also lets the test exit cleanly.

## Tests

The two tests from `HandleUnusedOptimisticID`:
- `Request with preexistingReportID`
- `OpenReport to a chat with preexistingReportID and clean up optimistic participant data`