### PR TITLE
fix: raise PaginationTest timeout to 240s to fix CI flake (92493)

### DIFF
--- a/tests/ui/PaginationTest.tsx
+++ b/tests/ui/PaginationTest.tsx
@@ -19,7 +19,7 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 import waitForNetworkPromises from '../utils/waitForNetworkPromises';
 
 // We need a large timeout here as we are lazy loading React Navigation screens and this test is running against the entire mounted App
-jest.setTimeout(120000);
+jest.setTimeout(240000);
 
 jest.mock('@libs/BootSplash', () => ({
     hide: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Problem
`tests/ui/PaginationTest.tsx` › `opens a chat and load initial messages` intermittently fails in CI with `Exceeded timeout of 120000 ms for a test.`

## Root Cause
The first test in the suite pays the cold-start cost of mounting `<App/>` and lazy-loading every React Navigation screen (~42s locally). On loaded CI runners with `--coverage` instrumentation and 6 parallel workers, this intermittently crosses the 120s ceiling.

## Fix
Raise `jest.setTimeout(120000)` to `jest.setTimeout(240000)` — matching the precedent already established by `SessionTest.tsx:33` for the same class of full-App UI integration tests.

## Scope
- Test-only change, 1 line
- No production code touched
- No test semantics changed

$ #92493