### PR TITLE
Include policy expense chats in search when hidden

### DIFF
--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -2451,6 +2451,7 @@ function getValidOptions(
                     report.item?.chatType !== CONST.REPORT.CHAT_TYPE.SELF_DM &&
                     report.item?.chatType !== CONST.REPORT.CHAT_TYPE.POLICY_ADMINS &&
                     report.item?.chatType !== CONST.REPORT.CHAT_TYPE.POLICY_ROOM &&
+                    report.item?.chatType !== CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT &&
                     report.item?.chatType !== CONST.REPORT.CHAT_TYPE.GROUP &&
                     !report.private_isArchived
                 ) {

--- a/tests/unit/OptionsListUtilsTest.tsx
+++ b/tests/unit/OptionsListUtilsTest.tsx
@@ -1460,6 +1460,57 @@ describe('OptionsListUtils', () => {
             expect(results.recentReports).toEqual(expect.arrayContaining([expect.objectContaining({reportID: '14'})]));
         });
 
+        it('should include policy expense chats when current user has hidden notification preference', () => {
+            const reportID = '1455140530846320';
+            const workspaceExpenseChat: SearchOption<Report> = {
+                item: {
+                    chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                    currency: 'USD',
+                    errorFields: {},
+                    lastActionType: 'CREATED',
+                    lastReadTime: '2025-03-21 07:25:46.279',
+                    lastVisibleActionCreated: '2024-12-15 21:13:24.317',
+                    lastVisibleActionLastModified: '2024-12-15 21:13:24.317',
+                    ownerAccountID: 1,
+                    permissions: ['read', 'write'],
+                    participants: {
+                        [CURRENT_USER_ACCOUNT_ID]: {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN},
+                        1: {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS},
+                    },
+                    policyID: '52A5ABD88FBBD18F',
+                    policyName: "A's Workspace",
+                    reportID,
+                    reportName: "A's Workspace chat",
+                    type: 'chat',
+                    writeCapability: 'all',
+                },
+                text: "A's Workspace chat",
+                alternateText: "A's Workspace",
+                allReportErrors: {},
+                subtitle: "A's Workspace",
+                participantsList: [],
+                reportID,
+                keyForList: reportID,
+                isDefaultRoom: true,
+                isChatRoom: true,
+                policyID: '52A5ABD88FBBD18F',
+                lastMessageText: '',
+                lastVisibleActionCreated: '2024-12-15 21:13:24.317',
+                notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+            };
+
+            const results = getValidOptions({reports: [workspaceExpenseChat], personalDetails: []}, allPolicies, {}, loginList, CURRENT_USER_ACCOUNT_ID, CURRENT_USER_EMAIL, undefined, {
+                includeRecentReports: true,
+                includeMultipleParticipantReports: true,
+                includeOwnedWorkspaceChats: true,
+                excludeHidden: true,
+                sortedActions: undefined,
+            });
+
+            expect(results.recentReports).toHaveLength(1);
+            expect(results.recentReports.at(0)?.reportID).toBe(reportID);
+        });
+
         it('should use personalDetails config for workspace chat lookups when shouldSeparateWorkspaceChat is true', () => {
             // Given a set of reports with workspace rooms and a custom personalDetails collection
             const customPersonalDetails: PersonalDetailsList = {


### PR DESCRIPTION
## Summary
- exempt `POLICY_EXPENSE_CHAT` from `excludeHidden` filtering in `getValidOptions()`
- keep existing hidden filtering behavior for other chat types unchanged
- add a unit test to verify policy expense chats still appear when the current user's participant notification preference is hidden

## Why
Workspace member chats can be created with hidden notification preference for admins, which currently causes search router filtering to hide those chats. This makes member workspace chats undiscoverable through search even though they should remain accessible.

## Testing
- `CI=1 npm test -- --runInBand --watchAll=false --runTestsByPath tests/unit/OptionsListUtilsTest.tsx -t "should include policy expense chats when current user has hidden notification preference"`

/claim #91779

Made with [Cursor](https://cursor.com)