### PR TITLE
Fix Spend/Search submitted dates timezone

### DIFF
--- a/src/components/Search/SearchList/ListItem/DateCell.tsx
+++ b/src/components/Search/SearchList/ListItem/DateCell.tsx
@@ -3,6 +3,7 @@ import DatePickerModal from '@components/DatePicker/DatePickerModal';
 import TextWithTooltip from '@components/TextWithTooltip';
 import {EditableCell, usePopoverEditState} from '@components/TransactionItemRow/EditableCell';
 import type {EditableProps} from '@components/TransactionItemRow/EditableCell/types';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import DateUtils from '@libs/DateUtils';
@@ -18,13 +19,20 @@ type DateCellProps = {
 function DateCell({date, showTooltip, isLargeScreenWidth, suffixText, canEdit, onSave}: DateCellProps) {
     const styles = useThemeStyles();
     const {isInNarrowPaneModal} = useResponsiveLayout();
+    const currentUserPersonalDetails = useCurrentUserPersonalDetails();
+    const selectedTimezone = currentUserPersonalDetails?.timezone?.selected;
     const {isEditing, anchorRef, isPopoverVisible, popoverPosition, isInverted, startEditing, cancelEditing, handleSave} = usePopoverEditState({
         canEdit,
         value: date,
         onSave,
     });
 
-    const formattedDate = DateUtils.formatWithUTCTimeZone(date, DateUtils.doesDateBelongToAPastYear(date) ? CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT : CONST.DATE.MONTH_DAY_ABBR_FORMAT);
+    const dateFormat = DateUtils.doesDateBelongToAPastYear(date) ? CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT : CONST.DATE.MONTH_DAY_ABBR_FORMAT;
+    const hasTimeComponent = /\d{2}:\d{2}/.test(date) || date.includes('T');
+    const formattedDate =
+        selectedTimezone && hasTimeComponent
+            ? DateUtils.formatUTCDateTimeToDateInTimezone(date, selectedTimezone, dateFormat) || DateUtils.formatWithUTCTimeZone(date, dateFormat)
+            : DateUtils.formatWithUTCTimeZone(date, dateFormat);
     const displayText = suffixText ? `${formattedDate} • ${suffixText}` : formattedDate;
 
     const displayContent = (

--- a/tests/unit/DateCellTest.tsx
+++ b/tests/unit/DateCellTest.tsx
@@ -1,0 +1,76 @@
+import {render, screen} from '@testing-library/react-native';
+import React from 'react';
+import DateCell from '@components/Search/SearchList/ListItem/DateCell';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+
+jest.mock('@hooks/useCurrentUserPersonalDetails', () => jest.fn());
+jest.mock('@hooks/useResponsiveLayout', () => () => ({isInNarrowPaneModal: false}));
+jest.mock('@hooks/useThemeStyles', () => () => ({
+    lineHeightLarge: {},
+    pre: {},
+    justifyContentCenter: {},
+    mutedNormalTextLabel: {},
+    flexShrink1: {},
+}));
+jest.mock('@components/TextWithTooltip', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
+    const RN = require('react-native') as typeof import('react-native');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
+    const ReactLocal = require('react') as typeof import('react');
+
+    return ({text}: {text: string}) => ReactLocal.createElement(RN.Text, null, text);
+});
+jest.mock('@components/DatePicker/DatePickerModal', () => () => null);
+jest.mock('@components/TransactionItemRow/EditableCell', () => ({
+    EditableCell: ({children}: {children: React.ReactNode}) => children,
+    usePopoverEditState: () => ({
+        isEditing: false,
+        anchorRef: {current: null},
+        isPopoverVisible: false,
+        popoverPosition: {},
+        isInverted: false,
+        startEditing: jest.fn(),
+        cancelEditing: jest.fn(),
+        handleSave: jest.fn(),
+    }),
+}));
+
+const mockUseCurrentUserPersonalDetails = jest.mocked(useCurrentUserPersonalDetails);
+
+describe('DateCell', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseCurrentUserPersonalDetails.mockReturnValue({
+            timezone: {selected: 'America/Los_Angeles', automatic: true},
+        } as never);
+    });
+
+    it('formats UTC datetime strings using the user timezone (regression guard for Spend/Search submitted column)', () => {
+        const year = new Date().getFullYear();
+
+        // 00:30 UTC on July 1st is still the previous day in America/Los_Angeles.
+        render(
+            <DateCell
+                date={`${year}-07-01 00:30:00`}
+                showTooltip={false}
+                isLargeScreenWidth
+            />,
+        );
+
+        expect(screen.getByText(/Jun 30/)).toBeTruthy();
+    });
+
+    it('keeps date-only values stable by formatting them in UTC (prevents timezone shifting)', () => {
+        const year = new Date().getFullYear();
+
+        render(
+            <DateCell
+                date={`${year}-07-01`}
+                showTooltip={false}
+                isLargeScreenWidth
+            />,
+        );
+
+        expect(screen.getByText(/Jul 1/)).toBeTruthy();
+    });
+});


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/91520

### Problem
Spend/Search table dates were always formatted in UTC via `DateUtils.formatWithUTCTimeZone()`, so `report.submitted` (stored as a UTC datetime) could show the wrong calendar day for users in non-UTC timezones.

### Solution
- In `DateCell`, detect date-time strings (those with a time component / ISO `T`) and format them in the current user's selected timezone via `DateUtils.formatUTCDateTimeToDateInTimezone()`.
- Keep date-only values formatted in UTC to avoid timezone shifting of pure calendar dates.

### Tests
- `npm test -- tests/unit/DateCellTest.tsx`