### PR TITLE
Fix cursor position at end when opening Travel monthly spend limit field

### DIFF
--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -203,8 +203,8 @@ function NumberWithSymbolForm({
     const wasFocused = usePrevious(isFocused);
 
     const [selection, setSelection] = useState({
-        start: currentNumber.length,
-        end: currentNumber.length,
+        start: displayAsTextInput ? 0 : currentNumber.length,
+        end: displayAsTextInput ? 0 : currentNumber.length,
     });
 
     const forwardDeletePressedRef = useRef(false);
@@ -504,6 +504,14 @@ function NumberWithSymbolForm({
                 autoGrowMarginSide={props.autoGrowMarginSide}
                 onSubmitEditing={onSubmitEditing}
                 onFocus={props.onFocus}
+                selection={selection}
+                onSelectionChange={(event) => {
+                    if (!shouldUpdateSelection) {
+                        return;
+                    }
+                    const {start, end} = event.nativeEvent.selection;
+                    setSelection({start, end});
+                }}
                 rightHandSideComponent={shouldShowCurrencyButton || shouldShowFlipButton ? textInputRightHandSideComponent : undefined}
             />
         );


### PR DESCRIPTION
$ #90779

When tapping the Monthly spend limit per member row in the Travel workspace settings, the cursor was placed at the end of the amount field instead of the beginning. This made it so users couldn't immediately type a new value — they had to manually move the cursor first.

The root cause was in `NumberWithSymbolForm`. When `displayAsTextInput` is true, the initial selection state was set to `currentNumber.length` (end of the string), and the `selection` prop wasn't being passed down to the underlying `TextInput` at all. This meant the browser/native layer controlled the cursor position and placed it at the end.

The fix initializes the selection to position 0 when `displayAsTextInput` is true (matching the expected UX of most text fields: focus puts cursor at start so the user can type immediately). It also wires up `selection` and `onSelectionChange` on the TextInput so selection state is controlled throughout the input lifecycle.

**Testing:**
- Go to Workspace > Travel tab
- Tap Monthly spend limit per member
- Cursor should now start at the beginning, allowing immediate input