### PR TITLE
Fix report title link to stay in Spend

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -42,6 +42,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useTransactionViolations from '@hooks/useTransactionViolations';
 import type {ViolationField} from '@hooks/useViolations';
 import useViolations from '@hooks/useViolations';
+import getMoneyRequestViewReportTitle from '@libs/getMoneyRequestViewReportTitle';
 import {updateMoneyRequestBillable, updateMoneyRequestReimbursable, updateMoneyRequestTaxRate} from '@libs/actions/IOU/UpdateMoneyRequest';
 import initSplitExpense from '@libs/actions/SplitExpenses';
 import {enrichAndSortAttendees, getIsMissingAttendeesViolation} from '@libs/AttendeeUtils';
@@ -898,6 +899,12 @@ function MoneyRequestView({
     const reportNameToDisplay = isFromMergeTransaction
         ? (updatedTransaction?.reportName ?? translate('common.none'))
         : getReportName(parentReport, reportAttributes) || parentReport?.reportName;
+    const reportTitleWithLink = getMoneyRequestViewReportTitle({
+        reportName: reportNameToDisplay,
+        reportID: parentReportID,
+        canEditReport,
+        activeRoute: getReportRHPActiveRoute() || lastVisitedPath || '',
+    });
     const shouldShowReport = !!parentReportID || (isFromMergeTransaction && !!reportNameToDisplay);
     const reportCopyValue = !canEditReport && reportNameToDisplay !== translate('common.none') ? reportNameToDisplay : undefined;
     const shouldShowCategoryAnalyzing = isCategoryBeingAnalyzed(updatedTransaction ?? transaction);
@@ -1294,7 +1301,7 @@ function MoneyRequestView({
                     <OfflineWithFeedback pendingAction={getPendingFieldAction('reportID')}>
                         <MenuItemWithTopDescription
                             shouldShowRightIcon={canEditReport}
-                            title={reportNameToDisplay}
+                            title={reportTitleWithLink}
                             description={translate('common.report')}
                             style={[styles.moneyRequestMenuItem]}
                             titleStyle={styles.flex1}

--- a/src/libs/getMoneyRequestViewReportTitle.ts
+++ b/src/libs/getMoneyRequestViewReportTitle.ts
@@ -1,0 +1,24 @@
+import {toMarkdownLink} from '@libs/MarkdownLinkHelpers';
+import ROUTES from '@src/ROUTES';
+
+type Params = {
+    reportName: string | undefined;
+    reportID: string | undefined;
+    canEditReport: boolean;
+    activeRoute: string;
+};
+
+function getMoneyRequestViewReportTitle({reportName, reportID, canEditReport, activeRoute}: Params): string | undefined {
+    if (!reportName || canEditReport || !reportID) {
+        return reportName;
+    }
+
+    const normalizedActiveRoute = activeRoute.startsWith('/') ? activeRoute.slice(1) : activeRoute;
+    const shouldOpenReportInSearch = normalizedActiveRoute.startsWith('search/');
+
+    const reportRoute = shouldOpenReportInSearch ? ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID}) : ROUTES.REPORT_WITH_ID.getRoute(reportID);
+
+    return toMarkdownLink(reportName, reportRoute);
+}
+
+export default getMoneyRequestViewReportTitle;

--- a/tests/unit/getMoneyRequestViewReportTitleTest.ts
+++ b/tests/unit/getMoneyRequestViewReportTitleTest.ts
@@ -1,0 +1,48 @@
+import getMoneyRequestViewReportTitle from '@libs/getMoneyRequestViewReportTitle';
+
+describe('getMoneyRequestViewReportTitle', () => {
+    it('returns plain title when the report is editable', () => {
+        expect(
+            getMoneyRequestViewReportTitle({
+                reportName: 'My Report',
+                reportID: '123',
+                canEditReport: true,
+                activeRoute: '/search/expenses',
+            }),
+        ).toBe('My Report');
+    });
+
+    it('returns plain title when reportID is missing', () => {
+        expect(
+            getMoneyRequestViewReportTitle({
+                reportName: 'My Report',
+                reportID: undefined,
+                canEditReport: false,
+                activeRoute: '/search/expenses',
+            }),
+        ).toBe('My Report');
+    });
+
+    it('links to the Search report route when opened from Spend/Search', () => {
+        expect(
+            getMoneyRequestViewReportTitle({
+                reportName: 'My Report',
+                reportID: '123',
+                canEditReport: false,
+                activeRoute: '/search/expenses',
+            }),
+        ).toBe('[My Report](search/r/123)');
+    });
+
+    it('links to the Inbox report route when not opened from Spend/Search', () => {
+        expect(
+            getMoneyRequestViewReportTitle({
+                reportName: 'My Report',
+                reportID: '123',
+                canEditReport: false,
+                activeRoute: '/r/456',
+            }),
+        ).toBe('[My Report](r/123)');
+    });
+});
+


### PR DESCRIPTION
### Problem
When viewing an expense from **Spend > Expenses**, the **More > View details** report title link opens the report in **Inbox** instead of opening it in the **Spend** super-wide modal.

### Solution
When the report field is **not editable** in `MoneyRequestView`, render the report title as a markdown link that routes to:
- `search/r/:reportID` when the current active route is in `search/*`
- `r/:reportID` otherwise

This keeps navigation within the Spend/Search context.

### Tests
- `npm test -- tests/unit/getMoneyRequestViewReportTitleTest.ts`
- `npm run typecheck`

$ https://github.com/Expensify/App/issues/91889