### PR TITLE
Fix chart tooltip/tap by routing plot gestures through CartesianChart

### DIFF
--- a/src/components/Charts/BarChart/BarChartContent.tsx
+++ b/src/components/Charts/BarChart/BarChartContent.tsx
@@ -147,7 +147,7 @@ function BarChartContent({data, isLoading, yAxisUnit, yAxisUnitPosition = 'left'
         return args.cursorX >= barLeft && args.cursorX <= barRight && args.cursorY >= barTop && args.cursorY <= barBottom;
     };
 
-    const {customGestures, setPointPositions, matchedIndex, isTooltipActive, isCursorOverClickable, initialTooltipPosition} = useChartInteractions({
+    const {plotGestures, labelGestures, setPointPositions, matchedIndex, isTooltipActive, isCursorOverClickable, initialTooltipPosition} = useChartInteractions({
         handlePress: handleBarPress,
         checkIsOver: checkIsOverBar,
         isCursorOverLabel,
@@ -255,7 +255,7 @@ function BarChartContent({data, isLoading, yAxisUnit, yAxisUnitPosition = 'left'
     }
 
     return (
-        <GestureDetector gesture={customGestures}>
+        <GestureDetector gesture={labelGestures}>
             <Animated.View
                 style={[styles.chartContent, dynamicChartStyle, cursorStyle]}
                 onLayout={handleLayout}
@@ -263,6 +263,7 @@ function BarChartContent({data, isLoading, yAxisUnit, yAxisUnitPosition = 'left'
                 {chartWidth > 0 && (
                     <CartesianChart
                         xKey="x"
+                        customGestures={plotGestures}
                         padding={chartPadding}
                         yKeys={['y']}
                         domainPadding={domainPadding}

--- a/src/components/Charts/LineChart/LineChartContent.tsx
+++ b/src/components/Charts/LineChart/LineChartContent.tsx
@@ -153,7 +153,7 @@ function LineChartContent({data, isLoading, yAxisUnit, yAxisUnitPosition = 'left
         return Math.sqrt(dx * dx + dy * dy) <= DOT_RADIUS + DOT_HOVER_EXTRA_RADIUS;
     };
 
-    const {customGestures, setPointPositions, matchedIndex, isTooltipActive, isCursorOverClickable, initialTooltipPosition} = useChartInteractions({
+    const {plotGestures, labelGestures, setPointPositions, matchedIndex, isTooltipActive, isCursorOverClickable, initialTooltipPosition} = useChartInteractions({
         handlePress: handlePointPress,
         checkIsOver: checkIsOverDot,
         isCursorOverLabel,
@@ -251,7 +251,7 @@ function LineChartContent({data, isLoading, yAxisUnit, yAxisUnitPosition = 'left
     }
 
     return (
-        <GestureDetector gesture={customGestures}>
+        <GestureDetector gesture={labelGestures}>
             <Animated.View
                 style={[styles.chartContent, dynamicChartStyle, cursorStyle]}
                 onLayout={handleLayout}
@@ -259,6 +259,7 @@ function LineChartContent({data, isLoading, yAxisUnit, yAxisUnitPosition = 'left
                 {chartWidth > 0 && (
                     <CartesianChart
                         xKey="x"
+                        customGestures={plotGestures}
                         padding={chartPadding}
                         yKeys={['y']}
                         domainPadding={domainPadding}

--- a/src/components/Charts/hooks/useChartInteractions.ts
+++ b/src/components/Charts/hooks/useChartInteractions.ts
@@ -174,9 +174,6 @@ function useChartInteractions({handlePress, checkIsOver, isCursorOverLabel, reso
      * Hover gesture to be placed on the full-height outer container (chart + label area).
      * Clamps the y coordinate to chartBottom before passing to Victory so that hovering
      * over x-axis labels below the plot area still resolves the nearest data point.
-     * This gesture is returned separately and must NOT be passed to CartesianChart's
-     * customGestures prop, because Victory's internal GestureHandler view only covers
-     * the plot area and would drop events from the label area.
      */
     const hoverGesture = () =>
         Gesture.Hover()
@@ -279,11 +276,14 @@ function useChartInteractions({handlePress, checkIsOver, isCursorOverLabel, reso
         };
     });
 
-    const customGestures = Gesture.Race(hoverGesture(), tapGesture());
+    const plotGestures = Gesture.Race(hoverGesture(), tapGesture());
+    const labelGestures = hoverGesture();
 
     return {
-        /** Custom gestures to be passed to CartesianChart */
-        customGestures,
+        /** Gestures to be passed to CartesianChart's plot-area overlay */
+        plotGestures,
+        /** Hover-only gesture for the outer container (needed for x-axis label area) */
+        labelGestures,
         /**
          * Call this from handleScaleChange with the canvas x/y positions of each data point.
          * Derived from the d3 scale: ox[i] = xScale(i), oy[i] = yScale(data[i].total).

--- a/tests/unit/components/Charts/useChartInteractions.test.ts
+++ b/tests/unit/components/Charts/useChartInteractions.test.ts
@@ -100,10 +100,11 @@ describe('useChartInteractions', () => {
         checkIsOver: alwaysFalse,
     };
 
-    it('returns a customGestures object', () => {
+    it('returns plotGestures and labelGestures objects', () => {
         const {result} = renderHook(() => useChartInteractions(defaultProps));
 
-        expect(result.current.customGestures).toBeTruthy();
+        expect(result.current.plotGestures).toBeTruthy();
+        expect(result.current.labelGestures).toBeTruthy();
     });
 
     it('returns a setPointPositions function', () => {
@@ -154,6 +155,7 @@ describe('useChartInteractions', () => {
             }),
         );
 
-        expect(result.current.customGestures).toBeTruthy();
+        expect(result.current.plotGestures).toBeTruthy();
+        expect(result.current.labelGestures).toBeTruthy();
     });
 });


### PR DESCRIPTION
### Details
This PR addresses the chart interaction regression in #92149 by separating gestures between the plot area and the outer label area.

### Root cause
`CartesianChart` renders an internal plot-area gesture overlay. When no `customGestures` are passed, plot interactions can be swallowed before the outer container gesture resolves bar/point interactions.

### Changes
1. `useChartInteractions`
   - Return two gesture instances:
     - `plotGestures`: `Gesture.Race(hoverGesture(), tapGesture())`
     - `labelGestures`: `hoverGesture()`
2. `BarChartContent`
   - Use `labelGestures` on the outer `GestureDetector`
   - Pass `customGestures={plotGestures}` to `CartesianChart`
3. `LineChartContent`
   - Same split and wiring as `BarChartContent`
4. Unit test updates
   - Adjust `useChartInteractions` tests for `plotGestures` / `labelGestures`

### Validation
- `git diff --check`
- Unit test execution is currently blocked in this environment because `npm` is not installed on the runner path, so dependency install and jest execution could not be performed locally.

### Notes
- Proposal comment posted on the issue before implementation: https://github.com/Expensify/App/issues/92149#issuecomment-4585495778
- This contribution was prepared with AI assistance.