### PR TITLE
fix: buffer notification events during cold start to prevent race condition (issue #92138)

### DIFF
--- a/src/libs/Notification/PushNotification/index.native.ts
+++ b/src/libs/Notification/PushNotification/index.native.ts
@@ -18,6 +18,25 @@ type NotificationEventActionMap = Partial<Record<EventType, NotificationEventHan
 
 const notificationEventActionMap: NotificationEventActionMap = {};
 
+// Queue for notification events that arrive before handlers are registered.
+// This fixes the cold start race condition where the native bridge fires
+// notification_response before JS handlers are ready (issue #92138).
+const pendingNotificationQueue: Array<{eventType: EventType; notification: PushPayload}> = [];
+let handlersRegistered = false;
+
+function replayPendingNotifications() {
+    if (!handlersRegistered || pendingNotificationQueue.length === 0) {
+        return;
+    }
+    Log.info(`[PushNotification] Replaying ${pendingNotificationQueue.length} pending notification(s)`, false);
+    while (pendingNotificationQueue.length > 0) {
+        const pending = pendingNotificationQueue.shift();
+        if (pending) {
+            pushNotificationEventCallback(pending.eventType, pending.notification);
+        }
+    }
+}
+
 /**
  * Handle a push notification event, and trigger and bound actions.
  */
@@ -40,10 +59,14 @@ function pushNotificationEventCallback(eventType: EventType, notification: PushP
 
     const action = actionMap[data.type];
     if (!action) {
-        Log.warn('[PushNotification] No callback set up: ', {
+        // No handler registered yet — queue the event for later replay.
+        // This handles the cold start race condition where the native bridge
+        // fires notification_response before JS handlers are ready (issue #92138).
+        Log.info('[PushNotification] No callback set up, queuing notification for later replay', false, {
             event: eventType,
             notificationType: data.type,
         });
+        pendingNotificationQueue.push({eventType, notification});
         return;
     }
 
@@ -146,6 +169,13 @@ function bind<T extends NotificationTypes>(triggerEvent: EventType, notification
 
     actionMap[notificationType] = callback;
     notificationEventActionMap[triggerEvent] = actionMap;
+
+    // Mark handlers as registered and replay any pending notifications
+    // that arrived before this handler was bound (cold start race condition fix)
+    if (!handlersRegistered) {
+        handlersRegistered = true;
+    }
+    replayPendingNotifications();
 }
 
 /**


### PR DESCRIPTION
## Problem

When the app is cold-started by tapping a push notification on Android, the app navigates to the last active chat instead of the chat referenced in the notification.

## Root Cause

The native Airship bridge fires `notification_response` before the JS-side handlers are registered (via dynamic import of `subscribeToPushNotifications.ts`). The notification event is dispatched into the void — `navigateToReport` is never called.

## Fix

Added a pending notification queue in `index.native.ts` that buffers notification events when no handler is registered yet. When handlers are eventually bound (via `bind()`), any pending notifications are replayed.

### Changes
- Added `pendingNotificationQueue` array to buffer early events
- Added `handlersRegistered` flag to track initialization state
- Modified `pushNotificationEventCallback` to queue events instead of silently dropping them
- Added `replayPendingNotifications()` to flush the queue
- Modified `bind()` to trigger replay after registering handlers

## Testing
- [ ] Verify cold start from notification tap opens correct chat
- [ ] Verify warm start notification tap still works
- [ ] Verify no regression in normal notification flow