### PR TITLE
Fix false smartscan error for missing track transaction

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -10817,8 +10817,11 @@ function getReportActionWithSmartscanError(
         }
 
         const transactionID = isSplitOrTrackAction ? getOriginalMessage(action)?.IOUTransactionID : undefined;
-        const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`] ?? {};
-        const isTransactionThreadError = isSplitOrTrackAction && hasMissingSmartscanFieldsTransactionUtils(transaction as Transaction, report);
+        const transaction = transactionID ? allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`] : undefined;
+        if (!transaction) {
+            return false;
+        }
+        const isTransactionThreadError = isSplitOrTrackAction && hasMissingSmartscanFieldsTransactionUtils(transaction, report);
 
         return isTransactionThreadError;
     });

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -17537,6 +17537,26 @@ describe('ReportUtils', () => {
             expect(hasSmartscanError([splitAction], chatReport, allTransactions)).toBe(false);
             expect(getReportActionWithSmartscanError([splitAction], chatReport, allTransactions)).toBeUndefined();
         });
+
+        it('should NOT flag a track expense action when its linked transaction is missing', () => {
+            const trackTransactionID = '700';
+            const trackAction: ReportAction = {
+                ...createRandomReportAction(Number(trackTransactionID)),
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                actorAccountID: currentUserAccountID,
+                originalMessage: {
+                    IOUTransactionID: trackTransactionID,
+                    type: CONST.IOU.REPORT_ACTION_TYPE.TRACK,
+                    amount: 0,
+                    currency: CONST.CURRENCY.USD,
+                    comment: '',
+                    participantAccountIDs: [currentUserAccountID],
+                },
+            };
+
+            expect(hasSmartscanError([trackAction], chatReport, {})).toBe(false);
+            expect(getReportActionWithSmartscanError([trackAction], chatReport, {})).toBeUndefined();
+        });
     });
 
     describe('getEffectiveReportErrors', () => {


### PR DESCRIPTION
### Explanation of Change
When a split/track IOU action points to a transaction that is not present locally, `getReportActionWithSmartscanError()` was falling back to an empty object. That empty object could be evaluated as a transaction with missing smartscan fields, causing the Self-DM LHN row to incorrectly show the red `Fix` badge.

This change returns `false` when the linked transaction is absent, while preserving the existing smartscan validation path whenever the transaction exists.

### Fixed Issues
$ #91630

### Tests
- Added unit coverage for a track expense action with a missing linked transaction.
- `git diff --check` ✅
- `npx prettier --check src/libs/ReportUtils.ts tests/unit/ReportUtilsTest.ts` ✅

### Notes
Local targeted Jest was attempted but blocked by a local Jest/ESM runtime issue in this environment before assertions ran. CI should provide the authoritative validation.
