### PR TITLE
[Payment due @ShridharGoel] Remove gustoNewDot beta gate now that Gusto on New Expensify is launching to all users

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -981,7 +981,6 @@ const CONST = {
         EUR_BILLING: 'eurBilling',
         PAY_INVOICE_VIA_EXPENSIFY: 'payInvoiceViaExpensify',
         SUGGESTED_FOLLOWUPS: 'suggestedFollowups',
-        GUSTO: 'gustoNewDot',
         ZENEFITS: 'zenefitsNewDot',
         BULK_EDIT: 'bulkEdit',
         BULK_EDIT_WORKSPACES: 'bulkEditWorkspaces',

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -168,10 +168,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
         [CONST.POLICY.MORE_FEATURES.ARE_TAXES_ENABLED]: policy?.tax?.trackingEnabled,
         [CONST.POLICY.MORE_FEATURES.ARE_COMPANY_CARDS_ENABLED]: policy?.areCompanyCardsEnabled,
         [CONST.POLICY.MORE_FEATURES.ARE_CONNECTIONS_ENABLED]: !!policy?.areConnectionsEnabled || hasAccountingFeatureConnection(policy),
-        [CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED]:
-            (isBetaEnabled(CONST.BETAS.GUSTO) || isBetaEnabled(CONST.BETAS.ZENEFITS) || isBetaEnabled(CONST.BETAS.MERGE_HR)) &&
-            (policy?.isHREnabled === true || isAnyHRConnected(policy)) &&
-            canPolicyAccessFeature(policy, CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED),
+        [CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED]: (policy?.isHREnabled === true || isAnyHRConnected(policy)) && canPolicyAccessFeature(policy, CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED),
         [CONST.POLICY.MORE_FEATURES.ARE_EXPENSIFY_CARDS_ENABLED]: policy?.areExpensifyCardsEnabled,
         [CONST.POLICY.MORE_FEATURES.ARE_REPORT_FIELDS_ENABLED]: policy?.areReportFieldsEnabled,
         [CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED]: policy?.areRulesEnabled,

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -326,35 +326,33 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
                                 Navigation.navigate(ROUTES.WORKSPACE_RECEIPT_PARTNERS.getRoute(policyID));
                             }}
                         />
-                        {(isBetaEnabled(CONST.BETAS.GUSTO) || isBetaEnabled(CONST.BETAS.ZENEFITS) || isBetaEnabled(CONST.BETAS.MERGE_HR)) && (
-                            <MoreFeatureToggle
-                                icon={illustrations.Members}
-                                title={translate('workspace.hr.title')}
-                                subtitle={translate('workspace.hr.subtitle')}
-                                isActive={((policy?.isHREnabled === true || isAnyHRConnected(policy)) && canPolicyAccessFeature(policy, CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED)) ?? false}
-                                pendingAction={policy?.pendingFields?.isHREnabled}
-                                disabled={isAnyHRConnected(policy)}
-                                disabledAction={warnDisconnectHRFirst}
-                                onToggle={(isEnabled) => {
-                                    if (!policyID) {
-                                        return;
-                                    }
-                                    if (isEnabled && !isControlPolicy(policy)) {
-                                        Navigation.navigate(
-                                            ROUTES.WORKSPACE_UPGRADE.getRoute(policyID, CONST.UPGRADE_FEATURE_INTRO_MAPPING.hr.alias, ROUTES.WORKSPACE_MORE_FEATURES.getRoute(policyID)),
-                                        );
-                                        return;
-                                    }
-                                    enablePolicyHR(policyID, isEnabled);
-                                }}
-                                onPress={() => {
-                                    if (!policyID) {
-                                        return;
-                                    }
-                                    Navigation.navigate(ROUTES.WORKSPACE_HR.getRoute(policyID));
-                                }}
-                            />
-                        )}
+                        <MoreFeatureToggle
+                            icon={illustrations.Members}
+                            title={translate('workspace.hr.title')}
+                            subtitle={translate('workspace.hr.subtitle')}
+                            isActive={((policy?.isHREnabled === true || isAnyHRConnected(policy)) && canPolicyAccessFeature(policy, CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED)) ?? false}
+                            pendingAction={policy?.pendingFields?.isHREnabled}
+                            disabled={isAnyHRConnected(policy)}
+                            disabledAction={warnDisconnectHRFirst}
+                            onToggle={(isEnabled) => {
+                                if (!policyID) {
+                                    return;
+                                }
+                                if (isEnabled && !isControlPolicy(policy)) {
+                                    Navigation.navigate(
+                                        ROUTES.WORKSPACE_UPGRADE.getRoute(policyID, CONST.UPGRADE_FEATURE_INTRO_MAPPING.hr.alias, ROUTES.WORKSPACE_MORE_FEATURES.getRoute(policyID)),
+                                    );
+                                    return;
+                                }
+                                enablePolicyHR(policyID, isEnabled);
+                            }}
+                            onPress={() => {
+                                if (!policyID) {
+                                    return;
+                                }
+                                Navigation.navigate(ROUTES.WORKSPACE_HR.getRoute(policyID));
+                            }}
+                        />
                     </MoreFeaturesSection>
 
                     <MoreFeaturesSection title={translate('workspace.moreFeatures.organizeSection.title')}>

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -14,7 +14,6 @@ import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -77,7 +76,6 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
     const styles = useThemeStyles();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const {translate} = useLocalize();
-    const {isBetaEnabled} = usePermissions();
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
     const {showConfirmModal} = useConfirmModal();
     const illustrations = useMemoizedLazyIllustrations([

--- a/src/pages/workspace/hr/HRApprovalModePageBase.tsx
+++ b/src/pages/workspace/hr/HRApprovalModePageBase.tsx
@@ -30,7 +30,7 @@ type ApprovalModeValue = ValueOf<typeof CONST.GUSTO.APPROVAL_MODE> | ValueOf<typ
 
 type HRApprovalModeProviderConfig<T extends ApprovalModeValue = ApprovalModeValue> = {
     testID: string;
-    beta: Beta;
+    beta?: Beta;
     isConnected: (policy: OnyxEntry<Policy>) => boolean;
     approvalModes: {BASIC: T; MANAGER: T; CUSTOM: T};
     getCurrentApprovalMode: (policy: OnyxEntry<Policy>) => T | null;
@@ -119,7 +119,7 @@ function HRApprovalModePageBase<T extends ApprovalModeValue>({policyID, config}:
             accessVariants={[CONST.POLICY.ACCESS_VARIANTS.ADMIN, CONST.POLICY.ACCESS_VARIANTS.CONTROL]}
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED}
-            shouldBeBlocked={!isBetaEnabled(config.beta) || (!!policy && !config.isConnected(policy))}
+            shouldBeBlocked={(!!config.beta && !isBetaEnabled(config.beta)) || (!!policy && !config.isConnected(policy))}
         >
             <ScreenWrapper
                 enableEdgeToEdgeBottomSafeAreaPadding

--- a/src/pages/workspace/hr/HRFinalApproverPageBase.tsx
+++ b/src/pages/workspace/hr/HRFinalApproverPageBase.tsx
@@ -18,7 +18,7 @@ import type Policy from '@src/types/onyx/Policy';
 
 type HRFinalApproverProviderConfig = {
     testID: string;
-    beta: Beta;
+    beta?: Beta;
     isConnected: (policy: OnyxEntry<Policy>) => boolean;
     getCurrentFinalApprover: (policy: OnyxEntry<Policy>) => string | null;
     getHeaderTitle: (providerName: string) => string;
@@ -44,7 +44,7 @@ function HRFinalApproverPageBase({policyID, config}: HRFinalApproverPageBaseProp
             accessVariants={[CONST.POLICY.ACCESS_VARIANTS.ADMIN, CONST.POLICY.ACCESS_VARIANTS.CONTROL]}
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED}
-            shouldBeBlocked={!isBetaEnabled(config.beta) || (!!policy && !config.isConnected(policy))}
+            shouldBeBlocked={(!!config.beta && !isBetaEnabled(config.beta)) || (!!policy && !config.isConnected(policy))}
         >
             <ScreenWrapper
                 enableEdgeToEdgeBottomSafeAreaPadding

--- a/src/pages/workspace/hr/WorkspaceHRPage.tsx
+++ b/src/pages/workspace/hr/WorkspaceHRPage.tsx
@@ -33,8 +33,6 @@ import HRProviderCard from './HRProviderCard';
 import type {HRCardDescriptor} from './utils';
 import {getHRCards} from './utils';
 
-const HR_BETAS = [CONST.BETAS.GUSTO, CONST.BETAS.ZENEFITS, CONST.BETAS.MERGE_HR] as const;
-
 type WorkspaceHRPageProps = PlatformStackScreenProps<WorkspaceSplitNavigatorParamList, typeof SCREENS.WORKSPACE.HR>;
 
 function WorkspaceHRPage({
@@ -86,8 +84,6 @@ function WorkspaceHRPage({
     connectedCards.sort(byName);
     disconnectedCards.sort(byName);
 
-    const shouldBeBlocked = !HR_BETAS.some(isBetaEnabled);
-
     const handleConnect = (setupLink: string | undefined) => {
         if (!setupLink) {
             return;
@@ -113,7 +109,6 @@ function WorkspaceHRPage({
             accessVariants={[CONST.POLICY.ACCESS_VARIANTS.ADMIN, CONST.POLICY.ACCESS_VARIANTS.CONTROL]}
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED}
-            shouldBeBlocked={shouldBeBlocked}
         >
             <ScreenWrapper
                 enableEdgeToEdgeBottomSafeAreaPadding

--- a/src/pages/workspace/hr/gusto/GustoApprovalModePage.tsx
+++ b/src/pages/workspace/hr/gusto/GustoApprovalModePage.tsx
@@ -21,7 +21,6 @@ function GustoApprovalModePage({
 
     const config: HRApprovalModeProviderConfig<ValueOf<typeof CONST.GUSTO.APPROVAL_MODE>> = {
         testID: 'GustoApprovalModePage',
-        beta: CONST.BETAS.GUSTO,
         isConnected: isGustoConnected,
         approvalModes: CONST.GUSTO.APPROVAL_MODE,
         getCurrentApprovalMode: (policy) => policy?.connections?.gusto?.config?.approvalMode ?? null,

--- a/src/pages/workspace/hr/gusto/GustoFinalApproverPage.tsx
+++ b/src/pages/workspace/hr/gusto/GustoFinalApproverPage.tsx
@@ -6,7 +6,6 @@ import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import {isGustoConnected} from '@libs/PolicyUtils';
 import HRFinalApproverPageBase from '@pages/workspace/hr/HRFinalApproverPageBase';
 import type {HRFinalApproverProviderConfig} from '@pages/workspace/hr/HRFinalApproverPageBase';
-import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
 
 type GustoFinalApproverPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.HR_GUSTO_FINAL_APPROVER>;
@@ -20,7 +19,6 @@ function GustoFinalApproverPage({
 
     const config: HRFinalApproverProviderConfig = {
         testID: 'GustoFinalApproverPage',
-        beta: CONST.BETAS.GUSTO,
         isConnected: isGustoConnected,
         getCurrentFinalApprover: (policy) => policy?.connections?.gusto?.config?.finalApprover ?? null,
         getProviderName: () => translate('workspace.hr.gusto.title'),

--- a/src/pages/workspace/hr/utils.ts
+++ b/src/pages/workspace/hr/utils.ts
@@ -187,7 +187,7 @@ function getCardConfig(policy: OnyxEntry<Policy>, connectionName: HRConnectionNa
 const STATIC_HR_PROVIDERS = [
     {
         key: 'gusto',
-        beta: CONST.BETAS.GUSTO,
+        beta: undefined,
         connectionName: CONST.POLICY.CONNECTIONS.NAME.GUSTO,
         titleKey: 'workspace.hr.gusto.title',
         iconParam: 'gustoIcon',
@@ -238,7 +238,7 @@ function getHRCards({policy, connectionSyncProgress, isBetaEnabled, getLocalDate
     const cards: HRCardDescriptor[] = [];
 
     for (const provider of STATIC_HR_PROVIDERS) {
-        if (!isBetaEnabled(provider.beta)) {
+        if (provider.beta && !isBetaEnabled(provider.beta)) {
             continue;
         }
         const {connectionName} = provider;

--- a/src/pages/workspace/hr/utils.ts
+++ b/src/pages/workspace/hr/utils.ts
@@ -238,11 +238,11 @@ function getHRCards({policy, connectionSyncProgress, isBetaEnabled, getLocalDate
     const cards: HRCardDescriptor[] = [];
 
     for (const provider of STATIC_HR_PROVIDERS) {
-        if (provider.beta && !isBetaEnabled(provider.beta)) {
-            continue;
-        }
         const {connectionName} = provider;
         const state = getHRCardState({policy, connectionName, connectionSyncProgress, getLocalDateFromDatetime});
+        if (provider.beta && !isBetaEnabled(provider.beta) && !state.isConnected) {
+            continue;
+        }
         const config = getCardConfig(policy, connectionName);
         cards.push({
             key: provider.key,

--- a/tests/unit/HrUtilsTest.ts
+++ b/tests/unit/HrUtilsTest.ts
@@ -360,6 +360,23 @@ describe('getHRCards', () => {
         }
     });
 
+    it('returns the connected Zenefits card even when the Zenefits beta is disabled', () => {
+        const policy = makePolicy({
+            connections: {
+                zenefits: {
+                    config: {approvalMode: CONST.ZENEFITS.APPROVAL_MODE.BASIC, finalApprover: 'admin@test.com'},
+                    data: {},
+                    lastSync: {isSuccessful: true},
+                },
+            } as unknown as Policy['connections'],
+        });
+        const cards = getHRCards(makeGetHRCardsParams({policy, isBetaEnabled: noBetasEnabled}));
+        const zenefits = cards.find((c) => c.key === 'zenefits');
+
+        expect(zenefits?.isConnected).toBe(true);
+        expect(zenefits?.config).toBeDefined();
+    });
+
     it('marks the connected Gusto card as connected with config', () => {
         const policy = makePolicy({
             connections: {

--- a/tests/unit/HrUtilsTest.ts
+++ b/tests/unit/HrUtilsTest.ts
@@ -327,7 +327,6 @@ describe('getHRCards', () => {
         const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled}));
 
         const mergeKeys = Object.keys(MERGE_HR_PROVIDERS);
-        expect(cards).toHaveLength(mergeKeys.length);
         for (const slug of mergeKeys) {
             expect(cards.find((c) => c.key === `merge_${slug}`)).toBeDefined();
         }
@@ -343,16 +342,19 @@ describe('getHRCards', () => {
     it('sets correct routes for Zenefits cards', () => {
         const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.ZENEFITS;
         const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled}));
+        const zenefits = cards.find((c) => c.key === 'zenefits');
 
-        expect(cards?.at(0)?.approvalModeRoute).toBe(ROUTES.WORKSPACE_HR_ZENEFITS_APPROVAL_MODE.getRoute(POLICY_ID));
-        expect(cards?.at(0)?.finalApproverRoute).toBe(ROUTES.WORKSPACE_HR_ZENEFITS_FINAL_APPROVER.getRoute(POLICY_ID));
+        expect(zenefits?.approvalModeRoute).toBe(ROUTES.WORKSPACE_HR_ZENEFITS_APPROVAL_MODE.getRoute(POLICY_ID));
+        expect(zenefits?.finalApproverRoute).toBe(ROUTES.WORKSPACE_HR_ZENEFITS_FINAL_APPROVER.getRoute(POLICY_ID));
     });
 
     it('sets correct routes for Merge HR cards', () => {
         const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.MERGE_HR;
         const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled}));
+        const mergeCards = cards.filter((c) => c.key.startsWith('merge_'));
 
-        for (const card of cards) {
+        expect(mergeCards.length).toBeGreaterThan(0);
+        for (const card of mergeCards) {
             expect(card.approvalModeRoute).toBe(ROUTES.WORKSPACE_HR_MERGE_APPROVAL_MODE.getRoute(POLICY_ID));
             expect(card.finalApproverRoute).toBe(ROUTES.WORKSPACE_HR_MERGE_FINAL_APPROVER.getRoute(POLICY_ID));
         }
@@ -476,8 +478,10 @@ describe('getHRCards', () => {
     it('uses provider iconUrl for Merge cards', () => {
         const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.MERGE_HR;
         const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled}));
+        const mergeCards = cards.filter((c) => c.key.startsWith('merge_'));
 
-        for (const card of cards) {
+        expect(mergeCards.length).toBeGreaterThan(0);
+        for (const card of mergeCards) {
             const slug = card.key.replace('merge_', '');
             const expected = MERGE_HR_PROVIDERS[slug as keyof typeof MERGE_HR_PROVIDERS]?.iconUrl;
             expect(card.icon).toBe(expected);

--- a/tests/unit/HrUtilsTest.ts
+++ b/tests/unit/HrUtilsTest.ts
@@ -304,13 +304,15 @@ describe('getApprovalModeLabel', () => {
 });
 
 describe('getHRCards', () => {
-    it('returns no cards when no betas are enabled', () => {
+    it('returns only the Gusto card when no betas are enabled', () => {
         const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled: noBetasEnabled}));
-        expect(cards).toHaveLength(0);
+        expect(cards).toHaveLength(1);
+        expect(cards?.at(0)?.key).toBe('gusto');
+        expect(cards?.at(0)?.connectionName).toBe(GUSTO);
     });
 
-    it('returns Gusto and Zenefits cards when their betas are enabled', () => {
-        const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.GUSTO || beta === CONST.BETAS.ZENEFITS;
+    it('returns Gusto and Zenefits cards when the Zenefits beta is enabled', () => {
+        const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.ZENEFITS;
         const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled}));
 
         expect(cards).toHaveLength(2);
@@ -332,8 +334,7 @@ describe('getHRCards', () => {
     });
 
     it('sets correct routes for Gusto cards', () => {
-        const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.GUSTO;
-        const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled}));
+        const cards = getHRCards(makeGetHRCardsParams({isBetaEnabled: noBetasEnabled}));
 
         expect(cards?.at(0)?.approvalModeRoute).toBe(ROUTES.WORKSPACE_HR_GUSTO_APPROVAL_MODE.getRoute(POLICY_ID));
         expect(cards?.at(0)?.finalApproverRoute).toBe(ROUTES.WORKSPACE_HR_GUSTO_FINAL_APPROVER.getRoute(POLICY_ID));
@@ -367,8 +368,7 @@ describe('getHRCards', () => {
                 },
             } as unknown as Policy['connections'],
         });
-        const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.GUSTO;
-        const cards = getHRCards(makeGetHRCardsParams({policy, isBetaEnabled}));
+        const cards = getHRCards(makeGetHRCardsParams({policy, isBetaEnabled: noBetasEnabled}));
 
         expect(cards?.at(0)?.isConnected).toBe(true);
         expect(cards?.at(0)?.config).toBeDefined();
@@ -466,7 +466,7 @@ describe('getHRCards', () => {
     it('uses provider icons from params for static providers', () => {
         const gustoIcon = {testId: 'gusto'} as unknown as IconAsset;
         const trinetIcon = {testId: 'zenefits'} as unknown as IconAsset;
-        const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.GUSTO || beta === CONST.BETAS.ZENEFITS;
+        const isBetaEnabled: GetHRCardsParams['isBetaEnabled'] = (beta) => beta === CONST.BETAS.ZENEFITS;
         const cards = getHRCards(makeGetHRCardsParams({gustoIcon, trinetIcon, isBetaEnabled}));
 
         expect(cards?.at(0)?.icon).toBe(gustoIcon);


### PR DESCRIPTION
@Gonals please review

### Explanation of Change

Gusto on New Expensify is rolling out to all users, so the `gustoNewDot` beta flag no longer gates anything. This PR removes every reference to it: the `BETAS.GUSTO` constant, the OR-conditions on the workspace HR feature panel, the page-level beta blocks on `WorkspaceHRPage`, `GustoApprovalModePage`, and `GustoFinalApproverPage`, the `STATIC_HR_PROVIDERS` entry's `beta` field for Gusto, and the corresponding unit test setup. `beta` is now optional on the HR base page configs so Zenefits and Merge HR keep their gating.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/591910
PROPOSAL: N/A (internal cleanup; tracking issue is the Gusto rollout itself)

### Tests

1. Open the App on `main` with a non-beta account.
2. Open a Control workspace and go to **More features**.
3. Verify the **HR** card is visible (it used to be hidden without the Gusto beta).
4. Toggle HR on. Click **HR** in the workspace nav.
5. Verify the HR page renders the Gusto connect flow without redirecting.
6. From a workspace that already has Gusto connected, open the workspace and navigate to **HR → Gusto → Approval mode** and **HR → Gusto → Final approver**. Verify both pages load.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Same as above with the network disabled — the HR card and Gusto pages remain visible (no extra network call introduced).

### QA Steps

Same as Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

