### PR TITLE
Fix #91964: avoid Array.toReversed() for old Chrome

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -173,7 +173,8 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        // Avoid Array.prototype.toReversed() since it's not available on older Chromium/Safari builds (e.g. Chrome 103).
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;

--- a/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
+++ b/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
@@ -276,4 +276,30 @@ describe('MoneyRequestReportActionsList - Reject Educational Modal', () => {
         expect(screen.queryByTestId('HoldOrRejectEducationalModal')).toBeNull();
         expect(mockOriginalRejectOnSelected).toHaveBeenCalled();
     });
+
+    it('should not crash when Array.prototype.toReversed is unavailable (older Chromium)', async () => {
+        const originalToReversed = (Array.prototype as unknown as {toReversed?: unknown}).toReversed;
+        (Array.prototype as unknown as {toReversed?: unknown}).toReversed = undefined;
+
+        try {
+            await act(async () => {
+                await Onyx.multiSet({
+                    [ONYXKEYS.NVP_DISMISSED_REJECT_USE_EXPLANATION]: true,
+                    [`${ONYXKEYS.COLLECTION.REPORT}${FAKE_REPORT_ID}` as const]: mockReport,
+                    [`${ONYXKEYS.COLLECTION.POLICY}${FAKE_POLICY_ID}` as const]: mockPolicy,
+                    [`${ONYXKEYS.COLLECTION.TRANSACTION}${FAKE_TRANSACTION_ID}` as const]: mockTransaction,
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_REPORT_ID}` as const]: {[mockReportAction.reportActionID]: mockReportAction},
+                    [`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${FAKE_REPORT_ID}` as const]: {isLoadingInitialReportActions: false, hasOnceLoadedReportActions: true},
+                    [ONYXKEYS.SESSION]: {accountID: FAKE_ACCOUNT_ID, email: FAKE_EMAIL} as Session,
+                });
+            });
+
+            renderComponent();
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.getByTestId('MockMoneyRequestReportTransactionList')).toBeTruthy();
+        } finally {
+            (Array.prototype as unknown as {toReversed?: unknown}).toReversed = originalToReversed;
+        }
+    });
 });


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/91964

- Replace `filteredActions.toReversed()` with `filteredActions.slice().reverse()` to prevent crashes on Chrome < 110.
- Add regression test that simulates older Chromium by setting `Array.prototype.toReversed = undefined` and asserting the component renders.

Tested:
- `npm test -- tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx`
- `npm run typecheck`