### PR TITLE
[WIP] Add hover-zoom to receipt thumbnail in expense RHP

### DIFF
--- a/src/components/ReceiptHoverZoom/index.tsx
+++ b/src/components/ReceiptHoverZoom/index.tsx
@@ -1,0 +1,10 @@
+import type {ReactNode} from 'react';
+import type {ReceiptHoverZoomProps} from './types';
+
+function ReceiptHoverZoom({children}: ReceiptHoverZoomProps): ReactNode {
+    return children;
+}
+
+ReceiptHoverZoom.displayName = 'ReceiptHoverZoom';
+
+export default ReceiptHoverZoom;

--- a/src/components/ReceiptHoverZoom/index.web.tsx
+++ b/src/components/ReceiptHoverZoom/index.web.tsx
@@ -1,0 +1,94 @@
+import type {ReactNode} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import hasHoverSupport from '@libs/DeviceCapabilities/hasHoverSupport';
+import type {ReceiptHoverZoomProps} from './types';
+
+const DEFAULT_SCALE = 2.5;
+const TRANSITION = 'transform 80ms ease-out';
+
+function ReceiptHoverZoom({children, isEnabled = true, scale = DEFAULT_SCALE, hoverContainerRef}: ReceiptHoverZoomProps): ReactNode {
+    const innerRef = useRef<HTMLDivElement | null>(null);
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const [isZoomed, setIsZoomed] = useState(false);
+
+    const enabled = isEnabled && hasHoverSupport();
+
+    const applyOrigin = useCallback((clientX: number, clientY: number, rect: DOMRect) => {
+        if (!innerRef.current) {
+            return;
+        }
+        const x = ((clientX - rect.left) / rect.width) * 100;
+        const y = ((clientY - rect.top) / rect.height) * 100;
+        // Imperative DOM update avoids a React re-render on every mousemove (~60Hz) so panning stays smooth.
+        innerRef.current.style.transformOrigin = `${x}% ${y}%`;
+    }, []);
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+        // The hover surface is the parent's receipt container when provided so the zoom keeps engaging
+        // while the cursor crosses absolutely-positioned action buttons that sit on top of the image.
+        const containerEl = (hoverContainerRef?.current as unknown as HTMLElement | null) ?? wrapperRef.current;
+        if (!containerEl) {
+            return;
+        }
+
+        const handleEnter = () => setIsZoomed(true);
+        const handleLeave = () => {
+            setIsZoomed(false);
+            if (innerRef.current) {
+                innerRef.current.style.transformOrigin = 'center center';
+            }
+        };
+        const handleMove = (event: MouseEvent) => {
+            applyOrigin(event.clientX, event.clientY, containerEl.getBoundingClientRect());
+        };
+
+        containerEl.addEventListener('mouseenter', handleEnter);
+        containerEl.addEventListener('mouseleave', handleLeave);
+        containerEl.addEventListener('mousemove', handleMove);
+
+        // If the cursor is already over the element on mount, kick off the zoomed state.
+        if (containerEl.matches(':hover')) {
+            handleEnter();
+        }
+
+        return () => {
+            containerEl.removeEventListener('mouseenter', handleEnter);
+            containerEl.removeEventListener('mouseleave', handleLeave);
+            containerEl.removeEventListener('mousemove', handleMove);
+        };
+        // `hoverContainerRef` is a stable ref object; reading `.current` inside the effect is the
+        // correct pattern. ESLint's narrow-hook-deps rule conflicts with the refs rule here, so disable both.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled, applyOrigin]);
+
+    if (!enabled) {
+        return children;
+    }
+
+    return (
+        <div
+            ref={wrapperRef}
+            style={{width: '100%', height: '100%', overflow: 'hidden', position: 'relative'}}
+        >
+            <div
+                ref={innerRef}
+                style={{
+                    width: '100%',
+                    height: '100%',
+                    transform: `scale(${isZoomed ? scale : 1})`,
+                    transition: TRANSITION,
+                    willChange: 'transform',
+                }}
+            >
+                {children}
+            </div>
+        </div>
+    );
+}
+
+ReceiptHoverZoom.displayName = 'ReceiptHoverZoom';
+
+export default ReceiptHoverZoom;

--- a/src/components/ReceiptHoverZoom/types.ts
+++ b/src/components/ReceiptHoverZoom/types.ts
@@ -1,0 +1,23 @@
+import type {ReactNode, RefObject} from 'react';
+import type {View} from 'react-native';
+
+type ReceiptHoverZoomProps = {
+    /** Content to apply the zoom effect to. Typically the receipt image. */
+    children: ReactNode;
+
+    /** Disables the zoom effect when false. Used to opt out non-photo content (EReceipts, placeholders). */
+    isEnabled?: boolean;
+
+    /** Multiplier applied to the underlying image while hovered. Defaults to 2.5. */
+    scale?: number;
+
+    /**
+     * Optional element to bind hover/move listeners to. When provided, the zoom engages while the cursor
+     * is anywhere inside this element — including absolutely-positioned siblings like action buttons —
+     * rather than only over the scaled image itself.
+     */
+    hoverContainerRef?: RefObject<View | null>;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export type {ReceiptHoverZoomProps};

--- a/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
@@ -14,6 +14,7 @@ import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeed
 import PressableWithoutFocus from '@components/Pressable/PressableWithoutFocus';
 import ReceiptAudit, {ReceiptAuditMessages} from '@components/ReceiptAudit';
 import ReceiptEmptyState from '@components/ReceiptEmptyState';
+import ReceiptHoverZoom from '@components/ReceiptHoverZoom';
 import Tooltip from '@components/Tooltip';
 import useActiveRoute from '@hooks/useActiveRoute';
 import useAncestors from '@hooks/useAncestors';
@@ -54,6 +55,8 @@ import {
 import trackExpenseCreationError from '@libs/telemetry/trackExpenseCreationError';
 import {
     didReceiptScanSucceed as didReceiptScanSucceedTransactionUtils,
+    hasEReceipt,
+    hasReceiptSource,
     hasReceipt as hasReceiptTransactionUtils,
     isDistanceRequest as isDistanceRequestTransactionUtils,
     isManualDistanceRequest,
@@ -242,6 +245,9 @@ function MoneyRequestReceiptView({
     if (hasReceipt) {
         receiptURIs = getThumbnailAndImageURIs(updatedTransaction ?? transaction);
     }
+    const transactionForReceipt = updatedTransaction ?? transaction;
+    const isEReceiptTransaction = !!transactionForReceipt && !hasReceiptSource(transactionForReceipt) && hasEReceipt(transactionForReceipt);
+    const canZoomReceipt = hasReceipt && !isTransactionScanning && !isEReceiptTransaction && !!receiptURIs?.image;
     const pendingAction = transaction?.pendingAction;
     // Need to return undefined when we have pendingAction to avoid the duplicate pending action
     const getPendingFieldAction = (fieldPath: TransactionPendingFieldsKey) => {
@@ -563,23 +569,28 @@ function MoneyRequestReceiptView({
                             onMouseLeave={hoverBind.onMouseLeave}
                         >
                             <View style={[styles.flex1, isReceiptOfflinePending && styles.offlineFeedbackPending]}>
-                                <ReportActionItemImage
-                                    shouldUseThumbnailImage={!fillSpace}
-                                    shouldUseFullHeight={fillSpace}
-                                    thumbnail={receiptURIs?.thumbnail}
-                                    fileExtension={receiptURIs?.fileExtension}
-                                    isThumbnail={receiptURIs?.isThumbnail}
-                                    image={receiptURIs?.image}
-                                    isLocalFile={receiptURIs?.isLocalFile}
-                                    filename={receiptURIs?.filename}
-                                    transaction={updatedTransaction ?? transaction}
-                                    enablePreviewModal
-                                    readonly={readonly || !canEditReceipt}
-                                    mergeTransactionID={mergeTransactionID}
-                                    report={report}
-                                    onLoad={() => setIsLoading(false)}
-                                    onLoadFailure={() => setIsLoading(false)}
-                                />
+                                <ReceiptHoverZoom
+                                    isEnabled={canZoomReceipt}
+                                    hoverContainerRef={receiptContainerRef}
+                                >
+                                    <ReportActionItemImage
+                                        shouldUseThumbnailImage={!fillSpace}
+                                        shouldUseFullHeight={fillSpace}
+                                        thumbnail={receiptURIs?.thumbnail}
+                                        fileExtension={receiptURIs?.fileExtension}
+                                        isThumbnail={receiptURIs?.isThumbnail}
+                                        image={receiptURIs?.image}
+                                        isLocalFile={receiptURIs?.isLocalFile}
+                                        filename={receiptURIs?.filename}
+                                        transaction={updatedTransaction ?? transaction}
+                                        enablePreviewModal
+                                        readonly={readonly || !canEditReceipt}
+                                        mergeTransactionID={mergeTransactionID}
+                                        report={report}
+                                        onLoad={() => setIsLoading(false)}
+                                        onLoadFailure={() => setIsLoading(false)}
+                                    />
+                                </ReceiptHoverZoom>
                             </View>
                             {canShowReceiptActions && (
                                 <View style={[styles.receiptActionButtonsContainer, styles.pointerEventsBoxNone, !hovered && !isPickerOpen && deviceHasHoverSupport && styles.opacity0]}>


### PR DESCRIPTION
### Explanation of Change

Adds a lens-track hover-zoom on the receipt thumbnail in the expense right-hand pane on web/desktop. As the cursor moves over the receipt area, the underlying image scales ~2.5x and `transform-origin` follows the cursor so the point under the pointer stays under the pointer (Amazon-style image zoom). The zoom also stays engaged when the cursor passes over the absolutely-positioned action buttons (Add receipt, Expand) so reaching for them doesn't collapse the view.

Implementation:
- New `ReceiptHoverZoom` component (`src/components/ReceiptHoverZoom/`) — native is a no-op pass-through; web variant attaches `mouseenter`/`mouseleave`/`mousemove` listeners to the parent receipt container ref and drives `transform`/`transform-origin` imperatively to avoid re-rendering on every mouse move.
- Wired in `MoneyRequestReceiptView.tsx` around `ReportActionItemImage`. Gated by `canZoomReceipt` which skips scanning placeholders, EReceipt graphics, and rows without an image URL. Photo receipts, server-rendered PDF thumbnails (PNG), and Mapbox static map PNGs (distance receipts) all opt in.
- Click-through to the full-screen receipt is preserved — the wrapper does not intercept presses.

### Fixed Issues

$
PROPOSAL:

### Tests

1. Open Expensify on web (`https://dev.new.expensify.com:8082/`).
2. Open any expense with a photo receipt in the right-hand pane (single expense view).
3. Move the cursor over the receipt thumbnail — verify the image scales ~2.5x and the point under the cursor stays under the cursor as you move around.
4. Move the cursor up toward the Add receipt / Expand buttons — verify the zoom stays engaged and the action buttons remain clickable.
5. Move the cursor off the thumbnail entirely — verify the image smoothly returns to its normal size.
6. Click the receipt while not hovering — verify it still opens the full-screen attachment viewer.
7. Open a one-expense report (wide RHP / two-column layout where the header + body are combined) — verify the same zoom behavior on the left-column receipt.
8. Open an expense with a PDF receipt — verify the rendered PNG thumbnail zooms the same way.
9. Open a distance request — verify the map thumbnail zooms.
10. Open an EReceipt or a scanning-in-progress receipt — verify NO zoom is applied (these are intentionally excluded).
11. Verify that no errors appear in the JS console.

### Offline tests

Same as tests — the zoom is pure UI and not affected by network state.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the \`### Fixed Issues\` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the \`Tests\` section
    - [x] I added steps for the expected offline behavior in the \`Offline steps\` section
    - [x] I added steps for Staging and/or Production testing in the \`QA steps\` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. \`toggleReport\` and not \`onIconClick\`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to \`src/languages/*\` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80) — N/A, no user-facing copy added
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files.
    - [x] I verified the JSDocs style guidelines (in [\`STYLE.md\`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)- [ ] I verified that similar component doesn't exist in the codebase
- [ ] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [ ] I verified that each file is named correctly
- [ ] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [ ] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [ ] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [ ] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [ ] I verified that all JSX used for rendering exists in the render method
- [ ] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videosundefined