### PR TITLE
perf: stop WorkspacesListPage re-renders triggered by policy isLoading merges

### DIFF
--- a/src/hooks/usePoliciesWithCardFeedErrors.ts
+++ b/src/hooks/usePoliciesWithCardFeedErrors.ts
@@ -1,11 +1,12 @@
 import {isPolicyAdmin} from '@libs/PolicyUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
+import {policyCollectionWithoutLoadingFlagsSelector} from '@src/selectors/Policy';
 import type {Policy} from '@src/types/onyx';
 import useCardFeedErrors from './useCardFeedErrors';
 import useOnyx from './useOnyx';
 
 function usePoliciesWithCardFeedErrors() {
-    const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
+    const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: policyCollectionWithoutLoadingFlagsSelector});
     const [session] = useOnyx(ONYXKEYS.SESSION);
 
     // If a policy was just deleted from Onyx, then Onyx will pass a null value to the props, and

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -67,7 +67,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import {accountIDToLoginSelector} from '@src/selectors/PersonalDetails';
-import {ownerPoliciesSelector} from '@src/selectors/Policy';
+import {ownerPoliciesSelector, policyCollectionWithoutLoadingFlagsSelector} from '@src/selectors/Policy';
 import {reimbursementAccountErrorSelector} from '@src/selectors/ReimbursementAccount';
 import type {Policy as PolicyType} from '@src/types/onyx';
 import type * as OnyxCommon from '@src/types/onyx/OnyxCommon';
@@ -116,7 +116,7 @@ function WorkspacesListPage() {
     const privateSubscription = usePrivateSubscription();
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const [allConnectionSyncProgresses] = useOnyx(ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS);
-    const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
+    const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: policyCollectionWithoutLoadingFlagsSelector});
     const [reimbursementAccount] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT);
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);

--- a/src/selectors/Policy.ts
+++ b/src/selectors/Policy.ts
@@ -146,6 +146,35 @@ const iouRequestPolicyCollectionSelector = (policies: OnyxCollection<Policy>): O
     return result;
 };
 
+// Strips transient `isLoading*` flags merged onto policies by per-page reads (e.g.
+// openPolicyWorkflowsPage), so useOnyx's deepEqual elides re-renders when another screen flips them.
+// Flag-free policies are returned by reference (Onyx keeps unchanged entries stable, so deepEqual
+// short-circuits on `===` instead of deep-traversing all fields). We strip whenever a flag is present
+// (true OR false) so the output stays flag-free across a true->false merge.
+const policyCollectionWithoutLoadingFlagsSelector = (policies: OnyxCollection<Policy>): OnyxCollection<Policy> => {
+    if (!policies) {
+        return undefined;
+    }
+
+    const result: Record<string, Policy> = {};
+
+    for (const [id, policyItem] of Object.entries(policies)) {
+        if (!policyItem) {
+            continue;
+        }
+
+        if (policyItem.isLoading === undefined && policyItem.isLoadingReceiptPartners === undefined && policyItem.isLoadingWorkspaceReimbursement === undefined) {
+            result[id] = policyItem;
+            continue;
+        }
+
+        const {isLoading, isLoadingReceiptPartners, isLoadingWorkspaceReimbursement, ...rest} = policyItem;
+        result[id] = rest as Policy;
+    }
+
+    return result;
+};
+
 const hasOnlyPersonalPoliciesSelector = (policies: OnyxCollection<Policy>): boolean => {
     return !Object.values(policies ?? {}).some((policy) => policy && policy.type !== CONST.POLICY.TYPE.PERSONAL && policy.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
 };
@@ -261,6 +290,7 @@ export {
     hasMultipleOutputCurrenciesSelector,
     groupPaidPoliciesWithExpenseChatEnabledSelector,
     iouRequestPolicyCollectionSelector,
+    policyCollectionWithoutLoadingFlagsSelector,
     policyMapper,
     adminPoliciesConnectedToQBDSelector,
     reusablePoliciesConnectedToSelector,


### PR DESCRIPTION
### Explanation of Change

Adds a `policyCollectionWithoutLoadingFlagsSelector` that strips transient `isLoading*` flags from the policy collection, and applies it to `WorkspacesListPage` and `usePoliciesWithCardFeedErrors`. Also replaces an unstable inline `style` array literal with a stable `undefined` so the shallow compare on the prop can hold.

##### Why this selector is safe?

The three flags this selector strips (isLoading, isLoadingReceiptPartners, isLoadingWorkspaceReimbursement) are only ever read off a single policy entry — every consumer subscribes via useOnyx(${ONYXKEYS.COLLECTION.POLICY}${policyID}) (directly or through usePolicy(policyID)), never off the policy collection. Since Onyx single-entry subscriptions are independent from collection subscriptions and the selector only filters what it returns (it doesn't mutate stored data), the two collection consumers using this selector (WorkspacesListPage and usePoliciesWithCardFeedErrors, neither of which reads these flags) stop re-rendering on loading-flag flips, while every spinner that depends on those flags keeps working unchanged.

Main:


https://github.com/user-attachments/assets/faa167b2-d171-4746-bf16-074b0d2b169b



The optimized version:

> [!IMPORTANT]
> Rows still re-render when the page re-renders, because menuItems and onPress are built inline per row and defeat React.memo; this is orthogonal to the loading-flag churn fixed here and should be addressed in a follow-up perf PR.

https://github.com/user-attachments/assets/6ae5218f-4f64-4749-9b60-b63d10ce1af3





### Fixed Issues

$ https://github.com/Expensify/App/issues/91175
PROPOSAL:


### Tests

1. Sign in to an account with several workspaces (a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) gives the clearest signal).
2. Open **Settings → Workspaces** and wait for the list to settle.
3. Open the React DevTools Profiler (web) and start recording.
4. Tap any workspace to navigate into it, then open a tab that calls `openPolicyWorkflowsPage` (e.g. **Workflows**).
5. Stop recording **without** tapping back.
6. Verify that `WorkspacesListPage` does **not** commit while the workspace screen is foregrounded, apart from the expected single `isFocused` blur transition. Before this PR, the page would re-render twice per optimistic `isLoading` flip on the policy entry (and the cascade re-rendered every row).

1. Sign in to an account with several workspaces.
2. Open **Settings → Workspaces**, scroll partway down, and tap one workspace to open it.
3. Navigate through a few workspace tabs (Workflows, Members, etc.) and then tap back to the workspaces list.
4. Verify that scroll position is preserved, the row that was tapped is not stuck in a hovered/pressed state, and the list renders normally.

1. Sign in to an account that both **owns** at least one workspace and is a **member** of another workspace it doesn't own.
2. Open **Settings → Workspaces** and tap the three-dots menu on each kind of workspace row.
3. Verify the expected entries appear based on role (Go to workspace / Leave / Duplicate / Set as default / Delete / Transfer owner) and that selecting each performs its action without errors.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this change only affects which fields on the policy collection trigger re-renders. It does not add API calls and does not change offline persistence behaviour.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
