### PR TITLE
Fix room pagination merging disjoint start-marked pages

### DIFF
--- a/src/libs/PaginationUtils.ts
+++ b/src/libs/PaginationUtils.ts
@@ -19,6 +19,9 @@ type PageWithIndex = {
     /** The IDs we store in Onyx and which make up the page. */
     ids: string[];
 
+    /** The IDs that were originally stored for the page before expanding indexes against sortedItems. */
+    sourceIDs: string[];
+
     /** The first ID in the page. */
     firstID: string;
 
@@ -122,6 +125,7 @@ function getPagesWithIndexes<TResource>(sortedItems: TResource[], pages: Pages, 
 
             return {
                 ids,
+                sourceIDs: page,
                 firstID: firstItem.id,
                 firstIndex: firstItem.index,
                 lastID: lastItem.id,
@@ -142,6 +146,11 @@ function mergeAndSortContinuousPages<TResource>(sortedItems: TResource[], pages:
 
     // Pages need to be sorted by firstIndex ascending then by lastIndex descending
     const sortedPages = pagesWithIndexes.sort((a, b) => {
+        const areDisjointStartPages = a.firstID === CONST.PAGINATION_START_ID && b.firstID === CONST.PAGINATION_START_ID && !pagesShareAnyNonMarkerID(a.sourceIDs, b.sourceIDs);
+        if (areDisjointStartPages) {
+            return a.lastIndex - b.lastIndex;
+        }
+
         if (a.firstIndex !== b.firstIndex || a.firstID !== b.firstID) {
             if (a.firstID === CONST.PAGINATION_START_ID) {
                 return -1;
@@ -163,14 +172,22 @@ function mergeAndSortContinuousPages<TResource>(sortedItems: TResource[], pages:
             continue;
         }
 
+        const areDisjointStartPages =
+            page.firstID === CONST.PAGINATION_START_ID && prevPage.firstID === CONST.PAGINATION_START_ID && !pagesShareAnyNonMarkerID(prevPage.sourceIDs, page.sourceIDs);
+
         // Current page is inside the previous page, skip
-        if (page.lastIndex <= prevPage.lastIndex && page.lastID !== CONST.PAGINATION_END_ID) {
+        if (!areDisjointStartPages && page.lastIndex <= prevPage.lastIndex && page.lastID !== CONST.PAGINATION_END_ID) {
             continue;
         }
 
+        const hasSharedBoundaryID = page.firstID === prevPage.lastID && !isPaginationMarker(page.firstID);
+        const hasIndexOverlap = page.firstIndex < prevPage.lastIndex;
+
         // Current page overlaps with the previous page, merge.
-        // This happens if the ids from the current page and previous page are the same or if the indexes overlap
-        if (page.firstID === prevPage.lastID || page.firstIndex < prevPage.lastIndex) {
+        // This happens if the ids from the current page and previous page are the same or if the indexes overlap.
+        // Two disjoint pages can both contain PAGINATION_START_ID when each was fetched as the live tail at different times;
+        // that marker alone is not evidence that the pages are continuous.
+        if (hasSharedBoundaryID || (!areDisjointStartPages && hasIndexOverlap)) {
             result[result.length - 1] = {
                 firstID: prevPage.firstID,
                 firstIndex: prevPage.firstIndex,
@@ -178,12 +195,17 @@ function mergeAndSortContinuousPages<TResource>(sortedItems: TResource[], pages:
                 lastIndex: page.lastIndex,
                 // Only add items from prevPage that are not included in page in case of overlap.
                 ids: prevPage.ids.slice(0, prevPage.ids.indexOf(page.firstID)).concat(page.ids),
+                sourceIDs: prevPage.sourceIDs.concat(page.sourceIDs),
             };
             continue;
         }
 
-        // No overlap, add the current page as is.
-        result.push(page);
+        // No overlap, add the current page as is. If this page only looks newest because of a stale start marker,
+        // preserve its original IDs but drop that stale marker so it doesn't cover newer actions.
+        result.push({
+            ...page,
+            ids: areDisjointStartPages && page.sourceIDs.at(0) === CONST.PAGINATION_START_ID ? page.sourceIDs.slice(1) : page.ids,
+        });
     }
 
     return result.map((page) => page?.ids ?? []);
@@ -396,6 +418,7 @@ function getContinuousChain<TResource>(sortedItems: TResource[], pages: Pages, g
 
     let page: PageWithIndex = {
         ids: [],
+        sourceIDs: [],
         firstID: '',
         firstIndex: 0,
         lastID: '',

--- a/tests/unit/PaginationUtilsTest.ts
+++ b/tests/unit/PaginationUtilsTest.ts
@@ -1,3 +1,7 @@
+jest.mock('react-native-key-command', () => ({
+    constants: {},
+}));
+
 import CONST from '@src/CONST';
 import type {Pages} from '@src/types/onyx';
 import {getContinuousChain, mergeAndSortContinuousPages, mergePagesByIDOverlap, prunePagesToNewestWindow, selectNewestPageWithIndex} from '../../src/libs/PaginationUtils';
@@ -603,6 +607,32 @@ describe('PaginationUtils', () => {
             const result = mergeAndSortContinuousPages(sortedItems, pages, getID);
             expect(result).toStrictEqual(expectedResult);
         });
+
+        it('does not merge disjoint pages only because both were marked as the newest page at different times', () => {
+            const sortedItems = createItems([
+                // Newer page fetched after the app was closed for a while
+                '300',
+                '299',
+                '298',
+                // Gap: many actions between 298 and 200 are not loaded locally yet
+                '200',
+                '199',
+                '198',
+            ]);
+            const pages = [
+                // Fresh OpenReport response for the live tail
+                [CONST.PAGINATION_START_ID, '300', '299', '298'],
+                // Stale cached page that used to be the live tail before newer messages arrived
+                [CONST.PAGINATION_START_ID, '200', '199', '198', CONST.PAGINATION_END_ID],
+            ];
+            const expectedResult = [
+                [CONST.PAGINATION_START_ID, '300', '299', '298'],
+                // The stale start marker should be ignored because this page is no longer the newest local window.
+                ['200', '199', '198', CONST.PAGINATION_END_ID],
+            ];
+            const result = mergeAndSortContinuousPages(sortedItems, pages, getID);
+            expect(result).toStrictEqual(expectedResult);
+        });
     });
 
     describe('mergePagesByIDOverlap', () => {
@@ -669,6 +699,7 @@ describe('PaginationUtils', () => {
         it('returns the only page when there is a single page', () => {
             const only = {
                 ids: ['3', '2', '1'],
+                sourceIDs: ['3', '2', '1'],
                 firstID: '3',
                 firstIndex: 0,
                 lastID: '1',
@@ -680,6 +711,7 @@ describe('PaginationUtils', () => {
         it('prefers the page whose firstID is the pagination start marker', () => {
             const withStart = {
                 ids: [CONST.PAGINATION_START_ID, '2', '1'],
+                sourceIDs: [CONST.PAGINATION_START_ID, '2', '1'],
                 firstID: CONST.PAGINATION_START_ID,
                 firstIndex: 2,
                 lastID: '1',
@@ -687,6 +719,7 @@ describe('PaginationUtils', () => {
             };
             const newerByIndex = {
                 ids: ['5', '4'],
+                sourceIDs: ['5', '4'],
                 firstID: '5',
                 firstIndex: 0,
                 lastID: '4',
@@ -699,6 +732,7 @@ describe('PaginationUtils', () => {
         it('when no start marker, picks the page with the smallest firstIndex (chronologically newest in descending-sorted data)', () => {
             const olderWindow = {
                 ids: ['2', '1'],
+                sourceIDs: ['2', '1'],
                 firstID: '2',
                 firstIndex: 3,
                 lastID: '1',
@@ -706,6 +740,7 @@ describe('PaginationUtils', () => {
             };
             const newerWindow = {
                 ids: ['5', '4'],
+                sourceIDs: ['5', '4'],
                 firstID: '5',
                 firstIndex: 0,
                 lastID: '4',


### PR DESCRIPTION
## Summary

Fixes a pagination edge case where two disjoint report-action pages can be merged only because both contain `PAGINATION_START_ID`.

This can happen when a large room has an older cached page that was previously the newest window, then the app is closed/offline while newer actions arrive. After reopening, `OpenReport` can fetch the fresh newest window, while the stale cached window still contains `PAGINATION_START_ID`. The previous merge logic treated the duplicate start marker / index overlap as continuity, even when the pages shared no real report action IDs. That can collapse separate windows and make the room appear to skip or mix messages from different dates while scrolling upward.

The change keeps track of the original page IDs before page expansion and avoids treating `PAGINATION_START_ID` alone as overlap evidence. If two start-marked pages share no non-marker IDs, they remain separate and the stale start marker is dropped from the older page.

## Regression test

Added a unit test covering:

- fresh newest page: `[PAGINATION_START_ID, 300, 299, 298]`
- stale cached page: `[PAGINATION_START_ID, 200, 199, 198, PAGINATION_END_ID]`
- no real shared action IDs between the pages

Expected result preserves both windows without implying that the stale page is still the live tail:

```ts
[
    [PAGINATION_START_ID, '300', '299', '298'],
    ['200', '199', '198', PAGINATION_END_ID],
]
```

## Tests

```bash
npx -y -p node@20.20.0 -p npm@10.8.2 npm test -- --runTestsByPath tests/unit/PaginationUtilsTest.ts --runInBand
npx -y -p node@20.20.0 -p npm@10.8.2 npx prettier --check src/libs/PaginationUtils.ts tests/unit/PaginationUtilsTest.ts
```

Result:

- `tests/unit/PaginationUtilsTest.ts`: 39 passed
- Prettier check passed

$ #34687
