### PR TITLE
Split docs and code review into separate jobs in claude-review.yml

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,7 +41,7 @@ jobs:
           USERNAME: ${{ github.event.review.user.login }}
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-  review:
+  review-code:
     needs: [validate, checkCPlusApproval]
     if: |
       !cancelled()
@@ -70,15 +70,14 @@ jobs:
           filters: |
             code:
               - 'src/**'
-            docs:
-              - 'docs/**/*.md'
-              - 'docs/**/*.csv'
 
       - name: Setup Claude review toolkit
+        if: steps.filter.outputs.code == 'true'
         id: toolkit
         uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@43c1b4348cd46637e44064b02f5d316bfab990ee
 
       - name: Mark review as in progress
+        if: steps.filter.outputs.code == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -99,7 +98,7 @@ jobs:
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(check-compiler.sh:*)" --json-schema '${{ steps.toolkit.outputs.schema_json }}'
 
       - name: Post code review results
-        if: steps.code-review.outcome == 'success' && steps.filter.outputs.code == 'true'
+        if: steps.code-review.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           STRUCTURED_OUTPUT: ${{ steps.code-review.outputs.structured_output }}
@@ -120,6 +119,52 @@ jobs:
             done
           fi
 
+      - name: Remove in-progress indicator
+        if: always() && steps.filter.outputs.code == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          removePrReaction.sh "$PR_NUMBER" "eyes" "github-actions[bot]"
+
+  review-docs:
+    needs: [validate, checkCPlusApproval]
+    if: |
+      !cancelled()
+      && github.event.pull_request.draft != true
+      && !contains(github.event.pull_request.title, 'Revert')
+      && (
+        (github.event_name == 'pull_request_target' && needs.validate.outputs.IS_AUTHORIZED == 'true')
+        || (github.event_name == 'pull_request_review' && needs.checkCPlusApproval.outputs.IS_CPLUS == 'true')
+      )
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout repository
+        uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
+        with:
+          fetch-depth: 1
+
+      - name: Filter paths
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**/*.md'
+              - 'docs/**/*.csv'
+
+      - name: Setup Claude review toolkit
+        if: steps.filter.outputs.docs == 'true'
+        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@43c1b4348cd46637e44064b02f5d316bfab990ee
+
+      - name: Mark review as in progress
+        if: steps.filter.outputs.docs == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          addPrReaction.sh "$PR_NUMBER" "eyes"
+
       - name: Run Claude Code (docs)
         if: steps.filter.outputs.docs == 'true'
         uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1.0.86
@@ -134,7 +179,7 @@ jobs:
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
 
       - name: Remove in-progress indicator
-        if: always()
+        if: always() && steps.filter.outputs.docs == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
### Explanation of Change

Untangles the docs and code review flows in `.github/workflows/claude-review.yml` by splitting the existing single `review` job into two sibling jobs (`review-code` and `review-docs`).

Today the workflow runs both `claude-code-action` invocations sequentially inside one job, gated by a single `dorny/paths-filter` step that emits two outputs. That makes the code-review path diverge from the shape used by `Expensify/Auth` and `Expensify/Web-Expensify`, which each run a single `claude-code-action` per job. This PR aligns the code-review path with that shape so the three repos can converge on a shared `claude-review` workflow in a follow-up slice.

What changed:
- `review` job split into `review-code` and `review-docs`. Both depend on the existing `validate` and `checkCPlusApproval` gate jobs via `needs:`, so contributor authorisation is unchanged.
- Each job owns its own `dorny/paths-filter` step (`src/**` for code, `docs/**/*.md` + `docs/**/*.csv` for docs), its own toolkit setup, its own eyes add/remove lifecycle, and its own `claude-code-action` call.
- `review-code` keeps the `Setup Node` step because the code review prompt uses `Bash(check-compiler.sh:*)` from its allowedTools. `review-docs` does not need it and skips the setup.
- Workflow-level `name`, `permissions`, `on:`, `concurrency`, and the `validate` / `checkCPlusApproval` jobs are untouched.

Net steady-state behaviour is identical: same triggers, same contributor gate, same path filtering, same prompts, same allowedTools, same toolkit SHA pin, same `claude-code-action` SHA pin, same post-processing of structured output, same eyes reactions on PRs that touch code and/or docs.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/635397
PROPOSAL: N/A (infra refactor, no proposal required)

### Related Issues

- https://github.com/Expensify/Expensify/issues/635397

### Tests

This change only touches a GitHub Actions workflow, so the verification is observational on the workflow runs themselves:

1. Open a draft PR against `main`, mark it ready for review.
2. Verify both `review-code` and `review-docs` jobs are visible in the Actions tab under the `PR Reviews with Claude Code` workflow.
3. Verify the `validate` job runs once and both review jobs depend on it.
4. On a PR that only touches `src/**`, verify `review-code` posts comments / +1 reaction and `review-docs` short-circuits (path filter `false`, no eyes, no `claude-code-action` invocation).
5. On a PR that only touches `docs/**/*.md` or `docs/**/*.csv`, verify the reverse.
6. On a PR that touches both, verify both jobs run and each posts its own results independently.
7. On a draft PR or a PR with `Revert` in the title, verify neither review job runs.
8. Verify a `pull_request_review` `submitted` event from a Contributor+ reviewer still triggers both jobs as before.

### Offline tests

N/A - GitHub Actions workflow change, no runtime client behaviour.

### QA Steps

Same as Tests above; QA can observe the workflow runs on real PRs once merged.

### PR Author Checklist

CI-only change (single workflow file). The platform-test and runtime checklist items below do not apply to this PR.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors
- [ ] I followed proper code patterns
- [ ] I tested other components that can be impacted by my changes
- [ ] I verified all code is DRY
- [ ] I added unit tests for any new feature or bug fix in this PR