### PR TITLE
fix: don't prompt to add bank account when one is already connected

### DIFF
--- a/src/libs/actions/ReimbursementAccount/hasCreditBankAccount.ts
+++ b/src/libs/actions/ReimbursementAccount/hasCreditBankAccount.ts
@@ -9,7 +9,7 @@ function hasCreditBankAccount(bankAccountList: OnyxEntry<OnyxTypes.BankAccountLi
 
     return Object.values(bankAccountList).some((bankAccountJSON) => {
         const bankAccount = new BankAccount(bankAccountJSON);
-        return bankAccount.isDefaultCredit();
+        return bankAccount.isDefaultCredit() || bankAccount.isOpen();
     });
 }
 

--- a/tests/unit/ReimbursementAccountTest.ts
+++ b/tests/unit/ReimbursementAccountTest.ts
@@ -25,6 +25,26 @@ describe('ReimbursementAccountTest', () => {
             expect(result).toBe(false);
         });
 
+        it('should return true if there is an open bank account without defaultCredit', () => {
+            const BANK_ACCOUNT_LIST: BankAccountList = {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                '1': {accountData: {defaultCredit: false}, bankCurrency: 'USD', bankCountry: 'US', state: 'OPEN'},
+            };
+
+            const result = hasCreditBankAccount(BANK_ACCOUNT_LIST);
+            expect(result).toBe(true);
+        });
+
+        it('should return false if bank account is not open and not defaultCredit', () => {
+            const BANK_ACCOUNT_LIST: BankAccountList = {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                '1': {accountData: {defaultCredit: false}, bankCurrency: 'USD', bankCountry: 'US', state: 'SETUP'},
+            };
+
+            const result = hasCreditBankAccount(BANK_ACCOUNT_LIST);
+            expect(result).toBe(false);
+        });
+
         it('should return false if there is no bank account list', () => {
             const result = hasCreditBankAccount(undefined);
             expect(result).toBe(false);


### PR DESCRIPTION
getIndicatedMissingPaymentMethod gated the Add bank account button on hasCreditBankAccount, which only treated accounts with accountData.defaultCredit === true as valid. A workspace's connected business bank account lands in bankAccountList in an OPEN state but without defaultCredit, so the app incorrectly prompted the submitter to add a bank account they already have.
hasCreditBankAccount now also accepts an already-open (verified) bank account as a valid reimbursement destination.
Explanation of Change
hasCreditBankAccount was only returning true when a bank account had accountData.defaultCredit === true. A workspace's connected Business Bank Account is an OPEN, verified account but is flagged as a withdrawal account (allowDebit: true) without defaultCredit. This caused getIndicatedMissingPaymentMethod to conclude the submitter had no bank account and show the "Add bank account" button and "Waiting for X to add a bank account" thread message, even though a connected account already existed.
The fix adds || bankAccount.isOpen() to the check so that any already-open (verified) bank account satisfies the condition. hasCreditBankAccount has a single caller so the change is fully contained. Accounts in SETUP/PENDING/VERIFYING still return false, preserving the prompt for genuinely missing bank accounts.
Fixed Issues
$ https://github.com/Expensify/App/issues/91063
PROPOSAL: (add your proposal comment link here after it's approved)
Tests

Connect a workspace to a Business Bank Account
Create an expense and submit it
Approve the expense
Pay the expense using the connected bank account
Verify the expense is paid and no "Add bank account" button or "Waiting for X to add a bank account" thread message appears


 Verify that no errors appear in the JS console

Offline tests
No offline-specific behavior changed. The bankAccountList Onyx value is cached locally, so the check behaves the same offline as online.
QA Steps

On staging, connect a workspace to a Business Bank Account
Create an expense, submit, approve, and pay it using the connected bank account
Verify the expense thread does not show a "Waiting for X to add a bank account" message or an "Add bank account" button
As a negative test: with no bank account connected, pay an expense and verify the button does still appear


 Verify that no errors appear in the JS console

PR Author Checklist

 I linked the correct issue in the ### Fixed Issues section above
 I wrote clear testing steps that cover the changes made in this PR

 I added steps for local testing in the Tests section
 I added steps for the expected offline behavior in the Offline steps section
 I added steps for Staging and/or Production testing in the QA steps section
 I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
 I turned off my network connection and tested it while offline to ensure it matches the expected behavior
 I tested this PR with a High Traffic account against the staging or production API


 I included screenshots or videos for tests on all platforms
 I ran the tests on all platforms & verified they passed on:

 Android: Native
 Android: mWeb Chrome
 iOS: Native
 iOS: mWeb Safari
 MacOS: Chrome / Safari


 I verified there are no console errors
 I followed proper code patterns

 I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle
 I verified that comments were added to code that is not self explanatory
 I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
 I verified any copy / text shown in the product is localized (no new copy added)
 I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods (no new display values added)
 I verified proper file naming conventions were followed for any new files or renamed files
 I verified the JSDocs style guidelines were followed


 I followed the guidelines as stated in the Review Guidelines
 I verified all code is DRY
 I verified any variables that can be defined as constants are defined as such
 I verified that if a function's arguments changed that all usages have also been updated correctly
 I added unit tests for the bug fix in tests/unit/ReimbursementAccountTest.ts

Screenshots/Videos
<details>
<summary>Android: Native</summary>
<!-- add screenshots or videos here -->
</details>
<details>
<summary>Android: mWeb Chrome</summary>
<!-- add screenshots or videos here -->
</details>
<details>
<summary>iOS: Native</summary>
<!-- add screenshots or videos here -->
</details>
<details>
<summary>iOS: mWeb Safari</summary>
<!-- add screenshots or videos here -->
</details>
<details>
<summary>MacOS: Chrome / Safari</summary>
<!-- add screenshots or videos here -->
</details>