### PR TITLE
[codex] Fix numeric workspace policy text crash

### DIFF
--- a/src/libs/PolicyCustomRulesUtils.ts
+++ b/src/libs/PolicyCustomRulesUtils.ts
@@ -1,0 +1,11 @@
+import type {OnyxEntry} from 'react-native-onyx';
+import type {Policy} from '@src/types/onyx';
+
+/**
+ * Returns custom rules as displayable text.
+ */
+function getPolicyCustomRulesText(policy: OnyxEntry<Policy>): string {
+    return String(policy?.customRules ?? '');
+}
+
+export {getPolicyCustomRulesText};

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -53,6 +53,7 @@ import type {MemberForList} from './OptionsListUtils';
 import {getAccountIDsByLogins, getLoginByAccountID, getLoginsByAccountIDs, getPersonalDetailByEmail} from './PersonalDetailsUtils';
 import {getAllSortedTransactions, getCategory, getTag, getTagArrayFromName} from './TransactionUtils';
 import {isPublicDomain, isValidAccountRoute} from './ValidationUtils';
+import {getPolicyCustomRulesText} from './PolicyCustomRulesUtils';
 
 type MemberEmailsToAccountIDs = Record<string, number>;
 
@@ -829,7 +830,7 @@ function hasConfiguredRules(policy: OnyxEntry<Policy>): boolean {
         return false;
     }
 
-    if (!!policy.customRules && policy.customRules.trim().length > 0) {
+    if (getPolicyCustomRulesText(policy).trim().length > 0) {
         return true;
     }
 

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -6036,9 +6036,10 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string, current
  * @param policyID - id of the policy to set the max expense age
  * @param customRules - the custom rules description in natural language
  */
-function updateCustomRules(policyID: string, customRules: string, currentCustomRules: string | undefined) {
+function updateCustomRules(policyID: string, customRules: string, currentCustomRules: string | number | undefined) {
     const parsedCustomRules = ReportUtils.getParsedComment(customRules);
-    if (parsedCustomRules === currentCustomRules) {
+    const currentCustomRulesText = String(currentCustomRules ?? '');
+    if (parsedCustomRules === currentCustomRulesText) {
         return;
     }
 
@@ -6073,7 +6074,7 @@ function updateCustomRules(policyID: string, customRules: string, currentCustomR
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    customRules: currentCustomRules,
+                    customRules: currentCustomRulesText,
                     pendingFields: {customRules: null},
                     errorFields: {customRules: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
                     // TODO

--- a/src/pages/workspace/WorkspaceOverviewPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewPage.tsx
@@ -195,6 +195,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
     };
     const policyName = policy?.name ?? '';
     const policyDescription = policy?.description ?? translate('workspace.common.defaultDescription');
+    const policyCustomRulesText = String(policy?.customRules ?? '');
     const policyCurrency = policy?.outputCurrency ?? '';
     const readOnly = !canEditWorkspaceSettings(policy);
     const currencyReadOnly = readOnly || isBankAccountVerified;
@@ -214,7 +215,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
     );
 
     const hasRulesDocument = !!policy?.rulesDocumentURL;
-    const hasCustomRulesText = !StringUtils.isEmptyString(policy?.customRules ?? '');
+    const hasCustomRulesText = !StringUtils.isEmptyString(policyCustomRulesText);
 
     const handleRulesDocumentPicked = useCallback(
         (files: FileObject[]) => {
@@ -949,7 +950,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
                         {(isPolicyAdmin || hasCustomRulesText) && (
                             <OfflineWithFeedback pendingAction={policy?.pendingFields?.customRules}>
                                 <MenuItemWithTopDescription
-                                    title={policy?.customRules ?? ''}
+                                    title={policyCustomRulesText}
                                     description={translate('workspace.rules.customRules.policyText')}
                                     sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.OVERVIEW.CUSTOM_RULES}
                                     shouldShowRightIcon={!readOnly}

--- a/src/pages/workspace/rules/RulesCustomPage.tsx
+++ b/src/pages/workspace/rules/RulesCustomPage.tsx
@@ -13,6 +13,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import Parser from '@libs/Parser';
+import {getPolicyCustomRulesText} from '@libs/PolicyCustomRulesUtils';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import {updateCustomRules} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
@@ -32,8 +33,9 @@ function RulesCustomPage({
     const {inputCallbackRef} = useAutoFocusInput();
     const {translate} = useLocalize();
     const styles = useThemeStyles();
+    const policyCustomRulesText = getPolicyCustomRulesText(policy);
 
-    const [customRulesValue, setCustomRulesValue] = useState(() => Parser.htmlToMarkdown(policy?.customRules ?? ''));
+    const [customRulesValue, setCustomRulesValue] = useState(() => Parser.htmlToMarkdown(policyCustomRulesText));
 
     const onChangeCustomRules = useCallback((newValue: string) => {
         setCustomRulesValue(newValue);
@@ -57,7 +59,7 @@ function RulesCustomPage({
                     style={[styles.flexGrow1, styles.ph5]}
                     formID={ONYXKEYS.FORMS.RULES_CUSTOM_FORM}
                     onSubmit={({customRules}) => {
-                        updateCustomRules(policyID, customRules, policy?.customRules);
+                        updateCustomRules(policyID, customRules, policyCustomRulesText);
                         Navigation.setNavigationActionToMicrotaskQueue(Navigation.goBack);
                     }}
                     submitButtonText={translate('workspace.editor.save')}

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -2214,7 +2214,7 @@ type Policy = OnyxCommon.OnyxValueWithOfflineFeedback<
         };
 
         /** A set of custom rules defined with natural language */
-        customRules?: string;
+        customRules?: string | number;
 
         /** URL of the workspace rules PDF document stored in a private S3 bucket */
         rulesDocumentURL?: string;

--- a/tests/unit/libs/PolicyCustomRulesUtilsTest.ts
+++ b/tests/unit/libs/PolicyCustomRulesUtilsTest.ts
@@ -3,10 +3,15 @@ import type {Policy} from '@src/types/onyx';
 
 describe('PolicyCustomRulesUtils', () => {
     describe('getPolicyCustomRulesText', () => {
-        it('coerces numeric custom rules to text', () => {
-            const policy = {customRules: 123} as unknown as Policy;
-
-            expect(getPolicyCustomRulesText(policy)).toBe('123');
+        it.each([
+            ['missing policy', undefined, ''],
+            ['missing custom rules', {}, ''],
+            ['empty text', {customRules: ''}, ''],
+            ['numeric zero', {customRules: 0}, '0'],
+            ['numeric custom rules', {customRules: 123}, '123'],
+            ['text custom rules', {customRules: 'Policy text'}, 'Policy text'],
+        ])('returns displayable text for %s', (_caseName, policy, expected) => {
+            expect(getPolicyCustomRulesText(policy as unknown as Policy)).toBe(expected);
         });
     });
 });

--- a/tests/unit/libs/PolicyCustomRulesUtilsTest.ts
+++ b/tests/unit/libs/PolicyCustomRulesUtilsTest.ts
@@ -1,0 +1,12 @@
+import {getPolicyCustomRulesText} from '@libs/PolicyCustomRulesUtils';
+import type {Policy} from '@src/types/onyx';
+
+describe('PolicyCustomRulesUtils', () => {
+    describe('getPolicyCustomRulesText', () => {
+        it('coerces numeric custom rules to text', () => {
+            const policy = {customRules: 123} as unknown as Policy;
+
+            expect(getPolicyCustomRulesText(policy)).toBe('123');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Normalize workspace policy text/custom rules before passing it into string-only helpers and UI props.
- Guard the custom rules save rollback/compare path so numeric runtime values are treated as text.
- Add a small regression test for numeric custom rules coercion.

## Root cause
`policy.customRules` is typed as text, but numeric-only policy text can be returned through API/Onyx as a JavaScript number. Consumers then passed the value into string-only code such as `StringUtils.isEmptyString`, `Parser.htmlToMarkdown`, and `.trim()`, which can throw and trigger the Refresh crash screen.

## Validation
- `npx prettier --write src/libs/PolicyCustomRulesUtils.ts src/libs/PolicyUtils.ts src/libs/actions/Policy/Policy.ts src/pages/workspace/WorkspaceOverviewPage.tsx src/pages/workspace/rules/RulesCustomPage.tsx src/types/onyx/Policy.ts tests/unit/libs/PolicyCustomRulesUtilsTest.ts`
- `$env:TZ='utc'; $env:NODE_OPTIONS='--experimental-vm-modules --max_old_space_size=8192'; npx jest tests/unit/libs/PolicyCustomRulesUtilsTest.ts --runInBand`
- `git diff --check`
- `sh scripts/lintChanged.sh src/libs/PolicyCustomRulesUtils.ts src/libs/PolicyUtils.ts src/libs/actions/Policy/Policy.ts src/pages/workspace/WorkspaceOverviewPage.tsx src/pages/workspace/rules/RulesCustomPage.tsx src/types/onyx/Policy.ts tests/unit/libs/PolicyCustomRulesUtilsTest.ts`
- `npm run react-compiler-compliance-check -- check-changed`

`npm run typecheck-tsgo` was attempted and failed on existing broad repo/dependency type errors unrelated to this change, including `TextInputPasteEventData` missing from `react-native`, `ScreenOptionsOrCallback` missing from `@react-navigation/native`, and many existing `userSelect: "contain"` style type errors.

$ #91069
