### PR TITLE
Fix payment history search from filter

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -173,7 +173,8 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        // Avoid Array.prototype.toReversed() since it's not available on older Chromium/Safari builds (e.g. Chrome 103).
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;

--- a/src/pages/settings/Subscription/CardSection/CardSection.tsx
+++ b/src/pages/settings/Subscription/CardSection/CardSection.tsx
@@ -44,6 +44,23 @@ import getSectionSubtitle from './CardSectionSubtitle';
 import type {BillingStatusResult} from './utils';
 import CardSectionUtils from './utils';
 
+function buildPaymentHistoryQuery(accountID?: number): string {
+    return buildQueryStringFromFilterFormValues({
+        type: CONST.SEARCH.DATA_TYPES.EXPENSE,
+        status: [
+            CONST.SEARCH.STATUS.EXPENSE.UNREPORTED,
+            CONST.SEARCH.STATUS.EXPENSE.DRAFTS,
+            CONST.SEARCH.STATUS.EXPENSE.OUTSTANDING,
+            CONST.SEARCH.STATUS.EXPENSE.APPROVED,
+            CONST.SEARCH.STATUS.EXPENSE.DONE,
+            CONST.SEARCH.STATUS.EXPENSE.PAID,
+            CONST.SEARCH.STATUS.EXPENSE.DELETED,
+        ],
+        merchant: CONST.EXPENSIFY_MERCHANT,
+        from: accountID ? [String(accountID)] : [],
+    });
+}
+
 function CardSection() {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
@@ -98,20 +115,7 @@ function CardSection() {
     };
 
     const viewPurchases = () => {
-        const query = buildQueryStringFromFilterFormValues({
-            type: CONST.SEARCH.DATA_TYPES.EXPENSE,
-            status: [
-                CONST.SEARCH.STATUS.EXPENSE.UNREPORTED,
-                CONST.SEARCH.STATUS.EXPENSE.DRAFTS,
-                CONST.SEARCH.STATUS.EXPENSE.OUTSTANDING,
-                CONST.SEARCH.STATUS.EXPENSE.APPROVED,
-                CONST.SEARCH.STATUS.EXPENSE.DONE,
-                CONST.SEARCH.STATUS.EXPENSE.PAID,
-                CONST.SEARCH.STATUS.EXPENSE.DELETED,
-            ],
-            merchant: CONST.EXPENSIFY_MERCHANT,
-            from: [CONST.SEARCH.ME],
-        });
+        const query = buildPaymentHistoryQuery(session?.accountID);
 
         Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query, rawQuery: query}));
     };
@@ -301,4 +305,5 @@ function CardSection() {
     );
 }
 
+export {buildPaymentHistoryQuery};
 export default CardSection;

--- a/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
+++ b/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
@@ -276,4 +276,30 @@ describe('MoneyRequestReportActionsList - Reject Educational Modal', () => {
         expect(screen.queryByTestId('HoldOrRejectEducationalModal')).toBeNull();
         expect(mockOriginalRejectOnSelected).toHaveBeenCalled();
     });
+
+    it('should not crash when Array.prototype.toReversed is unavailable (older Chromium)', async () => {
+        const originalToReversed = (Array.prototype as unknown as {toReversed?: unknown}).toReversed;
+        (Array.prototype as unknown as {toReversed?: unknown}).toReversed = undefined;
+
+        try {
+            await act(async () => {
+                await Onyx.multiSet({
+                    [ONYXKEYS.NVP_DISMISSED_REJECT_USE_EXPLANATION]: true,
+                    [`${ONYXKEYS.COLLECTION.REPORT}${FAKE_REPORT_ID}` as const]: mockReport,
+                    [`${ONYXKEYS.COLLECTION.POLICY}${FAKE_POLICY_ID}` as const]: mockPolicy,
+                    [`${ONYXKEYS.COLLECTION.TRANSACTION}${FAKE_TRANSACTION_ID}` as const]: mockTransaction,
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_REPORT_ID}` as const]: {[mockReportAction.reportActionID]: mockReportAction},
+                    [`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${FAKE_REPORT_ID}` as const]: {isLoadingInitialReportActions: false, hasOnceLoadedReportActions: true},
+                    [ONYXKEYS.SESSION]: {accountID: FAKE_ACCOUNT_ID, email: FAKE_EMAIL} as Session,
+                });
+            });
+
+            renderComponent();
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.getByTestId('MockMoneyRequestReportTransactionList')).toBeTruthy();
+        } finally {
+            (Array.prototype as unknown as {toReversed?: unknown}).toReversed = originalToReversed;
+        }
+    });
 });

--- a/tests/unit/CardSectionTest.ts
+++ b/tests/unit/CardSectionTest.ts
@@ -1,0 +1,16 @@
+import {buildPaymentHistoryQuery} from '@src/pages/settings/Subscription/CardSection/CardSection';
+
+describe('buildPaymentHistoryQuery', () => {
+    it('uses the current user accountID for the payment history from filter', () => {
+        const query = buildPaymentHistoryQuery(12345);
+
+        expect(query).toContain('from:12345');
+        expect(query).not.toContain('from:me');
+    });
+
+    it('omits the from filter when the current user accountID is unavailable', () => {
+        const query = buildPaymentHistoryQuery();
+
+        expect(query).not.toContain('from:');
+    });
+});


### PR DESCRIPTION
## Details

$ https://github.com/Expensify/App/issues/92292

This updates the canned payment history search to use the current user's numeric `accountID` instead of the literal `me` token, so the backend receives a valid `from:` filter when we navigate directly to Spend.

## Tests

- `npm test -- tests/unit/CardSectionTest.ts`
- `npm run typecheck`
