### PR TITLE
fix: prefer selected destination report after expense merge

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -450,7 +450,10 @@ function IOURequestStepConfirmation({
     const hasPreInsertFired = useRef(false);
     const isTransactionReady = !!transaction;
     const selfDMReportID = iouType === CONST.IOU.TYPE.TRACK ? findSelfDMReportID() : undefined;
-    const destinationReportID = backToReport ?? report?.reportID ?? selfDMReportID;
+    // For merge flows, prefer the selected destination report over a stale backToReport
+    // so post-submit background context matches where the expense was merged.
+    const destinationReportID =
+        action === CONST.IOU.ACTION.MERGE ? report?.reportID ?? backToReport ?? selfDMReportID : backToReport ?? report?.reportID ?? selfDMReportID;
 
     useEffect(() => {
         if (hasPreInsertFired.current || !isTransactionReady || !getIsNarrowLayout()) {


### PR DESCRIPTION
### Explanation of Change
This change fixes post-merge navigation context by prioritizing the selected destination report ID for merge flows. Previously, stale `backToReport` could force navigation back to Unreported even when the merge destination was a report.

### Fixed Issues
$ https://github.com/Expensify/App/issues/89799
PROPOSAL: https://github.com/Expensify/App/issues/89799#issuecomment-4522235668

### Tests
1. Not run in this runner (full Expensify app setup was not completed in this environment).
2. Change is intentionally minimal (1 file) and only adjusts merge destination priority order.

- [ ] Verify that no errors appear in the JS console

### Offline tests
Not run in this runner.

### QA Steps
Same as Tests.

### Screenshots/Videos
N/A (logic-only navigation target priority adjustment).