### PR TITLE
fix: show prevent-spotnana modal on workspace travel CTA

### DIFF
--- a/src/pages/workspace/travel/BookOrManageYourTrip.tsx
+++ b/src/pages/workspace/travel/BookOrManageYourTrip.tsx
@@ -1,16 +1,26 @@
+import {emailSelector} from '@selectors/Session';
+import {Str} from 'expensify-common';
 import React from 'react';
 import MenuItem from '@components/MenuItem';
 import Section from '@components/Section';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useConfirmModal from '@hooks/useConfirmModal';
+import {useMemoizedLazyExpensifyIcons, useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
 import usePermissions from '@hooks/usePermissions';
 import usePolicy from '@hooks/usePolicy';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
+import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {setPolicyTravelSettings} from '@libs/actions/Policy/Travel';
+import {isEmailPublicDomain} from '@libs/LoginUtils';
+import Navigation from '@libs/Navigation/Navigation';
 import {openTravelDotLink} from '@libs/openTravelDotLink';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
+import colors from '@styles/theme/colors';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import WorkspaceTravelInvoicingSection from './WorkspaceTravelInvoicingSection';
 
 type GetStartedTravelProps = {
@@ -20,10 +30,16 @@ type GetStartedTravelProps = {
 function GetStartedTravel({policyID}: GetStartedTravelProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
     const policy = usePolicy(policyID);
     const {canWrite: canWriteMoreFeatures, withReadOnlyFallback} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.MORE_FEATURES);
     const icons = useMemoizedLazyExpensifyIcons(['LuggageWithLines', 'NewWindow']);
+    const illustrations = useMemoizedLazyIllustrations(['RocketDude']);
     const {isBetaEnabled} = usePermissions();
+    const {showConfirmModal} = useConfirmModal();
+    const [account] = useOnyx(ONYXKEYS.ACCOUNT);
+    const [sessionEmail] = useOnyx(ONYXKEYS.SESSION, {selector: emailSelector});
+    const primaryContactMethod = account?.primaryLogin ?? sessionEmail ?? '';
     const isPreventSpotnanaTravelEnabled = isBetaEnabled(CONST.BETAS.PREVENT_SPOTNANA_TRAVEL);
 
     const autoAddTripName = policy?.travelSettings?.autoAddTripName !== false;
@@ -33,10 +49,31 @@ function GetStartedTravel({policyID}: GetStartedTravelProps) {
     };
 
     const handleManageTravel = () => {
-        // TODO: Show the prevention modal when the beta is enabled
         if (isPreventSpotnanaTravelEnabled) {
+            showConfirmModal({
+                title: translate('travel.blockedFeatureModal.title'),
+                titleStyles: styles.textHeadlineH1,
+                titleContainerStyles: styles.mb2,
+                image: illustrations.RocketDude,
+                imageStyles: StyleUtils.getBackgroundColorStyle(colors.ice600),
+                prompt: translate('travel.blockedFeatureModal.message'),
+                promptStyles: styles.mb2,
+                confirmText: translate('common.buttonConfirm'),
+                shouldShowCancelButton: false,
+            });
             return;
         }
+
+        if (!primaryContactMethod || Str.isSMSLogin(primaryContactMethod)) {
+            Navigation.navigate(ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.getRoute(policyID));
+            return;
+        }
+
+        if (isEmailPublicDomain(primaryContactMethod)) {
+            Navigation.navigate(ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.getRoute(policyID));
+            return;
+        }
+
         openTravelDotLink(policyID);
     };
 

--- a/src/pages/workspace/travel/BookOrManageYourTrip.tsx
+++ b/src/pages/workspace/travel/BookOrManageYourTrip.tsx
@@ -14,13 +14,15 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {setPolicyTravelSettings} from '@libs/actions/Policy/Travel';
 import {isEmailPublicDomain} from '@libs/LoginUtils';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import {openTravelDotLink} from '@libs/openTravelDotLink';
+import {getSearchParamFromPath} from '@libs/Url';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 import colors from '@styles/theme/colors';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import WorkspaceTravelInvoicingSection from './WorkspaceTravelInvoicingSection';
 
 type GetStartedTravelProps = {
@@ -48,6 +50,12 @@ function GetStartedTravel({policyID}: GetStartedTravelProps) {
         setPolicyTravelSettings(policy, {autoAddTripName: enabled});
     };
 
+    const navigateToPublicDomainError = () => {
+        const hasPolicyIDInActiveRoute = getSearchParamFromPath(Navigation.getActiveRoute(), CONST.SEARCH.SYNTAX_FILTER_KEYS.POLICY_ID) !== null;
+        const dynamicSuffix = hasPolicyIDInActiveRoute ? DYNAMIC_ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.path : DYNAMIC_ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.getRoute(policyID);
+        Navigation.navigate(createDynamicRoute(dynamicSuffix));
+    };
+
     const handleManageTravel = () => {
         if (isPreventSpotnanaTravelEnabled) {
             showConfirmModal({
@@ -65,12 +73,12 @@ function GetStartedTravel({policyID}: GetStartedTravelProps) {
         }
 
         if (!primaryContactMethod || Str.isSMSLogin(primaryContactMethod)) {
-            Navigation.navigate(ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.getRoute(policyID));
+            navigateToPublicDomainError();
             return;
         }
 
         if (isEmailPublicDomain(primaryContactMethod)) {
-            Navigation.navigate(ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.getRoute(policyID));
+            navigateToPublicDomainError();
             return;
         }
 

--- a/src/pages/workspace/travel/BookOrManageYourTrip.tsx
+++ b/src/pages/workspace/travel/BookOrManageYourTrip.tsx
@@ -1,28 +1,19 @@
-import {emailSelector} from '@selectors/Session';
-import {Str} from 'expensify-common';
 import React from 'react';
 import MenuItem from '@components/MenuItem';
 import Section from '@components/Section';
 import useConfirmModal from '@hooks/useConfirmModal';
 import {useMemoizedLazyExpensifyIcons, useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
-import useOnyx from '@hooks/useOnyx';
 import usePermissions from '@hooks/usePermissions';
 import usePolicy from '@hooks/usePolicy';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {setPolicyTravelSettings} from '@libs/actions/Policy/Travel';
-import {isEmailPublicDomain} from '@libs/LoginUtils';
-import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
-import Navigation from '@libs/Navigation/Navigation';
 import {openTravelDotLink} from '@libs/openTravelDotLink';
-import {getSearchParamFromPath} from '@libs/Url';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 import colors from '@styles/theme/colors';
 import CONST from '@src/CONST';
-import ONYXKEYS from '@src/ONYXKEYS';
-import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import WorkspaceTravelInvoicingSection from './WorkspaceTravelInvoicingSection';
 
 type GetStartedTravelProps = {
@@ -39,21 +30,12 @@ function GetStartedTravel({policyID}: GetStartedTravelProps) {
     const illustrations = useMemoizedLazyIllustrations(['RocketDude']);
     const {isBetaEnabled} = usePermissions();
     const {showConfirmModal} = useConfirmModal();
-    const [account] = useOnyx(ONYXKEYS.ACCOUNT);
-    const [sessionEmail] = useOnyx(ONYXKEYS.SESSION, {selector: emailSelector});
-    const primaryContactMethod = account?.primaryLogin ?? sessionEmail ?? '';
     const isPreventSpotnanaTravelEnabled = isBetaEnabled(CONST.BETAS.PREVENT_SPOTNANA_TRAVEL);
 
     const autoAddTripName = policy?.travelSettings?.autoAddTripName !== false;
 
     const toggleAutoAddTripName = (enabled: boolean) => {
         setPolicyTravelSettings(policy, {autoAddTripName: enabled});
-    };
-
-    const navigateToPublicDomainError = () => {
-        const hasPolicyIDInActiveRoute = getSearchParamFromPath(Navigation.getActiveRoute(), CONST.SEARCH.SYNTAX_FILTER_KEYS.POLICY_ID) !== null;
-        const dynamicSuffix = hasPolicyIDInActiveRoute ? DYNAMIC_ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.path : DYNAMIC_ROUTES.TRAVEL_PUBLIC_DOMAIN_ERROR.getRoute(policyID);
-        Navigation.navigate(createDynamicRoute(dynamicSuffix));
     };
 
     const handleManageTravel = () => {
@@ -69,16 +51,6 @@ function GetStartedTravel({policyID}: GetStartedTravelProps) {
                 confirmText: translate('common.buttonConfirm'),
                 shouldShowCancelButton: false,
             });
-            return;
-        }
-
-        if (!primaryContactMethod || Str.isSMSLogin(primaryContactMethod)) {
-            navigateToPublicDomainError();
-            return;
-        }
-
-        if (isEmailPublicDomain(primaryContactMethod)) {
-            navigateToPublicDomainError();
             return;
         }
 


### PR DESCRIPTION
### Explanation of Change
`BookOrManageYourTrip` already checked the `preventSpotnanaTravel` beta, but that branch only returned, so the workspace travel CTA did nothing for blocked users.

This wires that branch to the same blocked-travel modal used by `BookTravelButton`: existing `travel.blockedFeatureModal.*` copy, `RocketDude`, and the standard confirm-only modal.

I kept this scoped to the workspace travel CTA. The other travel entry points already have their own beta handling or blocked views.

### Fixed Issues
$ https://github.com/Expensify/App/issues/81764
PROPOSAL: https://github.com/Expensify/App/issues/81764#issuecomment-4536902904

### Tests
1. Enable the `preventSpotnanaTravel` beta for the test account.
2. Open a workspace.
3. Go to More features, enable Travel, then scroll to the Travel get-started section.
4. Click Book or manage your trip.
5. Verify the blocked-feature modal appears with the RocketDude illustration, the blocked-feature title/message, and a single Confirm button.
6. Disable the beta.
7. Click Book or manage your trip again.
8. Verify the CTA still opens TravelDot.

- [x] Verify that no errors appear in the JS console.

### Offline tests
1. Enable the `preventSpotnanaTravel` beta.
2. Turn off network.
3. Repeat steps 2-5 from Tests.
4. Verify the blocked-feature modal still appears.

### QA Steps
Same as Tests.

- [x] Verify that no errors appear in the JS console.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Pending.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Pending.

</details>

<details>
<summary>iOS: Native</summary>

Pending.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="393" height="852" alt="iOS Safari emulation modal" src="https://raw.githubusercontent.com/yuvrajangadsingh/App/evidence-pr92647/.evidence/iphone-safari-modal.png" />

Captured via Chrome DevTools iPhone 15 Pro emulation (393x852, iOS Safari user agent, mobile, touch). The modal is the shared `useConfirmModal` UI, identical to the MacOS web capture above.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="3380" height="1874" alt="prevent_spotnana_modal_web" src="https://github.com/user-attachments/assets/2773f602-94d4-40ba-9928-9e8d941926d0" />


</details>




