### PR TITLE
Fix train passenger label spacing

### DIFF
--- a/src/pages/Travel/TrainTripDetails.tsx
+++ b/src/pages/Travel/TrainTripDetails.tsx
@@ -104,6 +104,7 @@ function TrainTripDetails({reservation, personalDetails}: TrainTripDetailsProps)
                     description={personalDetails?.login ?? reservation.travelerPersonalInfo?.email}
                     interactive={false}
                     wrapperStyle={styles.pb3}
+                    labelStyle={styles.mb2}
                 />
             )}
         </>


### PR DESCRIPTION
# Expensify Proposal: Train Passenger Label Indentation

Issue: `Expensify/App#91334`

## Proposal

### Please re-state the problem that we are trying to solve in this issue.

The Passenger label has different vertical spacing/indentation in train trip
details compared with flight trip details.

### What is the root cause of that problem?

`FlightTripDetails.tsx` passes `labelStyle={styles.mb2}` to the passenger
`MenuItem`, but `TrainTripDetails.tsx` does not. That makes the same passenger
label render with different spacing between flight and train reservation views.

### What changes do you think we should make in order to solve the problem?

Add `labelStyle={styles.mb2}` to the passenger `MenuItem` in
`TrainTripDetails.tsx`, matching the existing flight implementation.

### What alternative solutions did you explore?

I considered changing `MenuItem` defaults, but this would affect a shared
component and risk unrelated UI regressions. The smallest safe fix is to align
the train passenger row with the flight passenger row at the call site.

## Local branch

- Repo: `projects/money-mission-2026-05-21/expensify-app`
- Branch: `fix/train-passenger-label-spacing`
- Commit: `0076c99 Fix train passenger label spacing`

## Verification

Static parity check against `FlightTripDetails.tsx`.

```bash
npx -y -p node@20.20.0 -p npm@10.8.2 npm exec -- prettier --experimental-cli --no-cache --check src/pages/Travel/TrainTripDetails.tsx
npx -y -p node@20.20.0 -p npm@10.8.2 npm exec -- eslint src/pages/Travel/TrainTripDetails.tsx
```

Full repo test suite was not run because the change is a one-line style parity
fix and targeted formatting/lint passed.
