### PR TITLE
perf: Defer EditableCell interactivity

### DIFF
--- a/src/components/TransactionItemRow/EditableCell/EditableCell.tsx
+++ b/src/components/TransactionItemRow/EditableCell/EditableCell.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useId} from 'react';
+import React, {useDeferredValue, useEffect, useId} from 'react';
 import type {ReactNode, RefObject} from 'react';
 import {View} from 'react-native';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
@@ -51,6 +51,7 @@ function EditableCell({children, editContent, popoverContent, isEditing, canEdit
     const isEditable = isLargeScreenWidth && !shouldUseNarrowLayout;
     const cellId = useId();
     const {setIsEditingCell, setFocusedCellId} = useEditingCellActions();
+    const isInteractive = useDeferredValue(true, false);
 
     useEffect(() => {
         if (!isEditable || !isEditing) {
@@ -85,9 +86,11 @@ function EditableCell({children, editContent, popoverContent, isEditing, canEdit
         );
     }
 
-    // Transient non-editable state (loading, permissions pending): render the container for layout
-    // consistency but skip the pressable so the user cannot trigger edit mode.
-    if (!canEdit) {
+    // Render a layout-identical plain View when editing isn't permitted OR while the
+    // PressableWithFeedback tree is deferred.  This avoids mounting the expensive
+    // Tooltip / Hoverable / BoundsObserver subtree during the initial skeleton render,
+    // unblocking the main thread so the network response can be processed sooner.
+    if (!canEdit || !isInteractive) {
         return <View style={[styles.editableCell]}>{children}</View>;
     }
 


### PR DESCRIPTION
### Explanation of Change

This PR defers rendering of `EditableCell`s  `PressableWithFeedback` tree.  This avoids mounting the expensive `Tooltip` / `Hoverable` / `BoundsObserver` subtree during the initial skeleton render, unblocking the main thread so the network response can be processed sooner.


#### Perf gains

Each run = 3 navigations: **#1 is the first (cold) navigate**, **#2–#3 are repeat navigations** to the already-mounted screen.

## Branch: `deferred`

| Run | First load (ms) | 2nd nav (ms) | 3rd nav (ms) |
|----:|----------------:|-------------:|-------------:|
| 1   | 3194            | 73           | 69           |
| 2   | 3174            | 72           | 70           |
| 3   | 3127            | 73           | 71           |
| 4   | 3220            | 74           | 74           |
| 5   | 3150            | 71           | 71           |
| **Avg** | **3173**    | **72.6**     | **71.0**     |

## Branch: `main`

| Run | First load (ms) | 2nd nav (ms) | 3rd nav (ms) |
|----:|----------------:|-------------:|-------------:|
| 1   | 3456            | 72           | 72           |
| 2   | 3523            | 77           | 74           |
| 3   | 3485            | 71           | 73           |
| 4   | 3522            | 70           | 70           |
| 5   | 3517            | 72           | 71           |
| **Avg** | **3500.6**  | **72.4**     | **72.0**     |

## Summary

| Metric              | main avg | deferred avg | Δ (deferred − main) | Δ %     |
|---------------------|---------:|-------------:|--------------------:|--------:|
| **First load**      | 3500.6   | 3173.0       | **−327.6 ms**       | **−9.4%** |
| Consecutive nav (2nd+3rd combined) | 72.2     | 71.8         | −0.4 ms             | −0.6%   |

**Takeaway:** `deferred` is ~330 ms (~9%) faster on the **cold/first** navigation to Reports. Subsequent navigations are effectively identical between the two branches (~72 ms), as expected — the screen is already mounted, so deferral has nothing left to defer.

### Fixed Issues

$ https://github.com/Expensify/App/issues/91037
PROPOSAL:




### Tests

Note: This change only affects web release.

1. Start @ `Home`
2. Navigate to `Spend`
3. Verify that an editable cell can be edited

### Offline tests

Note: This change only affects web release.

Same as tests

### QA Steps


Note: This change only affects web release.

Same as tests

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English &gt; Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named &#34;index.js&#34;. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn&#39;t include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function&#39;s arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn&#39;t already exist
    - [x] The style can&#39;t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it&#39;s using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos



MacOS: Chrome / Safari


https://github.com/user-attachments/assets/2cfd8aa2-9cd4-42e3-bc04-fd5b88fbe5f6


