### PR TITLE
fix: prevent card-issued system messages from being hidden on emoji reaction

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -203,6 +203,7 @@ function isDeletedAction(reportAction: OnyxInputOrEntry<ReportAction | Optimisti
 
     // for report actions with this type we get an empty array as message by design
     if (
+        isCardIssuedAction(reportAction) ||
         reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENT_DIRECTOR_INFORMATION_REQUIRED ||
         reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED_REPORT_FOR_UNAPPROVED_TRANSACTIONS ||
         reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REASSIGN_APPROVER

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -1701,6 +1701,36 @@ describe('ReportActionsUtils', () => {
             expect(ReportActionsUtils.isDeletedAction(reportAction)).toBe(false);
         });
 
+        it('should return false for CARD_ISSUED_VIRTUAL action with empty message array', () => {
+            const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL> = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL,
+                reportActionID: 'card-issued-virtual-action-123',
+                actorAccountID: 123,
+                created: '2024-01-01',
+                message: [],
+                originalMessage: {
+                    assigneeAccountID: 456,
+                    cardID: 789,
+                },
+            };
+            expect(ReportActionsUtils.isDeletedAction(reportAction)).toBe(false);
+        });
+
+        it('should return true for shouldReportActionBeVisible on CARD_ISSUED_VIRTUAL action with empty message array', () => {
+            const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL> = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL,
+                reportActionID: 'card-issued-virtual-action-456',
+                actorAccountID: 123,
+                created: '2024-01-01',
+                message: [],
+                originalMessage: {
+                    assigneeAccountID: 456,
+                    cardID: 789,
+                },
+            };
+            expect(ReportActionsUtils.shouldReportActionBeVisible(reportAction, reportAction.reportActionID, true)).toBe(true);
+        });
+
         it('should return false for CARDFROZEN action with a backend-provided message fragment', () => {
             const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.CARD_FROZEN> = {
                 actionName: CONST.REPORT.ACTIONS.TYPE.CARD_FROZEN,


### PR DESCRIPTION
## Problem

$ #89140

Reacting (adding an emoji) to an Expensify Card system message in a workspace chat causes that system message to disappear from the report timeline.

## Root Cause

Card-issued system actions (`CARD_ISSUED`, `CARD_ISSUED_VIRTUAL`, `CARD_MISSING_ADDRESS`, `CARD_ASSIGNED`, `CARD_REPLACED_VIRTUAL`, `CARD_REPLACED`) intentionally carry an empty `message` array — their display text is derived from `originalMessage` via `getCardIssuedMessage()`. When an emoji reaction is added, `isDeletedAction()` treats `message.length === 0` as a legacy deleted comment, causing `shouldReportActionBeVisible()` to return `false` and hide the message.

## Fix

Add `isCardIssuedAction(reportAction)` to the existing early-return exemption block in `isDeletedAction()` at [line 205](https://github.com/Expensify/App/blob/main/src/libs/ReportActionsUtils.ts#L205), alongside the other intentionally empty-message action types (`REIMBURSEMENT_DIRECTOR_INFORMATION_REQUIRED`, `CREATED_REPORT_FOR_UNAPPROVED_TRANSACTIONS`, `REASSIGN_APPROVER`).

The `isCardIssuedAction()` helper already groups all six card action names, so this is a one-line addition that covers all card-issued action types and any future additions to the family.

## Tests

Added two regression tests in `tests/unit/ReportActionsUtilsTest.ts`:
- `isDeletedAction` returns `false` for `CARD_ISSUED_VIRTUAL` with empty message array
- `shouldReportActionBeVisible` returns `true` for `CARD_ISSUED_VIRTUAL` with empty message array

## Scope

- Files touched: `src/libs/ReportActionsUtils.ts` (1 line), `tests/unit/ReportActionsUtilsTest.ts` (2 test cases)
- No API contracts or backend changes
- No emoji reaction, `IssueCardMessage`, or `getCardIssuedMessage` changes