### PR TITLE
fix: avoid toReversed on old Chrome

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -171,7 +171,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;


### PR DESCRIPTION
## Summary
- replace `filteredActions.toReversed()` with `filteredActions.slice().reverse()`
- keep the same non-mutating behavior for report actions ordering
- avoid Chrome 103 / older Chromium crash where `toReversed` is undefined

## Testing
- `git diff --check`
- verified the only changed call site now uses `slice().reverse()` in `MoneyRequestReportActionsList.tsx`