### PR TITLE
Fix edited URL comments losing autolink

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -3152,6 +3152,11 @@ function handleUserDeletedLinksInHtml(newCommentText: string, originalCommentMar
         return newCommentText;
     }
 
+    const isSelfTitledMarkdownLink = (link: string): boolean => {
+        const escapedLink = Str.escapeForRegExp(link);
+        return new RegExp(`\\[${escapedLink}\\]\\(${escapedLink}\\)`).test(originalCommentMarkdown);
+    };
+
     const userEmailDomain = isEmailPublicDomain(currentUserLogin) ? '' : Str.extractEmailDomain(currentUserLogin);
     const allPersonalDetailLogins = Object.values(allPersonalDetails ?? {}).map((personalDetail) => personalDetail?.login ?? '');
 
@@ -3165,7 +3170,11 @@ function handleUserDeletedLinksInHtml(newCommentText: string, originalCommentMar
     });
 
     const removedLinks = Parser.getRemovedMarkdownLinks(originalCommentMarkdown, newCommentText);
-    return removeLinksFromHtml(htmlForNewComment, removedLinks);
+    // If the original markdown link's label is identical to its target (e.g. `[https://example.com](https://example.com)`),
+    // it's effectively an auto-link representation. In that case, "removing" the markdown formatting while keeping the
+    // URL text should still preserve auto-linking when the edited comment is saved.
+    const removedLinksToStrip = removedLinks.filter((link) => !isSelfTitledMarkdownLink(link));
+    return removeLinksFromHtml(htmlForNewComment, removedLinksToStrip);
 }
 
 /** Saves a new message for a comment. Marks the comment as edited, which will be reflected in the UI. */

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -847,11 +847,11 @@ describe('actions/Report', () => {
         expect(newCommentHTML).toBe(expectedOutput);
 
         // User edits and deletes the link containing underscores
-        // We should not generate link
+        // We should generate link
         originalCommentMarkdown = '[https://www.facebook.com/hashtag/__main/?__eep__=6](https://www.facebook.com/hashtag/__main/?__eep__=6)';
         afterEditCommentText = 'https://www.facebook.com/hashtag/__main/?__eep__=6';
         newCommentHTML = Report.handleUserDeletedLinksInHtml(afterEditCommentText, originalCommentMarkdown, TEST_USER_LOGIN);
-        expectedOutput = 'https://www.facebook.com/hashtag/__main/?__eep__=6';
+        expectedOutput = '<a href="https://www.facebook.com/hashtag/__main/?__eep__=6" target="_blank" rel="noreferrer noopener">https://www.facebook.com/hashtag/__main/?__eep__=6</a>';
         expect(newCommentHTML).toBe(expectedOutput);
 
         // User edits and replaces comment with a link containing asterisks
@@ -863,11 +863,11 @@ describe('actions/Report', () => {
         expect(newCommentHTML).toBe(expectedOutput);
 
         // User edits and deletes the link containing asterisks
-        // We should not generate link
+        // We should generate link
         originalCommentMarkdown = '[http://example.com/foo/*/bar/*/test.txt](http://example.com/foo/*/bar/*/test.txt)';
         afterEditCommentText = 'http://example.com/foo/*/bar/*/test.txt';
         newCommentHTML = Report.handleUserDeletedLinksInHtml(afterEditCommentText, originalCommentMarkdown, TEST_USER_LOGIN);
-        expectedOutput = 'http://example.com/foo/*/bar/*/test.txt';
+        expectedOutput = '<a href="http://example.com/foo/*/bar/*/test.txt" target="_blank" rel="noreferrer noopener">http://example.com/foo/*/bar/*/test.txt</a>';
         expect(newCommentHTML).toBe(expectedOutput);
 
         // User edits comment to add mention


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/91431

### Problem
Editing a comment that previously contained an auto-linked URL could result in the saved message rendering the URL as plain text (no `<a>` tag).

### Solution
When computing `removedLinks`, treat self-titled markdown links (`[url](url)`) as an auto-link representation and do not strip their anchors from the edited HTML. This preserves auto-linking when a user re-pastes the URL while editing.

### Tests
- `npm test -- tests/actions/ReportTest.ts -t "Should properly update comment with links"`
