### PR TITLE
Fix floating camera button contrast

### DIFF
--- a/src/components/FloatingCameraButton/BaseFloatingCameraButton.tsx
+++ b/src/components/FloatingCameraButton/BaseFloatingCameraButton.tsx
@@ -104,7 +104,7 @@ function BaseFloatingCameraButton({icon}: BaseFloatingCameraButtonProps) {
             sentryLabel={CONST.SENTRY_LABEL.NAVIGATION_TAB_BAR.FLOATING_CAMERA_BUTTON}
         >
             <View
-                style={styles.floatingActionButton}
+                style={[styles.floatingActionButton, styles.floatingCameraActionButton]}
                 testID="floating-camera-button-container"
             >
                 <Icon

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1801,6 +1801,10 @@ const staticStyles = (theme: ThemeColors) =>
             boxShadow: theme.shadow,
         },
 
+        floatingCameraActionButton: {
+            backgroundColor: colors.green600,
+        },
+
         floatingSecondaryActionButton: {
             backgroundColor: theme.buttonDefaultBG,
             height: variables.componentSizeLarge,


### PR DESCRIPTION
## Summary

Fixes the WCAG 1.4.11 non-text contrast issue for the floating camera button by giving the camera FAB a dedicated accessible green background while leaving the general success button color unchanged.

## Changes

- Added `floatingCameraActionButton` style using the existing `colors.green600`.
- Applied that style only to `BaseFloatingCameraButton`.

## Contrast Verification

- Previous reported contrast: `#FFFFFF` on `#03D37B` = `1.98:1`
- New contrast: `#FFFFFF` on `#008C59` = `4.29:1`
- Required non-text contrast: `3.00:1`

## Tests

- `git diff --check`
- Local contrast calculation with WCAG relative luminance formula

Note: full app typecheck was not run locally because dependencies were not installed in the fresh clone.

$ https://github.com/Expensify/App/issues/77406
