### PR TITLE
Add hover-to-zoom on receipt thumbnails (web)

### DIFF
--- a/src/components/ReceiptHoverZoom/index.tsx
+++ b/src/components/ReceiptHoverZoom/index.tsx
@@ -1,0 +1,9 @@
+import type ReceiptHoverZoomProps from './types';
+
+function ReceiptHoverZoom({children}: ReceiptHoverZoomProps) {
+    return children;
+}
+
+ReceiptHoverZoom.displayName = 'ReceiptHoverZoom';
+
+export default ReceiptHoverZoom;

--- a/src/components/ReceiptHoverZoom/index.web.tsx
+++ b/src/components/ReceiptHoverZoom/index.web.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type ReceiptHoverZoomProps from './types';
+import useReceiptHoverZoom from './useReceiptHoverZoom';
+
+const DEFAULT_SCALE = 2.5;
+
+const wrapperStyle: React.CSSProperties = {position: 'relative', overflow: 'hidden', width: '100%', height: '100%'};
+const innerStyle: React.CSSProperties = {width: '100%', height: '100%', transition: 'transform 80ms ease-out', willChange: 'transform'};
+
+function ReceiptHoverZoom({children, isEnabled = true, scale = DEFAULT_SCALE, hoverContainerRef}: ReceiptHoverZoomProps) {
+    const {wrapperRef, innerRef, isActive} = useReceiptHoverZoom({isEnabled, scale, hoverContainerRef});
+
+    if (!isActive) {
+        return children;
+    }
+
+    return (
+        <div
+            ref={wrapperRef}
+            style={wrapperStyle}
+        >
+            <div
+                ref={innerRef}
+                style={innerStyle}
+            >
+                {children}
+            </div>
+        </div>
+    );
+}
+
+ReceiptHoverZoom.displayName = 'ReceiptHoverZoom';
+
+export default ReceiptHoverZoom;

--- a/src/components/ReceiptHoverZoom/types.ts
+++ b/src/components/ReceiptHoverZoom/types.ts
@@ -1,0 +1,18 @@
+import type {ReactNode, RefObject} from 'react';
+import type {View} from 'react-native';
+
+type ReceiptHoverZoomProps = {
+    /** Children to render inside the zoom container */
+    children: ReactNode;
+
+    /** When false the wrapper is a pass-through with no DOM/listener overhead */
+    isEnabled?: boolean;
+
+    /** Maximum scale applied on hover. Defaults to 2.5 */
+    scale?: number;
+
+    /** Outer element the listeners should attach to. Lets the zoom stay engaged while the cursor crosses overlay buttons. Falls back to the wrapper element. */
+    hoverContainerRef?: RefObject<View | null>;
+};
+
+export default ReceiptHoverZoomProps;

--- a/src/components/ReceiptHoverZoom/useReceiptHoverZoom.ts
+++ b/src/components/ReceiptHoverZoom/useReceiptHoverZoom.ts
@@ -42,10 +42,6 @@ function useReceiptHoverZoom({isEnabled, scale, hoverContainerRef}: UseReceiptHo
 
         let bounds: DOMRect | null = null;
 
-        const startZoom = () => {
-            bounds = target.getBoundingClientRect();
-            inner.style.transform = `scale(${scale})`;
-        };
         const endZoom = () => {
             bounds = null;
             inner.style.transform = 'scale(1)';
@@ -61,19 +57,13 @@ function useReceiptHoverZoom({isEnabled, scale, hoverContainerRef}: UseReceiptHo
             const x = ((event.clientX - left) / width) * 100;
             const y = ((event.clientY - top) / height) * 100;
             inner.style.transformOrigin = `${x}% ${y}%`;
+            inner.style.transform = `scale(${scale})`;
         };
 
-        target.addEventListener('pointerenter', startZoom);
         target.addEventListener('pointerleave', endZoom);
         target.addEventListener('pointermove', updateZoomOrigin);
 
-        // Browsers don't fire pointerenter when an element mounts under the cursor — kick off manually.
-        if (target.matches?.(':hover')) {
-            startZoom();
-        }
-
         return () => {
-            target.removeEventListener('pointerenter', startZoom);
             target.removeEventListener('pointerleave', endZoom);
             target.removeEventListener('pointermove', updateZoomOrigin);
             inner.style.transform = '';

--- a/src/components/ReceiptHoverZoom/useReceiptHoverZoom.ts
+++ b/src/components/ReceiptHoverZoom/useReceiptHoverZoom.ts
@@ -1,0 +1,87 @@
+import {useEffect, useRef} from 'react';
+import type {RefObject} from 'react';
+import type {View} from 'react-native';
+import {hasHoverSupport} from '@libs/DeviceCapabilities';
+
+type UseReceiptHoverZoomConfig = {
+    isEnabled: boolean;
+    scale: number;
+    hoverContainerRef?: RefObject<View | null>;
+};
+
+type UseReceiptHoverZoomResult = {
+    wrapperRef: RefObject<HTMLDivElement | null>;
+    innerRef: RefObject<HTMLDivElement | null>;
+    isActive: boolean;
+};
+
+function resolveHoverTarget(wrapper: HTMLDivElement | null, externalRef: RefObject<View | null> | undefined): HTMLElement | null {
+    if (externalRef) {
+        const external = externalRef.current as unknown as HTMLElement | null;
+        if (external) {
+            return external;
+        }
+    }
+    return wrapper;
+}
+
+function useReceiptHoverZoom({isEnabled, scale, hoverContainerRef}: UseReceiptHoverZoomConfig): UseReceiptHoverZoomResult {
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const innerRef = useRef<HTMLDivElement | null>(null);
+    const isActive = isEnabled && hasHoverSupport();
+
+    useEffect(() => {
+        if (!isActive) {
+            return undefined;
+        }
+        const inner = innerRef.current;
+        const target = resolveHoverTarget(wrapperRef.current, hoverContainerRef);
+        if (!inner || !target) {
+            return undefined;
+        }
+
+        let bounds: DOMRect | null = null;
+
+        const startZoom = () => {
+            bounds = target.getBoundingClientRect();
+            inner.style.transform = `scale(${scale})`;
+        };
+        const endZoom = () => {
+            bounds = null;
+            inner.style.transform = 'scale(1)';
+        };
+        const updateZoomOrigin = (event: PointerEvent) => {
+            if (!bounds) {
+                bounds = target.getBoundingClientRect();
+            }
+            const {left, top, width, height} = bounds;
+            if (!width || !height) {
+                return;
+            }
+            const x = ((event.clientX - left) / width) * 100;
+            const y = ((event.clientY - top) / height) * 100;
+            inner.style.transformOrigin = `${x}% ${y}%`;
+        };
+
+        target.addEventListener('pointerenter', startZoom);
+        target.addEventListener('pointerleave', endZoom);
+        target.addEventListener('pointermove', updateZoomOrigin);
+
+        // Browsers don't fire pointerenter when an element mounts under the cursor — kick off manually.
+        if (target.matches?.(':hover')) {
+            startZoom();
+        }
+
+        return () => {
+            target.removeEventListener('pointerenter', startZoom);
+            target.removeEventListener('pointerleave', endZoom);
+            target.removeEventListener('pointermove', updateZoomOrigin);
+            inner.style.transform = '';
+            inner.style.transformOrigin = '';
+        };
+    }, [isActive, scale, hoverContainerRef]);
+
+    return {wrapperRef, innerRef, isActive};
+}
+
+export default useReceiptHoverZoom;

--- a/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
@@ -15,6 +15,7 @@ import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeed
 import PressableWithoutFocus from '@components/Pressable/PressableWithoutFocus';
 import ReceiptAudit, {ReceiptAuditMessages} from '@components/ReceiptAudit';
 import ReceiptEmptyState from '@components/ReceiptEmptyState';
+import ReceiptHoverZoom from '@components/ReceiptHoverZoom';
 import Tooltip from '@components/Tooltip';
 import useActiveRoute from '@hooks/useActiveRoute';
 import useAncestors from '@hooks/useAncestors';
@@ -55,6 +56,8 @@ import {
 import trackExpenseCreationError from '@libs/telemetry/trackExpenseCreationError';
 import {
     didReceiptScanSucceed as didReceiptScanSucceedTransactionUtils,
+    hasEReceipt,
+    hasReceiptSource,
     hasReceipt as hasReceiptTransactionUtils,
     isDistanceRequest as isDistanceRequestTransactionUtils,
     isManualDistanceRequest,
@@ -250,6 +253,9 @@ function MoneyRequestReceiptView({
     if (hasReceipt) {
         receiptURIs = getThumbnailAndImageURIs(updatedTransaction ?? transaction);
     }
+    const transactionForReceipt = updatedTransaction ?? transaction;
+    const isEReceiptTransaction = !!transactionForReceipt && !hasReceiptSource(transactionForReceipt) && hasEReceipt(transactionForReceipt);
+    const canZoomReceipt = hasReceipt && !isLoading && !isTransactionScanning && !isEReceiptTransaction && !!receiptURIs?.image;
     const pendingAction = transaction?.pendingAction;
     // Need to return undefined when we have pendingAction to avoid the duplicate pending action
     const getPendingFieldAction = (fieldPath: TransactionPendingFieldsKey) => {
@@ -595,23 +601,28 @@ function MoneyRequestReceiptView({
                             onMouseLeave={hoverBind.onMouseLeave}
                         >
                             <View style={[styles.flex1, isReceiptOfflinePending && styles.offlineFeedbackPending]}>
-                                <ReportActionItemImage
-                                    shouldUseThumbnailImage={!fillSpace}
-                                    shouldUseFullHeight={fillSpace}
-                                    thumbnail={receiptURIs?.thumbnail}
-                                    fileExtension={receiptURIs?.fileExtension}
-                                    isThumbnail={receiptURIs?.isThumbnail}
-                                    image={receiptURIs?.image}
-                                    isLocalFile={receiptURIs?.isLocalFile}
-                                    filename={receiptURIs?.filename}
-                                    transaction={updatedTransaction ?? transaction}
-                                    enablePreviewModal
-                                    readonly={readonly || !canEditReceipt}
-                                    mergeTransactionID={mergeTransactionID}
-                                    report={report}
-                                    onLoad={() => setIsLoading(false)}
-                                    onLoadFailure={() => setIsLoading(false)}
-                                />
+                                <ReceiptHoverZoom
+                                    isEnabled={canZoomReceipt}
+                                    hoverContainerRef={receiptContainerRef}
+                                >
+                                    <ReportActionItemImage
+                                        shouldUseThumbnailImage={!fillSpace}
+                                        shouldUseFullHeight={fillSpace}
+                                        thumbnail={receiptURIs?.thumbnail}
+                                        fileExtension={receiptURIs?.fileExtension}
+                                        isThumbnail={receiptURIs?.isThumbnail}
+                                        image={receiptURIs?.image}
+                                        isLocalFile={receiptURIs?.isLocalFile}
+                                        filename={receiptURIs?.filename}
+                                        transaction={updatedTransaction ?? transaction}
+                                        enablePreviewModal
+                                        readonly={readonly || !canEditReceipt}
+                                        mergeTransactionID={mergeTransactionID}
+                                        report={report}
+                                        onLoad={() => setIsLoading(false)}
+                                        onLoadFailure={() => setIsLoading(false)}
+                                    />
+                                </ReceiptHoverZoom>
                             </View>
                             {canShowReceiptActions && (
                                 <View style={[styles.receiptActionButtonsContainer, styles.pointerEventsBoxNone, !hovered && !isPickerOpen && deviceHasHoverSupport && styles.opacity0]}>

--- a/tests/unit/useReceiptHoverZoomTest.ts
+++ b/tests/unit/useReceiptHoverZoomTest.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for the `useReceiptHoverZoom` hook.
+ *
+ * The hook attaches pointer-event listeners to a real DOM element and mutates inline styles
+ * imperatively, so we test through react-dom + jsdom rather than @testing-library/react-native
+ * (which renders via react-test-renderer and would not produce HTMLElement refs).
+ */
+/* eslint-disable testing-library/no-unnecessary-act -- we drive react-dom roots manually, not Testing Library, so `act` is required around render/event dispatch. */
+/* eslint-disable @typescript-eslint/naming-convention -- the Probe fixture passes kebab-case `data-*` attributes through `React.createElement`, which requires string keys that don't fit the camelCase/PascalCase rule. */
+import {act, createElement} from 'react';
+import type {RefObject} from 'react';
+import {createRoot} from 'react-dom/client';
+import type {Root} from 'react-dom/client';
+import type {View} from 'react-native';
+import useReceiptHoverZoom from '@components/ReceiptHoverZoom/useReceiptHoverZoom';
+import {hasHoverSupport} from '@libs/DeviceCapabilities';
+
+jest.mock('@libs/DeviceCapabilities', () => ({
+    __esModule: true,
+    hasHoverSupport: jest.fn(),
+}));
+
+const mockHasHoverSupport = hasHoverSupport as jest.MockedFunction<typeof hasHoverSupport>;
+
+type ProbeProps = {
+    isEnabled: boolean;
+    scale: number;
+    hoverContainerRef?: RefObject<View | null>;
+};
+
+// The Probe surfaces `isActive` via a `data-active` attribute on the wrapper, and the test
+// queries the rendered DOM rather than capturing the hook's return value through a module-level
+// holder. Mutating outer state from a component body would violate React Compiler's rules.
+const WRAPPER_TEST_ID = 'rhz-wrapper';
+const INNER_TEST_ID = 'rhz-inner';
+
+function Probe({isEnabled, scale, hoverContainerRef}: ProbeProps) {
+    const result = useReceiptHoverZoom({isEnabled, scale, hoverContainerRef});
+    return createElement(
+        'div',
+        {ref: result.wrapperRef, 'data-testid': WRAPPER_TEST_ID, 'data-active': String(result.isActive)},
+        createElement('div', {ref: result.innerRef, 'data-testid': INNER_TEST_ID}),
+    );
+}
+
+function wrapper(): HTMLDivElement {
+    const el = document.querySelector<HTMLDivElement>(`[data-testid="${WRAPPER_TEST_ID}"]`);
+    if (!el) {
+        throw new Error('Probe wrapper was not rendered');
+    }
+    return el;
+}
+
+function inner(): HTMLDivElement {
+    const el = document.querySelector<HTMLDivElement>(`[data-testid="${INNER_TEST_ID}"]`);
+    if (!el) {
+        throw new Error('Probe inner was not rendered');
+    }
+    return el;
+}
+
+function isActive(): boolean {
+    return wrapper().dataset.active === 'true';
+}
+
+function makeRect(overrides: Partial<DOMRect> = {}): DOMRect {
+    return {
+        left: 0,
+        top: 0,
+        right: 200,
+        bottom: 100,
+        width: 200,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
+        ...overrides,
+    } as DOMRect;
+}
+
+describe('useReceiptHoverZoom', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        mockHasHoverSupport.mockReturnValue(true);
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => {
+            root.unmount();
+        });
+        container.remove();
+        jest.restoreAllMocks();
+    });
+
+    const mount = (props: ProbeProps) => {
+        act(() => {
+            root.render(createElement(Probe, props));
+        });
+    };
+
+    describe('isActive flag', () => {
+        it('returns false when isEnabled=false even if hover is supported', () => {
+            mount({isEnabled: false, scale: 2.5});
+            expect(isActive()).toBe(false);
+        });
+
+        it('returns false when the device lacks hover support', () => {
+            mockHasHoverSupport.mockReturnValue(false);
+            mount({isEnabled: true, scale: 2.5});
+            expect(isActive()).toBe(false);
+        });
+
+        it('returns true when enabled and hover is supported', () => {
+            mount({isEnabled: true, scale: 2.5});
+            expect(isActive()).toBe(true);
+        });
+    });
+
+    describe('pointer interactions', () => {
+        it('applies scale transform on pointerenter', () => {
+            mount({isEnabled: true, scale: 2.5});
+            act(() => {
+                wrapper().dispatchEvent(new Event('pointerenter'));
+            });
+            expect(inner().style.transform).toBe('scale(2.5)');
+        });
+
+        it('resets scale to 1 on pointerleave', () => {
+            mount({isEnabled: true, scale: 3});
+            act(() => {
+                wrapper().dispatchEvent(new Event('pointerenter'));
+                wrapper().dispatchEvent(new Event('pointerleave'));
+            });
+            expect(inner().style.transform).toBe('scale(1)');
+        });
+
+        it('updates transformOrigin on pointermove using the cached rect', () => {
+            mount({isEnabled: true, scale: 2.5});
+            const target = wrapper();
+            target.getBoundingClientRect = jest.fn(() => makeRect({width: 200, height: 100}));
+
+            act(() => {
+                target.dispatchEvent(new Event('pointerenter'));
+                target.dispatchEvent(new MouseEvent('pointermove', {clientX: 50, clientY: 25}));
+            });
+
+            expect(inner().style.transformOrigin).toBe('25% 25%');
+        });
+
+        it('skips pointermove updates when the cached rect has no area', () => {
+            mount({isEnabled: true, scale: 2.5});
+            const target = wrapper();
+            // jsdom default rect is all zeros — exercise the early return.
+            act(() => {
+                target.dispatchEvent(new Event('pointerenter'));
+                target.dispatchEvent(new MouseEvent('pointermove', {clientX: 10, clientY: 10}));
+            });
+            expect(inner().style.transformOrigin).toBe('');
+        });
+    });
+
+    describe('mount-while-hovered kickoff', () => {
+        it('engages zoom immediately when matches(":hover") is true at mount', () => {
+            // `jest.spyOn` is auto-restored by `jest.restoreAllMocks()` in afterEach.
+            jest.spyOn(HTMLElement.prototype, 'matches').mockImplementation((selector: string) => selector === ':hover');
+
+            mount({isEnabled: true, scale: 2.5});
+            expect(inner().style.transform).toBe('scale(2.5)');
+        });
+    });
+
+    describe('cleanup on unmount', () => {
+        it('removes listeners and clears inline transform/origin', () => {
+            mount({isEnabled: true, scale: 2.5});
+            const target = wrapper();
+            const innerEl = inner();
+            target.getBoundingClientRect = jest.fn(() => makeRect());
+            const removeSpy = jest.spyOn(target, 'removeEventListener');
+
+            act(() => {
+                target.dispatchEvent(new Event('pointerenter'));
+                target.dispatchEvent(new MouseEvent('pointermove', {clientX: 100, clientY: 50}));
+            });
+            expect(innerEl.style.transform).toBe('scale(2.5)');
+
+            act(() => {
+                root.unmount();
+            });
+            // Re-create the root so the shared afterEach can unmount cleanly.
+            root = createRoot(container);
+
+            expect(removeSpy).toHaveBeenCalledWith('pointerenter', expect.any(Function));
+            expect(removeSpy).toHaveBeenCalledWith('pointerleave', expect.any(Function));
+            expect(removeSpy).toHaveBeenCalledWith('pointermove', expect.any(Function));
+            expect(innerEl.style.transform).toBe('');
+            expect(innerEl.style.transformOrigin).toBe('');
+        });
+    });
+
+    describe('external hoverContainerRef precedence', () => {
+        it('attaches listeners to the external ref when provided, not the auto-wrapper', () => {
+            const external = document.createElement('div');
+            document.body.appendChild(external);
+            const externalAdd = jest.spyOn(external, 'addEventListener');
+
+            try {
+                const externalRef = {current: external} as unknown as RefObject<View | null>;
+                mount({isEnabled: true, scale: 2.5, hoverContainerRef: externalRef});
+
+                expect(externalAdd).toHaveBeenCalledWith('pointerenter', expect.any(Function));
+                expect(externalAdd).toHaveBeenCalledWith('pointerleave', expect.any(Function));
+                expect(externalAdd).toHaveBeenCalledWith('pointermove', expect.any(Function));
+
+                external.getBoundingClientRect = jest.fn(() => makeRect());
+                act(() => {
+                    external.dispatchEvent(new Event('pointerenter'));
+                });
+                expect(inner().style.transform).toBe('scale(2.5)');
+            } finally {
+                external.remove();
+            }
+        });
+
+        it('falls back to the auto-wrapper when the external ref has no current element', () => {
+            const externalRef = {current: null} as unknown as RefObject<View | null>;
+            mount({isEnabled: true, scale: 2.5, hoverContainerRef: externalRef});
+
+            act(() => {
+                wrapper().dispatchEvent(new Event('pointerenter'));
+            });
+            expect(inner().style.transform).toBe('scale(2.5)');
+        });
+    });
+
+    describe('inactive state', () => {
+        it('does not attach pointer listeners when disabled', () => {
+            const addSpy = jest.spyOn(HTMLDivElement.prototype, 'addEventListener');
+            mount({isEnabled: false, scale: 2.5});
+            const pointerCalls = addSpy.mock.calls.filter(([eventName]) => typeof eventName === 'string' && eventName.startsWith('pointer'));
+            expect(pointerCalls).toHaveLength(0);
+        });
+    });
+});

--- a/tests/unit/useReceiptHoverZoomTest.ts
+++ b/tests/unit/useReceiptHoverZoomTest.ts
@@ -122,34 +122,43 @@ describe('useReceiptHoverZoom', () => {
     });
 
     describe('pointer interactions', () => {
-        it('applies scale transform on pointerenter', () => {
-            mount({isEnabled: true, scale: 2.5});
-            act(() => {
-                wrapper().dispatchEvent(new Event('pointerenter'));
-            });
-            expect(inner().style.transform).toBe('scale(2.5)');
-        });
-
-        it('resets scale to 1 on pointerleave', () => {
-            mount({isEnabled: true, scale: 3});
-            act(() => {
-                wrapper().dispatchEvent(new Event('pointerenter'));
-                wrapper().dispatchEvent(new Event('pointerleave'));
-            });
-            expect(inner().style.transform).toBe('scale(1)');
-        });
-
-        it('updates transformOrigin on pointermove using the cached rect', () => {
+        it('applies scale and transformOrigin on the first pointermove', () => {
             mount({isEnabled: true, scale: 2.5});
             const target = wrapper();
             target.getBoundingClientRect = jest.fn(() => makeRect({width: 200, height: 100}));
 
             act(() => {
-                target.dispatchEvent(new Event('pointerenter'));
                 target.dispatchEvent(new MouseEvent('pointermove', {clientX: 50, clientY: 25}));
             });
 
+            expect(inner().style.transform).toBe('scale(2.5)');
             expect(inner().style.transformOrigin).toBe('25% 25%');
+        });
+
+        it('does not apply zoom until pointermove fires (no zoom on mount, no pointerenter listener)', () => {
+            mount({isEnabled: true, scale: 2.5});
+            // Mount-time `:hover` would previously trigger zoom from center; now it should stay idle.
+            jest.spyOn(HTMLElement.prototype, 'matches').mockImplementation((selector: string) => selector === ':hover');
+            expect(inner().style.transform).toBe('');
+            expect(inner().style.transformOrigin).toBe('');
+
+            act(() => {
+                wrapper().dispatchEvent(new Event('pointerenter'));
+            });
+            expect(inner().style.transform).toBe('');
+            expect(inner().style.transformOrigin).toBe('');
+        });
+
+        it('resets scale to 1 on pointerleave', () => {
+            mount({isEnabled: true, scale: 3});
+            const target = wrapper();
+            target.getBoundingClientRect = jest.fn(() => makeRect({width: 200, height: 100}));
+
+            act(() => {
+                target.dispatchEvent(new MouseEvent('pointermove', {clientX: 50, clientY: 25}));
+                target.dispatchEvent(new Event('pointerleave'));
+            });
+            expect(inner().style.transform).toBe('scale(1)');
         });
 
         it('skips pointermove updates when the cached rect has no area', () => {
@@ -157,20 +166,10 @@ describe('useReceiptHoverZoom', () => {
             const target = wrapper();
             // jsdom default rect is all zeros — exercise the early return.
             act(() => {
-                target.dispatchEvent(new Event('pointerenter'));
                 target.dispatchEvent(new MouseEvent('pointermove', {clientX: 10, clientY: 10}));
             });
+            expect(inner().style.transform).toBe('');
             expect(inner().style.transformOrigin).toBe('');
-        });
-    });
-
-    describe('mount-while-hovered kickoff', () => {
-        it('engages zoom immediately when matches(":hover") is true at mount', () => {
-            // `jest.spyOn` is auto-restored by `jest.restoreAllMocks()` in afterEach.
-            jest.spyOn(HTMLElement.prototype, 'matches').mockImplementation((selector: string) => selector === ':hover');
-
-            mount({isEnabled: true, scale: 2.5});
-            expect(inner().style.transform).toBe('scale(2.5)');
         });
     });
 
@@ -183,7 +182,6 @@ describe('useReceiptHoverZoom', () => {
             const removeSpy = jest.spyOn(target, 'removeEventListener');
 
             act(() => {
-                target.dispatchEvent(new Event('pointerenter'));
                 target.dispatchEvent(new MouseEvent('pointermove', {clientX: 100, clientY: 50}));
             });
             expect(innerEl.style.transform).toBe('scale(2.5)');
@@ -194,7 +192,6 @@ describe('useReceiptHoverZoom', () => {
             // Re-create the root so the shared afterEach can unmount cleanly.
             root = createRoot(container);
 
-            expect(removeSpy).toHaveBeenCalledWith('pointerenter', expect.any(Function));
             expect(removeSpy).toHaveBeenCalledWith('pointerleave', expect.any(Function));
             expect(removeSpy).toHaveBeenCalledWith('pointermove', expect.any(Function));
             expect(innerEl.style.transform).toBe('');
@@ -212,13 +209,12 @@ describe('useReceiptHoverZoom', () => {
                 const externalRef = {current: external} as unknown as RefObject<View | null>;
                 mount({isEnabled: true, scale: 2.5, hoverContainerRef: externalRef});
 
-                expect(externalAdd).toHaveBeenCalledWith('pointerenter', expect.any(Function));
                 expect(externalAdd).toHaveBeenCalledWith('pointerleave', expect.any(Function));
                 expect(externalAdd).toHaveBeenCalledWith('pointermove', expect.any(Function));
 
                 external.getBoundingClientRect = jest.fn(() => makeRect());
                 act(() => {
-                    external.dispatchEvent(new Event('pointerenter'));
+                    external.dispatchEvent(new MouseEvent('pointermove', {clientX: 100, clientY: 50}));
                 });
                 expect(inner().style.transform).toBe('scale(2.5)');
             } finally {
@@ -229,9 +225,11 @@ describe('useReceiptHoverZoom', () => {
         it('falls back to the auto-wrapper when the external ref has no current element', () => {
             const externalRef = {current: null} as unknown as RefObject<View | null>;
             mount({isEnabled: true, scale: 2.5, hoverContainerRef: externalRef});
+            const target = wrapper();
+            target.getBoundingClientRect = jest.fn(() => makeRect());
 
             act(() => {
-                wrapper().dispatchEvent(new Event('pointerenter'));
+                target.dispatchEvent(new MouseEvent('pointermove', {clientX: 100, clientY: 50}));
             });
             expect(inner().style.transform).toBe('scale(2.5)');
         });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Adds hover-to-zoom on receipt thumbnails in `MoneyRequestReceiptView` (web/desktop only). A new `ReceiptHoverZoom` component wraps the receipt image and applies a CSS `scale` transform that tracks the cursor via pointer events. It is a no-op on native and on devices without hover support, and stays disabled for e-receipts, scanning states, and missing images.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90793
PROPOSAL:


<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Sign in on web at https://dev.new.expensify.com:8082/ in a desktop browser.
2. Open an expense report that contains a money request with an uploaded receipt image (JPG/PNG/PDF thumbnail) and open the money request so the receipt thumbnail is visible in `MoneyRequestReceiptView`.
3. Move the cursor over the receipt thumbnail and verify the image smoothly scales up (~2.5x) and that the zoomed region follows the cursor as you move within the thumbnail bounds.
4. Move the cursor off the thumbnail and verify the image returns to its original size with no flicker.
5. Hover near the receipt's overlay action buttons (edit/replace/etc.) and verify the zoom stays engaged while the cursor crosses those buttons (does not reset).

---

1. Open a money request that has no receipt (empty state) and verify no zoom behavior occurs.
2. Open a money request whose receipt is still scanning and verify no zoom behavior occurs while the scan indicator is shown.
3. Open an e-receipt money request (no uploaded image) and verify no zoom behavior occurs.

---

1. In Chrome DevTools, enable touch emulation (or test on a touch-only device) and reopen a money request with a receipt.
2. Verify no zoom is applied on tap/touch and that existing tap behavior on the thumbnail is unchanged.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this change is a purely client-side visual interaction (CSS transform driven by pointer events) and does not involve API calls, network requests, or Onyx writes.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
