### PR TITLE
fix: show contact names when importing device contacts

### DIFF
--- a/src/libs/PersonalDetailOptionsListUtils/index.ts
+++ b/src/libs/PersonalDetailOptionsListUtils/index.ts
@@ -65,7 +65,7 @@ function createOption(
     result.keyForList = String(personalDetail.accountID);
     result.alternateText = formatPhoneNumber(personalDetail.login ?? '');
 
-    result.text = getDisplayNameForParticipant({accountID: personalDetail.accountID, formatPhoneNumber}) || formatPhoneNumber(personalDetail.login ?? '');
+    result.text = getDisplayNameForParticipant({accountID: personalDetail.accountID, formatPhoneNumber}) || personalDetail.displayName || formatPhoneNumber(personalDetail.login ?? '');
     result.icons = [
         {
             id: personalDetail.accountID,


### PR DESCRIPTION
## Explanation

When device contacts are imported (Android/iOS), contact names don't appear — only phone numbers are shown.

### Root Cause

The data flow for imported device contacts:

1. `ContactsNitroModule.getAll()` correctly fetches `firstName` and `lastName` from the device
2. `getContacts()` in `ContactUtils.ts` correctly reads these fields
3. `getContactOption()` correctly constructs `displayName: "John Doe"` and passes it to `createOption()`
4. **Bug:** `createOption()` in `PersonalDetailOptionsListUtils.ts` ignores the `displayName` and instead calls `getDisplayNameForParticipant({accountID})`, which looks up the account in Onyx
5. Device contacts aren't Expensify users, so the Onyx lookup returns empty
6. Falls back to `formatPhoneNumber(login)` — showing just the phone number

The `displayName` constructed in step 3 was being completely discarded.

### Fix

Added `personalDetail.displayName` as a fallback in `createOption()` between the Onyx participant lookup and the phone number formatting:

```typescript
// Before:
result.text = getDisplayNameForParticipant({...}) || formatPhoneNumber(login);

// After:
result.text = getDisplayNameForParticipant({...}) || personalDetail.displayName || formatPhoneNumber(login);
```

This is a 1-line change. For Expensify users, `getDisplayNameForParticipant` returns the correct name from Onyx (no behavior change). For device contacts, `personalDetail.displayName` now provides the name that was already correctly constructed from the imported contact data.

## Fixed Issues

$ #91150

## Tests

1. Launch the app on Android or iOS
2. Log in with valid credentials
3. Create an expense (press + > create expense > take a photo)
4. When the soft permission modal appears, tap "Continue"
5. Allow access to device contacts
6. Scroll down in the contact list
7. Verify contacts show their names (not just phone numbers)

## Offline tests

N/A — requires native contact import which only works on device.

## QA Steps

1. On Android or iOS, create an expense
2. When prompted, grant contact permission
3. Verify the contact list shows contact names alongside phone numbers
4. Verify contacts with only phone numbers (no name) still display correctly

## PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps
- [x] I added clear steps for QA
- [x] I verified the fix logic for both Expensify users (Onyx lookup) and device contacts (displayName fallback)
