### PR TITLE
fix: iOS Fatal C++ Exception: St14overflow_error

### DIFF
--- a/patches/@fullstory/react-native/@fullstory+react-native+1.9.0.patch
+++ b/patches/@fullstory/react-native/@fullstory+react-native+1.9.0.patch
@@ -1,0 +1,35 @@
+diff --git a/node_modules/@fullstory/react-native/ios/FullStory.mm b/node_modules/@fullstory/react-native/ios/FullStory.mm
+index bd30520..26a834a 100644
+--- a/node_modules/@fullstory/react-native/ios/FullStory.mm
++++ b/node_modules/@fullstory/react-native/ios/FullStory.mm
+@@ -22,6 +22,11 @@
+     return self;
+ }
+ 
++- (void)invalidate {
++    // Clear the event emitter callback to prevent a use-after-free crash.
++    _eventEmitterCallback = nullptr;
++}
++
+ NSString *const PagesAPIError = @"Unable to access native FullStory pages API and call %@. Pages API will not function correctly. Make sure that your plugin is at least version 1.41; if the issue persists, please contact FullStory Support.";
+ 
+ RCT_EXPORT_MODULE()
+@@ -200,11 +205,13 @@ RCT_EXPORT_METHOD(updatePage:(NSString *)nonce pageProperties:(NSDictionary *)pa
+     }
+ 
+ #ifdef RCT_NEW_ARCH_ENABLED
+-    [self emitOnSessionStarted:@{
+-        @"replayStartUrl": sessionUrl,
+-        @"replayNowUrl": [FS currentSessionURL: true] ?: @"",
+-        @"sessionId": FS.currentSession ?: @"",
+-    }];
++    if (_eventEmitterCallback) {
++        [self emitOnSessionStarted:@{
++            @"replayStartUrl": sessionUrl,
++            @"replayNowUrl": [FS currentSessionURL: true] ?: @"",
++            @"sessionId": FS.currentSession ?: @"",
++        }];
++    }
+ #endif
+ }
+ 

--- a/patches/@fullstory/react-native/details.md
+++ b/patches/@fullstory/react-native/details.md
@@ -10,7 +10,7 @@
     NativeFullStorySpecJSI TurboModule object) — inside the ObjC FullStory module's
     _eventEmitterCallback field.
 
-    In HybridApp, the JS runtime is torn down during background/foreground transitions,
+    In HybridApp, the JS runtime is torn down when switching from ND to OD (after sign in with SAML),
     destroying the C++ TurboModule. However, the ObjC FullStory instance stays alive as
     an FS SDK delegate. When the app returns to the foreground, FullStory fires
     fullstoryDidStartSession:, which invokes _eventEmitterCallback — a lambda that now
@@ -24,5 +24,5 @@
     ```
 
 - Upstream PR/issue: 🛑 TODO
-- E/App issue: 🛑 TODO
+- E/App issue: https://github.com/Expensify/App/issues/91225
 - PR introducing patch: 🛑 TODO

--- a/patches/@fullstory/react-native/details.md
+++ b/patches/@fullstory/react-native/details.md
@@ -1,0 +1,28 @@
+# `@fullstory/react-native` patches
+
+### [@fullstory+react-native+1.9.0.patch](@fullstory+react-native+1.9.0.patch)
+
+- Reason:
+
+    ```
+    Version 1.9.0 introduced the onFullstoryDidStartSession event emitter API (PR #147).
+    The implementation stores a C++ lambda — which implicitly captures `this` (the
+    NativeFullStorySpecJSI TurboModule object) — inside the ObjC FullStory module's
+    _eventEmitterCallback field.
+
+    In HybridApp, the JS runtime is torn down during background/foreground transitions,
+    destroying the C++ TurboModule. However, the ObjC FullStory instance stays alive as
+    an FS SDK delegate. When the app returns to the foreground, FullStory fires
+    fullstoryDidStartSession:, which invokes _eventEmitterCallback — a lambda that now
+    holds a dangling pointer to the destroyed C++ object. Accessing the freed
+    eventEmitterMap_ causes a crash in std::__hash_table::__rehash_unique
+    (bad_array_new_length / overflow_error).
+
+    The fix adds an invalidate method that clears _eventEmitterCallback (destroying the
+    dangling lambda when the bridge tears down) and guards the emitOnSessionStarted: call
+    so it is skipped if the callback has already been cleared.
+    ```
+
+- Upstream PR/issue: 🛑 TODO
+- E/App issue: 🛑 TODO
+- PR introducing patch: 🛑 TODO


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Fixes a use-after-free crash in `@fullstory/react-native` on iOS in HybridApp. When signing in via SAML, the JS runtime is torn down (destroying the C++ TurboModule), but the ObjC FullStory instance stays alive as an FS SDK delegate. On foreground resume, FullStory fires `fullstoryDidStartSession:` which invokes a lambda holding a dangling pointer, causing a crash in `std::__hash_table::__rehash_unique`. The patch adds an `invalidate` method to clear `_eventEmitterCallback` on bridge teardown and guards `emitOnSessionStarted:` to skip if the callback is already cleared.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/91225
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**iOS only** — requires an account with SAML configured to redirect to OldDot after sign-in.

1. Sign in using SAML (the sign-in flow should redirect you to OldDot).
2. Navigate through a few OldDot screens.
3. Background the app.
4. Wait a few seconds.
5. Reopen the app.
6. Verify that there is no crash.

### Offline tests

N/A

### QA Steps

**iOS only** — requires an account with SAML configured to redirect to OldDot after sign-in.

1. Sign in using SAML (the sign-in flow should redirect you to OldDot).
2. Navigate through a few OldDot screens.
3. Background the app.
4. Wait a few seconds.
5. Reopen the app.
6. Verify that there is no crash.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
