### PR TITLE
Use run-claude-action composite in claude-review.yml

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -87,12 +87,13 @@ jobs:
       - name: Run Claude Code (code)
         id: code-review
         if: steps.filter.outputs.code == 'true'
-        uses: Expensify/GitHub-Actions/.github/actions/run-claude-action@a7c05c4cf02c24d625101e9c30295c5a837cd84a
+        uses: Expensify/GitHub-Actions/.github/actions/run-claude-action@594081dca9e97739085087497164a0af7e3b1844
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: "/review-code-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(check-compiler.sh:*)" --json-schema '${{ steps.toolkit.outputs.schema_json }}'
 
       - name: Post code review results
@@ -119,12 +120,13 @@ jobs:
 
       - name: Run Claude Code (docs)
         if: steps.filter.outputs.docs == 'true'
-        uses: Expensify/GitHub-Actions/.github/actions/run-claude-action@a7c05c4cf02c24d625101e9c30295c5a837cd84a
+        uses: Expensify/GitHub-Actions/.github/actions/run-claude-action@594081dca9e97739085087497164a0af7e3b1844
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: "/review-helpdot-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
 
       - name: Remove in-progress indicator

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -87,15 +87,12 @@ jobs:
       - name: Run Claude Code (code)
         id: code-review
         if: steps.filter.outputs.code == 'true'
-        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1.0.86
+        uses: Expensify/GitHub-Actions/.github/actions/run-claude-action@a7c05c4cf02c24d625101e9c30295c5a837cd84a
         with:
-          display_report: "true"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: "*"
           prompt: "/review-code-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
-            --model claude-opus-4-6
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(check-compiler.sh:*)" --json-schema '${{ steps.toolkit.outputs.schema_json }}'
 
       - name: Post code review results
@@ -122,15 +119,12 @@ jobs:
 
       - name: Run Claude Code (docs)
         if: steps.filter.outputs.docs == 'true'
-        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1.0.86
+        uses: Expensify/GitHub-Actions/.github/actions/run-claude-action@a7c05c4cf02c24d625101e9c30295c5a837cd84a
         with:
-          display_report: "true"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: "*"
           prompt: "/review-helpdot-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
-            --model claude-opus-4-6
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
 
       - name: Remove in-progress indicator


### PR DESCRIPTION
### Details

Rewires both `claude-code-action` invocations in `.github/workflows/claude-review.yml` (code review and docs review) to use the new shared composite at `Expensify/GitHub-Actions/.github/actions/run-claude-action`.

The composite pins the `anthropics/claude-code-action` SHA in a single place so future bumps require touching only that composite instead of three client workflows. Caller-specific `claude_args` (`--allowedTools`, `--json-schema`) stay in this workflow because they vary per invocation - App's code review uses different tools than App's docs review.

Net behaviour is unchanged: same upstream SHA (`ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae` / `v1.0.86`), same model (`claude-opus-4-6`), same `display_report` / `allowed_non_write_users` defaults.

The composite reference uses a placeholder SHA on the branch tip of the GitHub-Actions PR; it will be re-stamped to the merged-main SHA once that PR lands.

### Related Issues

https://github.com/Expensify/Expensify/issues/635397

Depends on Expensify/GitHub-Actions#67 (composite action source).

### Manual Tests

Diff is a pure mechanical swap (one `uses:` line + drop of inputs now defaulted by the composite). Runtime parity verified by inspection - same SHA pin, same defaults, same `claude_args` content modulo the now-defaulted `--model` line.

### Linked PRs

- Expensify/GitHub-Actions#67