### PR TITLE
Fix: Add Cards button hidden behind Android navigation bar

### DIFF
--- a/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
@@ -382,7 +382,7 @@ function WorkspaceCompanyCardsTable({
             {!shouldUseNarrowTableLayout && ListHeader}
 
             {(isLoading || isFeedPending || isNoFeed) && !feedErrorKey && (
-                <ScrollView>
+                <ScrollView addBottomSafeAreaPadding>
                     {isLoading && LoadingComponent}
 
                     {!isLoading && isFeedPending && (


### PR DESCRIPTION
## Fix for #91207

### Problem
On Android, the **Add Cards** button on the Workspace > Company Cards page is displayed behind the system navigation bar when no card feed is connected.

### Root Cause
`WorkspaceCompanyCardsPage` renders inside `WorkspacePageWithSections`, which uses `ScreenWrapper` with `enableEdgeToEdgeBottomSafeAreaPadding`. This opts out of automatic bottom safe-area padding — children must apply their own bottom inset.

The `ScrollView` that wraps the loading/pending/no-feed states in `WorkspaceCompanyCardsTable/index.tsx` (line 385) has **no** `addBottomSafeAreaPadding` prop and **no** `contentContainerStyle` with bottom safe-area padding. As a result, the "Add Cards" CTA inside `WorkspaceCompanyCardPageEmptyState` scrolls behind the Android navigation bar.

The parallel error-state `ScrollView` (line 407) already correctly applies `bottomSafeAreaPaddingStyle` — only the no-feed branch was missed.

### Fix
Add `addBottomSafeAreaPadding` to the `<ScrollView>` at `src/components/Tables/WorkspaceCompanyCardsTable/index.tsx:385`:

```diff
-                <ScrollView>
+                <ScrollView addBottomSafeAreaPadding>
```

This is a one-line change. The project's `@components/ScrollView` wrapper already routes the `addBottomSafeAreaPadding` prop through `useBottomSafeSafeAreaPaddingStyle` and merges it into `contentContainerStyle`, so no new imports or styles are needed.

### Testing
- Verified the fix follows the same pattern used in `WorkspaceCompanyCardsFeedAddedEmptyPage` and the sibling error `ScrollView` in the same file.
- `useBottomSafeSafeAreaPaddingStyle` resolves to zero on iOS/wide layouts where there is no system inset, so no visual regression on those platforms.
- The fix also covers the loading skeleton and feed-pending states wrapped by the same `ScrollView`.

### Alternative Solutions Considered
1. **Pass `shouldUseScrollView` from `WorkspaceCompanyCardsPage`** — Rejected because it would nest scrollables and break FlashList/header sticky behavior.
2. **Add padding inside `WorkspaceCompanyCardPageEmptyState` or `FeatureList`** — Rejected because those components are reused in `WorkspaceCompanyCardsFeedAddedEmptyPage`, which already applies its own safe-area padding. Adding inset there would double-pad.
3. **Use `contentContainerStyle={bottomSafeAreaPaddingStyle}`** instead of the prop — Functionally equivalent but less idiomatic; the `addBottomSafeAreaPadding` prop is the project's standard API for this purpose.

$ #91207