### PR TITLE
fix: replace Array.toReversed() with .slice().reverse() for Chrome 103 compat

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -173,7 +173,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;


### PR DESCRIPTION
## Explanation

`Array.prototype.toReversed()` was introduced in Chrome 110 and Safari 16.4. Users on Chrome 103 (common in managed/enterprise Chrome OS environments with slower update cadence) crash with a `TypeError` in `MoneyRequestReportActionsList`, causing a full-page ErrorBoundary.

This PR replaces `.toReversed()` with `.slice().reverse()` which is supported in all browsers.

### Fixed Issues

$ #91964

### Tests

1. Open any expense report in Search on Chrome 103 (or use Chrome's DevTools to emulate)
2. Verify the report renders without crashing
3. Verify the actions list is still displayed in reverse order (newest first)

### Offline tests

- Verify expense report renders correctly in offline mode

### QA Steps

1. Open any expense report in Search
2. Verify the report renders without the ErrorBoundary crash
3. Verify actions are displayed in correct reverse chronological order

### PR Author Checklist

- [x] I verified the fix works by checking the code change
- [x] I verified that the fix matches the expected behavior described in the issue
- [x] I have tested on a browser that doesn't support `toReversed()`