### PR TITLE
Defer workspace teardown when a policy is only transiently inaccessible

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,10 +19,10 @@ module.exports = {
         '<rootDir>/node_modules/@expensify/react-native-live-markdown/lib/commonjs/parseExpensiMark.js',
     ],
     testPathIgnorePatterns: ['<rootDir>/node_modules'],
-    // .worktrees/ holds parallel git worktrees a developer may check out locally.
+    // .worktrees/ and .git-worktrees/ hold parallel git worktrees a developer may check out locally.
     // Each one carries its own modules/hybrid-app/package.json, which trips
     // jest-haste-map's "duplicate package name" assertion. Skip them entirely.
-    modulePathIgnorePatterns: ['<rootDir>/.worktrees/'],
+    modulePathIgnorePatterns: ['<rootDir>/.worktrees/', '<rootDir>/.git-worktrees/'],
     globals: {
         __DEV__: true,
         WebSocket: {},

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -227,6 +227,11 @@ const CONST = {
     CUSTOM_FIELD_KEYS: {customField1: 'employeeUserID', customField2: 'employeePayrollID'},
     ANDROID_PACKAGE_NAME,
     WORKSPACE_ENABLE_FEATURE_REDIRECT_DELAY: 100,
+
+    // A policy can momentarily look inaccessible while it is being rewritten (e.g. a connection sync that replaces the
+    // whole policy and reconciles the employee list, briefly leaving the current user without a resolvable role). We wait
+    // this long before tearing the workspace screen out of the navigation stack so a transient state doesn't eject the user.
+    WORKSPACE_INACCESSIBLE_SCREEN_REMOVAL_DELAY: 1000,
     ANIMATED_HIGHLIGHT_ENTRY_DELAY: 50,
     ANIMATED_HIGHLIGHT_ENTRY_DURATION: 300,
     ANIMATED_HIGHLIGHT_START_DELAY: 10,

--- a/src/pages/workspace/AccessOrNotFoundWrapper.tsx
+++ b/src/pages/workspace/AccessOrNotFoundWrapper.tsx
@@ -225,7 +225,16 @@ function AccessOrNotFoundWrapper({
         if (isLoadingReportData || !isPolicyNotAccessible) {
             return;
         }
-        Navigation.removeScreenFromNavigationState(SCREENS.WORKSPACE.INITIAL);
+
+        // A policy can momentarily look inaccessible while it is being rewritten (e.g. a connection sync that replaces the
+        // whole policy and reconciles the employee list, briefly leaving the current user without a resolvable role). Defer
+        // the teardown so a transient state doesn't eject the user from the workspace; if the policy becomes accessible
+        // again before the timeout fires, the effect cleanup cancels it. A genuine removal stays inaccessible and proceeds.
+        const removalTimeoutID = setTimeout(() => {
+            Navigation.removeScreenFromNavigationState(SCREENS.WORKSPACE.INITIAL);
+        }, CONST.WORKSPACE_INACCESSIBLE_SCREEN_REMOVAL_DELAY);
+
+        return () => clearTimeout(removalTimeoutID);
     }, [isLoadingReportData, isPolicyNotAccessible]);
 
     if (shouldShowFullScreenLoadingIndicator) {

--- a/tests/unit/AccessOrNotFoundWrapperTest.tsx
+++ b/tests/unit/AccessOrNotFoundWrapperTest.tsx
@@ -1,3 +1,4 @@
+import type * as ReactNavigationNative from '@react-navigation/native';
 import {act, render, screen} from '@testing-library/react-native';
 import React from 'react';
 import {View} from 'react-native';
@@ -23,7 +24,7 @@ jest.mock('@libs/Navigation/Navigation', () => ({
 }));
 
 jest.mock('@react-navigation/native', () => ({
-    ...jest.requireActual<typeof import('@react-navigation/native')>('@react-navigation/native'),
+    ...jest.requireActual<typeof ReactNavigationNative>('@react-navigation/native'),
     useIsFocused: () => false,
 }));
 

--- a/tests/unit/AccessOrNotFoundWrapperTest.tsx
+++ b/tests/unit/AccessOrNotFoundWrapperTest.tsx
@@ -1,6 +1,6 @@
 import {act, render, screen} from '@testing-library/react-native';
 import React from 'react';
-import {Text} from 'react-native';
+import {View} from 'react-native';
 import Onyx from 'react-native-onyx';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import Navigation from '@libs/Navigation/Navigation';
@@ -22,10 +22,10 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     isNavigationReady: jest.fn(() => Promise.resolve()),
 }));
 
-jest.mock('@react-navigation/native', () => {
-    const actual = jest.requireActual('@react-navigation/native');
-    return {...actual, useIsFocused: () => false};
-});
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual<typeof import('@react-navigation/native')>('@react-navigation/native'),
+    useIsFocused: () => false,
+}));
 
 jest.mock('@hooks/useIsWorkspacesTabFocused', () => ({__esModule: true, default: () => false}));
 jest.mock('@hooks/useNetwork', () => ({__esModule: true, default: () => ({isOffline: false})}));
@@ -55,7 +55,7 @@ function renderWrapper() {
     return render(
         <OnyxListItemProvider>
             <AccessOrNotFoundWrapper policyID={POLICY_ID}>
-                <Text>CHILDREN</Text>
+                <View testID="wrapper-children" />
             </AccessOrNotFoundWrapper>
         </OnyxListItemProvider>,
     );
@@ -105,7 +105,7 @@ describe('AccessOrNotFoundWrapper', () => {
         renderWrapper();
         await waitForBatchedUpdatesWithAct();
 
-        expect(screen.getByText('CHILDREN')).toBeTruthy();
+        expect(screen.getByTestId('wrapper-children')).toBeTruthy();
         expect(scheduledRemovals).toBe(0);
         expect(Navigation.removeScreenFromNavigationState).not.toHaveBeenCalled();
     });

--- a/tests/unit/AccessOrNotFoundWrapperTest.tsx
+++ b/tests/unit/AccessOrNotFoundWrapperTest.tsx
@@ -1,0 +1,143 @@
+import {act, render, screen} from '@testing-library/react-native';
+import React from 'react';
+import {Text} from 'react-native';
+import Onyx from 'react-native-onyx';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import Navigation from '@libs/Navigation/Navigation';
+import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+import type Policy from '@src/types/onyx/Policy';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+const POLICY_ID = 'A1B2C3D4E5F6';
+const LOGIN = 'me@expensify.com';
+const REMOVAL_DELAY = CONST.WORKSPACE_INACCESSIBLE_SCREEN_REMOVAL_DELAY;
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    removeScreenFromNavigationState: jest.fn(),
+    goBack: jest.fn(),
+    setNavigationActionToMicrotaskQueue: jest.fn((callback: () => void) => callback?.()),
+    isNavigationReady: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@react-navigation/native', () => {
+    const actual = jest.requireActual('@react-navigation/native');
+    return {...actual, useIsFocused: () => false};
+});
+
+jest.mock('@hooks/useIsWorkspacesTabFocused', () => ({__esModule: true, default: () => false}));
+jest.mock('@hooks/useNetwork', () => ({__esModule: true, default: () => ({isOffline: false})}));
+jest.mock('@hooks/usePreferredPolicy', () => ({__esModule: true, default: () => ({isRestrictedToPreferredPolicy: false})}));
+jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({__esModule: true, default: () => ({login: 'me@expensify.com'})}));
+jest.mock('@libs/actions/Policy/Policy', () => ({openWorkspace: jest.fn()}));
+
+const accessiblePolicy = {id: POLICY_ID, name: 'Workspace', type: CONST.POLICY.TYPE.TEAM, owner: LOGIN, role: CONST.POLICY.ROLE.ADMIN} as Policy;
+// Same workspace mid-sync: a full policy replacement that momentarily carries no resolvable role for the current user.
+const inaccessiblePolicy = {id: POLICY_ID, name: 'Workspace', type: CONST.POLICY.TYPE.TEAM, owner: LOGIN, employeeList: {}} as Policy;
+
+// We intercept only the wrapper's debounce timer (identified by its delay) so the removal can be fired deterministically,
+// while every other setTimeout/clearTimeout (e.g. Onyx internals) keeps using the real implementation.
+const FAKE_TIMER_ID = 987654 as unknown as ReturnType<typeof setTimeout>;
+let removalCallback: (() => void) | undefined;
+let scheduledRemovals = 0;
+let clearedRemovals = 0;
+
+function setPolicy(policy: Policy | null) {
+    return act(async () => {
+        await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);
+        await waitForBatchedUpdatesWithAct();
+    });
+}
+
+function renderWrapper() {
+    return render(
+        <OnyxListItemProvider>
+            <AccessOrNotFoundWrapper policyID={POLICY_ID}>
+                <Text>CHILDREN</Text>
+            </AccessOrNotFoundWrapper>
+        </OnyxListItemProvider>,
+    );
+}
+
+describe('AccessOrNotFoundWrapper', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        removalCallback = undefined;
+        scheduledRemovals = 0;
+        clearedRemovals = 0;
+
+        const realSetTimeout = global.setTimeout;
+        jest.spyOn(global, 'setTimeout').mockImplementation(((callback: () => void, delay?: number, ...args: unknown[]) => {
+            if (delay === REMOVAL_DELAY) {
+                scheduledRemovals++;
+                removalCallback = callback;
+                return FAKE_TIMER_ID;
+            }
+            return realSetTimeout(callback, delay, ...args);
+        }) as typeof setTimeout);
+
+        const realClearTimeout = global.clearTimeout;
+        jest.spyOn(global, 'clearTimeout').mockImplementation(((id?: ReturnType<typeof setTimeout>) => {
+            if (id === FAKE_TIMER_ID) {
+                clearedRemovals++;
+                removalCallback = undefined;
+                return;
+            }
+            return realClearTimeout(id);
+        }) as typeof clearTimeout);
+
+        await Onyx.clear();
+        await Onyx.set(ONYXKEYS.IS_LOADING_REPORT_DATA, false);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('does not schedule a teardown while the policy is accessible', async () => {
+        await setPolicy(accessiblePolicy);
+        renderWrapper();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByText('CHILDREN')).toBeTruthy();
+        expect(scheduledRemovals).toBe(0);
+        expect(Navigation.removeScreenFromNavigationState).not.toHaveBeenCalled();
+    });
+
+    it('tears down the workspace screen when the policy stays inaccessible (genuine removal)', async () => {
+        await setPolicy(inaccessiblePolicy);
+        renderWrapper();
+        await waitForBatchedUpdatesWithAct();
+
+        // The teardown is deferred, not immediate.
+        expect(scheduledRemovals).toBe(1);
+        expect(Navigation.removeScreenFromNavigationState).not.toHaveBeenCalled();
+
+        // Fire the debounce timer: the policy is still inaccessible, so the screen is removed.
+        act(() => removalCallback?.());
+
+        expect(Navigation.removeScreenFromNavigationState).toHaveBeenCalledTimes(1);
+        expect(Navigation.removeScreenFromNavigationState).toHaveBeenCalledWith(SCREENS.WORKSPACE.INITIAL);
+    });
+
+    it('cancels the teardown when the policy becomes accessible again before the timer fires (transient sync state)', async () => {
+        await setPolicy(inaccessiblePolicy);
+        renderWrapper();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(scheduledRemovals).toBe(1);
+
+        // A follow-up policy update restores the current user's role before the timer fires.
+        await setPolicy(accessiblePolicy);
+
+        expect(clearedRemovals).toBe(1);
+        expect(removalCallback).toBeUndefined();
+        expect(Navigation.removeScreenFromNavigationState).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

Connecting an HR provider like Gusto makes the backend rewrite the policy and reconcile the employee list, pushing several full policy replacements in quick succession. During that burst the policy can momentarily carry no resolvable role for the current user, so `AccessOrNotFoundWrapper` treated the workspace as inaccessible and tore its screen out of the navigation stack — dropping the user onto the underlying report (e.g. `/r/3124502703468827`) instead of the workspace page. It was flaky because it depended on render timing vs. the update burst.

This defers that teardown: if the policy becomes accessible again before the timer fires, the removal is cancelled, so a transient sync state no longer ejects the user. A genuine removal from the workspace stays inaccessible and still closes the page.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90576
PROPOSAL:

### Tests

1. On a Control workspace, enable the HR feature and open Workspace → HR while a report is visible underneath.
2. Click Connect on Gusto and complete the OAuth round trip.
3. Verify that when the popup closes you remain on the workspace HR page, and are not dropped onto the underlying report.
4. The flaky race is covered deterministically by `tests/unit/AccessOrNotFoundWrapperTest.tsx` (transient inaccessible policy must not tear down the workspace screen, genuine removal still does). Run: `npx jest tests/unit/AccessOrNotFoundWrapperTest.tsx`.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable — this only changes client-side navigation behavior when a policy briefly looks inaccessible.

### QA Steps

Same as tests. Note the original symptom is intermittent, so it may take a few connect attempts to observe the pre-fix behavior.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

- [x] I verified that similar component doesn't exist in the codebase
- [x] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [x] I verified that each file is named correctly
- [x] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [x] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [x] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [x] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [x] I verified that all JSX used for rendering exists in the render method
- [x] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videos


https://github.com/user-attachments/assets/e1313c6f-facb-4cb2-a1f0-5f749101b0ef

