### PR TITLE
[codex] Fix video popover Escape handling

### DIFF
--- a/src/components/PopoverMenu/index.tsx
+++ b/src/components/PopoverMenu/index.tsx
@@ -1,6 +1,6 @@
 import {deepEqual} from 'fast-equals';
 import type {ReactNode, RefObject} from 'react';
-import React, {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import type {GestureResponderEvent, LayoutChangeEvent, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import CompactMenuContext from '@components/CompactMenuContext';
@@ -328,6 +328,7 @@ function BasePopoverMenu({
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['BackArrow', 'ReceiptScan', 'MoneyCircle']);
     const prevMenuItems = usePrevious(menuItems);
     const [hasKeyBeenPressed, setHasKeyBeenPressed] = useState(false);
+    const cleanupEscapeKeyUpSuppressorRef = useRef<(() => void) | undefined>(undefined);
 
     const getPreviousSubMenu = () => {
         let currentItems = menuItems;
@@ -507,6 +508,36 @@ function BasePopoverMenu({
             </Text>
         );
     };
+
+    const closeMenuFromEscape = useCallback(() => {
+        setCurrentMenuItems(menuItems);
+        setEnteredSubMenuIndexes(CONST.EMPTY_ARRAY);
+
+        if (isWeb && typeof document !== 'undefined') {
+            cleanupEscapeKeyUpSuppressorRef.current?.();
+
+            const suppressEscapeKeyUp = (event: KeyboardEvent) => {
+                if (event.key !== CONST.KEYBOARD_SHORTCUTS.ESCAPE.shortcutKey) {
+                    return;
+                }
+
+                event.stopImmediatePropagation();
+                cleanupEscapeKeyUpSuppressorRef.current?.();
+            };
+
+            document.addEventListener('keyup', suppressEscapeKeyUp, true);
+            cleanupEscapeKeyUpSuppressorRef.current = () => {
+                document.removeEventListener('keyup', suppressEscapeKeyUp, true);
+                cleanupEscapeKeyUpSuppressorRef.current = undefined;
+            };
+        }
+
+        onClose();
+    }, [isWeb, menuItems, onClose]);
+
+    useKeyboardShortcut(CONST.KEYBOARD_SHORTCUTS.ESCAPE, closeMenuFromEscape, {isActive: isVisible, shouldBubble: false});
+
+    useEffect(() => () => cleanupEscapeKeyUpSuppressorRef.current?.(), []);
 
     useKeyboardShortcut(
         CONST.KEYBOARD_SHORTCUTS.ENTER,


### PR DESCRIPTION
## Summary
- Make `PopoverMenu` claim Escape while visible so parent fullscreen/lightbox Escape handlers do not run first.
- Close the whole popover, including nested playback-speed submenu state, on Escape.
- Suppress the matching web `keyup` event once so the parent modal does not close from the trailing Escape keyup.

## Root cause
The video menu is a `PopoverMenu` shown above the fullscreen attachment viewer. The popover did not subscribe to the app keyboard shortcut stack for Escape, so the parent attachment/fullscreen modal could handle Escape before the menu. On web, the modal Escape fallback also runs on `keyup`, so the same key press could still close the parent after the menu closes.

## Validation
- `git diff --check`

Could not run formatter/lint locally because this checkout has no `node_modules`, `npm install --ignore-scripts` is blocked by the repo engine requirement (`node 20.20.0`, `npm 10.8.2`; current environment is `node 26.1.0`, `npm 11.14.1`), and `bash scripts/lintChanged.sh` is unavailable because WSL bash is not installed.

$ #91146
