### PR TITLE
Validate address zip against the selected country

### DIFF
--- a/src/components/AddressForm.tsx
+++ b/src/components/AddressForm.tsx
@@ -96,8 +96,9 @@ function AddressForm({
 
     const validator = useCallback(
         (rawValues: FormOnyxValues<typeof ONYXKEYS.FORMS.HOME_ADDRESS_FORM>): Errors => {
-            // When hidden, the country input is unregistered so fall back to the country prop.
-            const values = shouldHideCountrySelector ? {...rawValues, country: rawValues.country || country} : rawValues;
+            // `country` is controlled by the parent so AddressSearch/CountrySelector changes immediately update
+            // the zip validation and hint even if the form draft still contains the previous country.
+            const values = {...rawValues, country: country || rawValues.country};
 
             const errors: Errors & {
                 zipPostCode?: string | string[];


### PR DESCRIPTION
## Summary

Fixes the address form zip/postal code validation so it uses the currently selected country from the parent component instead of relying on a possibly stale form value.

In the add-bank-account address flow, the selected country is controlled by the parent (`AddressStep`) and passed into `AddressForm`. The zip/postal hint already uses that controlled `country` prop, but validation could still read `rawValues.country` from the form values. After changing the country, this can leave validation tied to the previous country while the UI is showing the new country/hint.

This updates validation to normalize the form values with the controlled `country` prop first, so the zip/postal rules match the currently selected country immediately after country changes.

## Tests

```bash
npx -y -p node@20.20.0 -p npm@10.8.2 npx prettier --check src/components/AddressForm.tsx
npx -y -p node@20.20.0 -p npm@10.8.2 npx tsc --noEmit --pretty false --skipLibCheck 2>&1 | grep -E 'AddressForm' || true
```

Result:

- Prettier check passed
- No `AddressForm` type errors reported

$ #90491
