### PR TITLE
Fix #90861: preserve test drive suggestion when in: typed without value

### DIFF
--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -1878,7 +1878,19 @@ function getQueryWithUpdatedValues(query: string, shouldSkipAmountConversion = f
     const hasInFilter = rawFilterList?.some((filter) => !filter.isDefault && filter.key === CONST.SEARCH.SYNTAX_FILTER_KEYS.IN) ?? false;
     const hasExplicitType = rawFilterList?.some((filter) => filter.key === CONST.SEARCH.SYNTAX_ROOT_KEYS.TYPE) ?? false;
 
-    if (hasInFilter && !hasExplicitType) {
+    // Only force type=CHAT when in: filter has a non-empty value.
+    // If the user just typed "in:" without a value (still in autocomplete mode),
+    // don't override the query type, allowing onboarding suggestions like "Take a test drive" to appear.
+    const hasInFilterWithValue = rawFilterList?.some(
+        (filter) =>
+            !filter.isDefault &&
+            filter.key === CONST.SEARCH.SYNTAX_FILTER_KEYS.IN &&
+            Array.isArray(filter.value) &&
+            filter.value.length > 0 &&
+            filter.value.some((val) => typeof val === 'string' && val.trim().length > 0),
+    );
+
+    if (hasInFilterWithValue && !hasExplicitType) {
         standardizedQuery.type = CONST.SEARCH.DATA_TYPES.CHAT;
     }
 


### PR DESCRIPTION
## $ #90861\n\n**Problem:** "Take a test drive" suggestion no longer appears when typing "in:" in search.\n\n**Root cause:** PR #83138 introduced logic that auto-forces type=CHAT when an `in:` filter is present without an explicit `type:`. This correctly handles completed `in:` filters, but also triggers when the user typed `in:` with no value (autocomplete mode), suppressing onboarding suggestions.\n\n**Fix:** Added a check ensuring `in:` filter has a non-empty value before forcing type=CHAT.\n\n**File:** src/libs/SearchQueryUtils.ts