### PR TITLE
docs: add troubleshooting note for Windows esbuild error

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ For detailed setup instructions for each platform, see the following guides:
    Access to fetch at 'https://www.expensify.com/api/BeginSignIn' from origin 'http://localhost:8080' has been blocked by CORS policy
    ```
    You probably have a misconfigured `.env` file - remove it (`rm .env`) and try again.
-
+3. If you are on Windows and encounter an error regarding `@esbuild/win32-x64`, run:
+   ```bash
+   npm install @esbuild/win32-x64 --ignore-scripts
+   ```
 **Note:** Expensify engineers that will be testing with the API in your local dev environment please refer to [these additional instructions](https://stackoverflow.com/c/expensify/questions/7699/7700).
 
 ## Environment variables


### PR DESCRIPTION
I encountered a consistent error with @esbuild/win32-x64 while setting up the project on Windows 11. This troubleshooting note helps other Windows contributors resolve the issue quickly using a surgical npm install command.