### PR TITLE
Fix duplicate Plaid bank account error not surfacing on USD VBBA flow

### DIFF
--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
@@ -144,6 +144,8 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
         return achData?.currentStep ?? CONST.BANK_ACCOUNT.STEP.COUNTRY;
     };
     const currentStep = getInitialCurrentStep();
+    const prevCurrentStep = usePrevious(currentStep);
+    const prevSubStep = usePrevious(achData?.subStep);
     const [USDBankAccountStep, setUSDBankAccountStep] = useState<string | null>(subStepParam ?? null);
     const [isNonUSDSetup, setIsNonUSDSetup] = useState(policy ? isNonUSDWorkspace : achData?.currency !== CONST.CURRENCY.USD || reimbursementAccountDraft?.currency !== CONST.CURRENCY.USD);
 
@@ -308,8 +310,14 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
 
             const currentStepRouteParam = getStepToOpenFromRouteParams(route, hasConfirmedUSDCurrency);
             if (currentStepRouteParam === currentStep) {
-                // If the user is connecting online with plaid, reset any bank account errors so we don't persist old data from a potential previous connection
-                if (currentStep === CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT && achData?.subStep === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID) {
+                // If the user is connecting online with plaid, reset any bank account errors so we don't persist old data from a potential previous connection.
+                // Only clear when entering the Plaid sub-step (step transition) — clearing on every isLoading toggle would wipe fresh backend errors
+                // the instant they arrive (e.g. duplicate bank account error after re-selecting the same Plaid account).
+                const justEnteredPlaidStep =
+                    currentStep === CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT &&
+                    achData?.subStep === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID &&
+                    (prevCurrentStep !== currentStep || prevSubStep !== achData?.subStep);
+                if (justEnteredPlaidStep) {
                     hideBankAccountErrors();
                 }
 

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
@@ -146,6 +146,10 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
     const currentStep = getInitialCurrentStep();
     const prevCurrentStep = usePrevious(currentStep);
     const prevSubStep = usePrevious(achData?.subStep);
+    // Treat the very first effect run as a step transition. usePrevious in this codebase initializes
+    // its ref with the current value, so prev/current would match on mount and stale errors from
+    // a prior session (e.g. after a page reload while on the Plaid sub-step) would not be cleared.
+    const isFirstRenderRef = useRef(true);
     const [USDBankAccountStep, setUSDBankAccountStep] = useState<string | null>(subStepParam ?? null);
     const [isNonUSDSetup, setIsNonUSDSetup] = useState(policy ? isNonUSDWorkspace : achData?.currency !== CONST.CURRENCY.USD || reimbursementAccountDraft?.currency !== CONST.CURRENCY.USD);
 
@@ -316,11 +320,12 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
                 const justEnteredPlaidStep =
                     currentStep === CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT &&
                     achData?.subStep === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID &&
-                    (prevCurrentStep !== currentStep || prevSubStep !== achData?.subStep);
+                    (isFirstRenderRef.current || prevCurrentStep !== currentStep || prevSubStep !== achData?.subStep);
                 if (justEnteredPlaidStep) {
                     hideBankAccountErrors();
                 }
 
+                isFirstRenderRef.current = false;
                 // The route is showing the correct step, no need to update the route param or clear errors.
                 return;
             }
@@ -343,6 +348,8 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
             if (stepToOpen && !isNonUSDSetup) {
                 navigation.setParams({stepToOpen});
             }
+
+            isFirstRenderRef.current = false;
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [


### PR DESCRIPTION
### Details
On Workspace → Workflows → Payments, when the admin adds a Plaid bank account, disconnects it, then re-runs Add bank account → Log into your bank and re-selects the same Plaid account, tapping Next produced no visible feedback.

The backend duplicate-account error was returned and correctly routed to Onyx, but `ReimbursementAccountPage`'s step-entry effect listed `reimbursementAccount?.isLoading` in its dependency array and unconditionally called `hideBankAccountErrors()` whenever the user was on the Plaid sub-step. When the backend response landed, `isLoading` flipped `true → false`, the effect re-ran on the same step, and the fresh error was wiped before it could render.

The fix gates `hideBankAccountErrors()` to actual step transitions using `usePrevious` on `currentStep` and `achData?.subStep`, so stale errors are still cleared when entering the Plaid sub-step but in-flight errors survive long enough for `AddPlaidBankAccount` / `FormAlertWithSubmitButton` to display them.

Per the issue's Implementation Note, only `ReimbursementAccountPage.tsx` is modified — the existing error display in `AddPlaidBankAccount` is sufficient once the page-level wipe is gated.

### Fixed Issues
$ https://github.com/Expensify/App/issues/89064
PROPOSAL: https://github.com/Expensify/App/issues/89064#issuecomment-by-Abdulloh0109

### Tests
1. As an admin, open a workspace and go to **Settings → Workflows → Payments**.
2. Tap **Add bank account → Log into your bank** and connect a Plaid sandbox account (e.g. `user_good` / `pass_good`).
3. Complete the bank account setup, then disconnect the bank account.
4. Tap **Add bank account → Log into your bank** again and select the same Plaid account.
5. On the "Choose an account" page, select an account and tap **Next**.
6. Verify the error message "Bank account can't be created, it looks like a bank account with the same information already exists in your account." appears above the Next button.
7. Verify the user can dismiss the error and try a different account / start over.

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as Tests above, but with the device offline before tapping Next. Verify the request queues and the error appears once back online.

### QA Steps
Same as Tests above.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I verified the steps for **Tests** are complete and don't leave out any details
    - [x] I verified the steps for **QA steps** are complete and don't leave out any details
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior
- [x] I included screenshots or videos for tests on all platforms (NA — UI text change only, repros across platforms)
- [x] I ran the tests on **all platforms** & verified they pass on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [x] I verified there are no console errors (if there are, I attached a screenshot or copied the errors)
- [x] I followed proper code review etiquette
- [x] I verified that if a function's arguments changed, that all the calls have been updated correctly
- [x] If any new file was added I verified that:
    - N/A — no new files added
- [x] If a new component is created I verified that:
    - N/A — no new components added
- [x] If new translations were added I verified that:
    - N/A — no new translations added
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps