### PR TITLE
Fix inline wrapping for comment links

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.tsx
@@ -141,7 +141,7 @@ function AnchorRenderer({tnode, style, key}: AnchorRendererProps) {
                 styles.textUnderlinePositionUnder,
                 styles.textDecorationSkipInkNone,
                 isChildOfTaskTitle && styles.taskTitleMenuItem,
-                styles.dInlineFlex,
+                styles.dInline,
                 hoverStyle,
             ]}
             key={key}
@@ -167,7 +167,7 @@ function AnchorRenderer({tnode, style, key}: AnchorRendererProps) {
                                     textDecorationLineStyle,
                                     styles.textUnderlinePositionUnder,
                                     styles.textDecorationSkipInkNone,
-                                    styles.dInlineFlex,
+                                    styles.dInline,
                                     hoverStyle,
                                 ]}
                             >


### PR DESCRIPTION
## Summary

Fixes inline hyperlink wrapping in chat comments by rendering comment links as inline text instead of inline-flex boxes.

## Root Cause

Comment anchors were styled with `styles.dInlineFlex`. On web, `inline-flex` creates an atomic inline-level flex container, so the whole hyperlink is laid out as one unbreakable box. When the linked phrase does not fit at the end of a line, the browser moves the entire link to the next line instead of wrapping it naturally with the surrounding sentence.

## Changes

- Changed comment link wrapper style from `dInlineFlex` to `dInline`.
- Changed the rendered text child style from `dInlineFlex` to `dInline`.
- Kept the existing link styling, hover color, underline handling, task title style, and context-menu behavior intact.

## Tests

- `git diff --check`
- Static verification of the renderer: chat-comment links now use `display: inline`, which allows natural line wrapping at word boundaries.

Note: full app typecheck was not run locally because dependencies were not installed in the fresh clone.

$ https://github.com/Expensify/App/issues/90362
