### PR TITLE
[CP Staging] fix: prevent focus-return side effects on confirmation-field save and SelectionList RHP close

### DIFF
--- a/src/components/Search/SearchList/BaseSearchList/index.tsx
+++ b/src/components/Search/SearchList/BaseSearchList/index.tsx
@@ -64,7 +64,7 @@ function BaseSearchList({
     });
 
     const handleFocusByIndex = (index: number, event: NativeSyntheticEvent<ExtendedTargetedEvent>) => {
-        // Don't let the accessibility focus-return restore drive the arrow-cursor — it would highlight + scroll the row on back nav. DOM focus is still restored by the .focus() itself.
+        // The focus-return restore shouldn't move the keyboard cursor here, or the row gets highlighted and scrolled into view on back nav. The .focus() still restores DOM focus for screen readers.
         if (isFocusRestoreInProgress()) {
             return;
         }

--- a/src/components/Search/SearchList/BaseSearchList/index.tsx
+++ b/src/components/Search/SearchList/BaseSearchList/index.tsx
@@ -11,6 +11,7 @@ import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
 import useStableIndexedHandler from '@hooks/useStableIndexedHandler';
 import {isMobileChrome} from '@libs/Browser';
 import {addKeyDownPressListener, removeKeyDownPressListener} from '@libs/KeyboardShortcut/KeyDownPressListener';
+import {isFocusRestoreInProgress} from '@libs/NavigationFocusReturn';
 import CONST from '@src/CONST';
 import type BaseSearchListProps from './types';
 
@@ -63,6 +64,10 @@ function BaseSearchList({
     });
 
     const handleFocusByIndex = (index: number, event: NativeSyntheticEvent<ExtendedTargetedEvent>) => {
+        // Don't let the accessibility focus-return restore drive the arrow-cursor — it would highlight + scroll the row on back nav. DOM focus is still restored by the .focus() itself.
+        if (isFocusRestoreInProgress()) {
+            return;
+        }
         // Prevent unexpected scrolling on mobile Chrome after the context menu closes by ignoring programmatic focus not triggered by direct user interaction.
         if (isMobileChrome() && event.nativeEvent) {
             if (!event.nativeEvent.sourceCapabilities) {

--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -229,12 +229,15 @@ function BaseSelectionList<TItem extends ListItem>({
     });
 
     // Keep the cursor on the restored row so keyboard nav continues from there, but don't scroll to it on the way back.
-    const setFocusedIndexFromRowFocus = (index: number) => {
-        if (isFocusRestoreInProgress() && index !== focusedIndex) {
-            suppressNextFocusScrollRef.current = true;
-        }
-        setFocusedIndex(index);
-    };
+    const setFocusedIndexFromRowFocus = useCallback(
+        (index: number) => {
+            if (isFocusRestoreInProgress() && index !== focusedIndex) {
+                suppressNextFocusScrollRef.current = true;
+            }
+            setFocusedIndex(index);
+        },
+        [focusedIndex, setFocusedIndex],
+    );
 
     // extraData helps FlashList detect when data changes significantly (e.g., during filtering)
     // Including data.length ensures FlashList resets its layout cache when the list size changes

--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -18,6 +18,7 @@ import useSingleExecution from '@hooks/useSingleExecution';
 import {focusedItemRef} from '@hooks/useSyncFocus/useSyncFocusImplementation';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {addKeyDownPressListener, removeKeyDownPressListener} from '@libs/KeyboardShortcut/KeyDownPressListener';
+import {isFocusRestoreInProgress} from '@libs/NavigationFocusReturn';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import CONST from '@src/CONST';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
@@ -227,6 +228,17 @@ function BaseSelectionList<TItem extends ListItem>({
         onArrowUpDownCallback,
     });
 
+    // Focus-return restore: keep the cursor sync (keyboard nav continues from the row) but suppress the scroll it would trigger (deploy blocker #90839).
+    const setFocusedIndexFromRowFocus = useCallback(
+        (index: number) => {
+            if (isFocusRestoreInProgress() && index !== focusedIndex) {
+                suppressNextFocusScrollRef.current = true;
+            }
+            setFocusedIndex(index);
+        },
+        [focusedIndex, setFocusedIndex],
+    );
+
     // extraData helps FlashList detect when data changes significantly (e.g., during filtering)
     // Including data.length ensures FlashList resets its layout cache when the list size changes
     // This prevents "index out of bounds" errors when filtering reduces the list size
@@ -373,7 +385,7 @@ function BaseSelectionList<TItem extends ListItem>({
                     isSelected: selected,
                     ...item,
                 }}
-                setFocusedIndex={setFocusedIndex}
+                setFocusedIndex={setFocusedIndexFromRowFocus}
                 index={index}
                 isFocused={isItemFocused}
                 isFocusVisible={isItemVisuallyFocused}

--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -228,16 +228,13 @@ function BaseSelectionList<TItem extends ListItem>({
         onArrowUpDownCallback,
     });
 
-    // Focus-return restore: keep the cursor sync (keyboard nav continues from the row) but suppress the scroll it would trigger (deploy blocker #90839).
-    const setFocusedIndexFromRowFocus = useCallback(
-        (index: number) => {
-            if (isFocusRestoreInProgress() && index !== focusedIndex) {
-                suppressNextFocusScrollRef.current = true;
-            }
-            setFocusedIndex(index);
-        },
-        [focusedIndex, setFocusedIndex],
-    );
+    // Keep the cursor on the restored row so keyboard nav continues from there, but don't scroll to it on the way back.
+    const setFocusedIndexFromRowFocus = (index: number) => {
+        if (isFocusRestoreInProgress() && index !== focusedIndex) {
+            suppressNextFocusScrollRef.current = true;
+        }
+        setFocusedIndex(index);
+    };
 
     // extraData helps FlashList detect when data changes significantly (e.g., during filtering)
     // Including data.length ensures FlashList resets its layout cache when the list size changes

--- a/src/components/SelectionList/ListItem/ListItemRenderer.tsx
+++ b/src/components/SelectionList/ListItem/ListItemRenderer.tsx
@@ -3,7 +3,6 @@ import type {NativeSyntheticEvent, StyleProp, TextStyle, ViewStyle} from 'react-
 import type {SelectionListProps} from '@components/SelectionList/types';
 import type useArrowKeyFocusManager from '@hooks/useArrowKeyFocusManager';
 import type useSingleExecution from '@hooks/useSingleExecution';
-import {isMobileChrome} from '@libs/Browser';
 import {isTransactionGroupListItemType} from '@libs/SearchUIUtils';
 import type {ExtendedTargetedEvent, ListItem, SelectableListItemProps} from './types';
 
@@ -93,8 +92,8 @@ function ListItemRenderer<TItem extends ListItem>({
                     if (shouldIgnoreFocus || isDisabled) {
                         return;
                     }
-                    // Prevent unexpected scrolling on mobile Chrome after the context menu closes by ignoring programmatic focus not triggered by direct user interaction.
-                    if (isMobileChrome() && event.nativeEvent && !event.nativeEvent.sourceCapabilities) {
+                    // No sourceCapabilities = programmatic focus (focus-return restore, context-menu close); don't move the cursor or it scroll-jumps the list. Pointer focus carries sourceCapabilities.
+                    if (event.nativeEvent && !event.nativeEvent.sourceCapabilities) {
                         return;
                     }
                     setFocusedIndex(normalizedIndex ?? index);

--- a/src/components/SelectionList/ListItem/ListItemRenderer.tsx
+++ b/src/components/SelectionList/ListItem/ListItemRenderer.tsx
@@ -4,7 +4,6 @@ import type {SelectionListProps} from '@components/SelectionList/types';
 import type useArrowKeyFocusManager from '@hooks/useArrowKeyFocusManager';
 import type useSingleExecution from '@hooks/useSingleExecution';
 import {isMobileChrome} from '@libs/Browser';
-import {isFocusRestoreInProgress} from '@libs/NavigationFocusReturn';
 import {isTransactionGroupListItemType} from '@libs/SearchUIUtils';
 import type {ExtendedTargetedEvent, ListItem, SelectableListItemProps} from './types';
 
@@ -94,8 +93,8 @@ function ListItemRenderer<TItem extends ListItem>({
                     if (shouldIgnoreFocus || isDisabled) {
                         return;
                     }
-                    // Keyboard Tab also lacks sourceCapabilities but must still sync the cursor — so gate on the restore/mobile-Chrome signals, not sourceCapabilities alone.
-                    if (event.nativeEvent && !event.nativeEvent.sourceCapabilities && (isFocusRestoreInProgress() || isMobileChrome())) {
+                    // Prevent unexpected scrolling on mobile Chrome after the context menu closes by ignoring programmatic focus not triggered by direct user interaction.
+                    if (isMobileChrome() && event.nativeEvent && !event.nativeEvent.sourceCapabilities) {
                         return;
                     }
                     setFocusedIndex(normalizedIndex ?? index);

--- a/src/components/SelectionList/ListItem/ListItemRenderer.tsx
+++ b/src/components/SelectionList/ListItem/ListItemRenderer.tsx
@@ -3,6 +3,8 @@ import type {NativeSyntheticEvent, StyleProp, TextStyle, ViewStyle} from 'react-
 import type {SelectionListProps} from '@components/SelectionList/types';
 import type useArrowKeyFocusManager from '@hooks/useArrowKeyFocusManager';
 import type useSingleExecution from '@hooks/useSingleExecution';
+import {isMobileChrome} from '@libs/Browser';
+import {isFocusRestoreInProgress} from '@libs/NavigationFocusReturn';
 import {isTransactionGroupListItemType} from '@libs/SearchUIUtils';
 import type {ExtendedTargetedEvent, ListItem, SelectableListItemProps} from './types';
 
@@ -92,8 +94,8 @@ function ListItemRenderer<TItem extends ListItem>({
                     if (shouldIgnoreFocus || isDisabled) {
                         return;
                     }
-                    // No sourceCapabilities = programmatic focus (focus-return restore, context-menu close); don't move the cursor or it scroll-jumps the list. Pointer focus carries sourceCapabilities.
-                    if (event.nativeEvent && !event.nativeEvent.sourceCapabilities) {
+                    // Keyboard Tab also lacks sourceCapabilities but must still sync the cursor — so gate on the restore/mobile-Chrome signals, not sourceCapabilities alone.
+                    if (event.nativeEvent && !event.nativeEvent.sourceCapabilities && (isFocusRestoreInProgress() || isMobileChrome())) {
                         return;
                     }
                     setFocusedIndex(normalizedIndex ?? index);

--- a/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
+++ b/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
@@ -1,7 +1,7 @@
 import {useIsFocused} from '@react-navigation/native';
 import {FlashList} from '@shopify/flash-list';
 import type {FlashListRef, ListRenderItemInfo} from '@shopify/flash-list';
-import React, {useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
+import React, {useEffect, useImperativeHandle, useRef, useState} from 'react';
 import type {TextInputKeyPressEvent} from 'react-native';
 import {View} from 'react-native';
 import type {ValueOf} from 'type-fest';
@@ -166,16 +166,13 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
         onArrowUpDownCallback: () => setShouldDisableHoverStyle(true),
     });
 
-    // Focus-return restore: keep the cursor sync (keyboard nav continues from the row) but suppress the scroll it would trigger (deploy blocker #90839).
-    const setFocusedIndexFromRowFocus = useCallback(
-        (index: number) => {
-            if (isFocusRestoreInProgress() && index !== focusedIndex) {
-                suppressNextFocusScrollRef.current = true;
-            }
-            setFocusedIndex(index);
-        },
-        [focusedIndex, setFocusedIndex],
-    );
+    // Keep the cursor on the restored row so keyboard nav continues from there, but don't scroll to it on the way back.
+    const setFocusedIndexFromRowFocus = (index: number) => {
+        if (isFocusRestoreInProgress() && index !== focusedIndex) {
+            suppressNextFocusScrollRef.current = true;
+        }
+        setFocusedIndex(index);
+    };
 
     const getFocusedItem = (): TItem | undefined => {
         if (focusedIndex < 0 || focusedIndex >= flattenedData.length) {

--- a/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
+++ b/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
@@ -1,7 +1,7 @@
 import {useIsFocused} from '@react-navigation/native';
 import {FlashList} from '@shopify/flash-list';
 import type {FlashListRef, ListRenderItemInfo} from '@shopify/flash-list';
-import React, {useEffect, useImperativeHandle, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import type {TextInputKeyPressEvent} from 'react-native';
 import {View} from 'react-native';
 import type {ValueOf} from 'type-fest';
@@ -29,6 +29,7 @@ import {focusedItemRef} from '@hooks/useSyncFocus/useSyncFocusImplementation';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {addKeyDownPressListener, removeKeyDownPressListener} from '@libs/KeyboardShortcut/KeyDownPressListener';
 import Log from '@libs/Log';
+import {isFocusRestoreInProgress} from '@libs/NavigationFocusReturn';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import CONST from '@src/CONST';
 import type {FlattenedItem, ListItem, SelectionListWithSectionsProps} from './types';
@@ -164,6 +165,17 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
         isFocused: isScreenFocused,
         onArrowUpDownCallback: () => setShouldDisableHoverStyle(true),
     });
+
+    // Focus-return restore: keep the cursor sync (keyboard nav continues from the row) but suppress the scroll it would trigger (deploy blocker #90839).
+    const setFocusedIndexFromRowFocus = useCallback(
+        (index: number) => {
+            if (isFocusRestoreInProgress() && index !== focusedIndex) {
+                suppressNextFocusScrollRef.current = true;
+            }
+            setFocusedIndex(index);
+        },
+        [focusedIndex, setFocusedIndex],
+    );
 
     const getFocusedItem = (): TItem | undefined => {
         if (focusedIndex < 0 || focusedIndex >= flattenedData.length) {
@@ -382,7 +394,7 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
                         shouldSingleExecuteRowSelect={shouldSingleExecuteRowSelect}
                         onDismissError={onDismissError}
                         rightHandSideComponent={rightHandSideComponent}
-                        setFocusedIndex={setFocusedIndex}
+                        setFocusedIndex={setFocusedIndexFromRowFocus}
                         singleExecution={singleExecution}
                         shouldSyncFocus={!isTextInputFocusedRef.current && isKeyboardNavigating}
                         shouldIgnoreFocus={shouldIgnoreFocus}

--- a/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
+++ b/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
@@ -166,12 +166,21 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
         onArrowUpDownCallback: () => setShouldDisableHoverStyle(true),
     });
 
-    // Keep the cursor on the restored row so keyboard nav continues from there, but don't scroll to it on the way back.
-    const setFocusedIndexFromRowFocus = (index: number) => {
-        if (isFocusRestoreInProgress() && index !== focusedIndex) {
+    // Move the cursor, and skip the scroll the move would otherwise trigger when the index actually changes.
+    const setFocusedIndexWithoutScrollOnChange = (index: number) => {
+        if (index !== focusedIndex) {
             suppressNextFocusScrollRef.current = true;
         }
         setFocusedIndex(index);
+    };
+
+    // Keep the cursor on the restored row so keyboard nav continues from there, but don't scroll to it on the way back.
+    const setFocusedIndexFromRowFocus = (index: number) => {
+        if (isFocusRestoreInProgress()) {
+            setFocusedIndexWithoutScrollOnChange(index);
+        } else {
+            setFocusedIndex(index);
+        }
     };
 
     const getFocusedItem = (): TItem | undefined => {
@@ -199,10 +208,7 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
             }
         }
         if (shouldUpdateFocusedIndex && typeof indexToFocus === 'number') {
-            if (indexToFocus !== focusedIndex) {
-                suppressNextFocusScrollRef.current = true;
-            }
-            setFocusedIndex(indexToFocus);
+            setFocusedIndexWithoutScrollOnChange(indexToFocus);
         }
         onSelectRow(item);
 

--- a/src/libs/NavigationFocusReturn.native.ts
+++ b/src/libs/NavigationFocusReturn.native.ts
@@ -7,9 +7,18 @@ function notifyPushParamsForward(_routeKey: string, _prevParams: unknown): void 
 function notifyPushParamsBackward(_routeKey: string, _targetParams: unknown): void {}
 /* eslint-enable @typescript-eslint/no-unused-vars */
 function cancelPendingFocusRestore(): void {}
+function skipNextFocusRestore(): void {}
 // Web-only guard; native has no DOM activeElement, so AUTO never needs to skip.
 function shouldSkipAutoFocusDueToExistingFocus(): boolean {
     return false;
 }
 
-export {setupNavigationFocusReturn, teardownNavigationFocusReturn, notifyPushParamsForward, notifyPushParamsBackward, cancelPendingFocusRestore, shouldSkipAutoFocusDueToExistingFocus};
+export {
+    setupNavigationFocusReturn,
+    teardownNavigationFocusReturn,
+    notifyPushParamsForward,
+    notifyPushParamsBackward,
+    cancelPendingFocusRestore,
+    skipNextFocusRestore,
+    shouldSkipAutoFocusDueToExistingFocus,
+};

--- a/src/libs/NavigationFocusReturn.native.ts
+++ b/src/libs/NavigationFocusReturn.native.ts
@@ -8,6 +8,9 @@ function notifyPushParamsBackward(_routeKey: string, _targetParams: unknown): vo
 /* eslint-enable @typescript-eslint/no-unused-vars */
 function cancelPendingFocusRestore(): void {}
 function skipNextFocusRestore(): void {}
+function isFocusRestoreInProgress(): boolean {
+    return false;
+}
 // Web-only guard; native has no DOM activeElement, so AUTO never needs to skip.
 function shouldSkipAutoFocusDueToExistingFocus(): boolean {
     return false;
@@ -20,5 +23,6 @@ export {
     notifyPushParamsBackward,
     cancelPendingFocusRestore,
     skipNextFocusRestore,
+    isFocusRestoreInProgress,
     shouldSkipAutoFocusDueToExistingFocus,
 };

--- a/src/libs/NavigationFocusReturn.ts
+++ b/src/libs/NavigationFocusReturn.ts
@@ -140,12 +140,12 @@ function notifyPushParamsBackward(routeKey: string, targetParams: unknown): void
     scheduleRestore(compoundParamsKey(routeKey, targetParams));
 }
 
-/** Suppress focus-restore for the next backward nav. Call before a form-submit goBack so the re-focused row doesn't shadow the page's pressOnEnter submit. Back/Esc dismissals don't call this, so they still restore (WCAG 2.4.3). */
+/** Suppress focus-restore for the next backward nav. Call before a form-submit goBack so the re-focused row doesn't swallow a follow-up pressOnEnter submit; Back/Esc don't call it (WCAG 2.4.3 still holds). */
 function skipNextFocusRestore(): void {
     skipNextRestore = true;
 }
 
-/** True while restoreTriggerForRoute is calling .focus(). Lists consult this in onFocus to skip cursor-sync for the programmatic restore without suppressing genuine keyboard Tab focus (neither carries sourceCapabilities). */
+/** True only while restoreTriggerForRoute is calling .focus(). Lists check this to suppress the restore's scroll without misclassifying keyboard Tab (neither carries sourceCapabilities). */
 function isFocusRestoreInProgress(): boolean {
     return isRestoringFocus;
 }

--- a/src/libs/NavigationFocusReturn.ts
+++ b/src/libs/NavigationFocusReturn.ts
@@ -140,12 +140,12 @@ function notifyPushParamsBackward(routeKey: string, targetParams: unknown): void
     scheduleRestore(compoundParamsKey(routeKey, targetParams));
 }
 
-/** Suppress focus-restore for the next backward nav. Call before a form-submit goBack so the re-focused row doesn't swallow a follow-up pressOnEnter submit; Back/Esc don't call it (WCAG 2.4.3 still holds). */
+/** Skips the focus restore for the next back navigation. Call it before a form-submit goBack so the re-focused row doesn't eat the next Enter (which should hit the page's submit). Back and Esc don't call it, so they still restore focus. */
 function skipNextFocusRestore(): void {
     skipNextRestore = true;
 }
 
-/** True only while restoreTriggerForRoute is calling .focus(). Lists check this to suppress the restore's scroll without misclassifying keyboard Tab (neither carries sourceCapabilities). */
+/** True only while restoreTriggerForRoute is in its .focus() call. Lists use it to tell the restore apart from a real keyboard Tab, which also has no sourceCapabilities. */
 function isFocusRestoreInProgress(): boolean {
     return isRestoringFocus;
 }

--- a/src/libs/NavigationFocusReturn.ts
+++ b/src/libs/NavigationFocusReturn.ts
@@ -46,6 +46,7 @@ function setTriggerEntry(routeKey: string, entry: TriggerEntry): void {
 let prevState: NavigationState | undefined;
 let pendingRestore: {cancel: () => void} | null = null;
 let skipNextRestore = false;
+let isRestoringFocus = false;
 let focusinHandler: ((e: FocusEvent) => void) | null = null;
 let mouseActivationHandler: ((e: MouseEvent) => void) | null = null;
 let stateUnsubscribe: (() => void) | null = null;
@@ -142,6 +143,11 @@ function notifyPushParamsBackward(routeKey: string, targetParams: unknown): void
 /** Suppress focus-restore for the next backward nav. Call before a form-submit goBack so the re-focused row doesn't shadow the page's pressOnEnter submit. Back/Esc dismissals don't call this, so they still restore (WCAG 2.4.3). */
 function skipNextFocusRestore(): void {
     skipNextRestore = true;
+}
+
+/** True while restoreTriggerForRoute is calling .focus(). Lists consult this in onFocus to skip cursor-sync for the programmatic restore without suppressing genuine keyboard Tab focus (neither carries sourceCapabilities). */
+function isFocusRestoreInProgress(): boolean {
+    return isRestoringFocus;
 }
 
 // 'retry' = in DOM but cannot accept focus now; 'gone' = detached, drop the entry.
@@ -266,7 +272,12 @@ function restoreTriggerForRoute(routeKey: string): boolean {
     const focusOptions: FocusOptions = {preventScroll: true, focusVisible: getHadTabNavigation()};
     for (const candidate of candidates) {
         const before = document.activeElement;
-        candidate.focus(focusOptions);
+        isRestoringFocus = true;
+        try {
+            candidate.focus(focusOptions);
+        } finally {
+            isRestoringFocus = false;
+        }
         const after = document.activeElement;
         if (after === candidate) {
             triggerMap.delete(routeKey);
@@ -512,6 +523,7 @@ export {
     notifyPushParamsBackward,
     cancelPendingFocusRestore,
     skipNextFocusRestore,
+    isFocusRestoreInProgress,
     compoundParamsKey,
     shouldSkipAutoFocusDueToExistingFocus,
     resetForTests,

--- a/src/libs/NavigationFocusReturn.ts
+++ b/src/libs/NavigationFocusReturn.ts
@@ -45,6 +45,7 @@ function setTriggerEntry(routeKey: string, entry: TriggerEntry): void {
 
 let prevState: NavigationState | undefined;
 let pendingRestore: {cancel: () => void} | null = null;
+let skipNextRestore = false;
 let focusinHandler: ((e: FocusEvent) => void) | null = null;
 let mouseActivationHandler: ((e: MouseEvent) => void) | null = null;
 let stateUnsubscribe: (() => void) | null = null;
@@ -136,6 +137,11 @@ function notifyPushParamsForward(routeKey: string, prevParams: unknown): void {
 
 function notifyPushParamsBackward(routeKey: string, targetParams: unknown): void {
     scheduleRestore(compoundParamsKey(routeKey, targetParams));
+}
+
+/** Suppress focus-restore for the next backward nav. Call before a form-submit goBack so the re-focused row doesn't shadow the page's pressOnEnter submit. Back/Esc dismissals don't call this, so they still restore (WCAG 2.4.3). */
+function skipNextFocusRestore(): void {
+    skipNextRestore = true;
 }
 
 // 'retry' = in DOM but cannot accept focus now; 'gone' = detached, drop the entry.
@@ -356,6 +362,7 @@ function handleStateChange(newState: NavigationState | undefined): void {
     }
 
     if (action.type === 'forward') {
+        skipNextRestore = false;
         cancelPendingRestore();
         captureTriggerForRoute(action.captureKey);
         // Loose refs would pin detached unmounted nodes; triggerMap holds the captured copy.
@@ -363,8 +370,14 @@ function handleStateChange(newState: NavigationState | undefined): void {
         lastMouseTrigger = null;
         lastMouseTriggerAt = 0;
     } else if (action.type === 'backward') {
-        scheduleRestore(action.restoreKey);
+        if (skipNextRestore) {
+            skipNextRestore = false;
+            cancelPendingRestore();
+        } else {
+            scheduleRestore(action.restoreKey);
+        }
     } else if (action.type === 'lateral') {
+        skipNextRestore = false;
         // Stale restore would steal focus back on sibling nav.
         cancelPendingRestore();
     }
@@ -447,6 +460,7 @@ function teardownNavigationFocusReturn(): void {
     lastInteractiveElement = null;
     lastMouseTrigger = null;
     lastMouseTriggerAt = 0;
+    skipNextRestore = false;
     if (typeof document !== 'undefined') {
         if (focusinHandler) {
             document.removeEventListener('focusin', focusinHandler, true);
@@ -474,6 +488,7 @@ function resetForTests(): void {
     lastMouseTrigger = null;
     lastMouseTriggerAt = 0;
     lastRestoreTarget = null;
+    skipNextRestore = false;
 }
 
 function setLastInteractiveElementForTests(element: HTMLElement | null): void {
@@ -496,6 +511,7 @@ export {
     notifyPushParamsForward,
     notifyPushParamsBackward,
     cancelPendingFocusRestore,
+    skipNextFocusRestore,
     compoundParamsKey,
     shouldSkipAutoFocusDueToExistingFocus,
     resetForTests,

--- a/src/pages/iou/request/step/IOURequestStepMerchant.tsx
+++ b/src/pages/iou/request/step/IOURequestStepMerchant.tsx
@@ -83,7 +83,7 @@ function IOURequestStepMerchant({
             return;
         }
         shouldNavigateAfterSaveRef.current = false;
-        // Save path only — the Back button (onBackButtonPress) must still restore focus.
+        // Only on the save path. The Back button (onBackButtonPress) should still restore focus.
         skipNextFocusRestore();
         navigateBack();
     }, [isSaved, navigateBack]);

--- a/src/pages/iou/request/step/IOURequestStepMerchant.tsx
+++ b/src/pages/iou/request/step/IOURequestStepMerchant.tsx
@@ -16,6 +16,7 @@ import useShowNotFoundPageInIOUStep from '@hooks/useShowNotFoundPageInIOUStep';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
+import {skipNextFocusRestore} from '@libs/NavigationFocusReturn';
 import {getTransactionDetails, isExpenseRequest, isPolicyExpenseChat} from '@libs/ReportUtils';
 import {hasReceipt} from '@libs/TransactionUtils';
 import {isInvalidMerchantValue, isValidInputLength} from '@libs/ValidationUtils';
@@ -82,6 +83,8 @@ function IOURequestStepMerchant({
             return;
         }
         shouldNavigateAfterSaveRef.current = false;
+        // Save path only — the Back button (onBackButtonPress) must still restore focus.
+        skipNextFocusRestore();
         navigateBack();
     }, [isSaved, navigateBack]);
 

--- a/tests/unit/BaseSelectionListTest.tsx
+++ b/tests/unit/BaseSelectionListTest.tsx
@@ -7,6 +7,7 @@ import BaseSelectionList from '@components/SelectionList/BaseSelectionList';
 import SingleSelectListItem from '@components/SelectionList/ListItem/SingleSelectListItem';
 import type {ListItem} from '@components/SelectionList/types';
 import type Navigation from '@libs/Navigation/Navigation';
+import type * as NavigationFocusReturnModule from '@libs/NavigationFocusReturn';
 import CONST from '@src/CONST';
 
 // Captures scrollToIndex calls so tests can assert on scroll behaviour
@@ -112,12 +113,19 @@ jest.mock('@hooks/useLocalize', () =>
 
 jest.mock('@hooks/useKeyboardShortcut', () => jest.fn());
 
+const mockIsFocusRestoreInProgress = jest.fn<boolean, []>(() => false);
+jest.mock('@libs/NavigationFocusReturn', () => ({
+    ...jest.requireActual<typeof NavigationFocusReturnModule>('@libs/NavigationFocusReturn'),
+    isFocusRestoreInProgress: () => mockIsFocusRestoreInProgress(),
+}));
+
 describe('BaseSelectionList', () => {
     const onSelectRowMock = jest.fn();
 
     beforeEach(() => {
         onSelectRowMock.mockClear();
         mockScrollToIndex.mockClear();
+        mockIsFocusRestoreInProgress.mockReturnValue(false);
     });
 
     function SelectionListRenderer<TItem extends ListItem>(props: BaseSelectionListTestProps<TItem>) {
@@ -316,20 +324,35 @@ describe('BaseSelectionList', () => {
         expect(screen.queryByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}0`)).toBeNull();
     });
 
-    it('does not scroll-jump the list on programmatic row focus (no sourceCapabilities) — focus-return restoring the trigger on back nav must not move the cursor', () => {
+    it('does not scroll-jump the list when the focus-return restore focuses a row (no sourceCapabilities, restore in progress)', () => {
         (NativeNavigation.useIsFocused as jest.Mock).mockReturnValue(true);
+        mockIsFocusRestoreInProgress.mockReturnValue(true);
         render(<SelectionListRenderer data={mockItems} />);
         mockScrollToIndex.mockClear();
 
         const row = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}5`);
-        // NavigationFocusReturn's .focus() (and context-menu close) produce a focus event with no sourceCapabilities.
+        // NavigationFocusReturn.restoreTriggerForRoute's .focus() — no sourceCapabilities, isFocusRestoreInProgress() true.
         fireEvent(row, 'focus', {nativeEvent: {sourceCapabilities: null}});
 
         expect(mockScrollToIndex).not.toHaveBeenCalled();
     });
 
+    it('still syncs the cursor on genuine keyboard Tab focus (no sourceCapabilities, restore NOT in progress) — regression guard for Codex P2', () => {
+        (NativeNavigation.useIsFocused as jest.Mock).mockReturnValue(true);
+        mockIsFocusRestoreInProgress.mockReturnValue(false);
+        render(<SelectionListRenderer data={mockItems} />);
+        mockScrollToIndex.mockClear();
+
+        const row = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}5`);
+        // Keyboard Tab focus carries no sourceCapabilities either — but it must still move the arrow cursor.
+        fireEvent(row, 'focus', {nativeEvent: {sourceCapabilities: null}});
+
+        expect(mockScrollToIndex).toHaveBeenCalledWith(expect.objectContaining({index: 5}));
+    });
+
     it('still scrolls to a row on genuine pointer focus (sourceCapabilities present)', () => {
         (NativeNavigation.useIsFocused as jest.Mock).mockReturnValue(true);
+        mockIsFocusRestoreInProgress.mockReturnValue(false);
         render(<SelectionListRenderer data={mockItems} />);
         mockScrollToIndex.mockClear();
 

--- a/tests/unit/BaseSelectionListTest.tsx
+++ b/tests/unit/BaseSelectionListTest.tsx
@@ -315,4 +315,27 @@ describe('BaseSelectionList', () => {
 
         expect(screen.queryByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}0`)).toBeNull();
     });
+
+    it('does not scroll-jump the list on programmatic row focus (no sourceCapabilities) — focus-return restoring the trigger on back nav must not move the cursor', () => {
+        (NativeNavigation.useIsFocused as jest.Mock).mockReturnValue(true);
+        render(<SelectionListRenderer data={mockItems} />);
+        mockScrollToIndex.mockClear();
+
+        const row = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}5`);
+        // NavigationFocusReturn's .focus() (and context-menu close) produce a focus event with no sourceCapabilities.
+        fireEvent(row, 'focus', {nativeEvent: {sourceCapabilities: null}});
+
+        expect(mockScrollToIndex).not.toHaveBeenCalled();
+    });
+
+    it('still scrolls to a row on genuine pointer focus (sourceCapabilities present)', () => {
+        (NativeNavigation.useIsFocused as jest.Mock).mockReturnValue(true);
+        render(<SelectionListRenderer data={mockItems} />);
+        mockScrollToIndex.mockClear();
+
+        const row = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}5`);
+        fireEvent(row, 'focus', {nativeEvent: {sourceCapabilities: {firesTouchEvents: false}}});
+
+        expect(mockScrollToIndex).toHaveBeenCalledWith(expect.objectContaining({index: 5}));
+    });
 });

--- a/tests/unit/BaseSelectionListTest.tsx
+++ b/tests/unit/BaseSelectionListTest.tsx
@@ -324,17 +324,22 @@ describe('BaseSelectionList', () => {
         expect(screen.queryByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}0`)).toBeNull();
     });
 
-    it('does not scroll-jump the list when the focus-return restore focuses a row (no sourceCapabilities, restore in progress)', () => {
+    it('suppresses the scroll on a focus-return restore but still syncs the cursor (no scroll-jump, no stale focusedIndex)', () => {
         (NativeNavigation.useIsFocused as jest.Mock).mockReturnValue(true);
         mockIsFocusRestoreInProgress.mockReturnValue(true);
         render(<SelectionListRenderer data={mockItems} />);
         mockScrollToIndex.mockClear();
 
         const row = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}5`);
-        // NavigationFocusReturn.restoreTriggerForRoute's .focus() — no sourceCapabilities, isFocusRestoreInProgress() true.
         fireEvent(row, 'focus', {nativeEvent: {sourceCapabilities: null}});
 
         expect(mockScrollToIndex).not.toHaveBeenCalled();
+
+        // Cursor still synced: the one-shot suppress is consumed, so a later non-restore focus on another row scrolls (focusedIndex moved, not stale).
+        mockIsFocusRestoreInProgress.mockReturnValue(false);
+        const otherRow = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}7`);
+        fireEvent(otherRow, 'focus', {nativeEvent: {sourceCapabilities: {firesTouchEvents: false}}});
+        expect(mockScrollToIndex).toHaveBeenCalledWith(expect.objectContaining({index: 7}));
     });
 
     it('still syncs the cursor on genuine keyboard Tab focus (no sourceCapabilities, restore NOT in progress) — regression guard for Codex P2', () => {
@@ -344,7 +349,6 @@ describe('BaseSelectionList', () => {
         mockScrollToIndex.mockClear();
 
         const row = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}5`);
-        // Keyboard Tab focus carries no sourceCapabilities either — but it must still move the arrow cursor.
         fireEvent(row, 'focus', {nativeEvent: {sourceCapabilities: null}});
 
         expect(mockScrollToIndex).toHaveBeenCalledWith(expect.objectContaining({index: 5}));

--- a/tests/unit/BaseSelectionListTest.tsx
+++ b/tests/unit/BaseSelectionListTest.tsx
@@ -335,7 +335,7 @@ describe('BaseSelectionList', () => {
 
         expect(mockScrollToIndex).not.toHaveBeenCalled();
 
-        // Cursor still synced: the one-shot suppress is consumed, so a later non-restore focus on another row scrolls (focusedIndex moved, not stale).
+        // Cursor still moved: a later non-restore focus on another row scrolls, so focusedIndex wasn't left stale.
         mockIsFocusRestoreInProgress.mockReturnValue(false);
         const otherRow = screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}7`);
         fireEvent(otherRow, 'focus', {nativeEvent: {sourceCapabilities: {firesTouchEvents: false}}});

--- a/tests/unit/NavigationFocusReturnTest.ts
+++ b/tests/unit/NavigationFocusReturnTest.ts
@@ -1431,7 +1431,6 @@ describe('handleStateChange integration', () => {
             handleStateChange(onAB);
             trigger.blur();
 
-            // Form-submit save calls skipNextFocusRestore() right before goBack.
             skipNextFocusRestore();
             const spy = jest.spyOn(trigger, 'focus');
             handleStateChange(onA);
@@ -1455,7 +1454,6 @@ describe('handleStateChange integration', () => {
             const trigger = appendButton();
             fireFocusIn(trigger);
 
-            // Flag set but a forward nav happens before any backward — must not persist.
             skipNextFocusRestore();
             handleStateChange(onAB);
 

--- a/tests/unit/NavigationFocusReturnTest.ts
+++ b/tests/unit/NavigationFocusReturnTest.ts
@@ -1206,7 +1206,7 @@ describe('isFocusRestoreInProgress', () => {
 
         expect(isFocusRestoreInProgress()).toBe(false);
 
-        // The list consumers (BaseSelectionList / BaseSearchList) read this in the row's onFocus, which fires synchronously inside .focus().
+        // Lists read this in the row's onFocus, which fires synchronously during .focus().
         let valueDuringFocus: boolean | undefined;
         trigger.addEventListener('focus', () => {
             valueDuringFocus = isFocusRestoreInProgress();

--- a/tests/unit/NavigationFocusReturnTest.ts
+++ b/tests/unit/NavigationFocusReturnTest.ts
@@ -1227,6 +1227,20 @@ describe('isFocusRestoreInProgress', () => {
         el.focus();
         expect(valueDuringFocus).toBe(false);
     });
+
+    it('resets to false even when .focus() throws', () => {
+        const trigger = appendButton();
+        trigger.focus();
+        setLastInteractiveElementForTests(trigger);
+        captureTriggerForRoute('route-a');
+        trigger.blur();
+        jest.spyOn(trigger, 'focus').mockImplementation(() => {
+            throw new Error('boom');
+        });
+
+        expect(() => restoreTriggerForRoute('route-a')).toThrow('boom');
+        expect(isFocusRestoreInProgress()).toBe(false);
+    });
 });
 
 describe('shouldSkipAutoFocusDueToExistingFocus', () => {

--- a/tests/unit/NavigationFocusReturnTest.ts
+++ b/tests/unit/NavigationFocusReturnTest.ts
@@ -21,6 +21,7 @@ const {
     notifyPushParamsForward,
     notifyPushParamsBackward,
     cancelPendingFocusRestore,
+    skipNextFocusRestore,
     compoundParamsKey,
     shouldSkipAutoFocusDueToExistingFocus,
     setupNavigationFocusReturn,
@@ -37,6 +38,7 @@ const {
     notifyPushParamsForward: (routeKey: string, prevParams: unknown) => void;
     notifyPushParamsBackward: (routeKey: string, targetParams: unknown) => void;
     cancelPendingFocusRestore: () => void;
+    skipNextFocusRestore: () => void;
     compoundParamsKey: (routeKey: string, params: unknown) => string;
     shouldSkipAutoFocusDueToExistingFocus: () => boolean;
     setupNavigationFocusReturn: () => void;
@@ -1414,6 +1416,52 @@ describe('handleStateChange integration', () => {
             handleStateChange(onA);
 
             const spy = jest.spyOn(trigger, 'focus');
+            jest.runAllTimers();
+            expect(spy).toHaveBeenCalled();
+        });
+    });
+
+    it('skipNextFocusRestore suppresses the restore for the next backward nav only (form-submit goBack), then resumes', () => {
+        withFakeTimers(() => {
+            simulateTab();
+            handleStateChange(onA);
+
+            const trigger = appendButton();
+            fireFocusIn(trigger);
+            handleStateChange(onAB);
+            trigger.blur();
+
+            // Form-submit save calls skipNextFocusRestore() right before goBack.
+            skipNextFocusRestore();
+            const spy = jest.spyOn(trigger, 'focus');
+            handleStateChange(onA);
+            jest.runAllTimers();
+            expect(spy).not.toHaveBeenCalled();
+
+            // The flag is one-shot: a subsequent Back-button dismissal restores normally.
+            handleStateChange(onAB);
+            trigger.blur();
+            handleStateChange(onA);
+            jest.runAllTimers();
+            expect(spy).toHaveBeenCalled();
+        });
+    });
+
+    it('skipNextFocusRestore flag is cleared by an intervening forward nav so it cannot leak into a later backward', () => {
+        withFakeTimers(() => {
+            simulateTab();
+            handleStateChange(onA);
+
+            const trigger = appendButton();
+            fireFocusIn(trigger);
+
+            // Flag set but a forward nav happens before any backward — must not persist.
+            skipNextFocusRestore();
+            handleStateChange(onAB);
+
+            trigger.blur();
+            const spy = jest.spyOn(trigger, 'focus');
+            handleStateChange(onA);
             jest.runAllTimers();
             expect(spy).toHaveBeenCalled();
         });

--- a/tests/unit/NavigationFocusReturnTest.ts
+++ b/tests/unit/NavigationFocusReturnTest.ts
@@ -22,6 +22,7 @@ const {
     notifyPushParamsBackward,
     cancelPendingFocusRestore,
     skipNextFocusRestore,
+    isFocusRestoreInProgress,
     compoundParamsKey,
     shouldSkipAutoFocusDueToExistingFocus,
     setupNavigationFocusReturn,
@@ -39,6 +40,7 @@ const {
     notifyPushParamsBackward: (routeKey: string, targetParams: unknown) => void;
     cancelPendingFocusRestore: () => void;
     skipNextFocusRestore: () => void;
+    isFocusRestoreInProgress: () => boolean;
     compoundParamsKey: (routeKey: string, params: unknown) => string;
     shouldSkipAutoFocusDueToExistingFocus: () => boolean;
     setupNavigationFocusReturn: () => void;
@@ -1187,6 +1189,43 @@ describe('restoreTriggerForRoute', () => {
         const spy = jest.spyOn(trigger, 'focus');
         expect(restoreTriggerForRoute('route-a')).toBe(true);
         expect(spy).toHaveBeenCalledWith({preventScroll: true, focusVisible: expectedFocusVisible});
+    });
+});
+
+describe('isFocusRestoreInProgress', () => {
+    beforeEach(() => {
+        simulateTab();
+    });
+
+    it('is false normally, true synchronously inside the restore .focus(), and false again after', () => {
+        const trigger = appendButton();
+        trigger.focus();
+        setLastInteractiveElementForTests(trigger);
+        captureTriggerForRoute('route-a');
+        trigger.blur();
+
+        expect(isFocusRestoreInProgress()).toBe(false);
+
+        // The list consumers (BaseSelectionList / BaseSearchList) read this in the row's onFocus, which fires synchronously inside .focus().
+        let valueDuringFocus: boolean | undefined;
+        trigger.addEventListener('focus', () => {
+            valueDuringFocus = isFocusRestoreInProgress();
+        });
+
+        expect(restoreTriggerForRoute('route-a')).toBe(true);
+
+        expect(valueDuringFocus).toBe(true);
+        expect(isFocusRestoreInProgress()).toBe(false);
+    });
+
+    it('stays false for a focus not driven by restoreTriggerForRoute (e.g. genuine keyboard Tab)', () => {
+        const el = appendButton();
+        let valueDuringFocus: boolean | undefined;
+        el.addEventListener('focus', () => {
+            valueDuringFocus = isFocusRestoreInProgress();
+        });
+        el.focus();
+        expect(valueDuringFocus).toBe(false);
     });
 });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

#87852 restores keyboard focus to the element you came from on back navigation. That programmatic `.focus()` is the right thing for accessibility, but three places were mistaking it for the user actually navigating there by keyboard — three deploy blockers, one root cause.

To tell a real focus from the restore, `NavigationFocusReturn` now exposes `isFocusRestoreInProgress()`, true only for the synchronous moment `restoreTriggerForRoute` calls `.focus()`. Lists check it in their `onFocus` handlers.

**#90838 — Merchant: pressing Enter again re-opens Merchant instead of creating the expense.**
Saving the field with Enter returns to the confirm page and focus lands back on the Merchant row. Because that row is a button, `Button.shouldDisableEnterShortcut` switches off the page's "Create expense" Enter shortcut, so the next Enter just re-opens Merchant. Fix: a one-shot `skipNextFocusRestore()` that the merchant screen sets right before its save-and-go-back. Back and Esc don't set it, so normal dismissals still restore focus (WCAG intact).

**#90839 — Categories: the list scroll-jumps after closing the details RHP.**
The restored row's `onFocus` moved the SelectionList's arrow cursor, which scrolled the list to it. Fix: on a focus-return restore the cursor still tracks the restored row (so keyboard nav continues from the right place), but the scroll that move would trigger is suppressed.

**#90845 — Spend: the expense stays highlighted after closing the RHP.**
Same `onFocus` path in the Search list, where the cursor is the row highlight — so the opened expense stayed lit up and scrolled into view. Fix: the Search list ignores the restore for cursor purposes; focus is still restored for screen readers, it just doesn't paint the keyboard highlight.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/90838
$ https://github.com/Expensify/App/issues/90839
$ https://github.com/Expensify/App/issues/90845
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**[#90838] Confirmation field save → Enter creates the expense**
1. Open a DM with any user.
2. Click **+ > Create expense > Manual**.
3. Enter an amount, click **Next**.
4. On the confirm page, click **Merchant**.
5. Type a merchant and press **Enter** (saves, returns to the confirm page).
6. Press **Enter** again → the **expense is created** (you land back on the report); Merchant does **not** re-open.

**[#90839] Category details RHP close → no scroll jump**
1. Go to **workspace settings > Categories**.
2. Click the **Advertising** category (RHP opens).
3. Click the **RHP back** button.
4. The category list does **not** scroll (stays at the top) and focus returns to the **Advertising** row.


**[#90845] Spend expense RHP close → row not highlighted**
1. Create 2–3 expenses, go to the **Spend** page (Expenses).
2. Press **Enter** / click an expense to open it (RHP opens).
3. Click the **RHP back** button.
4. The expense row is **not** highlighted and the list does **not** scroll to it; focus is still restored to the row for screen readers.

All steps verified on web (dev); the three blockers are fixed with no regression to focus-return, keyboard arrow/Tab navigation, or mouse interaction.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/22e7692b-a2d1-42d3-9fff-9b0d2cd56b96

</details>