### PR TITLE
[No QA] Fix flaky SessionTest job 8 timeout

### DIFF
--- a/tests/ui/SessionTest.tsx
+++ b/tests/ui/SessionTest.tsx
@@ -1,10 +1,10 @@
-import {render} from '@testing-library/react-native';
+import {act, cleanup, render} from '@testing-library/react-native';
 import {Str} from 'expensify-common';
 import {Linking} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import * as AppActions from '@libs/actions/App';
-import {hasAuthToken, signOutAndRedirectToSignIn} from '@libs/actions/Session';
+import {hasAuthToken} from '@libs/actions/Session';
 import * as Session from '@libs/actions/Session';
 import {getCurrentUserEmail, setLastShortAuthToken} from '@libs/Network/NetworkStore';
 import App from '@src/App';
@@ -12,9 +12,11 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import {createRandomReport} from '../utils/collections/reports';
+import PusherHelper from '../utils/PusherHelper';
 import * as TestHelper from '../utils/TestHelper';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
 import waitForNetworkPromises from '../utils/waitForNetworkPromises';
+import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
 
 jest.mock('@libs/BootSplash', () => ({
     hide: jest.fn().mockResolvedValue(undefined),
@@ -30,7 +32,8 @@ const TEST_USER_LOGIN_2 = 'test2@test.com';
 // cspell:disable-next-line
 const TEST_AUTH_TOKEN_2 = 'zxcvbnm';
 
-jest.setTimeout(240000);
+// We need a large timeout here as we are lazy loading React Navigation screens and this test is running against the entire mounted App
+jest.setTimeout(120000);
 TestHelper.setupApp();
 TestHelper.setupGlobalFetchMock();
 
@@ -49,6 +52,7 @@ function getInitialURL() {
 
 describe('Deep linking', () => {
     let lastVisitedPath: string | undefined;
+    let lastVisitedPathConnectionID: ReturnType<typeof Onyx.connect> | undefined;
     let originalSignInWithShortLivedAuthToken: typeof Session.signInWithShortLivedAuthToken;
     let originalOpenApp: typeof AppActions.openApp;
 
@@ -58,7 +62,9 @@ describe('Deep linking', () => {
     });
 
     beforeEach(() => {
-        Onyx.connect({
+        wrapOnyxWithWaitForBatchedUpdates(Onyx);
+
+        lastVisitedPathConnectionID = Onyx.connect({
             key: ONYXKEYS.LAST_VISITED_PATH,
             callback: (val: OnyxEntry<string>) => (lastVisitedPath = val),
         });
@@ -96,8 +102,16 @@ describe('Deep linking', () => {
     });
 
     afterEach(async () => {
-        await Onyx.clear();
-        await waitForNetworkPromises();
+        if (lastVisitedPathConnectionID) {
+            Onyx.disconnect(lastVisitedPathConnectionID);
+            lastVisitedPathConnectionID = undefined;
+        }
+        cleanup();
+        await act(async () => {
+            await Onyx.clear();
+        });
+        await waitForBatchedUpdatesWithAct();
+        PusherHelper.teardown();
         jest.clearAllMocks();
         lastVisitedPath = undefined;
         Linking.setInitialURL('');
@@ -119,9 +133,9 @@ describe('Deep linking', () => {
 
         expect(hasAuthToken()).toBe(true);
 
-        signOutAndRedirectToSignIn();
-
+        await TestHelper.signOutTestUser();
         await waitForBatchedUpdatesWithAct();
+        await waitForNetworkPromises();
 
         expect(hasAuthToken()).toBe(false);
 
@@ -134,6 +148,7 @@ describe('Deep linking', () => {
 
         unmount();
         await waitForBatchedUpdatesWithAct();
+        await waitForNetworkPromises();
     });
 
     it('should not reuse the last deep link and log in again when signing out', async () => {
@@ -150,6 +165,7 @@ describe('Deep linking', () => {
         unmount1();
 
         await waitForBatchedUpdatesWithAct();
+        await waitForNetworkPromises();
 
         const url = getInitialURL();
         // User signs in automatically when the app is remounted because of the deep link.
@@ -161,13 +177,16 @@ describe('Deep linking', () => {
 
         expect(getCurrentUserEmail()).toBe(TEST_USER_LOGIN_1);
 
-        signOutAndRedirectToSignIn();
-
+        await TestHelper.signOutTestUser();
         await waitForBatchedUpdatesWithAct();
+        await waitForNetworkPromises();
 
         // In a failing scenario, remounting triggers the sign-in with the deep link again because it still remembers it.
         // However, we've implemented a fix so that it does not reuse the last deep link.
         unmount2();
+        await waitForBatchedUpdatesWithAct();
+        await waitForNetworkPromises();
+
         const {unmount: unmount3} = render(<App />);
 
         await waitForBatchedUpdatesWithAct();
@@ -176,5 +195,6 @@ describe('Deep linking', () => {
 
         unmount3();
         await waitForBatchedUpdatesWithAct();
+        await waitForNetworkPromises();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Fixes flaky `tests/ui/SessionTest.tsx` failures on CI job 8 (test shard 8/8), which were timing out at 240s when deep-link sign-out/remount async work did not settle.

Aligns the test with existing full-`<App />` UI test patterns:

- `TestHelper.signOutTestUser()` instead of bare `signOutAndRedirectToSignIn()`
- `Onyx.disconnect` for the `LAST_VISITED_PATH` subscription before `Onyx.clear()`
- `wrapOnyxWithWaitForBatchedUpdates`, `cleanup()`, `act(() => Onyx.clear())`, and `PusherHelper.teardown()` in teardown (same as `PaginationTest`)
- `waitForBatchedUpdatesWithAct()` + `waitForNetworkPromises()` between unmount/remount cycles
- Reverts suite timeout from 240s back to 120s (matching other App UI tests; no further timeout increase)

### Fixed Issues

$ https://github.com/Expensify/App/issues/92538

### Tests

1. Run `npx jest tests/ui/SessionTest.tsx --no-cache` and confirm both tests in the `Deep linking` describe block pass.
2. Run the command 3–5 times locally to confirm the suite is stable (no timeout).
3. Optionally run CI shard parity: `npm test -- --silent --shard=8/8 --maxWorkers=6 tests/ui/SessionTest.tsx`

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — test infrastructure only; no offline behavior changed.

### QA Steps

N/A — [No QA]. Test-only change; no production code or user-visible behavior changed.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — no UI changes (test infrastructure only).

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — no UI changes (test infrastructure only).

</details>

<details>
<summary>iOS: Native</summary>

N/A — no UI changes (test infrastructure only).

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — no UI changes (test infrastructure only).

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — no UI changes (test infrastructure only).

</details>
