### PR TITLE
Fix Victory chart legend spacing

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/context/VictoryChartContext.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/context/VictoryChartContext.tsx
@@ -6,6 +6,9 @@ import processVictoryChartTree from '@components/HTMLEngineProvider/HTMLRenderer
 import type {ChartType, ProcessNodeResult} from '@components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/types';
 import parseStyles from '@components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/utils/parseStyles';
 
+const DEFAULT_LEGEND_FONT_SIZE = 14;
+const LEGEND_AXIS_GAP = 12;
+
 type VictoryChartContextValue = {
     tnode: TNode;
     data: ProcessNodeResult['data'];
@@ -27,14 +30,80 @@ type VictoryChartContextValue = {
 
 const VictoryChartContext = createContext<VictoryChartContextValue | null>(null);
 
+function getPaddingBottom(padding: ProcessNodeResult['padding']): number {
+    if (typeof padding === 'number') {
+        return padding;
+    }
+    return padding?.bottom ?? 0;
+}
+
+function getLegendHeight(legendItem: ProcessNodeResult['legendItems'][number]): number {
+    return legendItem.entries.reduce((maxHeight, entry) => {
+        const symbolHeight = (entry.symbolSize ?? 0) * 2;
+        const textHeight = entry.fontSize ?? DEFAULT_LEGEND_FONT_SIZE;
+        return Math.max(maxHeight, symbolHeight, textHeight);
+    }, 0);
+}
+
+function reserveLegendBottomPadding({
+    chartHeight,
+    isHorizontal,
+    legendItems,
+    padding,
+}: {
+    chartHeight: number | undefined;
+    isHorizontal: ProcessNodeResult['isHorizontal'];
+    legendItems: ProcessNodeResult['legendItems'];
+    padding: ProcessNodeResult['padding'];
+}): ProcessNodeResult['padding'] {
+    if (!chartHeight || isHorizontal || legendItems.length === 0) {
+        return padding;
+    }
+
+    const requiredBottomPadding = legendItems.reduce((maxPadding, legendItem) => {
+        if (legendItem.y < chartHeight / 2) {
+            return maxPadding;
+        }
+
+        const legendHeight = getLegendHeight(legendItem);
+        const distanceFromBottom = chartHeight - legendItem.y;
+        return Math.max(maxPadding, Math.ceil(distanceFromBottom + legendHeight + LEGEND_AXIS_GAP));
+    }, getPaddingBottom(padding));
+
+    if (typeof padding === 'number') {
+        return Math.max(padding, requiredBottomPadding);
+    }
+
+    return {...padding, bottom: requiredBottomPadding};
+}
+
 /**
  * Parses the HTML tnode tree into chart config and makes it available to all chart sub-components.
  * Returns null when the chart data is invalid (no data points, or mixed cartesian/polar content).
  */
 function VictoryChartProvider({tnode, children}: {tnode: TNode; children: React.ReactNode}) {
     const {regular: regularTypeface} = useChartDefaultTypeface();
-    const {data, xKey, yKeys, xAxis, yAxis, domain, domainPadding, padding, isHorizontal, categories, labelItems, legendItems} = processVictoryChartTree(tnode, regularTypeface, null);
     const {nodeStyles: chartContentStyles, parentNodeStyles: chartContainerStyles} = parseStyles(tnode);
+    const {
+        data,
+        xKey,
+        yKeys,
+        xAxis,
+        yAxis,
+        domain,
+        domainPadding,
+        padding: parsedPadding,
+        isHorizontal,
+        categories,
+        labelItems,
+        legendItems,
+    } = processVictoryChartTree(tnode, regularTypeface, null);
+    const padding = reserveLegendBottomPadding({
+        chartHeight: typeof chartContentStyles.height === 'number' ? chartContentStyles.height : undefined,
+        isHorizontal,
+        legendItems,
+        padding: parsedPadding,
+    });
 
     const hasCartesianData = Object.values(data).some((entry) => X_KEY in entry);
     const hasPolarData = Object.values(data).some((entry) => LABEL_KEY in entry);


### PR DESCRIPTION
## Summary

Fixes the vertical Victory chart legend overlap by reserving bottom padding for legends that are positioned near the bottom of the chart canvas.

The renderer uses absolute coordinates from `<victorylegend>` nodes, while `victory-native` does not automatically reserve plot padding for those overlay elements. When a vertical chart places the legend near the bottom, the x-axis labels can occupy the same space. This change computes the minimum required bottom padding from the chart height, legend y-position, symbol/text size, and a small axis gap, then applies it only for vertical cartesian charts with lower-half legends.

## Changes

- Adds a `reserveLegendBottomPadding()` helper in `VictoryChartContext`.
- Preserves existing numeric or object padding values and only increases `bottom` when needed.
- Leaves horizontal charts and charts without bottom legends unchanged.

## Test

- `git diff --check`

Full typecheck was not run locally because this checkout does not have `node_modules` installed.

$ #91860
