### PR TITLE
[No QA] One Weird Trick To Make Your Jest Suite 10x Faster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,11 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .jest-cache
-          key: ${{ runner.os }}-jest
+          # Per-shard key: each shard only instruments the ~1/8 of suites it runs, so a single
+          # shared key freezes one shard's partial cache for all shards. The hash refreshes the
+          # cache when dependencies or Babel config change; restore-keys warms it in between.
+          key: ${{ runner.os }}-jest-${{ matrix.chunk }}-${{ hashFiles('package-lock.json', 'babel.config.js') }}
+          restore-keys: ${{ runner.os }}-jest-${{ matrix.chunk }}-
 
       - name: Jest tests
         run: npm test -- --silent --shard=${{ fromJSON(matrix.chunk) }}/${{ strategy.job-total }} --maxWorkers=6 --coverage --coverageDirectory=coverage/shard-${{ matrix.chunk }}

--- a/tests/ui/SessionTest.tsx
+++ b/tests/ui/SessionTest.tsx
@@ -167,7 +167,7 @@ describe('Deep linking', () => {
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },
-        4 * 60 * 1000,
+        3 * 60 * 1000,
     );
 
     // This test renders the full App three times, so it runs significantly longer than
@@ -220,6 +220,6 @@ describe('Deep linking', () => {
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },
-        4 * 60 * 1000,
+        3 * 60 * 1000,
     );
 });

--- a/tests/ui/SessionTest.tsx
+++ b/tests/ui/SessionTest.tsx
@@ -167,7 +167,7 @@ describe('Deep linking', () => {
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },
-        3 * 60 * 1000,
+        4 * 60 * 1000,
     );
 
     // This test renders the full App three times, so it runs significantly longer than
@@ -220,6 +220,6 @@ describe('Deep linking', () => {
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },
-        3 * 60 * 1000,
+        4 * 60 * 1000,
     );
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

This PR improves our jest cache keying, significantly speeding up runs (especially the SessionTest that has been timing out a lot on main)

| Metric | [Run 1](https://github.com/Expensify/App/actions/runs/26970443438/job/79583994366?pr=92720#step:6:164) — cold cache | [Run 2](https://github.com/Expensify/App/actions/runs/26970443438/job/79590870943?pr=92720#step:6:67) — warm cache | Speedup |
| --- | --- | --- | --- |
| `SessionTest.tsx` suite | 169.2 s | 14.5 s | **~11.6×** |
| Shard 8 total (`Time:`) | 368.5 s | 102.9 s | **~3.6×** |
| "Jest tests" step (wall clock) | ~6m 10s | ~1m 44s | **~3.6×** |
| Full job | ~7m 22s | ~3m 02s | **~2.4×** |

The unit test workflow runs across 8 parallel shards, and every shard restors the Jest transform cache (`.jest-cache`) using the same constant key, `${{ runner.os }}-jest`.

Each shard only runs ~1/8 of the test suites, so each one instruments and caches a different subset of files. Because the key was identical for all shards and `actions/cache` keys are immutable (a cache is only uploaded on a miss of the exact key, and never overwritten afterward), the first shard to finish froze _its_ partial cache under `Linux-jest`. Every run since restored that same partial cache — a `Cache hit` of only ~69 MB, versus ~2.2 GB for a complete local cache (at least on my machine). 

When a shard restores a cache that is missing the instrumented output for the files it needs, Jest re-instruments those files inline on first `require`. For the shard that runs `tests/ui/SessionTest.tsx`, that means paying the full `babel-plugin-istanbul` instrumentation cost for the entire `<App/>` import graph _during the test itself_. Measured locally: a warm cache runs this suite in ~13s, a cold cache in ~172s. This is why I think it times out.

This PR scopes the cache key per shard and makes it content-aware:

```yaml
key: ${{ runner.os }}-jest-${{ matrix.chunk }}-${{ hashFiles('package-lock.json', 'babel.config.js') }}
restore-keys: ${{ runner.os }}-jest-${{ matrix.chunk }}-
```

- **Per shard** (`matrix.chunk`) so each shard caches the files it actually runs, instead of inheriting another shard's partial subset.
- **Content hash** of `package-lock.json` + `babel.config.js` so the cache refreshes when dependencies or Babel/instrumentation config change, instead of being frozen forever.
- **`restore-keys`** so that when the hash changes the run still restores the shard's previous cache as a warm base; Jest's own per-file content hashing then re-transforms only the files that actually changed, and the post-job step saves the updated complete cache under the new key. Steady state stays warm — a dependency bump does not cause a fully cold run.
- Net effect: each shard keeps a complete, self-refreshing instrumentation cache, so `SessionTest` (and any other heavy full-`<App/>` suite) runs against warm instrumented output instead of paying the cold cost inline.

 ### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>