### PR TITLE
Fix welcome modal showing again for users who already dismissed it (race condition in MigratedUserWelcomeModalGuard.evaluate)

### DIFF
--- a/src/libs/Navigation/guards/MigratedUserWelcomeModalGuard.ts
+++ b/src/libs/Navigation/guards/MigratedUserWelcomeModalGuard.ts
@@ -123,6 +123,16 @@ const MigratedUserWelcomeModalGuard: NavigationGuard = {
             return {type: 'ALLOW'};
         }
 
+        // Guard against the race condition where NVP_TRY_NEW_DOT arrives before
+        // NVP_DISMISSED_PRODUCT_TRAINING has been fetched. Without this check, a
+        // navigation firing between those two Onyx callbacks would see an undefined
+        // dismissedProductTraining and incorrectly redirect users who already dismissed
+        // the modal (most noticeable in copilot sessions or on large accounts with
+        // slow OpenApp responses).
+        if (!isDismissedProductTrainingLoaded) {
+            return {type: 'ALLOW'};
+        }
+
         if (hasBeenAddedToNudgeMigration && !isProductTrainingElementDismissed('migratedUserWelcomeModal', dismissedProductTraining)) {
             Log.info('[MigratedUserWelcomeModalGuard] Redirecting to migrated user welcome modal');
             hasRedirectedToMigratedUserModal = true;
@@ -139,3 +149,15 @@ const MigratedUserWelcomeModalGuard: NavigationGuard = {
 
 export default MigratedUserWelcomeModalGuard;
 export {resetSessionFlag, onSessionOrLoadingAppChanged};
+
+/**
+ * Resets the dismissal-NVP loaded flag and cached value.
+ * Only intended for use in unit tests to simulate the race condition where
+ * NVP_DISMISSED_PRODUCT_TRAINING has not yet been delivered by Onyx.
+ */
+function resetDismissedProductTrainingState() {
+    isDismissedProductTrainingLoaded = false;
+    dismissedProductTraining = undefined;
+}
+
+export {resetDismissedProductTrainingState};

--- a/tests/unit/Navigation/guards/MigratedUserWelcomeModalGuard.test.ts
+++ b/tests/unit/Navigation/guards/MigratedUserWelcomeModalGuard.test.ts
@@ -1,6 +1,6 @@
 import type {NavigationAction, NavigationState} from '@react-navigation/native';
 import Onyx from 'react-native-onyx';
-import MigratedUserWelcomeModalGuard, {onSessionOrLoadingAppChanged, resetSessionFlag} from '@libs/Navigation/guards/MigratedUserWelcomeModalGuard';
+import MigratedUserWelcomeModalGuard, {onSessionOrLoadingAppChanged, resetDismissedProductTrainingState, resetSessionFlag} from '@libs/Navigation/guards/MigratedUserWelcomeModalGuard';
 import type {GuardContext} from '@libs/Navigation/guards/types';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
@@ -58,6 +58,36 @@ describe('MigratedUserWelcomeModalGuard', () => {
         });
         await waitForBatchedUpdates();
 
+        const result = MigratedUserWelcomeModalGuard.evaluate(mockState, mockAction, defaultContext);
+        expect(result.type).toBe('ALLOW');
+    });
+
+    it('should allow when nudge migration is set but NVP_DISMISSED_PRODUCT_TRAINING has not loaded yet (race condition)', async () => {
+        // Simulate the race condition: NVP_TRY_NEW_DOT has arrived but
+        // NVP_DISMISSED_PRODUCT_TRAINING has not yet been delivered by Onyx.
+        // This happens on large accounts (e.g. copilot sessions) where OpenApp takes
+        // 20-30 seconds and the user navigates before the full Onyx payload is processed.
+        await Onyx.merge(ONYXKEYS.NVP_TRY_NEW_DOT, {
+            nudgeMigration: {
+                timestamp: new Date(),
+                cohort: 'test',
+            },
+        });
+
+        // Merge a placeholder so Onyx.clear() in the next beforeEach sees a real value
+        // change and re-fires the NVP_DISMISSED_PRODUCT_TRAINING callback (Onyx skips
+        // the callback when the value was already undefined on both sides of clear()).
+        await Onyx.merge(ONYXKEYS.NVP_DISMISSED_PRODUCT_TRAINING, {});
+        await waitForBatchedUpdates();
+
+        // Reset module-level state to replicate the window where NVP_DISMISSED_PRODUCT_TRAINING
+        // has not yet been delivered — i.e. isDismissedProductTrainingLoaded is still false.
+        // This is the exact moment the race condition strikes.
+        resetDismissedProductTrainingState();
+
+        // evaluate must return ALLOW while the dismissal NVP is still in-flight,
+        // regardless of whether the user previously dismissed the modal. Without the
+        // isDismissedProductTrainingLoaded guard this would incorrectly return REDIRECT.
         const result = MigratedUserWelcomeModalGuard.evaluate(mockState, mockAction, defaultContext);
         expect(result.type).toBe('ALLOW');
     });


### PR DESCRIPTION
### Explanation of Change

`MigratedUserWelcomeModalGuard` has two paths that can redirect to the welcome modal:

1. **Proactive path** (`navigateToMigratedUserWelcomeModalIfReady`) — already guards on `!isDismissedProductTrainingLoaded` before deciding whether to navigate.
2. **`evaluate()` path** (triggered by user-initiated navigation) — did **not** check `isDismissedProductTrainingLoaded`, causing the race condition.

When `NVP_TRY_NEW_DOT` (nudge migration eligibility) arrived in Onyx before `NVP_DISMISSED_PRODUCT_TRAINING` (the dismissal record), any navigation action would fire `evaluate()` with `dismissedProductTraining = undefined`. `isProductTrainingElementDismissed()` treats `undefined` as "not dismissed", so the guard incorrectly redirected to the modal — even for users who dismissed it weeks ago.

This race is most noticeable for copilot sessions on large accounts (VL data shows `expenses@hellopebl.com` has 6,000–9,600 reports and OpenApp takes 23–29 seconds). Each new copilot session triggers a fresh `ReconnectApp`/`OpenApp`, giving a wide window where the two NVPs can arrive out of order.

**Fix:** add `!isDismissedProductTrainingLoaded` early-return in `evaluate()`, mirroring the guard already in `navigateToMigratedUserWelcomeModalIfReady()`. This is safe for first-time users: `isDismissedProductTrainingLoaded` becomes `true` on the first Onyx callback regardless of value (even `undefined`), so the modal is still shown once data has loaded.

Also adds a unit test that proves the race condition and verifies the fix.

### Fixed Issues

$ https://github.com/Expensify/App/issues/92686

### Tests

1. Run `npx jest tests/unit/Navigation/guards/MigratedUserWelcomeModalGuard.test.ts --no-coverage`
2. Verify all 21 tests pass, including the new `should allow when nudge migration is set but NVP_DISMISSED_PRODUCT_TRAINING has not loaded yet (race condition)` test
3. To verify the fix manually: find a user with a large account who has already dismissed the welcome modal (`nvp_dismissedProductTraining.migratedUserWelcomeModal` has a timestamp); copilot into their account; navigate immediately after the app loads (before the Onyx payload finishes processing); confirm the modal does **not** reappear

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — no offline-specific behavior changed. The guard's `evaluate()` path operates on already-cached Onyx module-level state and is unaffected by network state.

### QA Steps

1. Find a user who is on nudge migration (`nvp_tryNewDot.nudgeMigration` has a timestamp) and has already dismissed the welcome modal (`nvp_dismissedProductTraining.migratedUserWelcomeModal` has a timestamp)
2. Copilot into their account on web
3. Immediately navigate to a screen (e.g. click the Search tab) while the app is still loading Onyx data
4. Verify the migrated user welcome modal does **not** appear

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>