### PR TITLE
[CP Staging] fix: Update 'Save search' to 'Save view'

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -7840,7 +7840,7 @@ const translations = {
         resetColumns: 'Reset columns',
         groupColumns: 'Group columns',
         expenseColumns: 'Expense Columns',
-        saveSearch: 'Save search',
+        saveSearch: 'Save view',
         deleteSavedSearch: 'Delete saved search',
         deleteSavedSearchConfirm: 'Are you sure you want to delete this search?',
         searchName: 'Search name',


### PR DESCRIPTION
### Details

Updates the 'Save search' button text and page title to 'Save view' as requested.

### Fixed Issues

$ https://github.com/Expensify/App/issues/91050

### Tests

- Go to Search page
- Verify button text shows 'Save view' instead of 'Save search'
- Verify page title shows 'Save view'

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots