### PR TITLE
Fix false-positive dynamic route matching when multiple suffixes match the same path

### DIFF
--- a/contributingGuides/NAVIGATION.md
+++ b/contributingGuides/NAVIGATION.md
@@ -728,7 +728,7 @@ Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.VERIFY_ACCOUNT.path));
 
 The `entryScreens` array in `DYNAMIC_ROUTES` defines which base screens are allowed to open this dynamic route.
 
-When parsing a URL, `src/libs/Navigation/helpers/getStateFromPath.ts` resolves the base path (without the dynamic suffix), gets the focused route for that path, and checks whether it is in `entryScreens`. If it is not, the dynamic route state is not built and a warning is logged. This prevents opening e.g. `/some/random/path/verify-account` when that path's screen is not allowed.
+When parsing a URL, `src/libs/Navigation/helpers/getStateFromPath.ts` calls `findAllMatchingDynamicSuffixes` to get all syntactically matching suffixes in priority order, then iterates through them: for each candidate it resolves the base path (without the dynamic suffix), gets the focused route for that path, and checks whether it is in `entryScreens`. The first candidate that passes this check is used. If no candidate passes, the dynamic route state is not built and a warning is logged. This prevents opening e.g. `/some/random/path/verify-account` when that path's screen is not allowed, while also handling ambiguous matches gracefully by falling back to lower-priority candidates.
 
 When adding or extending a dynamic route, list every screen that should be able to open it (e.g. `SCREENS.SETTINGS.WALLET.ROOT` for Verify Account from Wallet).
 
@@ -774,11 +774,25 @@ DYNAMIC_ROUTES: {
 },
 ```
 
+#### Suffix resolution (`findAllMatchingDynamicSuffixes`)
+
+The core matching logic lives in
+[`src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts`](../src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts).
+
+Given a path, `findAllMatchingDynamicSuffixes` returns **all** registered suffixes that
+syntactically match the end of that path, ordered by priority. The caller (e.g. `getStateFromPath`)
+then iterates through the list and picks the first candidate whose base path resolves to a screen
+listed in `entryScreens`. This prevents false-positive greedy matches where a user-defined name
+(e.g. a tag named "gl-code") coincides with a registered static suffix.
+
+A convenience wrapper `findMatchingDynamicSuffix` (named export from the same file) returns only
+the first (highest-priority) match — equivalent to `findAllMatchingDynamicSuffixes(path)[0]`.
+Use it only when you don't need to validate against additional context.
+
 #### Precedence rules
 
-When several registered suffixes could match the same URL, the matcher uses a deterministic
-three-phase order. Each phase exhausts all sub-suffix lengths (longest to shortest) before the
-next phase begins:
+The priority order within the returned array is determined by a three-phase algorithm.
+Each phase exhausts all sub-suffix lengths (longest to shortest) before the next phase begins:
 
 1. **Static beats everything.** All sub-suffix lengths are checked for an exact static match
    first. A short static match (e.g. single-segment `country`) always beats a longer parametric
@@ -801,12 +815,12 @@ they can span multiple segments separated by `/`.
 For example, the suffix `add-bank-account/verify-account` is a valid
 multi-segment suffix that combines two segments into one dynamic route.
 
-When the URL is parsed, the matching algorithm
+When the URL is parsed, `findAllMatchingDynamicSuffixes`
 iterates from the longest candidate suffix to the shortest,
 so overlapping registrations are resolved deterministically.
 For instance, if both `verify-account` and `add-bank-account/verify-account`
 are registered, a path ending with `/add-bank-account/verify-account`
-will always match the longer, more specific suffix.
+will always match the longer, more specific suffix first in the returned array.
 
 ### Suffix layering (stacking dynamic routes)
 

--- a/src/hooks/useDynamicBackPath.ts
+++ b/src/hooks/useDynamicBackPath.ts
@@ -1,4 +1,4 @@
-import findMatchingDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/findMatchingDynamicSuffix';
+import findAllMatchingDynamicSuffixes from '@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
 import getPathWithoutDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix';
 import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
 import type {State} from '@libs/Navigation/types';
@@ -31,8 +31,8 @@ function useDynamicBackPath(dynamicRouteSuffix: DynamicRouteSuffix): Route {
     }
 
     const pathWithoutLeadingSlash = path.replaceAll(/^\/+/g, '');
-    const match = findMatchingDynamicSuffix(pathWithoutLeadingSlash);
-    if (match && match.pattern === dynamicRouteSuffix) {
+    const match = findAllMatchingDynamicSuffixes(pathWithoutLeadingSlash).find((m) => m.pattern === dynamicRouteSuffix);
+    if (match) {
         return getPathWithoutDynamicSuffix(pathWithoutLeadingSlash, match.actualSuffix, match.pattern);
     }
 

--- a/src/hooks/useDynamicForwardPath.ts
+++ b/src/hooks/useDynamicForwardPath.ts
@@ -1,4 +1,4 @@
-import findMatchingDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/findMatchingDynamicSuffix';
+import findAllMatchingDynamicSuffixes from '@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
 import getPathWithoutDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix';
 import findFocusedRouteWithOnyxTabGuard from '@libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard';
 import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
@@ -58,8 +58,8 @@ function useDynamicForwardPath(dynamicRouteSuffix: DynamicRouteSuffix): Route | 
     }
 
     const pathWithoutLeadingSlash = path.replaceAll(/^\/+/g, '');
-    const match = findMatchingDynamicSuffix(pathWithoutLeadingSlash);
-    if (!match || match.pattern !== dynamicRouteSuffix) {
+    const match = findAllMatchingDynamicSuffixes(pathWithoutLeadingSlash).find((m) => m.pattern === dynamicRouteSuffix);
+    if (!match) {
         return undefined;
     }
 

--- a/src/libs/Navigation/AppNavigator/KeyboardShortcutsHandler/ShortcutsOverviewHandler.tsx
+++ b/src/libs/Navigation/AppNavigator/KeyboardShortcutsHandler/ShortcutsOverviewHandler.tsx
@@ -2,7 +2,7 @@ import {useEffect} from 'react';
 import useShouldShowRequire2FAPage from '@hooks/useShouldShowRequire2FAPage';
 import KeyboardShortcut from '@libs/KeyboardShortcut';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
-import findMatchingDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/findMatchingDynamicSuffix';
+import {findMatchingDynamicSuffix} from '@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
 import Navigation from '@libs/Navigation/Navigation';
 import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
@@ -48,54 +48,68 @@ function tryMatchParametric(candidate: string, candidateSegmentCount: number, pa
 }
 
 /**
- * Finds a registered dynamic route suffix that matches the end of the given path.
+ * Collects ALL registered dynamic route suffixes that syntactically match the end of the given path,
+ * across all three phases and in priority order:
+ *   1. Static matches (`dynamicRoutePaths` Set lookup), longest to shortest.
+ *   2. Strict parametric patterns (no optional params), longest to shortest.
+ *   3. Optional parametric patterns (has at least one `:param?`), longest to shortest.
  *
- * Uses three-phase matching with decreasing specificity. Each phase iterates
- * all sub-suffixes from longest to shortest before the next phase begins:
- *   1. Static matches (`dynamicRoutePaths` Set lookup).
- *   2. Strict parametric patterns (no optional params).
- *   3. Optional parametric patterns (has at least one `:param?`).
+ * Use this instead of `findMatchingDynamicSuffix` when you need to validate matches against
+ * additional context (e.g. `entryScreens`) and fall back to the next candidate if the first
+ * one doesn't satisfy the constraint. This prevents false-positive greedy matches where a
+ * user-defined name (e.g. a tag named "gl-code") coincides with a registered static suffix.
  *
- * This guarantees that any static match, even a short one, always beats
- * a parametric match, and any strict-parametric match always beats an
- * optional-parametric match.
+ * Each pattern appears at most once in the result array. The first element is always equal
+ * to what `findMatchingDynamicSuffix` would return for the same path.
  *
- * @param path - The path to find the matching dynamic suffix for
- * @returns The matching dynamic suffix, or undefined if no matching suffix is found
+ * @param path - The path to find all matching dynamic suffixes for
+ * @returns Array of all matching dynamic suffixes in priority order (may be empty)
  */
-function findMatchingDynamicSuffix(path = ''): DynamicSuffixMatch | undefined {
+function findAllMatchingDynamicSuffixes(path = ''): DynamicSuffixMatch[] {
     const [normalizedPath] = splitPathAndQuery(path);
     if (!normalizedPath) {
-        return undefined;
+        return [];
     }
 
     const segments = normalizedPath.split('/').filter(Boolean);
+    const results: DynamicSuffixMatch[] = [];
+    const seenPatterns = new Set<string>();
 
     // Phase 1: Static matches (longest to shortest)
     for (let i = 0; i < segments.length; i++) {
         const candidate = segments.slice(i).join('/');
         if (dynamicRoutePaths.has(candidate)) {
-            return {pattern: candidate, actualSuffix: candidate, pathParams: {}};
+            results.push({pattern: candidate, actualSuffix: candidate, pathParams: {}});
+            seenPatterns.add(candidate);
         }
     }
 
     // Phase 2: Strict parametric patterns - no optional params (longest to shortest)
     for (let i = 0; i < segments.length; i++) {
-        const result = tryMatchParametric(segments.slice(i).join('/'), segments.length - i, compiledStrictParametricDynamicRoutes);
-        if (result) {
-            return result;
+        const match = tryMatchParametric(segments.slice(i).join('/'), segments.length - i, compiledStrictParametricDynamicRoutes);
+        if (match && !seenPatterns.has(match.pattern)) {
+            results.push(match);
+            seenPatterns.add(match.pattern);
         }
     }
 
     // Phase 3: Optional parametric patterns - has at least one :param? (longest to shortest)
     for (let i = 0; i < segments.length; i++) {
-        const result = tryMatchParametric(segments.slice(i).join('/'), segments.length - i, compiledOptionalParametricDynamicRoutes);
-        if (result) {
-            return result;
+        const match = tryMatchParametric(segments.slice(i).join('/'), segments.length - i, compiledOptionalParametricDynamicRoutes);
+        if (match && !seenPatterns.has(match.pattern)) {
+            results.push(match);
+            seenPatterns.add(match.pattern);
         }
     }
 
-    return undefined;
+    return results;
 }
 
-export default findMatchingDynamicSuffix;
+/** Mirrors previous `findMatchingDynamicSuffix` logic - returns only the first (highest-priority) match. */
+function findMatchingDynamicSuffix(path = ''): DynamicSuffixMatch | undefined {
+    return findAllMatchingDynamicSuffixes(path).at(0);
+}
+
+export type {DynamicSuffixMatch};
+export {findMatchingDynamicSuffix};
+export default findAllMatchingDynamicSuffixes;

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
@@ -48,7 +48,7 @@ function tryMatchParametric(candidate: string, candidateSegmentCount: number, pa
 }
 
 /**
- * Collects ALL registered dynamic route suffixes that syntactically match the end of the given path,
+ * Collects all registered dynamic route suffixes that syntactically match the end of the given path,
  * across all three phases and in priority order:
  *   1. Static matches (`dynamicRoutePaths` Set lookup), longest to shortest.
  *   2. Strict parametric patterns (no optional params), longest to shortest.

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
@@ -90,11 +90,9 @@ function getDynamicRouteAdaptedState(state: PartialState<NavigationState>, focus
                 continue;
             }
             const candidateBaseState = getStateFromPath(candidateBasePath as Route);
-            if (!candidateBaseState) {
-                continue;
-            }
-            const lastRoute = candidateBaseState.routes?.at(-1);
-            if (!lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
+            const lastRoute = candidateBaseState?.routes?.at(-1);
+
+            if (!candidateBaseState || !lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
                 continue;
             }
             resolvedMatch = candidate;

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
@@ -3,7 +3,8 @@ import findFocusedRouteWithOnyxTabGuard from '@libs/Navigation/helpers/findFocus
 import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
 import type {Route} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
-import findMatchingDynamicSuffix from './findMatchingDynamicSuffix';
+import findAllMatchingDynamicSuffixes from './findAllMatchingDynamicSuffixes';
+import type {DynamicSuffixMatch} from './findAllMatchingDynamicSuffixes';
 import getPathWithoutDynamicSuffix from './getPathWithoutDynamicSuffix';
 import isDynamicRouteScreen from './isDynamicRouteScreen';
 
@@ -75,25 +76,36 @@ function getDynamicRouteAdaptedState(state: PartialState<NavigationState>, focus
 
     let newFocused = findFocusedRouteWithOnyxTabGuard(accumulatedState);
     do {
-        const suffixMatch = findMatchingDynamicSuffix(currentPath);
-        if (!suffixMatch) {
+        // Iterate all candidates so a false-positive greedy first match (e.g. a tag named
+        // "gl-code" coinciding with a static suffix) doesn't produce a wrong base state.
+        let resolvedMatch: DynamicSuffixMatch | undefined;
+        let resolvedBasePath: Route | undefined;
+        let resolvedBaseState: PartialState<NavigationState> | undefined;
+        const allSuffixMatches = findAllMatchingDynamicSuffixes(currentPath);
+
+        for (const candidate of allSuffixMatches) {
+            const candidateBasePath = getPathWithoutDynamicSuffix(currentPath, candidate.actualSuffix, candidate.pattern);
+            if (!candidateBasePath || candidateBasePath === currentPath) {
+                continue;
+            }
+            const candidateBaseState = getStateFromPath(candidateBasePath as Route);
+            if (!candidateBaseState) {
+                continue;
+            }
+            resolvedMatch = candidate;
+            resolvedBasePath = candidateBasePath;
+            resolvedBaseState = candidateBaseState;
             break;
         }
 
-        const basePath = getPathWithoutDynamicSuffix(currentPath, suffixMatch.actualSuffix, suffixMatch.pattern);
-        if (!basePath || basePath === currentPath) {
+        if (!resolvedMatch || !resolvedBasePath || !resolvedBaseState) {
             break;
         }
 
-        const baseState = getStateFromPath(basePath as Route);
-        if (!baseState) {
-            break;
-        }
+        accumulatedState = insertStateBelow(accumulatedState, resolvedBaseState);
+        currentPath = resolvedBasePath;
 
-        accumulatedState = insertStateBelow(accumulatedState, baseState);
-        currentPath = basePath;
-
-        newFocused = findFocusedRouteWithOnyxTabGuard(baseState);
+        newFocused = findFocusedRouteWithOnyxTabGuard(resolvedBaseState);
     } while (!!newFocused && isDynamicRouteScreen(newFocused.name as Screen));
 
     return accumulatedState;

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
@@ -3,6 +3,7 @@ import findFocusedRouteWithOnyxTabGuard from '@libs/Navigation/helpers/findFocus
 import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
 import type {Route} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
+import SCREENS from '@src/SCREENS';
 import findAllMatchingDynamicSuffixes from './findAllMatchingDynamicSuffixes';
 import type {DynamicSuffixMatch} from './findAllMatchingDynamicSuffixes';
 import getPathWithoutDynamicSuffix from './getPathWithoutDynamicSuffix';
@@ -90,6 +91,10 @@ function getDynamicRouteAdaptedState(state: PartialState<NavigationState>, focus
             }
             const candidateBaseState = getStateFromPath(candidateBasePath as Route);
             if (!candidateBaseState) {
+                continue;
+            }
+            const lastRoute = candidateBaseState.routes?.at(-1);
+            if (!lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
                 continue;
             }
             resolvedMatch = candidate;

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -12,7 +12,7 @@ import type {Route as RoutePath} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Screen} from '@src/SCREENS';
-import findMatchingDynamicSuffix from './dynamicRoutesUtils/findMatchingDynamicSuffix';
+import findAllMatchingDynamicSuffixes from './dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
 import getDynamicRouteAdaptedState from './dynamicRoutesUtils/getDynamicRouteAdaptedState';
 import getPathWithoutDynamicSuffix from './dynamicRoutesUtils/getPathWithoutDynamicSuffix';
 import isDynamicRouteScreen from './dynamicRoutesUtils/isDynamicRouteScreen';
@@ -229,16 +229,18 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
         return getTabNavigatorState(splitState);
     }
 
-    // Handle dynamic routes: find the appropriate full screen route
+    // Handle dynamic routes: find the appropriate full screen route.
+    // Iterate all candidates so that a false-positive first match (e.g. a tag named "gl-code"
+    // colliding with the registered static suffix) does not produce a NOT_FOUND state.
     if (route.path) {
-        const suffixMatch = findMatchingDynamicSuffix(route.path);
-        if (suffixMatch) {
+        const allSuffixMatches = findAllMatchingDynamicSuffixes(route.path);
+        for (const suffixMatch of allSuffixMatches) {
             // Strip the suffix from the URL. For parametric routes we pass both the actual URL
             // suffix and the registered pattern so query params can be resolved correctly.
             const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(route.path, suffixMatch.actualSuffix, suffixMatch.pattern);
 
             if (!pathWithoutDynamicSuffix) {
-                return undefined;
+                continue;
             }
 
             // Parse the base path (without dynamic suffix) into a navigation state
@@ -247,7 +249,7 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
             const lastRoute = stateUnderDynamicRoute?.routes.at(-1);
 
             if (!stateUnderDynamicRoute || !lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
-                return undefined;
+                continue;
             }
 
             const isLastRouteFullScreen = isFullScreenName(lastRoute.name);
@@ -259,7 +261,7 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
             const focusedRouteUnderDynamicRoute = findFocusedRouteWithOnyxTabGuard(stateUnderDynamicRoute);
 
             if (!focusedRouteUnderDynamicRoute) {
-                return undefined;
+                continue;
             }
 
             // Recursively find the matching full screen route for the focused dynamic route

--- a/src/libs/Navigation/helpers/getStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getStateFromPath.ts
@@ -6,7 +6,7 @@ import type {Route} from '@src/ROUTES';
 import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
 import SCREENS from '@src/SCREENS';
-import findMatchingDynamicSuffix from './dynamicRoutesUtils/findMatchingDynamicSuffix';
+import findAllMatchingDynamicSuffixes from './dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
 import getPathWithoutDynamicSuffix from './dynamicRoutesUtils/getPathWithoutDynamicSuffix';
 import getStateForDynamicRoute from './dynamicRoutesUtils/getStateForDynamicRoute';
 import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
@@ -20,13 +20,17 @@ function getStateFromPath(path: Route): PartialState<NavigationState> {
     const normalizedPath = !path.startsWith('/') ? `/${path}` : path;
     const normalizedPathAfterRedirection = getMatchingNewRoute(normalizedPath) ?? normalizedPath;
 
-    const suffixMatch = findMatchingDynamicSuffix(normalizedPathAfterRedirection);
-    if (suffixMatch) {
+    // Collect all syntactic matches and validate each one against entryScreens.
+    // This prevents false-positive greedy matches where a user-defined name (e.g. a tag
+    // named "gl-code") coincides with a registered static suffix like WORKSPACE_CATEGORY_GL_CODE.
+    const allSuffixMatches = findAllMatchingDynamicSuffixes(normalizedPathAfterRedirection);
+
+    type DynamicRouteKey = keyof typeof DYNAMIC_ROUTES;
+    const dynamicRouteKeys = Object.keys(DYNAMIC_ROUTES) as DynamicRouteKey[];
+
+    for (const suffixMatch of allSuffixMatches) {
         const {pattern, actualSuffix, pathParams} = suffixMatch;
         const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(normalizedPathAfterRedirection, actualSuffix, pattern);
-
-        type DynamicRouteKey = keyof typeof DYNAMIC_ROUTES;
-        const dynamicRouteKeys = Object.keys(DYNAMIC_ROUTES) as DynamicRouteKey[];
 
         // Find the DYNAMIC_ROUTES config key whose path matches the extracted pattern.
         const dynamicRoute = dynamicRouteKeys.find((key) => DYNAMIC_ROUTES[key].path === pattern) ?? '';
@@ -37,29 +41,29 @@ function getStateFromPath(path: Route): PartialState<NavigationState> {
         const focusedRoute = findFocusedRouteWithOnyxTabGuard(getStateFromPath(pathWithoutDynamicSuffix) ?? {});
         const entryScreens: ReadonlyArray<Screen | '*'> = DYNAMIC_ROUTES[dynamicRoute as DynamicRouteKey]?.entryScreens ?? [];
 
-        if (focusedRoute?.name) {
-            if (entryScreens.some((s) => s === '*' || s === focusedRoute.name)) {
-                // Merge the base route's params with
-                // params extracted from the dynamic suffix.
-                // This gives the dynamic route screen access to all context it needs.
-                const mergedParams = {
-                    ...(focusedRoute?.params as Record<string, unknown> | undefined),
-                    ...pathParams,
-                };
-                const dynamicRouteState = getStateForDynamicRoute(normalizedPath, dynamicRoute as DynamicRouteKey, mergedParams);
-                return dynamicRouteState;
-            }
-
-            // Fallback: if the base path is empty
-            // there's no underlying screen - show Not Found.
-            if (!pathWithoutDynamicSuffix) {
-                const state = {routes: [{name: SCREENS.NOT_FOUND, path: normalizedPathAfterRedirection}]};
-
-                return state;
-            }
-
-            Log.warn(`[getStateFromPath.ts][DynamicRoute] Focused route ${focusedRoute.name} is not allowed to access dynamic route with suffix ${pattern}`);
+        if (focusedRoute?.name && entryScreens.some((s) => s === '*' || s === focusedRoute.name)) {
+            // Merge the base route's params with params extracted from the dynamic suffix.
+            // This gives the dynamic route screen access to all context it needs.
+            const mergedParams = {
+                ...(focusedRoute?.params as Record<string, unknown> | undefined),
+                ...pathParams,
+            };
+            return getStateForDynamicRoute(normalizedPath, dynamicRoute as DynamicRouteKey, mergedParams);
         }
+
+        // If the base path is empty there's no underlying screen - show Not Found immediately.
+        if (!pathWithoutDynamicSuffix) {
+            const state = {routes: [{name: SCREENS.NOT_FOUND, path: normalizedPathAfterRedirection}]};
+
+            return state;
+        }
+    }
+
+    // All syntactic candidates failed entryScreens validation - log for debugging.
+    if (allSuffixMatches.length > 0) {
+        Log.warn(
+            `[getStateFromPath.ts][DynamicRoute] None of the ${allSuffixMatches.length} dynamic suffix candidate(s) passed entryScreens validation for path: ${normalizedPathAfterRedirection} (tried patterns: ${allSuffixMatches.map((m) => m.pattern).join(', ')})`,
+        );
     }
 
     // This function is used in the linkTo function where we want to use default getStateFromPath function.

--- a/tests/navigation/compileDynamicRoutePatternTests.ts
+++ b/tests/navigation/compileDynamicRoutePatternTests.ts
@@ -2,7 +2,7 @@ import compileDynamicRoutePattern from '@libs/Navigation/helpers/dynamicRoutesUt
 
 /**
  * Helper: try to match a candidate against a compiled regex.
- * Mirrors how findMatchingDynamicSuffix tests the regex (always with a trailing slash).
+ * Mirrors how findAllMatchingDynamicSuffixes tests the regex (always with a trailing slash).
  */
 function execMatch(compiled: ReturnType<typeof compileDynamicRoutePattern>, candidate: string): Record<string, string> | undefined {
     const normalized = candidate.endsWith('/') ? candidate : `${candidate}/`;

--- a/tests/navigation/findAllMatchingDynamicSuffixesTests.ts
+++ b/tests/navigation/findAllMatchingDynamicSuffixesTests.ts
@@ -1,4 +1,4 @@
-import findMatchingDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/findMatchingDynamicSuffix';
+import findAllMatchingDynamicSuffixes, {findMatchingDynamicSuffix} from '@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
 
 jest.mock('@src/ROUTES', () => ({
     DYNAMIC_ROUTES: {
@@ -10,6 +10,9 @@ jest.mock('@src/ROUTES', () => ({
         KEYBOARD_SHORTCUTS: {path: 'keyboard-shortcuts'},
         OPT_TRAILING: {path: 'opt-page/:id?'},
         OPT_MIDDLE: {path: 'wrap/:p?/end'},
+        CATEGORY_GL_CODE: {path: 'gl-code'},
+        TAG_SETTINGS: {path: 'tag-settings/:orderWeight/:tagName'},
+        TAG_APPROVER: {path: 'tag-approver'},
     },
 }));
 
@@ -166,5 +169,60 @@ describe('findMatchingDynamicSuffix', () => {
                 pathParams: {},
             });
         });
+    });
+});
+
+describe('findAllMatchingDynamicSuffixes', () => {
+    it('should return an empty array when no suffix matches', () => {
+        expect(findAllMatchingDynamicSuffixes('/settings/wallet/unknown-page')).toEqual([]);
+    });
+
+    it('should return an empty array for an empty path', () => {
+        expect(findAllMatchingDynamicSuffixes('')).toEqual([]);
+    });
+
+    it('should return an empty array for undefined', () => {
+        expect(findAllMatchingDynamicSuffixes(undefined)).toEqual([]);
+    });
+
+    it('should return a single-element array for an unambiguous static path', () => {
+        expect(findAllMatchingDynamicSuffixes('settings/wallet/verify-account')).toEqual([{pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}}]);
+    });
+
+    it('should return both a static and a parametric candidate when a tag name matches a static suffix (gl-code collision)', () => {
+        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/gl-code')).toEqual([
+            {pattern: 'gl-code', actualSuffix: 'gl-code', pathParams: {}},
+            {
+                pattern: 'tag-settings/:orderWeight/:tagName',
+                actualSuffix: 'tag-settings/0/gl-code',
+                pathParams: {orderWeight: '0', tagName: 'gl-code'},
+            },
+        ]);
+    });
+
+    it('should place static candidates before strict parametric candidates (priority order)', () => {
+        const results = findAllMatchingDynamicSuffixes('/base/flag/123/verify-account');
+        expect(results).toHaveLength(2);
+        expect(results.at(0)).toEqual({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
+        expect(results.at(1)).toEqual({
+            pattern: 'flag/:reportID/:reportActionID',
+            actualSuffix: 'flag/123/verify-account',
+            pathParams: {reportID: '123', reportActionID: 'verify-account'},
+        });
+    });
+
+    it('should place static candidates before optional parametric candidates (priority order)', () => {
+        const results = findAllMatchingDynamicSuffixes('/base/opt-page/verify-account');
+        expect(results).toHaveLength(2);
+        expect(results.at(0)).toEqual({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
+        expect(results.at(1)).toEqual({
+            pattern: 'opt-page/:id?',
+            actualSuffix: 'opt-page/verify-account',
+            pathParams: {id: 'verify-account'},
+        });
+    });
+
+    it('should return a single-element array when only one candidate exists (tag-approver at the end)', () => {
+        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/tagname/tag-approver')).toEqual([{pattern: 'tag-approver', actualSuffix: 'tag-approver', pathParams: {}}]);
     });
 });

--- a/tests/navigation/getStateFromPathTests.ts
+++ b/tests/navigation/getStateFromPathTests.ts
@@ -48,6 +48,14 @@ jest.mock('@src/ROUTES', () => ({
             path: 'wildcard-suffix',
             entryScreens: ['*'],
         },
+        AMBIGUOUS_STATIC: {
+            path: 'gl-code',
+            entryScreens: ['CategorySettingsScreen'],
+        },
+        TAG_SETTINGS_PARAM: {
+            path: 'tag-settings/:orderWeight/:tagName',
+            entryScreens: ['TagsRootScreen'],
+        },
     },
 }));
 
@@ -117,7 +125,7 @@ describe('getStateFromPath', () => {
         const result = getStateFromPath(fullPath as unknown as Route);
 
         expect(result).toBe(standardState);
-        expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('is not allowed to access dynamic route'));
+        expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('None of the'));
     });
 
     describe('layered dynamic suffixes', () => {
@@ -145,7 +153,7 @@ describe('getStateFromPath', () => {
 
             expect(result).toBe(standardState);
             expect(mockGetStateForDynamicRoute).toHaveBeenCalledWith('/base/suffix-a', 'SUFFIX_A', focusedRouteParams);
-            expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('is not allowed to access dynamic route'));
+            expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('None of the'));
         });
 
         it('should pass the full layered path including query params to the outer dynamic route builder', () => {
@@ -186,6 +194,68 @@ describe('getStateFromPath', () => {
             expect(result).toBe(dynamicWildcardState);
             expect(mockGetStateForDynamicRoute).toHaveBeenCalledWith('/base/suffix-a', 'SUFFIX_A', focusedRouteParams);
             expect(mockGetStateForDynamicRoute).toHaveBeenCalledWith(fullPath, 'WILDCARD_SUFFIX', focusedRouteParams);
+            expect(mockLogWarn).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('ambiguous suffix disambiguation', () => {
+        const tagsRootParams = {policyID: '456'};
+        const tagsRootState = {routes: [{name: 'TagsRootScreen', params: tagsRootParams}]};
+        const categorySettingsParams = {categoryName: 'food'};
+        const categorySettingsState = {routes: [{name: 'CategorySettingsScreen', params: categorySettingsParams}]};
+        const tagSettingsParamState = {routes: [{name: 'TagSettingsParamScreen'}]};
+        const ambiguousStaticState = {routes: [{name: 'AmbiguousStaticScreen'}]};
+
+        beforeEach(() => {
+            const baseImpl = mockGetStateForDynamicRoute.getMockImplementation();
+            mockGetStateForDynamicRoute.mockImplementation((path: string, dynamicRouteKey: string) => {
+                if (dynamicRouteKey === 'AMBIGUOUS_STATIC') {
+                    return ambiguousStaticState;
+                }
+                if (dynamicRouteKey === 'TAG_SETTINGS_PARAM') {
+                    return tagSettingsParamState;
+                }
+                return baseImpl?.(path, dynamicRouteKey) as unknown;
+            });
+        });
+
+        it('should warn and fallback to RN when ALL dynamic candidates fail entryScreens validation', () => {
+            const fullPath = '/tags-root/tag-settings/0/gl-code';
+            const unknownState = {routes: [{name: 'UnknownScreen'}]};
+            const fallbackState = {routes: [{name: 'FallbackRoute'}]};
+            mockRNGetStateFromPath.mockImplementation((path: string) => {
+                if (path === fullPath) {
+                    return fallbackState;
+                }
+                return unknownState;
+            });
+
+            const result = getStateFromPath(fullPath as unknown as Route);
+
+            expect(result).toBe(fallbackState);
+            expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('None of the'));
+            expect(mockGetStateForDynamicRoute).not.toHaveBeenCalled();
+        });
+
+        it('should resolve to the parametric candidate when the greedy static match fails but a longer parametric suffix validates (post-fix)', () => {
+            const fullPath = '/tags-root/tag-settings/0/gl-code';
+            mockRNGetStateFromPath.mockReturnValue(tagsRootState);
+
+            const result = getStateFromPath(fullPath as unknown as Route);
+
+            expect(result).toBe(tagSettingsParamState);
+            expect(mockGetStateForDynamicRoute).toHaveBeenCalledWith(fullPath, 'TAG_SETTINGS_PARAM', expect.objectContaining({orderWeight: '0', tagName: 'gl-code'}));
+            expect(mockLogWarn).not.toHaveBeenCalled();
+        });
+
+        it('should use the first matching candidate immediately when entryScreens validation passes', () => {
+            const fullPath = '/category-settings/gl-code';
+            mockRNGetStateFromPath.mockReturnValue(categorySettingsState);
+
+            const result = getStateFromPath(fullPath as unknown as Route);
+
+            expect(result).toBe(ambiguousStaticState);
+            expect(mockGetStateForDynamicRoute).toHaveBeenCalledWith(fullPath, 'AMBIGUOUS_STATIC', expect.objectContaining(categorySettingsParams));
             expect(mockLogWarn).not.toHaveBeenCalled();
         });
     });

--- a/tests/navigation/useDynamicForwardPathTests.ts
+++ b/tests/navigation/useDynamicForwardPathTests.ts
@@ -4,14 +4,18 @@ import type {DynamicRouteSuffix} from '@src/ROUTES';
 
 jest.mock('@hooks/useRootNavigationState', () => jest.fn());
 jest.mock('@libs/Navigation/helpers/getPathFromState', () => jest.fn());
-jest.mock('@libs/Navigation/helpers/dynamicRoutesUtils/findMatchingDynamicSuffix', () => jest.fn());
+jest.mock('@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes', () => ({
+    __esModule: true,
+    default: jest.fn(),
+    findMatchingDynamicSuffix: jest.fn(),
+}));
 jest.mock('@libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix', () => jest.fn());
 jest.mock('@libs/Navigation/helpers/getStateFromPath', () => jest.fn());
 jest.mock('@libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard', () => jest.fn());
 
 const useRootNavigationStateMock = jest.requireMock<jest.Mock>('@hooks/useRootNavigationState');
 const getPathFromStateMock: jest.Mock = jest.requireMock('@libs/Navigation/helpers/getPathFromState');
-const findMatchingDynamicSuffixMock: jest.Mock = jest.requireMock('@libs/Navigation/helpers/dynamicRoutesUtils/findMatchingDynamicSuffix');
+const findAllMatchingDynamicSuffixesMock: jest.Mock = jest.requireMock<{default: jest.Mock}>('@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes').default;
 const getPathWithoutDynamicSuffixMock: jest.Mock = jest.requireMock('@libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix');
 const getStateFromPathMock: jest.Mock = jest.requireMock('@libs/Navigation/helpers/getStateFromPath');
 const findFocusedRouteWithOnyxTabGuardMock: jest.Mock = jest.requireMock('@libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard');
@@ -36,7 +40,7 @@ describe('useDynamicForwardPath', () => {
 
     it('returns undefined when the matched suffix does not equal the expected dynamicRouteSuffix', () => {
         getPathFromStateMock.mockReturnValue('settings/wallet/two-factor-auth/success');
-        findMatchingDynamicSuffixMock.mockReturnValue({pattern: SUCCESS_SUFFIX, actualSuffix: 'two-factor-auth/success'});
+        findAllMatchingDynamicSuffixesMock.mockReturnValue([{pattern: SUCCESS_SUFFIX, actualSuffix: 'two-factor-auth/success'}]);
 
         const {result} = renderHook(() => useDynamicForwardPath(VERIFY_ACCOUNT_SUFFIX));
 
@@ -45,7 +49,7 @@ describe('useDynamicForwardPath', () => {
 
     it('returns undefined when no suffix match is found in the path', () => {
         getPathFromStateMock.mockReturnValue('settings/wallet');
-        findMatchingDynamicSuffixMock.mockReturnValue(null);
+        findAllMatchingDynamicSuffixesMock.mockReturnValue([]);
 
         const {result} = renderHook(() => useDynamicForwardPath(VERIFY_ACCOUNT_SUFFIX));
 
@@ -54,7 +58,7 @@ describe('useDynamicForwardPath', () => {
 
     it('returns the forward route when suffix, base state, and screen mapping all resolve', () => {
         getPathFromStateMock.mockReturnValue('settings/wallet/verify-account');
-        findMatchingDynamicSuffixMock.mockReturnValue({pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'});
+        findAllMatchingDynamicSuffixesMock.mockReturnValue([{pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'}]);
         getPathWithoutDynamicSuffixMock.mockReturnValue('settings/wallet');
         getStateFromPathMock.mockReturnValue({routes: [{name: WALLET_SCREEN}]});
         findFocusedRouteWithOnyxTabGuardMock.mockReturnValue({name: WALLET_SCREEN});
@@ -66,7 +70,7 @@ describe('useDynamicForwardPath', () => {
 
     it('returns undefined when the focused screen has no mapping in FORWARD_TO_MAPPINGS', () => {
         getPathFromStateMock.mockReturnValue('settings/profile/verify-account');
-        findMatchingDynamicSuffixMock.mockReturnValue({pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'});
+        findAllMatchingDynamicSuffixesMock.mockReturnValue([{pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'}]);
         getPathWithoutDynamicSuffixMock.mockReturnValue('settings/profile');
         getStateFromPathMock.mockReturnValue({routes: [{name: 'Settings_Profile'}]});
         findFocusedRouteWithOnyxTabGuardMock.mockReturnValue({name: 'Settings_Profile'});
@@ -78,7 +82,7 @@ describe('useDynamicForwardPath', () => {
 
     it('returns undefined when getStateFromPath returns null for the base path', () => {
         getPathFromStateMock.mockReturnValue('settings/wallet/verify-account');
-        findMatchingDynamicSuffixMock.mockReturnValue({pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'});
+        findAllMatchingDynamicSuffixesMock.mockReturnValue([{pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'}]);
         getPathWithoutDynamicSuffixMock.mockReturnValue('settings/wallet');
         getStateFromPathMock.mockReturnValue(null);
 
@@ -89,7 +93,7 @@ describe('useDynamicForwardPath', () => {
 
     it('returns undefined when no focused route is found in the base state', () => {
         getPathFromStateMock.mockReturnValue('settings/wallet/verify-account');
-        findMatchingDynamicSuffixMock.mockReturnValue({pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'});
+        findAllMatchingDynamicSuffixesMock.mockReturnValue([{pattern: VERIFY_ACCOUNT_SUFFIX, actualSuffix: 'verify-account'}]);
         getPathWithoutDynamicSuffixMock.mockReturnValue('settings/wallet');
         getStateFromPathMock.mockReturnValue({routes: [{name: WALLET_SCREEN}]});
         findFocusedRouteWithOnyxTabGuardMock.mockReturnValue(null);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Refactored `findMatchingDynamicSuffix` into `findAllMatchingDynamicSuffixes`, which returns all syntactically matching suffixes in priority order instead of just the first one. Callers (`getStateFromPath`, `getAdaptedStateFromPath`, `getDynamicRouteAdaptedState`, hooks) now iterate candidates and validate each against `entryScreens`, preventing false-positive greedy matches where a user-defined name (e.g. a tag named "gl-code") coincides with a registered static suffix.

### Fixed Issues
$ https://github.com/Expensify/App/issues/91703
$ https://github.com/Expensify/App/issues/91480

### Tests

**Test 1: Workspace invite role**

1. Click Workspaces in the left navigation
2. Select an existing workspace (or create one)
3. On the workspace **Overview** page, click **Members** in the sidebar
4. Click the **Invite member** button
5. Enter an email address in the search field, select the contact, and click **Next**
6. You should now be on the **Invite message** screen (URL: `/workspaces/<policyID>/overview/invite/invite-message`)
7. Click the **Role** option on this screen
8. Refresh the page 
9. Verify that the **Role** screen loads correctly after refresh
10. Press the back button
11. Verify that you navigate back to the **Invite message** screen (not to the workspace overview or a blank page)
12. Press the **back button** again
13. Verify that you navigate back to the **Invite** screen


**Test 2: Settings profile address country**

1. Open settings 
2. Click **Profile** in the settings menu
3. Scroll down and click the **Address** field
4. You should now be on the **Address** edit screen (URL: `/settings/profile/address`)
5. Click the **Country** field
6. You should now be on the **Country** picker screen (URL: `/settings/profile/address/country?country=<country>`)
7. Refresh the page 
8. Verify that the **Country** picker screen loads correctly after refresh
9. Press the back button
10. Verify that you navigate back to the **Address** edit screen (not to the settings profile or a blank page)

**Test 3: gl-code**

1. Create a tag named "gl-code" in a workspace
2. Navigate to `settings/<policyID>/tags` (where `policyID` is the ID of the workspace)
3. Click on the "gl-code" tag
4. Verify that the modal loads correctly and everything works as expected
5. Reload the page and verify that the state builds correctly (same fullscreen underneath the modal, same modal with the opened "gl-code" tag)
6. Go back and verify that navigation to the previous modal works correctly

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Test 1:


https://github.com/user-attachments/assets/36c9fa3b-19b3-4350-aaaf-f31e9a5970f5



Test 2:


https://github.com/user-attachments/assets/b0815758-dc10-4fc9-b614-4eb6e202dea7

Test 3:


https://github.com/user-attachments/assets/29348f19-bfc3-4ac4-a84f-fa9a1d825519




<!-- add screenshots or videos here -->

</details>
