### PR TITLE
[CP Staging] fix: gate chatReportID destination heuristic to per-diem only

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -479,7 +479,8 @@ function IOURequestStepConfirmation({
     const isTransactionReady = !!transaction;
     const selfDMReportID = iouType === CONST.IOU.TYPE.TRACK ? findSelfDMReportID() : undefined;
     const isMRReport = isMoneyRequestReport(report);
-    const destinationReportID = backToReport ?? (isMRReport && Navigation.getTopmostReportId() !== report?.reportID ? report?.chatReportID : report?.reportID) ?? selfDMReportID;
+    const destinationReportID =
+        backToReport ?? (isPerDiemRequest && isMRReport && Navigation.getTopmostReportId() !== report?.reportID ? report?.chatReportID : report?.reportID) ?? selfDMReportID;
 
     useEffect(() => {
         if (hasPreInsertFired.current || !isTransactionReady || !getIsNarrowLayout()) {


### PR DESCRIPTION
### Explanation of Change

PR #91266 added a heuristic in `IOURequestStepConfirmation.tsx` that redirected `destinationReportID` to `report.chatReportID` whenever `report` was a money-request report not currently topmost. The intent was to handle per diem launched from a report preview's **Add expense** (#91093), where `backToReport` is set on the parent route but dropped by the per-diem step screens (`STEP_DESTINATION`, `STEP_TIME`, `STEP_SUBRATE` don't carry it). The heuristic was not scoped, so other flows hit the same branch.

In the deploy-blocker repro the user starts at the workspace chat, runs Manual, and on the confirm page changes the Report field to A:

- `backToReport` is `undefined` (Manual from the workspace chat does not set it).
- `report` becomes Report A, so `isMRReport` is `true`.
- The workspace chat is still the topmost report behind the RHP, so `getTopmostReportId() !== report.reportID` is `true`.
- The new branch resolves `destinationReportID` to `report.chatReportID` — Report A's parent workspace chat — instead of Report A itself.

The pre-insert and submit-dismiss flows then reveal that chat instead of Report A. Picking **Create report** in step 7 hits the same branch because the new report is also a money-request report.

This PR gates the heuristic on `isPerDiemRequest` (already declared at line 144 of the same file), so the change is a single added condition. After the change:

- Manual / Scan / Distance fall back to `report?.reportID` exactly as they did before PR #91266 — the explicitly selected Report A opens.
- Per diem from a report preview (#91093) still enters the `chatReportID` branch, so the original fix is preserved.

The matching `backToReport ?? activeReportID` change in `useExpenseSubmission.ts` lives inside `submitPerDiemExpense` and never runs for Manual / Scan / Distance, so it does not need to change for this fix.

### Fixed Issues

$ https://github.com/Expensify/App/issues/92641
PROPOSAL: https://github.com/Expensify/App/issues/92641#issuecomment-4621119129

### Tests

Precondition: a workspace chat the user can post in, and the `+` action available in the composer.

1. Sign in.
2. Open the workspace chat.
3. Create two empty reports and rename them to A and B.
4. In the chat composer click `+` > **Create expense** > **Manual**.
5. Enter an amount > **Next**.
6. On the confirm page, enter a merchant and click the **Report** field.
7. Select report A.
8. Click **Create expense**.
9. Verify report A opens after submission (the app does not stay on the workspace chat).
10. Repeat steps 4–8 with **Scan** and **Distance**. Verify each lands on Report A.
11. Repeat steps 4–8 but in step 7 select **Create report** instead of report A. Verify the newly created report opens.
12. Regression check for #91093: from the workspace chat, create an empty report, on its preview tap **Add expense** > **Create expense** > **Per diem**, complete the flow. Verify the app stays on the workspace chat (does not navigate into the new expense report).

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as **Tests** with the network disabled before each submission.

1. Go offline.
2. Repeat steps 4–9 above with **Manual**.
3. Verify the expense is created optimistically, Report A is opened, and the new expense appears in Report A.
4. Reconnect and verify the expense persists with no errors.
5. Repeat for **Scan**, **Distance**, **Per diem from preview** (step 12 in **Tests**) to confirm offline parity.

### QA Steps

Same as **Tests**.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/2542a3f7-2871-4f1b-9bcc-8c11e71ef631


</details>
