### PR TITLE
Fix Chrome 103 crash in money request report actions

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -171,7 +171,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;


### PR DESCRIPTION
## Summary

$ #91964.

`Array.prototype.toReversed()` is not available in Chrome 103 / older Chromium browsers, so rendering `MoneyRequestReportActionsList` can throw and trip the ErrorBoundary. This replaces the call with `slice().reverse()`, preserving the existing non-mutating behavior while supporting older browsers.

## Tests

- [x] Ran `git diff HEAD~1 HEAD --check`
- [ ] Full lint/typecheck not run locally because dependencies are not installed and the local Node version is 22.18.0 while the repo expects 20.20.0.
