### PR TITLE
Perf: Defer Search/Reports list mount via NavigationDeferredMount

### DIFF
--- a/src/components/Search/SearchWithNavigationDeferredMount.tsx
+++ b/src/components/Search/SearchWithNavigationDeferredMount.tsx
@@ -5,10 +5,24 @@ import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {endSpanWithAttributes} from '@libs/telemetry/activeSpans';
+import {endSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import CONST from '@src/CONST';
 import Search from './index';
 
 const REASON_ATTRIBUTES = {context: 'SearchPage.NavigationDeferred'} as const;
+
+function handleSkeletonLayout() {
+    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
+
+    // Skeleton paint is the first user-perceivable signal that the submit destination
+    // (Search) is up. End the submit-to-destination-visible span here for any pending
+    // action that targets Search. DISMISS_MODAL_AND_OPEN_REPORT is excluded because
+    // that flow's destination is the report, not Search.
+    const pending = getPendingSubmitFollowUpAction();
+    if (pending && pending.followUpAction !== CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT) {
+        endSubmitFollowUpActionSpan(pending.followUpAction, undefined, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
+    }
+}
 
 function SearchWithNavigationDeferredMount(props: ComponentProps<typeof Search>) {
     const styles = useThemeStyles();
@@ -21,7 +35,7 @@ function SearchWithNavigationDeferredMount(props: ComponentProps<typeof Search>)
             placeholder={
                 <SearchRowSkeleton
                     shouldAnimate
-                    onLayout={() => endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true})}
+                    onLayout={handleSkeletonLayout}
                     containerStyle={containerStyle}
                     reasonAttributes={REASON_ATTRIBUTES}
                 />

--- a/src/components/Search/SearchWithNavigationDeferredMount.tsx
+++ b/src/components/Search/SearchWithNavigationDeferredMount.tsx
@@ -1,0 +1,35 @@
+import type {ComponentProps} from 'react';
+import React from 'react';
+import NavigationDeferredMount from '@components/NavigationDeferredMount';
+import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {endSpanWithAttributes} from '@libs/telemetry/activeSpans';
+import CONST from '@src/CONST';
+import Search from './index';
+
+const REASON_ATTRIBUTES = {context: 'SearchPage.NavigationDeferred'} as const;
+
+function SearchWithNavigationDeferredMount(props: ComponentProps<typeof Search>) {
+    const styles = useThemeStyles();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const containerStyle = shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!props.hasFilterBars) : styles.mt3;
+
+    return (
+        <NavigationDeferredMount
+            waitForUpcomingTransition={false}
+            placeholder={
+                <SearchRowSkeleton
+                    shouldAnimate
+                    onLayout={() => endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true})}
+                    containerStyle={containerStyle}
+                    reasonAttributes={REASON_ATTRIBUTES}
+                />
+            }
+        >
+            <Search {...props} />
+        </NavigationDeferredMount>
+    );
+}
+
+export default SearchWithNavigationDeferredMount;

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -17,6 +17,7 @@ import {useSearchResultsContext, useSearchSelectionActions} from '@components/Se
 import SearchLoadingSkeleton from '@components/Search/SearchLoadingSkeleton';
 import SearchPageFooter from '@components/Search/SearchPageFooter';
 import SearchPageHeaderNarrow from '@components/Search/SearchPageHeader/SearchPageHeaderNarrow';
+import SearchWithNavigationDeferredMount from '@components/Search/SearchWithNavigationDeferredMount';
 import type {SearchParams, SearchQueryJSON} from '@components/Search/types';
 import useAndroidBackButtonHandler from '@hooks/useAndroidBackButtonHandler';
 import useEndSubmitNavigationSpans from '@hooks/useEndSubmitNavigationSpans';
@@ -398,7 +399,7 @@ function SearchPageNarrow({
                                             }}
                                         />
                                     ) : (
-                                        <Search
+                                        <SearchWithNavigationDeferredMount
                                             searchResults={searchResults}
                                             queryJSON={queryJSON}
                                             key={queryJSON.hash}

--- a/src/pages/Search/SearchPageWide.tsx
+++ b/src/pages/Search/SearchPageWide.tsx
@@ -6,12 +6,12 @@ import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView
 import ReceiptScanDropZone from '@components/ReceiptScanDropZone';
 import ScreenWrapper from '@components/ScreenWrapper';
 import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
-import Search from '@components/Search';
 import {useSearchResultsContext} from '@components/Search/SearchContext';
 import SearchLoadingSkeleton from '@components/Search/SearchLoadingSkeleton';
 import SearchPageFooter from '@components/Search/SearchPageFooter';
 import SearchActionsBarWide from '@components/Search/SearchPageHeader/SearchActionsBarWide';
 import SearchPageHeaderWide from '@components/Search/SearchPageHeader/SearchPageHeaderWide';
+import SearchWithNavigationDeferredMount from '@components/Search/SearchWithNavigationDeferredMount';
 import type {SearchParams, SearchQueryJSON} from '@components/Search/types';
 import useEndSubmitNavigationSpans from '@hooks/useEndSubmitNavigationSpans';
 import useNetwork from '@hooks/useNetwork';
@@ -131,7 +131,7 @@ function SearchPageWide({
                                         }}
                                     />
                                 ) : (
-                                    <Search
+                                    <SearchWithNavigationDeferredMount
                                         key={queryJSON.hash}
                                         queryJSON={queryJSON}
                                         searchResults={searchResults}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Warm start of the Reports/Search page (first render in a session, data already cached) takes ~550ms (Mac M4 Pro) because we wait for the full list to render before showing anything to the user. This PR applies `NavigationDeferredMount` to that path so the warm start behaves like a cold start visually:

- On first mount of `SearchPage`, a `SearchRowSkeleton` placeholder paints immediately and ends `ManualNavigateToReports` with `is_warm: true`.
- The heavy `Search` subtree mounts inside `startTransition` after the navigation transition completes, so the list does not compete with the navigation animation frame budget.
- Subsequent navigations to the same tab (react-freeze cache hit) re-use the already-mounted `Search`, do not show the skeleton, and end the span via the existing `useFocusEffect` — that path still measures to list visible.

Implementation:
- New `src/components/Search/SearchWithNavigationDeferredMount.tsx`. Accepts `ComponentProps<typeof Search>`, picks the placeholder container style from `useResponsiveLayout()` + `props.hasFilterBars`, and spreads props to `Search`.
- `SearchPageWide` and `SearchPageNarrow` (non-static branch) render `SearchWithNavigationDeferredMount` instead of `Search` directly. The static-rendering branch in `SearchPageNarrow` (post-submit overlay path) is left untouched.

Results:

<img width="1760" height="692" alt="image" src="https://github.com/user-attachments/assets/41bf17b6-f668-46f8-b003-7e82d6c2a0bf" />

Warm full - this is the time it takes for the first warm render to display the full list, rather than just the skeleton.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/91731
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Log in.
2. **Cold start** — In Troubleshoot, run "Reset Onyx", refresh the page, then navigate to the Reports page. Verify the page-level skeleton is shown until data arrives, then the list renders.
3. **Warm start, first render** — Go to Home, refresh the page, then navigate to the Reports page. Verify a skeleton briefly paints before the list appears.
4. **Warm start, cached render** — Go to Home, then back to the Reports page. Verify the list shows immediately without a skeleton.
- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/0b7cd03d-97c5-4191-b98b-f95c1cf60dfd


</details>



<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/7c626c23-2575-453e-97df-3adfb7bbe823


</details>



<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/5c4ece89-2b26-48e4-ab2b-b2ad80b5d5b2

</details>
