### PR TITLE
Fix video popover Escape handling

### DIFF
--- a/src/components/PopoverMenu/index.tsx
+++ b/src/components/PopoverMenu/index.tsx
@@ -516,6 +516,7 @@ function BasePopoverMenu({
         if (isWeb && typeof document !== 'undefined') {
             cleanupEscapeKeyUpSuppressorRef.current?.();
 
+            let timeoutID: ReturnType<typeof setTimeout> | undefined;
             const suppressEscapeKeyUp = (event: KeyboardEvent) => {
                 if (event.key !== CONST.KEYBOARD_SHORTCUTS.ESCAPE.shortcutKey) {
                     return;
@@ -528,8 +529,12 @@ function BasePopoverMenu({
             document.addEventListener('keyup', suppressEscapeKeyUp, true);
             cleanupEscapeKeyUpSuppressorRef.current = () => {
                 document.removeEventListener('keyup', suppressEscapeKeyUp, true);
+                if (timeoutID) {
+                    clearTimeout(timeoutID);
+                }
                 cleanupEscapeKeyUpSuppressorRef.current = undefined;
             };
+            timeoutID = setTimeout(() => cleanupEscapeKeyUpSuppressorRef.current?.(), 1000);
         }
 
         onClose();

--- a/src/components/PopoverMenu/index.tsx
+++ b/src/components/PopoverMenu/index.tsx
@@ -1,6 +1,6 @@
 import {deepEqual} from 'fast-equals';
 import type {ReactNode, RefObject} from 'react';
-import React, {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import type {GestureResponderEvent, LayoutChangeEvent, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import CompactMenuContext from '@components/CompactMenuContext';
@@ -328,6 +328,7 @@ function BasePopoverMenu({
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['BackArrow', 'ReceiptScan', 'MoneyCircle']);
     const prevMenuItems = usePrevious(menuItems);
     const [hasKeyBeenPressed, setHasKeyBeenPressed] = useState(false);
+    const cleanupEscapeKeyUpSuppressorRef = useRef<(() => void) | undefined>(undefined);
 
     const getPreviousSubMenu = () => {
         let currentItems = menuItems;
@@ -507,6 +508,36 @@ function BasePopoverMenu({
             </Text>
         );
     };
+
+    const closeMenuFromEscape = useCallback(() => {
+        setCurrentMenuItems(menuItems);
+        setEnteredSubMenuIndexes(CONST.EMPTY_ARRAY);
+
+        if (isWeb && typeof document !== 'undefined') {
+            cleanupEscapeKeyUpSuppressorRef.current?.();
+
+            const suppressEscapeKeyUp = (event: KeyboardEvent) => {
+                if (event.key !== CONST.KEYBOARD_SHORTCUTS.ESCAPE.shortcutKey) {
+                    return;
+                }
+
+                event.stopImmediatePropagation();
+                cleanupEscapeKeyUpSuppressorRef.current?.();
+            };
+
+            document.addEventListener('keyup', suppressEscapeKeyUp, true);
+            cleanupEscapeKeyUpSuppressorRef.current = () => {
+                document.removeEventListener('keyup', suppressEscapeKeyUp, true);
+                cleanupEscapeKeyUpSuppressorRef.current = undefined;
+            };
+        }
+
+        onClose();
+    }, [isWeb, menuItems, onClose]);
+
+    useKeyboardShortcut(CONST.KEYBOARD_SHORTCUTS.ESCAPE, closeMenuFromEscape, {isActive: isVisible, shouldBubble: false});
+
+    useEffect(() => () => cleanupEscapeKeyUpSuppressorRef.current?.(), []);
 
     useKeyboardShortcut(
         CONST.KEYBOARD_SHORTCUTS.ENTER,

--- a/src/components/PopoverMenu/v2/content/useContentController.ts
+++ b/src/components/PopoverMenu/v2/content/useContentController.ts
@@ -1,4 +1,7 @@
+import {useEffect, useRef} from 'react';
 import {useRootActions, useRootVisibility} from '@components/PopoverMenu/v2/root/RootContext';
+import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
+import CONST from '@src/CONST';
 import type {ContentClose, ContentFocus, ContentItemActions, ContentNavigation, ContentSubActions} from './ContentContext';
 import useCloseOnModalCover from './useCloseOnModalCover';
 import useCloseOnScreenBlur from './useCloseOnScreenBlur';
@@ -14,6 +17,7 @@ function useContentController(componentName: string): {
 } {
     const {isVisible} = useRootVisibility(componentName);
     const {setIsVisible} = useRootActions(componentName);
+    const cleanupEscapeKeyUpSuppressorRef = useRef<(() => void) | undefined>(undefined);
 
     const focus = useFocusableRegistry({isVisible});
     // Order matters: `focus` must exist before `subNav` so `resetFocus` is in scope for `onLevelChange`.
@@ -23,6 +27,38 @@ function useContentController(componentName: string): {
         setIsVisible(false);
         subNav.actions.exitSub(null);
     };
+
+    const closeFromEscape = () => {
+        if (typeof document !== 'undefined') {
+            cleanupEscapeKeyUpSuppressorRef.current?.();
+
+            let timeoutID: ReturnType<typeof setTimeout> | undefined;
+            const suppressEscapeKeyUp = (event: KeyboardEvent) => {
+                if (event.key !== CONST.KEYBOARD_SHORTCUTS.ESCAPE.shortcutKey) {
+                    return;
+                }
+
+                event.stopImmediatePropagation();
+                cleanupEscapeKeyUpSuppressorRef.current?.();
+            };
+
+            document.addEventListener('keyup', suppressEscapeKeyUp, true);
+            cleanupEscapeKeyUpSuppressorRef.current = () => {
+                document.removeEventListener('keyup', suppressEscapeKeyUp, true);
+                if (timeoutID) {
+                    clearTimeout(timeoutID);
+                }
+                cleanupEscapeKeyUpSuppressorRef.current = undefined;
+            };
+            timeoutID = setTimeout(() => cleanupEscapeKeyUpSuppressorRef.current?.(), 1000);
+        }
+
+        close();
+    };
+
+    useKeyboardShortcut(CONST.KEYBOARD_SHORTCUTS.ESCAPE, closeFromEscape, {isActive: isVisible, shouldBubble: false});
+
+    useEffect(() => () => cleanupEscapeKeyUpSuppressorRef.current?.(), []);
 
     useCloseOnModalCover(isVisible, close);
     useCloseOnScreenBlur(close);


### PR DESCRIPTION
﻿### Details
Fixes Escape handling when a fullscreen video popover menu is open. The video player menu uses PopoverMenu v2, so this closes the active v2 menu on Escape and suppresses the matching Escape keyup before parent modal/fullscreen handlers can consume it. Also adds timeout cleanup to the existing v1 keyup suppressor.

### Fixed Issues
$ 91146
PROPOSAL: N/A

### Tests
- Press the three-dot menu on a fullscreen video.
- Press Escape.
- Verify only the menu closes and fullscreen remains active.
- Press Escape again.
- Verify fullscreen exits normally.

### Automated tests
- `git diff --check` passed.
- `npm run react-compiler-compliance-check -- check-changed` passed.
- `sh scripts/lintChanged.sh ...` could not run in this local install because ESLint cannot resolve `eslint-config-airbnb-base/rules/best-practices` from `node_modules`.
