### PR TITLE
Account - Copy URL to clipboard menu does not open when right-clicking on "What's new"

### DIFF
--- a/src/libs/Navigation/helpers/useIsSidebarRouteActive.ts
+++ b/src/libs/Navigation/helpers/useIsSidebarRouteActive.ts
@@ -3,9 +3,17 @@ import {findFocusedRoute} from '@react-navigation/native';
 import useRootNavigationState from '@hooks/useRootNavigationState';
 import {SPLIT_TO_SIDEBAR} from '@libs/Navigation/linkingConfig/RELATIONS';
 import type {SplitNavigatorName} from '@libs/Navigation/types';
+import {getTabState} from './tabNavigatorUtils';
 
 function useIsSidebarRouteActive(splitNavigatorName: SplitNavigatorName, isNarrowLayout: boolean) {
-    const currentSplitNavigatorRoute = useRootNavigationState((rootState) => rootState?.routes.at(-1));
+    const currentSplitNavigatorRoute = useRootNavigationState((rootState) => {
+        const lastRoute = rootState?.routes.at(-1);
+        const tabState = getTabState(lastRoute);
+        if (!tabState) {
+            return lastRoute;
+        }
+        return tabState.routes.at(tabState.index ?? 0);
+    });
 
     if (currentSplitNavigatorRoute?.name !== splitNavigatorName) {
         return false;

--- a/tests/unit/hooks/useIsSidebarRouteActive.test.ts
+++ b/tests/unit/hooks/useIsSidebarRouteActive.test.ts
@@ -1,0 +1,181 @@
+import {findFocusedRoute} from '@react-navigation/native';
+import {renderHook} from '@testing-library/react-native';
+import useIsSidebarRouteActive from '@libs/Navigation/helpers/useIsSidebarRouteActive';
+import navigationRef from '@libs/Navigation/navigationRef';
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    getRootState: jest.fn(() => undefined),
+    isReady: jest.fn(() => true),
+    addListener: jest.fn(() => () => {}),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+    findFocusedRoute: jest.fn(),
+}));
+
+/* eslint-disable @typescript-eslint/unbound-method -- jest.fn() mocks don't rely on `this` binding */
+const mockedGetRootState = navigationRef.getRootState as unknown as jest.Mock;
+const mockedFindFocusedRoute = findFocusedRoute as unknown as jest.Mock;
+/* eslint-enable @typescript-eslint/unbound-method */
+
+describe('useIsSidebarRouteActive', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // Regression test for #89181: post-#85234, TAB_NAVIGATOR wraps every split navigator, so the hook
+    // must descend one level into the active tab to find the split navigator.
+    it('returns true when TAB_NAVIGATOR wraps the requested split on a wide layout', () => {
+        mockedGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 3,
+                        routes: [
+                            {name: SCREENS.HOME},
+                            {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+                            {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR},
+                            {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, state: {routes: [{name: SCREENS.SETTINGS.ROOT}, {name: SCREENS.SETTINGS.PROFILE.ROOT}]}},
+                        ],
+                    },
+                },
+            ],
+        });
+        mockedFindFocusedRoute.mockReturnValue({name: SCREENS.SETTINGS.PROFILE.ROOT});
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, false));
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returns true on narrow layout when the focused route is the sidebar route', () => {
+        mockedGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 3,
+                        routes: [
+                            {name: SCREENS.HOME},
+                            {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+                            {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR},
+                            {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, state: {routes: [{name: SCREENS.SETTINGS.ROOT}]}},
+                        ],
+                    },
+                },
+            ],
+        });
+        mockedFindFocusedRoute.mockReturnValue({name: SCREENS.SETTINGS.ROOT});
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, true));
+
+        expect(result.current).toBe(true);
+    });
+
+    // Preserves the protection added by #63231: on narrow layouts the popover must not open
+    // when a sub-page is focused, because the sidebar row is off-screen-equivalent there.
+    it('returns false on narrow layout when the focused route is a sub-page (preserves #63231 guard)', () => {
+        mockedGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 3,
+                        routes: [
+                            {name: SCREENS.HOME},
+                            {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+                            {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR},
+                            {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, state: {routes: [{name: SCREENS.SETTINGS.ROOT}, {name: SCREENS.SETTINGS.PROFILE.ROOT}]}},
+                        ],
+                    },
+                },
+            ],
+        });
+        mockedFindFocusedRoute.mockReturnValue({name: SCREENS.SETTINGS.PROFILE.ROOT});
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, true));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returns false when TAB_NAVIGATOR active tab is a different split than requested', () => {
+        mockedGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 1,
+                        routes: [
+                            {name: SCREENS.HOME},
+                            {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR, state: {routes: [{name: SCREENS.INBOX}]}},
+                            {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, state: {routes: [{name: SCREENS.SETTINGS.ROOT}]}},
+                        ],
+                    },
+                },
+            ],
+        });
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, false));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returns false when the last root route is an RHP/modal stacked on top of TAB_NAVIGATOR', () => {
+        mockedGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        index: 3,
+                        routes: [{name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, state: {routes: [{name: SCREENS.SETTINGS.ROOT}]}}],
+                    },
+                },
+                {name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR},
+            ],
+        });
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, false));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returns false without throwing when the navigation state is not hydrated', () => {
+        mockedGetRootState.mockReturnValue(undefined);
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, false));
+
+        expect(result.current).toBe(false);
+    });
+
+    // Regression test: during partial hydration / linking, `state.index` can be absent. React Navigation's
+    // convention is to treat the first route as focused in that case — falling back to the last route would
+    // incorrectly resolve to WORKSPACE_NAVIGATOR (the last tab) and break Settings.
+    it('falls back to the first tab when TAB_NAVIGATOR state has no index', () => {
+        mockedGetRootState.mockReturnValue({
+            routes: [
+                {
+                    name: NAVIGATORS.TAB_NAVIGATOR,
+                    state: {
+                        routes: [{name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, state: {routes: [{name: SCREENS.SETTINGS.ROOT}]}}, {name: NAVIGATORS.WORKSPACE_NAVIGATOR}],
+                    },
+                },
+            ],
+        });
+        mockedFindFocusedRoute.mockReturnValue({name: SCREENS.SETTINGS.ROOT});
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, false));
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returns false without throwing when TAB_NAVIGATOR has no nested state', () => {
+        mockedGetRootState.mockReturnValue({routes: [{name: NAVIGATORS.TAB_NAVIGATOR}]});
+
+        const {result} = renderHook(() => useIsSidebarRouteActive(NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR, false));
+
+        expect(result.current).toBe(false);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

Right-click (web) and long-press (native) on Account settings items stopped opening the "Copy URL to clipboard" popover after #85234 introduced the Bottom Tab Navigator. `useIsSidebarRouteActive` was reading the root stack's last route, which is now always `TAB_NAVIGATOR`, so the name comparison against `SETTINGS_SPLIT_NAVIGATOR` always failed. The hook now descends one level into the active tab via the existing `getTabState()` helper before comparing.

https://github.com/user-attachments/assets/27999879-9e44-4def-9603-11a507cb8ee2


### Fixed Issues

$ https://github.com/Expensify/App/issues/89181
PROPOSAL:


### Tests

1. Sign in and open Account (Settings tab).
2. Right-click on "What's new" (on web) or long-press (on native).
3. Verify that the "Copy URL to clipboard" popover appears with the deep-link URL.
4. Repeat on Profile, Wallet, and Subscription rows — verify the popover appears for each.
5. Resize the browser to a narrow/mobile width, open Account, tap into a sub-page (e.g. Profile), then right-click on a row within the sub-page sidebar area.
6. Verify that the popover does **not** open on narrow layout sub-pages (preserves the #63231 guard).
7. Switch to the Reports and Search tabs and confirm nothing about those tabs changed.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — the change only affects local navigation state lookup; no network calls or Onyx operations are involved.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
