### PR TITLE
[50] Fix null.replace crash on onboarding purpose - Sentry APP-BSG

### DIFF
--- a/src/components/FormHelpMessage.tsx
+++ b/src/components/FormHelpMessage.tsx
@@ -90,7 +90,7 @@ function FormHelpMessage({
     });
 
     const HTMLMessage = useMemo(() => {
-        if (typeof message !== 'string' || !shouldRenderMessageAsHTML) {
+        if (typeof message !== 'string' || !shouldRenderMessageAsHTML || !message) {
             return '';
         }
 

--- a/src/components/RenderHTML.tsx
+++ b/src/components/RenderHTML.tsx
@@ -42,7 +42,7 @@ function RenderHTML({html: htmlParam, onLinkPress, isSelectable}: RenderHTMLProp
     const {windowWidth} = useWindowDimensions();
     const html = useMemo(() => {
         return (
-            Parser.replace(htmlParam, {shouldEscapeText: false, filterRules: ['emoji']})
+            Parser.replace(htmlParam ?? '', {shouldEscapeText: false, filterRules: ['emoji']})
                 // Escape brackets when pasting a link, since unescaped [] can break Markdown link syntax
                 .replaceAll(RE_BRACKET_ESCAPE, (m) => (m.at(7) === '1' ? '[' : ']'))
                 // Remove double <emoji> tag if exists and keep the outermost tag (always the original tag).


### PR DESCRIPTION
Fixes Sentry crash: null.replace at /onboarding/purpose. 94 users. Added null guards to FormHelpMessage and RenderHTML.