### PR TITLE
Fix Share visibility for bank accounts with no real recipients

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -318,17 +318,18 @@ function getDistanceRateCustomUnitRate(policy: OnyxEntry<Policy>, customUnitRate
 function getEligibleBankAccountShareRecipients(policies: OnyxCollection<Policy> | null, currentUserLogin: string | undefined, bankAccountID: string | undefined): MemberForList[] {
     const currentBankAccount = getBankAccountFromID(Number(bankAccountID));
     const activePolicies = getActiveAdminWorkspaces(policies, currentUserLogin);
-    if (!activePolicies) {
+    if (!activePolicies.length) {
         return [];
     }
     const adminMap = new Map<string, MemberForList>();
     // O(1) checks for already-shared emails
     const shareesSet = new Set(currentBankAccount?.accountData?.sharees ?? []);
     for (const policy of Object.values(activePolicies)) {
+        const hideExpensifyTeam = shouldFilterExpensifyTeam(policy?.owner, currentUserLogin);
         for (const admin of getAdminEmployees(policy)) {
             const email = admin?.email;
             // Check if the email is for the active user or an existing user in the sharees array or admins list to avoid extra iterations
-            if (!email || email === currentUserLogin || adminMap.has(email) || shareesSet.has(email)) {
+            if (!email || email === currentUserLogin || adminMap.has(email) || shareesSet.has(email) || (hideExpensifyTeam && isExpensifyTeam(email))) {
                 continue;
             }
             const personalDetails = getPersonalDetailByEmail(email);
@@ -358,17 +359,18 @@ function getEligibleBankAccountShareRecipients(policies: OnyxCollection<Policy> 
  */
 function hasEligibleActiveAdminFromWorkspaces(policies: OnyxCollection<Policy> | null, currentUserLogin: string | undefined, bankAccountID: string | undefined): boolean {
     const currentBankAccount = getBankAccountFromID(Number(bankAccountID));
-    const activePolicies = getActivePolicies(policies, currentUserLogin);
-    if (!activePolicies) {
+    const activePolicies = getActiveAdminWorkspaces(policies, currentUserLogin);
+    if (!activePolicies.length) {
         return false;
     }
     // Normalize sharees to a Set for O(1) lookups
     const alreadySharedSharees = new Set(currentBankAccount?.accountData?.sharees ?? []);
     for (const policy of Object.values(activePolicies)) {
+        const hideExpensifyTeam = shouldFilterExpensifyTeam(policy?.owner, currentUserLogin);
         const admins = getAdminEmployees(policy);
         for (const admin of admins) {
             const email = admin?.email;
-            if (!email || email === currentUserLogin || alreadySharedSharees.has(email)) {
+            if (!email || email === currentUserLogin || alreadySharedSharees.has(email) || (hideExpensifyTeam && isExpensifyTeam(email))) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- align `hasEligibleActiveAdminFromWorkspaces()` with admin-only workspaces by using `getActiveAdminWorkspaces()`
- exclude Expensify team/guide emails from both share-eligibility and recipient list checks via `shouldFilterExpensifyTeam()` + `isExpensifyTeam()`
- keep existing checks for current user and already-shared recipients

## Why
The Share menu item can appear even when the workspace has no real member to share with, and the share sheet can include Expensify guide contacts. This makes the Wallet menu and recipient list feel inconsistent for non-Expensify-owned workspaces.

## Testing
- `CI=1 npm test -- --runInBand --watchAll=false --runTestsByPath tests/unit/PolicyUtilsTest.ts -t getEligibleBankAccountShareRecipients`

/claim #91834

Made with [Cursor](https://cursor.com)