### PR TITLE
[codex] Fix zero amount expense table display

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestReportPreview/index.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/index.tsx
@@ -15,6 +15,7 @@ import useTransactionViolations from '@hooks/useTransactionViolations';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getIOUActionForReportID, isSplitBillAction as isSplitBillActionReportActionsUtils, isTrackExpenseAction as isTrackExpenseActionReportActionsUtils} from '@libs/ReportActionsUtils';
 import {isIOUReport} from '@libs/ReportUtils';
+import {hasValidModifiedAmount} from '@libs/TransactionUtils';
 import {startSpan} from '@libs/telemetry/activeSpans';
 import Navigation from '@navigation/Navigation';
 import {contextMenuRef} from '@pages/inbox/report/ContextMenu/ReportActionContextMenu';
@@ -94,7 +95,7 @@ function MoneyRequestReportPreview({
             return false;
         }
 
-        return transactions.some((transaction) => (Number(transaction?.modifiedAmount) || transaction?.amount) < 0);
+        return transactions.some((transaction) => (hasValidModifiedAmount(transaction) ? Number(transaction?.modifiedAmount) : transaction?.amount) < 0);
     }, [transactions, action.childType, iouReport]);
 
     const openReportFromPreview = useCallback(() => {

--- a/src/components/ReportActionItem/TransactionPreview/index.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/index.tsx
@@ -15,7 +15,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import {getOriginalMessage, isMoneyRequestAction as isMoneyRequestActionReportActionsUtils} from '@libs/ReportActionsUtils';
 import {getTransactionDetails} from '@libs/ReportUtils';
 import {getReviewNavigationRoute} from '@libs/TransactionPreviewUtils';
-import {getExpenseTypeTranslationKey, getOriginalTransactionWithSplitInfo, getTransactionType, removeSettledAndApprovedTransactions} from '@libs/TransactionUtils';
+import {getExpenseTypeTranslationKey, getOriginalTransactionWithSplitInfo, getTransactionType, hasValidModifiedAmount, removeSettledAndApprovedTransactions} from '@libs/TransactionUtils';
 import type {PlatformStackRouteProp} from '@navigation/PlatformStackNavigation/types';
 import type {TransactionDuplicateNavigatorParamList} from '@navigation/types';
 import {clearWalletTermsError} from '@userActions/PaymentMethods';
@@ -89,7 +89,7 @@ function TransactionPreview(props: TransactionPreviewProps) {
 
     // See description of `transactionRawAmount` prop for more context
 
-    const transactionRawAmount = (Number(transaction?.modifiedAmount) || transaction?.amount) ?? 0;
+    const transactionRawAmount = hasValidModifiedAmount(transaction) ? Number(transaction?.modifiedAmount) : (transaction?.amount ?? 0);
 
     const shouldDisableOnPress = isBillSplit && isEmptyObject(transaction);
     const isReviewDuplicateTransactionPage = route.name === SCREENS.TRANSACTION_DUPLICATE.REVIEW;

--- a/src/components/TransactionItemRow/TransactionItemRowWide.tsx
+++ b/src/components/TransactionItemRow/TransactionItemRowWide.tsx
@@ -32,6 +32,7 @@ import {
     getOriginalCurrencyForDisplay,
     getReimbursable,
     getTaxName,
+    hasValidModifiedAmount,
     isDeletedTransaction as isDeletedTransactionUtil,
     isExpenseUnreported,
     isScanning,
@@ -537,9 +538,11 @@ function TransactionItemRowWide({
                 );
             case CONST.SEARCH.TABLE_COLUMNS.TOTAL: {
                 const isFromExpenseReport = isExpenseReport(transactionItem.report ?? report);
-                const hasConvertedAmount = transactionItem.convertedAmount != null;
+                const hasConvertedAmount = transactionItem.convertedAmount != null && !hasValidModifiedAmount(transactionItem);
                 // Offline expenses don't have a BE-computed convertedAmount yet — fall back to the unconverted
                 // amount in the transaction's own currency so users don't see a misleading $0.00 placeholder.
+                // Edited expenses also fall back to the transaction amount because convertedAmount can be stale
+                // until the backend returns a fresh converted value. This includes modifiedAmount = 0.
                 // Pass isFromExpenseReport so IOU reports stay positive while expense reports get NewDot's signed display.
                 const totalAmount = hasConvertedAmount ? getConvertedAmount(transactionItem, isFromExpenseReport) : getAmount(transactionItem, isFromExpenseReport);
                 // When converted, display in the report's output currency; otherwise use the transaction's own currency.

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -285,6 +285,7 @@ import {
     getCreated as getTransactionCreated,
     getTransactionID,
     getWaypoints,
+    hasValidModifiedAmount,
     hasMissingSmartscanFields as hasMissingSmartscanFieldsTransactionUtils,
     hasNoticeTypeViolation,
     hasReceipt as hasReceiptTransactionUtils,
@@ -13304,7 +13305,7 @@ function getTransactionSortValue(transaction: Transaction, key: SortableColumnNa
         case CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT:
             return getTransactionAmount(transaction, isExpenseReport(report), transaction.reportID === CONST.REPORT.UNREPORTED_REPORT_ID);
         case CONST.SEARCH.TABLE_COLUMNS.TOTAL:
-            return Math.abs(transaction.convertedAmount ?? 0);
+            return Math.abs(hasValidModifiedAmount(transaction) ? Number(transaction.modifiedAmount) : (transaction.convertedAmount ?? 0));
         case CONST.SEARCH.TABLE_COLUMNS.DESCRIPTION:
             return Parser.htmlToText(transaction.comment?.comment ?? '');
         case CONST.SEARCH.TABLE_COLUMNS.REIMBURSABLE:

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -12632,7 +12632,7 @@ function doesReportContainRequestsFromMultipleUsers(iouReport: OnyxEntry<Report>
         (transaction) => !shouldExcludeDeletedTransactions || transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
     );
 
-    return isIOUReport(iouReport) && transactions.some((transaction) => (Number(transaction?.modifiedAmount) || transaction?.amount) <= 0);
+    return isIOUReport(iouReport) && transactions.some((transaction) => (hasValidModifiedAmount(transaction) ? Number(transaction?.modifiedAmount) : transaction?.amount) <= 0);
 }
 
 /**

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -191,6 +191,7 @@ import {
     getAmount as getTransactionAmount,
     getCreated as getTransactionCreatedDate,
     getMerchant as getTransactionMerchant,
+    hasValidModifiedAmount,
     isDeletedTransaction,
     isPending,
     isScanning,
@@ -1327,7 +1328,7 @@ function isAmountTooLong(amount: number, maxLength = 8): boolean {
 }
 
 function isTransactionAmountTooLong(transactionItem: TransactionListItemType | OnyxTypes.Transaction) {
-    const amount = Math.abs(Number(transactionItem.modifiedAmount) || transactionItem.amount);
+    const amount = Math.abs(hasValidModifiedAmount(transactionItem) ? Number(transactionItem.modifiedAmount) : transactionItem.amount);
     return isAmountTooLong(amount);
 }
 
@@ -1707,7 +1708,7 @@ function getToFieldValueForTransaction(
                     report?.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID,
                     personalDetailsList,
 
-                    Number(transactionItem.modifiedAmount) || transactionItem.amount,
+                    hasValidModifiedAmount(transactionItem) ? Number(transactionItem.modifiedAmount) : transactionItem.amount,
                 )?.to ?? emptyPersonalDetails
             );
         }

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -921,7 +921,7 @@ function getUpdatedTransaction({
         // No locally resolvable rate (e.g. track expense without policy loaded) → scale the previous
         // amount by the distance ratio so the optimistic value isn't 0. `modifiedAmount` is `""` for
         // unedited transactions, so coerce via Number() and fall through to `amount`.
-        const previousAmount = Number(transaction?.modifiedAmount) || transaction?.amount || 0;
+        const previousAmount = hasValidModifiedAmount(transaction) ? Number(transaction?.modifiedAmount) : (transaction?.amount ?? 0);
         const useFallback = !rate && !!previousDistanceInMeters && !!previousAmount && !!distanceInMeters;
         if (useFallback) {
             updatedTransaction.modifiedAmount = Math.round(previousAmount * (distanceInMeters / previousDistanceInMeters));

--- a/src/libs/actions/IOU/MoneyRequestBuilder.ts
+++ b/src/libs/actions/IOU/MoneyRequestBuilder.ts
@@ -45,6 +45,7 @@ import {
     buildOptimisticTransaction,
     getAmount,
     getCurrency,
+    hasValidModifiedAmount,
     isDistanceRequest as isDistanceRequestTransactionUtils,
     isManualDistanceRequest as isManualDistanceRequestTransactionUtils,
     isPerDiemRequest as isPerDiemRequestTransactionUtils,
@@ -1365,9 +1366,9 @@ function getMoneyRequestInformation(moneyRequestInformation: MoneyRequestInforma
 
         // Calculate proportional convertedAmount for the split based on the original conversion rate
 
-        const originalAmount = Number(existingTransaction.modifiedAmount) || existingTransaction.amount;
+        const originalAmount = hasValidModifiedAmount(existingTransaction) ? Number(existingTransaction.modifiedAmount) : existingTransaction.amount;
 
-        const splitAmount = Number(optimisticTransaction.modifiedAmount) || optimisticTransaction.amount;
+        const splitAmount = hasValidModifiedAmount(optimisticTransaction) ? Number(optimisticTransaction.modifiedAmount) : optimisticTransaction.amount;
         if (originalConvertedAmount && originalAmount && splitAmount) {
             optimisticTransaction.convertedAmount = Math.round((originalConvertedAmount * splitAmount) / originalAmount);
         }

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -16591,6 +16591,12 @@ describe('ReportUtils', () => {
             expect(result).toBe(-5000);
         });
 
+        it('should prefer modified amount over stale converted amount for TOTAL column', () => {
+            const transaction = createMockTransaction({amount: -5000, convertedAmount: -5000, modifiedAmount: 0});
+            const result = getTransactionSortValue(transaction, CONST.SEARCH.TABLE_COLUMNS.TOTAL, mockReport, mockPolicy);
+            expect(result).toBe(0);
+        });
+
         it('should return description for DESCRIPTION column', () => {
             const transaction = createMockTransaction({comment: {comment: 'Test description'}});
             const result = getTransactionSortValue(transaction, CONST.SEARCH.TABLE_COLUMNS.DESCRIPTION, mockReport, mockPolicy);

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -16591,8 +16591,8 @@ describe('ReportUtils', () => {
             expect(result).toBe(-5000);
         });
 
-        it('should prefer modified amount over stale converted amount for TOTAL column', () => {
-            const transaction = createMockTransaction({amount: -5000, convertedAmount: -5000, modifiedAmount: 0});
+        it.each([0, '0'])('should prefer zero modified amount over stale converted amount for TOTAL column', (modifiedAmount) => {
+            const transaction = createMockTransaction({amount: -5000, convertedAmount: -5000, modifiedAmount});
             const result = getTransactionSortValue(transaction, CONST.SEARCH.TABLE_COLUMNS.TOTAL, mockReport, mockPolicy);
             expect(result).toBe(0);
         });


### PR DESCRIPTION
## Summary
- Make the report table TOTAL column prefer a valid edited amount over stale `convertedAmount`.
- Apply the same precedence in report table TOTAL sorting.
- Add regression coverage for `modifiedAmount: 0` with stale non-zero `convertedAmount`.

## Root cause
The expense report table displayed `convertedAmount` whenever it was present. After editing an expense amount to `0.00`, the transaction has `modifiedAmount = 0`, but the old backend-computed `convertedAmount` can remain on the row until a fresh value comes back. Because the table and sort path prioritized `convertedAmount`, they kept using the original amount instead of the explicit zero edit.

## Validation
- `npx prettier --write src/components/TransactionItemRow/TransactionItemRowWide.tsx src/libs/ReportUtils.ts tests/unit/ReportUtilsTest.ts`
- `git diff --check`
- `sh scripts/lintChanged.sh src/components/TransactionItemRow/TransactionItemRowWide.tsx src/libs/ReportUtils.ts tests/unit/ReportUtilsTest.ts`
- `npm run react-compiler-compliance-check -- check-changed`

Attempted focused Jest:
- `$env:TZ='utc'; $env:NODE_OPTIONS='--experimental-vm-modules --max_old_space_size=8192'; npx jest tests/unit/ReportUtilsTest.ts --runInBand --testNamePattern="getTransactionSortValue"`
- Failed before running tests due existing Jest/ESM mock setup issue in this checkout: `Must use import to load ES Module: @react-navigation/core`.

`npm run typecheck-tsgo` was attempted and failed on existing broad repo/dependency type errors unrelated to this change, including `TextInputPasteEventData` missing from `react-native`, `ScreenOptionsOrCallback` missing from `@react-navigation/native`, and many existing `userSelect: "contain"` style type errors.

$ #91006
