### PR TITLE
Fix 2FA work email error handling during onboarding

### DIFF
--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -1511,12 +1511,14 @@ function AddWorkEmail(workEmail: string) {
             return;
         }
 
-        if (response?.message?.includes(CONST.MERGE_ACCOUNT_2FA_ERROR)) {
+        const responseMessage = response?.message ?? '';
+        const responseTitle = response?.title ?? '';
+        if (responseMessage.includes(CONST.MERGE_ACCOUNT_2FA_ERROR) || responseTitle.includes(CONST.MERGE_ACCOUNT_2FA_ERROR)) {
             Onyx.merge(ONYXKEYS.ONBOARDING_ERROR_MESSAGE_TRANSLATION_KEY, 'onboarding.workEmail2FAError');
             return;
         }
 
-        if (response?.message === CONST.WORK_ACCOUNT_CLOSED_ERROR || response?.title === CONST.WORK_ACCOUNT_CLOSED_ERROR) {
+        if (responseMessage === CONST.WORK_ACCOUNT_CLOSED_ERROR || responseTitle === CONST.WORK_ACCOUNT_CLOSED_ERROR) {
             Onyx.merge(ONYXKEYS.ONBOARDING_ERROR_MESSAGE_TRANSLATION_KEY, 'onboarding.mergeBlockScreen.workAccountClosedSubtitle');
             return;
         }

--- a/tests/ui/WorkEmailOnboarding.tsx
+++ b/tests/ui/WorkEmailOnboarding.tsx
@@ -212,6 +212,21 @@ function AddWorkEmailShouldValidate() {
     return waitForBatchedUpdates().then(() => (HttpUtils.xhr = originalXhr));
 }
 
+function AddWorkEmailTwoFactorAuthFailure() {
+    const originalXhr = HttpUtils.xhr;
+    HttpUtils.xhr = jest.fn().mockImplementation(() => {
+        const mockedResponse: OnyxResponse<typeof ONYXKEYS.ONBOARDING_ERROR_MESSAGE_TRANSLATION_KEY> = {
+            jsonCode: CONST.JSON_CODE.EXP_ERROR,
+            title: `${workEmail} ${CONST.MERGE_ACCOUNT_2FA_ERROR}`,
+        };
+
+        // Return a Promise that resolves with the mocked response
+        return Promise.resolve(mockedResponse);
+    });
+    AddWorkEmail(workEmail);
+    return waitForBatchedUpdates().then(() => (HttpUtils.xhr = originalXhr));
+}
+
 describe('OnboardingWorkEmail Page', () => {
     beforeAll(() => {
         Onyx.init({
@@ -338,6 +353,33 @@ describe('OnboardingWorkEmail Page', () => {
         await waitFor(() => {
             expect(navigate).toHaveBeenCalledWith(ROUTES.ONBOARDING_WORK_EMAIL_VALIDATION.getRoute());
         });
+
+        unmount();
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    it('should show 2FA error when adding a work email from an account with 2FA enabled', async () => {
+        await TestHelper.signInWithTestUser();
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {
+                hasCompletedGuidedSetupFlow: false,
+            });
+        });
+
+        const {unmount} = renderOnboardingWorkEmailPage(SCREENS.ONBOARDING.WORK_EMAIL, {backTo: ''});
+
+        await waitForBatchedUpdatesWithAct();
+
+        AddWorkEmailTwoFactorAuthFailure();
+
+        await waitForBatchedUpdatesWithAct();
+
+        await waitFor(() => {
+            expect(screen.getByText(TestHelper.translateLocal('onboarding.workEmail2FAError'))).toBeOnTheScreen();
+        });
+
+        expect(navigate).not.toHaveBeenCalledWith(ROUTES.ONBOARDING_PRIVATE_DOMAIN.getRoute(), {forceReplace: true});
 
         unmount();
         await waitForBatchedUpdatesWithAct();


### PR DESCRIPTION
### Details

This fixes the onboarding work email flow when `AddWorkEmail` fails because the target account has two-factor authentication enabled.

The API can return the 2FA merge-account error in either `message` or `title`. Previously, the client only checked `response.message`, so `response.title` fell through to the generic merge-blocked flow and showed the wrong error.

This change normalizes both fields and checks both before falling back to other merge-blocked states.

### Fixed Issues

$ https://github.com/Expensify/App/issues/91566

### Tests

1. Run targeted onboarding work email test:

```bash
npx -y -p node@20.20.0 -p npm@10.8.2 npm run test -- tests/ui/WorkEmailOnboarding.tsx --runInBand
```

Result:

```text
PASS tests/ui/WorkEmailOnboarding.tsx
Test Suites: 1 passed, 1 total
Tests: 15 passed, 15 total
```

2. Run Prettier on changed files:

```bash
npx -y -p node@20.20.0 -p npm@10.8.2 npx prettier --write src/libs/actions/Session/index.ts tests/ui/WorkEmailOnboarding.tsx
```

Result: unchanged.

3. Run ESLint on changed files:

```bash
npx -y -p node@20.20.0 -p npm@10.8.2 npx eslint src/libs/actions/Session/index.ts tests/ui/WorkEmailOnboarding.tsx
```

Result:

```text
✖ 12 problems (0 errors, 12 warnings)
✔ Lint done.
```

Warnings are existing seatbelt warnings in `Session/index.ts`.

### Notes

Full `typecheck-tsgo` currently fails on unrelated existing errors outside changed files (`MapView`, `API/types`, and migration GPS point files). See local validation notes.
