### PR TITLE
chore: upgrade `react-native-view-shot` to 5.1.0

### DIFF
--- a/ios/NewExpensify.xcodeproj/project.pbxproj
+++ b/ios/NewExpensify.xcodeproj/project.pbxproj
@@ -811,6 +811,7 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/nanopb/nanopb_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-blob-util/ReactNativeBlobUtilPrivacyInfo.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-view-shot/RNViewShotPrivacyInfo.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -840,6 +841,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/nanopb_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReactNativeBlobUtilPrivacyInfo.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNViewShotPrivacyInfo.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -137,7 +137,7 @@ PODS:
   - ExpoImageManipulator (55.0.2):
     - ExpoModulesCore
     - SDWebImageWebPCoder
-  - ExpoLocation (55.0.3):
+  - ExpoLocation (55.1.10):
     - ExpoModulesCore
   - ExpoLogBox (55.0.7):
     - React-Core
@@ -2879,7 +2879,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-view-shot (4.0.0):
+  - react-native-view-shot (5.1.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4781,7 +4781,7 @@ SPEC CHECKSUMS:
   ExpoFont: 86ceec09ffed1c99cfee36ceb79ba149074901b5
   ExpoImage: 8f835720453ed5be7764d9650aa1efde8109abc7
   ExpoImageManipulator: ae244131e2c3da68a030332fcbd87287fbdd8f97
-  ExpoLocation: fec7703a4922c4748b380723669f771376ffbd05
+  ExpoLocation: b9fb270b71354bffc20edbb1f9d1f99dcfbc3dc8
   ExpoLogBox: 89b634d5a8a64c4a6a7caad8f9985a28463c7002
   ExpoModulesCore: a0657acfb83a882b48f84492a095fd44fd43b26c
   ExpoModulesJSI: 1685389cde9f19c40f98ca0ad46d4804471486cc
@@ -4881,7 +4881,7 @@ SPEC CHECKSUMS:
   react-native-plaid-link-sdk: 425c0a3a923310fcd8489142209ff1508372a7bf
   react-native-safe-area-context: 0a3b034bb63a5b684dd2f5fffd3c90ef6ed41ee8
   react-native-skia: 51f30133876025c83e933f4f7253479e6de5d937
-  react-native-view-shot: 28aca10c6c6e5331959ba4b6cb2fced572f88af3
+  react-native-view-shot: 1a01c96f6fb09b99539142749cd93f685af7fe48
   react-native-wallet: 4e3cc1f48ca653ad4a96df8da7e6bd9c8987b3e3
   react-native-webview: cdce419e8022d0ef6f07db21890631258e7a9e6e
   React-NativeModulesApple: e554252d69442010807867cc7d70c0008048ad20

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,7 @@
         "react-native-svg": "15.12.1",
         "react-native-tab-view": "^4.3.0",
         "react-native-url-polyfill": "^2.0.0",
-        "react-native-view-shot": "4.0.0",
+        "react-native-view-shot": "5.1.0",
         "react-native-vision-camera": "^4.7.2",
         "react-native-web": "0.21.2",
         "react-native-webview": "13.16.0",
@@ -35904,14 +35904,20 @@
       }
     },
     "node_modules/react-native-view-shot": {
-      "version": "4.0.0",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-5.1.0.tgz",
+      "integrity": "sha512-JZgElCD82aO+hejIF/leUzI7JufL9mgJ6ChzGWIcdZ2ajpaEvvSnvIcw0qD32XWkrbId8wfSbyz/4u/ulTQzQA==",
       "license": "MIT",
       "dependencies": {
         "html2canvas": "^1.4.1"
       },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
+      },
       "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
+        "react": ">=18.0.0",
+        "react-native": ">=0.76.0"
       }
     },
     "node_modules/react-native-vision-camera": {

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "react-native-svg": "15.12.1",
     "react-native-tab-view": "^4.3.0",
     "react-native-url-polyfill": "^2.0.0",
-    "react-native-view-shot": "4.0.0",
+    "react-native-view-shot": "5.1.0",
     "react-native-vision-camera": "^4.7.2",
     "react-native-web": "0.21.2",
     "react-native-webview": "13.16.0",

--- a/src/components/QRShare/QRShareWithDownload/index.native.tsx
+++ b/src/components/QRShare/QRShareWithDownload/index.native.tsx
@@ -1,5 +1,6 @@
 import React, {useImperativeHandle, useRef} from 'react';
 import ViewShot from 'react-native-view-shot';
+import type {ViewShotRef} from 'react-native-view-shot';
 import getQrCodeFileName from '@components/QRShare/getQrCodeDownloadFileName';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
@@ -11,7 +12,7 @@ function QRShareWithDownload({ref, ...props}: QRShareWithDownloadProps) {
     const {isOffline} = useNetwork();
     const {translate} = useLocalize();
 
-    const qrCodeScreenshotRef = useRef<ViewShot>(null);
+    const qrCodeScreenshotRef = useRef<ViewShotRef>(null);
 
     useImperativeHandle(
         ref,

--- a/src/pages/settings/Profile/Avatar/AvatarCapture/index.native.tsx
+++ b/src/pages/settings/Profile/Avatar/AvatarCapture/index.native.tsx
@@ -1,4 +1,5 @@
 import React, {useImperativeHandle, useRef} from 'react';
+import type {ViewShotRef} from 'react-native-view-shot';
 import ViewShot from 'react-native-view-shot';
 import variables from '@styles/variables';
 import type {AvatarCaptureProps} from './types';
@@ -7,7 +8,7 @@ import type {AvatarCaptureProps} from './types';
  * Native implementation of AvatarCapture using react-native-view-shot
  */
 function AvatarCapture({children, fileName, ref}: AvatarCaptureProps) {
-    const viewShotRef = useRef<ViewShot>(null);
+    const viewShotRef = useRef<ViewShotRef>(null);
 
     useImperativeHandle(
         ref,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Upgrades `react-native-view-shot` from 4.0.0 to 5.1.0. This native dependency upgrade is required for React Native 0.85.3 compatibility.

### Fixed Issues
$ https://github.com/Expensify/App/issues/92531
PROPOSAL:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/13965

### Tests
**QR code download (iOS & Android)**
1. Go to Settings > Profile and tap your avatar to open the QR share screen.
2. Tap the download button to save the QR code image.
3. Verify the QR code is saved to the device gallery/files without errors.

**Avatar capture (iOS & Android)**
1. Go to Settings > Profile > Edit avatar.
2. Select an image and confirm the avatar crop/preview.
3. Verify the avatar is captured and saved successfully without errors.

### Offline tests
N/A — dependency version bump with no behavioral changes.

### QA Steps
Same as tests.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
