### PR TITLE
Fix: strip merged prefix from display name and login

### DIFF
--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -62,13 +62,19 @@ function getDisplayNameOrDefault(
     youAfterTranslation = youTranslation,
 ): string {
     let displayName = passedPersonalDetails?.displayName ?? '';
-
     let login = passedPersonalDetails?.login ?? '';
 
+    // FIX 1: Use a local, non-global regex pattern for testing to prevent lastIndex state bugs
+    const MERGED_ACCOUNT_TEST = /^MERGED_\d+@/;
+
     // If the displayName starts with the merged account prefix, remove it.
-    if (regexMergedAccount.test(displayName)) {
-        // Remove the merged account prefix from the displayName.
+    if (MERGED_ACCOUNT_TEST.test(displayName)) {
         displayName = displayName.replaceAll(CONST.REGEX.MERGED_ACCOUNT_PREFIX, '');
+    }
+
+    // FIX 2: Symmetrically strip the prefix from the login string as well
+    if (MERGED_ACCOUNT_TEST.test(login)) {
+        login = login.replaceAll(CONST.REGEX.MERGED_ACCOUNT_PREFIX, '');
     }
 
     // If the displayName is not set by the user, the backend sets the displayName same as the login so
@@ -101,6 +107,7 @@ function getDisplayNameOrDefault(
     }
     return shouldFallbackToHidden ? hiddenTranslation : '';
 }
+
 
 /**
  * Given a list of account IDs (as number) it will return an array of personal details objects.


### PR DESCRIPTION
### Explanation of Change
Replaced the stateful module-level global regex check (`regexMergedAccount.test`) with a local, deterministic, non-global check (`MERGED_ACCOUNT_TEST = /^MERGED_\d+@/`) inside `src/libs/PersonalDetailsUtils.ts`. This completely stops `lastIndex` from advancing across consecutive renders, which was causing the prefix-stripping logic to intermittently fail.

Additionally, symmetrically applied the `replaceAll` cleanup to the `login` field right after sanitizing the `displayName`. This ensures that if a user's display name collapses to an empty string during an account merge, the fallback chain evaluates a clean login string instead of leaking raw merge markers that default downstream views to "Hidden".

### Fixed Issues
$https://github.com/Expensify/App/issues/91592$ PROPOSAL: https://github.com/Expensify/App/issues/91592

### Tests
1. Log into your local environment at http://localhost:9000
2. Verify that your primary account display names render completely stably without flipping or defaulting to "Hidden" on dashboard hot-reloads.
- [x] Verify that no errors appear in the JS console

### Offline tests
1. Turn off your internet connection.
2. Navigate your local application views and verify that the user display formatting handles fallback states gracefully without console failures.

### QA Steps
1. Log in to the staging application environment.
2. Navigate to search and open workspace or archived chats that underwent an historic user account merge.
3. Verify that the primary login identity is correctly readable in the header parameters and search listings instead of displaying as "Hidden".
- [x] Verify that no errors appear in the JS console