### PR TITLE
perf: extract money report transaction thread into context

### DIFF
--- a/src/components/MoneyReportHeaderActions/index.tsx
+++ b/src/components/MoneyReportHeaderActions/index.tsx
@@ -3,13 +3,13 @@ import {View} from 'react-native';
 import type {ValueOf} from 'type-fest';
 import type {ButtonWithDropdownMenuRef} from '@components/ButtonWithDropdownMenu/types';
 import MoneyReportHeaderPrimaryAction from '@components/MoneyReportHeaderPrimaryAction';
+import {useMoneyReportTransactionThread} from '@components/MoneyReportTransactionThreadContext';
 import {useSearchSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
 import useExportAgainModal from '@hooks/useExportAgainModal';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useResponsiveLayoutOnWideRHP from '@hooks/useResponsiveLayoutOnWideRHP';
 import useThemeStyles from '@hooks/useThemeStyles';
-import useTransactionThreadReport from '@hooks/useTransactionThreadReport';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -40,7 +40,7 @@ function MoneyReportHeaderActions({reportID, primaryAction, isReportInSearch, ba
     const [moneyRequestReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(moneyRequestReport?.chatReportID)}`);
 
-    const {transactionThreadReportID} = useTransactionThreadReport(reportID);
+    const {transactionThreadReportID} = useMoneyReportTransactionThread();
 
     const {triggerExportOrConfirm} = useExportAgainModal(moneyRequestReport?.reportID, moneyRequestReport?.policyID);
 

--- a/src/components/MoneyReportHeaderEducationalModals.tsx
+++ b/src/components/MoneyReportHeaderEducationalModals.tsx
@@ -5,21 +5,17 @@ import type {ValueOf} from 'type-fest';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
-import useTransactionsAndViolationsForReport from '@hooks/useTransactionsAndViolationsForReport';
 import {setNameValuePair} from '@libs/actions/User';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getFilteredReportActionsForReportView, getOneTransactionThreadReportID, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {changeMoneyRequestHoldStatus, rejectMoneyRequestReason} from '@libs/ReportUtils';
 import {dismissRejectUseExplanation} from '@userActions/IOU/RejectMoneyRequest';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type * as OnyxTypes from '@src/types/onyx';
 import HoldOrRejectEducationalModal from './HoldOrRejectEducationalModal';
 import HoldSubmitterEducationalModal from './HoldSubmitterEducationalModal';
+import {useMoneyReportTransactionThread} from './MoneyReportTransactionThreadContext';
 
 type RejectModalAction = ValueOf<
     typeof CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.HOLD | typeof CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.REJECT | typeof CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.REJECT_BULK
@@ -42,27 +38,9 @@ function MoneyReportHeaderEducationalModals({reportID, ref}: MoneyReportHeaderEd
     const {isOffline} = useNetwork();
     const [shouldFailAllRequests] = useOnyx(ONYXKEYS.NETWORK, {selector: shouldFailAllRequestsSelector});
 
-    // Fetch report data needed for educational modals
-    const [moneyRequestReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
-    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${moneyRequestReport?.chatReportID}`);
-    const {reportActions: unfilteredReportActions} = usePaginatedReportActions(moneyRequestReport?.reportID);
-    const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
-    const {transactions: reportTransactions} = useTransactionsAndViolationsForReport(moneyRequestReport?.reportID);
     const {login: currentUserLogin, accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
-    // Derive transaction thread and parent action
-    const nonDeletedTransactions = getAllNonDeletedTransactions(reportTransactions, reportActions, isOffline, true);
-    const visibleTransactionsForThreadID = nonDeletedTransactions?.filter((t) => isOffline || t.pendingAction !== 'delete');
-    const reportTransactionIDs = visibleTransactionsForThreadID?.map((t) => t.transactionID);
-    const transactionThreadReportID = getOneTransactionThreadReportID(moneyRequestReport, chatReport, reportActions ?? [], isOffline, reportTransactionIDs);
-    const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`);
-
-    const requestParentReportAction =
-        reportActions && transactionThreadReport?.parentReportActionID
-            ? reportActions.find((action): action is OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.IOU> => action.reportActionID === transactionThreadReport.parentReportActionID)
-            : null;
-
-    const iouTransactionID = isMoneyRequestAction(requestParentReportAction) ? getOriginalMessage(requestParentReportAction)?.IOUTransactionID : undefined;
+    const {iouTransactionID, requestParentReportAction} = useMoneyReportTransactionThread();
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(iouTransactionID)}`);
 
     useImperativeHandle(ref, () => ({

--- a/src/components/MoneyReportHeaderModals.tsx
+++ b/src/components/MoneyReportHeaderModals.tsx
@@ -18,6 +18,7 @@ import MoneyReportHeaderEducationalModals from './MoneyReportHeaderEducationalMo
 import type {MoneyReportHeaderEducationalModalsHandle, RejectModalAction} from './MoneyReportHeaderEducationalModals';
 import MoneyReportHeaderModalsContext from './MoneyReportHeaderModalsContext';
 import type {HoldMenuParams} from './MoneyReportHeaderModalsContext';
+import {MoneyReportTransactionThreadProvider} from './MoneyReportTransactionThreadContext';
 import ReportPDFDownloadModal from './ReportPDFDownloadModal';
 
 type MoneyReportHeaderModalsProps = {
@@ -109,18 +110,20 @@ function MoneyReportHeaderModals({reportID, children}: MoneyReportHeaderModalsPr
 
     return (
         <MoneyReportHeaderModalsContext.Provider value={contextValue}>
-            {children}
+            <MoneyReportTransactionThreadProvider reportID={moneyRequestReport?.reportID}>
+                {children}
 
-            <MoneyReportHeaderEducationalModals
-                ref={educationalModalsRef}
-                reportID={moneyRequestReport?.reportID}
-            />
+                <MoneyReportHeaderEducationalModals
+                    ref={educationalModalsRef}
+                    reportID={moneyRequestReport?.reportID}
+                />
 
-            <ReportPDFDownloadModal
-                reportID={moneyRequestReport?.reportID}
-                isVisible={isPDFModalVisible}
-                onClose={() => setIsPDFModalVisible(false)}
-            />
+                <ReportPDFDownloadModal
+                    reportID={moneyRequestReport?.reportID}
+                    isVisible={isPDFModalVisible}
+                    onClose={() => setIsPDFModalVisible(false)}
+                />
+            </MoneyReportTransactionThreadProvider>
         </MoneyReportHeaderModalsContext.Provider>
     );
 }

--- a/src/components/MoneyReportHeaderMoreContent.tsx
+++ b/src/components/MoneyReportHeaderMoreContent.tsx
@@ -4,18 +4,13 @@ import {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 import useMoneyReportHeaderStatusBar from '@hooks/useMoneyReportHeaderStatusBar';
-import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
-import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useResponsiveLayoutOnWideRHP from '@hooks/useResponsiveLayoutOnWideRHP';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
-import {getFilteredReportActionsForReportView, getOneTransactionThreadReportID, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {isInvoiceReport as isInvoiceReportUtil} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -23,6 +18,7 @@ import SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
 import MoneyReportHeaderNextStep from './MoneyReportHeaderNextStep';
 import MoneyReportHeaderStatusBarSection from './MoneyReportHeaderStatusBarSection';
+import {useMoneyReportTransactionThread} from './MoneyReportTransactionThreadContext';
 import MoneyRequestReportNavigation from './MoneyRequestReportView/MoneyRequestReportNavigation';
 
 type MoneyReportHeaderMoreContentProps = {
@@ -76,29 +72,13 @@ type MoneyReportHeaderMoreContentBodyProps = {
 
 function MoneyReportHeaderMoreContentBody({moneyRequestReport, statusBarType, isReportInSearch, shouldShowNextStep}: MoneyReportHeaderMoreContentBodyProps) {
     const styles = useThemeStyles();
-    const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout, isMediumScreenWidth} = useResponsiveLayout();
     const shouldDisplayNarrowVersion = shouldUseNarrowLayout || isMediumScreenWidth;
     const {isWideRHPDisplayedOnWideLayout, isSuperWideRHPDisplayedOnWideLayout} = useResponsiveLayoutOnWideRHP();
     const shouldDisplayNarrowMoreButton = !shouldDisplayNarrowVersion || isWideRHPDisplayedOnWideLayout || isSuperWideRHPDisplayedOnWideLayout;
 
     const reportID = moneyRequestReport?.reportID;
-    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${moneyRequestReport?.chatReportID}`);
-
-    const {reportActions: unfilteredReportActions} = usePaginatedReportActions(reportID);
-    const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
-
-    const allReportTransactions = useReportTransactionsCollection(reportID);
-    const nonDeletedTransactions = getAllNonDeletedTransactions(allReportTransactions, reportActions, isOffline, true);
-    const visibleTransactionsForThreadID = nonDeletedTransactions?.filter((t) => isOffline || t.pendingAction !== 'delete');
-    const reportTransactionIDs = visibleTransactionsForThreadID?.map((t) => t.transactionID);
-    const transactionThreadReportID = getOneTransactionThreadReportID(moneyRequestReport, chatReport, reportActions ?? [], isOffline, reportTransactionIDs);
-    const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`);
-
-    const requestParentReportAction =
-        reportActions && transactionThreadReport?.parentReportActionID ? reportActions.find((action) => action.reportActionID === transactionThreadReport.parentReportActionID) : null;
-
-    const iouTransactionID = isMoneyRequestAction(requestParentReportAction) ? getOriginalMessage(requestParentReportAction)?.IOUTransactionID : undefined;
+    const {iouTransactionID} = useMoneyReportTransactionThread();
 
     return (
         <View style={[styles.flexRow, styles.gap2, styles.justifyContentStart, styles.flexNoWrap, styles.ph5, styles.pb3]}>

--- a/src/components/MoneyReportTransactionThreadContext.tsx
+++ b/src/components/MoneyReportTransactionThreadContext.tsx
@@ -1,0 +1,53 @@
+import React, {createContext, useContext} from 'react';
+import type {ReactNode} from 'react';
+import useTransactionThreadReport from '@hooks/useTransactionThreadReport';
+import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
+import type CONST from '@src/CONST';
+import type * as OnyxTypes from '@src/types/onyx';
+
+type MoneyReportTransactionThreadContextValue = {
+    iouTransactionID: string | undefined;
+    requestParentReportAction: OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.IOU> | null;
+    transactionThreadReportID: string | undefined;
+    reportActions: OnyxTypes.ReportAction[];
+};
+
+const defaultValue: MoneyReportTransactionThreadContextValue = {
+    iouTransactionID: undefined,
+    requestParentReportAction: null,
+    transactionThreadReportID: undefined,
+    reportActions: [],
+};
+
+const MoneyReportTransactionThreadContext = createContext<MoneyReportTransactionThreadContextValue>(defaultValue);
+
+type MoneyReportTransactionThreadProviderProps = {
+    reportID: string | undefined;
+    children: ReactNode;
+};
+
+function MoneyReportTransactionThreadProvider({reportID, children}: MoneyReportTransactionThreadProviderProps) {
+    const {transactionThreadReportID, transactionThreadReport, reportActions} = useTransactionThreadReport(reportID);
+
+    const requestParentReportAction =
+        reportActions?.find((action): action is OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.IOU> => action.reportActionID === transactionThreadReport?.parentReportActionID) ??
+        null;
+
+    const iouTransactionID = isMoneyRequestAction(requestParentReportAction) ? getOriginalMessage(requestParentReportAction)?.IOUTransactionID : undefined;
+
+    const value: MoneyReportTransactionThreadContextValue = {
+        iouTransactionID,
+        requestParentReportAction: requestParentReportAction ?? null,
+        transactionThreadReportID,
+        reportActions: reportActions ?? [],
+    };
+
+    return <MoneyReportTransactionThreadContext.Provider value={value}>{children}</MoneyReportTransactionThreadContext.Provider>;
+}
+
+function useMoneyReportTransactionThread() {
+    return useContext(MoneyReportTransactionThreadContext);
+}
+
+export default MoneyReportTransactionThreadContext;
+export {MoneyReportTransactionThreadProvider, useMoneyReportTransactionThread};

--- a/src/components/MoneyReportTransactionThreadContext.tsx
+++ b/src/components/MoneyReportTransactionThreadContext.tsx
@@ -1,8 +1,11 @@
 import React, {createContext, useContext} from 'react';
 import type {ReactNode} from 'react';
+import useOnyx from '@hooks/useOnyx';
 import useTransactionThreadReport from '@hooks/useTransactionThreadReport';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import type CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
 
 type MoneyReportTransactionThreadContextValue = {
@@ -28,10 +31,12 @@ type MoneyReportTransactionThreadProviderProps = {
 
 function MoneyReportTransactionThreadProvider({reportID, children}: MoneyReportTransactionThreadProviderProps) {
     const {transactionThreadReportID, transactionThreadReport, reportActions} = useTransactionThreadReport(reportID);
+    const [reportActionsForParent] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getNonEmptyStringOnyxID(reportID)}`);
 
-    const requestParentReportAction =
-        reportActions?.find((action): action is OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.IOU> => action.reportActionID === transactionThreadReport?.parentReportActionID) ??
-        null;
+    // Parent lookup uses the raw Onyx collection so Hold/Unhold still work when the parent IOU is
+    // filtered from the report view (e.g. deleted money request) or outside the paginated window.
+    const parentReportAction = transactionThreadReport?.parentReportActionID ? reportActionsForParent?.[transactionThreadReport.parentReportActionID] : undefined;
+    const requestParentReportAction = isMoneyRequestAction(parentReportAction) ? parentReportAction : null;
 
     const iouTransactionID = isMoneyRequestAction(requestParentReportAction) ? getOriginalMessage(requestParentReportAction)?.IOUTransactionID : undefined;
 

--- a/src/components/MoneyReportTransactionThreadContext.tsx
+++ b/src/components/MoneyReportTransactionThreadContext.tsx
@@ -9,9 +9,13 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
 
 type MoneyReportTransactionThreadContextValue = {
+    /** The transaction ID from the parent IOU report action */
     iouTransactionID: string | undefined;
+    /** The parent IOU report action for the transaction thread */
     requestParentReportAction: OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.IOU> | null;
+    /** The transaction thread report ID */
     transactionThreadReportID: string | undefined;
+    /** Filtered report actions for the transaction thread */
     reportActions: OnyxTypes.ReportAction[];
 };
 
@@ -25,7 +29,9 @@ const defaultValue: MoneyReportTransactionThreadContextValue = {
 const MoneyReportTransactionThreadContext = createContext<MoneyReportTransactionThreadContextValue>(defaultValue);
 
 type MoneyReportTransactionThreadProviderProps = {
+    /** The money request report ID */
     reportID: string | undefined;
+    /** The children */
     children: ReactNode;
 };
 

--- a/src/hooks/useExpenseActions.ts
+++ b/src/hooks/useExpenseActions.ts
@@ -8,6 +8,7 @@ import type {ValueOf} from 'type-fest';
 import type {DropdownOption} from '@components/ButtonWithDropdownMenu/types';
 import {ModalActions} from '@components/Modal/Global/ModalContext';
 import type {SecondaryActionEntry} from '@components/MoneyReportHeaderActions/types';
+import {useMoneyReportTransactionThread} from '@components/MoneyReportTransactionThreadContext';
 import {useSearchQueryContext, useSearchSelectionActions} from '@components/Search/SearchContext';
 import {duplicateReport as duplicateReportAction, duplicateExpenseTransaction as duplicateTransactionAction} from '@libs/actions/IOU/Duplicate';
 import {setupMergeTransactionDataAndNavigate} from '@libs/actions/MergeTransaction';
@@ -19,7 +20,7 @@ import Log from '@libs/Log';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import {isPolicyAccessible} from '@libs/PolicyUtils';
-import {getIOUActionForTransactionID, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
+import {getIOUActionForTransactionID} from '@libs/ReportActionsUtils';
 import {
     canEditFieldOfMoneyRequest,
     canUserPerformWriteAction as canUserPerformWriteActionReportUtils,
@@ -62,7 +63,6 @@ import useReportIsArchived from './useReportIsArchived';
 import useTheme from './useTheme';
 import useThrottledButtonState from './useThrottledButtonState';
 import useTransactionsAndViolationsForReport from './useTransactionsAndViolationsForReport';
-import useTransactionThreadReport from './useTransactionThreadReport';
 import useTransactionViolations from './useTransactionViolations';
 
 type UseExpenseActionsParams = {
@@ -96,7 +96,7 @@ function useExpenseActions({reportID, isReportInSearch = false, backTo, onDuplic
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${getNonEmptyStringOnyxID(moneyRequestReport?.policyID)}`);
     const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(moneyRequestReport?.chatReportID)}`);
 
-    const {transactionThreadReportID, transactionThreadReport, reportActions} = useTransactionThreadReport(reportID);
+    const {iouTransactionID, requestParentReportAction, transactionThreadReportID, reportActions} = useMoneyReportTransactionThread();
 
     const {transactions: reportTransactions} = useTransactionsAndViolationsForReport(moneyRequestReport?.reportID);
 
@@ -110,11 +110,6 @@ function useExpenseActions({reportID, isReportInSearch = false, backTo, onDuplic
     }
 
     const currentTransaction = transactions.at(0);
-    const requestParentReportAction =
-        reportActions?.find((action): action is OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.IOU> => action.reportActionID === transactionThreadReport?.parentReportActionID) ??
-        null;
-
-    const iouTransactionID = isMoneyRequestAction(requestParentReportAction) ? getOriginalMessage(requestParentReportAction)?.IOUTransactionID : undefined;
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(iouTransactionID)}`);
     const [originalTransaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(transaction?.comment?.originalTransactionID)}`);
     const {iouReport, chatReport: chatIOUReport, isChatIOUReportArchived} = useGetIOUReportFromReportAction(requestParentReportAction);

--- a/src/hooks/useHoldRejectActions.ts
+++ b/src/hooks/useHoldRejectActions.ts
@@ -2,9 +2,9 @@ import type {ValueOf} from 'type-fest';
 import {useDelegateNoAccessActions, useDelegateNoAccessState} from '@components/DelegateNoAccessModalProvider';
 import type {SecondaryActionEntry} from '@components/MoneyReportHeaderActions/types';
 import type {RejectModalAction} from '@components/MoneyReportHeaderEducationalModals';
+import {useMoneyReportTransactionThread} from '@components/MoneyReportTransactionThreadContext';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
-import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {changeMoneyRequestHoldStatus, isCurrentUserSubmitter, isDM} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -15,7 +15,6 @@ import {useMemoizedLazyExpensifyIcons} from './useLazyAsset';
 import useLocalize from './useLocalize';
 import useNetwork from './useNetwork';
 import useOnyx from './useOnyx';
-import useTransactionThreadReport from './useTransactionThreadReport';
 
 type UseHoldRejectActionsParams = {
     reportID: string | undefined;
@@ -38,18 +37,12 @@ function useHoldRejectActions({reportID, onHoldEducationalOpen, onRejectModalOpe
 
     const [moneyRequestReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(moneyRequestReport?.chatReportID)}`);
-    const {transactionThreadReport} = useTransactionThreadReport(reportID);
+    const {iouTransactionID, requestParentReportAction} = useMoneyReportTransactionThread();
     const {login: currentUserLogin, accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
-
-    const [reportActionsForParent] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getNonEmptyStringOnyxID(moneyRequestReport?.reportID)}`);
-    const requestParentReportAction = transactionThreadReport?.parentReportActionID ? reportActionsForParent?.[transactionThreadReport.parentReportActionID] : undefined;
 
     const {chatReport: chatIOUReport} = useGetIOUReportFromReportAction(requestParentReportAction);
 
-    const iouTransactionID = isMoneyRequestAction(requestParentReportAction)
-        ? (getOriginalMessage(requestParentReportAction)?.IOUTransactionID ?? CONST.DEFAULT_NUMBER_ID)
-        : CONST.DEFAULT_NUMBER_ID;
-    const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${iouTransactionID}`);
+    const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(iouTransactionID)}`);
 
     const [dismissedRejectUseExplanation] = useOnyx(ONYXKEYS.NVP_DISMISSED_REJECT_USE_EXPLANATION);
     const [dismissedHoldUseExplanation] = useOnyx(ONYXKEYS.NVP_DISMISSED_HOLD_USE_EXPLANATION);

--- a/src/hooks/useReportPrimaryAction.ts
+++ b/src/hooks/useReportPrimaryAction.ts
@@ -1,4 +1,5 @@
 import type {ValueOf} from 'type-fest';
+import {useMoneyReportTransactionThread} from '@components/MoneyReportTransactionThreadContext';
 import {usePaymentAnimationsContext} from '@components/PaymentAnimationsContext';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {isPaidGroupPolicy} from '@libs/PolicyUtils';
@@ -11,7 +12,6 @@ import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
 import useOnyx from './useOnyx';
 import useReportIsArchived from './useReportIsArchived';
 import useTransactionsAndViolationsForReport from './useTransactionsAndViolationsForReport';
-import useTransactionThreadReport from './useTransactionThreadReport';
 
 function useReportPrimaryAction(reportID: string | undefined): ValueOf<typeof CONST.REPORT.PRIMARY_ACTIONS> | '' {
     const {isPaidAnimationRunning, isApprovedAnimationRunning, isSubmittingAnimationRunning} = usePaymentAnimationsContext();
@@ -27,7 +27,7 @@ function useReportPrimaryAction(reportID: string | undefined): ValueOf<typeof CO
         `${ONYXKEYS.COLLECTION.POLICY}${chatReport?.invoiceReceiver && 'policyID' in chatReport.invoiceReceiver ? chatReport.invoiceReceiver.policyID : undefined}`,
     );
 
-    const {reportActions} = useTransactionThreadReport(reportID);
+    const {reportActions} = useMoneyReportTransactionThread();
     const {transactions: reportTransactions, violations} = useTransactionsAndViolationsForReport(moneyRequestReport?.reportID);
 
     const isChatReportArchived = useReportIsArchived(chatReport?.reportID);

--- a/tests/unit/components/MoneyReportTransactionThreadContext.test.tsx
+++ b/tests/unit/components/MoneyReportTransactionThreadContext.test.tsx
@@ -1,0 +1,189 @@
+import {renderHook} from '@testing-library/react-native';
+import React from 'react';
+import type {PropsWithChildren} from 'react';
+import type {OnyxKey, ResultMetadata, UseOnyxResult} from 'react-native-onyx';
+import {MoneyReportTransactionThreadProvider, useMoneyReportTransactionThread} from '@components/MoneyReportTransactionThreadContext';
+import useOnyx from '@hooks/useOnyx';
+import useTransactionThreadReport from '@hooks/useTransactionThreadReport';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report, ReportAction, ReportActions} from '@src/types/onyx';
+
+jest.mock('@hooks/useOnyx', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+jest.mock('@hooks/useTransactionThreadReport', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+const mockUseOnyx = jest.mocked(useOnyx);
+const mockUseTransactionThreadReport = jest.mocked(useTransactionThreadReport);
+
+const MONEY_REPORT_ID = '10001';
+const THREAD_REPORT_ID = '10002';
+const PARENT_ACTION_ID = '9001';
+const IOU_TRANSACTION_ID = '3106135972713435169';
+
+const loadedMetadata: ResultMetadata<ReportActions> = {status: 'loaded'};
+
+function asReportActionsOnyxResult(reportActions: ReportActions | undefined): UseOnyxResult<ReportActions> {
+    return [reportActions, loadedMetadata];
+}
+
+function createIOUReportAction(reportActionID: string, transactionID: string = IOU_TRANSACTION_ID): ReportAction {
+    return {
+        reportActionID,
+        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+        originalMessage: {
+            IOUTransactionID: transactionID,
+            type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+        },
+        created: '2025-02-14 08:12:05.165',
+        actorAccountID: 1,
+        person: [{type: 'TEXT', style: 'strong', text: 'Test'}],
+        message: [{type: 'COMMENT', html: '', text: '', isEdited: false, whisperedTo: [], isDeletedParentAction: false}],
+    } as ReportAction;
+}
+
+function createTransactionThreadReport(parentReportActionID: string | undefined): Report {
+    return {
+        reportID: THREAD_REPORT_ID,
+        parentReportActionID,
+    } as Report;
+}
+
+function renderContextHook(reportID: string | undefined = MONEY_REPORT_ID) {
+    function wrapper({children}: PropsWithChildren) {
+        return <MoneyReportTransactionThreadProvider reportID={reportID}>{children}</MoneyReportTransactionThreadProvider>;
+    }
+
+    return renderHook(() => useMoneyReportTransactionThread(), {wrapper});
+}
+
+describe('MoneyReportTransactionThreadContext', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseOnyx.mockReturnValue(asReportActionsOnyxResult(undefined));
+        mockUseTransactionThreadReport.mockReturnValue({
+            transactionThreadReportID: undefined,
+            transactionThreadReport: undefined,
+            reportActions: [],
+        });
+    });
+
+    it('returns default values when used outside the provider', () => {
+        const {result} = renderHook(() => useMoneyReportTransactionThread());
+
+        expect(result.current).toEqual({
+            iouTransactionID: undefined,
+            requestParentReportAction: null,
+            transactionThreadReportID: undefined,
+            reportActions: [],
+        });
+    });
+
+    it('exposes transaction thread data and resolves the IOU transaction ID from the parent action', () => {
+        const parentReportAction = createIOUReportAction(PARENT_ACTION_ID);
+        const filteredReportActions: ReportAction[] = [
+            {
+                reportActionID: 'filtered-action',
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                created: '2025-02-14 08:12:05.165',
+                actorAccountID: 1,
+                person: [{type: 'TEXT', style: 'strong', text: 'Test'}],
+                message: [{type: 'COMMENT', html: '', text: '', isEdited: false, whisperedTo: [], isDeletedParentAction: false}],
+            },
+        ];
+        const reportActionsForParent: ReportActions = {
+            [PARENT_ACTION_ID]: parentReportAction,
+        };
+
+        mockUseTransactionThreadReport.mockReturnValue({
+            transactionThreadReportID: THREAD_REPORT_ID,
+            transactionThreadReport: createTransactionThreadReport(PARENT_ACTION_ID),
+            reportActions: filteredReportActions,
+        });
+        mockUseOnyx.mockImplementation((key: OnyxKey) => {
+            if (key === `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${MONEY_REPORT_ID}`) {
+                return asReportActionsOnyxResult(reportActionsForParent);
+            }
+            return asReportActionsOnyxResult(undefined);
+        });
+
+        const {result} = renderContextHook();
+
+        expect(mockUseTransactionThreadReport).toHaveBeenCalledWith(MONEY_REPORT_ID);
+        expect(result.current.transactionThreadReportID).toBe(THREAD_REPORT_ID);
+        expect(result.current.reportActions).toEqual(filteredReportActions);
+        expect(result.current.requestParentReportAction).toEqual(parentReportAction);
+        expect(result.current.iouTransactionID).toBe(IOU_TRANSACTION_ID);
+    });
+
+    it('resolves the parent action from the raw Onyx collection even when it is absent from filtered report actions', () => {
+        const parentReportAction = createIOUReportAction(PARENT_ACTION_ID);
+        const reportActionsForParent: ReportActions = {
+            [PARENT_ACTION_ID]: parentReportAction,
+        };
+
+        mockUseTransactionThreadReport.mockReturnValue({
+            transactionThreadReportID: THREAD_REPORT_ID,
+            transactionThreadReport: createTransactionThreadReport(PARENT_ACTION_ID),
+            reportActions: [],
+        });
+        mockUseOnyx.mockImplementation((key: OnyxKey) => {
+            if (key === `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${MONEY_REPORT_ID}`) {
+                return asReportActionsOnyxResult(reportActionsForParent);
+            }
+            return asReportActionsOnyxResult(undefined);
+        });
+
+        const {result} = renderContextHook();
+
+        expect(result.current.requestParentReportAction).toEqual(parentReportAction);
+        expect(result.current.iouTransactionID).toBe(IOU_TRANSACTION_ID);
+    });
+
+    it('returns null requestParentReportAction when the parent action is not a money request action', () => {
+        const nonIOUParentAction: ReportAction = {
+            reportActionID: PARENT_ACTION_ID,
+            actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+            created: '2025-02-14 08:12:05.165',
+            actorAccountID: 1,
+            person: [{type: 'TEXT', style: 'strong', text: 'Test'}],
+            message: [{type: 'COMMENT', html: '', text: '', isEdited: false, whisperedTo: [], isDeletedParentAction: false}],
+        };
+
+        mockUseTransactionThreadReport.mockReturnValue({
+            transactionThreadReportID: THREAD_REPORT_ID,
+            transactionThreadReport: createTransactionThreadReport(PARENT_ACTION_ID),
+            reportActions: [],
+        });
+        mockUseOnyx.mockImplementation((key: OnyxKey) => {
+            if (key === `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${MONEY_REPORT_ID}`) {
+                return asReportActionsOnyxResult({[PARENT_ACTION_ID]: nonIOUParentAction});
+            }
+            return asReportActionsOnyxResult(undefined);
+        });
+
+        const {result} = renderContextHook();
+
+        expect(result.current.requestParentReportAction).toBeNull();
+        expect(result.current.iouTransactionID).toBeUndefined();
+    });
+
+    it('returns null requestParentReportAction when the transaction thread has no parent action ID', () => {
+        mockUseTransactionThreadReport.mockReturnValue({
+            transactionThreadReportID: THREAD_REPORT_ID,
+            transactionThreadReport: createTransactionThreadReport(undefined),
+            reportActions: [],
+        });
+
+        const {result} = renderContextHook();
+
+        expect(result.current.requestParentReportAction).toBeNull();
+        expect(result.current.iouTransactionID).toBeUndefined();
+    });
+});


### PR DESCRIPTION


### Explanation of Change

The same heavy logic is called across multiple components and hooks related to money request header when opening the report. This PR introduces context that holds the value in a single place, sharing it across those components and hooks.

**Perf gain on iOS:** `ManualOpenReport` 2.1s -> 1.9s (13% improvement)

### Fixed Issues

$ https://github.com/Expensify/App/issues/91947
PROPOSAL:




### Tests

1. Open Spend tab
2. Go to Expenses
3. Open any expense
4. Press More button
5. Verify the menu opens correctly

- [x] Verify that no errors appear in the JS console

### Offline tests


### QA Steps

// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari




