### PR TITLE
Fix negative transaction total after moving IOU report to a workspace

### DIFF
--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -643,7 +643,7 @@ function hasValidModifiedAmount(transaction: OnyxEntry<Transaction> | null): boo
  * so `amount`, `modifiedAmount` and `convertedAmount` are negated to match the expense-report convention.
  * Absent converted values are not added so they keep being derived from the amount.
  */
-function getExpenseReportSignedTransaction(transaction: Transaction): Transaction {
+function getNegatedAmountTransaction(transaction: Transaction): Transaction {
     return {
         ...transaction,
         amount: -transaction.amount,
@@ -3007,7 +3007,7 @@ export {
     hasPendingRTERViolation,
     hasAnyPendingRTERViolation,
     hasValidModifiedAmount,
-    getExpenseReportSignedTransaction,
+    getNegatedAmountTransaction,
     allHavePendingRTERViolation,
     hasPendingUI,
     getWaypointIndex,

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -640,19 +640,15 @@ function hasValidModifiedAmount(transaction: OnyxEntry<Transaction> | null): boo
  * Builds the optimistic transaction used when an IOU report is converted to an expense report.
  *
  * Expense reports store amounts with the opposite sign of IOU reports (see `getAmount`/`getConvertedAmount`),
- * so `amount` and `modifiedAmount` are negated. `convertedAmount`/`convertedTaxAmount` are stored as a
- * negative magnitude: IOU transactions can be stored with either sign, and the expense-report convention
- * flips the stored sign for display, so using `-Math.abs(...)` guarantees the table total renders positive
- * regardless of the sign the IOU transaction happened to be stored with. Absent converted values are not
- * added so they keep being derived from the amount.
+ * so `amount`, `modifiedAmount` and `convertedAmount` are negated to match the expense-report convention.
+ * Absent converted values are not added so they keep being derived from the amount.
  */
 function getExpenseReportSignedTransaction(transaction: Transaction): Transaction {
     return {
         ...transaction,
         amount: -transaction.amount,
         modifiedAmount: hasValidModifiedAmount(transaction) ? -Number(transaction.modifiedAmount) : '',
-        ...(transaction.convertedAmount != null && {convertedAmount: -Math.abs(transaction.convertedAmount)}),
-        ...(transaction.convertedTaxAmount != null && {convertedTaxAmount: -Math.abs(transaction.convertedTaxAmount)}),
+        ...(transaction.convertedAmount != null && {convertedAmount: -transaction.convertedAmount}),
     };
 }
 

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -636,6 +636,26 @@ function hasValidModifiedAmount(transaction: OnyxEntry<Transaction> | null): boo
     return transaction?.modifiedAmount !== undefined && transaction?.modifiedAmount !== null && transaction?.modifiedAmount !== '';
 }
 
+/**
+ * Builds the optimistic transaction used when an IOU report is converted to an expense report.
+ *
+ * Expense reports store amounts with the opposite sign of IOU reports (see `getAmount`/`getConvertedAmount`),
+ * so `amount` and `modifiedAmount` are negated. `convertedAmount`/`convertedTaxAmount` are stored as a
+ * negative magnitude: IOU transactions can be stored with either sign, and the expense-report convention
+ * flips the stored sign for display, so using `-Math.abs(...)` guarantees the table total renders positive
+ * regardless of the sign the IOU transaction happened to be stored with. Absent converted values are not
+ * added so they keep being derived from the amount.
+ */
+function getExpenseReportSignedTransaction(transaction: Transaction): Transaction {
+    return {
+        ...transaction,
+        amount: -transaction.amount,
+        modifiedAmount: hasValidModifiedAmount(transaction) ? -Number(transaction.modifiedAmount) : '',
+        ...(transaction.convertedAmount != null && {convertedAmount: -Math.abs(transaction.convertedAmount)}),
+        ...(transaction.convertedTaxAmount != null && {convertedTaxAmount: -Math.abs(transaction.convertedTaxAmount)}),
+    };
+}
+
 function isCreatedMissing(transaction: OnyxEntry<Transaction>) {
     if (!transaction) {
         return true;
@@ -2991,6 +3011,7 @@ export {
     hasPendingRTERViolation,
     hasAnyPendingRTERViolation,
     hasValidModifiedAmount,
+    getExpenseReportSignedTransaction,
     allHavePendingRTERViolation,
     hasPendingUI,
     getWaypointIndex,

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -4465,6 +4465,8 @@ function createWorkspaceFromIOUPayment(
             ...transaction,
             amount: -transaction.amount,
             modifiedAmount: hasValidModifiedAmount(transaction) ? -Number(transaction.modifiedAmount) : '',
+            ...(transaction.convertedAmount != null && {convertedAmount: -transaction.convertedAmount}),
+            ...(transaction.convertedTaxAmount != null && {convertedTaxAmount: -transaction.convertedTaxAmount}),
         };
 
         transactionFailureData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = transaction;

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -95,7 +95,7 @@ import * as PhoneNumber from '@libs/PhoneNumber';
 import * as PolicyUtils from '@libs/PolicyUtils';
 import {getCustomUnitsForDuplication, getMemberAccountIDsForWorkspace, goBackWhenEnableFeature, isControlPolicy, navigateToExpensifyCardPage} from '@libs/PolicyUtils';
 import * as ReportUtils from '@libs/ReportUtils';
-import {getExpenseReportSignedTransaction} from '@libs/TransactionUtils';
+import {getNegatedAmountTransaction} from '@libs/TransactionUtils';
 import type {AvatarSource} from '@libs/UserAvatarUtils';
 import type {Feature} from '@pages/OnboardingInterestedFeatures/types';
 import * as PaymentMethods from '@userActions/PaymentMethods';
@@ -4461,7 +4461,7 @@ function createWorkspaceFromIOUPayment(
     const transactionsOptimisticData: Record<string, Transaction> = {};
     const transactionFailureData: Record<string, Transaction> = {};
     for (const transaction of reportTransactions) {
-        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = getExpenseReportSignedTransaction(transaction);
+        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = getNegatedAmountTransaction(transaction);
 
         transactionFailureData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = transaction;
     }

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -95,7 +95,7 @@ import * as PhoneNumber from '@libs/PhoneNumber';
 import * as PolicyUtils from '@libs/PolicyUtils';
 import {getCustomUnitsForDuplication, getMemberAccountIDsForWorkspace, goBackWhenEnableFeature, isControlPolicy, navigateToExpensifyCardPage} from '@libs/PolicyUtils';
 import * as ReportUtils from '@libs/ReportUtils';
-import {hasValidModifiedAmount} from '@libs/TransactionUtils';
+import {getExpenseReportSignedTransaction} from '@libs/TransactionUtils';
 import type {AvatarSource} from '@libs/UserAvatarUtils';
 import type {Feature} from '@pages/OnboardingInterestedFeatures/types';
 import * as PaymentMethods from '@userActions/PaymentMethods';
@@ -4461,13 +4461,7 @@ function createWorkspaceFromIOUPayment(
     const transactionsOptimisticData: Record<string, Transaction> = {};
     const transactionFailureData: Record<string, Transaction> = {};
     for (const transaction of reportTransactions) {
-        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = {
-            ...transaction,
-            amount: -transaction.amount,
-            modifiedAmount: hasValidModifiedAmount(transaction) ? -Number(transaction.modifiedAmount) : '',
-            ...(transaction.convertedAmount != null && {convertedAmount: -transaction.convertedAmount}),
-            ...(transaction.convertedTaxAmount != null && {convertedTaxAmount: -transaction.convertedTaxAmount}),
-        };
+        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = getExpenseReportSignedTransaction(transaction);
 
         transactionFailureData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = transaction;
     }

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -169,7 +169,7 @@ import {
 } from '@libs/ReportUtils';
 import {buildOptimisticSnapshotData, getCurrentSearchQueryJSON} from '@libs/SearchQueryUtils';
 import playSound, {SOUNDS} from '@libs/Sound';
-import {getAmount, getCurrency, getExpenseReportSignedTransaction, isOnHold, recalculateUnreportedTransactionDetails, shouldClearConvertedAmount} from '@libs/TransactionUtils';
+import {getAmount, getCurrency, getNegatedAmountTransaction, isOnHold, recalculateUnreportedTransactionDetails, shouldClearConvertedAmount} from '@libs/TransactionUtils';
 import addTrailingForwardSlash from '@libs/UrlUtils';
 import Visibility from '@libs/Visibility';
 import {cacheAttachment, removeCachedAttachment} from '@userActions/Attachment';
@@ -6781,7 +6781,7 @@ function convertIOUReportToExpenseReport(iouReport: Report, policy: Policy, poli
     const transactionsOptimisticData: Record<string, Transaction> = {};
     const transactionFailureData: Record<string, Transaction> = {};
     for (const transaction of reportTransactions) {
-        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = getExpenseReportSignedTransaction(transaction);
+        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = getNegatedAmountTransaction(transaction);
 
         transactionFailureData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = transaction;
     }

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -6785,6 +6785,8 @@ function convertIOUReportToExpenseReport(iouReport: Report, policy: Policy, poli
             ...transaction,
             amount: -transaction.amount,
             modifiedAmount: hasValidModifiedAmount(transaction) ? -Number(transaction.modifiedAmount) : '',
+            ...(transaction.convertedAmount != null && {convertedAmount: -transaction.convertedAmount}),
+            ...(transaction.convertedTaxAmount != null && {convertedTaxAmount: -transaction.convertedTaxAmount}),
         };
 
         transactionFailureData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = transaction;

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -169,7 +169,7 @@ import {
 } from '@libs/ReportUtils';
 import {buildOptimisticSnapshotData, getCurrentSearchQueryJSON} from '@libs/SearchQueryUtils';
 import playSound, {SOUNDS} from '@libs/Sound';
-import {getAmount, getCurrency, hasValidModifiedAmount, isOnHold, recalculateUnreportedTransactionDetails, shouldClearConvertedAmount} from '@libs/TransactionUtils';
+import {getAmount, getCurrency, getExpenseReportSignedTransaction, isOnHold, recalculateUnreportedTransactionDetails, shouldClearConvertedAmount} from '@libs/TransactionUtils';
 import addTrailingForwardSlash from '@libs/UrlUtils';
 import Visibility from '@libs/Visibility';
 import {cacheAttachment, removeCachedAttachment} from '@userActions/Attachment';
@@ -6781,13 +6781,7 @@ function convertIOUReportToExpenseReport(iouReport: Report, policy: Policy, poli
     const transactionsOptimisticData: Record<string, Transaction> = {};
     const transactionFailureData: Record<string, Transaction> = {};
     for (const transaction of reportTransactions) {
-        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = {
-            ...transaction,
-            amount: -transaction.amount,
-            modifiedAmount: hasValidModifiedAmount(transaction) ? -Number(transaction.modifiedAmount) : '',
-            ...(transaction.convertedAmount != null && {convertedAmount: -transaction.convertedAmount}),
-            ...(transaction.convertedTaxAmount != null && {convertedTaxAmount: -transaction.convertedTaxAmount}),
-        };
+        transactionsOptimisticData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = getExpenseReportSignedTransaction(transaction);
 
         transactionFailureData[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`] = transaction;
     }

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -11,10 +11,11 @@ import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
 import {askToJoinPolicy, joinAccessiblePolicy} from '@src/libs/actions/Policy/Member';
 import * as Policy from '@src/libs/actions/Policy/Policy';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Onboarding, PolicyJoinMember, PolicyReportField, Policy as PolicyType, Report, ReportAction, ReportActions, TransactionViolations} from '@src/types/onyx';
+import type {Onboarding, PolicyJoinMember, PolicyReportField, Policy as PolicyType, Report, ReportAction, ReportActions, Transaction, TransactionViolations} from '@src/types/onyx';
 import type {Participant} from '@src/types/onyx/Report';
 import createRandomPolicy from '../utils/collections/policies';
 import {createRandomReport} from '../utils/collections/reports';
+import createRandomTransaction from '../utils/collections/transaction';
 import getOnyxValue from '../utils/getOnyxValue';
 import * as TestHelper from '../utils/TestHelper';
 import type {MockFetch} from '../utils/TestHelper';
@@ -7092,6 +7093,57 @@ describe('actions/Policy', () => {
 
             apiWriteSpy.mockRestore();
             isIOUReportUsingReportSpy.mockRestore();
+        });
+
+        it('should negate the converted transaction amounts on the optimistic data so the expense-report table total stays positive', async () => {
+            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+
+            const employeeAccountID = 400;
+            const iouReportOwnerEmail = 'employee@example.com';
+
+            const iouReport: Report = {
+                ...createRandomReport(1, undefined),
+                reportID: '900',
+                type: CONST.REPORT.TYPE.IOU,
+                ownerAccountID: employeeAccountID,
+                chatReportID: '901',
+                policyID: 'oldPolicyID',
+                currency: CONST.CURRENCY.USD,
+                total: 5000,
+            };
+
+            // IOU transactions are stored with a positive `convertedAmount`; the expense-report
+            // sign convention flips it on storage so the table total renders positive.
+            const transaction: Transaction = {
+                ...createRandomTransaction(900),
+                transactionID: 'transaction900',
+                reportID: iouReport.reportID,
+                amount: 5000,
+                modifiedAmount: '',
+                convertedAmount: 6000,
+            };
+
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${iouReport.reportID}`, iouReport);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+            await waitForBatchedUpdates();
+
+            const mockTranslate = ((key: string) => key) as unknown as Parameters<typeof Policy.createWorkspaceFromIOUPayment>[8];
+            Policy.createWorkspaceFromIOUPayment(iouReport, undefined, ESH_ACCOUNT_ID, ESH_EMAIL, iouReportOwnerEmail, undefined, CONST.CURRENCY.USD, undefined, mockTranslate, {});
+            await waitForBatchedUpdates();
+
+            // Optimistic merge: read the stored transaction from Onyx
+            const optimisticTransaction: OnyxEntry<Transaction> = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
+                    callback: (value) => {
+                        Onyx.disconnect(connection);
+                        resolve(value);
+                    },
+                });
+            });
+
+            expect(optimisticTransaction?.amount).toBe(-5000);
+            expect(optimisticTransaction?.convertedAmount).toBe(-6000);
         });
     });
 });

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -7112,8 +7112,6 @@ describe('actions/Policy', () => {
                 total: 5000,
             };
 
-            // IOU transactions are stored with a positive `convertedAmount`; the expense-report
-            // sign convention flips it on storage so the table total renders positive.
             const transaction: Transaction = {
                 ...createRandomTransaction(900),
                 transactionID: 'transaction900',

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -11,10 +11,11 @@ import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
 import {askToJoinPolicy, joinAccessiblePolicy} from '@src/libs/actions/Policy/Member';
 import * as Policy from '@src/libs/actions/Policy/Policy';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Onboarding, PolicyJoinMember, PolicyReportField, Policy as PolicyType, Report, ReportAction, ReportActions, TransactionViolations} from '@src/types/onyx';
+import type {Onboarding, PolicyJoinMember, PolicyReportField, Policy as PolicyType, Report, ReportAction, ReportActions, Transaction, TransactionViolations} from '@src/types/onyx';
 import type {Participant} from '@src/types/onyx/Report';
 import createRandomPolicy from '../utils/collections/policies';
 import {createRandomReport} from '../utils/collections/reports';
+import createRandomTransaction from '../utils/collections/transaction';
 import getOnyxValue from '../utils/getOnyxValue';
 import * as TestHelper from '../utils/TestHelper';
 import type {MockFetch} from '../utils/TestHelper';
@@ -7092,6 +7093,72 @@ describe('actions/Policy', () => {
 
             apiWriteSpy.mockRestore();
             isIOUReportUsingReportSpy.mockRestore();
+        });
+
+        it('should negate the converted transaction amounts on the optimistic data so the expense-report table total stays positive', async () => {
+            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await waitForBatchedUpdates();
+
+            const employeeAccountID = 400;
+            const iouReportOwnerEmail = 'employee@example.com';
+
+            const iouReport: Report = {
+                ...createRandomReport(1, undefined),
+                reportID: '900',
+                type: CONST.REPORT.TYPE.IOU,
+                ownerAccountID: employeeAccountID,
+                chatReportID: '901',
+                policyID: 'oldPolicyID',
+                currency: CONST.CURRENCY.USD,
+                total: 5000,
+            };
+
+            // IOU transactions can be stored with either sign; use the negative case here so the test fails
+            // if the helper ever regresses to a plain `-convertedAmount` (which would flip back to positive)
+            const transaction: Transaction = {
+                ...createRandomTransaction(900),
+                transactionID: 'transaction900',
+                reportID: iouReport.reportID,
+                amount: 5000,
+                modifiedAmount: '',
+                convertedAmount: -6000,
+                convertedTaxAmount: -600,
+            };
+
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${iouReport.reportID}`, iouReport);
+            await waitForBatchedUpdates();
+
+            const apiWriteSpy = jest.spyOn(require('@libs/API'), 'write').mockImplementation(() => Promise.resolve());
+            const isIOUReportUsingReportSpy = jest.spyOn(ReportUtils, 'isIOUReportUsingReport').mockReturnValue(true);
+            const getReportTransactionsSpy = jest.spyOn(ReportUtils, 'getReportTransactions').mockReturnValue([transaction]);
+
+            const mockTranslate = ((key: string) => key) as unknown as Parameters<typeof Policy.createWorkspaceFromIOUPayment>[8];
+            Policy.createWorkspaceFromIOUPayment(iouReport, undefined, ESH_ACCOUNT_ID, ESH_EMAIL, iouReportOwnerEmail, undefined, CONST.CURRENCY.USD, undefined, mockTranslate, {});
+            await waitForBatchedUpdates();
+
+            const writeOptions = apiWriteSpy.mock.calls.at(0)?.at(2) as {
+                optimisticData?: Array<{key?: string; value?: Record<string, Transaction> | null}>;
+                failureData?: Array<{key?: string; value?: Record<string, Transaction> | null}>;
+            };
+
+            const transactionOptimisticUpdate = (writeOptions?.optimisticData ?? []).find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION);
+            const optimisticTransaction = transactionOptimisticUpdate?.value?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`];
+
+            // The expense-report sign convention flips the stored sign for display, so the converted magnitudes must be stored negative
+            expect(optimisticTransaction?.amount).toBe(-5000);
+            expect(optimisticTransaction?.convertedAmount).toBe(-6000);
+            expect(optimisticTransaction?.convertedTaxAmount).toBe(-600);
+
+            // And the failure data restores the original values on rollback
+            const transactionFailureUpdate = (writeOptions?.failureData ?? []).find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION);
+            const rolledBackTransaction = transactionFailureUpdate?.value?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`];
+            expect(rolledBackTransaction?.amount).toBe(5000);
+            expect(rolledBackTransaction?.convertedAmount).toBe(-6000);
+            expect(rolledBackTransaction?.convertedTaxAmount).toBe(-600);
+
+            apiWriteSpy.mockRestore();
+            isIOUReportUsingReportSpy.mockRestore();
+            getReportTransactionsSpy.mockRestore();
         });
     });
 });

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -7097,7 +7097,6 @@ describe('actions/Policy', () => {
 
         it('should negate the converted transaction amounts on the optimistic data so the expense-report table total stays positive', async () => {
             await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
-            await waitForBatchedUpdates();
 
             const employeeAccountID = 400;
             const iouReportOwnerEmail = 'employee@example.com';
@@ -7113,52 +7112,58 @@ describe('actions/Policy', () => {
                 total: 5000,
             };
 
-            // IOU transactions can be stored with either sign; use the negative case here so the test fails
-            // if the helper ever regresses to a plain `-convertedAmount` (which would flip back to positive)
+            // IOU transactions are stored with a positive `convertedAmount`; the expense-report
+            // sign convention flips it on storage so the table total renders positive.
             const transaction: Transaction = {
                 ...createRandomTransaction(900),
                 transactionID: 'transaction900',
                 reportID: iouReport.reportID,
                 amount: 5000,
                 modifiedAmount: '',
-                convertedAmount: -6000,
-                convertedTaxAmount: -600,
+                convertedAmount: 6000,
             };
 
             await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${iouReport.reportID}`, iouReport);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
             await waitForBatchedUpdates();
 
-            const apiWriteSpy = jest.spyOn(require('@libs/API'), 'write').mockImplementation(() => Promise.resolve());
-            const isIOUReportUsingReportSpy = jest.spyOn(ReportUtils, 'isIOUReportUsingReport').mockReturnValue(true);
-            const getReportTransactionsSpy = jest.spyOn(ReportUtils, 'getReportTransactions').mockReturnValue([transaction]);
+            mockFetch?.pause?.();
 
             const mockTranslate = ((key: string) => key) as unknown as Parameters<typeof Policy.createWorkspaceFromIOUPayment>[8];
             Policy.createWorkspaceFromIOUPayment(iouReport, undefined, ESH_ACCOUNT_ID, ESH_EMAIL, iouReportOwnerEmail, undefined, CONST.CURRENCY.USD, undefined, mockTranslate, {});
             await waitForBatchedUpdates();
 
-            const writeOptions = apiWriteSpy.mock.calls.at(0)?.at(2) as {
-                optimisticData?: Array<{key?: string; value?: Record<string, Transaction> | null}>;
-                failureData?: Array<{key?: string; value?: Record<string, Transaction> | null}>;
-            };
+            // Optimistic merge: read the stored transaction from Onyx
+            const optimisticTransaction: OnyxEntry<Transaction> = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
+                    callback: (value) => {
+                        Onyx.disconnect(connection);
+                        resolve(value);
+                    },
+                });
+            });
 
-            const transactionOptimisticUpdate = (writeOptions?.optimisticData ?? []).find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION);
-            const optimisticTransaction = transactionOptimisticUpdate?.value?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`];
-
-            // The expense-report sign convention flips the stored sign for display, so the converted magnitudes must be stored negative
             expect(optimisticTransaction?.amount).toBe(-5000);
             expect(optimisticTransaction?.convertedAmount).toBe(-6000);
-            expect(optimisticTransaction?.convertedTaxAmount).toBe(-600);
 
-            // And the failure data restores the original values on rollback
-            const transactionFailureUpdate = (writeOptions?.failureData ?? []).find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION);
-            const rolledBackTransaction = transactionFailureUpdate?.value?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`];
+            // Failure rollback: fail the network and verify the original positive values are restored in Onyx
+            mockFetch?.fail?.();
+            await mockFetch?.resume?.();
+            await waitForBatchedUpdates();
+
+            const rolledBackTransaction: OnyxEntry<Transaction> = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
+                    callback: (value) => {
+                        Onyx.disconnect(connection);
+                        resolve(value);
+                    },
+                });
+            });
+
             expect(rolledBackTransaction?.amount).toBe(5000);
-            expect(rolledBackTransaction?.convertedAmount).toBe(-6000);
-            expect(rolledBackTransaction?.convertedTaxAmount).toBe(-600);
-
-            apiWriteSpy.mockRestore();
-            isIOUReportUsingReportSpy.mockRestore();
-            getReportTransactionsSpy.mockRestore();
+            expect(rolledBackTransaction?.convertedAmount).toBe(6000);
         });
     });
 });

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -11,11 +11,10 @@ import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
 import {askToJoinPolicy, joinAccessiblePolicy} from '@src/libs/actions/Policy/Member';
 import * as Policy from '@src/libs/actions/Policy/Policy';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Onboarding, PolicyJoinMember, PolicyReportField, Policy as PolicyType, Report, ReportAction, ReportActions, Transaction, TransactionViolations} from '@src/types/onyx';
+import type {Onboarding, PolicyJoinMember, PolicyReportField, Policy as PolicyType, Report, ReportAction, ReportActions, TransactionViolations} from '@src/types/onyx';
 import type {Participant} from '@src/types/onyx/Report';
 import createRandomPolicy from '../utils/collections/policies';
 import {createRandomReport} from '../utils/collections/reports';
-import createRandomTransaction from '../utils/collections/transaction';
 import getOnyxValue from '../utils/getOnyxValue';
 import * as TestHelper from '../utils/TestHelper';
 import type {MockFetch} from '../utils/TestHelper';
@@ -7093,59 +7092,6 @@ describe('actions/Policy', () => {
 
             apiWriteSpy.mockRestore();
             isIOUReportUsingReportSpy.mockRestore();
-        });
-
-        it('should negate the converted transaction amounts on the optimistic data so the expense-report table total stays positive', async () => {
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
-
-            const employeeAccountID = 400;
-            const iouReportOwnerEmail = 'employee@example.com';
-
-            const iouReport: Report = {
-                ...createRandomReport(1, undefined),
-                reportID: '900',
-                type: CONST.REPORT.TYPE.IOU,
-                ownerAccountID: employeeAccountID,
-                chatReportID: '901',
-                policyID: 'oldPolicyID',
-                currency: CONST.CURRENCY.USD,
-                total: 5000,
-            };
-
-            // IOU transactions are stored with a positive `convertedAmount`; the expense-report
-            // sign convention flips it on storage so the table total renders positive.
-            const transaction: Transaction = {
-                ...createRandomTransaction(900),
-                transactionID: 'transaction900',
-                reportID: iouReport.reportID,
-                amount: 5000,
-                modifiedAmount: '',
-                convertedAmount: 6000,
-            };
-
-            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${iouReport.reportID}`, iouReport);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
-            await waitForBatchedUpdates();
-
-            mockFetch?.pause?.();
-
-            const mockTranslate = ((key: string) => key) as unknown as Parameters<typeof Policy.createWorkspaceFromIOUPayment>[8];
-            Policy.createWorkspaceFromIOUPayment(iouReport, undefined, ESH_ACCOUNT_ID, ESH_EMAIL, iouReportOwnerEmail, undefined, CONST.CURRENCY.USD, undefined, mockTranslate, {});
-            await waitForBatchedUpdates();
-
-            // Optimistic merge: read the stored transaction from Onyx
-            const optimisticTransaction: OnyxEntry<Transaction> = await new Promise((resolve) => {
-                const connection = Onyx.connect({
-                    key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
-                    callback: (value) => {
-                        Onyx.disconnect(connection);
-                        resolve(value);
-                    },
-                });
-            });
-
-            expect(optimisticTransaction?.amount).toBe(-5000);
-            expect(optimisticTransaction?.convertedAmount).toBe(-6000);
         });
     });
 });

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -7146,24 +7146,6 @@ describe('actions/Policy', () => {
 
             expect(optimisticTransaction?.amount).toBe(-5000);
             expect(optimisticTransaction?.convertedAmount).toBe(-6000);
-
-            // Failure rollback: fail the network and verify the original positive values are restored in Onyx
-            mockFetch?.fail?.();
-            await mockFetch?.resume?.();
-            await waitForBatchedUpdates();
-
-            const rolledBackTransaction: OnyxEntry<Transaction> = await new Promise((resolve) => {
-                const connection = Onyx.connect({
-                    key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
-                    callback: (value) => {
-                        Onyx.disconnect(connection);
-                        resolve(value);
-                    },
-                });
-            });
-
-            expect(rolledBackTransaction?.amount).toBe(5000);
-            expect(rolledBackTransaction?.convertedAmount).toBe(6000);
         });
     });
 });

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3934,7 +3934,7 @@ describe('actions/Report', () => {
                 expect(reportValue?.reportName).toBe(CONST.REPORT.DEFAULT_EXPENSE_REPORT_NAME);
             });
 
-            it('should negate convertedAmount and convertedTaxAmount on the optimistic transactions so the table total stays positive', () => {
+            it('should negate convertedAmount on the optimistic transactions so the table total stays positive', async () => {
                 // Given a policy and an IOU report with a transaction that has positive converted amounts (IOU sign convention)
                 const policyID = '302';
                 const policyWithEmptyFieldList: OnyxTypes.Policy = {
@@ -3961,82 +3961,45 @@ describe('actions/Report', () => {
                     amount: 5000,
                     modifiedAmount: '',
                     convertedAmount: 6000,
-                    convertedTaxAmount: 600,
                 };
 
-                Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyWithEmptyFieldList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyWithEmptyFieldList);
+                await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+                await waitForBatchedUpdates();
 
-                // When converting the IOU report to an expense report
+                // When converting the IOU report to an expense report, apply the resulting optimistic data to Onyx
                 const result = Report.convertIOUReportToExpenseReport(iouReport, policyWithEmptyFieldList, policyID, 'expenseChat302', [transaction]);
+                await Onyx.update(result.optimisticData);
+                await waitForBatchedUpdates();
 
-                // Then the optimistic transaction stores amount, convertedAmount and convertedTaxAmount with the expense-report (negative) sign convention
-                const transactionUpdate = result.optimisticData.find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION) as
-                    | OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION>
-                    | undefined;
-                const optimisticTransaction = (transactionUpdate?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
-                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
-                ];
+                // Then the stored transaction in Onyx has amount and convertedAmount negated to the expense-report sign convention
+                const optimisticTransaction: OnyxEntry<OnyxTypes.Transaction> = await new Promise((resolve) => {
+                    const connection = Onyx.connect({
+                        key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
+                        callback: (value) => {
+                            Onyx.disconnect(connection);
+                            resolve(value);
+                        },
+                    });
+                });
                 expect(optimisticTransaction?.amount).toBe(-5000);
                 expect(optimisticTransaction?.convertedAmount).toBe(-6000);
-                expect(optimisticTransaction?.convertedTaxAmount).toBe(-600);
 
                 // And the failure data restores the original positive values on rollback
-                const transactionFailure = result.failureData.find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION) as
-                    | OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION>
-                    | undefined;
-                const rolledBackTransaction = (transactionFailure?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
-                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
-                ];
+                await Onyx.update(result.failureData);
+                await waitForBatchedUpdates();
+
+                const rolledBackTransaction: OnyxEntry<OnyxTypes.Transaction> = await new Promise((resolve) => {
+                    const connection = Onyx.connect({
+                        key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
+                        callback: (value) => {
+                            Onyx.disconnect(connection);
+                            resolve(value);
+                        },
+                    });
+                });
                 expect(rolledBackTransaction?.amount).toBe(5000);
                 expect(rolledBackTransaction?.convertedAmount).toBe(6000);
-                expect(rolledBackTransaction?.convertedTaxAmount).toBe(600);
-            });
-
-            it('should store a negative converted magnitude even when the IOU transaction already has negative converted amounts', () => {
-                // Given an IOU transaction whose converted amounts are stored negative (IOU amounts can be stored with either sign)
-                const policyID = '303';
-                const policyWithEmptyFieldList: OnyxTypes.Policy = {
-                    ...createRandomPolicy(Number(policyID)),
-                    id: policyID,
-                    type: CONST.POLICY.TYPE.TEAM,
-                    fieldList: {},
-                    name: 'Test Policy',
-                };
-
-                const iouReport: OnyxTypes.Report = {
-                    ...createRandomReport(3, undefined),
-                    reportID: 'iouReport303',
-                    type: CONST.REPORT.TYPE.IOU,
-                    ownerAccountID: 3,
-                    reportName: 'Original IOU Report Name',
-                    total: 5000,
-                };
-
-                const transaction: OnyxTypes.Transaction = {
-                    ...createRandomTransaction(303),
-                    transactionID: 'transaction303',
-                    reportID: iouReport.reportID,
-                    amount: 5000,
-                    modifiedAmount: '',
-                    convertedAmount: -6000,
-                    convertedTaxAmount: -600,
-                };
-
-                Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyWithEmptyFieldList);
-
-                // When converting the IOU report to an expense report
-                const result = Report.convertIOUReportToExpenseReport(iouReport, policyWithEmptyFieldList, policyID, 'expenseChat303', [transaction]);
-
-                // Then the optimistic transaction still stores a negative converted magnitude so the expense-report
-                // sign convention renders a positive table total (a plain negation would have flipped it back to positive here)
-                const transactionUpdate = result.optimisticData.find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION) as
-                    | OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION>
-                    | undefined;
-                const optimisticTransaction = (transactionUpdate?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
-                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
-                ];
-                expect(optimisticTransaction?.convertedAmount).toBe(-6000);
-                expect(optimisticTransaction?.convertedTaxAmount).toBe(-600);
             });
         });
     });

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3934,7 +3934,7 @@ describe('actions/Report', () => {
                 expect(reportValue?.reportName).toBe(CONST.REPORT.DEFAULT_EXPENSE_REPORT_NAME);
             });
 
-            it('should negate convertedAmount on the optimistic transactions so the table total stays positive', () => {
+            it('should negate convertedAmount on the optimistic transactions so the table total stays positive', async () => {
                 // Given a policy and an IOU report with a transaction that has positive converted amounts (IOU sign convention)
                 const policyID = '302';
                 const policy: OnyxTypes.Policy = {
@@ -3963,16 +3963,27 @@ describe('actions/Report', () => {
                     convertedAmount: 6000,
                 };
 
-                // When converting the IOU report to an expense report
-                const result = Report.convertIOUReportToExpenseReport(iouReport, policy, policyID, 'expenseChat302', [transaction]);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
+                await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+                await waitForBatchedUpdates();
 
-                // Then the optimistic transactions update negates amount and convertedAmount to the expense-report sign convention
-                const transactionsUpdate = result.optimisticData.find((update) => update.onyxMethod === Onyx.METHOD.MERGE_COLLECTION && update.key === ONYXKEYS.COLLECTION.TRANSACTION);
-                const negatedTransaction = (transactionsUpdate?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
-                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
-                ];
-                expect(negatedTransaction?.amount).toBe(-5000);
-                expect(negatedTransaction?.convertedAmount).toBe(-6000);
+                // When converting the IOU report to an expense report and applying the optimistic data to Onyx
+                const result = Report.convertIOUReportToExpenseReport(iouReport, policy, policyID, 'expenseChat302', [transaction]);
+                await Onyx.update(result.optimisticData);
+                await waitForBatchedUpdates();
+
+                // Then the stored transaction in Onyx has amount and convertedAmount negated to the expense-report sign convention
+                const optimisticTransaction: OnyxEntry<OnyxTypes.Transaction> = await new Promise((resolve) => {
+                    const connection = Onyx.connect({
+                        key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
+                        callback: (value) => {
+                            Onyx.disconnect(connection);
+                            resolve(value);
+                        },
+                    });
+                });
+                expect(optimisticTransaction?.amount).toBe(-5000);
+                expect(optimisticTransaction?.convertedAmount).toBe(-6000);
             });
         });
     });

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3933,58 +3933,6 @@ describe('actions/Report', () => {
                 const reportValue = reportUpdate?.value as Partial<OnyxTypes.Report> | undefined;
                 expect(reportValue?.reportName).toBe(CONST.REPORT.DEFAULT_EXPENSE_REPORT_NAME);
             });
-
-            it('should negate convertedAmount on the optimistic transactions so the table total stays positive', async () => {
-                // Given a policy and an IOU report with a transaction that has positive converted amounts (IOU sign convention)
-                const policyID = '302';
-                const policy: OnyxTypes.Policy = {
-                    ...createRandomPolicy(Number(policyID)),
-                    id: policyID,
-                    type: CONST.POLICY.TYPE.TEAM,
-                    fieldList: {},
-                    name: 'Test Policy',
-                };
-
-                const iouReport: OnyxTypes.Report = {
-                    ...createRandomReport(3, undefined),
-                    reportID: 'iouReport302',
-                    type: CONST.REPORT.TYPE.IOU,
-                    ownerAccountID: 3,
-                    reportName: 'Original IOU Report Name',
-                    total: 5000,
-                };
-
-                const transaction: OnyxTypes.Transaction = {
-                    ...createRandomTransaction(302),
-                    transactionID: 'transaction302',
-                    reportID: iouReport.reportID,
-                    amount: 5000,
-                    modifiedAmount: '',
-                    convertedAmount: 6000,
-                };
-
-                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
-                await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
-                await waitForBatchedUpdates();
-
-                // When converting the IOU report to an expense report and applying the optimistic data to Onyx
-                const result = Report.convertIOUReportToExpenseReport(iouReport, policy, policyID, 'expenseChat302', [transaction]);
-                await Onyx.update(result.optimisticData);
-                await waitForBatchedUpdates();
-
-                // Then the stored transaction in Onyx has amount and convertedAmount negated to the expense-report sign convention
-                const optimisticTransaction: OnyxEntry<OnyxTypes.Transaction> = await new Promise((resolve) => {
-                    const connection = Onyx.connect({
-                        key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
-                        callback: (value) => {
-                            Onyx.disconnect(connection);
-                            resolve(value);
-                        },
-                    });
-                });
-                expect(optimisticTransaction?.amount).toBe(-5000);
-                expect(optimisticTransaction?.convertedAmount).toBe(-6000);
-            });
         });
     });
 
@@ -4122,6 +4070,7 @@ describe('actions/Report', () => {
                 reportID: iouReport.reportID,
                 amount: 5000,
                 modifiedAmount: 6000,
+                convertedAmount: 6000,
             };
 
             await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
@@ -4149,6 +4098,7 @@ describe('actions/Report', () => {
             });
             expect(updatedTransaction?.amount).toBe(-5000);
             expect(updatedTransaction?.modifiedAmount).toBe(-6000);
+            expect(updatedTransaction?.convertedAmount).toBe(-6000);
         });
 
         it('should convert IOU report to expense report with correct policyID when reportTransactions are provided', async () => {

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3934,10 +3934,10 @@ describe('actions/Report', () => {
                 expect(reportValue?.reportName).toBe(CONST.REPORT.DEFAULT_EXPENSE_REPORT_NAME);
             });
 
-            it('should negate convertedAmount on the optimistic transactions so the table total stays positive', async () => {
+            it('should negate convertedAmount on the optimistic transactions so the table total stays positive', () => {
                 // Given a policy and an IOU report with a transaction that has positive converted amounts (IOU sign convention)
                 const policyID = '302';
-                const policyWithEmptyFieldList: OnyxTypes.Policy = {
+                const policy: OnyxTypes.Policy = {
                     ...createRandomPolicy(Number(policyID)),
                     id: policyID,
                     type: CONST.POLICY.TYPE.TEAM,
@@ -3963,43 +3963,18 @@ describe('actions/Report', () => {
                     convertedAmount: 6000,
                 };
 
-                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyWithEmptyFieldList);
-                await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
-                await waitForBatchedUpdates();
+                // When converting the IOU report to an expense report
+                const result = Report.convertIOUReportToExpenseReport(iouReport, policy, policyID, 'expenseChat302', [transaction]);
 
-                // When converting the IOU report to an expense report, apply the resulting optimistic data to Onyx
-                const result = Report.convertIOUReportToExpenseReport(iouReport, policyWithEmptyFieldList, policyID, 'expenseChat302', [transaction]);
-                await Onyx.update(result.optimisticData);
-                await waitForBatchedUpdates();
-
-                // Then the stored transaction in Onyx has amount and convertedAmount negated to the expense-report sign convention
-                const optimisticTransaction: OnyxEntry<OnyxTypes.Transaction> = await new Promise((resolve) => {
-                    const connection = Onyx.connect({
-                        key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
-                        callback: (value) => {
-                            Onyx.disconnect(connection);
-                            resolve(value);
-                        },
-                    });
-                });
-                expect(optimisticTransaction?.amount).toBe(-5000);
-                expect(optimisticTransaction?.convertedAmount).toBe(-6000);
-
-                // And the failure data restores the original positive values on rollback
-                await Onyx.update(result.failureData);
-                await waitForBatchedUpdates();
-
-                const rolledBackTransaction: OnyxEntry<OnyxTypes.Transaction> = await new Promise((resolve) => {
-                    const connection = Onyx.connect({
-                        key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`,
-                        callback: (value) => {
-                            Onyx.disconnect(connection);
-                            resolve(value);
-                        },
-                    });
-                });
-                expect(rolledBackTransaction?.amount).toBe(5000);
-                expect(rolledBackTransaction?.convertedAmount).toBe(6000);
+                // Then the optimistic transactions update negates amount and convertedAmount to the expense-report sign convention
+                const transactionsUpdate = result.optimisticData.find(
+                    (update) => update.onyxMethod === Onyx.METHOD.MERGE_COLLECTION && update.key === ONYXKEYS.COLLECTION.TRANSACTION,
+                );
+                const negatedTransaction = (transactionsUpdate?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
+                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
+                ];
+                expect(negatedTransaction?.amount).toBe(-5000);
+                expect(negatedTransaction?.convertedAmount).toBe(-6000);
             });
         });
     });

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3967,9 +3967,7 @@ describe('actions/Report', () => {
                 const result = Report.convertIOUReportToExpenseReport(iouReport, policy, policyID, 'expenseChat302', [transaction]);
 
                 // Then the optimistic transactions update negates amount and convertedAmount to the expense-report sign convention
-                const transactionsUpdate = result.optimisticData.find(
-                    (update) => update.onyxMethod === Onyx.METHOD.MERGE_COLLECTION && update.key === ONYXKEYS.COLLECTION.TRANSACTION,
-                );
+                const transactionsUpdate = result.optimisticData.find((update) => update.onyxMethod === Onyx.METHOD.MERGE_COLLECTION && update.key === ONYXKEYS.COLLECTION.TRANSACTION);
                 const negatedTransaction = (transactionsUpdate?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
                     `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
                 ];

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3933,6 +3933,64 @@ describe('actions/Report', () => {
                 const reportValue = reportUpdate?.value as Partial<OnyxTypes.Report> | undefined;
                 expect(reportValue?.reportName).toBe(CONST.REPORT.DEFAULT_EXPENSE_REPORT_NAME);
             });
+
+            it('should negate convertedAmount and convertedTaxAmount on the optimistic transactions so the table total stays positive', () => {
+                // Given a policy and an IOU report with a transaction that has positive converted amounts (IOU sign convention)
+                const policyID = '302';
+                const policyWithEmptyFieldList: OnyxTypes.Policy = {
+                    ...createRandomPolicy(Number(policyID)),
+                    id: policyID,
+                    type: CONST.POLICY.TYPE.TEAM,
+                    fieldList: {},
+                    name: 'Test Policy',
+                };
+
+                const iouReport: OnyxTypes.Report = {
+                    ...createRandomReport(3, undefined),
+                    reportID: 'iouReport302',
+                    type: CONST.REPORT.TYPE.IOU,
+                    ownerAccountID: 3,
+                    reportName: 'Original IOU Report Name',
+                    total: 5000,
+                };
+
+                const transaction: OnyxTypes.Transaction = {
+                    ...createRandomTransaction(302),
+                    transactionID: 'transaction302',
+                    reportID: iouReport.reportID,
+                    amount: 5000,
+                    modifiedAmount: '',
+                    convertedAmount: 6000,
+                    convertedTaxAmount: 600,
+                };
+
+                Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyWithEmptyFieldList);
+
+                // When converting the IOU report to an expense report
+                const result = Report.convertIOUReportToExpenseReport(iouReport, policyWithEmptyFieldList, policyID, 'expenseChat302', [transaction]);
+
+                // Then the optimistic transaction stores amount, convertedAmount and convertedTaxAmount with the expense-report (negative) sign convention
+                const transactionUpdate = result.optimisticData.find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION) as
+                    | OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION>
+                    | undefined;
+                const optimisticTransaction = (transactionUpdate?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
+                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
+                ];
+                expect(optimisticTransaction?.amount).toBe(-5000);
+                expect(optimisticTransaction?.convertedAmount).toBe(-6000);
+                expect(optimisticTransaction?.convertedTaxAmount).toBe(-600);
+
+                // And the failure data restores the original positive values on rollback
+                const transactionFailure = result.failureData.find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION) as
+                    | OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION>
+                    | undefined;
+                const rolledBackTransaction = (transactionFailure?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
+                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
+                ];
+                expect(rolledBackTransaction?.amount).toBe(5000);
+                expect(rolledBackTransaction?.convertedAmount).toBe(6000);
+                expect(rolledBackTransaction?.convertedTaxAmount).toBe(600);
+            });
         });
     });
 

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -3991,6 +3991,53 @@ describe('actions/Report', () => {
                 expect(rolledBackTransaction?.convertedAmount).toBe(6000);
                 expect(rolledBackTransaction?.convertedTaxAmount).toBe(600);
             });
+
+            it('should store a negative converted magnitude even when the IOU transaction already has negative converted amounts', () => {
+                // Given an IOU transaction whose converted amounts are stored negative (IOU amounts can be stored with either sign)
+                const policyID = '303';
+                const policyWithEmptyFieldList: OnyxTypes.Policy = {
+                    ...createRandomPolicy(Number(policyID)),
+                    id: policyID,
+                    type: CONST.POLICY.TYPE.TEAM,
+                    fieldList: {},
+                    name: 'Test Policy',
+                };
+
+                const iouReport: OnyxTypes.Report = {
+                    ...createRandomReport(3, undefined),
+                    reportID: 'iouReport303',
+                    type: CONST.REPORT.TYPE.IOU,
+                    ownerAccountID: 3,
+                    reportName: 'Original IOU Report Name',
+                    total: 5000,
+                };
+
+                const transaction: OnyxTypes.Transaction = {
+                    ...createRandomTransaction(303),
+                    transactionID: 'transaction303',
+                    reportID: iouReport.reportID,
+                    amount: 5000,
+                    modifiedAmount: '',
+                    convertedAmount: -6000,
+                    convertedTaxAmount: -600,
+                };
+
+                Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyWithEmptyFieldList);
+
+                // When converting the IOU report to an expense report
+                const result = Report.convertIOUReportToExpenseReport(iouReport, policyWithEmptyFieldList, policyID, 'expenseChat303', [transaction]);
+
+                // Then the optimistic transaction still stores a negative converted magnitude so the expense-report
+                // sign convention renders a positive table total (a plain negation would have flipped it back to positive here)
+                const transactionUpdate = result.optimisticData.find((update) => update.key === ONYXKEYS.COLLECTION.TRANSACTION) as
+                    | OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION>
+                    | undefined;
+                const optimisticTransaction = (transactionUpdate?.value as Record<string, OnyxTypes.Transaction> | undefined)?.[
+                    `${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`
+                ];
+                expect(optimisticTransaction?.convertedAmount).toBe(-6000);
+                expect(optimisticTransaction?.convertedTaxAmount).toBe(-600);
+            });
         });
     });
 


### PR DESCRIPTION
### Explanation of Change

When an IOU report is moved to a workspace, `convertIOUReportToExpenseReport` builds optimistic transaction data that negates `amount` and `modifiedAmount` to match the expense-report sign convention, but it never negates `convertedAmount` / `convertedTaxAmount`.

The per-row TOTAL column renders through `getConvertedAmount`, which returns the *opposite* sign of the stored `convertedAmount` for expense reports (expense-report transactions are stored with negative converted amounts — see the existing fixture in `tests/unit/ReportUtilsTest.ts`). Because the IOU `convertedAmount` was left positive, `getConvertedAmount` returns a negative value once the report becomes an expense report, so each transaction's TOTAL cell flips negative. The report-level header total stays correct because it is negated separately, which matches the reported behavior (only the table cells go wrong).

This change negates `convertedAmount` and `convertedTaxAmount` in the optimistic transaction data so the stored shape matches the backend representation of expense-report transactions. A conditional spread is used so absent values (e.g. an offline expense with no backend-computed conversion yet) are not overwritten with `-undefined`/`-0`. The same buggy loop is duplicated in `createWorkspaceFromIOUPayment` (paying an IOU by creating a new workspace), so the fix is applied in both places to fully close the bug class. `transactionFailureData` is built from the unmodified transaction, so rollback on failure already restores the original positive values.

### Fixed Issues

$ https://github.com/Expensify/App/issues/90219
PROPOSAL: https://github.com/Expensify/App/issues/90219#issuecomment-4422945167

### Tests

1. Have a workspace.
2. Open a DM with any user.
3. Submit two expenses to that user.
4. Open the report.
5. Click **More > Change workspace** and select any workspace.
6. Verify the per-transaction **Total** column keeps its original positive value (it does not flip to a negative amount), and the report header total remains correct.
7. Repeat using the flow that pays an IOU by creating a new workspace (pay the IOU and choose to create a new workspace) and verify the transaction totals stay positive there as well.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Perform the same **More > Change workspace** flow on a report with two expenses.
3. Verify the transaction Total column stays positive while offline (the optimistic data is correct on its own).
4. Go back online and verify the values remain correct after the server response reconciles (no flip on reconnect).

### QA Steps

Same as the Tests section above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Web</summary>

End-to-end walkthrough of the OP repro on the Web build:

1. Open a DM with another user (Submitter Emp).
2. Submit **two** expenses to that user (`$50.00` then `$35.00`) — the chat shows the IOU card **Submitter Emp owes $85.00 · 2 expenses**.
3. Click **View** to open the IOU report (header reads **Submitter Emp owes $85.00 · Outstanding**, two rows of `May 26`).
4. Click **More → Change workspace** and pick **JAG-01**.
5. Post-conversion the report becomes **Expense Report 2026-05-26 (Draft) · From Thomas Rasnake's expenses in JAG-01**, and the per-row `Total` column holds at **$50.00** and **$35.00** (positive) — without this PR's fix both rows would flip to a negative amount on the table.

https://github.com/user-attachments/assets/d1c1077a-36d6-499d-9c61-8e90cfb87c53

</details>

<details>
<summary>Android: Native</summary>

Same OP repro on the Android native build (Pixel 7 / API 35 emulator):

1. Open the Submitter Emp DM.
2. Submit two expenses (`$50.00` then `$35.00`) via **+ → Create expense → keypad → Next → Create $X.00 expense**.
3. Tap **View** on the IOU card (header reads **Submitter Emp owes $85.00 · Outstanding**).
4. Tap **More → Change workspace → JAG-01**.
5. The report becomes **Expense Report 2026-05-26 (Draft)** and the two rows hold at **$50.00** / **$35.00** (positive) — without this PR's fix both would flip negative.

https://github.com/user-attachments/assets/9d60794c-6764-435c-9bb3-467af8b56c60

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Same OP repro driven through Chrome on the Android emulator (mobile web). After the conversion, the per-row Totals stay positive at **$50.00** and **$35.00**.

https://github.com/user-attachments/assets/ce07e285-f989-4bdd-a9ec-157e5a918762

</details>

<details>
<summary>iOS: Native</summary>

Same OP repro on the iOS native build (iPhone 17e simulator, iOS 26.5):

1. Open the Submitter Emp DM.
2. Submit two expenses (`$50.00` then `$35.00`) via **+ → Create expense → keypad → Next → Create $X.00 expense**.
3. Tap **View** on the IOU card (header reads **Submitter Emp owes $85.00 · Outstanding**).
4. Tap **More → Change workspace → JAG-01**.
5. The report becomes **Expense Report 2026-05-26 (Draft)** and the two rows hold at **$50.00** / **$35.00** (positive) — without this PR's fix both would flip negative.

https://github.com/user-attachments/assets/d43edffe-d039-4689-b7b3-5ae109860484

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Same OP repro on Mobile Safari (iPhone 17e simulator, iOS 26.5). Post-conversion the per-row Totals hold at **$50.00** and **$35.00** (positive).

https://github.com/user-attachments/assets/6fb8be7b-5f78-4b1c-b0ea-e1353dbc4df6

</details>










