### PR TITLE
[NO QA] perf(search): add FirstPaint/ContentLoad telemetry spans for navigate-to-reports

### DIFF
--- a/contributingGuides/OBSERVABILITY_METRICS.md
+++ b/contributingGuides/OBSERVABILITY_METRICS.md
@@ -83,7 +83,7 @@ This document lists all implemented telemetry metrics in the Expensify App.
 
 **Constant**: `CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD`
 **Sentry Name**: `ManualNavigateToReportsContentLoad`
-**Threshold**: No fixed threshold (runs longer than First Paint - skips the skeleton and waits for the real content)
+**Threshold**: 1000ms (P90)
 **What's Measured**: Time from clicking the reports tab to the real content paint (list or chart), ignoring any skeleton shown in between. Runs alongside the legacy `ManualNavigateToReports` span ([`src/libs/telemetry/navigateToReportsSpans.ts`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts))
 **Start**: User clicks search/reports tab, started via `startNavigateToReportsSpans()` ([`src/libs/telemetry/navigateToReportsSpans.ts`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts#L42))
 **End**:

--- a/contributingGuides/OBSERVABILITY_METRICS.md
+++ b/contributingGuides/OBSERVABILITY_METRICS.md
@@ -64,6 +64,36 @@ This document lists all implemented telemetry metrics in the Expensify App.
 - Technical: Search skeleton layout complete (onLayoutSkeleton event)
   - Skeleton layout rendered ([`src/components/Search/index.tsx`](https://github.com/Expensify/App/blob/e8d4f62021987e5821d69ce483349562918a948a/src/components/Search/index.tsx#L1162))
 
+### Navigate to Reports Tab (First Paint)
+
+**Constant**: `CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT`
+**Sentry Name**: `ManualNavigateToReportsFirstPaint`
+**Threshold**: 400ms (P90)
+**What's Measured**: Time from clicking the reports tab to the first visible paint - skeleton on a cold start, content on a warm start. Runs alongside the legacy `ManualNavigateToReports` span and ends at the same moment ([`src/libs/telemetry/navigateToReportsSpans.ts`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts))
+**Start**: User clicks search/reports tab, started via `startNavigateToReportsSpans()` ([`src/libs/telemetry/navigateToReportsSpans.ts`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts#L42))
+**End**:
+- User sees: First visible paint (cold skeleton or warm content)
+- Technical: First paint layout complete via [`endNavigateToReportsFirstPaint()`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts#L48) (first call wins)
+  - Cold start: skeleton layout complete, tagged `start_type: cold` ([`SearchLoadingSkeleton.tsx`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/SearchLoadingSkeleton.tsx#L27))
+  - Warm start: content or chart layout complete, tagged `start_type: warm_first` ([list](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/index.tsx#L1550), [chart](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/index.tsx#L1596), [deferred-mount skeleton](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/SearchWithNavigationDeferredMount.tsx#L17))
+  - Cached re-visit: screen re-focus, tagged `start_type: warm_subsequent` ([`src/components/Search/index.tsx`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/index.tsx#L1626))
+**Attributes**: `start_type` (`cold` | `warm_first` | `warm_subsequent`), `search_type`, `search_view`, `search_group_by`
+
+### Navigate to Reports Tab (Content Load)
+
+**Constant**: `CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD`
+**Sentry Name**: `ManualNavigateToReportsContentLoad`
+**Threshold**: No fixed threshold (runs longer than First Paint - skips the skeleton and waits for the real content)
+**What's Measured**: Time from clicking the reports tab to the real content paint (list or chart), ignoring any skeleton shown in between. Runs alongside the legacy `ManualNavigateToReports` span ([`src/libs/telemetry/navigateToReportsSpans.ts`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts))
+**Start**: User clicks search/reports tab, started via `startNavigateToReportsSpans()` ([`src/libs/telemetry/navigateToReportsSpans.ts`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts#L42))
+**End**:
+- User sees: Real search content displayed (list or chart, never the skeleton)
+- Technical: Content layout complete via [`endNavigateToReportsContentLoad()`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/libs/telemetry/navigateToReportsSpans.ts#L61) (first call wins)
+  - Content layout complete ([`src/components/Search/index.tsx`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/index.tsx#L1551))
+  - Chart layout complete ([`src/components/Search/index.tsx`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/index.tsx#L1597))
+  - Cached re-visit: screen re-focus ([`src/components/Search/index.tsx`](https://github.com/Expensify/App/blob/c6476c33675cc5620c090234869cd04125878e48/src/components/Search/index.tsx#L1627))
+**Attributes**: `start_type` (copied from First Paint; `unknown` is a fallback that signals First Paint did not run), `search_type`, `search_view`, `search_group_by`
+
 ### Navigate to Inbox Tab
 
 **Constant**: `CONST.TELEMETRY.SPAN_NAVIGATE_TO_INBOX_TAB`

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@react-ng/bounds-observer": "^0.2.1",
         "@rnmapbox/maps": "10.1.44",
         "@sbaiahmed1/react-native-biometrics": "0.15.0",
+        "@sentry/core": "10.39.0",
         "@sentry/react-native": "8.2.0",
         "@shopify/flash-list": "2.3.0",
         "@shopify/react-native-skia": "^2.4.14",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@react-ng/bounds-observer": "^0.2.1",
     "@rnmapbox/maps": "10.1.44",
     "@sbaiahmed1/react-native-biometrics": "0.15.0",
+    "@sentry/core": "10.39.0",
     "@sentry/react-native": "8.2.0",
     "@shopify/flash-list": "2.3.0",
     "@shopify/react-native-skia": "^2.4.14",

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2236,6 +2236,7 @@ const CONST = {
             COLD: 'cold',
             WARM_FIRST: 'warm_first',
             WARM_SUBSEQUENT: 'warm_subsequent',
+            UNKNOWN: 'unknown',
         },
         // Event names
         EVENT_SKELETON_ATTRIBUTES_UPDATE: 'skeleton_attributes_updated',

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2100,6 +2100,8 @@ const CONST = {
         SPAN_APP_STARTUP: 'ManualAppStartup',
         SPAN_APP_STARTUP_NETWORK_REQUEST: 'ManualAppStartupNetworkRequest',
         SPAN_NAVIGATE_TO_REPORTS: 'ManualNavigateToReports',
+        SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT: 'ManualNavigateToReportsFirstPaint',
+        SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD: 'ManualNavigateToReportsContentLoad',
         SPAN_NAVIGATE_TO_INBOX_TAB: 'ManualNavigateToInboxTab',
         SPAN_OD_ND_TRANSITION: 'ManualOdNdTransition',
         SPAN_OD_ND_TRANSITION_LOGGED_OUT: 'ManualOdNdTransitionLoggedOut',
@@ -2173,6 +2175,10 @@ const CONST = {
         ATTRIBUTE_WAS_LIST_EMPTY: 'was_list_empty',
         ATTRIBUTE_SKELETON_PREFIX: 'skeleton.',
         ATTRIBUTE_SCENARIO: 'scenario',
+        // Search query descriptors parsed from the route, stamped on the navigate-to-reports spans.
+        ATTRIBUTE_SEARCH_TYPE: 'search_type',
+        ATTRIBUTE_SEARCH_VIEW: 'search_view',
+        ATTRIBUTE_SEARCH_GROUP_BY: 'search_group_by',
         ATTRIBUTE_HAS_RECEIPT: 'has_receipt',
         ATTRIBUTE_IS_FROM_GLOBAL_CREATE: 'is_from_global_create',
         /** Sentry span attribute: follow-up action taken after submit (e.g. dismiss_modal_and_open_report, navigate_to_search). */
@@ -2223,6 +2229,13 @@ const CONST = {
             INVOICE: 'invoice',
             PER_DIEM: 'per_diem',
             SEND_MONEY: 'send_money',
+        },
+        // Start type for the navigate-to-reports first-paint span. Splits the warm start into
+        // first render (warm_first) vs cached tab-navigator re-visit (warm_subsequent).
+        NAVIGATE_TO_REPORTS_SCENARIO: {
+            COLD: 'cold',
+            WARM_FIRST: 'warm_first',
+            WARM_SUBSEQUENT: 'warm_subsequent',
         },
         // Event names
         EVENT_SKELETON_ATTRIBUTES_UPDATE: 'skeleton_attributes_updated',

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2175,6 +2175,8 @@ const CONST = {
         ATTRIBUTE_WAS_LIST_EMPTY: 'was_list_empty',
         ATTRIBUTE_SKELETON_PREFIX: 'skeleton.',
         ATTRIBUTE_SCENARIO: 'scenario',
+        // Start type stamped on the navigate-to-reports spans: cold, warm_first, or warm_subsequent.
+        ATTRIBUTE_START_TYPE: 'start_type',
         // Search query fields parsed from the route, stamped on the navigate-to-reports spans.
         ATTRIBUTE_SEARCH_TYPE: 'search_type',
         ATTRIBUTE_SEARCH_VIEW: 'search_view',
@@ -2232,7 +2234,7 @@ const CONST = {
         },
         // Start type stamped on the navigate-to-reports spans: cold, warm on the first render (warm_first),
         // or warm on a cached re-visit (warm_subsequent). UNKNOWN is a fallback that signals a bug.
-        NAVIGATE_TO_REPORTS_SCENARIO: {
+        NAVIGATE_TO_REPORTS_START_TYPE: {
             COLD: 'cold',
             WARM_FIRST: 'warm_first',
             WARM_SUBSEQUENT: 'warm_subsequent',

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2175,7 +2175,7 @@ const CONST = {
         ATTRIBUTE_WAS_LIST_EMPTY: 'was_list_empty',
         ATTRIBUTE_SKELETON_PREFIX: 'skeleton.',
         ATTRIBUTE_SCENARIO: 'scenario',
-        // Search query descriptors parsed from the route, stamped on the navigate-to-reports spans.
+        // Search query fields parsed from the route, stamped on the navigate-to-reports spans.
         ATTRIBUTE_SEARCH_TYPE: 'search_type',
         ATTRIBUTE_SEARCH_VIEW: 'search_view',
         ATTRIBUTE_SEARCH_GROUP_BY: 'search_group_by',
@@ -2230,8 +2230,8 @@ const CONST = {
             PER_DIEM: 'per_diem',
             SEND_MONEY: 'send_money',
         },
-        // Start type for the navigate-to-reports first-paint span. Splits the warm start into
-        // first render (warm_first) vs cached tab-navigator re-visit (warm_subsequent).
+        // Start type stamped on the navigate-to-reports spans: cold, warm on the first render (warm_first),
+        // or warm on a cached re-visit (warm_subsequent). UNKNOWN is a fallback that signals a bug.
         NAVIGATE_TO_REPORTS_SCENARIO: {
             COLD: 'cold',
             WARM_FIRST: 'warm_first',

--- a/src/components/Navigation/NavigationTabBar/SearchTabButton.tsx
+++ b/src/components/Navigation/NavigationTabBar/SearchTabButton.tsx
@@ -10,6 +10,7 @@ import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import Navigation from '@libs/Navigation/Navigation';
 import {buildCannedSearchQuery, buildSearchQueryJSON, buildSearchQueryString} from '@libs/SearchQueryUtils';
 import {startSpan} from '@libs/telemetry/activeSpans';
+import {startNavigateToReportsSpans} from '@libs/telemetry/navigateToReportsSpans';
 import navigationRef from '@navigation/navigationRef';
 import type {SearchFullscreenNavigatorParamList} from '@navigation/types';
 import CONST from '@src/CONST';
@@ -44,6 +45,7 @@ function SearchTabButton({selectedTab, isWideLayout}: SearchTabButtonProps) {
                 op: CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS,
                 forceTransaction: true,
             });
+            startNavigateToReportsSpans();
 
             const lastSearchRoute = getLastRoute(navigationRef.getRootState(), NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR, SCREENS.SEARCH.ROOT);
 

--- a/src/components/Search/SearchLoadingSkeleton.tsx
+++ b/src/components/Search/SearchLoadingSkeleton.tsx
@@ -24,7 +24,7 @@ function SearchLoadingSkeleton({containerStyle, reasonAttributes}: SearchLoading
             style={[styles.flex1]}
             onLayout={() => {
                 endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: false});
-                endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.COLD);
+                endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE.COLD);
             }}
         >
             <SearchRowSkeleton

--- a/src/components/Search/SearchLoadingSkeleton.tsx
+++ b/src/components/Search/SearchLoadingSkeleton.tsx
@@ -4,6 +4,7 @@ import Animated, {FadeIn, FadeOut} from 'react-native-reanimated';
 import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {endSpanWithAttributes} from '@libs/telemetry/activeSpans';
+import {endNavigateToReportsFirstPaint} from '@libs/telemetry/navigateToReportsSpans';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import CONST from '@src/CONST';
 
@@ -23,6 +24,7 @@ function SearchLoadingSkeleton({containerStyle, reasonAttributes}: SearchLoading
             style={[styles.flex1]}
             onLayout={() => {
                 endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: false});
+                endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.COLD);
             }}
         >
             <SearchRowSkeleton

--- a/src/components/Search/SearchWithNavigationDeferredMount.tsx
+++ b/src/components/Search/SearchWithNavigationDeferredMount.tsx
@@ -5,6 +5,7 @@ import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {endSpanWithAttributes} from '@libs/telemetry/activeSpans';
+import {endNavigateToReportsFirstPaint} from '@libs/telemetry/navigateToReportsSpans';
 import {endSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import CONST from '@src/CONST';
 import Search from './index';
@@ -13,6 +14,7 @@ const REASON_ATTRIBUTES = {context: 'SearchPage.NavigationDeferred'} as const;
 
 function handleSkeletonLayout() {
     endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
+    endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_FIRST);
 
     // Skeleton paint is the first user-perceivable signal that the submit destination
     // (Search) is up. End the submit-to-destination-visible span here for any pending

--- a/src/components/Search/SearchWithNavigationDeferredMount.tsx
+++ b/src/components/Search/SearchWithNavigationDeferredMount.tsx
@@ -14,7 +14,7 @@ const REASON_ATTRIBUTES = {context: 'SearchPage.NavigationDeferred'} as const;
 
 function handleSkeletonLayout() {
     endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
-    endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_FIRST);
+    endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE.WARM_FIRST);
 
     // Skeleton paint is the first user-perceivable signal that the submit destination
     // (Search) is up. End the submit-to-destination-visible span here for any pending

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -982,24 +982,10 @@ function Search({
                 return;
             }
 
-            const activeNavigateToReportsSpan = getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
-            if (activeNavigateToReportsSpan !== navigateToReportsSpanOnMount.current) {
-                return;
+            if (getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS) === navigateToReportsSpanOnMount.current) {
+                cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
             }
 
-            cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
-        },
-        [],
-    );
-
-    // ContentLoad outlives the legacy span and FirstPaint in a cold start (it keeps ticking through the
-    // skeleton), so it needs its own unmount cancel. The per-span identity guard skips any new span that
-    // already ended or that a newer navigation restarted, matching the legacy span's mount-identity check.
-    useEffect(
-        () => () => {
-            if (hasHadFirstLayout.current) {
-                return;
-            }
             cancelNavigateToReportsSpansIfSame(newNavigateToReportsSpansOnMount.current);
         },
         [],

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1662,6 +1662,9 @@ function Search({
         useCallback(() => {
             return () => {
                 cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
+                // Unconditional, like the legacy span above and unlike the unmount cancel: blur fires before the
+                // next Search tab tap starts new spans, so there is no freshly-started span to protect with a
+                // mount-identity guard here (and the mount-captured ref would be stale across re-focus cycles).
                 cancelNavigateToReportsSpans();
             };
         }, []),

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -68,6 +68,13 @@ import {
     shouldShowYear as shouldShowYearUtil,
 } from '@libs/SearchUIUtils';
 import {cancelSpan, endSpanWithAttributes, getSpan, startSpan} from '@libs/telemetry/activeSpans';
+import {
+    cancelNavigateToReportsSpans,
+    cancelNavigateToReportsSpansIfSame,
+    endNavigateToReportsContentLoad,
+    endNavigateToReportsFirstPaint,
+    getNavigateToReportsSpans,
+} from '@libs/telemetry/navigateToReportsSpans';
 import {cancelSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {getOriginalTransactionWithSplitInfo, hasValidModifiedAmount, isOnHold, isTransactionPendingDelete, shouldShowAttendees} from '@libs/TransactionUtils';
@@ -965,6 +972,7 @@ function Search({
     const isUnmounted = useRef(false);
     const hasHadFirstLayout = useRef(false);
     const navigateToReportsSpanOnMount = useRef(getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS));
+    const newNavigateToReportsSpansOnMount = useRef(getNavigateToReportsSpans());
 
     useEffect(
         () => () => {
@@ -980,6 +988,19 @@ function Search({
             }
 
             cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
+        },
+        [],
+    );
+
+    // ContentLoad outlives the legacy span and FirstPaint in a cold start (it keeps ticking through the
+    // skeleton), so it needs its own unmount cancel. The per-span identity guard skips any new span that
+    // already ended or that a newer navigation restarted, matching the legacy span's mount-identity check.
+    useEffect(
+        () => () => {
+            if (hasHadFirstLayout.current) {
+                return;
+            }
+            cancelNavigateToReportsSpansIfSame(newNavigateToReportsSpansOnMount.current);
         },
         [],
     );
@@ -1540,6 +1561,8 @@ function Search({
         hasHadFirstLayout.current = true;
         onDestinationVisible?.(isSearchResultsEmptyRef.current, 'layout');
         endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
+        endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_FIRST);
+        endNavigateToReportsContentLoad();
         TransitionTracker.runAfterTransitions({
             callback: () => flushDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH),
         });
@@ -1560,6 +1583,7 @@ function Search({
 
     const cancelNavigationSpans = useCallback(() => {
         cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
+        cancelNavigateToReportsSpans();
         if (getPendingSubmitFollowUpAction()?.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH) {
             cancelSubmitFollowUpActionSpan();
         }
@@ -1583,6 +1607,8 @@ function Search({
     const onLayoutChart = useCallback(() => {
         hasHadFirstLayout.current = true;
         endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
+        endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_FIRST);
+        endNavigateToReportsContentLoad();
     }, []);
 
     // Tracks whether the pending-expense tracking was re-armed on re-focus
@@ -1611,6 +1637,8 @@ function Search({
             endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {
                 [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: !shouldShowLoadingState,
             });
+            endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_SUBSEQUENT);
+            endNavigateToReportsContentLoad();
             // On re-focus (e.g. DISMISS_MODAL_ONLY) onLayout won't re-fire — flush here.
             flushDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);
         }, [shouldShowLoadingState, onDestinationVisible, showPendingExpensePlaceholder, rearmTracking]),
@@ -1634,6 +1662,7 @@ function Search({
         useCallback(() => {
             return () => {
                 cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
+                cancelNavigateToReportsSpans();
             };
         }, []),
     );

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1547,7 +1547,7 @@ function Search({
         hasHadFirstLayout.current = true;
         onDestinationVisible?.(isSearchResultsEmptyRef.current, 'layout');
         endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
-        endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_FIRST);
+        endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE.WARM_FIRST);
         endNavigateToReportsContentLoad();
         TransitionTracker.runAfterTransitions({
             callback: () => flushDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH),
@@ -1593,7 +1593,7 @@ function Search({
     const onLayoutChart = useCallback(() => {
         hasHadFirstLayout.current = true;
         endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
-        endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_FIRST);
+        endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE.WARM_FIRST);
         endNavigateToReportsContentLoad();
     }, []);
 
@@ -1623,7 +1623,7 @@ function Search({
             endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {
                 [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: !shouldShowLoadingState,
             });
-            endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.WARM_SUBSEQUENT);
+            endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE.WARM_SUBSEQUENT);
             endNavigateToReportsContentLoad();
             // On re-focus (e.g. DISMISS_MODAL_ONLY) onLayout won't re-fire — flush here.
             flushDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1648,9 +1648,6 @@ function Search({
         useCallback(() => {
             return () => {
                 cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS);
-                // Unconditional, like the legacy span above and unlike the unmount cancel: blur fires before the
-                // next Search tab tap starts new spans, so there is no freshly-started span to protect with a
-                // mount-identity guard here (and the mount-captured ref would be stale across re-focus cycles).
                 cancelNavigateToReportsSpans();
             };
         }, []),

--- a/src/libs/Navigation/AppNavigator/Navigators/TabNavigatorBar.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/TabNavigatorBar.tsx
@@ -12,13 +12,12 @@ import useSafeAreaPaddings from '@hooks/useSafeAreaPaddings';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import isTabRouteAtRoot from '@libs/Navigation/helpers/isTabRouteAtRoot';
-import cancelTabNavigationSpans from '@libs/telemetry/cancelTabNavigationSpans';
-import CONST from '@src/CONST';
+import cancelTabNavigationSpans, {INBOX_TAB_SPAN_IDS, REPORTS_TAB_SPAN_IDS} from '@libs/telemetry/cancelTabNavigationSpans';
 import SCREENS from '@src/SCREENS';
 
-const NAVIGATION_TAB_TO_SPAN: Partial<Record<ValueOf<typeof NAVIGATION_TABS>, string>> = {
-    [NAVIGATION_TABS.INBOX]: CONST.TELEMETRY.SPAN_NAVIGATE_TO_INBOX_TAB,
-    [NAVIGATION_TABS.SEARCH]: CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS,
+const NAVIGATION_TAB_TO_SPANS: Partial<Record<ValueOf<typeof NAVIGATION_TABS>, readonly string[]>> = {
+    [NAVIGATION_TABS.INBOX]: INBOX_TAB_SPAN_IDS,
+    [NAVIGATION_TABS.SEARCH]: REPORTS_TAB_SPAN_IDS,
 };
 
 /**
@@ -60,7 +59,7 @@ function TabNavigatorBar({state}: Pick<BottomTabBarProps, 'state'>) {
     // Cancel any in-flight tab-navigation span that doesn't match the new focused tab.
     // The span for the new tab is started by the tab button before navigation, so we keep it via `except`.
     useEffect(() => {
-        cancelTabNavigationSpans(NAVIGATION_TAB_TO_SPAN[selectedTab]);
+        cancelTabNavigationSpans(NAVIGATION_TAB_TO_SPANS[selectedTab]);
     }, [selectedTab]);
 
     const isHidden = shouldHide || (shouldApplyDelay && animationDoneKey !== stateKey);

--- a/src/libs/telemetry/cancelTabNavigationSpans.ts
+++ b/src/libs/telemetry/cancelTabNavigationSpans.ts
@@ -1,9 +1,8 @@
 import CONST from '@src/CONST';
 import {cancelSpan} from './activeSpans';
 
-// Spans grouped by the tab they belong to. The Reports tab owns three: the legacy span plus the
-// FirstPaint/ContentLoad split. Callers pass the focused tab's whole group as `preserve` so navigating
-// to that tab does not cancel its freshly started spans.
+// Spans grouped by the tab they belong to. The Reports tab owns three (legacy plus the FirstPaint/ContentLoad
+// split). Callers pass a tab's whole group as `preserve` so landing on that tab does not cancel its fresh spans.
 const REPORTS_TAB_SPAN_IDS: readonly string[] = [
     CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS,
     CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT,
@@ -13,8 +12,8 @@ const INBOX_TAB_SPAN_IDS: readonly string[] = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_
 const TAB_NAVIGATION_SPAN_IDS: readonly string[] = [...REPORTS_TAB_SPAN_IDS, ...INBOX_TAB_SPAN_IDS];
 
 /**
- * Cancels in-flight tab-navigation spans so an abandoned tap doesn't leave one ticking until the user returns.
- * Pass `preserve` with the span group of the tab the user is now on, so its freshly started spans survive.
+ * Cancels running tab-navigation spans so an abandoned tap does not leave one ticking until the user returns.
+ * Pass the focused tab's span group as `preserve` so its freshly started spans survive.
  */
 function cancelTabNavigationSpans(preserve: readonly string[] = []) {
     for (const id of TAB_NAVIGATION_SPAN_IDS) {

--- a/src/libs/telemetry/cancelTabNavigationSpans.ts
+++ b/src/libs/telemetry/cancelTabNavigationSpans.ts
@@ -2,9 +2,8 @@ import CONST from '@src/CONST';
 import {cancelSpan} from './activeSpans';
 
 // Spans grouped by the tab they belong to. The Reports tab owns three: the legacy span plus the
-// FirstPaint/ContentLoad split. `except` carries a single span id (the focused tab's legacy span),
-// so it must preserve the whole group of that tab, otherwise navigating to Reports would cancel the
-// freshly started FirstPaint/ContentLoad spans.
+// FirstPaint/ContentLoad split. Callers pass the focused tab's whole group as `preserve` so navigating
+// to that tab does not cancel its freshly started spans.
 const REPORTS_TAB_SPAN_IDS: readonly string[] = [
     CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS,
     CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT,
@@ -13,29 +12,13 @@ const REPORTS_TAB_SPAN_IDS: readonly string[] = [
 const INBOX_TAB_SPAN_IDS: readonly string[] = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_INBOX_TAB];
 const TAB_NAVIGATION_SPAN_IDS: readonly string[] = [...REPORTS_TAB_SPAN_IDS, ...INBOX_TAB_SPAN_IDS];
 
-/** Returns the span group the focused tab owns, so the whole group is preserved from cancellation. */
-function getPreservedGroup(except?: string): readonly string[] | undefined {
-    if (except === undefined) {
-        return undefined;
-    }
-    if (REPORTS_TAB_SPAN_IDS.includes(except)) {
-        return REPORTS_TAB_SPAN_IDS;
-    }
-    if (INBOX_TAB_SPAN_IDS.includes(except)) {
-        return INBOX_TAB_SPAN_IDS;
-    }
-    return undefined;
-}
-
 /**
  * Cancels in-flight tab-navigation spans so an abandoned tap doesn't leave one ticking until the user returns.
- * Pass `except` to preserve the whole span group for the tab the user is now on.
+ * Pass `preserve` with the span group of the tab the user is now on, so its freshly started spans survive.
  */
-function cancelTabNavigationSpans(except?: string) {
-    const preservedGroup = getPreservedGroup(except);
-
+function cancelTabNavigationSpans(preserve: readonly string[] = []) {
     for (const id of TAB_NAVIGATION_SPAN_IDS) {
-        if (preservedGroup?.includes(id)) {
+        if (preserve.includes(id)) {
             continue;
         }
         cancelSpan(id);
@@ -43,3 +26,4 @@ function cancelTabNavigationSpans(except?: string) {
 }
 
 export default cancelTabNavigationSpans;
+export {REPORTS_TAB_SPAN_IDS, INBOX_TAB_SPAN_IDS};

--- a/src/libs/telemetry/cancelTabNavigationSpans.ts
+++ b/src/libs/telemetry/cancelTabNavigationSpans.ts
@@ -1,15 +1,41 @@
 import CONST from '@src/CONST';
 import {cancelSpan} from './activeSpans';
 
-const TAB_NAVIGATION_SPAN_IDS = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, CONST.TELEMETRY.SPAN_NAVIGATE_TO_INBOX_TAB] as const;
+// Spans grouped by the tab they belong to. The Reports tab owns three: the legacy span plus the
+// FirstPaint/ContentLoad split. `except` carries a single span id (the focused tab's legacy span),
+// so it must preserve the whole group of that tab, otherwise navigating to Reports would cancel the
+// freshly started FirstPaint/ContentLoad spans.
+const REPORTS_TAB_SPAN_IDS: readonly string[] = [
+    CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS,
+    CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT,
+    CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD,
+];
+const INBOX_TAB_SPAN_IDS: readonly string[] = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_INBOX_TAB];
+const TAB_NAVIGATION_SPAN_IDS: readonly string[] = [...REPORTS_TAB_SPAN_IDS, ...INBOX_TAB_SPAN_IDS];
+
+/** Returns the span group the focused tab owns, so the whole group is preserved from cancellation. */
+function getPreservedGroup(except?: string): readonly string[] | undefined {
+    if (except === undefined) {
+        return undefined;
+    }
+    if (REPORTS_TAB_SPAN_IDS.includes(except)) {
+        return REPORTS_TAB_SPAN_IDS;
+    }
+    if (INBOX_TAB_SPAN_IDS.includes(except)) {
+        return INBOX_TAB_SPAN_IDS;
+    }
+    return undefined;
+}
 
 /**
  * Cancels in-flight tab-navigation spans so an abandoned tap doesn't leave one ticking until the user returns.
- * Pass `except` to preserve the span for the tab the user is now on.
+ * Pass `except` to preserve the whole span group for the tab the user is now on.
  */
 function cancelTabNavigationSpans(except?: string) {
+    const preservedGroup = getPreservedGroup(except);
+
     for (const id of TAB_NAVIGATION_SPAN_IDS) {
-        if (id === except) {
+        if (preservedGroup?.includes(id)) {
             continue;
         }
         cancelSpan(id);

--- a/src/libs/telemetry/navigateToReportsSpans.ts
+++ b/src/libs/telemetry/navigateToReportsSpans.ts
@@ -1,0 +1,110 @@
+import type {SpanAttributeValue} from '@sentry/core';
+import type {ValueOf} from 'type-fest';
+import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
+import navigationRef from '@navigation/navigationRef';
+import CONST from '@src/CONST';
+import {cancelSpan, endSpanWithAttributes, getSpan, startSpan} from './activeSpans';
+
+type NavigateToReportsScenario = ValueOf<typeof CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO>;
+
+type SpanAttributes = Record<string, SpanAttributeValue | undefined>;
+
+const SPAN_IDS = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD] as const;
+
+// Scenario and the query descriptors are properties of the navigation, not of one span, so they are captured
+// once at the first paint and shared with ContentLoad, which ends later at the real content paint and cannot
+// tell cold from warm_first on its own. The query descriptors are read from the active route here (rather than
+// passed in by callers) so no call site has to thread query data into the span helpers.
+let activeScenario: NavigateToReportsScenario | undefined;
+let activeQueryAttributes: SpanAttributes = {};
+
+/** Reads type/view/groupBy from the active search route so the spans can be tagged without callers passing them in. */
+function readSearchQueryAttributes(): SpanAttributes {
+    const params = navigationRef.getCurrentRoute()?.params;
+    if (!params || typeof params !== 'object' || !('q' in params) || typeof params.q !== 'string') {
+        return {};
+    }
+    const queryJSON = buildSearchQueryJSON(params.q);
+    if (!queryJSON) {
+        return {};
+    }
+    return {
+        [CONST.TELEMETRY.ATTRIBUTE_SEARCH_TYPE]: queryJSON.type,
+        [CONST.TELEMETRY.ATTRIBUTE_SEARCH_VIEW]: queryJSON.view,
+        [CONST.TELEMETRY.ATTRIBUTE_SEARCH_GROUP_BY]: queryJSON.groupBy,
+    };
+}
+
+/**
+ * The two spans split the legacy ManualNavigateToReports metric, while it is kept running alongside untouched:
+ * - FirstPaint: ends at the first visible paint (skeleton in a cold start, content in a warm start).
+ * - ContentLoad: ends only at the real content paint, so it keeps ticking through skeletons.
+ *
+ * Both share the tab-tap start time and the same `scenario`. Each ends at several call sites; the first
+ * end-call wins because `activeSpans` keeps one span per id and a later end on an already-ended span is a no-op.
+ */
+function startNavigateToReportsSpans() {
+    activeScenario = undefined;
+    activeQueryAttributes = {};
+    for (const spanId of SPAN_IDS) {
+        startSpan(spanId, {name: spanId, op: spanId, forceTransaction: true});
+    }
+}
+
+function endNavigateToReportsFirstPaint(scenario: NavigateToReportsScenario) {
+    // Only the genuine first paint may capture scenario/query attributes. Later no-op end calls (e.g. a
+    // content layout firing after a cold skeleton already ended FirstPaint) must not overwrite them.
+    if (!getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT)) {
+        return;
+    }
+    activeScenario = scenario;
+    activeQueryAttributes = readSearchQueryAttributes();
+    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, {
+        [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
+        ...activeQueryAttributes,
+    });
+}
+
+function endNavigateToReportsContentLoad() {
+    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD, {
+        [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: activeScenario,
+        ...activeQueryAttributes,
+    });
+}
+
+function cancelNavigateToReportsSpans() {
+    for (const spanId of SPAN_IDS) {
+        cancelSpan(spanId);
+    }
+}
+
+/** Snapshot of the active span instances, captured on mount for the identity-guarded unmount cancel. */
+function getNavigateToReportsSpans() {
+    return {
+        firstPaint: getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT),
+        contentLoad: getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD),
+    };
+}
+
+/**
+ * Cancels each new span only if the still-active instance is the same one captured on mount, so an
+ * unmount can't cancel a span that a newer navigation already restarted. A span that already ended
+ * (e.g. FirstPaint after a skeleton paint) is skipped because its captured instance no longer matches.
+ */
+function cancelNavigateToReportsSpansIfSame(captured: ReturnType<typeof getNavigateToReportsSpans>) {
+    if (captured.firstPaint && getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT) === captured.firstPaint) {
+        cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT);
+    }
+    if (captured.contentLoad && getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD) === captured.contentLoad) {
+        cancelSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD);
+    }
+}
+
+export {
+    startNavigateToReportsSpans,
+    endNavigateToReportsFirstPaint,
+    endNavigateToReportsContentLoad,
+    cancelNavigateToReportsSpans,
+    getNavigateToReportsSpans,
+    cancelNavigateToReportsSpansIfSame,
+};

--- a/src/libs/telemetry/navigateToReportsSpans.ts
+++ b/src/libs/telemetry/navigateToReportsSpans.ts
@@ -1,24 +1,19 @@
-import type {SpanAttributeValue} from '@sentry/core';
+import type {SpanAttributes} from '@sentry/core';
 import type {ValueOf} from 'type-fest';
 import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
 import navigationRef from '@navigation/navigationRef';
 import CONST from '@src/CONST';
-import {cancelSpan, endSpanWithAttributes, getSpan, startSpan} from './activeSpans';
+import {cancelSpan, endSpan, endSpanWithAttributes, getSpan, startSpan} from './activeSpans';
 
 type NavigateToReportsScenario = ValueOf<typeof CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO>;
 
-type SpanAttributes = Record<string, SpanAttributeValue | undefined>;
-
 const SPAN_IDS = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD] as const;
 
-// Scenario and the query descriptors are properties of the navigation, not of one span, so they are captured
-// once at the first paint and shared with ContentLoad, which ends later at the real content paint and cannot
-// tell cold from warm_first on its own. The query descriptors are read from the active route here (rather than
-// passed in by callers) so no call site has to thread query data into the span helpers.
-let activeScenario: NavigateToReportsScenario | undefined;
-let activeQueryAttributes: SpanAttributes = {};
-
-/** Reads type/view/groupBy from the active search route so the spans can be tagged without callers passing them in. */
+/**
+ * Reads type/view/groupBy from the active search route so the spans can be tagged without callers passing
+ * them in. Read at first paint rather than at span start: the start fires before `Navigation.navigate`, so
+ * the route still points at the previous page; by the first paint it is the resolved search route.
+ */
 function readSearchQueryAttributes(): SpanAttributes {
     const params = navigationRef.getCurrentRoute()?.params;
     if (!params || typeof params !== 'object' || !('q' in params) || typeof params.q !== 'string') {
@@ -44,32 +39,32 @@ function readSearchQueryAttributes(): SpanAttributes {
  * end-call wins because `activeSpans` keeps one span per id and a later end on an already-ended span is a no-op.
  */
 function startNavigateToReportsSpans() {
-    activeScenario = undefined;
-    activeQueryAttributes = {};
     for (const spanId of SPAN_IDS) {
         startSpan(spanId, {name: spanId, op: spanId, forceTransaction: true});
     }
 }
 
 function endNavigateToReportsFirstPaint(scenario: NavigateToReportsScenario) {
-    // Only the genuine first paint may capture scenario/query attributes. Later no-op end calls (e.g. a
-    // content layout firing after a cold skeleton already ended FirstPaint) must not overwrite them.
+    // Only the first paint records scenario/query. This runs from several paint sites: in a cold start the
+    // skeleton paint ends FirstPaint (scenario COLD), then the later content paint calls this again (WARM_FIRST).
+    // The guard makes that second call bail (FirstPaint is already ended), so ContentLoad keeps its COLD tag.
     if (!getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT)) {
         return;
     }
-    activeScenario = scenario;
-    activeQueryAttributes = readSearchQueryAttributes();
-    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, {
+    const attributes: SpanAttributes = {
         [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
-        ...activeQueryAttributes,
-    });
+        ...readSearchQueryAttributes(),
+    };
+    // Scenario and the query descriptors are properties of the navigation, not of one span. ContentLoad ends
+    // later (at the real content paint) and cannot tell cold from warm itself, so stamp them onto its span
+    // instance now instead of carrying them in module state shared across navigations.
+    getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD)?.setAttributes(attributes);
+    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, attributes);
 }
 
 function endNavigateToReportsContentLoad() {
-    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD, {
-        [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: activeScenario,
-        ...activeQueryAttributes,
-    });
+    // Scenario and query were stamped onto this span instance when FirstPaint ended.
+    endSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD);
 }
 
 function cancelNavigateToReportsSpans() {

--- a/src/libs/telemetry/navigateToReportsSpans.ts
+++ b/src/libs/telemetry/navigateToReportsSpans.ts
@@ -11,9 +11,9 @@ type NavigateToReportsScenario = ValueOf<typeof CONST.TELEMETRY.NAVIGATE_TO_REPO
 const SPAN_IDS = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD] as const;
 
 /**
- * Reads type/view/groupBy from the active search route so the spans can be tagged without callers passing
- * them in. Read at first paint rather than at span start: the start fires before `Navigation.navigate`, so
- * the route still points at the previous page; by the first paint it is the resolved search route.
+ * Reads the search query fields (type/view/groupBy) from the active route to tag the spans. Read at first
+ * paint, not at span start: at start the navigation has not happened yet, so the route still points at the
+ * previous page; by first paint it is the resolved search route.
  */
 function readSearchQueryAttributes(): SpanAttributes {
     const params = navigationRef.getCurrentRoute()?.params;
@@ -32,12 +32,12 @@ function readSearchQueryAttributes(): SpanAttributes {
 }
 
 /**
- * The two spans split the legacy ManualNavigateToReports metric, while it is kept running alongside untouched:
- * - FirstPaint: ends at the first visible paint (skeleton in a cold start, content in a warm start).
- * - ContentLoad: ends only at the real content paint, so it keeps ticking through skeletons.
+ * Splits the legacy ManualNavigateToReports metric into two spans that run alongside the untouched legacy span:
+ * - FirstPaint ends at the first visible paint (skeleton on a cold start, content on a warm start).
+ * - ContentLoad ends only at the real content paint, so it keeps running through skeletons.
  *
- * Both share the tab-tap start time and the same `scenario`. Each ends at several call sites; the first
- * end-call wins because `activeSpans` keeps one span per id and a later end on an already-ended span is a no-op.
+ * Both start at the tab tap and share the same scenario. Each can be ended from several places; the first
+ * end wins, because ending an already-ended span does nothing.
  */
 function startNavigateToReportsSpans() {
     for (const spanId of SPAN_IDS) {
@@ -46,11 +46,11 @@ function startNavigateToReportsSpans() {
 }
 
 function endNavigateToReportsFirstPaint(scenario: NavigateToReportsScenario) {
-    // The guard bails when FirstPaint already ended (e.g. a later content paint after the skeleton), so ContentLoad keeps its COLD tag.
+    // If FirstPaint already ended (e.g. the content painted after the skeleton), bail so ContentLoad keeps its COLD scenario.
     if (!getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT)) {
         return;
     }
-    // Since ContentLoad ends later and cannot determine the start type (cold/warm), tag its span with the scenario now.
+    // ContentLoad ends later and cannot tell cold from warm itself, so tag it with the scenario now.
     getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD)?.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SCENARIO, scenario);
     endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, {
         [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
@@ -85,9 +85,8 @@ function getNavigateToReportsSpans() {
 }
 
 /**
- * Cancels each new span only if the still-active instance is the same one captured on mount, so an
- * unmount can't cancel a span that a newer navigation already restarted. A span that already ended
- * (e.g. FirstPaint after a skeleton paint) is skipped because its captured instance no longer matches.
+ * Cancels each span only if it is still the same instance captured on mount. This stops an unmount from
+ * canceling spans that a newer navigation already restarted, and skips spans that already ended.
  */
 function cancelNavigateToReportsSpansIfSame(captured: ReturnType<typeof getNavigateToReportsSpans>) {
     if (captured.firstPaint && getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT) === captured.firstPaint) {

--- a/src/libs/telemetry/navigateToReportsSpans.ts
+++ b/src/libs/telemetry/navigateToReportsSpans.ts
@@ -1,9 +1,10 @@
+import {spanToJSON} from '@sentry/core';
 import type {SpanAttributes} from '@sentry/core';
 import type {ValueOf} from 'type-fest';
 import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
 import navigationRef from '@navigation/navigationRef';
 import CONST from '@src/CONST';
-import {cancelSpan, endSpan, endSpanWithAttributes, getSpan, startSpan} from './activeSpans';
+import {cancelSpan, endSpanWithAttributes, getSpan, startSpan} from './activeSpans';
 
 type NavigateToReportsScenario = ValueOf<typeof CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO>;
 
@@ -45,26 +46,28 @@ function startNavigateToReportsSpans() {
 }
 
 function endNavigateToReportsFirstPaint(scenario: NavigateToReportsScenario) {
-    // Only the first paint records scenario/query. This runs from several paint sites: in a cold start the
-    // skeleton paint ends FirstPaint (scenario COLD), then the later content paint calls this again (WARM_FIRST).
-    // The guard makes that second call bail (FirstPaint is already ended), so ContentLoad keeps its COLD tag.
+    // The guard bails when FirstPaint already ended (e.g. a later content paint after the skeleton), so ContentLoad keeps its COLD tag.
     if (!getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT)) {
         return;
     }
-    const attributes: SpanAttributes = {
+    // Since ContentLoad ends later and cannot determine the start type (cold/warm), tag its span with the scenario now.
+    getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD)?.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SCENARIO, scenario);
+    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, {
         [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
         ...readSearchQueryAttributes(),
-    };
-    // Scenario and the query descriptors are properties of the navigation, not of one span. ContentLoad ends
-    // later (at the real content paint) and cannot tell cold from warm itself, so stamp them onto its span
-    // instance now instead of carrying them in module state shared across navigations.
-    getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD)?.setAttributes(attributes);
-    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, attributes);
+    });
 }
 
 function endNavigateToReportsContentLoad() {
-    // Scenario and query were stamped onto this span instance when FirstPaint ended.
-    endSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD);
+    const span = getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD);
+    if (!span) {
+        return;
+    }
+    // FirstPaint should set the scenario on this span. UNKNOWN is a fallback: if we see it, FirstPaint did not run and there is a bug.
+    if (spanToJSON(span).data?.[CONST.TELEMETRY.ATTRIBUTE_SCENARIO] === undefined) {
+        span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SCENARIO, CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.UNKNOWN);
+    }
+    endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD, readSearchQueryAttributes());
 }
 
 function cancelNavigateToReportsSpans() {

--- a/src/libs/telemetry/navigateToReportsSpans.ts
+++ b/src/libs/telemetry/navigateToReportsSpans.ts
@@ -6,7 +6,7 @@ import navigationRef from '@navigation/navigationRef';
 import CONST from '@src/CONST';
 import {cancelSpan, endSpanWithAttributes, getSpan, startSpan} from './activeSpans';
 
-type NavigateToReportsScenario = ValueOf<typeof CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO>;
+type NavigateToReportsStartType = ValueOf<typeof CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE>;
 
 const SPAN_IDS = [CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD] as const;
 
@@ -45,15 +45,15 @@ function startNavigateToReportsSpans() {
     }
 }
 
-function endNavigateToReportsFirstPaint(scenario: NavigateToReportsScenario) {
-    // If FirstPaint already ended (e.g. the content painted after the skeleton), bail so ContentLoad keeps its COLD scenario.
+function endNavigateToReportsFirstPaint(startType: NavigateToReportsStartType) {
+    // If FirstPaint already ended (e.g. the content painted after the skeleton), bail so ContentLoad keeps its COLD start type.
     if (!getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT)) {
         return;
     }
-    // ContentLoad ends later and cannot tell cold from warm itself, so tag it with the scenario now.
-    getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD)?.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SCENARIO, scenario);
+    // ContentLoad ends later and cannot tell cold from warm itself, so tag it with the start type now.
+    getSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD)?.setAttribute(CONST.TELEMETRY.ATTRIBUTE_START_TYPE, startType);
     endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_FIRST_PAINT, {
-        [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
+        [CONST.TELEMETRY.ATTRIBUTE_START_TYPE]: startType,
         ...readSearchQueryAttributes(),
     });
 }
@@ -63,9 +63,9 @@ function endNavigateToReportsContentLoad() {
     if (!span) {
         return;
     }
-    // FirstPaint should set the scenario on this span. UNKNOWN is a fallback: if we see it, FirstPaint did not run and there is a bug.
-    if (spanToJSON(span).data?.[CONST.TELEMETRY.ATTRIBUTE_SCENARIO] === undefined) {
-        span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SCENARIO, CONST.TELEMETRY.NAVIGATE_TO_REPORTS_SCENARIO.UNKNOWN);
+    // FirstPaint should set the start type on this span. UNKNOWN is a fallback: if we see it, FirstPaint did not run and there is a bug.
+    if (spanToJSON(span).data?.[CONST.TELEMETRY.ATTRIBUTE_START_TYPE] === undefined) {
+        span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_START_TYPE, CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE.UNKNOWN);
     }
     endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS_CONTENT_LOAD, readSearchQueryAttributes());
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Slack discussion (part 1): https://expensify.slack.com/archives/C05LX9D6E07/p1779895369593329?thread_ts=1779738175.511259&cid=C05LX9D6E07
Slack discussion (part 2): https://expensify.slack.com/archives/C05LX9D6E07/p1780415761788419?thread_ts=1780334564.264769&cid=C05LX9D6E07

This PR splits the single legacy `ManualNavigateToReports` navigation metric into two finer-grained telemetry spans. The legacy span keeps emitting unchanged alongside them (so existing dashboards are unaffected); the intent is to remove it once the new spans have a baseline:

- **`ManualNavigateToReportsFirstPaint`** - ends at the first visible paint after tapping the Reports/Search tab. That first paint is a skeleton in both a cold start (the data-loading skeleton shown while results are still being fetched) and a warm first render (the `NavigationDeferredMount` placeholder skeleton, painted before the real content mounts). Only on a cached re-visit is the first paint the content itself.
- **`ManualNavigateToReportsContentLoad`** - ends only at the real content paint, so it keeps ticking through any skeleton (cold data-loading or warm deferred-mount) and measures time-to-usable-content.

Both spans share the tab-tap start time and a single `start_type` value, and both are tagged with search query descriptors parsed from the resolved route, so the metrics can be sliced without callers passing anything in:

- `start_type`: `cold` | `warm_first` | `warm_subsequent` - the start type, captured when FirstPaint ends and copied onto the ContentLoad span instance so both carry the same value:
  - `cold`: data not yet fetched from the backend - the data-loading skeleton paints first.
  - `warm_first`: data ready, first render of Search in the session - the deferred-mount skeleton paints, then the content.
  - `warm_subsequent`: Search already cached by the tab navigator - re-focused and painted directly, no skeleton.
- `search_type`, `search_view` and the optional `search_group_by` - read from the active search route at first paint (the span starts before `Navigation.navigate`, so the route is only resolved by first paint).

Implementation notes:
- A new `src/libs/telemetry/navigateToReportsSpans.ts` module owns the start/end/cancel lifecycle of both spans. `start_type` and the query attributes are stamped onto the `ContentLoad` span instance when `FirstPaint` ends, because `ContentLoad` ends later and cannot tell cold from warm itself.
- End calls are wired at every existing paint site (`SearchLoadingSkeleton`, `SearchWithNavigationDeferredMount`, `Search/index.tsx` layout/chart/refocus handlers). The first end-call per span wins; later ends on an already-ended span are no-ops.
- The unmount cancel uses a per-span mount-identity guard so an abandoned navigation cannot cancel a span that a newer navigation already restarted; the blur cancel is unconditional (blur fires before the next tab tap starts new spans, so there is no freshly-started span to protect).
- `cancelTabNavigationSpans` now preserves the whole Reports-tab span group (legacy + FirstPaint + ContentLoad) for the focused tab, instead of only the single legacy span.

`ManualNavigateToReportsFirstPaint` example:
```json
{
    "spanId": "ManualNavigateToReportsFirstPaint",
    "durationMs": 222,
    "timestamp": 7572.0999999940395,
    "attributes": {
        "sentry.op": "ManualNavigateToReportsFirstPaint",
        "start_type": "cold", // 'cold' | 'warm_first' | 'warm_subsequent'
        "search_type": "expense", // 'expense' | 'expense-report' | 'invoice' | 'task' | 'trip' | 'chat'
        "search_view": "table", // 'table' | 'bar' | 'line' | 'pie'
        // "search_group_by" (optional ) 'from' | 'card' | 'withdrawal-id' | 'category' | 'merchant' | 'tag' | 'month' | 'week' | 'year' | 'quarter'
    }
}
```

`ManualNavigateToReportsContentLoad` example:
```json
{
    "spanId": "ManualNavigateToReportsContentLoad",
    "durationMs": 850,
    "timestamp": 8199.70000000298,
    "attributes": {
        "sentry.op": "ManualNavigateToReportsContentLoad",
        "start_type": "cold", // 'cold' | 'warm_first' | 'warm_subsequent'
        "search_type": "expense", // 'expense' | 'expense-report' | 'invoice' | 'task' | 'trip' | 'chat'
        "search_view": "table", // 'table' | 'bar' | 'line' | 'pie'
        // "search_group_by" (optional ) 'from' | 'card' | 'withdrawal-id' | 'category' | 'merchant' | 'tag' | 'month' | 'week' | 'year' | 'quarter'
    }
}
```

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/92516
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

These spans are dev/telemetry-only and are observed in the browser console on the development environment (`https://dev.new.expensify.com:8082/`).

Setup:
1. Log in on dev (`npm run web`).
2. Go to **Settings > Troubleshoot**, scroll to the **Sentry debug** section, enable **Log Sentry requests to console**, and set **Highlighted span names** to `ManualNavigateToReportsFirstPaint, ManualNavigateToReportsContentLoad` so the two new spans are surfaced as `[SENTRY][SPAN][...]` lines.
   - Note: each span is also logged unconditionally as a `[Sentry][<spanId>] Ending span (Xms)` line (from `activeSpans`), so you can alternatively filter the console for `[Sentry][ManualNavigateToReports`.
3. Open the browser DevTools console.
4. **Cold start** — In Troubleshoot, run **Reset Onyx**, refresh the page, then navigate to the Reports page. Verify the page-level skeleton is shown until data arrives, then the list renders.
   - Verify `ManualNavigateToReportsFirstPaint` ends at the skeleton paint with `start_type: "cold"`, and `ManualNavigateToReportsContentLoad` keeps running through the skeleton and ends later at the list paint, also with `start_type: "cold"`.
5. **Warm start, first render** — Go to Home, refresh the page, then navigate to the Reports page. Verify a skeleton briefly paints before the list appears.
   - Verify `ManualNavigateToReportsFirstPaint` ends at the deferred-mount skeleton paint with `start_type: "warm_first"`, and `ManualNavigateToReportsContentLoad` ends at the list paint.
6. **Warm start, cached render** — Go to Home, then back to the Reports page. Verify the list shows immediately without a skeleton.
   - Verify both spans end with `start_type: "warm_subsequent"`.
7. For each span, verify the `search_type`, `search_view` and (when grouping is active) `search_group_by` attributes match the current search query/route.
8. Verify the legacy `ManualNavigateToReports` span is still logged unchanged alongside the new ones.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A - this PR only adds client-side telemetry spans logged to the console; there is no offline-specific behavior to validate.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

N/A - dev/telemetry-only change with no user-facing behavior; nothing to validate on staging. PR is marked `[NO QA]`.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


https://github.com/user-attachments/assets/9f0cf948-301e-45b4-8924-04fbdd89d9b2


