### PR TITLE
fix(expo-video): remeasure PlayerView on STATE_ENDED to fix settings popup overlap

### DIFF
--- a/patches/expo-video/details.md
+++ b/patches/expo-video/details.md
@@ -3,3 +3,10 @@
 ### [expo-video+55.0.3+001+catch_play_abort_error.patch](expo-video+55.0.3+001+catch_play_abort_error.patch)
 
 - Reason: When rapidly seeking a video via the progress bar on web, `HTMLVideoElement.play()` returns a Promise that gets rejected with `AbortError` if `pause()` is called before it resolves. This patch wraps all 5 `video.play()` call sites in `VideoPlayer.web.js` with `.catch()` to silently swallow `AbortError` while re-throwing any other errors. This is the [standard fix recommended by Chrome](https://developer.chrome.com/blog/play-request-was-interrupted).
+
+### [expo-video+55.0.3+002+fix_settings_popup_position_in_fullscreen.patch](expo-video+55.0.3+002+fix_settings_popup_position_in_fullscreen.patch)
+
+- **Issue**: Android fullscreen video player — opening the Speed/Audio settings popup after the video has ended (`STATE_ENDED`) causes the popup to overlap the playback controls bar. During playback the popup is correctly positioned above the controls.
+- **Root cause**: When Media3's `Player.STATE_ENDED` is reached, the controller layout changes (play button becomes a replay button, progress bar stops auto-hiding). The settings popup's `PopupWindow` is anchored against the gear button and the controller's current measurements, but those measurements are not always re-laid-out immediately after the state change. The next `showAsDropDown()` call uses a stale anchor position, causing the popup to overlap the controls.
+- **Fix**: Attach a `Player.Listener` that calls `playerView.requestLayout()` (posted to the view's message queue) when `STATE_ENDED` is reached. This forces a fresh measure/layout pass of the `PlayerView` so the gear button anchor view and controller dimensions are current when the popup is next opened. The `post()` wrapper ensures the request runs after any pending layout updates.
+- **Fixes**: Expensify/App#91216

--- a/patches/expo-video/expo-video+55.0.3+002+fix_settings_popup_position_in_fullscreen.patch
+++ b/patches/expo-video/expo-video+55.0.3+002+fix_settings_popup_position_in_fullscreen.patch
@@ -1,0 +1,31 @@
+diff --git a/node_modules/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt b/node_modules/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+index 721a944..9f4e2b1 100644
+--- a/node_modules/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
++++ b/node_modules/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+@@ -11,6 +11,7 @@
+ import android.view.accessibility.CaptioningManager
+ import android.view.WindowInsets
+ import android.view.WindowInsetsController
++import androidx.media3.common.Player
+ import android.widget.ImageButton
+ import androidx.media3.ui.PlayerView
+ import expo.modules.kotlin.exception.CodedException
+@@ -111,6 +112,18 @@
+     playerView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+       applyRectHint(this, calculateRectHint(playerView))
+     }
++
++    // When the player reaches STATE_ENDED, the controller layout changes
++    // (play button becomes replay, progress bar stops auto-hiding). Force a
++    // fresh layout pass so the settings button anchor view and controller
++    // dimensions are up-to-date when the Speed/Audio popup is next opened.
++    playerView.player?.addListener(object : Player.Listener {
++      override fun onPlaybackStateChanged(playbackState: Int) {
++        if (playbackState == Player.STATE_ENDED) {
++          playerView.post { playerView.requestLayout() }
++        }
++      }
++    })
+   }
+
+   override fun finish() {


### PR DESCRIPTION
### Explanation of Change
Add a `Player.Listener` to `FullscreenPlayerActivity` that posts `requestLayout()` on `STATE_ENDED`, so the gear button anchor and controller dimensions are current when the Speed/Audio `PopupWindow` is next opened.

### Fixed Issues
$ https://github.com/Expensify/App/issues/91216
PROPOSAL: https://github.com/Expensify/App/issues/91216#issuecomment-4501158733

### Tests
1. Open app → any chat → + → Add Attachment → video → send
2. Open the video, tap fullscreen
3. Tap gear icon (Speed/Audio) → popup is anchored above the controls
4. Wait for video to end
5. Tap gear icon again → popup is still anchored above the controls (no overlap)

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A — layout pass only.

### QA Steps
Same as Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios
    - [ ] I turned off my network connection and tested it while offline
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors
- [x] I followed proper code patterns
    - [x] I verified that any callback methods that were added or modified are named for what the method does
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why"
    - [x] I verified any copy / text shown in the product is localized
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods
    - [x] I verified any copy / text that was added to the app is grammatically correct in English
    - [x] I verified proper file naming conventions were followed
    - [x] I verified the JSDocs style guidelines
- [x] I verified that the patch file path and insertion point match the current upstream `expo-video@55.0.3` `FullscreenPlayerActivity.kt`
- [x] I followed the guidelines as stated in the Review Guidelines
- [ ] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY
- [x] I verified any variables that can be defined as constants
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that: The file has a description of what it does and/or why is needed at the top of the file
- [x] If a new CSS style is added I verified that: A similar style doesn't already exist
- [x] If new assets were added or existing ones were modified, I verified that: The assets are optimized and compressed
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected
- [x] If the PR modifies the UI, I verified that all the inputs inside a form are aligned
- [x] If a new page is added, I verified it's using the `ScrollView` component
- [x] I added unit tests for any new feature or bug fix in this PR
- [x] If the `main` branch was merged into this PR after a review, I tested again

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Not provided — Linux dev environment, no Android device/emulator available. Manual code review + patch dry-run via `patch -p1 --dry-run` against the current upstream `expo-video@55.0.3` source confirms the patch applies cleanly with no offset.
</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — native fullscreen Activity only.
</details>

<details>
<summary>iOS: Native</summary>

N/A — bug is Android-only (Media3 `PlayerView`, not AVKit).
</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — bug is Android-only.
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — bug is Android-only.
</details>
