### PR TITLE
Show receipt actions for map distance receipts

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
@@ -60,7 +60,6 @@ import {
     hasReceiptSource,
     hasReceipt as hasReceiptTransactionUtils,
     isDistanceRequest as isDistanceRequestTransactionUtils,
-    isManualDistanceRequest,
     isScanning,
 } from '@libs/TransactionUtils';
 import ViolationsUtils, {filterReceiptViolations} from '@libs/Violations/ViolationsUtils';
@@ -486,9 +485,7 @@ function MoneyRequestReceiptView({
 
     const showBorderlessLoading = isLoading && fillSpace;
 
-    const isMapDistanceRequest = !!transaction && isDistanceRequest && !isManualDistanceRequest(transaction);
-
-    const canShowReceiptActions = hasReceipt && !isLoading && isEditable && !isMapDistanceRequest && !mergeTransactionID;
+    const canShowReceiptActions = hasReceipt && !isLoading && isEditable && !mergeTransactionID;
     const receiptPendingAction = isDistanceRequest ? getPendingFieldAction('waypoints') : getPendingFieldAction('receipt');
     const isReceiptOfflinePending = isOffline && !!receiptPendingAction;
     const receiptAuditMessagesRow = (


### PR DESCRIPTION
# Expensify Proposal: Map Receipt Preview Missing Action Buttons

Issue: `Expensify/App#91336`

## Proposal

### Please re-state the problem that we are trying to solve in this issue.

When viewing a map/distance receipt preview, hovering over the receipt does not
show the "Add additional receipt" and "Expand" buttons.

### What is the root cause of that problem?

`MoneyRequestReceiptView.tsx` computes `canShowReceiptActions` with an explicit
`!isMapDistanceRequest` guard. That prevents the existing receipt action button
container from rendering for non-manual distance requests, even when the expense
has a receipt, is loaded, is editable, and is not part of a merge flow.

### What changes do you think we should make in order to solve the problem?

Remove the map-distance exclusion from `canShowReceiptActions` so map distance
receipts use the same existing receipt action controls as other receipts:

```tsx
const canShowReceiptActions = hasReceipt && !isLoading && isEditable && !mergeTransactionID;
```

This reuses the existing add/expand button rendering path and keeps the rest of
the editability checks intact.

### What alternative solutions did you explore?

I considered special-casing map distance receipts with separate buttons, but that
would duplicate the existing action container and risk inconsistent behavior.
The safer fix is to let map distance receipts flow through the same action path
as other editable receipts.

## Local branch

- Repo: `projects/money-mission-2026-05-21/expensify-app`
- Branch: `fix/map-distance-receipt-actions`
- Commit: `2d3d908 Show receipt actions for map distance receipts`

## Verification

```bash
npx -y -p node@20.20.0 -p npm@10.8.2 npm exec -- prettier --experimental-cli --no-cache --check src/components/ReportActionItem/MoneyRequestReceiptView.tsx
npx -y -p node@20.20.0 -p npm@10.8.2 npm exec -- eslint src/components/ReportActionItem/MoneyRequestReceiptView.tsx
```

ESLint exits 0 with one existing seatbelt warning in the file for
`react-hooks/set-state-in-effect`.
