### PR TITLE
Fix focus-trap crash when a bottom-docked modal's initialFocus ref is null (Sentry APP-C26)

### DIFF
--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -319,7 +319,10 @@ function BaseModal({
 
     const shouldWrapChildrenInScrollView = shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode && isBottomDockedModalInLandscapeMode;
     const shouldShowBottomDockedDismissButton = isSmallScreenWidth && type === CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED && !!(onBackdropPress ?? onClose);
-    const modalInitialFocus = shouldShowBottomDockedDismissButton ? () => bottomDockedDismissButtonRef.current : initialFocus;
+    // `bottomDockedDismissButtonRef.current` can be `null` by the time focus-trap reads `initialFocus` (the read is
+    // deferred via setTimeout) — e.g. the sheet was dismissed quickly, or a layout change flipped `shouldShowBottomDockedDismissButton`
+    // and unmounted the button. focus-trap throws on a `null` (vs `false`) initial focus, so coerce it to `false` ("no initial focus").
+    const modalInitialFocus = shouldShowBottomDockedDismissButton ? () => bottomDockedDismissButtonRef.current ?? false : initialFocus;
 
     return (
         <ModalContext.Provider value={modalContextValue}>

--- a/tests/ui/BaseModalTest.tsx
+++ b/tests/ui/BaseModalTest.tsx
@@ -1,0 +1,41 @@
+import {render} from '@testing-library/react-native';
+import React from 'react';
+import type ReanimatedModalProps from '@components/Modal/ReanimatedModal/types';
+import CONST from '@src/CONST';
+
+describe('BaseModal', () => {
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    it('passes a non-null initialFocus for a bottom-docked modal when the dismiss-button ref is unmounted', () => {
+        // focus-trap throws when `initialFocus` resolves to `null` (vs `false`/`undefined`). For a bottom-docked
+        // modal, the dismiss-button ref can be `null` by the time focus-trap reads it (the read is deferred), so
+        // the getter must coerce that `null` to `false`. The ReanimatedModal mock is scoped to this test (via
+        // jest.doMock) so it doesn't leak into other BaseModal cases.
+        let captured: ReanimatedModalProps | undefined;
+        jest.doMock('@components/Modal/ReanimatedModal', () => ({
+            __esModule: true,
+            default: (props: ReanimatedModalProps) => {
+                captured = props;
+                return null;
+            },
+        }));
+        const BaseModal = (require('@components/Modal/BaseModal') as {default: React.ComponentType<Record<string, unknown>>}).default;
+
+        render(
+            <BaseModal
+                isVisible
+                type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+                onClose={jest.fn()}
+            >
+                {null}
+            </BaseModal>,
+        );
+
+        const initialFocus = captured?.initialFocus;
+        expect(typeof initialFocus).toBe('function');
+        // dismiss button never mounted -> ref.current is null -> the getter resolves to false (no crash)
+        expect((initialFocus as () => unknown)()).toBe(false);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

On web (narrow / mobile viewport), opening a bottom-docked popover or menu on `/home` — the FAB "create" menu, a report-action context menu, the emoji picker, attachment options (all render as bottom sheets on small screens) — could crash the screen with:

> `` `initialFocus` was specified but was not a node, or did not return a node ``

(Sentry **APP-C26**, ~153 users / 171 events, non-deterministic.)

**Root cause.** `BaseModal` passes `() => bottomDockedDismissButtonRef.current` as `initialFocus` for bottom-docked modals (`src/components/Modal/BaseModal.tsx`). focus-trap reads `initialFocus` on a deferred `setTimeout`, and by then the dismiss button can already be unmounted — the sheet was dismissed quickly, or a relayout (resize / rotate / keyboard) flipped `shouldShowBottomDockedDismissButton` — so the getter returns `null`. focus-trap's `getNodeForOption` treats `undefined` ("auto-focus first tabbable") and `false` ("skip initial focus") as valid, but **throws on any other falsy value** (`null` / `''` / `0`). So the transient `null` crashes the trap.

**Fix (two layers).**
1. `BaseModal` coerces the getter's `null` to `false` at the source: `() => bottomDockedDismissButtonRef.current ?? false`.
2. `FocusTrapForModal` (web) normalizes any throwing `initialFocus` value to `false` at the single choke point every modal trap flows through, so no current or future caller can crash the trap. `false` / `undefined` and real nodes pass through unchanged.

### Fixed Issues

$ https://github.com/Expensify/App/issues/92415
PROPOSAL: https://github.com/Expensify/App/issues/92415#issuecomment-4606134546

### Tests

1. Added regression coverage in `tests/unit/FocusTrapForModalTest.tsx`: an `initialFocus` getter that returns `null` (and a bare `null`) now resolves to `false` instead of crashing; a real node and `false` pass through unchanged. The new cases return `null` (and would crash focus-trap) without this change.
2. Manual (web, narrow / mobile viewport, on `/home`): repeatedly open and quickly dismiss the FAB create menu, a report-action context menu, and the emoji picker; rotate / resize the window while one is opening. The screen no longer throws the `initialFocus` error.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this is focus/UI behavior with no network dependency.

### QA Steps

1. On web with a narrow viewport (or mobile web), go to `/home`.
2. Open the FAB (+) create menu and dismiss it quickly; repeat several times.
3. Open a report-action context menu and the emoji picker and dismiss quickly; rotate or resize the window while one is opening.
4. Verify the app does not crash and no `` `initialFocus` was specified but was not a node `` error appears in the console.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

_Note: this is a **web-only** fix — focus-trap doesn't run on native — so the native platform items below are N/A (the change can't affect native); verified on web (recording in Screenshots/Videos)._


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/59dc3cde-bbb0-49b2-9e9b-017885da5ba5

</details>


