### PR TITLE
Fix Spend LHN icon and badge alignment

### DIFF
--- a/src/pages/Search/SearchTypeMenuAccordion.tsx
+++ b/src/pages/Search/SearchTypeMenuAccordion.tsx
@@ -92,7 +92,7 @@ function SearchTypeMenuAccordion({title, isExpanded, badgeText, children, onSect
         <View>
             <PressableWithoutFeedback
                 onPress={onSectionHeaderPress}
-                style={[styles.flexRow, styles.p2, styles.gap2, styles.alignItemsCenter, styles.br2]}
+                style={[styles.flexRow, styles.searchTypeMenuAccordionHeader, styles.gap2, styles.alignItemsCenter, styles.br2]}
                 role={CONST.ROLE.BUTTON}
                 accessibilityLabel={title}
                 sentryLabel={CONST.SENTRY_LABEL.ACCORDION_SECTION.TOGGLE}

--- a/src/pages/Search/SearchTypeMenuItem.tsx
+++ b/src/pages/Search/SearchTypeMenuItem.tsx
@@ -54,7 +54,7 @@ function SearchTypeMenuItem({title, icon, badgeText, focused = false, onPress}: 
             {({hovered, pressed}) => (
                 <>
                     {icon != null && (
-                        <View style={[styles.popoverMenuIcon, styles.wAuto]}>
+                        <View style={styles.popoverMenuIcon}>
                             <Icon
                                 src={icon}
                                 width={variables.iconSizeNormal}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1895,7 +1895,7 @@ const staticStyles = (theme: ThemeColors) =>
         },
 
         popoverMenuIcon: {
-            width: variables.componentSizeNormal,
+            width: 28,
             justifyContent: 'center',
             alignItems: 'center',
         },
@@ -5693,14 +5693,22 @@ const staticStyles = (theme: ThemeColors) =>
         },
 
         todoBadge: {
+            width: 28,
             alignItems: 'center',
             justifyContent: 'center',
         },
 
         searchSectionBadge: {
+            width: 28,
             alignItems: 'center',
             justifyContent: 'center',
             height: 16,
+        },
+
+        searchTypeMenuAccordionHeader: {
+            paddingLeft: 8,
+            paddingRight: 12,
+            paddingVertical: 8,
         },
 
         stickToBottom: {
@@ -6478,7 +6486,8 @@ const dynamicStyles = (theme: ThemeColors) =>
 
         sectionMenuItem: (shouldUseNarrowLayout: boolean) => ({
             borderRadius: 8,
-            paddingHorizontal: 16,
+            paddingLeft: 16,
+            paddingRight: 12,
             paddingVertical: shouldUseNarrowLayout ? 8 : 4,
             height: shouldUseNarrowLayout ? variables.sectionMenuItemHeight : variables.sectionMenuItemHeightCompact,
             alignItems: 'center',


### PR DESCRIPTION
### Explanation of Change

Aligns the Spend left-hand navigation rows with the agreed design in #90643:

- Uses a 28px fixed icon slot for menu row icons.
- Removes the `wAuto` override in `SearchTypeMenuItem` so the fixed icon slot actually applies.
- Gives row and section badges a 28px fixed slot.
- Changes section row right padding to 12px while preserving 16px left padding.
- Gives the accordion section header matching right padding and vertical spacing.

### Fixed Issues

$ https://github.com/Expensify/App/issues/90643
PROPOSAL: N/A - the implementation requirements are specified directly in the issue body.

### Tests

1. Reviewed the changed Spend/Search left navigation styles against the agreed design requirements in the issue body.
2. Verified the PR diff only touches the target Search menu item/header components and related styles.
3. Ran `git diff --check origin/main HEAD -- src/styles/index.ts src/pages/Search/SearchTypeMenuAccordion.tsx src/pages/Search/SearchTypeMenuItem.tsx` locally.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable. This is a static layout/style change and has no network-dependent behavior.

### QA Steps

1. Open the Spend left-hand navigation.
2. Verify icons in the row item column use a consistent 28px slot and are centered.
3. Verify badge counters use a consistent 28px slot and align with each other.
4. Expand and collapse the grouped Spend sections.
5. Verify the accordion section title row uses the same right gutter as the regular rows.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I followed proper code patterns for the small style-only change
- [x] I verified the PR only changes the intended Search/Spend LHN layout files

### Screenshots/Videos

Not attached. I was able to validate the targeted style diff locally, but did not run the full app UI in this Windows sparse checkout environment.