### PR TITLE
Fix: Per Diem tab missing when rates are not yet configured

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -115,8 +115,7 @@ function getActivePoliciesWithExpenseChatAndPerDiemEnabled(policies: OnyxCollect
 
 function getActivePoliciesWithExpenseChatAndPerDiemEnabledAndHasRates(policies: OnyxCollection<Policy> | null, currentUserLogin: string | undefined): Policy[] {
     return getActivePoliciesWithExpenseChat(policies, currentUserLogin).filter((policy) => {
-        const perDiemCustomUnit = getPerDiemCustomUnit(policy);
-        return policy?.arePerDiemRatesEnabled && isControlPolicy(policy) && !isEmptyObject(perDiemCustomUnit?.rates);
+        return policy?.arePerDiemRatesEnabled && isControlPolicy(policy);
     });
 }
 


### PR DESCRIPTION
### Description
Currently, the Per Diem tab is only visible if the policy has `arePerDiemRatesEnabled` set to true AND at least one rate is configured. This creates a chicken-and-egg problem where a user who just enabled Per Diem cannot see the tab to configure the initial rates.

This PR relaxes the visibility condition to only check `arePerDiemRatesEnabled`, ensuring the tab is visible so users can complete the setup.

### Fixed Issues
$ Expensify/App#92104

### Tests
1. Enable Per Diem in Workspace settings.
2. Verify the "Per Diem" tab appears in the global Create menu even if no rates are added yet.