### PR TITLE
Require focus before marking visible report read

### DIFF
--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -575,7 +575,7 @@ function ReportActionsList({
         const isFromNotification = route?.params?.referrer === CONST.REFERRER.NOTIFICATION;
         const isScrolledToEnd = scrollOffsetRef.current < CONST.REPORT.ACTIONS.ACTION_VISIBLE_THRESHOLD;
 
-        if ((isVisible || isFromNotification) && !hasNewerActions && isScrolledToEnd) {
+        if (((isVisible && isFocused) || isFromNotification) && !hasNewerActions && isScrolledToEnd) {
             readNewestAction(report.reportID, !!reportLoadingState?.hasOnceLoadedReportActions);
             if (isFromNotification) {
                 Navigation.setParams({referrer: undefined});
@@ -585,7 +585,7 @@ function ReportActionsList({
 
         readActionSkipped.current = true;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [report.lastVisibleActionCreated, transactionThreadReport?.lastVisibleActionCreated, report.reportID, isVisible, reportLoadingState?.hasOnceLoadedReportActions]);
+    }, [report.lastVisibleActionCreated, transactionThreadReport?.lastVisibleActionCreated, report.reportID, isVisible, isFocused, reportLoadingState?.hasOnceLoadedReportActions]);
 
     const handleAppVisibilityMarkAsRead = useCallback(() => {
         if (report.reportID !== prevReportID) {


### PR DESCRIPTION
## Summary

Fixes the visible-but-unfocused desktop notification gap by requiring window focus before auto-marking the currently open report as read.

When NewDot stays visible but another desktop app has focus, `Visibility.isVisible()` remains true while `Visibility.hasFocus()` is false. The current report was still auto-marked as read, causing the later notification gate to treat the incoming message as already seen. This change keeps the notification-referrer exception, but otherwise requires both visibility and focus before advancing `lastReadTime`.

## Test

- `git diff --check`

Manual browser notification testing was not run in this local checkout.

$ #92273
