### PR TITLE
Fix false 'Couldn't load card feeds' error for domain-based workspaces

### DIFF
--- a/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
@@ -128,13 +128,7 @@ function WorkspaceCompanyCardsTable({
     const hasNoAssignedCard = Object.keys(assignedCards ?? {}).length === 0;
     const areWorkspaceCardFeedsLoading = !!workspaceCardFeedsStatus?.[domainOrWorkspaceAccountID]?.isLoading && !hasOnceLoadedPage;
 
-    // Synthesize error locally since Onyx discards writes to collection keys with member ID '0'.
-    const shouldShowWorkspaceFeedsLoadError = domainOrWorkspaceAccountID === CONST.DEFAULT_NUMBER_ID && isPolicyLoaded && !isOffline;
-    const workspaceCardFeedsErrors = shouldShowWorkspaceFeedsLoadError
-        ? {
-              [CONST.COMPANY_CARDS.WORKSPACE_FEEDS_LOAD_ERROR]: translate('workspace.companyCards.error.workspaceFeedsCouldNotBeLoadedMessage'),
-          }
-        : workspaceCardFeedsStatus?.[domainOrWorkspaceAccountID]?.errors;
+    const workspaceCardFeedsErrors = workspaceCardFeedsStatus?.[domainOrWorkspaceAccountID]?.errors;
 
     const selectedFeedStatus = selectedFeed?.status;
     const selectedFeedErrors = selectedFeedStatus?.errors;


### PR DESCRIPTION
### Explanation of Change

`WorkspaceCompanyCardsTable` inferred a feed load failure from `domainOrWorkspaceAccountID === 0` and synthesized a "Couldn't load card feeds" error, because Onyx discards writes to collection keys with member ID `'0'` and so a real error could never be stored for that case. That inference was wrong in both directions: it fired while `OpenPolicyCompanyCardsPage` was still in flight, producing a flash on a cold cache, and it fired permanently for workspaces whose account ID never resolved, even though the backend returned 200. With Auth now returning `policyAccountID` from that command and linking cross-account CSV feeds to the importing policy, a `0` no longer means "load failed", so this deletes the synthesized error. Genuine failures are unaffected — they come from `failureData` in `openPolicyCompanyCardsPage`, which writes `WORKSPACE_FEEDS_LOAD_ERROR` into `workspaceCardFeedsStatus[id].errors`, and the rendering branch for that key is untouched.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/641057

### Tests

1. Sign in as an admin of a workspace with domain-level company cards.
2. Open Workspace -> Company cards.
3. Verify the page loads with no "Couldn't load card feeds" error, including on a cold cache.
4. Verify a workspace with no feeds still shows the empty state prompting you to add one.

Verified with the existing suites plus a probe on the zero-account-ID path, which renders the empty state rather than an error or a spinner:

```
before:  error=true
after:   error=false spinner=false empty=true
```

- `tests/ui/WorkspaceCompanyCardsTableTest.tsx` and `tests/unit/CompanyCardsLoadingStateTest.ts` - 6/6 passing
- [x] Verify that no errors appear in the JS console

### Offline tests

Offline behaviour is unchanged. The removed condition included `!isOffline`, and the remaining error path is only populated by an API failure response, which cannot arrive while offline.

### QA Steps

1. Sign in as an admin of a workspace with domain-level company cards.
2. Open Workspace -> Company cards.
3. Verify the page and cards load with no error banner.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>

