### PR TITLE
Fix per diem submit to return to workspace chat

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -1615,34 +1615,46 @@ const ROUTES = {
         },
     },
     MONEY_REQUEST_STEP_DESTINATION: {
-        route: ':action/:iouType/destination/:transactionID/:reportID',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backTo = '') =>
-            getUrlWithBackToParam(`${action as string}/${iouType as string}/destination/${transactionID}/${reportID}`, backTo),
+        route: ':action/:iouType/destination/:transactionID/:reportID/:backToReport?',
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backToReport?: string, backTo = '') =>
+            getUrlWithBackToParam(
+                `${action as string}/${iouType as string}/destination/${transactionID}/${reportID}${backToReport ? `/${backToReport}` : ''}`,
+                backTo,
+            ),
     },
     MONEY_REQUEST_STEP_TIME: {
-        route: ':action/:iouType/time/:transactionID/:reportID',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backTo = '') =>
-            getUrlWithBackToParam(`${action as string}/${iouType as string}/time/${transactionID}/${reportID}`, backTo),
+        route: ':action/:iouType/time/:transactionID/:reportID/:backToReport?',
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backToReport?: string, backTo = '') =>
+            getUrlWithBackToParam(`${action as string}/${iouType as string}/time/${transactionID}/${reportID}${backToReport ? `/${backToReport}` : ''}`, backTo),
     },
     MONEY_REQUEST_STEP_SUBRATE: {
-        route: ':action/:iouType/subrate/:transactionID/:reportID/:pageIndex',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backTo = '') =>
-            getUrlWithBackToParam(`${action as string}/${iouType as string}/subrate/${transactionID}/${reportID}/0`, backTo),
+        route: ':action/:iouType/subrate/:transactionID/:reportID/:pageIndex/:backToReport?',
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backToReport?: string, backTo = '') =>
+            getUrlWithBackToParam(
+                `${action as string}/${iouType as string}/subrate/${transactionID}/${reportID}/0${backToReport ? `/${backToReport}` : ''}`,
+                backTo,
+            ),
     },
     MONEY_REQUEST_STEP_DESTINATION_EDIT: {
-        route: ':action/:iouType/destination/:transactionID/:reportID/edit',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backTo = '') =>
-            getUrlWithBackToParam(`${action as string}/${iouType as string}/destination/${transactionID}/${reportID}/edit`, backTo),
+        route: ':action/:iouType/destination/:transactionID/:reportID/edit/:backToReport?',
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backToReport?: string, backTo = '') =>
+            getUrlWithBackToParam(
+                `${action as string}/${iouType as string}/destination/${transactionID}/${reportID}/edit${backToReport ? `/${backToReport}` : ''}`,
+                backTo,
+            ),
     },
     MONEY_REQUEST_STEP_TIME_EDIT: {
-        route: ':action/:iouType/time/:transactionID/:reportID/edit',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backTo = '') =>
-            getUrlWithBackToParam(`${action as string}/${iouType as string}/time/${transactionID}/${reportID}/edit`, backTo),
+        route: ':action/:iouType/time/:transactionID/:reportID/edit/:backToReport?',
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backToReport?: string, backTo = '') =>
+            getUrlWithBackToParam(`${action as string}/${iouType as string}/time/${transactionID}/${reportID}/edit${backToReport ? `/${backToReport}` : ''}`, backTo),
     },
     MONEY_REQUEST_STEP_SUBRATE_EDIT: {
-        route: ':action/:iouType/subrate/:transactionID/:reportID/edit/:pageIndex',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, pageIndex = 0, backTo = '') =>
-            getUrlWithBackToParam(`${action as string}/${iouType as string}/subrate/${transactionID}/${reportID}/edit/${pageIndex}`, backTo),
+        route: ':action/:iouType/subrate/:transactionID/:reportID/edit/:pageIndex/:backToReport?',
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, pageIndex = 0, backToReport?: string, backTo = '') =>
+            getUrlWithBackToParam(
+                `${action as string}/${iouType as string}/subrate/${transactionID}/${reportID}/edit/${pageIndex}${backToReport ? `/${backToReport}` : ''}`,
+                backTo,
+            ),
     },
     MONEY_REQUEST_STEP_REPORT: {
         route: ':action/:iouType/report/:transactionID/:reportID/:reportActionID?',

--- a/src/components/MoneyRequestConfirmationList/sections/PerDiemFields.tsx
+++ b/src/components/MoneyRequestConfirmationList/sections/PerDiemFields.tsx
@@ -47,7 +47,7 @@ function PerDiemFields({perDiemCustomUnit, transaction, isReadOnly, didConfirm, 
                 if (!transactionID) {
                     return;
                 }
-                Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_SUBRATE_EDIT.getRoute(action, iouType, transactionID, reportID, index, Navigation.getActiveRoute()));
+                Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_SUBRATE_EDIT.getRoute(action, iouType, transactionID, reportID, index, undefined, Navigation.getActiveRoute()));
             }}
             disabled={didConfirm}
             interactive={!isReadOnly}
@@ -103,7 +103,7 @@ function PerDiemFields({perDiemCustomUnit, transaction, isReadOnly, didConfirm, 
                     if (!transactionID) {
                         return;
                     }
-                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_DESTINATION_EDIT.getRoute(action, iouType, transactionID, reportID, Navigation.getActiveRoute()));
+                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_DESTINATION_EDIT.getRoute(action, iouType, transactionID, reportID, undefined, Navigation.getActiveRoute()));
                 }}
                 disabled={didConfirm}
                 interactive={!isReadOnly}

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -2142,6 +2142,7 @@ type MoneyRequestNavigatorParamList = {
         iouType: Exclude<IOUType, typeof CONST.IOU.TYPE.REQUEST | typeof CONST.IOU.TYPE.SEND>;
         transactionID: string;
         reportID: string;
+        backToReport?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes | undefined;
     };
@@ -2150,12 +2151,14 @@ type MoneyRequestNavigatorParamList = {
         iouType: Exclude<IOUType, typeof CONST.IOU.TYPE.REQUEST | typeof CONST.IOU.TYPE.SEND>;
         transactionID: string;
         reportID: string;
+        backToReport?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes | undefined;
     };
     [SCREENS.MONEY_REQUEST.STEP_SUBRATE]: {
         iouType: Exclude<IOUType, typeof CONST.IOU.TYPE.REQUEST | typeof CONST.IOU.TYPE.SEND>;
         reportID: string;
+        backToReport?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes | undefined;
         action: IOUAction;
@@ -2167,6 +2170,7 @@ type MoneyRequestNavigatorParamList = {
         iouType: Exclude<IOUType, typeof CONST.IOU.TYPE.REQUEST | typeof CONST.IOU.TYPE.SEND>;
         transactionID: string;
         reportID: string;
+        backToReport?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes | undefined;
     };
@@ -2175,12 +2179,14 @@ type MoneyRequestNavigatorParamList = {
         iouType: Exclude<IOUType, typeof CONST.IOU.TYPE.REQUEST | typeof CONST.IOU.TYPE.SEND>;
         transactionID: string;
         reportID: string;
+        backToReport?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes | undefined;
     };
     [SCREENS.MONEY_REQUEST.STEP_SUBRATE_EDIT]: {
         iouType: Exclude<IOUType, typeof CONST.IOU.TYPE.REQUEST | typeof CONST.IOU.TYPE.SEND>;
         reportID: string;
+        backToReport?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes | undefined;
         action: IOUAction;

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -580,7 +580,7 @@ function IOURequestStepConfirmation({
                 Navigation.goBack();
                 return;
             }
-            Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_SUBRATE.getRoute(action, iouType, initialTransactionID, reportID));
+            Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_SUBRATE.getRoute(action, iouType, initialTransactionID, reportID, backToReport));
             return;
         }
 

--- a/src/pages/iou/request/step/IOURequestStepDestination.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDestination.tsx
@@ -65,7 +65,7 @@ type IOURequestStepDestinationProps = WithWritableReportOrNotFoundProps<typeof S
 function IOURequestStepDestination({
     report,
     route: {
-        params: {transactionID, backTo, action, iouType, reportID},
+        params: {transactionID, backTo, action, iouType, reportID, backToReport},
     },
     transaction,
     openedFromStartPage = false,
@@ -150,7 +150,7 @@ function IOURequestStepDestination({
         if (backTo) {
             navigateBack();
         } else {
-            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, targetIouType, transactionID, targetReport?.reportID ?? reportID));
+            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, targetIouType, transactionID, targetReport?.reportID ?? reportID, backToReport));
         }
     };
 

--- a/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
+++ b/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
@@ -21,7 +21,7 @@ type IOURequestStepPerDiemWorkspaceProps = WithFullTransactionOrNotFoundProps<ty
 
 function IOURequestStepPerDiemWorkspace({route, navigation, transaction}: IOURequestStepPerDiemWorkspaceProps) {
     const {
-        params: {action, iouType, transactionID},
+        params: {action, iouType, transactionID, backToReport},
     } = route;
     const {accountID} = useCurrentUserPersonalDetails();
     const [selfDMReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${findSelfDMReportID()}`);
@@ -68,7 +68,7 @@ function IOURequestStepPerDiemWorkspace({route, navigation, transaction}: IOUReq
                 }
                 setCustomUnitID(transactionID, perDiemUnit?.customUnitID ?? CONST.CUSTOM_UNITS.FAKE_P2P_ID);
                 setMoneyRequestCategory(transactionID, perDiemUnit?.defaultCategory ?? '', undefined);
-                Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, targetIouType, transactionID, targetReport.reportID));
+                Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, targetIouType, transactionID, targetReport.reportID, backToReport));
             }}
         />
     );

--- a/src/pages/iou/request/step/IOURequestStepSubrate.tsx
+++ b/src/pages/iou/request/step/IOURequestStepSubrate.tsx
@@ -64,7 +64,7 @@ function getSubrateOptions(subRates: Subrate[], filledSubRates: CommentSubrate[]
 
 function IOURequestStepSubrate({
     route: {
-        params: {action, backTo, iouType, pageIndex, reportID, transactionID},
+        params: {action, backTo, iouType, pageIndex, reportID, transactionID, backToReport},
     },
     transaction,
     report,
@@ -119,7 +119,7 @@ function IOURequestStepSubrate({
             Navigation.goBack(backTo);
             return;
         }
-        Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, iouType, transactionID, reportID));
+        Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, iouType, transactionID, reportID, backToReport));
     };
 
     const validate = (values: FormOnyxValues<typeof ONYXKEYS.FORMS.MONEY_REQUEST_SUBRATE_FORM>): Partial<Record<string, TranslationPaths>> => {
@@ -159,7 +159,7 @@ function IOURequestStepSubrate({
         if (backTo) {
             goBack();
         } else {
-            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(action, iouType, transactionID, transactionReportID));
+            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(action, iouType, transactionID, transactionReportID, backToReport));
         }
     };
 

--- a/src/pages/iou/request/step/IOURequestStepTime.tsx
+++ b/src/pages/iou/request/step/IOURequestStepTime.tsx
@@ -44,7 +44,7 @@ type IOURequestStepTimeProps = WithWritableReportOrNotFoundProps<typeof SCREENS.
 
 function IOURequestStepTime({
     route: {
-        params: {action, iouType, reportID, transactionID, backTo},
+        params: {action, iouType, reportID, transactionID, backTo, backToReport},
         name,
     },
     transaction,
@@ -75,7 +75,7 @@ function IOURequestStepTime({
 
     const navigateBack = () => {
         if (isEditPage) {
-            Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(action, iouType, transactionID, reportID));
+            Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(action, iouType, transactionID, reportID, backToReport));
             return;
         }
 
@@ -88,7 +88,7 @@ function IOURequestStepTime({
             // We want to navigate to destination step only when the first step was the workspace selector.
             // If there is only one policy with per diem enabled, we want to navigate back to the start step because there is no separate destination step in that flow.
             if (hasMoreThanOnePolicyWithPerDiemEnabled) {
-                Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, iouType, transactionID, reportID));
+                Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, iouType, transactionID, reportID, backToReport));
                 return;
             }
 
@@ -96,7 +96,7 @@ function IOURequestStepTime({
             Navigation.goBack();
         }
 
-        Navigation.goBack(ROUTES.MONEY_REQUEST_CREATE_TAB_PER_DIEM.getRoute(action, iouType, transactionID, reportID));
+        Navigation.goBack(ROUTES.MONEY_REQUEST_CREATE_TAB_PER_DIEM.getRoute(action, iouType, transactionID, reportID, backToReport));
     };
 
     const validate = (value: FormOnyxValues<typeof ONYXKEYS.FORMS.MONEY_REQUEST_TIME_FORM>) => {
@@ -122,7 +122,7 @@ function IOURequestStepTime({
         if (isEditPage) {
             navigateBack();
         } else {
-            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_SUBRATE.getRoute(action, iouType, transactionID, reportID));
+            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_SUBRATE.getRoute(action, iouType, transactionID, reportID, backToReport));
         }
     };
 

--- a/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
+++ b/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
@@ -430,6 +430,7 @@ function useExpenseSubmission(params: UseExpenseSubmissionParams) {
                 existingChatReport,
             );
             const activeReportID = isExpenseReport && Navigation.getTopmostReportId() === report?.reportID ? report?.reportID : chatReportID;
+            const navigationActiveReportID = backToReport ?? activeReportID;
 
             const result = submitPerDiemExpenseIOUActions({
                 report,
@@ -472,13 +473,13 @@ function useExpenseSubmission(params: UseExpenseSubmissionParams) {
                 conciergeReportID,
                 shouldHandleNavigation: shouldHandleNav,
             });
-            if (shouldHandleNav && result && activeReportID) {
+            if (shouldHandleNav && result && navigationActiveReportID) {
                 navigateAfterExpenseCreate({
-                    activeReportID,
+                    activeReportID: navigationActiveReportID,
                     transactionID: result.transactionID,
                     isFromGlobalCreate: transaction.isFromFloatingActionButton ?? transaction.isFromGlobalCreate,
                     hasMultipleTransactions: reportTransactions.length > 0,
-                    shouldAddPendingNewTransactionIDs: activeReportID === chatReportID,
+                    shouldAddPendingNewTransactionIDs: navigationActiveReportID === chatReportID,
                 });
             }
         }

--- a/tests/unit/PerDiemBackToReportRoutesTest.ts
+++ b/tests/unit/PerDiemBackToReportRoutesTest.ts
@@ -1,0 +1,45 @@
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
+
+describe('Per diem money request routes', () => {
+    const action = CONST.IOU.ACTION.CREATE;
+    const iouType = CONST.IOU.TYPE.SUBMIT;
+    const transactionID = 'tx123';
+    const reportID = 'r456';
+    const backToReport = 'rBACK';
+
+    describe('STEP_DESTINATION', () => {
+        it('includes backToReport segment when provided', () => {
+            expect(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, iouType, transactionID, reportID, backToReport)).toBe(
+                `${action}/${iouType}/destination/${transactionID}/${reportID}/${backToReport}`,
+            );
+        });
+
+        it('omits backToReport segment when undefined', () => {
+            expect(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, iouType, transactionID, reportID)).toBe(`${action}/${iouType}/destination/${transactionID}/${reportID}`);
+        });
+    });
+
+    describe('STEP_TIME', () => {
+        it('includes backToReport segment when provided', () => {
+            expect(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, iouType, transactionID, reportID, backToReport)).toBe(`${action}/${iouType}/time/${transactionID}/${reportID}/${backToReport}`);
+        });
+
+        it('omits backToReport segment when undefined', () => {
+            expect(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, iouType, transactionID, reportID)).toBe(`${action}/${iouType}/time/${transactionID}/${reportID}`);
+        });
+    });
+
+    describe('STEP_SUBRATE', () => {
+        it('includes backToReport segment when provided', () => {
+            expect(ROUTES.MONEY_REQUEST_STEP_SUBRATE.getRoute(action, iouType, transactionID, reportID, backToReport)).toBe(
+                `${action}/${iouType}/subrate/${transactionID}/${reportID}/0/${backToReport}`,
+            );
+        });
+
+        it('omits backToReport segment when undefined', () => {
+            expect(ROUTES.MONEY_REQUEST_STEP_SUBRATE.getRoute(action, iouType, transactionID, reportID)).toBe(`${action}/${iouType}/subrate/${transactionID}/${reportID}/0`);
+        });
+    });
+});
+


### PR DESCRIPTION
$ #91093

### Problem
Creating a per diem expense from an empty report preview in a workspace chat navigates into the expense report after submit, unlike Manual/Scan/Distance which keep you in the workspace chat.

### Root cause
The per diem flow dropped `backToReport` when navigating through the per diem-only step screens (workspace -> destination -> time -> subrate -> confirmation). By the time the confirmation screen submitted, `backToReport` was missing so post-submit navigation opened the expense report.

### Solution
- Plumb `backToReport` through per diem step routes (destination/time/subrate + edit variants) and pass it between steps.
- Prefer `backToReport` for post-submit navigation in `useExpenseSubmission()` for per diem submissions.

### Tests
- `npm test -- tests/unit/PerDiemBackToReportRoutesTest.ts`
- `npm run typecheck`
