### PR TITLE
Avoid toReversed in money request report actions

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -171,7 +171,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;


### PR DESCRIPTION
## Summary

Fixes the Chrome 103 crash in `MoneyRequestReportActionsList` by replacing `Array.prototype.toReversed()` with the older-compatible `slice().reverse()` pattern.

`toReversed()` is not available in Chrome versions before 110, so managed Chrome OS / older Chromium users can hit a render-time `TypeError` and land in the ErrorBoundary. `slice().reverse()` keeps the original immutable behavior while working in those browsers.

## Test

- `git diff --check`
- Confirmed `MoneyRequestReportActionsList.tsx` no longer contains `toReversed()`

Full typecheck was not run locally because this checkout does not have `node_modules` installed.

$ #91964
