### PR TITLE
fix: Hide video controls when popover is visible in fullscreen to prevent overlap

### DIFF
--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -589,7 +589,7 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
                             {controlStatusState !== CONST.VIDEO_PLAYER.CONTROLS_STATUS.HIDE &&
                                 !shouldShowOfflineIndicator &&
                                 !shouldShowErrorIndicator &&
-                                (isPopoverVisible || isHovered || canUseTouchScreen || isEnded) && (
+                                ((isPopoverVisible && !isFullScreenRef.current) || isHovered || canUseTouchScreen || isEnded) && (
                                     <VideoPlayerControls
                                         duration={duration || 0}
                                         position={currentTime || 0}


### PR DESCRIPTION
### $ #91216

### Problem
In the video player fullscreen mode on Android, the Speed and Audio settings popover overlaps the playback controls bar when opened after the video has finished playing. This happens because:
1. The popover renders as a BOTTOM_DOCKED modal on Android (small screen) - it slides up from the bottom.
2. When the video ends, controls remain permanently visible.
3. Both occupy the same bottom area, causing overlap.

### Solution
Modified the controls render guard in  to hide the custom  when the popover is visible in fullscreen mode. When the popover is visible and we're in fullscreen ( is true), the controls are hidden so the bottom-docked popover does not overlap them.

### Changes
- **src/components/VideoPlayer/BaseVideoPlayer.tsx**: Added  condition so that when popover is visible in fullscreen, controls are hidden.

### Testing
1. Open video in chat
2. Play video and enter fullscreen
3. Wait for video to end
4. Tap gear icon
5. Verify Speed/Audio popover does not overlap controls bar