### PR TITLE
fix: replace Array.toReversed with slice().reverse() for Chrome 103 compatibility

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -173,7 +173,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;


### PR DESCRIPTION
## Summary

Fixes Chrome 103 crash caused by `Array.prototype.toReversed()` which is only available in Chrome 110+.

**Root cause:** `filteredActions.toReversed()` in `MoneyRequestReportActionsList.tsx` throws `TypeError: filteredActions.toReversed is not a function` on older browsers.

**Fix:** Replaced with `filteredActions.slice().reverse()` which has universal browser support.

## Test plan

1. Open Chrome 103 or Chrome OS device
2. Navigate to expense report in Search
3. Verify page loads without ErrorBoundary crash
4. Verify report actions display in correct (reversed) order

$ #91964