### PR TITLE
Gracefully handle malformed currency codes instead of crashing

### DIFF
--- a/src/components/CurrencyListContextProvider/index.tsx
+++ b/src/components/CurrencyListContextProvider/index.tsx
@@ -1,7 +1,7 @@
 import React, {createContext, useCallback, useContext, useMemo} from 'react';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import {convertToFrontendAmountAsInteger} from '@libs/CurrencyUtils';
+import {convertToFrontendAmountAsInteger, sanitizeCurrencyCode} from '@libs/CurrencyUtils';
 import {format, formatToParts} from '@libs/NumberFormatUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -34,15 +34,12 @@ function CurrencyListContextProvider({children}: React.PropsWithChildren) {
 
     const convertToDisplayString = useCallback(
         (amountInCents: number | undefined, currencyCode: string | undefined): string => {
-            const decimals = getCurrencyDecimals(currencyCode);
+            const sanitizedCurrency = sanitizeCurrencyCode(currencyCode);
+            const decimals = getCurrencyDecimals(sanitizedCurrency);
             const convertedAmount = convertToFrontendAmountAsInteger(amountInCents ?? 0, decimals);
-            let currencyWithFallback = currencyCode;
-            if (!currencyCode) {
-                currencyWithFallback = CONST.CURRENCY.USD;
-            }
             return format(preferredLocale, convertedAmount, {
                 style: 'currency',
-                currency: currencyWithFallback,
+                currency: sanitizedCurrency,
 
                 // We are forcing the number of decimals because we override the default number of decimals in the backend for some currencies
                 // See: https://github.com/Expensify/PHP-Libs/pull/834
@@ -56,11 +53,12 @@ function CurrencyListContextProvider({children}: React.PropsWithChildren) {
 
     const convertToDisplayStringWithoutCurrency = useCallback(
         (amountInCents: number, currencyCode: string = CONST.CURRENCY.USD): string => {
-            const decimals = getCurrencyDecimals(currencyCode);
+            const sanitizedCurrency = sanitizeCurrencyCode(currencyCode);
+            const decimals = getCurrencyDecimals(sanitizedCurrency);
             const convertedAmount = convertToFrontendAmountAsInteger(amountInCents, decimals);
             return formatToParts(preferredLocale, convertedAmount, {
                 style: 'currency',
-                currency: currencyCode,
+                currency: sanitizedCurrency,
 
                 // We are forcing the number of decimals because we override the default number of decimals in the backend for some currencies
                 // See: https://github.com/Expensify/PHP-Libs/pull/834

--- a/src/components/Search/SearchChartView.tsx
+++ b/src/components/Search/SearchChartView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import useLocalize from '@hooks/useLocalize';
-import {getCurrencySymbol} from '@libs/CurrencyUtils';
+import {getCurrencySymbol, sanitizeCurrencyCode} from '@libs/CurrencyUtils';
 import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
 import {formatToParts} from '@libs/NumberFormatUtils';
@@ -71,7 +71,7 @@ function SearchChartView({queryJSON, view, groupBy, data, isLoading}: SearchChar
     };
 
     const firstItem = data.at(0);
-    const currency = firstItem?.currency ?? 'USD';
+    const currency = sanitizeCurrencyCode(firstItem?.currency ?? 'USD');
     const parts = formatToParts(preferredLocale, 0, {style: 'currency', currency});
     const currencyIndex = parts.findIndex((p) => p.type === 'currency');
     const integerIndex = parts.findIndex((p) => p.type === 'integer');

--- a/src/components/Search/SearchChartView.tsx
+++ b/src/components/Search/SearchChartView.tsx
@@ -71,7 +71,7 @@ function SearchChartView({queryJSON, view, groupBy, data, isLoading}: SearchChar
     };
 
     const firstItem = data.at(0);
-    const currency = sanitizeCurrencyCode(firstItem?.currency ?? 'USD');
+    const currency = sanitizeCurrencyCode(firstItem?.currency ?? CONST.CURRENCY.USD);
     const parts = formatToParts(preferredLocale, 0, {style: 'currency', currency});
     const currencyIndex = parts.findIndex((p) => p.type === 'currency');
     const integerIndex = parts.findIndex((p) => p.type === 'integer');

--- a/src/components/TransactionItemRow/DataCells/TotalCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/TotalCell.tsx
@@ -8,7 +8,7 @@ import {useCurrencyListActions} from '@hooks/useCurrencyList';
 import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {convertToBackendAmount, convertToFrontendAmountAsString, getCurrencyDecimals} from '@libs/CurrencyUtils';
+import {convertToBackendAmount, convertToFrontendAmountAsString, getCurrencyDecimals, sanitizeCurrencyCode} from '@libs/CurrencyUtils';
 import {formatToParts} from '@libs/NumberFormatUtils';
 import {parseFloatAnyLocale, roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import {getTransactionDetails, isInvoiceReport, shouldEnableNegative} from '@libs/ReportUtils';
@@ -121,10 +121,11 @@ function TotalCell({shouldShowTooltip, transactionItem, canEdit, onSave, report,
     // Some currencies display with a space between symbol and amount (e.g., "CZK 100.00") in convertToDisplayString (in preview).
     // We detect this spacing and apply matching padding to the input to prevent visual flicker when entering edit mode.
     // See: https://github.com/Expensify/App/pull/83127#issuecomment-4240055145
+    const sanitizedCurrency = sanitizeCurrencyCode(currency);
     const hasSymbolSpaceInPreview = formatToParts(preferredLocale, 0, {
         style: 'currency',
-        currency,
-        minimumFractionDigits: getCurrencyDecimals(currency),
+        currency: sanitizedCurrency,
+        minimumFractionDigits: getCurrencyDecimals(sanitizedCurrency),
         maximumFractionDigits: CONST.DEFAULT_CURRENCY_DECIMALS,
     }).some((part) => part.type === 'literal' && part.value.trim() === '');
 

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -32,6 +32,14 @@ function isValidCurrencyCode(currencyCode: unknown): currencyCode is string {
 const warnedInvalidCurrencyCodes = new Set<string>();
 
 /**
+ * Test-only: clears the in-memory de-dup of malformed currency codes so tests asserting on `Log.warn`
+ * are not affected by warnings emitted by earlier tests. Production code should not call this.
+ */
+function resetInvalidCurrencyWarningsForTesting() {
+    warnedInvalidCurrencyCodes.clear();
+}
+
+/**
  * Validates a currency code and returns it unchanged if it is a valid ISO 4217 code.
  * Whitespace and case-only variations (e.g. " usd ") are normalized rather than discarded.
  * Returns CONST.CURRENCY.USD and logs a warning at most once per unique malformed value, to prevent Intl.NumberFormat
@@ -230,6 +238,7 @@ function convertToDisplayStringWithoutCurrency(amountInCents: number, currency: 
 export {
     isValidCurrencyCode,
     sanitizeCurrencyCode,
+    resetInvalidCurrencyWarningsForTesting,
     getCurrencyDecimals,
     getCurrencyUnit,
     getLocalizedCurrencySymbol,

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -1,10 +1,10 @@
 import Onyx from 'react-native-onyx';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
-import Log from '@src/libs/Log';
 import type {OnyxValues} from '@src/ONYXKEYS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Locale} from '@src/types/onyx';
+import Log from './Log';
 import {format, formatToParts} from './NumberFormatUtils';
 
 let currencyList: OnyxValues[typeof ONYXKEYS.CURRENCY_LIST] = {};
@@ -21,12 +21,20 @@ Onyx.connect({
 });
 
 /**
- * Validates a currency code and returns it unchanged if it is a valid ISO 4217 code (exactly 3 uppercase ASCII letters).
+ * Returns true when the provided value is a syntactically valid ISO 4217 currency code
+ * (exactly 3 uppercase ASCII letters).
+ */
+function isValidCurrencyCode(currencyCode: string | undefined | null): currencyCode is string {
+    return typeof currencyCode === 'string' && /^[A-Z]{3}$/.test(currencyCode);
+}
+
+/**
+ * Validates a currency code and returns it unchanged if it is a valid ISO 4217 code.
  * Returns CONST.CURRENCY.USD and logs a warning when the code is malformed or missing, to prevent Intl.NumberFormat
  * from throwing a RangeError. See https://github.com/Expensify/App/issues/91113
  */
 function sanitizeCurrencyCode(currencyCode: string): string {
-    if (/^[A-Z]{3}$/.test(currencyCode)) {
+    if (isValidCurrencyCode(currencyCode)) {
         return currencyCode;
     }
     Log.warn('CurrencyUtils: invalid currency code, defaulting to USD', {currencyCode});
@@ -209,6 +217,7 @@ function convertToDisplayStringWithoutCurrency(amountInCents: number, currency: 
 }
 
 export {
+    isValidCurrencyCode,
     sanitizeCurrencyCode,
     getCurrencyDecimals,
     getCurrencyUnit,

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -1,6 +1,7 @@
 import Onyx from 'react-native-onyx';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
+import Log from '@src/libs/Log';
 import type {OnyxValues} from '@src/ONYXKEYS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Locale} from '@src/types/onyx';
@@ -18,6 +19,19 @@ Onyx.connect({
         currencyList = val;
     },
 });
+
+/**
+ * Validates a currency code and returns it unchanged if it is a valid ISO 4217 code (exactly 3 uppercase ASCII letters).
+ * Returns CONST.CURRENCY.USD and logs a warning when the code is malformed or missing, to prevent Intl.NumberFormat
+ * from throwing a RangeError. See https://github.com/Expensify/App/issues/91113
+ */
+function sanitizeCurrencyCode(currencyCode: string): string {
+    if (/^[A-Z]{3}$/.test(currencyCode)) {
+        return currencyCode;
+    }
+    Log.warn('CurrencyUtils: invalid currency code, defaulting to USD', {currencyCode});
+    return CONST.CURRENCY.USD;
+}
 
 /**
  * Returns the number of digits after the decimal separator for a specific currency.
@@ -47,7 +61,7 @@ function getCurrencyUnit(currency: string = CONST.CURRENCY.USD): number {
 function getLocalizedCurrencySymbol(locale: Locale | undefined, currencyCode: string): string | undefined {
     const parts = formatToParts(locale, 0, {
         style: 'currency',
-        currency: currencyCode,
+        currency: sanitizeCurrencyCode(currencyCode),
     });
     return parts.find((part) => part.type === 'currency')?.value;
 }
@@ -97,15 +111,9 @@ function convertToFrontendAmountAsString(amountAsInt: number | null | undefined,
  * @param currency - IOU currency
  */
 function convertToDisplayString(amountInCents = 0, currency: string = CONST.CURRENCY.USD, shouldUseLocalCurrencySymbol = false): string {
-    const decimals = getCurrencyDecimals(currency);
+    const currencyWithFallback = sanitizeCurrencyCode(currency);
+    const decimals = getCurrencyDecimals(currencyWithFallback);
     const convertedAmount = convertToFrontendAmountAsInteger(amountInCents, decimals);
-    /**
-     * Fallback currency to USD if it empty string or undefined
-     */
-    let currencyWithFallback = currency;
-    if (!currency) {
-        currencyWithFallback = CONST.CURRENCY.USD;
-    }
 
     if (shouldUseLocalCurrencySymbol) {
         const currencySymbol = getCurrencySymbol(currencyWithFallback);
@@ -153,7 +161,7 @@ function convertToShortDisplayString(amountInCents = 0, currency: string = CONST
 
     return format(IntlStore.getCurrentLocale(), convertedAmount, {
         style: 'currency',
-        currency,
+        currency: sanitizeCurrencyCode(currency),
 
         // There will be no decimals displayed (e.g. $9)
         minimumFractionDigits: 0,
@@ -171,7 +179,7 @@ function convertAmountToDisplayString(amount = 0, currency: string = CONST.CURRE
     const convertedAmount = amount / 100.0;
     return format(IntlStore.getCurrentLocale(), convertedAmount, {
         style: 'currency',
-        currency,
+        currency: sanitizeCurrencyCode(currency),
         minimumFractionDigits: CONST.MIN_TAX_RATE_DECIMAL_PLACES,
         maximumFractionDigits: CONST.MAX_TAX_RATE_DECIMAL_PLACES,
     });
@@ -181,11 +189,12 @@ function convertAmountToDisplayString(amount = 0, currency: string = CONST.CURRE
  * Acts the same as `convertAmountToDisplayString` but the result string does not contain currency
  */
 function convertToDisplayStringWithoutCurrency(amountInCents: number, currency: string = CONST.CURRENCY.USD) {
-    const decimals = getCurrencyDecimals(currency);
+    const sanitizedCurrency = sanitizeCurrencyCode(currency);
+    const decimals = getCurrencyDecimals(sanitizedCurrency);
     const convertedAmount = convertToFrontendAmountAsInteger(amountInCents, decimals);
     return formatToParts(IntlStore.getCurrentLocale(), convertedAmount, {
         style: 'currency',
-        currency,
+        currency: sanitizedCurrency,
 
         // We are forcing the number of decimals because we override the default number of decimals in the backend for some currencies
         // See: https://github.com/Expensify/PHP-Libs/pull/834
@@ -200,6 +209,7 @@ function convertToDisplayStringWithoutCurrency(amountInCents: number, currency: 
 }
 
 export {
+    sanitizeCurrencyCode,
     getCurrencyDecimals,
     getCurrencyUnit,
     getLocalizedCurrencySymbol,

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -24,20 +24,31 @@ Onyx.connect({
  * Returns true when the provided value is a syntactically valid ISO 4217 currency code
  * (exactly 3 uppercase ASCII letters).
  */
-function isValidCurrencyCode(currencyCode: string | undefined | null): currencyCode is string {
+function isValidCurrencyCode(currencyCode: unknown): currencyCode is string {
     return typeof currencyCode === 'string' && /^[A-Z]{3}$/.test(currencyCode);
 }
 
+// Tracks invalid currency codes already warned about so the same bad value doesn't spam the log on every render.
+const warnedInvalidCurrencyCodes = new Set<string>();
+
 /**
  * Validates a currency code and returns it unchanged if it is a valid ISO 4217 code.
- * Returns CONST.CURRENCY.USD and logs a warning when the code is malformed or missing, to prevent Intl.NumberFormat
+ * Whitespace and case-only variations (e.g. " usd ") are normalized rather than discarded.
+ * Returns CONST.CURRENCY.USD and logs a warning at most once per unique malformed value, to prevent Intl.NumberFormat
  * from throwing a RangeError. See https://github.com/Expensify/App/issues/91113
  */
-function sanitizeCurrencyCode(currencyCode: string): string {
+function sanitizeCurrencyCode(currencyCode: unknown): string {
     if (isValidCurrencyCode(currencyCode)) {
         return currencyCode;
     }
-    Log.warn('CurrencyUtils: invalid currency code, defaulting to USD', {currencyCode});
+    const normalized = typeof currencyCode === 'string' ? currencyCode.trim().toUpperCase() : '';
+    if (isValidCurrencyCode(normalized)) {
+        return normalized;
+    }
+    if (!warnedInvalidCurrencyCodes.has(normalized)) {
+        warnedInvalidCurrencyCodes.add(normalized);
+        Log.warn('CurrencyUtils: invalid currency code, defaulting to USD', {currencyCode});
+    }
     return CONST.CURRENCY.USD;
 }
 

--- a/src/libs/Formula.ts
+++ b/src/libs/Formula.ts
@@ -4,7 +4,7 @@ import type {ValueOf} from 'type-fest';
 import CONST from '@src/CONST';
 import type {PersonalDetails, Policy, PolicyReportField, Report, Transaction} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
-import {convertToDisplayString, convertToDisplayStringWithoutCurrency} from './CurrencyUtils';
+import {convertToDisplayString, convertToDisplayStringWithoutCurrency, isValidCurrencyCode} from './CurrencyUtils';
 import formatDate from './FormulaDatetime';
 import getBase62ReportID from './getBase62ReportID';
 import Log from './Log';
@@ -580,10 +580,19 @@ function formatAmount(amount: number | undefined, currency: string | undefined, 
                 return null;
             }
 
+            // Return empty string for an unrecognized display currency so the placeholder is preserved upstream.
+            if (!isValidCurrencyCode(trimmedDisplayCurrency)) {
+                return '';
+            }
+
             return convertToDisplayString(absoluteAmount, trimmedDisplayCurrency);
         }
 
         if (currency) {
+            // Return empty string for an unrecognized source currency so the placeholder is preserved upstream.
+            if (!isValidCurrencyCode(currency)) {
+                return '';
+            }
             return convertToDisplayString(absoluteAmount, currency, true);
         }
 

--- a/src/libs/Formula.ts
+++ b/src/libs/Formula.ts
@@ -567,16 +567,17 @@ function formatAmount(amount: number | undefined, currency: string | undefined, 
     const absoluteAmount = Math.abs(amount);
 
     try {
+        const trimmedCurrency = currency?.trim().toUpperCase();
         const trimmedDisplayCurrency = displayCurrency?.trim().toUpperCase();
         if (trimmedDisplayCurrency) {
             if (trimmedDisplayCurrency === 'NOSYMBOL') {
-                return convertToDisplayStringWithoutCurrency(absoluteAmount, currency);
+                return convertToDisplayStringWithoutCurrency(absoluteAmount, trimmedCurrency);
             }
 
             // If a currency conversion is needed (displayCurrency differs from the source),
             // return null so the backend can compute it.
             // We can only compute the value optimistically when the amount is 0.
-            if (absoluteAmount !== 0 && currency !== trimmedDisplayCurrency) {
+            if (absoluteAmount !== 0 && trimmedCurrency !== trimmedDisplayCurrency) {
                 return null;
             }
 
@@ -588,12 +589,12 @@ function formatAmount(amount: number | undefined, currency: string | undefined, 
             return convertToDisplayString(absoluteAmount, trimmedDisplayCurrency);
         }
 
-        if (currency) {
+        if (trimmedCurrency) {
             // Return empty string for an unrecognized source currency so the placeholder is preserved upstream.
-            if (!isValidCurrencyCode(currency)) {
+            if (!isValidCurrencyCode(trimmedCurrency)) {
                 return '';
             }
-            return convertToDisplayString(absoluteAmount, currency, true);
+            return convertToDisplayString(absoluteAmount, trimmedCurrency, true);
         }
 
         return convertToDisplayStringWithoutCurrency(absoluteAmount, currency);

--- a/src/libs/NumberFormatUtils/index.ts
+++ b/src/libs/NumberFormatUtils/index.ts
@@ -1,7 +1,7 @@
 import intlPolyfill from '@libs/IntlPolyfill';
+import Log from '@libs/Log';
 import memoize from '@libs/memoize';
 import CONST from '@src/CONST';
-import Log from '@src/libs/Log';
 import type Locale from '@src/types/onyx/Locale';
 
 // Polyfill the Intl API if locale data is not as expected

--- a/src/libs/NumberFormatUtils/index.ts
+++ b/src/libs/NumberFormatUtils/index.ts
@@ -9,30 +9,29 @@ intlPolyfill();
 
 const MemoizedNumberFormat = memoize(Intl.NumberFormat, {maxSize: 10, monitoringName: 'NumberFormatUtils'});
 
-function format(locale: Locale | undefined, number: number, options?: Intl.NumberFormatOptions): string {
+/**
+ * Build an Intl.NumberFormat with a USD fallback for malformed currency codes.
+ * Intl throws RangeError for empty/malformed currency values; check presence of the option (not truthiness)
+ * so we still recover when currency is '' rather than rethrowing and crashing the screen.
+ */
+function createFormatter(locale: Locale | undefined, options?: Intl.NumberFormatOptions): Intl.NumberFormat {
     try {
-        return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).format(number);
+        return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options);
     } catch (e) {
-        // Intl throws RangeError for empty/malformed currency values; check presence of the option (not truthiness)
-        // so we still recover when currency is '' rather than rethrowing and crashing the screen.
         if (e instanceof RangeError && options && 'currency' in options) {
             Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
-            return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD}).format(number);
+            return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD});
         }
         throw e;
     }
 }
 
+function format(locale: Locale | undefined, number: number, options?: Intl.NumberFormatOptions): string {
+    return createFormatter(locale, options).format(number);
+}
+
 function formatToParts(locale: Locale | undefined, number: number, options?: Intl.NumberFormatOptions): Intl.NumberFormatPart[] {
-    try {
-        return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).formatToParts(number);
-    } catch (e) {
-        if (e instanceof RangeError && options && 'currency' in options) {
-            Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
-            return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD}).formatToParts(number);
-        }
-        throw e;
-    }
+    return createFormatter(locale, options).formatToParts(number);
 }
 
 export {format, formatToParts};

--- a/src/libs/NumberFormatUtils/index.ts
+++ b/src/libs/NumberFormatUtils/index.ts
@@ -13,7 +13,9 @@ function format(locale: Locale | undefined, number: number, options?: Intl.Numbe
     try {
         return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).format(number);
     } catch (e) {
-        if (e instanceof RangeError && options?.currency) {
+        // Intl throws RangeError for empty/malformed currency values; check presence of the option (not truthiness)
+        // so we still recover when currency is '' rather than rethrowing and crashing the screen.
+        if (e instanceof RangeError && options && 'currency' in options) {
             Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
             return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD}).format(number);
         }
@@ -25,7 +27,7 @@ function formatToParts(locale: Locale | undefined, number: number, options?: Int
     try {
         return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).formatToParts(number);
     } catch (e) {
-        if (e instanceof RangeError && options?.currency) {
+        if (e instanceof RangeError && options && 'currency' in options) {
             Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
             return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD}).formatToParts(number);
         }

--- a/src/libs/NumberFormatUtils/index.ts
+++ b/src/libs/NumberFormatUtils/index.ts
@@ -9,17 +9,26 @@ intlPolyfill();
 
 const MemoizedNumberFormat = memoize(Intl.NumberFormat, {maxSize: 10, monitoringName: 'NumberFormatUtils'});
 
+// Tracks malformed currency codes that have already produced a warning in this module, so the
+// safety-net log doesn't fire on every render for the same bad value.
+const warnedMalformedCurrencies = new Set<string>();
+
 /**
- * Build an Intl.NumberFormat with a USD fallback for malformed currency codes.
- * Intl throws RangeError for empty/malformed currency values; check presence of the option (not truthiness)
- * so we still recover when currency is '' rather than rethrowing and crashing the screen.
+ * Build an Intl.NumberFormat. If construction throws a RangeError due to a malformed currency
+ * code (Intl rejects empty strings and non-ISO-4217 codes), fall back to USD instead of letting
+ * the error crash the screen. We check `'currency' in options` rather than `options.currency`
+ * truthiness so an empty-string currency still triggers the fallback.
  */
 function createFormatter(locale: Locale | undefined, options?: Intl.NumberFormatOptions): Intl.NumberFormat {
     try {
         return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options);
     } catch (e) {
         if (e instanceof RangeError && options && 'currency' in options) {
-            Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
+            const currency = String(options.currency ?? '');
+            if (!warnedMalformedCurrencies.has(currency)) {
+                warnedMalformedCurrencies.add(currency);
+                Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
+            }
             return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD});
         }
         throw e;
@@ -34,4 +43,11 @@ function formatToParts(locale: Locale | undefined, number: number, options?: Int
     return createFormatter(locale, options).formatToParts(number);
 }
 
-export {format, formatToParts};
+/**
+ * Test-only: clears the malformed-currency deduplication so warn-assertion tests don't pollute each other.
+ */
+function resetMalformedCurrenciesForTesting() {
+    warnedMalformedCurrencies.clear();
+}
+
+export {format, formatToParts, resetMalformedCurrenciesForTesting};

--- a/src/libs/NumberFormatUtils/index.ts
+++ b/src/libs/NumberFormatUtils/index.ts
@@ -1,6 +1,7 @@
 import intlPolyfill from '@libs/IntlPolyfill';
 import memoize from '@libs/memoize';
 import CONST from '@src/CONST';
+import Log from '@src/libs/Log';
 import type Locale from '@src/types/onyx/Locale';
 
 // Polyfill the Intl API if locale data is not as expected
@@ -9,11 +10,27 @@ intlPolyfill();
 const MemoizedNumberFormat = memoize(Intl.NumberFormat, {maxSize: 10, monitoringName: 'NumberFormatUtils'});
 
 function format(locale: Locale | undefined, number: number, options?: Intl.NumberFormatOptions): string {
-    return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).format(number);
+    try {
+        return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).format(number);
+    } catch (e) {
+        if (e instanceof RangeError && options?.currency) {
+            Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
+            return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD}).format(number);
+        }
+        throw e;
+    }
 }
 
 function formatToParts(locale: Locale | undefined, number: number, options?: Intl.NumberFormatOptions): Intl.NumberFormatPart[] {
-    return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).formatToParts(number);
+    try {
+        return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, options).formatToParts(number);
+    } catch (e) {
+        if (e instanceof RangeError && options?.currency) {
+            Log.warn('NumberFormatUtils: malformed currency code, falling back to USD', {currency: options.currency});
+            return new MemoizedNumberFormat(locale ?? CONST.LOCALES.DEFAULT, {...options, currency: CONST.CURRENCY.USD}).formatToParts(number);
+        }
+        throw e;
+    }
 }
 
 export {format, formatToParts};

--- a/tests/unit/CurrencyUtilsTest.ts
+++ b/tests/unit/CurrencyUtilsTest.ts
@@ -214,6 +214,10 @@ describe('CurrencyUtils', () => {
     });
 
     describe('sanitizeCurrencyCode', () => {
+        beforeEach(() => {
+            CurrencyUtils.resetInvalidCurrencyWarningsForTesting();
+        });
+
         test('returns the input unchanged for a valid ISO 4217 code', () => {
             expect(CurrencyUtils.sanitizeCurrencyCode('EUR')).toBe('EUR');
         });
@@ -240,13 +244,12 @@ describe('CurrencyUtils', () => {
         test('logs a warning at most once per unique malformed value', () => {
             const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => undefined);
             try {
-                // Use unique fixtures so other tests don't already mark these as warned.
-                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_A');
-                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_A');
-                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_A');
+                CurrencyUtils.sanitizeCurrencyCode('XX');
+                CurrencyUtils.sanitizeCurrencyCode('XX');
+                CurrencyUtils.sanitizeCurrencyCode('XX');
                 expect(warnSpy).toHaveBeenCalledTimes(1);
 
-                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_B');
+                CurrencyUtils.sanitizeCurrencyCode('???');
                 expect(warnSpy).toHaveBeenCalledTimes(2);
             } finally {
                 warnSpy.mockRestore();
@@ -258,6 +261,18 @@ describe('CurrencyUtils', () => {
             try {
                 expect(CurrencyUtils.sanitizeCurrencyCode(' eur ')).toBe('EUR');
                 expect(warnSpy).not.toHaveBeenCalled();
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('shares the throttle across helpers that go through sanitizeCurrencyCode', () => {
+            const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => undefined);
+            try {
+                CurrencyUtils.convertToDisplayString(2500, 'XX');
+                CurrencyUtils.getLocalizedCurrencySymbol(CONST.LOCALES.EN, 'XX');
+                CurrencyUtils.convertToShortDisplayString(2500, 'XX');
+                expect(warnSpy).toHaveBeenCalledTimes(1);
             } finally {
                 warnSpy.mockRestore();
             }
@@ -305,6 +320,19 @@ describe('CurrencyUtils', () => {
             expect(() => CurrencyUtils.convertToDisplayStringWithoutCurrency(2500, input)).not.toThrow();
             // Output should not contain a currency symbol but should contain the numeric portion.
             const result = CurrencyUtils.convertToDisplayStringWithoutCurrency(2500, input);
+            expect(result).not.toMatch(/\$/);
+            expect(result).toContain('25');
+        });
+    });
+
+    describe('convertToDisplayStringWithExplicitCurrency with malformed currency', () => {
+        test.each(['XX', 'USDD', '???'])('does not throw and falls back to USD formatting for truthy malformed %p', (input) => {
+            expect(() => CurrencyUtils.convertToDisplayStringWithExplicitCurrency(2500, input)).not.toThrow();
+            expect(CurrencyUtils.convertToDisplayStringWithExplicitCurrency(2500, input)).toBe('$25.00');
+        });
+
+        test.each([undefined, ''])('returns the symbol-less form for falsy currency %p (delegates to convertToDisplayStringWithoutCurrency)', (input) => {
+            const result = CurrencyUtils.convertToDisplayStringWithExplicitCurrency(2500, input);
             expect(result).not.toMatch(/\$/);
             expect(result).toContain('25');
         });

--- a/tests/unit/CurrencyUtilsTest.ts
+++ b/tests/unit/CurrencyUtilsTest.ts
@@ -2,6 +2,7 @@ import Onyx from 'react-native-onyx';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import * as CurrencyUtils from '@src/libs/CurrencyUtils';
+import Log from '@src/libs/Log';
 import ONYXKEYS from '@src/ONYXKEYS';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 // This file can get outdated. In that case, you can follow these steps to update it:
@@ -203,6 +204,10 @@ describe('CurrencyUtils', () => {
             ['US1', false],
             [undefined, false],
             [null, false],
+            [42, false],
+            [{}, false],
+            [[], false],
+            [true, false],
         ])('isValidCurrencyCode(%p) → %p', (input, expected) => {
             expect(CurrencyUtils.isValidCurrencyCode(input)).toBe(expected);
         });
@@ -213,13 +218,49 @@ describe('CurrencyUtils', () => {
             expect(CurrencyUtils.sanitizeCurrencyCode('EUR')).toBe('EUR');
         });
 
-        test('normalizes whitespace and case before validating', () => {
-            expect(CurrencyUtils.sanitizeCurrencyCode(' usd ')).toBe('USD');
-            expect(CurrencyUtils.sanitizeCurrencyCode('eur')).toBe('EUR');
+        test.each([
+            [' usd ', 'USD'],
+            ['eur', 'EUR'],
+            ['UsD', 'USD'],
+            ['\tEUR', 'EUR'],
+            ['JPY\n', 'JPY'],
+            ['  GBP  ', 'GBP'],
+        ])('normalizes whitespace and case: %p → %p', (input, expected) => {
+            expect(CurrencyUtils.sanitizeCurrencyCode(input)).toBe(expected);
         });
 
-        test.each(['', 'XX', 'USDD', 'US1', '???'])('falls back to USD for malformed input %p', (input) => {
+        test.each(['', 'XX', 'USDD', 'US1', '???', 'us-d', 'U S D'])('falls back to USD for malformed string %p', (input) => {
             expect(CurrencyUtils.sanitizeCurrencyCode(input)).toBe(CONST.CURRENCY.USD);
+        });
+
+        test.each([undefined, null, 42, true, {}, []])('falls back to USD for non-string input %p', (input) => {
+            expect(CurrencyUtils.sanitizeCurrencyCode(input)).toBe(CONST.CURRENCY.USD);
+        });
+
+        test('logs a warning at most once per unique malformed value', () => {
+            const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => undefined);
+            try {
+                // Use unique fixtures so other tests don't already mark these as warned.
+                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_A');
+                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_A');
+                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_A');
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+
+                CurrencyUtils.sanitizeCurrencyCode('TEST_THROTTLE_B');
+                expect(warnSpy).toHaveBeenCalledTimes(2);
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('does not log a warning when normalization recovers a valid code', () => {
+            const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => undefined);
+            try {
+                expect(CurrencyUtils.sanitizeCurrencyCode(' eur ')).toBe('EUR');
+                expect(warnSpy).not.toHaveBeenCalled();
+            } finally {
+                warnSpy.mockRestore();
+            }
         });
     });
 
@@ -231,6 +272,41 @@ describe('CurrencyUtils', () => {
 
         test('normalizes case-only variations to the intended currency instead of USD', () => {
             expect(CurrencyUtils.convertToDisplayString(2500, 'eur')).toBe(CurrencyUtils.convertToDisplayString(2500, 'EUR'));
+        });
+
+        test('falls back to USD when shouldUseLocalCurrencySymbol is true and currency is malformed', () => {
+            expect(() => CurrencyUtils.convertToDisplayString(2500, 'invalid', true)).not.toThrow();
+            // USD has a known local symbol in the currencyList, so the local-symbol branch should produce a $-prefixed result.
+            expect(CurrencyUtils.convertToDisplayString(2500, 'invalid', true)).toMatch(/\$/);
+        });
+
+        test('handles undefined currency via the default parameter', () => {
+            expect(CurrencyUtils.convertToDisplayString(2500, undefined)).toBe('$25.00');
+        });
+    });
+
+    describe('convertToShortDisplayString with malformed currency', () => {
+        test.each(['', 'XX', 'USDD', '???'])('does not throw and falls back to USD formatting for %p', (input) => {
+            expect(() => CurrencyUtils.convertToShortDisplayString(2500, input)).not.toThrow();
+            expect(CurrencyUtils.convertToShortDisplayString(2500, input)).toBe('$25');
+        });
+    });
+
+    describe('convertAmountToDisplayString with malformed currency', () => {
+        test.each(['', 'XX', 'USDD', '???'])('does not throw and falls back to USD formatting for %p', (input) => {
+            expect(() => CurrencyUtils.convertAmountToDisplayString(2500, input)).not.toThrow();
+            // The result should at least include a $ symbol from the USD fallback.
+            expect(CurrencyUtils.convertAmountToDisplayString(2500, input)).toMatch(/\$/);
+        });
+    });
+
+    describe('convertToDisplayStringWithoutCurrency with malformed currency', () => {
+        test.each(['', 'XX', 'USDD', '???'])('does not throw and produces a numeric output for %p', (input) => {
+            expect(() => CurrencyUtils.convertToDisplayStringWithoutCurrency(2500, input)).not.toThrow();
+            // Output should not contain a currency symbol but should contain the numeric portion.
+            const result = CurrencyUtils.convertToDisplayStringWithoutCurrency(2500, input);
+            expect(result).not.toMatch(/\$/);
+            expect(result).toContain('25');
         });
     });
 

--- a/tests/unit/CurrencyUtilsTest.ts
+++ b/tests/unit/CurrencyUtilsTest.ts
@@ -189,4 +189,55 @@ describe('CurrencyUtils', () => {
             IntlStore.load(CONST.LOCALES.ES).then(() => expect(CurrencyUtils.convertToShortDisplayString(amount, currency)).toBe(expectedResult)),
         );
     });
+
+    describe('isValidCurrencyCode', () => {
+        test.each([
+            ['USD', true],
+            ['EUR', true],
+            ['JPY', true],
+            ['', false],
+            ['eur', false],
+            [' USD', false],
+            ['US', false],
+            ['USDX', false],
+            ['US1', false],
+            [undefined, false],
+            [null, false],
+        ])('isValidCurrencyCode(%p) → %p', (input, expected) => {
+            expect(CurrencyUtils.isValidCurrencyCode(input)).toBe(expected);
+        });
+    });
+
+    describe('sanitizeCurrencyCode', () => {
+        test('returns the input unchanged for a valid ISO 4217 code', () => {
+            expect(CurrencyUtils.sanitizeCurrencyCode('EUR')).toBe('EUR');
+        });
+
+        test('normalizes whitespace and case before validating', () => {
+            expect(CurrencyUtils.sanitizeCurrencyCode(' usd ')).toBe('USD');
+            expect(CurrencyUtils.sanitizeCurrencyCode('eur')).toBe('EUR');
+        });
+
+        test.each(['', 'XX', 'USDX', 'US1', '???'])('falls back to USD for malformed input %p', (input) => {
+            expect(CurrencyUtils.sanitizeCurrencyCode(input)).toBe(CONST.CURRENCY.USD);
+        });
+    });
+
+    describe('convertToDisplayString with malformed currency', () => {
+        test.each(['', 'XX', 'USDX', '???'])('does not throw and falls back to USD formatting for %p', (input) => {
+            expect(() => CurrencyUtils.convertToDisplayString(2500, input)).not.toThrow();
+            expect(CurrencyUtils.convertToDisplayString(2500, input)).toBe('$25.00');
+        });
+
+        test('normalizes case-only variations to the intended currency instead of USD', () => {
+            expect(CurrencyUtils.convertToDisplayString(2500, 'eur')).toBe(CurrencyUtils.convertToDisplayString(2500, 'EUR'));
+        });
+    });
+
+    describe('getLocalizedCurrencySymbol with malformed currency', () => {
+        test.each(['', 'XX', 'USDX'])('returns the USD symbol without throwing for %p', (input) => {
+            expect(() => CurrencyUtils.getLocalizedCurrencySymbol(CONST.LOCALES.EN, input)).not.toThrow();
+            expect(CurrencyUtils.getLocalizedCurrencySymbol(CONST.LOCALES.EN, input)).toBe(CurrencyUtils.getLocalizedCurrencySymbol(CONST.LOCALES.EN, CONST.CURRENCY.USD));
+        });
+    });
 });

--- a/tests/unit/CurrencyUtilsTest.ts
+++ b/tests/unit/CurrencyUtilsTest.ts
@@ -199,7 +199,7 @@ describe('CurrencyUtils', () => {
             ['eur', false],
             [' USD', false],
             ['US', false],
-            ['USDX', false],
+            ['USDD', false],
             ['US1', false],
             [undefined, false],
             [null, false],
@@ -218,13 +218,13 @@ describe('CurrencyUtils', () => {
             expect(CurrencyUtils.sanitizeCurrencyCode('eur')).toBe('EUR');
         });
 
-        test.each(['', 'XX', 'USDX', 'US1', '???'])('falls back to USD for malformed input %p', (input) => {
+        test.each(['', 'XX', 'USDD', 'US1', '???'])('falls back to USD for malformed input %p', (input) => {
             expect(CurrencyUtils.sanitizeCurrencyCode(input)).toBe(CONST.CURRENCY.USD);
         });
     });
 
     describe('convertToDisplayString with malformed currency', () => {
-        test.each(['', 'XX', 'USDX', '???'])('does not throw and falls back to USD formatting for %p', (input) => {
+        test.each(['', 'XX', 'USDD', '???'])('does not throw and falls back to USD formatting for %p', (input) => {
             expect(() => CurrencyUtils.convertToDisplayString(2500, input)).not.toThrow();
             expect(CurrencyUtils.convertToDisplayString(2500, input)).toBe('$25.00');
         });
@@ -235,7 +235,7 @@ describe('CurrencyUtils', () => {
     });
 
     describe('getLocalizedCurrencySymbol with malformed currency', () => {
-        test.each(['', 'XX', 'USDX'])('returns the USD symbol without throwing for %p', (input) => {
+        test.each(['', 'XX', 'USDD'])('returns the USD symbol without throwing for %p', (input) => {
             expect(() => CurrencyUtils.getLocalizedCurrencySymbol(CONST.LOCALES.EN, input)).not.toThrow();
             expect(CurrencyUtils.getLocalizedCurrencySymbol(CONST.LOCALES.EN, input)).toBe(CurrencyUtils.getLocalizedCurrencySymbol(CONST.LOCALES.EN, CONST.CURRENCY.USD));
         });

--- a/tests/unit/FormulaTest.ts
+++ b/tests/unit/FormulaTest.ts
@@ -503,6 +503,24 @@ describe('CustomFormula', () => {
                     const result = compute('{report:total:UNKNOWN}', currencyContext);
                     expect(result).toBe('{report:total:UNKNOWN}');
                 });
+
+                test('case-only source currency variations - should format like the canonical code', () => {
+                    currencyContext.report.currency = 'eur';
+                    const lowercase = compute('{report:total}', currencyContext);
+                    currencyContext.report.currency = 'EUR';
+                    const canonical = compute('{report:total}', currencyContext);
+                    expect(lowercase).toBe(canonical);
+                    expect(lowercase).not.toBe('{report:total}');
+                });
+
+                test('whitespace source currency variations - should format like the canonical code', () => {
+                    currencyContext.report.currency = '  USD  ';
+                    const padded = compute('{report:total}', currencyContext);
+                    currencyContext.report.currency = 'USD';
+                    const canonical = compute('{report:total}', currencyContext);
+                    expect(padded).toBe(canonical);
+                    expect(padded).not.toBe('{report:total}');
+                });
             });
         });
     });

--- a/tests/unit/NumberFormatUtilsTest.ts
+++ b/tests/unit/NumberFormatUtilsTest.ts
@@ -6,6 +6,7 @@ describe('NumberFormatUtils', () => {
     let warnSpy: jest.SpyInstance;
 
     beforeEach(() => {
+        NumberFormatUtils.resetMalformedCurrenciesForTesting();
         warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => undefined);
     });
 
@@ -80,6 +81,24 @@ describe('NumberFormatUtils', () => {
 
         test('does not swallow RangeErrors when options has no currency key', () => {
             expect(() => NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'unit', unit: 'not-a-real-unit'} as Intl.NumberFormatOptions)).toThrow(RangeError);
+        });
+    });
+
+    describe('malformed-currency warn deduplication', () => {
+        test('warns at most once per unique malformed currency across repeated format calls', () => {
+            NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: 'XX'});
+            NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: 'XX'});
+            NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: 'XX'});
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+
+            NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: '???'});
+            expect(warnSpy).toHaveBeenCalledTimes(2);
+        });
+
+        test('the deduplication is shared between format and formatToParts', () => {
+            NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: 'YY'});
+            NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'currency', currency: 'YY'});
+            expect(warnSpy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/tests/unit/NumberFormatUtilsTest.ts
+++ b/tests/unit/NumberFormatUtilsTest.ts
@@ -1,0 +1,85 @@
+import CONST from '@src/CONST';
+import Log from '@src/libs/Log';
+import * as NumberFormatUtils from '@src/libs/NumberFormatUtils';
+
+describe('NumberFormatUtils', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    describe('format', () => {
+        test('formats a valid currency without entering the fallback path', () => {
+            expect(NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: 'USD'})).toBe('$25.00');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test('formats decimal style without a currency option', () => {
+            expect(NumberFormatUtils.format(CONST.LOCALES.EN, 25.5, {style: 'decimal', minimumFractionDigits: 2})).toBe('25.50');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test.each(['', 'XX', '1USD', 'US-D', '???'])('falls back to USD without throwing for malformed currency %p', (input) => {
+            expect(() => NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: input})).not.toThrow();
+            expect(NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: input})).toBe('$25.00');
+            expect(warnSpy).toHaveBeenCalled();
+        });
+
+        test('explicitly recovers from an empty-string currency (RangeError guard via "in" check)', () => {
+            expect(() => NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: ''})).not.toThrow();
+            expect(NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: ''})).toBe('$25.00');
+        });
+
+        test('passes case-insensitive valid codes through without entering the fallback', () => {
+            // Intl.NumberFormat accepts lowercase ISO 4217 codes natively (it normalizes case),
+            // so no RangeError is thrown and the fallback should not run.
+            expect(NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'currency', currency: 'usd'})).toBe('$25.00');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test('does not swallow RangeErrors when options has no currency key', () => {
+            // An invalid `unit` triggers a RangeError but the fallback only applies when `currency` is in options,
+            // so this should still throw rather than being silently rewritten to USD.
+            expect(() => NumberFormatUtils.format(CONST.LOCALES.EN, 25, {style: 'unit', unit: 'not-a-real-unit'} as Intl.NumberFormatOptions)).toThrow(RangeError);
+        });
+
+        test('does not swallow RangeErrors when options is undefined', () => {
+            expect(NumberFormatUtils.format(CONST.LOCALES.EN, 25)).toBe('25');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test('uses the default locale when locale is undefined', () => {
+            expect(NumberFormatUtils.format(undefined, 25, {style: 'currency', currency: 'USD'})).toBe('$25.00');
+        });
+    });
+
+    describe('formatToParts', () => {
+        test('returns parts for a valid currency without entering the fallback path', () => {
+            const parts = NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'currency', currency: 'USD'});
+            expect(parts.find((part) => part.type === 'currency')?.value).toBe('$');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test.each(['', 'XX', '1USD', 'US-D', '???'])('falls back to USD without throwing for malformed currency %p', (input) => {
+            expect(() => NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'currency', currency: input})).not.toThrow();
+            const parts = NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'currency', currency: input});
+            expect(parts.find((part) => part.type === 'currency')?.value).toBe('$');
+            expect(warnSpy).toHaveBeenCalled();
+        });
+
+        test('explicitly recovers from an empty-string currency (RangeError guard via "in" check)', () => {
+            expect(() => NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'currency', currency: ''})).not.toThrow();
+            const parts = NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'currency', currency: ''});
+            expect(parts.find((part) => part.type === 'currency')?.value).toBe('$');
+        });
+
+        test('does not swallow RangeErrors when options has no currency key', () => {
+            expect(() => NumberFormatUtils.formatToParts(CONST.LOCALES.EN, 0, {style: 'unit', unit: 'not-a-real-unit'} as Intl.NumberFormatOptions)).toThrow(RangeError);
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

When a workspace policy or transaction has an invalid/malformed currency code stored in the backend, `Intl.NumberFormat` throws a `RangeError: Malformed currency code` that crashes the entire expense amount entry screen. This has been occurring since Feb 28, 2026 — 632 occurrences across 210 users (Sentry [APP-6MR](https://expensify.sentry.io/issues/APP-6MR)).

**Crash path:**
```
MoneyRequestAmountInput
  → getLocalizedCurrencySymbol (CurrencyUtils.ts)
    → formatToParts (NumberFormatUtils/index.ts)
      → new Intl.NumberFormat(locale, { style: 'currency', currency: <invalid> })
        → RangeError: Malformed currency code
```

**Two-layer fix:**

1. **`sanitizeCurrencyCode` in `CurrencyUtils.ts`** — validates the currency format (ISO 4217 = exactly 3 uppercase ASCII letters) and returns `CONST.CURRENCY.USD` with a `Log.warn` when invalid. Applied in all functions that pass a currency to `Intl.NumberFormat`: `getLocalizedCurrencySymbol`, `convertToDisplayString`, `convertToDisplayStringWithoutCurrency`, `convertToShortDisplayString`, `convertAmountToDisplayString`.

2. **Try/catch safety net in `NumberFormatUtils/index.ts`** — catches any `RangeError` from `Intl.NumberFormat` with a bad currency option that slips past layer 1, retries with USD, and logs a warning. This protects all current and future callers.

Also sanitized currency in `TotalCell.tsx` before its direct `formatToParts` call.

The backend root cause (malformed currency code stored in a policy or transaction) should be addressed separately.

### Fixed Issues
$ https://github.com/Expensify/App/issues/91113
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

- Supportal to the account of this user https://github.com/Expensify/Expensify/issues/638330 and make sure you can access the spend page just fine

### Offline tests

No offline-specific behavior changed.

### QA Steps

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>