### PR TITLE
Fix duplicate workspace history entry after creating workspace from FAB

### DIFF
--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -573,6 +573,7 @@ type CreateWorkspaceWithPolicyDraftParams = {
     betas: OnyxEntry<OnyxTypes.Beta[]>;
     hasActiveAdminPolicies: boolean;
     isAnnualSubscription?: boolean;
+    didPreinsertWorkspaceRouteUnderModal?: boolean;
 };
 
 /**
@@ -600,6 +601,7 @@ function createWorkspaceWithPolicyDraftAndNavigateToIt(params: CreateWorkspaceWi
         betas,
         hasActiveAdminPolicies,
         isAnnualSubscription = false,
+        didPreinsertWorkspaceRouteUnderModal = false,
     } = params;
 
     const policyIDWithDefault = policyID || generatePolicyID();
@@ -640,6 +642,11 @@ function createWorkspaceWithPolicyDraftAndNavigateToIt(params: CreateWorkspaceWi
                 Navigation.dismissModal({
                     afterTransition: () => Navigation.navigate(routeToNavigate),
                 });
+                return;
+            }
+
+            if (didPreinsertWorkspaceRouteUnderModal) {
+                Navigation.dismissModal();
                 return;
             }
 

--- a/src/pages/workspace/WorkspaceConfirmationPage.tsx
+++ b/src/pages/workspace/WorkspaceConfirmationPage.tsx
@@ -68,6 +68,7 @@ function WorkspaceConfirmationPage() {
             betas,
             hasActiveAdminPolicies,
             isAnnualSubscription,
+            didPreinsertWorkspaceRouteUnderModal: !shouldShowSuccessPage,
         });
     };
     const currentUrl = getCurrentUrl();


### PR DESCRIPTION
### Details
Fixes an extra history entry in mWeb when creating a workspace from FAB while an RHP modal is open.

- Add `didPreinsertWorkspaceRouteUnderModal` param to `createWorkspaceWithPolicyDraftAndNavigateToIt`.
- When this flag is true and target is fullscreen, dismiss the modal directly instead of calling `revealRouteBeforeDismissingModal` again.
- Pass the flag from `WorkspaceConfirmationPage` for non-success flow where route is already pre-inserted via `pushNewlyCreatedWorkspaceUnderActiveModal`.

### Issue
- $ https://github.com/Expensify/App/issues/90776

### Testing
- Not run locally in this environment (dependencies not installed).
