### PR TITLE
Fix composer local time hydration

### DIFF
--- a/src/hooks/useReportRecipientLocalTime.ts
+++ b/src/hooks/useReportRecipientLocalTime.ts
@@ -1,4 +1,5 @@
 import {canShowReportRecipientLocalTimeSelector} from '@selectors/Report';
+import {useMemo} from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
@@ -13,7 +14,8 @@ type UseReportRecipientLocalTimeParams = {
 function useReportRecipientLocalTime({report}: UseReportRecipientLocalTimeParams): boolean {
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
-    const [canShowRecipientLocalTime = false] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: canShowReportRecipientLocalTimeSelector(report, currentUserAccountID)});
+    const canShowRecipientLocalTimeSelector = useMemo(() => canShowReportRecipientLocalTimeSelector(report, currentUserAccountID), [report, currentUserAccountID]);
+    const [canShowRecipientLocalTime = false] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: canShowRecipientLocalTimeSelector}, [canShowRecipientLocalTimeSelector]);
 
     return canShowRecipientLocalTime;
 }

--- a/src/pages/inbox/report/ReportActionCompose/ComposerLocalTime.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerLocalTime.tsx
@@ -1,5 +1,5 @@
 import {personalDetailByAccountIDSelector} from '@selectors/PersonalDetails';
-import React from 'react';
+import React, {useMemo} from 'react';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useOnyx from '@hooks/useOnyx';
@@ -19,7 +19,8 @@ function ComposerLocalTime() {
     const canShowRecipientLocalTime = useReportRecipientLocalTime({report});
     const shouldShow = canShowRecipientLocalTime && !isComposerFullSize;
     const reportRecipientAccountID = getReportRecipientAccountIDs(report, currentUserAccountID).at(0);
-    const [reportRecipient] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: personalDetailByAccountIDSelector(shouldShow ? reportRecipientAccountID : undefined)});
+    const reportRecipientSelector = useMemo(() => personalDetailByAccountIDSelector(reportRecipientAccountID), [reportRecipientAccountID]);
+    const [reportRecipient] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: reportRecipientSelector}, [reportRecipientSelector]);
 
     if (!shouldShow || isEmptyObject(reportRecipient) || isAgentEmail(reportRecipient?.login)) {
         return null;

--- a/tests/unit/ComposerLocalTimeTest.tsx
+++ b/tests/unit/ComposerLocalTimeTest.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react-native';
+import {act, render, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 import ComposeProviders from '@components/ComposeProviders';
@@ -38,6 +38,19 @@ function buildReport(participantAccountIDs: number[]): Report {
     } as Report;
 }
 
+function buildPersonalDetails(login = 'normaluser@expensify.com'): PersonalDetailsList {
+    return {
+        [RECIPIENT_ACCOUNT_ID]: {
+            accountID: RECIPIENT_ACCOUNT_ID,
+            login,
+            displayName: login.startsWith('agent_') ? 'Agent 999' : 'Normal User',
+            firstName: login.startsWith('agent_') ? 'Agent' : 'Normal',
+            validated: true,
+            timezone: {automatic: true, selected: 'America/New_York'},
+        },
+    };
+}
+
 function renderWithProviders(component: React.ReactElement, reportID: string) {
     return render(
         <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
@@ -52,25 +65,19 @@ describe('ComposerLocalTime', () => {
     });
 
     afterEach(async () => {
-        await Onyx.clear();
+        await act(async () => {
+            await Onyx.clear();
+        });
     });
 
     it('renders local time for a non-agent participant', async () => {
         const report = buildReport([CURRENT_USER_ACCOUNT_ID, RECIPIENT_ACCOUNT_ID]);
-        const personalDetails: PersonalDetailsList = {
-            [RECIPIENT_ACCOUNT_ID]: {
-                accountID: RECIPIENT_ACCOUNT_ID,
-                login: 'normaluser@expensify.com',
-                displayName: 'Normal User',
-                firstName: 'Normal',
-                validated: true,
-                timezone: {automatic: true, selected: 'America/New_York'},
-            },
-        };
+        const personalDetails = buildPersonalDetails();
 
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
-        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
-        await waitForBatchedUpdates();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+        });
 
         renderWithProviders(<ComposerLocalTime />, REPORT_ID);
 
@@ -80,23 +87,38 @@ describe('ComposerLocalTime', () => {
         expect(screen.getByText(/Normal/)).toBeTruthy();
     });
 
+    it('renders local time when the report loads after personal details are already available', async () => {
+        const report = buildReport([CURRENT_USER_ACCOUNT_ID, RECIPIENT_ACCOUNT_ID]);
+        const personalDetails = buildPersonalDetails();
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+        });
+
+        renderWithProviders(<ComposerLocalTime />, REPORT_ID);
+
+        await waitForBatchedUpdates();
+
+        expect(screen.queryByText(/Normal/)).toBeNull();
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText(/Normal/)).toBeTruthy();
+        });
+    });
+
     it('returns null when the composer is full size', async () => {
         const report = buildReport([CURRENT_USER_ACCOUNT_ID, RECIPIENT_ACCOUNT_ID]);
-        const personalDetails: PersonalDetailsList = {
-            [RECIPIENT_ACCOUNT_ID]: {
-                accountID: RECIPIENT_ACCOUNT_ID,
-                login: 'normaluser@expensify.com',
-                displayName: 'Normal User',
-                firstName: 'Normal',
-                validated: true,
-                timezone: {automatic: true, selected: 'America/New_York'},
-            },
-        };
+        const personalDetails = buildPersonalDetails();
 
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
-        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${REPORT_ID}`, true);
-        await waitForBatchedUpdates();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${REPORT_ID}`, true);
+        });
 
         const {toJSON} = renderWithProviders(<ComposerLocalTime />, REPORT_ID);
 
@@ -107,20 +129,12 @@ describe('ComposerLocalTime', () => {
 
     it('returns null for an agent participant', async () => {
         const report = buildReport([CURRENT_USER_ACCOUNT_ID, RECIPIENT_ACCOUNT_ID]);
-        const personalDetails: PersonalDetailsList = {
-            [RECIPIENT_ACCOUNT_ID]: {
-                accountID: RECIPIENT_ACCOUNT_ID,
-                login: 'agent_999@expensify.ai',
-                displayName: 'Agent 999',
-                firstName: 'Agent',
-                validated: true,
-                timezone: {automatic: true, selected: 'America/New_York'},
-            },
-        };
+        const personalDetails = buildPersonalDetails('agent_999@expensify.ai');
 
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
-        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
-        await waitForBatchedUpdates();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+        });
 
         const {toJSON} = renderWithProviders(<ComposerLocalTime />, REPORT_ID);
 

--- a/tests/unit/hooks/useReportRecipientLocalTime.test.ts
+++ b/tests/unit/hooks/useReportRecipientLocalTime.test.ts
@@ -1,5 +1,8 @@
-import {renderHook, waitFor} from '@testing-library/react-native';
+import {act, render, screen, waitFor} from '@testing-library/react-native';
+import React from 'react';
 import Onyx from 'react-native-onyx';
+import type {OnyxEntry} from 'react-native-onyx';
+import Text from '@components/Text';
 import useReportRecipientLocalTime from '@hooks/useReportRecipientLocalTime';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -32,26 +35,53 @@ const RECIPIENT_PERSONAL_DETAILS: PersonalDetailsList = {
     },
 };
 
+function ReportRecipientLocalTimeProbe({report}: {report: OnyxEntry<Report>}) {
+    const canShowRecipientLocalTime = useReportRecipientLocalTime({report});
+    return React.createElement(Text, null, canShowRecipientLocalTime ? 'visible' : 'hidden');
+}
+
 describe('useReportRecipientLocalTime', () => {
     beforeAll(() => {
         Onyx.init({keys: ONYXKEYS});
     });
 
     beforeEach(async () => {
-        await Onyx.clear();
+        await act(async () => {
+            await Onyx.clear();
+        });
     });
 
     it('updates when personal details list changes', async () => {
-        const {result} = renderHook(() => useReportRecipientLocalTime({report: REPORT}));
+        render(React.createElement(ReportRecipientLocalTimeProbe, {report: REPORT}));
 
         await waitFor(() => {
-            expect(result.current).toBe(false);
+            expect(screen.getByText('hidden')).toBeOnTheScreen();
         });
 
-        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, RECIPIENT_PERSONAL_DETAILS);
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, RECIPIENT_PERSONAL_DETAILS);
+        });
 
         await waitFor(() => {
-            expect(result.current).toBe(true);
+            expect(screen.getByText('visible')).toBeOnTheScreen();
+        });
+    });
+
+    it('updates when the report loads after personal details are already available', async () => {
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, RECIPIENT_PERSONAL_DETAILS);
+        });
+
+        const {rerender} = render(React.createElement(ReportRecipientLocalTimeProbe, {report: undefined}));
+
+        await waitFor(() => {
+            expect(screen.getByText('hidden')).toBeOnTheScreen();
+        });
+
+        rerender(React.createElement(ReportRecipientLocalTimeProbe, {report: REPORT}));
+
+        await waitFor(() => {
+            expect(screen.getByText('visible')).toBeOnTheScreen();
         });
     });
 });


### PR DESCRIPTION
### Explanation of Change
This fixes the missing "It's {Time} for {Name}" composer row in 1:1 chats when personal details and report data hydrate in different orders.

`useReportRecipientLocalTime` now memoizes its `PERSONAL_DETAILS_LIST` selector and passes that selector to `useOnyx` as an explicit dependency, so Onyx re-evaluates when the selector's closed-over report/current-user inputs change. `ComposerLocalTime` also subscribes to the recipient personal detail by `reportRecipientAccountID` directly instead of gating that lookup behind `shouldShow`; the existing render guard still controls whether the row is displayed.

I added regression coverage for the cold-load order where personal details are already cached before the report hydrates.

### Fixed Issues
$ https://github.com/Expensify/App/issues/92225
PROPOSAL: https://github.com/Expensify/App/issues/92225#issuecomment-4593233306

### Tests
1. Run `npx jest tests/unit/hooks/useReportRecipientLocalTime.test.ts tests/unit/ComposerLocalTimeTest.tsx tests/unit/ReportUtilsCanShowReportRecipientLocalTimeTest.ts --runInBand`
2. Verify all tests pass.

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as QA steps. This change only affects client-side Onyx selector hydration and does not add network-specific behavior.

### QA Steps
1. Open the Expensify app.
2. Open a 1:1 chat with a validated recipient who has a selected timezone.
3. Verify the `It's {Time} for {Name}` label is visible above the composer.
4. Open a 1:1 chat where the recipient should not show local time, such as a recipient without a selected timezone or an agent participant.
5. Verify the label is not shown for that chat.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
- [x] I added unit tests for this bug fix in this PR to help automatically prevent regressions in this user flow.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Not captured. Covered by unit/regression tests.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not captured. Covered by unit/regression tests.

</details>

<details>
<summary>iOS: Native</summary>

Not captured. Covered by unit/regression tests.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not captured. Covered by unit/regression tests.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not captured. Covered by unit/regression tests.

</details>
