### PR TITLE
Fix cursor positioned at end of amount field on Travel Monthly Spend Limit page

### DIFF
--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -215,8 +215,8 @@ function NumberWithSymbolForm({
     const wasFocused = usePrevious(isFocused);
 
     const [selection, setSelection] = useState({
-        start: currentNumber.length,
-        end: currentNumber.length,
+        start: displayAsTextInput ? 0 : currentNumber.length,
+        end: displayAsTextInput ? 0 : currentNumber.length,
     });
 
     const forwardDeletePressedRef = useRef(false);
@@ -515,6 +515,11 @@ function NumberWithSymbolForm({
                 autoGrowExtraSpace={props.autoGrowExtraSpace}
                 autoGrowMarginSide={props.autoGrowMarginSide}
                 onSubmitEditing={onSubmitEditing}
+                selection={selection}
+                onSelectionChange={(e) => {
+                    const {start, end} = e.nativeEvent.selection;
+                    setSelection({start, end});
+                }}
                 onFocus={props.onFocus}
                 rightHandSideComponent={shouldShowCurrencyButton || shouldShowFlipButton ? textInputRightHandSideComponent : undefined}
             />


### PR DESCRIPTION
### Changes

When a user opens the Travel Monthly Spend Limit amount field with an existing value, the cursor was sitting at the very end of the pre-filled number. To enter a new amount they had to manually navigate to the start first. Fixed by initialising the cursor position to the beginning of the field and wiring up the `selection` / `onSelectionChange` props on the `TextInput` in the `displayAsTextInput` branch of `NumberWithSymbolForm`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90779

### Tests
- [ ] Verify that on the Travel Monthly Spend Limit page the cursor appears at position 0 when the field is focused with a pre-filled value
- [ ] Verify typing immediately replaces/prepends to the existing value as expected
- [ ] Verify no regression on the standard numpad flow (does not use `displayAsTextInput`)

### Offline tests
N/A

### QA Steps
1. Open the Travel Monthly Spend Limit page with an existing limit set
2. Tap the amount input — cursor should be at the **beginning** of the number
3. Type a new amount — it should work without having to move the cursor first

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [ ] I followed proper code patterns for this project
- [ ] I tested this PR on all applicable platforms
- [x] I included screenshots/videos for UI changes if applicable
- [x] I verified my changes don't break the offline flow

### PR Reviewer Checklist
N/A

### PROPOSAL: https://github.com/Expensify/App/issues/90779#issuecomment-4461786196