### PR TITLE
Fix duplicate distance rates after copy settings optimistic update

### DIFF
--- a/src/libs/actions/Policy/CopyPolicySettings.ts
+++ b/src/libs/actions/Policy/CopyPolicySettings.ts
@@ -86,7 +86,10 @@ function copyCustomUnitPreservingRateIDs(sourceUnit: CustomUnit, targetUnit: Cus
     for (const sourceRate of Object.values(sourceUnit.rates ?? {})) {
         const rateName = sourceRate.name ?? '';
         const existingTargetRateID = rateName ? targetRateIDByName[rateName] : undefined;
-        const rateID = existingTargetRateID ?? generateHexadecimalValue(13);
+        // Reuse the target's ID when names match. Otherwise keep the source ID so Auth can mint a
+        // fresh target ID and null the source key in its MERGE response — client-generated IDs
+        // would not be cleared and would duplicate the server rate.
+        const rateID = existingTargetRateID ?? sourceRate.customUnitRateID;
         remappedRates[rateID] = {
             ...sourceRate,
             customUnitRateID: rateID,
@@ -103,8 +106,8 @@ function copyCustomUnitPreservingRateIDs(sourceUnit: CustomUnit, targetUnit: Cus
 /**
  * Returns the customUnits patch to merge into the target policy when distanceRates and/or perDiem are
  * being copied. The source unit data is written under the target's existing unit ID — a new ID is
- * generated only when the target has no unit of that type yet. Rate IDs are remapped by name to match
- * the target's existing IDs so optimistic state stays aligned with the backend copy.
+ * generated only when the target has no unit of that type yet. Existing target rate IDs are reused
+ * when names match; otherwise source rate IDs are kept until Auth replaces them on save.
  */
 function buildCustomUnitsPatch(sourcePolicy: Policy, targetPolicy: Policy, isDistanceSelected: boolean, isPerDiemSelected: boolean): {customUnits: Record<string, CustomUnit>} | undefined {
     if (!isDistanceSelected && !isPerDiemSelected) {

--- a/src/libs/actions/Policy/CopyPolicySettings.ts
+++ b/src/libs/actions/Policy/CopyPolicySettings.ts
@@ -81,7 +81,7 @@ function buildTargetRateIDByName(targetUnit: CustomUnit | undefined): Record<str
 
 function copyCustomUnitPreservingRateIDs(sourceUnit: CustomUnit, targetUnit: CustomUnit | undefined, targetUnitID: string): CustomUnit {
     const targetRateIDByName = buildTargetRateIDByName(targetUnit);
-    const remappedRates: Record<string, Rate> = {};
+    const remappedRates: Record<string, Rate | null> = {};
 
     for (const sourceRate of Object.values(sourceUnit.rates ?? {})) {
         const rateName = sourceRate.name ?? '';
@@ -96,10 +96,25 @@ function copyCustomUnitPreservingRateIDs(sourceUnit: CustomUnit, targetUnit: Cus
         };
     }
 
+    // Null source workspace rate IDs remapped to a target ID (or dropped) so stale keys do not linger.
+    for (const sourceRate of Object.values(sourceUnit.rates ?? {})) {
+        const sourceRateID = sourceRate.customUnitRateID;
+        if (sourceRateID && remappedRates[sourceRateID] === undefined) {
+            remappedRates[sourceRateID] = null;
+        }
+    }
+
+    // Copy replaces target rates entirely. Null IDs the target had but the copy no longer uses.
+    for (const existingTargetRateID of Object.keys(targetUnit?.rates ?? {})) {
+        if (remappedRates[existingTargetRateID] === undefined) {
+            remappedRates[existingTargetRateID] = null;
+        }
+    }
+
     return {
         ...sourceUnit,
         customUnitID: targetUnitID,
-        rates: remappedRates,
+        rates: remappedRates as Record<string, Rate>,
     };
 }
 

--- a/src/libs/actions/Policy/CopyPolicySettings.ts
+++ b/src/libs/actions/Policy/CopyPolicySettings.ts
@@ -8,7 +8,7 @@ import {generateHexadecimalValue} from '@libs/NumberUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {CopyPolicySettings as CopyPolicySettingsState, Policy, PolicyCategories, PolicyTagLists} from '@src/types/onyx';
-import type {CustomUnit} from '@src/types/onyx/Policy';
+import type {CustomUnit, Rate} from '@src/types/onyx/Policy';
 
 type Part = 'overview' | 'members' | 'reports' | 'accounting' | 'categories' | 'tags' | 'taxes' | 'workflows' | 'rules' | 'codingRules' | 'distanceRates' | 'perDiem' | 'invoices' | 'travel';
 
@@ -65,10 +65,46 @@ function findCustomUnitByName(policy: Policy | undefined, unitName: string): Cus
     return Object.values(policy.customUnits).find((unit) => unit.name === unitName);
 }
 
+function buildTargetRateIDByName(targetUnit: CustomUnit | undefined): Record<string, string> {
+    if (!targetUnit?.rates) {
+        return {};
+    }
+
+    const targetRateIDByName: Record<string, string> = {};
+    for (const rate of Object.values(targetUnit.rates)) {
+        if (rate.name && rate.customUnitRateID) {
+            targetRateIDByName[rate.name] = rate.customUnitRateID;
+        }
+    }
+    return targetRateIDByName;
+}
+
+function copyCustomUnitPreservingRateIDs(sourceUnit: CustomUnit, targetUnit: CustomUnit | undefined, targetUnitID: string): CustomUnit {
+    const targetRateIDByName = buildTargetRateIDByName(targetUnit);
+    const remappedRates: Record<string, Rate> = {};
+
+    for (const sourceRate of Object.values(sourceUnit.rates ?? {})) {
+        const rateName = sourceRate.name ?? '';
+        const existingTargetRateID = rateName ? targetRateIDByName[rateName] : undefined;
+        const rateID = existingTargetRateID ?? generateHexadecimalValue(13);
+        remappedRates[rateID] = {
+            ...sourceRate,
+            customUnitRateID: rateID,
+        };
+    }
+
+    return {
+        ...sourceUnit,
+        customUnitID: targetUnitID,
+        rates: remappedRates,
+    };
+}
+
 /**
  * Returns the customUnits patch to merge into the target policy when distanceRates and/or perDiem are
  * being copied. The source unit data is written under the target's existing unit ID — a new ID is
- * generated only when the target has no unit of that type yet.
+ * generated only when the target has no unit of that type yet. Rate IDs are remapped by name to match
+ * the target's existing IDs so optimistic state stays aligned with the backend copy.
  */
 function buildCustomUnitsPatch(sourcePolicy: Policy, targetPolicy: Policy, isDistanceSelected: boolean, isPerDiemSelected: boolean): {customUnits: Record<string, CustomUnit>} | undefined {
     if (!isDistanceSelected && !isPerDiemSelected) {
@@ -82,7 +118,7 @@ function buildCustomUnitsPatch(sourcePolicy: Policy, targetPolicy: Policy, isDis
         if (sourceDistance) {
             const targetDistance = findCustomUnitByName(targetPolicy, CONST.CUSTOM_UNITS.NAME_DISTANCE);
             const targetUnitID = targetDistance?.customUnitID ?? generateHexadecimalValue(13);
-            patch[targetUnitID] = {...sourceDistance, customUnitID: targetUnitID};
+            patch[targetUnitID] = copyCustomUnitPreservingRateIDs(sourceDistance, targetDistance, targetUnitID);
         }
     }
 
@@ -91,7 +127,7 @@ function buildCustomUnitsPatch(sourcePolicy: Policy, targetPolicy: Policy, isDis
         if (sourcePerDiem) {
             const targetPerDiem = findCustomUnitByName(targetPolicy, CONST.CUSTOM_UNITS.NAME_PER_DIEM_INTERNATIONAL);
             const targetUnitID = targetPerDiem?.customUnitID ?? generateHexadecimalValue(13);
-            patch[targetUnitID] = {...sourcePerDiem, customUnitID: targetUnitID};
+            patch[targetUnitID] = copyCustomUnitPreservingRateIDs(sourcePerDiem, targetPerDiem, targetUnitID);
         }
     }
 

--- a/tests/actions/CopyPolicySettingsTest.ts
+++ b/tests/actions/CopyPolicySettingsTest.ts
@@ -294,9 +294,8 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(Object.keys(value.customUnits ?? {})).toEqual([targetExistingDistanceID]);
                 expect(value.customUnits?.[targetExistingDistanceID]?.customUnitID).toBe(targetExistingDistanceID);
                 const optimisticRates = value.customUnits?.[targetExistingDistanceID]?.rates ?? {};
-                expect(Object.keys(optimisticRates)).toHaveLength(1);
-                expect(optimisticRates[Object.keys(optimisticRates).at(0) ?? '']).toMatchObject({name: 'IRS', rate: 67, customUnitRateID: Object.keys(optimisticRates).at(0)});
-                expect(optimisticRates).not.toHaveProperty('SRC_RATE');
+                expect(Object.keys(optimisticRates)).toEqual(['SRC_RATE']);
+                expect(optimisticRates.SRC_RATE).toMatchObject({name: 'IRS', rate: 67, customUnitRateID: 'SRC_RATE'});
                 expect(optimisticRates).not.toHaveProperty('OLD');
                 expect(value.pendingFields?.customUnits).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
             });
@@ -346,6 +345,42 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(optimisticRates).not.toHaveProperty('SRC_RATE');
             });
 
+            it('reuses target rate IDs for matching names and source rate IDs for new names', () => {
+                const sourcePolicy = makeSourcePolicy({
+                    customUnits: {
+                        '0456CFF9A3C11': {
+                            customUnitID: '0456CFF9A3C11',
+                            name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
+                            attributes: {unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
+                            rates: {
+                                '7CC7FA1043DE4': {customUnitRateID: '7CC7FA1043DE4', name: 'Default Rate', rate: 72.5, enabled: true, currency: 'USD'},
+                                A43964868248C: {customUnitRateID: 'A43964868248C', name: 'ws', rate: 2200, enabled: true, currency: 'USD'},
+                            },
+                        },
+                    },
+                });
+                const targetPolicy = makeTargetPolicy({
+                    customUnits: {
+                        '2473AA45B9260': {
+                            customUnitID: '2473AA45B9260',
+                            name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
+                            attributes: {unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
+                            rates: {
+                                C34632101C99C: {customUnitRateID: 'C34632101C99C', name: 'Default Rate', rate: 72.5, enabled: true, currency: 'USD'},
+                            },
+                        },
+                    },
+                });
+
+                const {optimisticData} = buildCopyPolicySettingsData(sourcePolicy, [targetPolicy], ['distanceRates'], {}, {});
+
+                const optimisticRates = (findPolicyOptimistic(optimisticData)?.value as {customUnits?: Record<string, CustomUnit>}).customUnits?.['2473AA45B9260']?.rates ?? {};
+                expect(Object.keys(optimisticRates).sort()).toEqual(['A43964868248C', 'C34632101C99C'].sort());
+                expect(optimisticRates.C34632101C99C).toMatchObject({name: 'Default Rate', rate: 72.5, customUnitRateID: 'C34632101C99C'});
+                expect(optimisticRates.A43964868248C).toMatchObject({name: 'ws', rate: 2200, customUnitRateID: 'A43964868248C'});
+                expect(optimisticRates).not.toHaveProperty('7CC7FA1043DE4');
+            });
+
             it('generates a new unit ID when target has no distance unit', () => {
                 const sourcePolicy = makeSourcePolicy({customUnits: {[sourceDistanceUnit.customUnitID]: sourceDistanceUnit}});
                 const targetPolicy = makeTargetPolicy({customUnits: {}});
@@ -390,10 +425,10 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(Object.keys(value.customUnits ?? {}).sort()).toEqual([targetExistingDistanceID, targetExistingPerDiemID].sort());
                 const distanceRates = value.customUnits?.[targetExistingDistanceID]?.rates ?? {};
                 const perDiemRates = value.customUnits?.[targetExistingPerDiemID]?.rates ?? {};
-                expect(Object.keys(distanceRates)).toHaveLength(1);
-                expect(distanceRates[Object.keys(distanceRates).at(0) ?? '']).toMatchObject({name: 'IRS', rate: 67});
-                expect(Object.keys(perDiemRates)).toHaveLength(1);
-                expect(perDiemRates[Object.keys(perDiemRates).at(0) ?? '']).toMatchObject({name: 'NYC', rate: 100});
+                expect(Object.keys(distanceRates)).toEqual(['SRC_RATE']);
+                expect(distanceRates.SRC_RATE).toMatchObject({name: 'IRS', rate: 67, customUnitRateID: 'SRC_RATE'});
+                expect(Object.keys(perDiemRates)).toEqual(['SRC_PD_RATE']);
+                expect(perDiemRates.SRC_PD_RATE).toMatchObject({name: 'NYC', rate: 100, customUnitRateID: 'SRC_PD_RATE'});
             });
         });
 
@@ -483,11 +518,10 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 // The optimistic unit is keyed by target's existing ID, with source's rates (no old rates)
                 const optimisticUnit = value.customUnits?.[targetDistanceUnit.customUnitID];
                 const optimisticRates = optimisticUnit?.rates ?? {};
-                expect(Object.keys(optimisticRates)).toHaveLength(1);
-                expect(optimisticRates[Object.keys(optimisticRates).at(0) ?? '']).toMatchObject({name: 'New', rate: 67});
+                expect(Object.keys(optimisticRates)).toEqual(['NEW_RATE']);
+                expect(optimisticRates.NEW_RATE).toMatchObject({name: 'New', rate: 67, customUnitRateID: 'NEW_RATE'});
                 expect(optimisticRates).not.toHaveProperty('OLD_RATE_A');
                 expect(optimisticRates).not.toHaveProperty('OLD_RATE_B');
-                expect(optimisticRates).not.toHaveProperty('NEW_RATE');
             });
 
             it('failure SET fully restores target — newly-added custom unit IDs are removed', () => {

--- a/tests/actions/CopyPolicySettingsTest.ts
+++ b/tests/actions/CopyPolicySettingsTest.ts
@@ -294,9 +294,9 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(Object.keys(value.customUnits ?? {})).toEqual([targetExistingDistanceID]);
                 expect(value.customUnits?.[targetExistingDistanceID]?.customUnitID).toBe(targetExistingDistanceID);
                 const optimisticRates = value.customUnits?.[targetExistingDistanceID]?.rates ?? {};
-                expect(Object.keys(optimisticRates)).toEqual(['SRC_RATE']);
+                expect(Object.keys(optimisticRates).sort()).toEqual(['OLD', 'SRC_RATE'].sort());
                 expect(optimisticRates.SRC_RATE).toMatchObject({name: 'IRS', rate: 67, customUnitRateID: 'SRC_RATE'});
-                expect(optimisticRates).not.toHaveProperty('OLD');
+                expect(optimisticRates.OLD).toBeNull();
                 expect(value.pendingFields?.customUnits).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
             });
 
@@ -336,13 +336,13 @@ describe('actions/Policy/CopyPolicySettings', () => {
 
                 const value = findPolicyOptimistic(optimisticData)?.value as {customUnits?: Record<string, CustomUnit>};
                 const optimisticRates = value.customUnits?.[targetExistingDistanceID]?.rates ?? {};
-                expect(Object.keys(optimisticRates)).toEqual([targetExistingRateID]);
+                expect(Object.keys(optimisticRates).sort()).toEqual(['SRC_RATE', targetExistingRateID].sort());
                 expect(optimisticRates[targetExistingRateID]).toMatchObject({
                     customUnitRateID: targetExistingRateID,
                     name: 'Default Rate',
                     rate: 0.25,
                 });
-                expect(optimisticRates).not.toHaveProperty('SRC_RATE');
+                expect(optimisticRates.SRC_RATE).toBeNull();
             });
 
             it('reuses target rate IDs for matching names and source rate IDs for new names', () => {
@@ -375,10 +375,10 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 const {optimisticData} = buildCopyPolicySettingsData(sourcePolicy, [targetPolicy], ['distanceRates'], {}, {});
 
                 const optimisticRates = (findPolicyOptimistic(optimisticData)?.value as {customUnits?: Record<string, CustomUnit>}).customUnits?.['2473AA45B9260']?.rates ?? {};
-                expect(Object.keys(optimisticRates).sort()).toEqual(['A43964868248C', 'C34632101C99C'].sort());
+                expect(Object.keys(optimisticRates).sort()).toEqual(['7CC7FA1043DE4', 'A43964868248C', 'C34632101C99C'].sort());
                 expect(optimisticRates.C34632101C99C).toMatchObject({name: 'Default Rate', rate: 72.5, customUnitRateID: 'C34632101C99C'});
                 expect(optimisticRates.A43964868248C).toMatchObject({name: 'ws', rate: 2200, customUnitRateID: 'A43964868248C'});
-                expect(optimisticRates).not.toHaveProperty('7CC7FA1043DE4');
+                expect(optimisticRates['7CC7FA1043DE4']).toBeNull();
             });
 
             it('generates a new unit ID when target has no distance unit', () => {
@@ -515,13 +515,13 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 const {optimisticData} = buildCopyPolicySettingsData(sourcePolicy, [targetPolicy], ['distanceRates'], {}, {});
                 const value = findPolicyOptimistic(optimisticData)?.value as Policy;
 
-                // The optimistic unit is keyed by target's existing ID, with source's rates (no old rates)
+                // Copy replaces target rates; stale target IDs are nulled so merge/SET can drop them.
                 const optimisticUnit = value.customUnits?.[targetDistanceUnit.customUnitID];
                 const optimisticRates = optimisticUnit?.rates ?? {};
-                expect(Object.keys(optimisticRates)).toEqual(['NEW_RATE']);
+                expect(Object.keys(optimisticRates).sort()).toEqual(['NEW_RATE', 'OLD_RATE_A', 'OLD_RATE_B'].sort());
                 expect(optimisticRates.NEW_RATE).toMatchObject({name: 'New', rate: 67, customUnitRateID: 'NEW_RATE'});
-                expect(optimisticRates).not.toHaveProperty('OLD_RATE_A');
-                expect(optimisticRates).not.toHaveProperty('OLD_RATE_B');
+                expect(optimisticRates.OLD_RATE_A).toBeNull();
+                expect(optimisticRates.OLD_RATE_B).toBeNull();
             });
 
             it('failure SET fully restores target — newly-added custom unit IDs are removed', () => {

--- a/tests/actions/CopyPolicySettingsTest.ts
+++ b/tests/actions/CopyPolicySettingsTest.ts
@@ -293,8 +293,57 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(value.customUnits).toBeDefined();
                 expect(Object.keys(value.customUnits ?? {})).toEqual([targetExistingDistanceID]);
                 expect(value.customUnits?.[targetExistingDistanceID]?.customUnitID).toBe(targetExistingDistanceID);
-                expect(value.customUnits?.[targetExistingDistanceID]?.rates).toEqual(sourceDistanceUnit.rates);
+                const optimisticRates = value.customUnits?.[targetExistingDistanceID]?.rates ?? {};
+                expect(Object.keys(optimisticRates)).toHaveLength(1);
+                expect(optimisticRates[Object.keys(optimisticRates).at(0) ?? '']).toMatchObject({name: 'IRS', rate: 67, customUnitRateID: Object.keys(optimisticRates).at(0)});
+                expect(optimisticRates).not.toHaveProperty('SRC_RATE');
+                expect(optimisticRates).not.toHaveProperty('OLD');
                 expect(value.pendingFields?.customUnits).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
+            });
+
+            it('remaps distance rate IDs by name to match the target when names overlap', () => {
+                const targetExistingRateID = 'TARGET_RATE_ID01';
+                const sourcePolicy = makeSourcePolicy({
+                    customUnits: {
+                        [sourceDistanceUnit.customUnitID]: {
+                            ...sourceDistanceUnit,
+                            rates: {
+                                SRC_RATE: {customUnitRateID: 'SRC_RATE', name: 'Default Rate', rate: 0.25, enabled: true, currency: 'USD'},
+                            },
+                        },
+                    },
+                });
+                const targetExistingDistanceID = '2000000000001';
+                const targetPolicy = makeTargetPolicy({
+                    customUnits: {
+                        [targetExistingDistanceID]: {
+                            customUnitID: targetExistingDistanceID,
+                            name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
+                            attributes: {unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS},
+                            rates: {
+                                [targetExistingRateID]: {
+                                    customUnitRateID: targetExistingRateID,
+                                    name: 'Default Rate',
+                                    rate: 0.25,
+                                    enabled: true,
+                                    currency: 'USD',
+                                },
+                            },
+                        },
+                    },
+                });
+
+                const {optimisticData} = buildCopyPolicySettingsData(sourcePolicy, [targetPolicy], ['distanceRates'], {}, {});
+
+                const value = findPolicyOptimistic(optimisticData)?.value as {customUnits?: Record<string, CustomUnit>};
+                const optimisticRates = value.customUnits?.[targetExistingDistanceID]?.rates ?? {};
+                expect(Object.keys(optimisticRates)).toEqual([targetExistingRateID]);
+                expect(optimisticRates[targetExistingRateID]).toMatchObject({
+                    customUnitRateID: targetExistingRateID,
+                    name: 'Default Rate',
+                    rate: 0.25,
+                });
+                expect(optimisticRates).not.toHaveProperty('SRC_RATE');
             });
 
             it('generates a new unit ID when target has no distance unit', () => {
@@ -339,8 +388,12 @@ describe('actions/Policy/CopyPolicySettings', () => {
 
                 const value = findPolicyOptimistic(optimisticData)?.value as {customUnits?: Record<string, CustomUnit>};
                 expect(Object.keys(value.customUnits ?? {}).sort()).toEqual([targetExistingDistanceID, targetExistingPerDiemID].sort());
-                expect(value.customUnits?.[targetExistingDistanceID]?.rates).toEqual(sourceDistanceUnit.rates);
-                expect(value.customUnits?.[targetExistingPerDiemID]?.rates).toEqual(sourcePerDiemUnit.rates);
+                const distanceRates = value.customUnits?.[targetExistingDistanceID]?.rates ?? {};
+                const perDiemRates = value.customUnits?.[targetExistingPerDiemID]?.rates ?? {};
+                expect(Object.keys(distanceRates)).toHaveLength(1);
+                expect(distanceRates[Object.keys(distanceRates).at(0) ?? '']).toMatchObject({name: 'IRS', rate: 67});
+                expect(Object.keys(perDiemRates)).toHaveLength(1);
+                expect(perDiemRates[Object.keys(perDiemRates).at(0) ?? '']).toMatchObject({name: 'NYC', rate: 100});
             });
         });
 
@@ -429,9 +482,12 @@ describe('actions/Policy/CopyPolicySettings', () => {
 
                 // The optimistic unit is keyed by target's existing ID, with source's rates (no old rates)
                 const optimisticUnit = value.customUnits?.[targetDistanceUnit.customUnitID];
-                expect(optimisticUnit?.rates).toEqual(sourceDistanceUnit.rates);
-                expect(optimisticUnit?.rates).not.toHaveProperty('OLD_RATE_A');
-                expect(optimisticUnit?.rates).not.toHaveProperty('OLD_RATE_B');
+                const optimisticRates = optimisticUnit?.rates ?? {};
+                expect(Object.keys(optimisticRates)).toHaveLength(1);
+                expect(optimisticRates[Object.keys(optimisticRates).at(0) ?? '']).toMatchObject({name: 'New', rate: 67});
+                expect(optimisticRates).not.toHaveProperty('OLD_RATE_A');
+                expect(optimisticRates).not.toHaveProperty('OLD_RATE_B');
+                expect(optimisticRates).not.toHaveProperty('NEW_RATE');
             });
 
             it('failure SET fully restores target — newly-added custom unit IDs are removed', () => {


### PR DESCRIPTION
### Explanation of Change
When copying distance rates (or per diem) between workspaces, the optimistic update must align with Auth's async MERGE behavior. Onyx deep-merges `customUnits.rates`, so stale rate keys accumulate unless they are explicitly nulled.

This change remaps rate IDs and clears stale keys in the optimistic SET:

1. **Matching names on the target** — reuse the target's existing `customUnitRateID` (e.g. both workspaces have "Default Rate" but different underlying IDs). The source ID is nulled so it does not linger after merge.
2. **New rate names on the target** — keep the source rate ID temporarily instead of generating a client-only ID. Auth mints a fresh target ID on save and nulls the source key in its MERGE response; client-generated IDs would never be cleared and would duplicate the server rate.
3. **Dropped target rates** — null any pre-copy target rate ID the copy no longer uses so the SET replaces the target's rate list entirely.

Pairs with [Auth#22015](https://github.com/Expensify/Auth/pull/22015), which sends the full live rates object plus nulls for every dropped source/target ID in server MERGE Onyx.

### Fixed Issues
$ https://github.com/Expensify/App/issues/92329
PROPOSAL:

### Tests
1. Create workspace A and workspace B (both Control).
2. Enable distance rates on both workspaces.
3. On both, ensure there is a "Default Rate" with the same amount (e.g. $0.25/mi) but note they are separate workspaces (different underlying rate IDs).
4. On workspace A, open **Copy settings** and copy **Distance rates** to workspace B.
5. Without refreshing, open workspace B → **Workspaces** → **Distance rates**.
6. Verify there is only one "Default Rate" (no duplicate).
7. On workspace B, create a distance expense and verify it saves without rate-related errors.

8. On workspace A, add a new distance rate with a unique name (e.g. "ws") that workspace B does not have.
9. Copy **Distance rates** from A to B again and wait for the copy job to finish (`nvp_bulkPolicyCopySettings` → `complete`).
10. Open workspace B **Distance rates** and verify one entry per rate name (no duplicate "ws" or "Default Rate").
11. Create a distance expense on B using the copied rate and verify it succeeds.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests steps 1-7. Copy settings requires network; after the copy completes, opening Distance rates and creating a distance expense should work offline with the correct single rate.

### QA Steps
1. Create two Control workspaces (A and B) with distance rates enabled.
2. Set the same default distance rate value on both (e.g. $0.25/mi).
3. From workspace A, use **Copy settings** → copy **Distance rates** to workspace B.
4. On workspace B, open **Distance rates** immediately (do not refresh the app).
5. Confirm only one "Default Rate" is shown.
6. Create a distance expense on workspace B and confirm it succeeds.
7. Add a new named rate on A only, copy distance rates to B again, wait for completion, and confirm B shows one entry per name (not two "ws").
8. Confirm no errors in the JS console.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
N/A - logic-only change; QA steps above cover verification.
</details>

<details>
<summary>Android: mWeb Chrome</summary>
N/A
</details>

<details>
<summary>iOS: Native</summary>
N/A
</details>

<details>
<summary>iOS: mWeb Safari</summary>
N/A
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
N/A
</details>