### PR TITLE
fix: Android - Native crash (SIGSEGV) in JavaTurboModule event emitter callback

### DIFF
--- a/patches/react-native/details.md
+++ b/patches/react-native/details.md
@@ -265,6 +265,12 @@
 - Upstream PR/issue: [facebook/react-native#51835](https://github.com/facebook/react-native/pull/51835)
 - E/App issue: [#59953](https://github.com/Expensify/App/issues/59953)
 
+### [react-native+0.83.1+036+fix-turbomodule-event-emitter-uaf.patch](react-native+0.83.1+036+fix-turbomodule-event-emitter-uaf.patch)
+
+- Reason: Fixes an Android use-after-free crash in `JavaTurboModule::configureEventEmitterCallback`. The event-emitter callback lambda captured `this` by reference (`[&]`), so when the C++ TurboModule was deallocated (e.g. on screen unmount) a background thread invoking the callback would dereference freed memory via `eventEmitterMap_[name]` and crash with `SIGSEGV`. The fix copies the `shared_ptr` map by value into the lambda and replaces `operator[]` with `find()` + null-check, which both keeps the map alive for the callback's lifetime and avoids inserting empty entries on missing keys.
+- Upstream PR/issue: [facebook/react-native#55398](https://github.com/facebook/react-native/pull/55398)
+- E/App issue: [#90623](https://github.com/Expensify/App/issues/90623)
+
 ### [react-native+0.83.1+036+rounded-inline-code-background.patch](react-native+0.83.1+036+rounded-inline-code-background.patch)
 
 - Reason: Draws inline code block background with rounded corners on iOS when `borderTopLeftRadius` is set.

--- a/patches/react-native/react-native+0.83.1+036+fix-turbomodule-event-emitter-uaf.patch
+++ b/patches/react-native/react-native+0.83.1+036+fix-turbomodule-event-emitter-uaf.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+index 5c9b464..5766844 100644
+--- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
++++ b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+@@ -982,12 +982,17 @@ void JavaTurboModule::configureEventEmitterCallback() {
+     FACEBOOK_JNI_THROW_PENDING_EXCEPTION();
+   }
+
+-  auto callback = JCxxCallbackImpl::newObjectCxxArgs([&](folly::dynamic args) {
+-    auto eventName = args.at(0).asString();
+-    auto& eventEmitter = static_cast<AsyncEventEmitter<folly::dynamic>&>(
+-        *eventEmitterMap_[eventName].get());
+-    eventEmitter.emit(args.size() > 1 ? std::move(args).at(1) : nullptr);
+-  });
++  auto emitterMap = eventEmitterMap_;
++  auto callback =
++      JCxxCallbackImpl::newObjectCxxArgs([emitterMap](folly::dynamic args) {
++        auto eventName = args.at(0).asString();
++        auto it = emitterMap.find(eventName);
++        if (it != emitterMap.end() && it->second) {
++          auto& eventEmitter =
++              static_cast<AsyncEventEmitter<folly::dynamic>&>(*it->second);
++          eventEmitter.emit(args.size() > 1 ? std::move(args).at(1) : nullptr);
++        }
++      });
+
+   jvalue args[1];
+   args[0].l = callback.release();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Applies a patch to `react-native@0.83.1` fixing an Android SIGSEGV crash in `JavaTurboModule::configureEventEmitterCallback`. The lambda captured `this` by reference (`[&]`), so when the TurboModule was deallocated on screen unmount a background thread would dereference freed memory. The fix copies `eventEmitterMap_` by value into the lambda and replaces `operator[]` with `find()` + null-check, keeping the map alive for the callback's lifetime. Backport of [facebook/react-native#55398](https://github.com/facebook/react-native/pull/55398).

### Fixed Issues

$ https://github.com/Expensify/App/issues/90623
PROPOSAL:

### Tests

> **Android: Native only** — this crash is in Android-specific C++ code; iOS, mWeb, and MacOS are unaffected.

Prerequisites:
- An account with SAML/SSO enabled that opens OldDot after signing in

1. Install the app and open it fresh (not already signed in)
2. Enter the SAML-enabled account email and tap **Continue**
3. Tap **Use single sign-on (SSO)**
4. Complete sign-in in the browser that opens
5. Verify that the app does **not** crash after returning from the browser and successfully lands on the OD home screen

### Offline tests

N/A — this is a native C++ crash fix unrelated to network state.

### QA Steps

Same as tests (requires a SAML-enabled account on a physical Android device).

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/154c550e-2f39-4977-9253-fb54690dbdd8


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
