### PR TITLE
fix: translate distance rate rename action in workspace change log

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -7395,6 +7395,7 @@ Fügen Sie weitere Ausgabelimits hinzu, um den Cashflow Ihres Unternehmens zu sc
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? 'aktiviert' : 'deaktiviert'} den ${customUnitName}-Satz „${customUnitRateName}“`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `benannte die ${customUnitName}-Rate "${oldRateName}" in "${newRateName}" um`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `hat den „${customUnitName}“-Satz „${rateName}“ entfernt`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `Standardwert des Berichts­feldes „${fieldName}“ auf „${defaultValue}“ festlegen`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `die Option „${optionName}“ zum Berichtsfeld „${fieldName}“ hinzugefügt`,

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -7409,6 +7409,7 @@ const translations = {
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? 'enabled' : 'disabled'} the ${customUnitName} rate "${customUnitRateName}"`;
         },
+        renamedCustomUnitRate: (customUnitName: string, oldRateName: string, newRateName: string) => `renamed the ${customUnitName} rate "${oldRateName}" to "${newRateName}"`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `set the default value of report field "${fieldName}" to "${defaultValue}"`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `added the option "${optionName}" to the report field "${fieldName}"`,
         removedReportFieldOption: (fieldName: string, optionName: string) => `removed the option "${optionName}" from the report field "${fieldName}"`,

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -7200,6 +7200,7 @@ ${amount} para ${merchant} - ${date}`,
         updatedCustomUnitRateEnabled: (customUnitName, customUnitRateName, newValue) => {
             return `${newValue ? 'habilitó' : 'deshabilitó'} la tasa de ${customUnitName} "${customUnitRateName}"`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `renombró la tasa de ${customUnitName} "${oldRateName}" a "${newRateName}"`,
         updateReportFieldDefaultValue: (defaultValue, fieldName) => `estableció el valor predeterminado del campo de informe "${fieldName}" en "${defaultValue}"`,
         addedReportFieldOption: (fieldName, optionName) => `añadió la opción "${optionName}" al campo de informe "${fieldName}"`,
         removedReportFieldOption: (fieldName, optionName) => `eliminó la opción "${optionName}" del campo de informe "${fieldName}"`,

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -7423,6 +7423,7 @@ Ajoutez davantage de règles de dépenses pour protéger la trésorerie de l’e
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? 'Activé' : 'Désactivé'} le taux de ${customUnitName} « ${customUnitRateName} »`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `a renommé le tarif ${customUnitName} "${oldRateName}" en "${newRateName}"`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `a supprimé le taux « ${customUnitName} » « ${rateName} »`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `définir la valeur par défaut du champ de note de frais « ${fieldName} » sur « ${defaultValue} »`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `a ajouté l’option « ${optionName} » au champ de note de frais « ${fieldName} »`,

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -7381,6 +7381,7 @@ Aggiungi altre regole di spesa per proteggere il flusso di cassa aziendale.`,
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? 'abilitato' : 'disattivato'} la tariffa ${customUnitName} "${customUnitRateName}"`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `ha rinominato il tasso ${customUnitName} "${oldRateName}" in "${newRateName}"`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `ha rimosso la tariffa "${rateName}" per l'unità personalizzata "${customUnitName}"`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `imposta il valore predefinito del campo report "${fieldName}" su "${defaultValue}"`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `ha aggiunto l’opzione «${optionName}» al campo del rendiconto «${fieldName}»`,

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -7299,6 +7299,7 @@ ${reportName}
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? '有効' : '無効'} の ${customUnitName} レート「${customUnitRateName}」`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `${customUnitName} のレート「${oldRateName}」を「${newRateName}」に名前変更しました`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `「${customUnitName}」レート「${rateName}」を削除しました`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `レポートフィールド「${fieldName}」のデフォルト値を「${defaultValue}」に設定する`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `レポート項目「${fieldName}」にオプション「${optionName}」を追加しました`,

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -7356,6 +7356,7 @@ er bestedingsregels toe om de kasstroom van het bedrijf te beschermen.`,
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? 'ingeschakeld' : 'uitgeschakeld'} het ${customUnitName}-tarief "${customUnitRateName}"`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `heeft de ${customUnitName}-tarief "${oldRateName}" hernoemd naar "${newRateName}"`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `heeft het tarief „${rateName}” van de eenheid „${customUnitName}” verwijderd`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `stel de standaardwaarde van rapportveld "${fieldName}" in op "${defaultValue}"`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `heeft de optie ‘${optionName}’ toegevoegd aan het rapportveld ‘${fieldName}’`,

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -7351,6 +7351,7 @@ Dodaj więcej zasad wydatków, żeby chronić płynność finansową firmy.`,
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? 'włączone' : 'wyłączone'} stawkę jednostki niestandardowej ${customUnitName} „${customUnitRateName}”`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `zmieniono nazwę stawki ${customUnitName} "${oldRateName}" na "${newRateName}"`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `usunięto stawkę „${rateName}” jednostki „${customUnitName}”`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `ustaw domyślną wartość pola raportu „${fieldName}” na „${defaultValue}”`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `dodano opcję „${optionName}” do pola raportu „${fieldName}”`,

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -7354,6 +7354,7 @@ Adicione mais regras de gasto para proteger o fluxo de caixa da empresa.`,
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? 'ativado' : 'desativado'} a taxa de ${customUnitName} "${customUnitRateName}"`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `renomeou a taxa de ${customUnitName} "${oldRateName}" para "${newRateName}"`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `removeu a taxa "${rateName}" da unidade personalizada "${customUnitName}"`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `definir o valor padrão do campo de relatório "${fieldName}" como "${defaultValue}"`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `adicionou a opção "${optionName}" ao campo de relatório "${fieldName}"`,

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -7169,6 +7169,7 @@ ${reportName}
         updatedCustomUnitRateEnabled: (customUnitName: string, customUnitRateName: string, newValue: boolean) => {
             return `${newValue ? '已启用' : '已禁用'}${customUnitName}费率“${customUnitRateName}”`;
         },
+        renamedCustomUnitRate: (customUnitName, oldRateName, newRateName) => `已将 ${customUnitName} 费率 "${oldRateName}" 重命名为 "${newRateName}"`,
         deleteCustomUnitRate: (customUnitName: string, rateName: string) => `已删除“${customUnitName}”费率“${rateName}”`,
         updateReportFieldDefaultValue: (defaultValue?: string, fieldName?: string) => `将报表字段“${fieldName}”的默认值设置为“${defaultValue}”`,
         addedReportFieldOption: (fieldName: string, optionName: string) => `已将选项“${optionName}”添加到报表字段“${fieldName}”`,

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -3195,6 +3195,10 @@ function getWorkspaceCustomUnitRateUpdatedMessage(translate: LocalizedTranslate,
         return translate('workspaceActions.updatedCustomUnitRateEnabled', customUnitName, customUnitRateName, newValue);
     }
 
+    if (customUnitName && updatedField === 'name' && typeof oldValue === 'string' && typeof newValue === 'string') {
+        return translate('workspaceActions.renamedCustomUnitRate', customUnitName, oldValue, newValue);
+    }
+
     return getReportActionText(action);
 }
 


### PR DESCRIPTION
## Explanation

When a distance rate is renamed, the workspace change log action in the admin room was not translated. This happened because `getWorkspaceCustomUnitRateUpdatedMessage` in `ReportActionsUtils.ts` had cases for `rate`, `taxRateExternalID`, `taxClaimablePercentage`, and `enabled` fields, but **no case for `updatedField === 'name'`**. This caused the function to fall through to `getReportActionText(action)`, which returns the raw server-side HTML message — bypassing the client-side translation system entirely.

### Root Cause

In `src/libs/ReportActionsUtils.ts`, the function `getWorkspaceCustomUnitRateUpdatedMessage` handles various `updatedField` values but was missing the `name` field case:

```typescript
// Existing cases: rate, taxRateExternalID, taxClaimablePercentage, enabled
// Missing: name
```

### Fix

1. **`src/libs/ReportActionsUtils.ts`**: Added a new case for `updatedField === 'name'` that returns a translated message using a new `workspaceActions.renamedCustomUnitRate` translation key.

2. **All 10 language files** (`en.ts`, `es.ts`, `de.ts`, `fr.ts`, `it.ts`, `ja.ts`, `nl.ts`, `pl.ts`, `pt-BR.ts`, `zh-hans.ts`): Added the `renamedCustomUnitRate` translation key with localized strings.

## Fixed Issues

$ #91204

## Tests

1. Set preferred language to Spanish (or any non-English language)
2. Open a workspace with Distance rates enabled
3. Go to Distance rates > rename any rate
4. Open the admin room thread
5. Verify the rename action message is now translated

## Offline tests

N/A — this is a server-side action that creates report actions in the admin room.

## QA Steps

1. Set preferred language to Spanish
2. Go to Workspace settings > Distance rates
3. Rename any rate
4. Open the admin room thread
5. Verify the distance rate rename action is now translated in the thread and thread header

## PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps
- [x] I added clear steps for QA
- [x] I tested the change locally
- [x] I verified translations in all 10 supported languages