### PR TITLE
83856 migrate search report

### DIFF
--- a/contributingGuides/NAVIGATION.md
+++ b/contributingGuides/NAVIGATION.md
@@ -16,6 +16,14 @@ The navigation in the app is built on top of the `react-navigation` library. To 
   - [Multi-step flows with URL synchronization](#multi-step-flows-with-url-synchronization)
     - [When to use](#when-to-use)
     - [Implementation pattern](#implementation-pattern)
+      - [1. Define your routes](#1-define-your-routes)
+      - [2. Add navigation config](#2-add-navigation-config)
+      - [3. Define page constants](#3-define-page-constants)
+      - [4. Create sub-page components](#4-create-sub-page-components)
+      - [5. Implement the main flow component](#5-implement-the-main-flow-component)
+    - [Using InteractiveStepSubPageHeader](#using-interactivestepsubpageheader)
+      - [6. Handle edit mode](#6-handle-edit-mode)
+      - [7. Skip pages conditionally](#7-skip-pages-conditionally)
   - [Debugging](#debugging)
     - [Reading state when it changes](#reading-state-when-it-changes)
     - [Finding the code that calls the navigation function](#finding-the-code-that-calls-the-navigation-function)
@@ -25,14 +33,22 @@ The navigation in the app is built on top of the `react-navigation` library. To 
     - [When not to use dynamic routes](#when-not-to-use-dynamic-routes)
     - [Dynamic routes configuration](#dynamic-routes-configuration)
     - [Entry screens (access control)](#entry-screens-access-control)
-    - [Current limitations (work in progress)](#current-limitations-work-in-progress)
+      - [Wildcard access (`'*'`)](#wildcard-access-)
+    - [Optional path parameters](#optional-path-parameters)
+      - [Configuration example](#configuration-example)
+      - [Suffix resolution (`findAllMatchingDynamicSuffixes`)](#suffix-resolution-findallmatchingdynamicsuffixes)
+      - [Precedence rules](#precedence-rules)
     - [Multi-segment dynamic routes](#multi-segment-dynamic-routes)
     - [Suffix layering (stacking dynamic routes)](#suffix-layering-stacking-dynamic-routes)
+      - [Authorization per layer](#authorization-per-layer)
+      - [Configuration example](#configuration-example-1)
+      - [Multi-segment suffixes in layered paths](#multi-segment-suffixes-in-layered-paths)
     - [Dynamic routes with query parameters](#dynamic-routes-with-query-parameters)
+      - [How to add query parameters to a dynamic route](#how-to-add-query-parameters-to-a-dynamic-route)
     - [How to add a new dynamic route](#how-to-add-a-new-dynamic-route)
     - [Migrating from backTo to dynamic routes](#migrating-from-backto-to-dynamic-routes)
     - [Backward compatibility for changed paths](#backward-compatibility-for-changed-paths)
-  - [How to remove backTo from URL (Legacy)](#how-to-remove-backto-from-url)
+  - [How to remove backTo from URL](#how-to-remove-backto-from-url)
     - [Separating routes for each screen instance](#separating-routes-for-each-screen-instance)
   - [Generating state from a path](#generating-state-from-a-path)
   - [Setting the correct screen underneath RHP](#setting-the-correct-screen-underneath-rhp)
@@ -1105,7 +1121,7 @@ Considerations when removing `backTo` from a URL:
 ```ts
 type ReportScreenNavigationProps =
     | PlatformStackScreenProps<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-    | PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+    | PlatformStackScreenProps<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>;
 ```
 
 An example of a screen that is reused in several flows is `VerifyAccountPage`.

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -788,7 +788,7 @@ const DYNAMIC_ROUTES = {
     SEARCH_REPORT_VIEW: {
         path: 'view/:reportID/:reportActionID?',
         entryScreens: [SCREENS.SEARCH.ROOT, SCREENS.DYNAMIC_SEARCH_REPORT],
-        getRoute: (reportID: string, reportActionID?: string) => (reportActionID ? `view/${reportID}/${reportActionID}` : `view/${reportID}`),
+        getRoute: (reportID?: string, reportActionID?: string) => (reportActionID ? `view/${reportID}/${reportActionID}` : `view/${reportID}`),
     },
 } as const satisfies DynamicRoutes;
 

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -88,7 +88,7 @@ const DYNAMIC_ROUTES = {
             SCREENS.HOME,
             SCREENS.SEARCH.ROOT,
             SCREENS.REPORT,
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
         ],
@@ -113,7 +113,7 @@ const DYNAMIC_ROUTES = {
         path: 'add-bank-account/verify-account',
         entryScreens: [
             SCREENS.SETTINGS.WALLET.ROOT,
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
@@ -148,7 +148,7 @@ const DYNAMIC_ROUTES = {
         path: 'change-workspace-educational',
         entryScreens: [
             SCREENS.REPORT,
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
             SCREENS.REPORT_DETAILS.DYNAMIC_ROOT,
@@ -159,7 +159,7 @@ const DYNAMIC_ROUTES = {
         path: 'edit/policyField/:policyID/:fieldID',
         entryScreens: [
             SCREENS.REPORT,
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
             SCREENS.REPORT_DETAILS.DYNAMIC_ROOT,
@@ -539,7 +539,7 @@ const DYNAMIC_ROUTES = {
     },
     EXPENSIFY_CARD_DETAILS: {
         path: 'expensify-card-details/:cardID/:policyID',
-        entryScreens: [SCREENS.WORKSPACE.EXPENSIFY_CARD, SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.DYNAMIC_PROFILE],
+        entryScreens: [SCREENS.WORKSPACE.EXPENSIFY_CARD, SCREENS.REPORT, SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.DYNAMIC_PROFILE],
         getRoute: (cardID: string, policyID: string) => `expensify-card-details/${cardID}/${policyID}` as const,
     },
     EXPENSIFY_CARD_LIMIT_TYPE: {
@@ -669,12 +669,12 @@ const DYNAMIC_ROUTES = {
     },
     REPORT_DETAILS: {
         path: 'details',
-        entryScreens: [SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.SEARCH.ROOT],
+        entryScreens: [SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.SEARCH.ROOT],
     },
     REPORT_DETAILS_SHARE_CODE: {
         path: 'share-code',
         entryScreens: [
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
@@ -689,12 +689,12 @@ const DYNAMIC_ROUTES = {
     },
     REPORT_DETAILS_EXPORT: {
         path: 'details/export/:connectionName',
-        entryScreens: [SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.SEARCH.ROOT],
+        entryScreens: [SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.SEARCH.ROOT],
         getRoute: (connectionName: ConnectionName) => `details/export/${connectionName as string}` as const,
     },
     REPORT_CHANGE_WORKSPACE: {
         path: 'change-workspace',
-        entryScreens: [SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.SEARCH.ROOT],
+        entryScreens: [SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.SEARCH.ROOT],
     },
     TRAVEL_PUBLIC_DOMAIN_ERROR: {
         path: 'public-domain-error',
@@ -730,17 +730,17 @@ const DYNAMIC_ROUTES = {
     },
     REPORT_CHANGE_APPROVER: {
         path: 'change-approver',
-        entryScreens: [SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
+        entryScreens: [SCREENS.REPORT, SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
     },
     TASK_TITLE: {
         path: 'title',
-        entryScreens: [SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
+        entryScreens: [SCREENS.REPORT, SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
     },
     REPORT_DESCRIPTION: {
         path: 'description',
         entryScreens: [
             SCREENS.REPORT,
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
             SCREENS.REPORT_DETAILS.DYNAMIC_ROOT,
@@ -748,13 +748,13 @@ const DYNAMIC_ROUTES = {
     },
     TASK_ASSIGNEE: {
         path: 'assignee',
-        entryScreens: [SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
+        entryScreens: [SCREENS.REPORT, SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
     },
     PRIVATE_NOTES_LIST: {
         path: 'notes',
         entryScreens: [
             SCREENS.REPORT,
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
             SCREENS.REPORT_DETAILS.DYNAMIC_ROOT,
@@ -767,7 +767,7 @@ const DYNAMIC_ROUTES = {
         path: 'notes-edit/:accountID',
         entryScreens: [
             SCREENS.REPORT,
-            SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+            SCREENS.DYNAMIC_SEARCH_REPORT,
             SCREENS.RIGHT_MODAL.EXPENSE_REPORT,
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
             SCREENS.REPORT_DETAILS.DYNAMIC_ROOT,
@@ -782,8 +782,13 @@ const DYNAMIC_ROUTES = {
     },
     FLAG_COMMENT: {
         path: 'flag/:reportID/:reportActionID',
-        entryScreens: [SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
+        entryScreens: [SCREENS.REPORT, SCREENS.DYNAMIC_SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
         getRoute: (reportID: string, reportActionID: string) => `flag/${reportID}/${reportActionID}`,
+    },
+    SEARCH_REPORT_VIEW: {
+        path: 'view/:reportID/:reportActionID?',
+        entryScreens: [SCREENS.SEARCH.ROOT, SCREENS.DYNAMIC_SEARCH_REPORT],
+        getRoute: (reportID: string, reportActionID?: string) => (reportActionID ? `view/${reportID}/${reportActionID}` : `view/${reportID}`),
     },
 } as const satisfies DynamicRoutes;
 
@@ -824,18 +829,6 @@ const ROUTES = {
                 return baseRoute;
             }
             return `${baseRoute}/${subPage}` as const;
-        },
-    },
-    SEARCH_REPORT: {
-        route: 'search/view/:reportID/:reportActionID?',
-        getRoute: ({reportID, reportActionID, backTo}: {reportID: string | undefined; reportActionID?: string; backTo?: string}) => {
-            if (!reportID) {
-                Log.warn('Invalid reportID is used to build the SEARCH_REPORT route');
-            }
-
-            const baseRoute = reportActionID ? (`search/view/${reportID}/${reportActionID}` as const) : (`search/view/${reportID}` as const);
-
-            return getUrlWithBackToParam(baseRoute, backTo);
         },
     },
 

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -331,6 +331,7 @@ const SCREENS = {
         REFERRAL: 'Referral',
         TRANSACTION_DUPLICATE: 'TransactionDuplicate',
         TRAVEL: 'Travel',
+        SEARCH_REPORT: 'SearchReport',
         SEARCH_REPORT_ACTIONS: 'SearchReportActions',
         SEARCH_MONEY_REQUEST_REPORT: 'SearchMoneyRequestReport',
 

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -331,7 +331,6 @@ const SCREENS = {
         REFERRAL: 'Referral',
         TRANSACTION_DUPLICATE: 'TransactionDuplicate',
         TRAVEL: 'Travel',
-        SEARCH_REPORT: 'SearchReport',
         SEARCH_REPORT_ACTIONS: 'SearchReportActions',
         SEARCH_MONEY_REQUEST_REPORT: 'SearchMoneyRequestReport',
 
@@ -1004,6 +1003,7 @@ const SCREENS = {
         DETAILS: 'RoomMember_Details',
     },
     DYNAMIC_FLAG_COMMENT: 'Dynamic_Flag_Comment',
+    DYNAMIC_SEARCH_REPORT: 'Dynamic_Search_Report',
     DYNAMIC_TASK_TITLE: 'Dynamic_Task_Title',
     DYNAMIC_TASK_ASSIGNEE: 'Dynamic_Task_Assignee',
     DYNAMIC_REPORT_DESCRIPTION: 'Dynamic_Report_Description',

--- a/src/components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/index.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/index.tsx
@@ -8,12 +8,13 @@ import useOnyx from '@hooks/useOnyx';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getReportMentionDetails} from '@libs/MentionUtils';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from '@navigation/Navigation';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import MentionReportContext from './MentionReportContext';
 
@@ -44,9 +45,8 @@ function MentionReportRenderer({style, tnode, TDefaultRenderer, ...defaultRender
     const {reportID, mentionDisplayText} = mentionDetails;
 
     let navigationRoute: Route | undefined = reportID ? ROUTES.REPORT_WITH_ID.getRoute(reportID) : undefined;
-    const backTo = Navigation.getActiveRoute();
     if (isSearchTopmostFullScreenRoute()) {
-        navigationRoute = reportID ? ROUTES.SEARCH_REPORT.getRoute({reportID, backTo}) : undefined;
+        navigationRoute = reportID ? createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID)) : undefined;
     }
     const isCurrentRoomMention = reportID === currentReportIDValue;
 

--- a/src/components/MoneyReportHeader.tsx
+++ b/src/components/MoneyReportHeader.tsx
@@ -81,7 +81,7 @@ function MoneyReportHeaderContent({reportID: reportIDProp, shouldDisplayBackButt
     const shouldShowHeaderButtonsInHeaderRow = isInLandscapeMode || !shouldDisplayNarrowVersion || isWideRHPDisplayedOnWideLayout || isSuperWideRHPDisplayedOnWideLayout;
     const isReportInRHP = route.name !== SCREENS.REPORT;
     const shouldDisplaySearchRouter = !isReportInRHP || isSmallScreenWidth;
-    const isReportInSearch = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT || route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT;
+    const isReportInSearch = route.name === SCREENS.DYNAMIC_SEARCH_REPORT || route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT;
 
     const backTo = (route.params as {backTo?: Route} | undefined)?.backTo;
 

--- a/src/components/MoneyReportHeader.tsx
+++ b/src/components/MoneyReportHeader.tsx
@@ -13,7 +13,7 @@ import useTransactionsAndViolationsForReport from '@hooks/useTransactionsAndViol
 import {turnOffMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
@@ -64,7 +64,7 @@ function MoneyReportHeaderContent({reportID: reportIDProp, shouldDisplayBackButt
         | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.EXPENSE_REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT>
-        | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>
+        | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>
     >();
     const {isOffline} = useNetwork();
 

--- a/src/components/MoneyReportHeaderMoreContent.tsx
+++ b/src/components/MoneyReportHeaderMoreContent.tsx
@@ -36,7 +36,7 @@ function MoneyReportHeaderMoreContent({reportID}: MoneyReportHeaderMoreContentPr
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>
     >();
-    const isReportInSearch = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT || route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT;
+    const isReportInSearch = route.name === SCREENS.DYNAMIC_SEARCH_REPORT || route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT;
 
     const [moneyRequestReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${getNonEmptyStringOnyxID(moneyRequestReport?.policyID)}`);

--- a/src/components/MoneyReportHeaderMoreContent.tsx
+++ b/src/components/MoneyReportHeaderMoreContent.tsx
@@ -10,7 +10,7 @@ import useResponsiveLayoutOnWideRHP from '@hooks/useResponsiveLayoutOnWideRHP';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import {isInvoiceReport as isInvoiceReportUtil} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -34,7 +34,7 @@ function MoneyReportHeaderMoreContent({reportID}: MoneyReportHeaderMoreContentPr
         | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.EXPENSE_REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT>
-        | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>
+        | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>
     >();
     const isReportInSearch = route.name === SCREENS.DYNAMIC_SEARCH_REPORT || route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT;
 

--- a/src/components/MoneyRequestHeader.tsx
+++ b/src/components/MoneyRequestHeader.tsx
@@ -89,7 +89,7 @@ function MoneyRequestHeader({reportID: reportIDProp, onBackButtonPress}: MoneyRe
     const shouldShowBrokenConnectionViolation = shouldShowBrokenConnectionViolationTransactionUtils(parentReport, policy, transactionViolations);
 
     const reportID = report?.reportID;
-    const isReportInRHP = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+    const isReportInRHP = route.name === SCREENS.DYNAMIC_SEARCH_REPORT;
     const isFromReviewDuplicates = !!route.params.backTo?.replaceAll(/\?.*/g, '').endsWith('/duplicates/review');
     const shouldDisplayTransactionNavigation = !!(reportID && isReportInRHP);
     const shouldOpenParentReportInCurrentTab = !isSelfDM(parentReport);

--- a/src/components/MoneyRequestHeader.tsx
+++ b/src/components/MoneyRequestHeader.tsx
@@ -15,7 +15,7 @@ import useTransactionViolations from '@hooks/useTransactionViolations';
 import {isPersonalCard} from '@libs/CardUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {isMarkAsResolvedAction} from '@libs/ReportPrimaryActionUtils';
 import {isSelfDM, isSettled as isSettledReportUtils} from '@libs/ReportUtils';
@@ -61,7 +61,7 @@ function MoneyRequestHeader({reportID: reportIDProp, onBackButtonPress}: MoneyRe
     const {shouldUseNarrowLayout, isSmallScreenWidth} = useResponsiveLayout();
     const route = useRoute<
         | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-        | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>
+        | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT>
     >();
     const [parentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.parentReportID}`);
@@ -90,7 +90,7 @@ function MoneyRequestHeader({reportID: reportIDProp, onBackButtonPress}: MoneyRe
 
     const reportID = report?.reportID;
     const isReportInRHP = route.name === SCREENS.DYNAMIC_SEARCH_REPORT;
-    const isFromReviewDuplicates = !!route.params.backTo?.replaceAll(/\?.*/g, '').endsWith('/duplicates/review');
+    const isFromReviewDuplicates = !!('backTo' in route.params && route.params.backTo?.replaceAll(/\?.*/g, '').endsWith('/duplicates/review'));
     const shouldDisplayTransactionNavigation = !!(reportID && isReportInRHP);
     const shouldOpenParentReportInCurrentTab = !isSelfDM(parentReport);
     const shouldDisplayButtonsInSeparateLine = useShouldDisplayButtonsInSeparateLine() && (wideRHPRouteKeys.length === 0 || isSmallScreenWidth);

--- a/src/components/MoneyRequestHeaderActions.tsx
+++ b/src/components/MoneyRequestHeaderActions.tsx
@@ -5,7 +5,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useShouldDisplayButtonsInSeparateLine from '@hooks/useShouldDisplayButtonsInSeparateLine';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import SCREENS from '@src/SCREENS';
 import MoneyRequestHeaderPrimaryAction from './MoneyRequestHeaderPrimaryAction';
 import MoneyRequestHeaderSecondaryActions from './MoneyRequestHeaderSecondaryActions';
@@ -26,7 +26,7 @@ function MoneyRequestHeaderActions({reportID, onBackButtonPress}: MoneyRequestHe
     const {wideRHPRouteKeys} = useWideRHPState();
     const route = useRoute<
         | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-        | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>
+        | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT>
     >();
 

--- a/src/components/MoneyRequestHeaderActions.tsx
+++ b/src/components/MoneyRequestHeaderActions.tsx
@@ -32,7 +32,7 @@ function MoneyRequestHeaderActions({reportID, onBackButtonPress}: MoneyRequestHe
 
     const shouldDisplayButtonsInSeparateLine = useShouldDisplayButtonsInSeparateLine();
     const shouldDisplayNarrowButtons = !shouldDisplayButtonsInSeparateLine || (wideRHPRouteKeys.length > 0 && !isSmallScreenWidth);
-    const shouldDisplayTransactionNavigation = !!(reportID && route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT);
+    const shouldDisplayTransactionNavigation = !!(reportID && route.name === SCREENS.DYNAMIC_SEARCH_REPORT);
 
     return (
         <View

--- a/src/components/MoneyRequestHeaderPrimaryAction.tsx
+++ b/src/components/MoneyRequestHeaderPrimaryAction.tsx
@@ -14,7 +14,7 @@ import {markRejectViolationAsResolved} from '@libs/actions/IOU/RejectMoneyReques
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {getTransactionThreadPrimaryAction} from '@libs/ReportPrimaryActionUtils';
 import {changeMoneyRequestHoldStatus} from '@libs/ReportUtils';
@@ -45,14 +45,14 @@ function MoneyRequestHeaderPrimaryAction({reportID}: MoneyRequestHeaderPrimaryAc
     const {wideRHPRouteKeys} = useWideRHPState();
     const route = useRoute<
         | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-        | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>
+        | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT>
     >();
 
     const shouldUseDesktopLayout = !useShouldDisplayButtonsInSeparateLine();
     const isNarrowButton = shouldUseDesktopLayout || (wideRHPRouteKeys.length > 0 && !isSmallScreenWidth);
     const {isOffline} = useNetwork();
-    const isFromReviewDuplicates = !!route.params.backTo?.replaceAll(/\?.*/g, '').endsWith('/duplicates/review');
+    const isFromReviewDuplicates = !!('backTo' in route.params && route.params.backTo?.replaceAll(/\?.*/g, '').endsWith('/duplicates/review'));
 
     // Per-key Onyx subscriptions
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);

--- a/src/components/MoneyRequestHeaderSecondaryActions.tsx
+++ b/src/components/MoneyRequestHeaderSecondaryActions.tsx
@@ -37,7 +37,7 @@ import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getExistingTransactionID} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import {sortAndSectionPopoverMenuItems, TRANSACTION_MORE_MENU_SECTIONS} from '@libs/PopoverMenuSections';
 import {getOriginalMessage, isMoneyRequestAction, isTrackExpenseAction} from '@libs/ReportActionsUtils';
 import {getTransactionThreadPrimaryAction} from '@libs/ReportPrimaryActionUtils';
@@ -92,7 +92,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
     const {isInNarrowPaneModal, isSmallScreenWidth} = useResponsiveLayout();
     const route = useRoute<
         | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-        | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>
+        | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>
         | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT>
     >();
     const styles = useThemeStyles();
@@ -441,7 +441,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
                     if (!parentReportAction || !transaction) {
                         throw new Error('Data missing');
                     }
-                    const backToRoute = route.params?.backTo ?? Navigation.getActiveRoute();
+                    const backToRoute = ('backTo' in route.params ? route.params.backTo : undefined) ?? Navigation.getActiveRoute();
                     setDeleteTransactionNavigateBackUrl(backToRoute);
                     if (isTrackExpenseAction(parentReportAction) && !isExpenseSplit) {
                         deleteTrackExpense({

--- a/src/components/MoneyRequestHeaderSecondaryActions.tsx
+++ b/src/components/MoneyRequestHeaderSecondaryActions.tsx
@@ -168,7 +168,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
     const {currentSearchHash} = useSearchQueryContext();
     const {removeTransaction} = useSearchSelectionActions();
     const {duplicateTransactions, duplicateTransactionViolations} = useDuplicateTransactionsAndViolations(transaction?.transactionID ? [transaction.transactionID] : []);
-    const isReportInSearch = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT || route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT;
+    const isReportInSearch = route.name === SCREENS.DYNAMIC_SEARCH_REPORT || route.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT;
     const {getCurrencyDecimals} = useCurrencyListActions();
 
     // State

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -43,6 +43,7 @@ import {getReportLayoutGroupBy, setReportLayoutGroupBy} from '@libs/actions/Repo
 import {clearActiveTransactionIDs, setActiveTransactionIDs} from '@libs/actions/TransactionThreadNavigation';
 import {resolveTransactionCardFields} from '@libs/CardUtils';
 import {hasNonReimbursableTransactions, isBillableEnabledOnPolicy} from '@libs/MoneyRequestReportUtils';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import {navigationRef} from '@libs/Navigation/Navigation';
 import {isPolicyTaxEnabled} from '@libs/PolicyUtils';
 import {getIOUActionForTransactionID} from '@libs/ReportActionsUtils';
@@ -74,7 +75,7 @@ import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
@@ -443,7 +444,7 @@ function MoneyRequestReportTransactionList({
 
     useEffect(() => {
         const focusedRoute = findFocusedRoute(navigationRef.getRootState());
-        if (focusedRoute?.name !== SCREENS.RIGHT_MODAL.SEARCH_REPORT) {
+        if (focusedRoute?.name !== SCREENS.DYNAMIC_SEARCH_REPORT) {
             return;
         }
         setActiveTransactionIDs(visualOrderTransactionIDs);
@@ -508,6 +509,7 @@ function MoneyRequestReportTransactionList({
 
             const routeParams = {
                 reportID: reportIDToNavigate,
+                reportActionID: iouAction?.reportActionID,
                 backTo,
             } as ReportScreenNavigationProps;
 
@@ -536,7 +538,7 @@ function MoneyRequestReportTransactionList({
                 if (reportIDToNavigate) {
                     markReportIDAsExpense(reportIDToNavigate);
                 }
-                Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute(routeParams));
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(routeParams.reportID, routeParams.reportActionID)));
             });
         },
         [reportActions, visualOrderTransactionIDs, sortedTransactions, report, markReportIDAsExpense, introSelected, betas, currentUserDetails.email, currentUserDetails.accountID],

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
@@ -104,7 +104,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
     useEffect(() => {
         return () => {
             const focusedRoute = findFocusedRoute(navigationRef.getRootState());
-            if (focusedRoute?.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT || focusedRoute?.name === SCREENS.TRANSACTION_DUPLICATE.REVIEW) {
+            if (focusedRoute?.name === SCREENS.DYNAMIC_SEARCH_REPORT || focusedRoute?.name === SCREENS.TRANSACTION_DUPLICATE.REVIEW) {
                 return;
             }
             clearActiveTransactionIDs();

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
@@ -8,7 +8,6 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useOnyx from '@hooks/useOnyx';
 import {createTransactionThreadReport, setOptimisticTransactionThread} from '@libs/actions/Report';
 import {clearActiveTransactionIDs} from '@libs/actions/TransactionThreadNavigation';
-import type {RightModalNavigatorParamList} from '@libs/Navigation/types';
 import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import Navigation from '@navigation/Navigation';
 import navigationRef from '@navigation/navigationRef';
@@ -121,7 +120,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         let backTo = Navigation.getActiveRoute();
         if (isFromReviewDuplicates) {
             const currentRoute = navigationRef.getCurrentRoute();
-            const params = currentRoute?.params as RightModalNavigatorParamList[typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT] | undefined;
+                const params = currentRoute?.params as {backTo?: string} | undefined;
             backTo = params?.backTo ?? backTo;
         }
         const nextThreadReportID = nextParentReportAction?.childReportID;
@@ -157,7 +156,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         let backTo = Navigation.getActiveRoute();
         if (isFromReviewDuplicates) {
             const currentRoute = navigationRef.getCurrentRoute();
-            const params = currentRoute?.params as RightModalNavigatorParamList[typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT] | undefined;
+                const params = currentRoute?.params as {backTo?: string} | undefined;
             backTo = params?.backTo ?? backTo;
         }
         const prevThreadReportID = prevParentReportAction?.childReportID;

--- a/src/components/ParentNavigationSubtitle.tsx
+++ b/src/components/ParentNavigationSubtitle.tsx
@@ -10,6 +10,7 @@ import useRootNavigationState from '@hooks/useRootNavigationState';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import {isFullScreenName} from '@libs/Navigation/helpers/isNavigatorName';
 import Navigation from '@libs/Navigation/Navigation';
 import type {RightModalNavigatorParamList} from '@libs/Navigation/types';
@@ -19,7 +20,7 @@ import CONST from '@src/CONST';
 import type {ParentNavigationSummaryParams} from '@src/languages/params';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import StatusBadge from './StatusBadge';
 import Text from './Text';
@@ -104,7 +105,7 @@ function ParentNavigationSubtitle({
     const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
     const isReportArchived = useReportIsArchived(report?.reportID);
     const canUserPerformWriteAction = canUserPerformWriteActionReportUtils(report, isReportArchived);
-    const isReportInRHP = currentRoute.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+    const isReportInRHP = currentRoute.name === SCREENS.DYNAMIC_SEARCH_REPORT;
     const hasAccessToParentReport = currentReport?.hasParentAccess !== false;
     const {currentFullScreenRoute, currentFocusedNavigator} = useRootNavigationState((state) => {
         // Find the tab navigator, which wraps all full-screen navigators
@@ -178,7 +179,7 @@ function ParentNavigationSubtitle({
         if (openParentReportInCurrentTab && currentFocusedNavigator?.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR) {
             const lastRoute = currentFocusedNavigator?.state?.routes.at(-1);
             if (lastRoute?.name === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT) {
-                Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: parentReportID, reportActionID: parentReportActionID}));
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(parentReportID, parentReportActionID)));
                 return;
             }
 
@@ -186,7 +187,7 @@ function ParentNavigationSubtitle({
             // avoid stacking RHPs by going back to the search report if it's already there
             const previousRoute = currentFocusedNavigator?.state?.routes.at(-2);
 
-            if (previousRoute?.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT && previousRoute.params && 'reportID' in previousRoute.params) {
+            if (previousRoute?.name === SCREENS.DYNAMIC_SEARCH_REPORT && previousRoute.params && 'reportID' in previousRoute.params) {
                 const reportIDFromParams = previousRoute.params.reportID;
 
                 if (reportIDFromParams === parentReportID) {
@@ -216,7 +217,7 @@ function ParentNavigationSubtitle({
             // and the parent isn't already in the stack — otherwise the REPORT_WITH_ID fallback
             // would yank the user to Inbox.
             if (isReportInRHP) {
-                Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: parentReportID, reportActionID: isVisibleAction ? parentReportActionID : undefined}));
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(parentReportID, isVisibleAction ? parentReportActionID : undefined)));
                 return;
             }
         }

--- a/src/components/ReportActionItem/MoneyRequestAction.tsx
+++ b/src/components/ReportActionItem/MoneyRequestAction.tsx
@@ -10,6 +10,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {createTransactionThreadReport} from '@libs/actions/Report';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {TransactionDuplicateNavigatorParamList} from '@libs/Navigation/types';
@@ -26,7 +27,7 @@ import {useReportActionItemActions, useReportActionItemState} from '@pages/inbox
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
 import TransactionPreview from './TransactionPreview';
@@ -103,7 +104,7 @@ function MoneyRequestAction({action, chatReportID, requestReportID, reportID, is
                 iouReportAction: action,
             });
             if (shouldOpenReportInRHP) {
-                Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: transactionThreadReport?.reportID, backTo: Navigation.getActiveRoute()}));
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(transactionThreadReport?.reportID ?? '')));
                 return;
             }
             Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(transactionThreadReport?.reportID, undefined, undefined, Navigation.getActiveRoute()));
@@ -111,7 +112,7 @@ function MoneyRequestAction({action, chatReportID, requestReportID, reportID, is
         }
 
         if (shouldOpenReportInRHP) {
-            Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: action?.childReportID, backTo: Navigation.getActiveRoute()}));
+            Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(action?.childReportID ?? '')));
             return;
         }
 

--- a/src/components/ScreenWrapper/index.tsx
+++ b/src/components/ScreenWrapper/index.tsx
@@ -24,7 +24,7 @@ import mergeRefs from '@libs/mergeRefs';
 import NarrowPaneContext from '@libs/Navigation/AppNavigator/Navigators/NarrowPaneContext';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackNavigationProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, RootNavigatorParamList} from '@libs/Navigation/types';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList, RootNavigatorParamList, SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import {shouldHideOldAppRedirect} from '@libs/TryNewDotUtils';
 import {closeReactNativeApp} from '@userActions/HybridApp';
 import CONFIG from '@src/CONFIG';
@@ -58,7 +58,8 @@ type ScreenWrapperProps = Omit<ScreenWrapperContainerProps, 'children'> &
         navigation?:
             | PlatformStackNavigationProp<RootNavigatorParamList>
             | PlatformStackNavigationProp<ReportsSplitNavigatorParamList>
-            | PlatformStackNavigationProp<RightModalNavigatorParamList>;
+            | PlatformStackNavigationProp<RightModalNavigatorParamList>
+            | PlatformStackNavigationProp<SearchReportNavigatorParamList>;
 
         /** A unique ID to find the screen wrapper in tests */
         testID: string;

--- a/src/components/ScrollOffsetContextProvider.tsx
+++ b/src/components/ScrollOffsetContextProvider.tsx
@@ -108,7 +108,7 @@ function ScrollOffsetContextProvider({children}: ScrollOffsetContextProviderProp
 
             const isSearchScreen = routeName === SCREENS.SEARCH.ROOT;
             const isSearchMoneyRequestReport =
-                routeName === SCREENS.RIGHT_MODAL.EXPENSE_REPORT || routeName === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT || routeName === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+                routeName === SCREENS.RIGHT_MODAL.EXPENSE_REPORT || routeName === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT || routeName === SCREENS.DYNAMIC_SEARCH_REPORT;
 
             const scrollOffsetKeys = Object.keys(scrollOffsetsRef.current);
 

--- a/src/components/Search/SearchList/ListItem/TransactionGroupListExpanded.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionGroupListExpanded.tsx
@@ -34,7 +34,7 @@ import type {TransactionPreviewData} from '@userActions/Search';
 import {setActiveTransactionIDs} from '@userActions/TransactionThreadNavigation';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import {columnsSelector} from '@src/selectors/AdvancedSearchFiltersForm';
 import {hasCompletedGuidedSetupFlowSelector, hasSeenTourSelector} from '@src/selectors/Onboarding';
 import type * as OnyxTypes from '@src/types/onyx';

--- a/src/components/Search/SearchList/ListItem/TransactionGroupListExpanded.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionGroupListExpanded.tsx
@@ -21,6 +21,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getReportIDForTransaction} from '@libs/MoneyRequestReportUtils';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import openInternalRouteInNewTab, {isModifiedMousePress} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
 import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
 import Navigation from '@libs/Navigation/Navigation';
@@ -33,7 +34,7 @@ import type {TransactionPreviewData} from '@userActions/Search';
 import {setActiveTransactionIDs} from '@userActions/TransactionThreadNavigation';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import {columnsSelector} from '@src/selectors/AdvancedSearchFiltersForm';
 import {hasCompletedGuidedSetupFlowSelector, hasSeenTourSelector} from '@src/selectors/Onboarding';
 import type * as OnyxTypes from '@src/types/onyx';
@@ -178,7 +179,7 @@ function TransactionGroupListExpanded<TItem extends ListItem>({
                         shouldNavigate: false,
                     });
                     if (targetReportID) {
-                        openInternalRouteInNewTab(ROUTES.SEARCH_REPORT.getRoute({reportID: targetReportID, backTo}), event);
+                        openInternalRouteInNewTab(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(targetReportID)), event);
                     }
                     return;
                 }
@@ -196,7 +197,7 @@ function TransactionGroupListExpanded<TItem extends ListItem>({
                 return;
             }
             markReportIDAsExpense(reportID);
-            const route = ROUTES.SEARCH_REPORT.getRoute({reportID, backTo});
+            const route = createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID));
             if (openInternalRouteInNewTab(route, event)) {
                 return;
             }

--- a/src/components/Search/SearchStaticList.tsx
+++ b/src/components/Search/SearchStaticList.tsx
@@ -29,12 +29,13 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {hasDeferredWrite} from '@libs/deferredLayoutWrite';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import {getReportStatusColorStyle, getReportStatusTranslation, isOneTransactionReport} from '@libs/ReportUtils';
 import {createAndOpenSearchTransactionThread, getSections, getSortedSections, getValidGroupBy} from '@libs/SearchUIUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import {hasCompletedGuidedSetupFlowSelector, hasSeenTourSelector} from '@src/selectors/Onboarding';
 import type {SearchResults} from '@src/types/onyx';
 import type {TransactionListItemType} from './SearchList/ListItem/types';
@@ -162,7 +163,7 @@ function SearchStaticList({
             return;
         }
 
-        requestAnimationFrame(() => Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID, backTo})));
+        requestAnimationFrame(() => Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID))));
     };
 
     const renderItem = ({item, index}: ListRenderItemInfo<TransactionListItemType>) => {

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -37,6 +37,7 @@ import type {TransactionPreviewData} from '@libs/actions/Search';
 import {setOptimisticDataForTransactionThreadPreview} from '@libs/actions/Search';
 import {flushDeferredWrite, hasDeferredWrite} from '@libs/deferredLayoutWrite';
 import Log from '@libs/Log';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import openInternalRouteInNewTab, {isModifiedMousePress} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
 import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
@@ -77,7 +78,7 @@ import EmptySearchView from '@pages/Search/EmptySearchView';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import {columnsSelector} from '@src/selectors/AdvancedSearchFiltersForm';
 import {hasCompletedGuidedSetupFlowSelector, hasSeenTourSelector} from '@src/selectors/Onboarding';
@@ -1211,7 +1212,7 @@ function Search({
                     shouldNavigate: shouldOpenTransactionThread && !shouldOpenTransactionThreadInNewTab,
                 });
                 if (shouldOpenTransactionThreadInNewTab && targetReportID) {
-                    openInternalRouteInNewTab(ROUTES.SEARCH_REPORT.getRoute({reportID: targetReportID, backTo}), event);
+                    openInternalRouteInNewTab(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(targetReportID)), event);
                 }
                 if (shouldOpenTransactionThread) {
                     return;
@@ -1308,7 +1309,7 @@ function Search({
                     isCreatedTaskReportAction(reportActionItem) && (isOptimisticCreatedTaskAction || reportActionItem.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
 
                 const reportActionID = shouldSkipReportActionID ? undefined : reportActionItem.reportActionID;
-                const route = ROUTES.SEARCH_REPORT.getRoute({reportID, reportActionID, backTo});
+                const route = createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID, reportActionID));
                 if (openInternalRouteInNewTab(route, event)) {
                     return;
                 }
@@ -1317,7 +1318,7 @@ function Search({
             }
 
             if (isTaskListItemType(item)) {
-                const route = ROUTES.SEARCH_REPORT.getRoute({reportID, backTo});
+                const route = createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID));
                 if (openInternalRouteInNewTab(route, event)) {
                     return;
                 }
@@ -1331,7 +1332,7 @@ function Search({
                 setOptimisticDataForTransactionThreadPreview(transactionItem, transactionPreviewData, transactionItem?.reportAction?.childReportID);
             }
 
-            const route = ROUTES.SEARCH_REPORT.getRoute({reportID, backTo});
+            const route = createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID));
             if (openInternalRouteInNewTab(route, event)) {
                 return;
             }

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -34,8 +34,8 @@ import {
 import initSplitExpense from '@libs/actions/SplitExpenses';
 import {setNameValuePair} from '@libs/actions/User';
 import {getTransactionsAndReportsFromSearch} from '@libs/MergeTransactionUtils';
-import Navigation from '@libs/Navigation/Navigation';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
+import Navigation from '@libs/Navigation/Navigation';
 import {getLoginByAccountID} from '@libs/PersonalDetailsUtils';
 import {getConnectedIntegration} from '@libs/PolicyUtils';
 import {getSecondaryExportReportActions, isMergeActionForSelectedTransactions} from '@libs/ReportSecondaryActionUtils';
@@ -866,8 +866,6 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 return;
             }
 
-            const activeRoute = Navigation.getActiveRoute();
-
             for (const item of selectedOptions) {
                 const itemPolicyID = item.policyID;
                 const itemReportID = item.reportID;
@@ -894,14 +892,14 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 const hasSelectedBusinessBankAccount = expenseReportBankAccountID != null;
 
                 if (isExpenseReport && lastPolicyPaymentMethod !== CONST.IOU.PAYMENT_TYPE.ELSEWHERE && !hasPolicyVBBA && !hasSelectedBusinessBankAccount) {
-                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(item.reportID)));
+                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(itemReportID)));
                     return;
                 }
                 const isPolicyPaymentMethod = !Object.values(CONST.IOU.PAYMENT_TYPE).includes(lastPolicyPaymentMethod as ValueOf<typeof CONST.IOU.PAYMENT_TYPE>);
                 if (isPolicyPaymentMethod && isIOUReport) {
                     const adminPolicy = policies?.[`${ONYXKEYS.COLLECTION.POLICY}${lastPolicyPaymentMethod}`];
                     if (!adminPolicy) {
-                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(item.reportID)));
+                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(itemReportID)));
                         return;
                     }
                     const invite = moveIOUReportToPolicyAndInviteSubmitter(

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -35,6 +35,7 @@ import initSplitExpense from '@libs/actions/SplitExpenses';
 import {setNameValuePair} from '@libs/actions/User';
 import {getTransactionsAndReportsFromSearch} from '@libs/MergeTransactionUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import {getLoginByAccountID} from '@libs/PersonalDetailsUtils';
 import {getConnectedIntegration} from '@libs/PolicyUtils';
 import {getSecondaryExportReportActions, isMergeActionForSelectedTransactions} from '@libs/ReportSecondaryActionUtils';
@@ -73,7 +74,7 @@ import {dismissRejectUseExplanation} from '@userActions/IOU/RejectMoneyRequest';
 import {canIOUBePaid} from '@userActions/IOU/ReportWorkflow';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {BillingGraceEndPeriod, Policy, Report, ReportNameValuePairs, SearchResults, Transaction, TransactionViolations} from '@src/types/onyx';
 import type {SearchResultDataType} from '@src/types/onyx/SearchResults';
 import type DeepValueOf from '@src/types/utils/DeepValueOf';
@@ -880,12 +881,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 const lastPolicyPaymentMethod = paymentMethod ?? getLastPolicyPaymentMethod(itemPolicyID, personalPolicyID, lastPaymentMethods, reportType, isIOUReport);
 
                 if (!lastPolicyPaymentMethod) {
-                    Navigation.navigate(
-                        ROUTES.SEARCH_REPORT.getRoute({
-                            reportID: itemReportID,
-                            backTo: activeRoute,
-                        }),
-                    );
+                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(itemReportID)));
                     return;
                 }
 
@@ -898,24 +894,14 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 const hasSelectedBusinessBankAccount = expenseReportBankAccountID != null;
 
                 if (isExpenseReport && lastPolicyPaymentMethod !== CONST.IOU.PAYMENT_TYPE.ELSEWHERE && !hasPolicyVBBA && !hasSelectedBusinessBankAccount) {
-                    Navigation.navigate(
-                        ROUTES.SEARCH_REPORT.getRoute({
-                            reportID: item.reportID,
-                            backTo: activeRoute,
-                        }),
-                    );
+                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(item.reportID)));
                     return;
                 }
                 const isPolicyPaymentMethod = !Object.values(CONST.IOU.PAYMENT_TYPE).includes(lastPolicyPaymentMethod as ValueOf<typeof CONST.IOU.PAYMENT_TYPE>);
                 if (isPolicyPaymentMethod && isIOUReport) {
                     const adminPolicy = policies?.[`${ONYXKEYS.COLLECTION.POLICY}${lastPolicyPaymentMethod}`];
                     if (!adminPolicy) {
-                        Navigation.navigate(
-                            ROUTES.SEARCH_REPORT.getRoute({
-                                reportID: item.reportID,
-                                backTo: activeRoute,
-                            }),
-                        );
+                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(item.reportID)));
                         return;
                     }
                     const invite = moveIOUReportToPolicyAndInviteSubmitter(

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -41,6 +41,7 @@ import type {
     SearchAdvancedFiltersParamList,
     SearchColumnsParamList,
     SearchReportActionsParamList,
+    SearchReportNavigatorParamList,
     SearchSavedSearchParamList,
     SettingsNavigatorParamList,
     ShareNavigatorParamList,
@@ -1158,6 +1159,10 @@ const FlagCommentStackNavigator = createModalStackNavigator<FlagCommentNavigator
     [SCREENS.DYNAMIC_FLAG_COMMENT]: () => require<ReactComponentModule>('../../../../pages/DynamicFlagCommentPage').default,
 });
 
+const SearchReportModalStackNavigator = createModalStackNavigator<SearchReportNavigatorParamList>({
+    [SCREENS.DYNAMIC_SEARCH_REPORT]: () => require<ReactComponentModule>('../../../../pages/inbox/DynamicSearchReportPage').default,
+});
+
 const EditRequestStackNavigator = createModalStackNavigator<EditRequestNavigatorParamList>({
     [SCREENS.EDIT_REQUEST.DYNAMIC_REPORT_FIELD]: () => require<ReactComponentModule>('../../../../pages/DynamicEditReportFieldPage').default,
 });
@@ -1359,6 +1364,7 @@ export {
     SearchAdvancedFiltersModalStackNavigator,
     SearchColumnsModalStackNavigator,
     SearchReportActionsModalStackNavigator,
+    SearchReportModalStackNavigator,
     SearchSavedSearchModalStackNavigator,
     SettingsModalStackNavigator,
     ShareModalStackNavigator,

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -426,7 +426,7 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
                                 />
                                 <Stack.Screen
                                     name={SCREENS.RIGHT_MODAL.SEARCH_REPORT}
-                                    getComponent={loadRHPReportScreen}
+                                    component={ModalStackNavigators.SearchReportModalStackNavigator}
                                     options={(props) => {
                                         const options = modalStackScreenOptions(props);
                                         return {...options, animation: animationEnabledOnSearchReport ? Animations.SLIDE_FROM_RIGHT : Animations.NONE};

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -1167,7 +1167,7 @@ function removePreInsertedFullscreenIfNeeded() {
     });
 }
 
-function getTopmostSearchReportRouteParams(state = navigationRef.getRootState()): RightModalNavigatorParamList[typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT] | undefined {
+function getTopmostSearchReportRouteParams(state = navigationRef.getRootState()): {reportID: string; reportActionID?: string} | undefined {
     if (!state) {
         return undefined;
     }
@@ -1179,8 +1179,12 @@ function getTopmostSearchReportRouteParams(state = navigationRef.getRootState())
 
     const nestedRoutes = lastRoute.state?.routes ?? [];
     const lastSearchReport = [...nestedRoutes].reverse().find((route) => route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT);
+    if (!lastSearchReport?.state?.routes) {
+        return undefined;
+    }
 
-    return lastSearchReport?.params as RightModalNavigatorParamList[typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT] | undefined;
+    const innerRoute = lastSearchReport.state.routes.at(-1);
+    return innerRoute?.params as {reportID: string; reportActionID?: string} | undefined;
 }
 
 function getTopmostSearchReportID(state = navigationRef.getRootState()): string | undefined {

--- a/src/libs/Navigation/helpers/getReportRouteForCurrentContext.ts
+++ b/src/libs/Navigation/helpers/getReportRouteForCurrentContext.ts
@@ -1,6 +1,7 @@
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {Route} from '@src/ROUTES';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import isSearchTopmostFullScreenRoute from './isSearchTopmostFullScreenRoute';
 
 type GetReportRouteForCurrentContextParams = {
@@ -14,7 +15,7 @@ function getReportRouteForCurrentContext({reportID}: GetReportRouteForCurrentCon
 
     const backTo = Navigation.getActiveRoute();
     if (isSearchTopmostFullScreenRoute()) {
-        return ROUTES.SEARCH_REPORT.getRoute({reportID, backTo});
+        return createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID));
     }
 
     return ROUTES.REPORT_WITH_ID.getRoute(reportID, undefined, undefined, backTo);

--- a/src/libs/Navigation/helpers/isReportOpenInRHP.ts
+++ b/src/libs/Navigation/helpers/isReportOpenInRHP.ts
@@ -9,7 +9,7 @@ const isReportOpenInRHP = (state: NavigationState | undefined): boolean => {
         return false;
     }
     const params = lastRoute.params;
-    if (params && 'screen' in params && typeof params.screen === 'string' && params.screen === SCREENS.RIGHT_MODAL.SEARCH_REPORT) {
+    if (params && 'screen' in params && typeof params.screen === 'string' && (params.screen === SCREENS.RIGHT_MODAL.SEARCH_REPORT || params.screen === SCREENS.DYNAMIC_SEARCH_REPORT)) {
         return true;
     }
     return !!(lastRoute.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR && lastRoute.state?.routes?.some((route) => ALL_WIDE_RIGHT_MODALS.has(route.name)));

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -1957,7 +1957,11 @@ const config: LinkingOptions<RootNavigatorParamList>['config'] = {
                         [SCREENS.SEARCH.COLUMNS_RHP]: ROUTES.SEARCH_COLUMNS,
                     },
                 },
-                [SCREENS.RIGHT_MODAL.SEARCH_REPORT]: ROUTES.SEARCH_REPORT.route,
+                [SCREENS.RIGHT_MODAL.SEARCH_REPORT]: {
+                    screens: {
+                        [SCREENS.DYNAMIC_SEARCH_REPORT]: DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.path,
+                    },
+                },
                 [SCREENS.RIGHT_MODAL.SEARCH_REPORT_ACTIONS]: {
                     screens: {
                         [SCREENS.SEARCH.ROOT_VERIFY_ACCOUNT]: ROUTES.SEARCH_ROOT_VERIFY_ACCOUNT,

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -2581,12 +2581,7 @@ type RightModalNavigatorParamList = {
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo?: Routes;
     };
-    [SCREENS.RIGHT_MODAL.SEARCH_REPORT]: {
-        reportID: string;
-        reportActionID?: string;
-        // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
-        backTo?: Routes;
-    };
+    [SCREENS.RIGHT_MODAL.SEARCH_REPORT]: NavigatorScreenParams<SearchReportNavigatorParamList>;
     [SCREENS.RIGHT_MODAL.DOMAIN]: NavigatorScreenParams<WorkspacesDomainModalNavigatorParamList>;
     [SCREENS.RIGHT_MODAL.SEARCH_COLUMNS]: NavigatorScreenParams<SearchColumnsParamList>;
     [SCREENS.RIGHT_MODAL.MULTIFACTOR_AUTHENTICATION]: NavigatorScreenParams<MultifactorAuthenticationParamList>;
@@ -3140,6 +3135,13 @@ type AuthScreensParamList = SharedScreensParamList &
         [NAVIGATORS.TEST_TOOLS_MODAL_NAVIGATOR]: NavigatorScreenParams<TestToolsModalModalNavigatorParamList>;
     };
 
+type SearchReportNavigatorParamList = {
+    [SCREENS.DYNAMIC_SEARCH_REPORT]: {
+        reportID: string;
+        reportActionID?: string;
+    };
+};
+
 type SearchReportActionsParamList = {
     [SCREENS.SEARCH.REPORT_VERIFY_ACCOUNT]: {
         reportID: string;
@@ -3388,6 +3390,7 @@ export type {
     RootNavigatorParamList,
     SearchAdvancedFiltersParamList,
     SearchReportActionsParamList,
+    SearchReportNavigatorParamList,
     SearchSavedSearchParamList,
     SearchFullscreenNavigatorParamList,
     SettingsNavigatorParamList,

--- a/src/libs/PaymentUtils.ts
+++ b/src/libs/PaymentUtils.ts
@@ -213,7 +213,7 @@ const handleUnvalidatedAccount = (iouReport: OnyxEntry<Report>) => {
 
     if (activeRoute.includes(ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID}))) {
         Navigation.navigate(ROUTES.SEARCH_MONEY_REQUEST_REPORT_VERIFY_ACCOUNT.getRoute(reportID));
-    } else if (activeRoute.includes(ROUTES.SEARCH_REPORT.getRoute({reportID}))) {
+    } else if (activeRoute.includes(`search/view/${reportID}`)) {
         Navigation.navigate(ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT.getRoute(reportID));
     } else if (activeRoute.includes(ROUTES.EXPENSE_REPORT_RHP.getRoute({reportID}))) {
         Navigation.navigate(ROUTES.EXPENSE_REPORT_VERIFY_ACCOUNT.getRoute(reportID));

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -10310,13 +10310,7 @@ function navigateToLinkedReportAction(
             return;
         }
 
-        Navigation.navigate(
-            ROUTES.SEARCH_REPORT.getRoute({
-                reportID: ancestor.report.reportID,
-                reportActionID: ancestor.reportAction.reportActionID,
-                backTo: SCREENS.RIGHT_MODAL.SEARCH_REPORT,
-            }),
-        );
+        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(ancestor.report.reportID, ancestor.reportAction.reportActionID)));
         return;
     }
 

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -63,7 +63,7 @@ import type {ThemeColors} from '@styles/theme/types';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 import type {SearchAdvancedFiltersForm} from '@src/types/form';
 import FILTER_KEYS, {AMOUNT_FILTER_KEYS, DATE_FILTER_KEYS} from '@src/types/form/SearchAdvancedFiltersForm';
@@ -104,6 +104,7 @@ import {getCardDescriptionForSearchTable, getFeedNameForDisplay} from './CardUti
 import {getDecodedCategoryName} from './CategoryUtils';
 import DateUtils from './DateUtils';
 import interceptAnonymousUser from './interceptAnonymousUser';
+import createDynamicRoute from './Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import isSearchTopmostFullScreenRoute from './Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from './Navigation/Navigation';
 import Parser from './Parser';
@@ -2508,8 +2509,8 @@ type CreateAndOpenSearchTransactionThreadParams = {
     /** The intro selected by the user */
     introSelected: OnyxEntry<OnyxTypes.IntroSelected>;
 
-    /** The route to go back to after navigation */
-    backTo: string;
+    /** @deprecated No longer used with dynamic routes. Kept for backward compatibility. */
+    backTo?: string;
 
     /** The current user's login */
     currentUserLogin: string;
@@ -2540,7 +2541,6 @@ type CreateAndOpenSearchTransactionThreadParams = {
 function createAndOpenSearchTransactionThread({
     item,
     introSelected,
-    backTo,
     currentUserLogin,
     currentUserAccountID,
     betas,
@@ -2600,7 +2600,7 @@ function createAndOpenSearchTransactionThread({
         : item.reportID;
 
     if (shouldNavigate && targetReportID) {
-        Navigation.setNavigationActionToMicrotaskQueue(() => Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: targetReportID, backTo})));
+        Navigation.setNavigationActionToMicrotaskQueue(() => Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(targetReportID))));
     }
 
     return targetReportID;

--- a/src/libs/SettlementButtonUtils.ts
+++ b/src/libs/SettlementButtonUtils.ts
@@ -46,7 +46,7 @@ const getRouteMappings = (chatReportID: string, reportID?: string): RouteMapping
             navigate: () => Navigation.navigate(ROUTES.REPORT_VERIFY_ACCOUNT.getRoute(chatReportID)),
         },
         {
-            check: (activeRoute: string) => activeRoute.includes(ROUTES.SEARCH_REPORT.getRoute({reportID: chatReportID})),
+            check: (activeRoute: string) => activeRoute.includes(`search/view/${chatReportID}`),
             navigate: () => Navigation.navigate(ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT.getRoute(chatReportID)),
         },
         {
@@ -65,7 +65,7 @@ const getRouteMappings = (chatReportID: string, reportID?: string): RouteMapping
             navigate: () => Navigation.navigate(ROUTES.SEARCH_MONEY_REQUEST_REPORT_VERIFY_ACCOUNT.getRoute(reportID)),
         },
         {
-            check: (activeRoute: string) => activeRoute.includes(ROUTES.SEARCH_REPORT.getRoute({reportID})),
+            check: (activeRoute: string) => activeRoute.includes(`search/view/${reportID}`),
             navigate: () => Navigation.navigate(ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT.getRoute(reportID)),
         },
         {

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -2445,7 +2445,7 @@ function navigateToAndOpenChildReport(
     const report = childReport ?? createChildReport(childReport, parentReportAction, parentReport, currentUserAccountID, introSelected, betas, isSelfTourViewed, personalDetails);
 
     if (isSearchTopmostFullScreenRoute()) {
-        Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: report.reportID, backTo: Navigation.getActiveRoute()}));
+        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(report.reportID)));
     } else {
         Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report.reportID, undefined, undefined, Navigation.getActiveRoute()));
     }
@@ -2542,7 +2542,7 @@ function explain(
     const report = childReport ?? createChildReport(childReport, reportAction, originalReport, currentUserAccountID, introSelected, betas, isSelfTourViewed);
 
     if (isSearchTopmostFullScreenRoute()) {
-        Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: report.reportID, backTo: Navigation.getActiveRoute()}));
+        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(report.reportID)));
     } else {
         Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report.reportID, undefined, undefined, Navigation.getActiveRoute()));
     }

--- a/src/libs/actions/replaceOptimisticReportWithActualReport.ts
+++ b/src/libs/actions/replaceOptimisticReportWithActualReport.ts
@@ -187,7 +187,7 @@ function replaceOptimisticReportWithActualReport(report: Report, draftReportComm
         if (
             parentReportID &&
             isParentOneTransactionReport &&
-            (activeRoute.includes(ROUTES.REPORT_WITH_ID.getRoute(parentReportID)) || activeRoute.includes(ROUTES.SEARCH_REPORT.getRoute({reportID: parentReportID})))
+            (activeRoute.includes(ROUTES.REPORT_WITH_ID.getRoute(parentReportID)) || activeRoute.includes(`search/view/${parentReportID}`))
         ) {
             if (draftReportComment) {
                 // Draft must be saved first because the callback will clear the optimistic report and its associated draft

--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -979,7 +979,7 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
 
             // If the deleted expense is opened from the super wide rhp, go back there.
             if (
-                previousRoute?.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT &&
+                previousRoute?.name === SCREENS.DYNAMIC_SEARCH_REPORT &&
                 (previousRoute.params as RightModalNavigatorParamList[typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT])?.reportID === route.params.reportID
             ) {
                 if (isSuperWideRHPDisplayed) {

--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -980,7 +980,7 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
             // If the deleted expense is opened from the super wide rhp, go back there.
             if (
                 previousRoute?.name === SCREENS.DYNAMIC_SEARCH_REPORT &&
-                (previousRoute.params as RightModalNavigatorParamList[typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT])?.reportID === route.params.reportID
+                 (previousRoute.params as {reportID?: string} | undefined)?.reportID === route.params.reportID
             ) {
                 if (isSuperWideRHPDisplayed) {
                     const distanceToPop = rhpRoutes.length - 1 - superWideRHPIndex;

--- a/src/pages/Search/SearchReportVerifyAccountPage.tsx
+++ b/src/pages/Search/SearchReportVerifyAccountPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import {createDynamicRoute} from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
-import Navigation from '@libs/Navigation/Navigation';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SearchReportActionsParamList} from '@libs/Navigation/types';
 import VerifyAccountPageBase from '@pages/settings/VerifyAccountPageBase';
@@ -10,7 +9,6 @@ import type SCREENS from '@src/SCREENS';
 type SearchReportVerifyAccountPageProps = PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.REPORT_VERIFY_ACCOUNT>;
 
 function SearchReportVerifyAccountPage({route}: SearchReportVerifyAccountPageProps) {
-    const {reportID} = Navigation.getTopmostSearchReportRouteParams() ?? {};
     const navigateBackTo = createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(route.params.reportID));
     return <VerifyAccountPageBase navigateBackTo={navigateBackTo} />;
 }

--- a/src/pages/Search/SearchReportVerifyAccountPage.tsx
+++ b/src/pages/Search/SearchReportVerifyAccountPage.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
+import {createDynamicRoute} from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SearchReportActionsParamList} from '@libs/Navigation/types';
 import VerifyAccountPageBase from '@pages/settings/VerifyAccountPageBase';
-import ROUTES from '@src/ROUTES';
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 
 type SearchReportVerifyAccountPageProps = PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.REPORT_VERIFY_ACCOUNT>;
 
 function SearchReportVerifyAccountPage({route}: SearchReportVerifyAccountPageProps) {
-    const {reportID, backTo} = Navigation.getTopmostSearchReportRouteParams() ?? {};
-    const navigateBackTo =
-        reportID === route.params.reportID ? ROUTES.SEARCH_REPORT.getRoute({reportID: route.params.reportID, backTo}) : ROUTES.SEARCH_REPORT.getRoute({reportID: route.params.reportID});
+    const {reportID} = Navigation.getTopmostSearchReportRouteParams() ?? {};
+    const navigateBackTo = createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(route.params.reportID));
     return <VerifyAccountPageBase navigateBackTo={navigateBackTo} />;
 }
 

--- a/src/pages/TransactionDuplicate/Review.tsx
+++ b/src/pages/TransactionDuplicate/Review.tsx
@@ -19,6 +19,7 @@ import useTransactionViolations from '@hooks/useTransactionViolations';
 import {clearDeleteTransactionNavigateBackUrl, openReport} from '@libs/actions/Report';
 import {dismissDuplicateTransactionViolation, getDuplicateTransactionDetails} from '@libs/actions/Transaction';
 import {setActiveTransactionIDs} from '@libs/actions/TransactionThreadNavigation';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {TransactionDuplicateNavigatorParamList} from '@libs/Navigation/types';
@@ -28,7 +29,7 @@ import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan
 import {doesDeleteNavigateBackUrlIncludeSpecificDuplicatesReview, getParentReportActionDeletionStatus, hasLoadedReportActions, isThreadReportDeleted} from '@libs/TransactionNavigationUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {Transaction} from '@src/types/onyx';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
@@ -139,7 +140,7 @@ function TransactionDuplicateReview() {
     const onPreviewPressed = (reportID: string) => {
         const siblingTransactionIDsList = transactions.map((transaction) => transaction.transactionID);
         setActiveTransactionIDs(siblingTransactionIDsList).then(() => {
-            Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID, backTo: Navigation.getActiveRoute()}));
+            Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(reportID)));
         });
         // Store the initial value of transactionIDsList and only save it when the item is clicked for the first time
         // to ensure that transactionIDsList reflects its original value when this component is mounted

--- a/src/pages/TransactionMerge/ConfirmationPage.tsx
+++ b/src/pages/TransactionMerge/ConfirmationPage.tsx
@@ -21,6 +21,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {mergeTransactionRequest} from '@libs/actions/MergeTransaction';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {buildMergedTransactionData, getTransactionThreadReportID} from '@libs/MergeTransactionUtils';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -29,7 +30,7 @@ import {findSelfDMReportID} from '@libs/ReportUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {Transaction} from '@src/types/onyx';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
@@ -100,7 +101,7 @@ function ConfirmationPage({route}: ConfirmationPageProps) {
         if ((isOnSearch || isSearchTopmostFullScreenRoute()) && searchReportIDToOpen) {
             Navigation.dismissModal();
             Navigation.setNavigationActionToMicrotaskQueue(() => {
-                Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID: searchReportIDToOpen}));
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(searchReportIDToOpen)));
             });
             return;
         }

--- a/src/pages/inbox/DynamicSearchReportPage.tsx
+++ b/src/pages/inbox/DynamicSearchReportPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {SearchReportNavigatorParamList} from '@libs/Navigation/types';
+import type SCREENS from '@src/SCREENS';
+import ReportScreen from './ReportScreen';
+
+type PageProps = PlatformStackScreenProps<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>;
+
+// When switching search reports using arrows SET_PARAMS action is performed, but it's necessary to remount the whole component after changing the reportID due to the hooks dependencies.
+// It's suggested to refactor hooks in ReportScreen to remove this file and perform SET_PARAMS without the report screen remount.
+export default function DynamicSearchReportPage({route, navigation}: PageProps) {
+    return (
+        <ReportScreen
+            key={route.params?.reportID}
+            route={route}
+            navigation={navigation}
+        />
+    );
+}

--- a/src/pages/inbox/HeaderView.tsx
+++ b/src/pages/inbox/HeaderView.tsx
@@ -104,7 +104,7 @@ function HeaderView({onNavigationMenuButtonClicked, reportID}: HeaderViewProps) 
     const {isSmallScreenWidth, shouldUseNarrowLayout, isInLandscapeMode} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
     const route = useRoute();
-    const openParentReportInCurrentTab = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+    const openParentReportInCurrentTab = route.name === SCREENS.DYNAMIC_SEARCH_REPORT;
     const [parentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(report?.parentReportID) ?? getNonEmptyStringOnyxID(report?.reportID)}`);
     const [grandParentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(parentReport?.parentReportID)}`);
     const grandParentReportAction = useParentReportAction(parentReport);
@@ -239,7 +239,7 @@ function HeaderView({onNavigationMenuButtonClicked, reportID}: HeaderViewProps) 
         hasTitle: !!title,
     };
 
-    const isReportInRHP = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+    const isReportInRHP = route.name === SCREENS.DYNAMIC_SEARCH_REPORT;
     const shouldDisplaySearchRouter = !isInSidePanel && (!isReportInRHP || isSmallScreenWidth);
     const [onboardingPurposeSelected] = useOnyx(ONYXKEYS.ONBOARDING_PURPOSE_SELECTED);
     const isChatUsedForOnboarding = isChatUsedForOnboardingReportUtils(report, onboarding, conciergeReportID, onboardingPurposeSelected);

--- a/src/pages/inbox/RHPReportScreen.tsx
+++ b/src/pages/inbox/RHPReportScreen.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type {SearchReportNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import ReportScreen from './ReportScreen';
 
-type PageProps = PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+type PageProps = PlatformStackScreenProps<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>;
 
 // When switching search reports using arrows SET_PARAMS action is performed, but it's necessary to remount the whole component after changing the reportID due to the hooks dependencies.
 // It's suggested to refactor hooks in ReportScreen to remove this file and perform SET_PARAMS without the report screen remount.

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -325,7 +325,7 @@ function ReportFetchHandler() {
         // Skip if already created, coming from Search page, or thread already exists
         if (
             hasCreatedLegacyThreadRef.current ||
-            route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ||
+            route.name === SCREENS.DYNAMIC_SEARCH_REPORT ||
             transactionThreadReport ||
             (transactionThreadReportID && transactionThreadReportID !== '0') ||
             !reportLoadingState?.hasOnceLoadedReportActions ||

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -17,7 +17,7 @@ import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import {getFilteredReportActionsForReportView, getIOUActionForReportID, getOneTransactionThreadReportID, isCreatedAction} from '@libs/ReportActionsUtils';
 import {isChatThread, isHiddenForCurrentUser, isOneTransactionThread, isPolicyExpenseChat, isReportTransactionThread, isTaskReport, isValidReportIDFromPath} from '@libs/ReportUtils';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import type {ReportsSplitNavigatorParamList, SearchReportNavigatorParamList} from '@navigation/types';
 import {
     clearStaleDMRecoveryTargetByTargetReportID,
     createTransactionThreadReport,
@@ -34,7 +34,7 @@ import type {Transaction} from '@src/types/onyx';
 
 type ReportScreenRoute =
     | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-    | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+    | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>;
 
 const defaultReportMetadata = {
     isOptimisticReport: false,

--- a/src/pages/inbox/ReportHeader.tsx
+++ b/src/pages/inbox/ReportHeader.tsx
@@ -51,7 +51,7 @@ function ReportHeader() {
             closeSidePanel();
             return;
         }
-        if (backTo === SCREENS.RIGHT_MODAL.SEARCH_REPORT) {
+        if (backTo === SCREENS.DYNAMIC_SEARCH_REPORT) {
             Navigation.goBack();
             return;
         }

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -13,7 +13,7 @@ import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import {isDeletedParentAction} from '@libs/ReportActionsUtils';
 import {isAdminRoom, isAnnounceRoom, isGroupChat, isMoneyRequest, isMoneyRequestReport, isMoneyRequestReportPendingDeletion, isPolicyExpenseChat} from '@libs/ReportUtils';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import type {ReportsSplitNavigatorParamList, SearchReportNavigatorParamList} from '@navigation/types';
 import {navigateToConciergeChat} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -25,7 +25,7 @@ import useReportWasDeleted from './hooks/useReportWasDeleted';
 
 type ReportScreenRoute =
     | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-    | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+    | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>;
 
 const reportDetailScreens = [
     ...Object.values(SCREENS.REPORT_DETAILS),

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -94,7 +94,7 @@ function ReportNavigateAwayHandler() {
         const currentRoute = navigationRef.getCurrentRoute();
         const topmostReportIDInSearchRHP = Navigation.getTopmostSearchReportID();
         const isTopmostSearchReportID = reportIDFromRoute === topmostReportIDInSearchRHP;
-        const isHoldScreenOpenInRHP = currentRoute?.name === SCREENS.MONEY_REQUEST.HOLD && (route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ? isTopmostSearchReportID : isTopMostReportId);
+        const isHoldScreenOpenInRHP = currentRoute?.name === SCREENS.MONEY_REQUEST.HOLD && (route.name === SCREENS.DYNAMIC_SEARCH_REPORT ? isTopmostSearchReportID : isTopMostReportId);
         const isReportDetailOpenInRHP =
             isTopMostReportId &&
             reportDetailScreens.find((r) => r === currentRoute?.name) &&

--- a/src/pages/inbox/ReportRouteParamHandler.tsx
+++ b/src/pages/inbox/ReportRouteParamHandler.tsx
@@ -6,13 +6,13 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import {findLastAccessedReport} from '@libs/ReportUtils';
 import {isNumeric} from '@libs/ValidationUtils';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import type {ReportsSplitNavigatorParamList, SearchReportNavigatorParamList} from '@navigation/types';
 import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
 
 type ReportScreenRoute =
     | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-    | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+    | PlatformStackRouteProp<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>;
 
 /**
  * Component that does not render anything. Resolves the reportID route param when missing,

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -105,7 +105,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     return (
         <ReportScreenEditMessageProvider reportID={reportIDFromRoute}>
-            <WideRHPOverlayWrapper shouldWrap={route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT}>
+            <WideRHPOverlayWrapper shouldWrap={route.name === SCREENS.DYNAMIC_SEARCH_REPORT}>
                 <ActionListContext.Provider value={actionListValue}>
                     <ReactionListWrapper>
                         <ScreenWrapper

--- a/src/pages/inbox/WideRHPReceiptPanel.tsx
+++ b/src/pages/inbox/WideRHPReceiptPanel.tsx
@@ -30,7 +30,7 @@ function WideRHPReceiptPanel() {
     const route = useRoute();
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth} = useResponsiveLayout();
-    if (route.name !== SCREENS.RIGHT_MODAL.SEARCH_REPORT || isSmallScreenWidth) {
+    if (route.name !== SCREENS.DYNAMIC_SEARCH_REPORT || isSmallScreenWidth) {
         return null;
     }
     return <WideRHPReceiptPanelGate />;

--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
@@ -312,7 +312,7 @@ function ComposerWithSuggestions({
 
     const {superWideRHPRouteKeys, wideRHPRouteKeys} = useWideRHPState();
     // When SearchReport is stacked above another RHP (wide or super-wide), delay autofocus until after the transition completes to avoid animation jank
-    const shouldDelayAutoFocus = (superWideRHPRouteKeys.length > 0 || wideRHPRouteKeys.length > 0) && route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+    const shouldDelayAutoFocus = (superWideRHPRouteKeys.length > 0 || wideRHPRouteKeys.length > 0) && route.name === SCREENS.DYNAMIC_SEARCH_REPORT;
     const shouldDelayAutoFocusRef = useRef(shouldDelayAutoFocus);
     shouldDelayAutoFocusRef.current = shouldDelayAutoFocus;
 

--- a/src/pages/inbox/types.ts
+++ b/src/pages/inbox/types.ts
@@ -1,9 +1,9 @@
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import type {ReportsSplitNavigatorParamList, SearchReportNavigatorParamList} from '@navigation/types';
 import type SCREENS from '@src/SCREENS';
 
 type ReportScreenNavigationProps =
     | PlatformStackScreenProps<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
-    | PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+    | PlatformStackScreenProps<SearchReportNavigatorParamList, typeof SCREENS.DYNAMIC_SEARCH_REPORT>;
 
 export default ReportScreenNavigationProps;

--- a/tests/unit/Navigation/getReportRouteForCurrentContextTest.ts
+++ b/tests/unit/Navigation/getReportRouteForCurrentContextTest.ts
@@ -1,7 +1,8 @@
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import getReportRouteForCurrentContext from '@libs/Navigation/helpers/getReportRouteForCurrentContext';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from '@libs/Navigation/Navigation';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 
 jest.mock('@libs/Navigation/Navigation', () => ({
     getActiveRoute: jest.fn(),
@@ -26,11 +27,6 @@ describe('getReportRouteForCurrentContext', () => {
     it('returns the search report route when Search is the topmost fullscreen route', () => {
         mockIsSearchTopmostFullScreenRoute.mockReturnValue(true);
 
-        expect(getReportRouteForCurrentContext({reportID: '42'})).toBe(
-            ROUTES.SEARCH_REPORT.getRoute({
-                reportID: '42',
-                backTo: 'search?q=type:chat',
-            }),
-        );
+        expect(getReportRouteForCurrentContext({reportID: '42'})).toBe(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute('42')));
     });
 });

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -39,7 +39,7 @@ import DateUtils from '@src/libs/DateUtils';
 import {buildSearchQueryJSON, getDateRangeForPreset, getUserFriendlyValue} from '@src/libs/SearchQueryUtils';
 import * as SearchUIUtils from '@src/libs/SearchUIUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type * as OnyxTypes from '@src/types/onyx';
 import type {CustomCardFeedData} from '@src/types/onyx/CardFeeds';
 import type {Connections} from '@src/types/onyx/Policy';
@@ -8934,12 +8934,14 @@ describe('SearchUIUtils', () => {
             SearchUIUtils.createAndOpenSearchTransactionThread({...baseParams, shouldNavigate: true});
             // For one-transaction reports (isOneTransactionReport = true), navigation goes to the parent report (item.reportID)
             // instead of the transaction thread report
-            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(transactionListItem.reportID)));
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(transactionListItem.reportID!)));
         });
 
         test('Should default shouldNavigate to true when not provided', () => {
             SearchUIUtils.createAndOpenSearchTransactionThread(baseParams);
-            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(transactionListItem.reportID)));
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(transactionListItem.reportID!)));
         });
 
         test('Should fallback to childReportID from IOU action when transaction thread report is not in Onyx', async () => {

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -25,6 +25,7 @@ import type {
 } from '@components/Search/SearchList/ListItem/types';
 import type {SearchQueryJSON, SelectedTransactionInfo} from '@components/Search/types';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@navigation/Navigation';
 import type * as ReportUserActions from '@userActions/Report';
 import {createTransactionThreadReport} from '@userActions/Report';
@@ -38,7 +39,7 @@ import DateUtils from '@src/libs/DateUtils';
 import {buildSearchQueryJSON, getDateRangeForPreset, getUserFriendlyValue} from '@src/libs/SearchQueryUtils';
 import * as SearchUIUtils from '@src/libs/SearchUIUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type * as OnyxTypes from '@src/types/onyx';
 import type {CustomCardFeedData} from '@src/types/onyx/CardFeeds';
 import type {Connections} from '@src/types/onyx/Policy';
@@ -50,6 +51,7 @@ import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
 jest.mock('@src/components/ConfirmedRoute.tsx');
 jest.mock('@src/libs/Navigation/Navigation', () => ({
     navigate: jest.fn(),
+    getActiveRoute: jest.fn(() => ''),
     setNavigationActionToMicrotaskQueue: jest.fn((cb: () => void) => cb()),
 }));
 jest.mock('@userActions/Report', () => ({
@@ -8932,12 +8934,12 @@ describe('SearchUIUtils', () => {
             SearchUIUtils.createAndOpenSearchTransactionThread({...baseParams, shouldNavigate: true});
             // For one-transaction reports (isOneTransactionReport = true), navigation goes to the parent report (item.reportID)
             // instead of the transaction thread report
-            expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.SEARCH_REPORT.getRoute({reportID: transactionListItem.reportID, backTo}));
+            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(transactionListItem.reportID)));
         });
 
         test('Should default shouldNavigate to true when not provided', () => {
             SearchUIUtils.createAndOpenSearchTransactionThread(baseParams);
-            expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.SEARCH_REPORT.getRoute({reportID: transactionListItem.reportID, backTo}));
+            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(transactionListItem.reportID)));
         });
 
         test('Should fallback to childReportID from IOU action when transaction thread report is not in Onyx', async () => {
@@ -8962,7 +8964,7 @@ describe('SearchUIUtils', () => {
                 shouldNavigate: true,
             });
 
-            expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.SEARCH_REPORT.getRoute({reportID: childReportID, backTo}));
+            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.SEARCH_REPORT_VIEW.getRoute(childReportID)));
         });
 
         test('Should pass introSelected to createTransactionThreadReport when creating thread', () => {

--- a/tests/unit/SettlementButtonUtilsTest.ts
+++ b/tests/unit/SettlementButtonUtilsTest.ts
@@ -34,12 +34,12 @@ describe('handleUnvalidatedUserNavigation', () => {
         },
         {
             description: 'navigate to ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT.getRoute(reportID) when active route is ROUTES.SEARCH_REPORT.getRoute(reportID)',
-            mockActiveRoute: ROUTES.SEARCH_REPORT.getRoute({reportID: mockReportID}),
+            mockActiveRoute: `search/view/${mockReportID}`,
             expectedRouteToNavigate: ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT.getRoute(mockReportID),
         },
         {
             description: 'navigate to ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT.getRoute(chatReportID) when active route is ROUTES.SEARCH_REPORT.getRoute({reportID: chatReportID})',
-            mockActiveRoute: ROUTES.SEARCH_REPORT.getRoute({reportID: mockChatReportID}),
+            mockActiveRoute: `search/view/${mockChatReportID}`,
             expectedRouteToNavigate: ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT.getRoute(mockChatReportID),
         },
         {
@@ -82,7 +82,7 @@ describe('handleUnvalidatedUserNavigation', () => {
         },
         {
             description: 'do not navigate to ROUTES.SEARCH_REPORT_VERIFY_ACCOUNT when reportID is undefined',
-            mockActiveRoute: ROUTES.SEARCH_REPORT.getRoute({reportID: mockReportID}),
+            mockActiveRoute: `search/view/${mockReportID}`,
         },
         {
             description: 'do not navigate when active route is ROUTES.REPORT_WITH_ID.getRoute(reportID) and reportID is undefined',

--- a/tests/unit/useActiveRouteTest.ts
+++ b/tests/unit/useActiveRouteTest.ts
@@ -9,7 +9,7 @@ describe('useActiveRoute', () => {
         // Given an active route
         const navigation = jest.spyOn(Navigation, 'getReportRHPActiveRoute');
         const {result} = renderHook(() => useActiveRoute());
-        const expectedActiveRoute = ROUTES.SEARCH_REPORT.getRoute({reportID: '1'});
+        const expectedActiveRoute = `search/view/1`;
         navigation.mockReturnValueOnce(expectedActiveRoute);
 
         const actualActiveRoute = result.current.getReportRHPActiveRoute();


### PR DESCRIPTION
### Explanation of Change

### Fixed Issues

$ https://github.com/Expensify/App/issues/83856
PROPOSAL: 

### Tests

Same QA step

- [x] Verify that no errors appear in the JS console

### Offline tests

### QA Steps



- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>








</details>

<details>
<summary>Android: mWeb Chrome</summary>





</details>

<details>
<summary>iOS: Native</summary>







</details>

<details>
<summary>iOS: mWeb Safari</summary>






</details>

<details>
<summary>MacOS: Chrome / Safari</summary>






</details>