### PR TITLE
Remove pull_request_review trigger from claude-review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,8 +7,6 @@ permissions:
 on:
   pull_request_target:
     types: [opened, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.html_url }}
@@ -16,41 +14,19 @@ concurrency:
 
 jobs:
   validate:
-    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/contributorValidationGate.yml
     with:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
 
-  checkCPlusApproval:
-    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    outputs:
-      IS_CPLUS: ${{ steps.check.outputs.IS_CPLUS }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 1
-
-      - name: Check Contributor+ membership
-        id: check
-        uses: ./.github/actions/composite/isContributorPlus
-        with:
-          USERNAME: ${{ github.event.review.user.login }}
-          OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-
   review:
-    needs: [validate, checkCPlusApproval]
+    needs: validate
     if: |
       !cancelled()
       && github.event.pull_request.draft != true
       && !contains(github.event.pull_request.title, 'Revert')
-      && (
-        (github.event_name == 'pull_request_target' && needs.validate.outputs.IS_AUTHORIZED == 'true')
-        || (github.event_name == 'pull_request_review' && needs.checkCPlusApproval.outputs.IS_CPLUS == 'true')
-      )
+      && needs.validate.outputs.IS_AUTHORIZED == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Explanation of Change
The `claude-review` workflow currently runs on on `pull_request_review` (submitted). That mean Claude will start a new review immediately after someone else finishes theirs —usually not when we want automated review to happen.

This PR limits the workflow to `pull_request_target` (`opened`, `ready_for_review`) and removes the Contributor+ approval path (`checkCPlusApproval` job) that existed solely for the review trigger.

### Fixed Issues
$
PROPOSAL:

### Tests
N/A — GitHub Actions workflow change only.

### Offline tests
N/A

### QA Steps
N/A — [No QA]

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)

### Screenshots/Videos
N/A — workflow change only.


Made with [Cursor](https://cursor.com)