### PR TITLE
Default expense report searches to ascending date sort

### DIFF
--- a/src/libs/SearchParser/searchParser.js
+++ b/src/libs/SearchParser/searchParser.js
@@ -4721,6 +4721,10 @@ function peg$parse(input, options) {
       return;
     }
 
+    if (field === "type" && value === "expense-report" && !userProvidedSortOrder) {
+      defaultValues.sortOrder = "asc";
+    }
+
     // Track if user explicitly provided a custom (non-default) sortBy
     if (field === "sortBy" && !isDefaultSortValue(value)) {
       userProvidedSortBy = true;

--- a/src/libs/SearchParser/searchParser.peggy
+++ b/src/libs/SearchParser/searchParser.peggy
@@ -118,6 +118,10 @@
       return;
     }
 
+    if (field === "type" && value === "expense-report" && !userProvidedSortOrder) {
+      defaultValues.sortOrder = "asc";
+    }
+
     // Track if user explicitly provided a custom (non-default) sortBy
     if (field === "sortBy" && !isDefaultSortValue(value)) {
       userProvidedSortBy = true;


### PR DESCRIPTION
## Summary

Fixes the default Spend > Reports sort so report searches start at `Date / ASC` instead of `Date / DESC`.

The search parser has a global default of `sortBy: date` and `sortOrder: desc`, which is still correct for expense searches. For `type:expense-report`, the expected default is ascending date order so RBR pre-sort does not remain pinned at the top after changing sort. This change updates the parser default only when the query type is `expense-report` and the user did not explicitly provide a sort order.

## Test

- `git diff --check`
- Ran the generated parser directly with Node and confirmed:
  - `type:expense-report` -> `sortBy: date`, `sortOrder: asc`
  - `type:expense-report sort-order:desc` -> explicit `desc` is preserved
  - `type:expense` -> default `desc` is unchanged

Full typecheck was not run locally because this checkout does not have `node_modules` installed.

$ #91935
