### PR TITLE
Fix #90554: increase spacing between FAB green circle and New workspace text

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1869,7 +1869,7 @@ const staticStyles = (theme: ThemeColors) =>
 
         createMenuContainer: {
             width: variables.sideBarWidth - 40,
-            paddingVertical: variables.componentBorderRadiusLarge,
+            paddingVertical: variables.componentBorderRadiusLarge * 1.5,
         },
 
         compactPopoverMenuItemBase: compactPopoverMenuItemBaseStyle,


### PR DESCRIPTION
## $ #90554\n\n**Problem:** Gap between FAB green circle and New workspace text is too small.\n\n**Fix:** Increased paddingVertical on createMenuContainer by 1.5x to add more visual spacing.\n\n**File:** src/styles/index.ts (createMenuContainer style)