### PR TITLE
[NO QA] Use postCodeReviewResults.sh from claude-review-toolkit

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Setup Claude review toolkit
         id: toolkit
-        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@43c1b4348cd46637e44064b02f5d316bfab990ee
+        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@27d36e4f9e124ed03db877cd164f489078398da2
 
       - name: Mark review as in progress
         env:
@@ -103,22 +103,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           STRUCTURED_OUTPUT: ${{ steps.code-review.outputs.structured_output }}
-        run: |
-          if [ -z "$STRUCTURED_OUTPUT" ]; then
-            echo "::error::Claude Code Action returned empty structured output"
-            exit 1
-          fi
-          COUNT=$(echo "$STRUCTURED_OUTPUT" | jq '.violations | length')
-          if [ "$COUNT" -eq 0 ]; then
-            addPrReaction.sh "$PR_NUMBER" "+1"
-          else
-            echo "$STRUCTURED_OUTPUT" | jq -c '.violations[]' | while IFS= read -r v; do
-              PATH_ARG=$(echo "$v" | jq -r '.path')
-              BODY_ARG=$(echo "$v" | jq -r '.body')
-              LINE_ARG=$(echo "$v" | jq -r '.line')
-              createInlineComment.sh "$PR_NUMBER" "$PATH_ARG" "$BODY_ARG" "$LINE_ARG" || true
-            done
-          fi
+        run: postCodeReviewResults.sh "$PR_NUMBER"
 
       - name: Run Claude Code (docs)
         if: steps.filter.outputs.docs == 'true'


### PR DESCRIPTION
### Explanation of Change
Adopts the new `postCodeReviewResults.sh` helper added in Expensify/GitHub-Actions#66. Replaces the inline `jq` + while-loop in the `Post code review results` step with a single script call. Bumps the `claude-review-toolkit` pin to the SHA that introduces the script.

No steady-state behaviour change: 0 violations -> `+1` reaction; N violations -> N inline comments via `createInlineComment.sh` (failures per comment swallowed with `|| true`); empty `STRUCTURED_OUTPUT` -> `::error::` + exit 1.

This is part of slice 2 of the centralisation effort. The toolkit pin currently points at the SHA on the toolkit PR branch and will be re-stamped to the merged-`main` SHA once Expensify/GitHub-Actions#66 lands.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/635397
PROPOSAL:

### Tests
N/A - CI infrastructure with no user-facing behaviour change. Validation happens via the workflow itself running on this PR (will only fully validate once the toolkit SHA is re-stamped post-merge of Expensify/GitHub-Actions#66).

1. Verify that no errors appear in the JS console

### Offline tests
N/A - CI infrastructure change; doesn't affect runtime offline behaviour.

### QA Steps
@Julesssss and @kacper-mikolajczak will check out some AI Reviewer workflow runs on real PRs after merge.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the \`### Fixed Issues\` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the \`Tests\` section
    - [x] I added steps for the expected offline behavior in the \`Offline steps\` section
    - [x] I added steps for Staging and/or Production testing in the \`QA steps\` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
N/A - CI infra
</details>
<details>
<summary>Android: mWeb Chrome</summary>
N/A - CI infra
</details>
<details>
<summary>iOS: Native</summary>
N/A - CI infra
</details>
<details>
<summary>iOS: mWeb Safari</summary>
N/A - CI infra
</details>
<details>
<summary>MacOS: Chrome / Safari</summary>
N/A - CI infra
</details>

---
cc @Julesssss