### PR TITLE
fix: Show duplicate expense for grouped deleted expenses

### DIFF
--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -136,7 +136,7 @@ function getAllTransactionsForDuplicate({
     selectedTransactions,
     allTransactions,
     searchData,
-}: Pick<ShouldShowBulkDuplicateParams, 'selectedTransactionsKeys' | 'selectedTransactions' | 'allTransactions' | 'searchData'>): OnyxCollection<Transaction> {
+}: Pick<ShouldShowBulkDuplicateParams, 'selectedTransactionsKeys' | 'selectedTransactions' | 'allTransactions' | 'searchData'>): NonNullable<OnyxCollection<Transaction>> {
     const allTransactionsForDuplicate = {...(allTransactions ?? {})};
 
     for (const id of selectedTransactionsKeys) {

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -135,8 +135,7 @@ function getAllTransactionsForDuplicate({
     selectedTransactionsKeys,
     selectedTransactions,
     allTransactions,
-    searchData,
-}: Pick<ShouldShowBulkDuplicateParams, 'selectedTransactionsKeys' | 'selectedTransactions' | 'allTransactions' | 'searchData'>): NonNullable<OnyxCollection<Transaction>> {
+}: Pick<ShouldShowBulkDuplicateParams, 'selectedTransactionsKeys' | 'selectedTransactions' | 'allTransactions'>): NonNullable<OnyxCollection<Transaction>> {
     const allTransactionsForDuplicate = {...(allTransactions ?? {})};
 
     for (const id of selectedTransactionsKeys) {
@@ -145,7 +144,7 @@ function getAllTransactionsForDuplicate({
             continue;
         }
 
-        const transaction = selectedTransactions[id]?.transaction ?? (searchData?.[transactionKey] as Transaction | undefined);
+        const transaction = selectedTransactions[id]?.transaction;
         if (transaction) {
             allTransactionsForDuplicate[transactionKey] = transaction;
         }
@@ -181,7 +180,7 @@ function shouldShowBulkDuplicateOption({
               .filter((report): report is Report => report != null && 'reportID' in report)
         : [];
 
-    const allTransactionsForDuplicate = getAllTransactionsForDuplicate({selectedTransactionsKeys, selectedTransactions, allTransactions, searchData});
+    const allTransactionsForDuplicate = getAllTransactionsForDuplicate({selectedTransactionsKeys, selectedTransactions, allTransactions});
 
     return selectedTransactionsKeys.every((id) => {
         const transaction = allTransactionsForDuplicate[`${ONYXKEYS.COLLECTION.TRANSACTION}${id}`];
@@ -913,9 +912,8 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 selectedTransactionsKeys,
                 selectedTransactions,
                 allTransactions,
-                searchData: currentSearchResults?.data,
             }),
-        [selectedTransactionsKeys, selectedTransactions, allTransactions, currentSearchResults?.data],
+        [selectedTransactionsKeys, selectedTransactions, allTransactions],
     );
 
     const isDuplicateOptionVisible = useMemo(

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -120,7 +120,7 @@ function getRestrictedPolicyID(
 
 type ShouldShowBulkDuplicateParams = {
     selectedTransactionsKeys: string[];
-    selectedTransactions: Record<string, {reportID?: string}>;
+    selectedTransactions: Record<string, {reportID?: string; transaction?: Transaction}>;
     allTransactions: OnyxCollection<Transaction> | undefined;
     allReports: OnyxCollection<Report> | undefined;
     allTransactionViolations: OnyxCollection<TransactionViolations> | undefined;
@@ -130,6 +130,29 @@ type ShouldShowBulkDuplicateParams = {
     typeExpenseReport: boolean;
     searchData: Record<string, unknown> | undefined;
 };
+
+function getAllTransactionsForDuplicate({
+    selectedTransactionsKeys,
+    selectedTransactions,
+    allTransactions,
+    searchData,
+}: Pick<ShouldShowBulkDuplicateParams, 'selectedTransactionsKeys' | 'selectedTransactions' | 'allTransactions' | 'searchData'>): OnyxCollection<Transaction> {
+    const allTransactionsForDuplicate = {...(allTransactions ?? {})};
+
+    for (const id of selectedTransactionsKeys) {
+        const transactionKey = `${ONYXKEYS.COLLECTION.TRANSACTION}${id}`;
+        if (allTransactionsForDuplicate[transactionKey]) {
+            continue;
+        }
+
+        const transaction = selectedTransactions[id]?.transaction ?? (searchData?.[transactionKey] as Transaction | undefined);
+        if (transaction) {
+            allTransactionsForDuplicate[transactionKey] = transaction;
+        }
+    }
+
+    return allTransactionsForDuplicate;
+}
 
 /**
  * Determines whether the bulk duplicate option should be shown for the selected transactions.
@@ -158,8 +181,10 @@ function shouldShowBulkDuplicateOption({
               .filter((report): report is Report => report != null && 'reportID' in report)
         : [];
 
+    const allTransactionsForDuplicate = getAllTransactionsForDuplicate({selectedTransactionsKeys, selectedTransactions, allTransactions, searchData});
+
     return selectedTransactionsKeys.every((id) => {
-        const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${id}`];
+        const transaction = allTransactionsForDuplicate[`${ONYXKEYS.COLLECTION.TRANSACTION}${id}`];
         if (!transaction || isManagedCardTransaction(transaction) || isScanning(transaction)) {
             return false;
         }
@@ -882,12 +907,23 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         [currentUserPersonalDetails.accountID, defaultExpensePolicy?.id],
     );
 
+    const allTransactionsForDuplicate = useMemo(
+        () =>
+            getAllTransactionsForDuplicate({
+                selectedTransactionsKeys,
+                selectedTransactions,
+                allTransactions,
+                searchData: currentSearchResults?.data,
+            }),
+        [selectedTransactionsKeys, selectedTransactions, allTransactions, currentSearchResults?.data],
+    );
+
     const isDuplicateOptionVisible = useMemo(
         () =>
             shouldShowBulkDuplicateOption({
                 selectedTransactionsKeys,
                 selectedTransactions,
-                allTransactions,
+                allTransactions: allTransactionsForDuplicate,
                 allReports,
                 allTransactionViolations,
                 allReportNameValuePairs,
@@ -899,7 +935,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         [
             selectedTransactionsKeys,
             selectedTransactions,
-            allTransactions,
+            allTransactionsForDuplicate,
             allReports,
             allTransactionViolations,
             allReportNameValuePairs,
@@ -1644,12 +1680,12 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         setDuplicateHandler,
         isDuplicateReportOptionVisible,
         setDuplicateReportHandler,
-        allTransactions,
+        allTransactions: allTransactionsForDuplicate,
         allReports,
         searchData: currentSearchResults?.data,
     };
 }
 
 export default useSearchBulkActions;
-export {shouldShowBulkDuplicateOption};
+export {getAllTransactionsForDuplicate, shouldShowBulkDuplicateOption};
 export type {SearchHeaderOptionValue};

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -136,21 +136,31 @@ function getAllTransactionsForDuplicate({
     selectedTransactions,
     allTransactions,
 }: Pick<ShouldShowBulkDuplicateParams, 'selectedTransactionsKeys' | 'selectedTransactions' | 'allTransactions'>): NonNullable<OnyxCollection<Transaction>> {
-    const allTransactionsForDuplicate = {...(allTransactions ?? {})};
+    let missingSelectedTransactions: NonNullable<OnyxCollection<Transaction>> | undefined;
 
     for (const id of selectedTransactionsKeys) {
         const transactionKey = `${ONYXKEYS.COLLECTION.TRANSACTION}${id}`;
-        if (allTransactionsForDuplicate[transactionKey]) {
+        if (allTransactions?.[transactionKey]) {
             continue;
         }
 
         const transaction = selectedTransactions[id]?.transaction;
-        if (transaction) {
-            allTransactionsForDuplicate[transactionKey] = transaction;
+        if (!transaction) {
+            continue;
         }
+
+        missingSelectedTransactions = missingSelectedTransactions ?? {};
+        missingSelectedTransactions[transactionKey] = transaction;
     }
 
-    return allTransactionsForDuplicate;
+    if (!missingSelectedTransactions) {
+        return allTransactions ?? {};
+    }
+
+    return {
+        ...(allTransactions ?? {}),
+        ...missingSelectedTransactions,
+    };
 }
 
 /**
@@ -1685,5 +1695,5 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
 }
 
 export default useSearchBulkActions;
-export {getAllTransactionsForDuplicate, shouldShowBulkDuplicateOption};
+export {shouldShowBulkDuplicateOption};
 export type {SearchHeaderOptionValue};

--- a/src/hooks/useSelectedTransactionsActions.ts
+++ b/src/hooks/useSelectedTransactionsActions.ts
@@ -48,7 +48,7 @@ import useNetworkWithOfflineStatus from './useNetworkWithOfflineStatus';
 import useOnyx from './useOnyx';
 import usePermissions from './usePermissions';
 import useReportIsArchived from './useReportIsArchived';
-import {getAllTransactionsForDuplicate, shouldShowBulkDuplicateOption} from './useSearchBulkActions';
+import {shouldShowBulkDuplicateOption} from './useSearchBulkActions';
 
 const {HOLD, UNHOLD, MOVE, MERGE, SPLIT, DUPLICATE} = CONST.REPORT.SELECTED_TRANSACTIONS_BULK_ACTION_TYPES;
 
@@ -157,24 +157,13 @@ function useSelectedTransactionsActions({
     const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
 
     const selectedTransactionsForDuplicate = useMemo(() => {
-        const map: Record<string, {reportID?: string; transaction?: Transaction}> = {};
+        const map: Record<string, {reportID?: string}> = {};
         for (const id of selectedTransactionIDs) {
             const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${id}`];
-            map[id] = selectedTransactionsMeta[id] ?? {reportID: transaction?.reportID, transaction};
+            map[id] = {reportID: transaction?.reportID};
         }
         return map;
-    }, [selectedTransactionIDs, selectedTransactionsMeta, allTransactions]);
-
-    const allTransactionsForDuplicate = useMemo(
-        () =>
-            getAllTransactionsForDuplicate({
-                selectedTransactionsKeys: selectedTransactionIDs,
-                selectedTransactions: selectedTransactionsForDuplicate,
-                allTransactions,
-                searchData: undefined,
-            }),
-        [selectedTransactionIDs, selectedTransactionsForDuplicate, allTransactions],
-    );
+    }, [selectedTransactionIDs, allTransactions]);
 
     const activePolicyExpenseChat = useMemo(() => getPolicyExpenseChat(currentUserAccountID, defaultExpensePolicy?.id), [currentUserAccountID, defaultExpensePolicy?.id]);
 
@@ -183,7 +172,7 @@ function useSelectedTransactionsActions({
             shouldShowBulkDuplicateOption({
                 selectedTransactionsKeys: selectedTransactionIDs,
                 selectedTransactions: selectedTransactionsForDuplicate,
-                allTransactions: allTransactionsForDuplicate,
+                allTransactions,
                 allReports,
                 allTransactionViolations,
                 allReportNameValuePairs,
@@ -195,7 +184,7 @@ function useSelectedTransactionsActions({
         [
             selectedTransactionIDs,
             selectedTransactionsForDuplicate,
-            allTransactionsForDuplicate,
+            allTransactions,
             allReports,
             allTransactionViolations,
             allReportNameValuePairs,
@@ -546,7 +535,7 @@ function useSelectedTransactionsActions({
         hideDeleteModal,
         isDuplicateOptionVisible,
         setDuplicateHandler,
-        allTransactions: allTransactionsForDuplicate,
+        allTransactions,
         allReports,
     };
 }

--- a/src/hooks/useSelectedTransactionsActions.ts
+++ b/src/hooks/useSelectedTransactionsActions.ts
@@ -48,7 +48,7 @@ import useNetworkWithOfflineStatus from './useNetworkWithOfflineStatus';
 import useOnyx from './useOnyx';
 import usePermissions from './usePermissions';
 import useReportIsArchived from './useReportIsArchived';
-import {shouldShowBulkDuplicateOption} from './useSearchBulkActions';
+import {getAllTransactionsForDuplicate, shouldShowBulkDuplicateOption} from './useSearchBulkActions';
 
 const {HOLD, UNHOLD, MOVE, MERGE, SPLIT, DUPLICATE} = CONST.REPORT.SELECTED_TRANSACTIONS_BULK_ACTION_TYPES;
 
@@ -157,13 +157,24 @@ function useSelectedTransactionsActions({
     const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
 
     const selectedTransactionsForDuplicate = useMemo(() => {
-        const map: Record<string, {reportID?: string}> = {};
+        const map: Record<string, {reportID?: string; transaction?: Transaction}> = {};
         for (const id of selectedTransactionIDs) {
             const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${id}`];
-            map[id] = {reportID: transaction?.reportID};
+            map[id] = selectedTransactionsMeta[id] ?? {reportID: transaction?.reportID, transaction};
         }
         return map;
-    }, [selectedTransactionIDs, allTransactions]);
+    }, [selectedTransactionIDs, selectedTransactionsMeta, allTransactions]);
+
+    const allTransactionsForDuplicate = useMemo(
+        () =>
+            getAllTransactionsForDuplicate({
+                selectedTransactionsKeys: selectedTransactionIDs,
+                selectedTransactions: selectedTransactionsForDuplicate,
+                allTransactions,
+                searchData: undefined,
+            }),
+        [selectedTransactionIDs, selectedTransactionsForDuplicate, allTransactions],
+    );
 
     const activePolicyExpenseChat = useMemo(() => getPolicyExpenseChat(currentUserAccountID, defaultExpensePolicy?.id), [currentUserAccountID, defaultExpensePolicy?.id]);
 
@@ -172,7 +183,7 @@ function useSelectedTransactionsActions({
             shouldShowBulkDuplicateOption({
                 selectedTransactionsKeys: selectedTransactionIDs,
                 selectedTransactions: selectedTransactionsForDuplicate,
-                allTransactions,
+                allTransactions: allTransactionsForDuplicate,
                 allReports,
                 allTransactionViolations,
                 allReportNameValuePairs,
@@ -184,7 +195,7 @@ function useSelectedTransactionsActions({
         [
             selectedTransactionIDs,
             selectedTransactionsForDuplicate,
-            allTransactions,
+            allTransactionsForDuplicate,
             allReports,
             allTransactionViolations,
             allReportNameValuePairs,
@@ -535,7 +546,7 @@ function useSelectedTransactionsActions({
         hideDeleteModal,
         isDuplicateOptionVisible,
         setDuplicateHandler,
-        allTransactions,
+        allTransactions: allTransactionsForDuplicate,
         allReports,
     };
 }

--- a/tests/unit/hooks/useSearchBulkActionsDuplicateTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsDuplicateTest.ts
@@ -823,6 +823,46 @@ describe('useSearchBulkActions - duplicate option', () => {
         );
     });
 
+    it('should duplicate a grouped child transaction that only exists in selected transaction metadata', async () => {
+        const txnID = '1302';
+        const txn = {...createRandomTransaction(1), transactionID: txnID, reportID: 'report1', managedCard: false, category: 'Grouped child', amount: 9000};
+
+        mockSelectedTransactions = {
+            [txnID]: makeSelectedTransaction({reportID: 'report1', transaction: txn}),
+        };
+
+        const {result} = renderHook(() => useSearchBulkActionsWithDuplicate({queryJSON: baseQueryJSON}));
+
+        await waitFor(() => {
+            expect(result.current.headerButtonsOptions.find((o) => o.value === CONST.SEARCH.BULK_ACTION_TYPES.DUPLICATE)).toBeDefined();
+        });
+
+        result.current.headerButtonsOptions.find((o) => o.value === CONST.SEARCH.BULK_ACTION_TYPES.DUPLICATE)?.onSelected?.();
+
+        expect(bulkDuplicateExpenses).toHaveBeenCalledWith(
+            expect.objectContaining({
+                transactionIDs: [txnID],
+                allTransactions: expect.objectContaining({
+                    [`${ONYXKEYS.COLLECTION.TRANSACTION}${txnID}`]: expect.objectContaining({transactionID: txnID, category: 'Grouped child', amount: 9000}),
+                }),
+            }),
+        );
+    });
+
+    it('should not show duplicate option for a grouped child managed-card transaction from selected transaction metadata', async () => {
+        const txnID = '1303';
+        const txn = {...createRandomTransaction(1), transactionID: txnID, reportID: 'report1', managedCard: true};
+
+        mockSelectedTransactions = {
+            [txnID]: makeSelectedTransaction({reportID: 'report1', transaction: txn}),
+        };
+
+        const {result} = renderHook(() => useSearchBulkActions({queryJSON: baseQueryJSON}));
+        await waitFor(() => expect(result.current.headerButtonsOptions.length).toBeGreaterThan(0));
+
+        expect(result.current.headerButtonsOptions.find((o) => o.value === CONST.SEARCH.BULK_ACTION_TYPES.DUPLICATE)).toBeUndefined();
+    });
+
     it('should not show duplicate option for per-diem expense on non-default workspace', async () => {
         const defaultPolicyID = 'DEFAULT_POLICY';
         const otherPolicyID = 'OTHER_POLICY';


### PR DESCRIPTION
### Explanation of Change
This PR fixes the bulk `Duplicate expense` action for deleted expenses selected from expanded grouped Spend search results.

Grouped search rows can come from child snapshots and may not exist in the live `allTransactions` map. The duplicate flow now builds one resolved transaction map from `allTransactions` and selected row transactions, then uses that same map for both duplicate-option visibility and the duplicate execution handler.

### Fixed Issues
$ https://github.com/Expensify/App/issues/89872
PROPOSAL: https://github.com/Expensify/App/issues/89872#issuecomment-4407896961

### Tests
1. Log in to New Expensify.
2. Go to a workspace chat.
3. Create an expense and delete it.
4. Go to Spend > Expenses.
5. Search for `status:deleted`.
6. Select the deleted expense via checkbox.
7. Open the bulk action dropdown.
8. Verify `Duplicate expense` is shown.
9. Unselect the expense.
10. Search for `status:deleted group-by:from`.
11. Expand the grouped row.
12. Select the deleted expense via checkbox.
13. Open the bulk action dropdown.
14. Verify `Duplicate expense` is shown.
15. Select `Duplicate expense`.
16. Verify the duplicate flow starts instead of silently doing nothing.
17. Verify that no errors appear in the JS console.

### Offline tests
1. Repeat the grouped `status:deleted group-by:from` selection steps while offline.
2. Verify the app does not crash and no unexpected JS console errors appear.
3. Reconnect to the network and verify the page remains usable.

### QA Steps
Same as tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/48cb148c-9bf9-46b8-a37a-098bf9059714



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/4b842086-ecf1-4d8e-af2a-5621c0cab218



</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/3d777b5f-4b2c-4a2c-bfcd-376e71bb41b8



</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/038d0298-8b3c-4cf5-ba12-c10b348baa2e



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/dc8ec601-758d-44ea-a2c4-b9fc6a2df64c



</details>



