### PR TITLE
Fix internal routing for New Expensify links

### DIFF
--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -149,8 +149,12 @@ function getInternalNewExpensifyPath(href: string) {
     if (!href) {
         return '';
     }
-    const attrPath = Url.getPathFromURL(href);
-    return (Url.hasSameExpensifyOrigin(href, CONST.NEW_EXPENSIFY_URL) || Url.hasSameExpensifyOrigin(href, CONST.STAGING_NEW_EXPENSIFY_URL) || href.startsWith(CONST.DEV_NEW_EXPENSIFY_URL)) &&
+
+    const normalizedHref = href.replace(/^(\/\/)?(?=((?:dev|staging)\.)?new\.expensify\.com(?:[:/]|$))/i, 'https://');
+    const attrPath = Url.getPathFromURL(normalizedHref);
+    return (Url.hasSameExpensifyOrigin(normalizedHref, CONST.NEW_EXPENSIFY_URL) ||
+        Url.hasSameExpensifyOrigin(normalizedHref, CONST.STAGING_NEW_EXPENSIFY_URL) ||
+        normalizedHref.startsWith(CONST.DEV_NEW_EXPENSIFY_URL)) &&
         !CONST.PATHS_TO_TREAT_AS_EXTERNAL.find((path) => attrPath.startsWith(path))
         ? attrPath
         : '';
@@ -171,7 +175,6 @@ function getInternalExpensifyPath(href: string) {
 }
 
 function openLink(href: string, environmentURL: string, isAttachment = false) {
-    const hasSameOrigin = Url.hasSameExpensifyOrigin(href, environmentURL);
     const hasExpensifyOrigin = Url.hasSameExpensifyOrigin(href, CONFIG.EXPENSIFY.EXPENSIFY_URL) || Url.hasSameExpensifyOrigin(href, CONFIG.EXPENSIFY.STAGING_API_ROOT);
     const internalNewExpensifyPath = getInternalNewExpensifyPath(href);
     const internalExpensifyPath = getInternalExpensifyPath(href);
@@ -201,7 +204,7 @@ function openLink(href: string, environmentURL: string, isAttachment = false) {
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
-    if (internalNewExpensifyPath && hasSameOrigin) {
+    if (internalNewExpensifyPath) {
         if (isAnonymousUser() && !canAnonymousUserAccessRoute(internalNewExpensifyPath)) {
             signOutAndRedirectToSignIn();
             return;

--- a/tests/unit/LinkTest.ts
+++ b/tests/unit/LinkTest.ts
@@ -1,0 +1,105 @@
+import Navigation from '@libs/Navigation/Navigation';
+import asyncOpenURL from '@libs/asyncOpenURL';
+import {getInternalNewExpensifyPath, openLink} from '@libs/actions/Link';
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
+
+jest.mock('@react-navigation/native', () => ({
+    findFocusedRoute: jest.fn(),
+}));
+jest.mock('react-native-onyx', () => ({
+    __esModule: true,
+    default: {
+        connectWithoutView: jest.fn(() => 1),
+        disconnect: jest.fn(),
+    },
+}));
+jest.mock('@libs/asyncOpenURL', () => jest.fn());
+jest.mock('@libs/API', () => ({
+    makeRequestWithSideEffects: jest.fn(),
+}));
+jest.mock('@libs/API/types', () => ({
+    READ_COMMANDS: {
+        SEARCH_FOR_REPORTS: 'SearchForReports',
+        SEARCH_FOR_USERS: 'SearchForUsers',
+    },
+    SIDE_EFFECT_REQUEST_COMMANDS: {
+        GENERATE_SPOTNANA_TOKEN: 'GenerateSpotnanaToken',
+        OPEN_OLD_DOT_LINK: 'OpenOldDotLink',
+        RECONNECT_APP: 'ReconnectApp',
+    },
+    WRITE_COMMANDS: {
+        OPEN_APP: 'OpenApp',
+        OPEN_REPORT: 'OpenReport',
+    },
+}));
+jest.mock('@libs/isPublicScreenRoute', () => jest.fn(() => false));
+jest.mock('@libs/getIsNarrowLayout', () => jest.fn(() => true));
+jest.mock('@libs/Navigation/helpers/isNavigatorName', () => ({
+    isOnboardingFlowName: jest.fn(() => false),
+}));
+jest.mock('@libs/Navigation/helpers/shouldOpenOnAdminRoom', () => jest.fn(() => false));
+jest.mock('@libs/Navigation/helpers/willRouteNavigateToRHP', () => jest.fn(() => false));
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    getRootState: jest.fn(() => ({routes: []})),
+}));
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+    closeRHPFlow: jest.fn(),
+}));
+jest.mock('@libs/NetworkState', () => ({
+    getIsOffline: jest.fn(() => false),
+}));
+jest.mock('@libs/actions/Session', () => ({
+    canAnonymousUserAccessRoute: jest.fn(() => true),
+    isAnonymousUser: jest.fn(() => false),
+    signOutAndRedirectToSignIn: jest.fn(),
+    waitForUserSignIn: jest.fn(),
+}));
+jest.mock('@libs/actions/Report', () => ({
+    doneCheckingPublicRoom: jest.fn(),
+    navigateToConciergeChat: jest.fn(),
+    openReport: jest.fn(),
+}));
+jest.mock('@libs/actions/Welcome', () => ({
+    setOnboardingErrorMessage: jest.fn(),
+}));
+jest.mock('@libs/ReportUtils', () => ({
+    findLastAccessedReport: jest.fn(),
+    getReportIDFromLink: jest.fn(() => ''),
+    getRouteFromLink: jest.fn(() => ''),
+}));
+jest.mock('@libs/shouldSkipDeepLinkNavigation', () => jest.fn(() => false));
+jest.mock('@libs/telemetry/activeSpans', () => ({
+    endSpan: jest.fn(),
+    getSpan: jest.fn(),
+    startSpan: jest.fn(),
+}));
+jest.mock('@src/selectors/Onboarding', () => ({
+    hasCompletedGuidedSetupFlowSelector: jest.fn(() => true),
+}));
+
+describe('Link actions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getInternalNewExpensifyPath', () => {
+        it('returns the route path for New Expensify links without a protocol', () => {
+            expect(getInternalNewExpensifyPath('new.expensify.com/settings/wallet')).toBe(ROUTES.SETTINGS_WALLET);
+        });
+
+        it('returns the route path for protocol-relative New Expensify links', () => {
+            expect(getInternalNewExpensifyPath('//new.expensify.com/settings/wallet')).toBe(ROUTES.SETTINGS_WALLET);
+        });
+    });
+
+    describe('openLink', () => {
+        it('navigates New Expensify links internally when the link origin differs from the current environment', () => {
+            openLink(`https://new.expensify.com/${ROUTES.SETTINGS_WALLET}`, CONST.STAGING_NEW_EXPENSIFY_URL);
+
+            expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.SETTINGS_WALLET);
+            expect(asyncOpenURL).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
### Explanation of Change
I updated New Expensify link handling so recognized NewDot links navigate internally even when the link origin differs from the current app environment. I also normalize protocol-less and protocol-relative `new.expensify.com` links before extracting their route path.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90729
PROPOSAL: https://github.com/Expensify/App/issues/90729#issuecomment-4494580397

### Tests
1. Run `node node_modules/jest/bin/jest.js tests/unit/LinkTest.ts --runInBand`
2. Verify `new.expensify.com/settings/wallet` is recognized as `settings/wallet`
3. Verify `//new.expensify.com/settings/wallet` is recognized as `settings/wallet`
4. Verify `https://new.expensify.com/settings/wallet` navigates internally when the current environment URL is staging

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A. This change only changes how New Expensify links are classified and routed locally.

### QA Steps
1. Sign in to the app on iOS native
2. Open a report action/comment that contains a link to `https://new.expensify.com/settings/wallet`
3. Tap the link
4. Verify the app navigates to the Wallet section instead of opening mWeb

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos
N/A. The change is covered by unit tests and affects link routing behavior.