### PR TITLE
Fix duplicate Plaid feed modal flow

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -5283,6 +5283,10 @@ const translations = {
                 commercialFeedDetails: 'Requires setup with your bank. This is typically used by larger companies and is often the best option if you qualify.',
                 commercialFeedPlaidDetails: `Requires setup with your bank, but we'll guide you. This is typically limited to larger companies.`,
                 directFeedDetails: 'The simplest approach. Connect right away using your master credentials. This method is most common.',
+                duplicateFeedModal: {
+                    title: 'Card feed already connected',
+                    prompt: "You can't add the same card feed to the same workspace twice.",
+                },
                 enableFeed: {
                     title: (provider: string) => `Enable your ${provider} feed`,
                     heading: 'We have a direct integration with your card issuer and can import your transaction data into Expensify quickly and accurately.\n\nTo get started, simply:',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -5116,6 +5116,10 @@ ${amount} para ${merchant} - ${date}`,
                 commercialFeedDetails: 'Requiere configuración con tu banco. Esto suele ser utilizado por empresas más grandes y a menudo es la mejor opción si calificas.',
                 commercialFeedPlaidDetails: 'Requiere configurarlo con tu banco, pero te guiaremos. Esto suele estar limitado a empresas más grandes.',
                 directFeedDetails: 'El enfoque más simple. Conéctate de inmediato usando tus credenciales maestras. Este método es el más común.',
+                duplicateFeedModal: {
+                    title: 'Fuente de tarjetas ya conectada',
+                    prompt: 'No puedes añadir la misma fuente de tarjetas al mismo espacio de trabajo dos veces.',
+                },
                 enableFeed: {
                     title: (provider) => `Habilita tu feed ${provider}`,
                     heading:

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -1031,19 +1031,39 @@ function getCardAssignmentStartDate(isEditing: boolean | undefined, existingStar
     return isEditing ? (existingStartDate ?? format(new Date(), CONST.DATE.FNS_FORMAT_STRING)) : format(new Date(), CONST.DATE.FNS_FORMAT_STRING);
 }
 
-function checkIfNewFeedConnected(prevFeedsData: CombinedCardFeeds, currentFeedsData: CombinedCardFeeds, plaidBank?: string) {
+function checkIfNewFeedConnected(
+    prevFeedsData: CombinedCardFeeds,
+    currentFeedsData: CombinedCardFeeds,
+    plaidBank?: string,
+    prevRawFeedNames: string[] = [],
+    currentRawFeedNames: string[] = [],
+) {
     const prevFeeds = Object.keys(prevFeedsData);
     const currentFeeds = Object.keys(currentFeedsData);
+    const plaidFeedName = plaidBank ? `${CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID}.${plaidBank}` : undefined;
+    const doesFeedMatchPlaidBank = (feed: string) => {
+        if (!plaidFeedName) {
+            return false;
+        }
+
+        return (splitCardFeedWithDomainID(feed as CompanyCardFeedWithDomainID)?.feedName ?? feed) === plaidFeedName;
+    };
 
     const plaidBankFound =
         plaidBank &&
         currentFeeds.find((feed) => {
-            return splitCardFeedWithDomainID(feed as CompanyCardFeedWithDomainID)?.feedName === `${CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID}.${plaidBank}`;
+            return doesFeedMatchPlaidBank(feed);
         });
+    const newFeed = currentFeeds.find((feed) => !prevFeeds.includes(feed)) as CompanyCardFeedWithDomainID | undefined;
+    const rawPlaidBankFound = currentRawFeedNames.find(doesFeedMatchPlaidBank);
+    const didPlaidFeedAlreadyExist =
+        prevRawFeedNames.some(doesFeedMatchPlaidBank) ||
+        (!!plaidBankFound && prevFeeds.includes(plaidBankFound));
 
     return {
-        isNewFeedConnected: currentFeeds.length > prevFeeds.length || plaidBankFound,
-        newFeed: currentFeeds.find((feed) => !prevFeeds.includes(feed)) as CompanyCardFeedWithDomainID | undefined,
+        isNewFeedConnected: currentFeeds.length > prevFeeds.length || !!plaidBankFound || !!rawPlaidBankFound,
+        newFeed,
+        isDuplicatePlaidFeed: (!!rawPlaidBankFound || !!plaidBankFound) && didPlaidFeedAlreadyExist && !newFeed,
     };
 }
 

--- a/src/pages/workspace/companyCards/BankConnection/index.native.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.native.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import type {WebViewNavigation} from 'react-native-webview';
 import {WebView} from 'react-native-webview';
@@ -7,6 +7,7 @@ import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOffli
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useCardFeeds from '@hooks/useCardFeeds';
+import useConfirmModal from '@hooks/useConfirmModal';
 import useImportPlaidAccounts from '@hooks/useImportPlaidAccounts';
 import useIsBlockedToAddFeed from '@hooks/useIsBlockedToAddFeed';
 import useLocalize from '@hooks/useLocalize';
@@ -60,13 +61,30 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
     const plaidToken = addNewCard?.data?.publicToken ?? assignCard?.cardToAssign?.plaidAccessToken;
     const isPlaid = !!plaidToken;
     const url = getCompanyCardBankConnection(policyID, bankName);
-    const [cardFeeds] = useCardFeeds(policyID);
+    const [cardFeeds, , rawCardFeeds] = useCardFeeds(policyID);
+    const {showConfirmModal} = useConfirmModal();
     const [isConnectionCompleted, setConnectionCompleted] = useState(false);
     const prevFeedsData = usePrevious(cardFeeds);
+    const prevRawCardFeeds = usePrevious(rawCardFeeds);
     const isFeedExpired = feed ? isSelectedFeedExpired(cardFeeds?.[feed]) : false;
-    const {isNewFeedConnected, newFeed} = useMemo(
-        () => checkIfNewFeedConnected(prevFeedsData ?? {}, cardFeeds ?? {}, addNewCard?.data?.plaidConnectedFeed),
-        [addNewCard?.data?.plaidConnectedFeed, cardFeeds, prevFeedsData],
+    const rawFeedNames = useMemo(
+        () => Object.keys(rawCardFeeds?.settings?.companyCards ?? {}),
+        [rawCardFeeds?.settings?.companyCards],
+    );
+    const prevRawFeedNames = useMemo(
+        () => Object.keys(prevRawCardFeeds?.settings?.companyCards ?? {}),
+        [prevRawCardFeeds?.settings?.companyCards],
+    );
+    const {isNewFeedConnected, newFeed, isDuplicatePlaidFeed} = useMemo(
+        () =>
+            checkIfNewFeedConnected(
+                prevFeedsData ?? {},
+                cardFeeds ?? {},
+                addNewCard?.data?.plaidConnectedFeed,
+                prevRawFeedNames,
+                rawFeedNames,
+            ),
+        [addNewCard?.data?.plaidConnectedFeed, cardFeeds, prevFeedsData, prevRawFeedNames, rawFeedNames],
     );
     const headerTitleAddCards = !backTo ? translate('workspace.companyCards.addCards') : undefined;
     const headerTitle = feed ? translate('workspace.companyCards.assignCard') : headerTitleAddCards;
@@ -74,6 +92,15 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
     const {updateBrokenConnection, isFeedConnectionBroken} = useUpdateFeedBrokenConnection({policyID, feed});
     const isNewFeedHasError = !!(newFeed && cardFeeds?.[newFeed]?.errors);
     const {isBlockedToAddNewFeeds, isAllFeedsResultLoading} = useIsBlockedToAddFeed(policyID);
+
+    const showDuplicateFeedModal = useCallback(() => {
+        void showConfirmModal({
+            title: translate('workspace.companyCards.addNewCard.duplicateFeedModal.title'),
+            prompt: translate('workspace.companyCards.addNewCard.duplicateFeedModal.prompt'),
+            confirmText: translate('common.buttonConfirm'),
+            shouldShowCancelButton: false,
+        });
+    }, [showConfirmModal, translate]);
 
     const activityReasonAttributes: SkeletonSpanReasonAttributes = {
         context: 'BankConnection',
@@ -144,7 +171,10 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
             }
 
             Navigation.closeRHPFlow();
-            Navigation.navigate(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID), {forceReplace: true});
+            Navigation.navigate(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID), {
+                forceReplace: true,
+                afterTransition: isDuplicatePlaidFeed ? showDuplicateFeedModal : undefined,
+            });
             return;
         }
         if (isPlaid) {
@@ -163,6 +193,8 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
         isFeedConnectionBroken,
         updateBrokenConnection,
         isNewFeedHasError,
+        isDuplicatePlaidFeed,
+        showDuplicateFeedModal,
     ]);
 
     const checkIfConnectionCompleted = (navState: WebViewNavigation) => {

--- a/src/pages/workspace/companyCards/BankConnection/index.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.tsx
@@ -7,6 +7,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import TextLink from '@components/TextLink';
 import useCardFeeds from '@hooks/useCardFeeds';
+import useConfirmModal from '@hooks/useConfirmModal';
 import useImportPlaidAccounts from '@hooks/useImportPlaidAccounts';
 import useIsBlockedToAddFeed from '@hooks/useIsBlockedToAddFeed';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
@@ -56,15 +57,32 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
     const [assignCard] = useOnyx(ONYXKEYS.ASSIGN_CARD);
     const {feed: bankNameFromRoute, backTo, policyID: policyIDFromRoute} = route?.params ?? {};
     const policyID = policyIDFromProps ?? policyIDFromRoute;
-    const [cardFeeds] = useCardFeeds(policyID);
+    const [cardFeeds, , rawCardFeeds] = useCardFeeds(policyID);
     const prevFeedsData = usePrevious(cardFeeds);
+    const prevRawCardFeeds = usePrevious(rawCardFeeds);
+    const {showConfirmModal} = useConfirmModal();
     const illustrations = useMemoizedLazyIllustrations(['PendingBank']);
     const [shouldBlockWindowOpen, setShouldBlockWindowOpen] = useState(false);
     const selectedBank = addNewCard?.data?.selectedBank;
     const bankName = feed ? getBankName(getCompanyCardFeed(feed)) : (bankNameFromRoute ?? addNewCard?.data?.plaidConnectedFeed ?? selectedBank);
-    const {isNewFeedConnected, newFeed} = useMemo(
-        () => checkIfNewFeedConnected(prevFeedsData ?? {}, cardFeeds ?? {}, addNewCard?.data?.plaidConnectedFeed),
-        [addNewCard?.data?.plaidConnectedFeed, cardFeeds, prevFeedsData],
+    const rawFeedNames = useMemo(
+        () => Object.keys(rawCardFeeds?.settings?.companyCards ?? {}),
+        [rawCardFeeds?.settings?.companyCards],
+    );
+    const prevRawFeedNames = useMemo(
+        () => Object.keys(prevRawCardFeeds?.settings?.companyCards ?? {}),
+        [prevRawCardFeeds?.settings?.companyCards],
+    );
+    const {isNewFeedConnected, newFeed, isDuplicatePlaidFeed} = useMemo(
+        () =>
+            checkIfNewFeedConnected(
+                prevFeedsData ?? {},
+                cardFeeds ?? {},
+                addNewCard?.data?.plaidConnectedFeed,
+                prevRawFeedNames,
+                rawFeedNames,
+            ),
+        [addNewCard?.data?.plaidConnectedFeed, cardFeeds, prevFeedsData, prevRawFeedNames, rawFeedNames],
     );
     const {isOffline} = useNetwork();
     const plaidToken = addNewCard?.data?.publicToken ?? assignCard?.cardToAssign?.plaidAccessToken;
@@ -85,6 +103,15 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
         }
         customWindow = openBankConnection(url);
     }, [url]);
+
+    const showDuplicateFeedModal = useCallback(() => {
+        void showConfirmModal({
+            title: translate('workspace.companyCards.addNewCard.duplicateFeedModal.title'),
+            prompt: translate('workspace.companyCards.addNewCard.duplicateFeedModal.prompt'),
+            confirmText: translate('common.buttonConfirm'),
+            shouldShowCancelButton: false,
+        });
+    }, [showConfirmModal, translate]);
 
     useEffect(() => {
         if (!policyID || !isBlockedToAddNewFeeds || feed) {
@@ -157,7 +184,10 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
             }
 
             Navigation.closeRHPFlow();
-            Navigation.navigate(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID), {forceReplace: true});
+            Navigation.navigate(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID), {
+                forceReplace: true,
+                afterTransition: isDuplicatePlaidFeed ? showDuplicateFeedModal : undefined,
+            });
             return;
         }
         if (!shouldBlockWindowOpen) {
@@ -186,6 +216,8 @@ function BankConnection({policyID: policyIDFromProps, feed, route, title}: BankC
         isFeedConnectionBroken,
         updateBrokenConnection,
         isNewFeedHasError,
+        isDuplicatePlaidFeed,
+        showDuplicateFeedModal,
     ]);
 
     const getContent = () => {

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -8,6 +8,7 @@ import CONST from '@src/CONST';
 import type {CombinedCardFeeds} from '@src/hooks/useCardFeeds';
 import IntlStore from '@src/languages/IntlStore';
 import {
+    checkIfNewFeedConnected,
     doesCardFeedExist,
     feedHasCards,
     filterAllInactiveCards,
@@ -3126,6 +3127,70 @@ describe('CardUtils', () => {
         it('should handle plaid feed with domain ID', () => {
             const result = splitCardFeedWithDomainID('plaid.ins_129663#12345' as CardFeedWithDomainID);
             expect(result).toEqual({feedName: 'plaid.ins_129663', domainID: 12345});
+        });
+    });
+
+    describe('checkIfNewFeedConnected', () => {
+        const existingFeed = `${CONST.COMPANY_CARD.FEED_BANK_NAME.CHASE}#12345` as CompanyCardFeedWithDomainID;
+        const plaidFeed = 'plaid.ins_129663#12345' as CompanyCardFeedWithDomainID;
+
+        it('identifies a newly connected Plaid feed', () => {
+            const result = checkIfNewFeedConnected(
+                {[existingFeed]: {}} as unknown as CombinedCardFeeds,
+                {[existingFeed]: {}, [plaidFeed]: {}} as unknown as CombinedCardFeeds,
+                'ins_129663',
+            );
+
+            expect(result).toEqual({
+                isNewFeedConnected: true,
+                newFeed: plaidFeed,
+                isDuplicatePlaidFeed: false,
+            });
+        });
+
+        it('identifies an already connected Plaid feed as a duplicate', () => {
+            const feeds = {[existingFeed]: {}, [plaidFeed]: {}} as unknown as CombinedCardFeeds;
+            const result = checkIfNewFeedConnected(feeds, feeds, 'ins_129663');
+
+            expect(result).toEqual({
+                isNewFeedConnected: true,
+                newFeed: undefined,
+                isDuplicatePlaidFeed: true,
+            });
+        });
+
+        it('identifies a duplicate Plaid feed from raw feed data when the feed is filtered out', () => {
+            const feeds = {[existingFeed]: {}} as unknown as CombinedCardFeeds;
+            const result = checkIfNewFeedConnected(
+                feeds,
+                feeds,
+                'ins_129663',
+                ['plaid.ins_129663'],
+                ['plaid.ins_129663'],
+            );
+
+            expect(result).toEqual({
+                isNewFeedConnected: true,
+                newFeed: undefined,
+                isDuplicatePlaidFeed: true,
+            });
+        });
+
+        it('does not treat a newly added raw Plaid feed as a duplicate', () => {
+            const feeds = {[existingFeed]: {}} as unknown as CombinedCardFeeds;
+            const result = checkIfNewFeedConnected(
+                feeds,
+                feeds,
+                'ins_129663',
+                [],
+                ['plaid.ins_129663'],
+            );
+
+            expect(result).toEqual({
+                isNewFeedConnected: true,
+                newFeed: undefined,
+                isDuplicatePlaidFeed: false,
+            });
         });
     });
 


### PR DESCRIPTION
## Summary
- Detect duplicate Plaid company-card feeds using the raw workspace feed keys from `settings.companyCards`, so filtered-out direct feeds are still recognized.
- Close the add-cards RHP and then show the agreed duplicate-feed alert modal.
- Cover filtered/current-feed duplicate cases in `checkIfNewFeedConnected` unit tests.

$ #81573

## Test plan
- `git diff --check` (pass)
- `jest tests/unit/CardUtilsTest.ts --runInBand --testNamePattern="checkIfNewFeedConnected"` (blocked: local `node_modules` was corrupted after a disk-full install; Jest fails while parsing dependencies before running tests)
- `tsc --noEmit --pretty false` (blocked for the same local dependency corruption; TypeScript reports invalid characters in dependency `.d.ts` files)