### PR TITLE
Fix private domain onboarding resume path

### DIFF
--- a/src/libs/actions/Welcome/OnboardingFlow.ts
+++ b/src/libs/actions/Welcome/OnboardingFlow.ts
@@ -15,6 +15,7 @@ import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
 import {hasCompletedGuidedSetupFlowSelector} from '@src/selectors/Onboarding';
 import type {Locale, Onboarding} from '@src/types/onyx';
 
@@ -98,6 +99,19 @@ function startOnboardingFlow(startOnboardingFlowParams: GetOnboardingInitialPath
     } as PartialState<NavigationState>);
 }
 
+const PRIVATE_DOMAIN_ONBOARDING_SCREENS = new Set<string>([SCREENS.ONBOARDING.PERSONAL_DETAILS, SCREENS.ONBOARDING.PRIVATE_DOMAIN, SCREENS.ONBOARDING.WORKSPACES]);
+
+function isResumablePrivateDomainOnboardingPath(onboardingPath: OnyxEntry<string>): boolean {
+    if (!onboardingPath) {
+        return false;
+    }
+
+    const state = getStateFromPath(onboardingPath, linkingConfig.config);
+    const focusedRoute = findFocusedRoute(state as PartialState<NavigationState<RootNavigatorParamList>>);
+
+    return PRIVATE_DOMAIN_ONBOARDING_SCREENS.has(focusedRoute?.name ?? '');
+}
+
 function getOnboardingInitialPath(getOnboardingInitialPathParams: GetOnboardingInitialPathParamsType): string {
     const {
         isUserFromPublicDomain,
@@ -131,7 +145,7 @@ function getOnboardingInitialPath(getOnboardingInitialPathParams: GetOnboardingI
     }
 
     if (!isUserFromPublicDomain && hasAccessiblePolicies) {
-        if (onboardingInitialPath) {
+        if (isResumablePrivateDomainOnboardingPath(onboardingInitialPath)) {
             return onboardingInitialPath;
         }
         return `/${ROUTES.ONBOARDING_PERSONAL_DETAILS.route}`;

--- a/tests/unit/OnboardingFlowTest.ts
+++ b/tests/unit/OnboardingFlowTest.ts
@@ -1,6 +1,7 @@
 import {getOnboardingInitialPath} from '@libs/actions/Welcome/OnboardingFlow';
 import type {GetOnboardingInitialPathParamsType} from '@libs/actions/Welcome/OnboardingFlow';
 import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
 
 describe('OnboardingFlow', () => {
     describe('getOnboardingInitialPath', () => {
@@ -86,6 +87,48 @@ describe('OnboardingFlow', () => {
             };
             const path = getOnboardingInitialPath(params);
             expect(path).toBe('/onboarding/employees');
+        });
+
+        it('should ignore stale non-private-domain onboarding path for private domain users with accessible policies', () => {
+            const params: GetOnboardingInitialPathParamsType = {
+                isUserFromPublicDomain: false,
+                hasAccessiblePolicies: true,
+                onboardingValuesParam: {
+                    hasCompletedGuidedSetupFlow: false,
+                    shouldRedirectToClassicAfterMerge: false,
+                    shouldValidate: false,
+                    isMergingAccountBlocked: false,
+                    isMergeAccountStepCompleted: false,
+                    signupQualifier: CONST.ONBOARDING_SIGNUP_QUALIFIERS.SMB,
+                },
+                currentOnboardingPurposeSelected: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                currentOnboardingCompanySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
+                onboardingInitialPath: `/${ROUTES.ONBOARDING_EMPLOYEES.route}`,
+                onboardingValues: undefined,
+            };
+            const path = getOnboardingInitialPath(params);
+            expect(path).toBe(`/${ROUTES.ONBOARDING_PERSONAL_DETAILS.route}`);
+        });
+
+        it('should resume private-domain onboarding from a valid private-domain step', () => {
+            const params: GetOnboardingInitialPathParamsType = {
+                isUserFromPublicDomain: false,
+                hasAccessiblePolicies: true,
+                onboardingValuesParam: {
+                    hasCompletedGuidedSetupFlow: false,
+                    shouldRedirectToClassicAfterMerge: false,
+                    shouldValidate: false,
+                    isMergingAccountBlocked: false,
+                    isMergeAccountStepCompleted: false,
+                    signupQualifier: CONST.ONBOARDING_SIGNUP_QUALIFIERS.SMB,
+                },
+                currentOnboardingPurposeSelected: CONST.ONBOARDING_CHOICES.MANAGE_TEAM,
+                currentOnboardingCompanySize: CONST.ONBOARDING_COMPANY_SIZE.SMALL,
+                onboardingInitialPath: `/${ROUTES.ONBOARDING_WORKSPACES.route}`,
+                onboardingValues: undefined,
+            };
+            const path = getOnboardingInitialPath(params);
+            expect(path).toBe(`/${ROUTES.ONBOARDING_WORKSPACES.route}`);
         });
     });
 });


### PR DESCRIPTION
## Summary
$ #86498

Private-domain onboarding currently resumes any saved onboarding path. If the user is redirected from OldDot with a stale path from another onboarding branch (for example `/onboarding/employees`), the flow bypasses the private-domain steps that should show the "What is your name" and "Join existing policies" modals.

This change validates the saved onboarding path before reusing it for private-domain users with accessible policies. Only private-domain onboarding steps are resumable; stale paths from other onboarding branches reset to Personal Details.

## Tests
- ✅ `npx -y node@20.20.0 ./node_modules/.bin/prettier --check src/libs/actions/Welcome/OnboardingFlow.ts tests/unit/OnboardingFlowTest.ts`
- ⚠️ `TZ=utc NODE_OPTIONS="--experimental-vm-modules --max_old_space_size=8192" npx -y node@20.20.0 ./node_modules/.bin/jest tests/unit/OnboardingFlowTest.ts --runInBand` could not run in this local checkout due existing Jest/ESM mock setup error: `Must use import to load ES Module: node_modules/@react-navigation/core/lib/module/index.js` from `__mocks__/@react-navigation/native/index.ts`.
- ⚠️ `npx -y node@20.20.0 --max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --pretty false` reaches existing repo-wide type errors unrelated to this change (React Native style/userSelect and navigation type errors).

## Added coverage
- Stale non-private-domain saved path resets to `/onboarding/personal-details` for private-domain users with accessible policies.
- Valid private-domain saved path (`/onboarding/join-workspaces`) still resumes.
