### PR TITLE
Fix: highlight split expenses after saving

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -58,6 +58,7 @@ import variables from '@styles/variables';
 import {getOlderActions, openReport, readNewestAction, subscribeToNewActionEvent} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import {pendingNewTransactionIDsSelector} from '@src/selectors/ReportMetaData';
 import type SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
 import MoneyRequestReportTransactionList from './MoneyRequestReportTransactionList';
@@ -101,6 +102,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${getNonEmptyStringOnyxID(report?.policyID)}`);
     const [reportLoadingState] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${reportIDFromRoute}`);
     const [reportPaginationState] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_PAGINATION_STATE}${reportIDFromRoute}`);
+    const [pendingNewTransactionIDs] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {selector: pendingNewTransactionIDsSelector});
     const reportID = report?.reportID;
 
     const {reportActions: unfilteredReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, route?.params?.reportActionID);
@@ -116,7 +118,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
         () => Object.values(allReportTransactions ?? {}).some((transaction) => transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE),
         [allReportTransactions],
     );
-    const newTransactions = useNewTransactions(reportLoadingState?.hasOnceLoadedReportActions, reportTransactions);
+    const newTransactions = useNewTransactions(reportLoadingState?.hasOnceLoadedReportActions, reportTransactions, pendingNewTransactionIDs, reportIDFromRoute, isFocused);
     const showReportActionsLoadingState = reportLoadingState?.isLoadingInitialReportActions && !reportLoadingState?.hasOnceLoadedReportActions;
     const reportTransactionIDs = useMemo(() => transactions.map((transaction) => transaction.transactionID), [transactions]);
     const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(report?.chatReportID)}`);

--- a/src/libs/actions/IOU/SplitTransactionUpdate.ts
+++ b/src/libs/actions/IOU/SplitTransactionUpdate.ts
@@ -58,6 +58,7 @@ import {getAllReports, getMoneyRequestPolicyTags, getPolicyTagsData} from './ind
 import {getMoneyRequestParticipantsFromReport} from './MoneyRequest';
 import {getMoneyRequestInformation, getReportPreviewAction} from './MoneyRequestBuilder';
 import type {BuildOnyxDataForMoneyRequestKeys, MoneyRequestInformationParams} from './MoneyRequestBuilder';
+import {addPendingNewTransactionIDs} from './PendingNewTransactions';
 import {getDeleteTrackExpenseInformation} from './TrackExpense';
 import {getUpdateMoneyRequestParams} from './UpdateMoneyRequest';
 import type {UpdateMoneyRequestDataKeys} from './UpdateMoneyRequest';
@@ -524,6 +525,12 @@ function updateSplitTransactions({
             betas,
             personalDetails,
         });
+
+        // Ensure newly-created split transactions are highlighted in the report table after the split flow finishes.
+        // Without this, the transactions can be inserted while the report screen isn't focused and the highlight can be missed.
+        if (!isReverseSplitOperation && !splitTransaction) {
+            addPendingNewTransactionIDs(expenseReport?.reportID, optimisticTransactionFromGetMoneyRequest?.transactionID);
+        }
 
         let updateMoneyRequestParamsOnyxData: OnyxData<UpdateMoneyRequestDataKeys> = {};
         const currentSplit = splits.at(index);

--- a/tests/unit/useNewTransactionsTest.ts
+++ b/tests/unit/useNewTransactionsTest.ts
@@ -338,6 +338,52 @@ describe('useNewTransactions with pendingNewTransactionIDs (cross-navigation)', 
         expect(result.current).toEqual([]);
     });
 
+    it('returns pending new transactions after regaining focus (e.g. split flow)', () => {
+        const {rerender, result} = renderHook<
+            Transaction[],
+            {
+                transactions: Transaction[];
+                hasOnceLoadedReportActions: boolean;
+                pendingNewTransactionIDs: Record<string, true | null> | undefined;
+                isFocused?: boolean;
+            }
+        >((props) => useNewTransactions(props.hasOnceLoadedReportActions, props.transactions, props.pendingNewTransactionIDs, '1', props.isFocused), {
+            initialProps: {
+                hasOnceLoadedReportActions: true,
+                transactions: transactionsAlreadyInReport,
+                pendingNewTransactionIDs: undefined,
+                isFocused: true,
+            },
+        });
+
+        // While the report screen isn't focused, new transactions should not be returned.
+        rerender({
+            hasOnceLoadedReportActions: true,
+            transactions: transactionsAlreadyInReport,
+            pendingNewTransactionIDs: undefined,
+            isFocused: false,
+        });
+        expect(result.current).toEqual([]);
+
+        // The split flow inserts the new transaction while the report is not focused and records it as pending.
+        rerender({
+            hasOnceLoadedReportActions: true,
+            transactions: [...transactionsAlreadyInReport, newTransaction],
+            pendingNewTransactionIDs: {[newTransaction.transactionID]: true},
+            isFocused: false,
+        });
+        expect(result.current).toEqual([]);
+
+        // When focus returns, the pending transaction should be surfaced for highlight.
+        rerender({
+            hasOnceLoadedReportActions: true,
+            transactions: [...transactionsAlreadyInReport, newTransaction],
+            pendingNewTransactionIDs: {[newTransaction.transactionID]: true},
+            isFocused: true,
+        });
+        expect(result.current).toEqual([newTransaction]);
+    });
+
     it('does not highlight transactions without pendingNewTransactionIDs', () => {
         // Normal navigation to a report (no cross-navigation pending IDs)
         const {rerender, result} = renderHook<


### PR DESCRIPTION
### Problem
After splitting an expense (More → Split → Save), the newly-created split transactions can be inserted while the report screen isn't focused, so the existing “new transaction” highlight is missed.

### Solution
- Record newly-created split transaction IDs in `ReportMetadata.pendingNewTransactionIDs` during the split flow.
- Pass `pendingNewTransactionIDs` + `isFocused` into `useNewTransactions` for the Money Request report transaction list so the highlight happens when the report regains focus.
- Add unit coverage for the regain-focus scenario.

### Tests
- `npm test -- tests/unit/useNewTransactionsTest.ts`
- `npm run typecheck`

$ https://github.com/Expensify/App/issues/91679
