### PR TITLE
Fix test drive admin room redirect

### DIFF
--- a/src/components/TestDrive/Modal/AdminTestDriveModal.tsx
+++ b/src/components/TestDrive/Modal/AdminTestDriveModal.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {InteractionManager} from 'react-native';
 import {shouldOpenRHPVariant} from '@components/SidePanel/RHPVariantTest';
+import getTestDriveAdminRoomReport from '@components/TestDrive/getTestDriveAdminRoomReport';
 import useLocalize from '@hooks/useLocalize';
+import useOnboardingTaskInformation from '@hooks/useOnboardingTaskInformation';
 import useOnyx from '@hooks/useOnyx';
 import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
-import {isAdminRoom} from '@libs/ReportUtils';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import BaseTestDriveModal from './BaseTestDriveModal';
@@ -15,6 +17,10 @@ function AdminTestDriveModal() {
     const {translate} = useLocalize();
     const [onboarding] = useOnyx(ONYXKEYS.NVP_ONBOARDING);
     const [onboardingReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${onboarding?.chatReportID}`);
+    const [onboardingAdminsChatReportID] = useOnyx(ONYXKEYS.ONBOARDING_ADMINS_CHAT_REPORT_ID);
+    const [onboardingAdminsChatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${onboardingAdminsChatReportID}`, undefined, [onboardingAdminsChatReportID]);
+    const {taskParentReport: viewTourTaskParentReport} = useOnboardingTaskInformation(CONST.ONBOARDING_TASK_TYPE.VIEW_TOUR);
+    const adminRoomReport = getTestDriveAdminRoomReport(viewTourTaskParentReport, onboardingAdminsChatReport, onboardingReport);
 
     const navigate = () => {
         Log.hmmm('[AdminTestDriveModal] Navigate function called');
@@ -35,13 +41,13 @@ function AdminTestDriveModal() {
 
         Log.hmmm('[AdminTestDriveModal] Running after interactions');
         Navigation.setNavigationActionToMicrotaskQueue(() => {
-            if (!isAdminRoom(onboardingReport)) {
+            if (!adminRoomReport) {
                 Log.hmmm('[AdminTestDriveModal] Not an admin room');
                 return;
             }
 
-            Log.hmmm('[AdminTestDriveModal] Navigating to report', {reportID: onboardingReport?.reportID});
-            Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(onboardingReport?.reportID));
+            Log.hmmm('[AdminTestDriveModal] Navigating to report', {reportID: adminRoomReport.reportID});
+            Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(adminRoomReport.reportID));
         });
     };
 

--- a/src/components/TestDrive/TestDriveDemo.tsx
+++ b/src/components/TestDrive/TestDriveDemo.tsx
@@ -21,11 +21,11 @@ import {completeTestDriveTask} from '@libs/actions/Task';
 import {setSelfTourViewed} from '@libs/actions/Welcome';
 import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
-import {isAdminRoom} from '@libs/ReportUtils';
 import {getTestDriveURL} from '@libs/TourUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
+import getTestDriveAdminRoomReport from './getTestDriveAdminRoomReport';
 import TestDriveBanner from './TestDriveBanner';
 
 function TestDriveDemo() {
@@ -34,6 +34,8 @@ function TestDriveDemo() {
     const styles = useThemeStyles();
     const [onboarding] = useOnyx(ONYXKEYS.NVP_ONBOARDING);
     const [onboardingReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${onboarding?.chatReportID}`);
+    const [onboardingAdminsChatReportID] = useOnyx(ONYXKEYS.ONBOARDING_ADMINS_CHAT_REPORT_ID);
+    const [onboardingAdminsChatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${onboardingAdminsChatReportID}`, undefined, [onboardingAdminsChatReportID]);
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
     const [betas] = useOnyx(ONYXKEYS.BETAS);
@@ -48,6 +50,7 @@ function TestDriveDemo() {
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const parentReportAction = useParentReportAction(viewTourTaskReport);
     const isCurrentUserPolicyAdmin = useIsPaidPolicyAdmin();
+    const adminRoomReport = getTestDriveAdminRoomReport(viewTourTaskParentReport, onboardingAdminsChatReport, onboardingReport);
 
     const [hasSeenTour = false] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {
         selector: hasSeenTourSelector,
@@ -110,11 +113,11 @@ function TestDriveDemo() {
                 Log.hmmm('[AdminTestDriveModal] User was redirected to Workspace Editor, skipping navigation to admin room');
                 return;
             }
-            if (isAdminRoom(onboardingReport)) {
-                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(onboardingReport?.reportID));
+            if (adminRoomReport) {
+                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(adminRoomReport.reportID));
             }
         });
-    }, [onboardingReport]);
+    }, [adminRoomReport]);
 
     return (
         <SafeAreaConsumer>

--- a/src/components/TestDrive/getTestDriveAdminRoomReport.ts
+++ b/src/components/TestDrive/getTestDriveAdminRoomReport.ts
@@ -1,0 +1,23 @@
+import {isAdminRoom} from '@libs/ReportUtils';
+import CONST from '@src/CONST';
+import type {Report} from '@src/types/onyx';
+
+function isValidReportID(reportID: string | undefined): boolean {
+    return !!reportID && reportID !== CONST.DEFAULT_NUMBER_ID.toString();
+}
+
+function getTestDriveAdminRoomReport(...reports: Array<Report | null | undefined>): Report | undefined {
+    for (const report of reports) {
+        if (!report) {
+            continue;
+        }
+
+        if (isValidReportID(report.reportID) && isAdminRoom(report)) {
+            return report;
+        }
+    }
+
+    return undefined;
+}
+
+export default getTestDriveAdminRoomReport;

--- a/tests/unit/TestDriveUtilsTest.ts
+++ b/tests/unit/TestDriveUtilsTest.ts
@@ -1,0 +1,32 @@
+import getTestDriveAdminRoomReport from '@components/TestDrive/getTestDriveAdminRoomReport';
+import CONST from '@src/CONST';
+import type {Report} from '@src/types/onyx';
+
+const buildReport = (reportID: string, chatType?: string): Report =>
+    ({
+        reportID,
+        type: CONST.REPORT.TYPE.CHAT,
+        chatType,
+    }) as Report;
+
+describe('getTestDriveAdminRoomReport', () => {
+    it('returns the first valid admin room report', () => {
+        const taskParentReport = buildReport('1', CONST.REPORT.CHAT_TYPE.POLICY_ADMINS);
+        const onboardingReport = buildReport('2', CONST.REPORT.CHAT_TYPE.POLICY_ADMINS);
+
+        expect(getTestDriveAdminRoomReport(taskParentReport, onboardingReport)).toBe(taskParentReport);
+    });
+
+    it('falls back to the next admin room when earlier reports are missing or not admin rooms', () => {
+        const workspaceChat = buildReport('1', CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT);
+        const onboardingAdminsReport = buildReport('2', CONST.REPORT.CHAT_TYPE.POLICY_ADMINS);
+
+        expect(getTestDriveAdminRoomReport(undefined, workspaceChat, onboardingAdminsReport)).toBe(onboardingAdminsReport);
+    });
+
+    it('does not treat report 0 as a valid admin room target', () => {
+        const invalidAdminRoom = buildReport(CONST.DEFAULT_NUMBER_ID.toString(), CONST.REPORT.CHAT_TYPE.POLICY_ADMINS);
+
+        expect(getTestDriveAdminRoomReport(invalidAdminRoom)).toBeUndefined();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

This fixes the Test Drive admin-room redirect by resolving the target `#admins` report from reliable onboarding state instead of relying only on `NVP_ONBOARDING.chatReportID`.

Both admin Test Drive exits now use the same resolver. The resolver prefers the view-tour task parent report, then `ONBOARDING_ADMINS_CHAT_REPORT_ID`, and finally the legacy onboarding chat report. It also rejects `reportID = 0`, avoiding the regression noted in issue discussion where `activePolicy.chatReportIDAdmins` can be `0` when no admin room exists.

### Fixed Issues

$ https://github.com/Expensify/App/issues/91144
PROPOSAL: https://github.com/Expensify/App/issues/91144#issuecomment-4509503592

### Tests

1. Sign up as a new Spend user with a Gmail address without `+`.
2. Select Manage my team expenses.
3. Complete onboarding until the Take a test drive flow is shown.
4. Finish the test drive and click Get started.
5. Verify the app redirects to the workspace `#admins` room.
6. Repeat by skipping the test drive from the admin test drive modal and verify the same redirect.
7. Verify accounts without a valid admins room do not navigate to `report_0`.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests.

### Automated Tests

- `npm test -- --runTestsByPath tests/unit/TestDriveUtilsTest.ts --runInBand`
- `npm run lint -- --quiet src/components/TestDrive/getTestDriveAdminRoomReport.ts src/components/TestDrive/TestDriveDemo.tsx src/components/TestDrive/Modal/AdminTestDriveModal.tsx tests/unit/TestDriveUtilsTest.ts`
- `npm run typecheck`
