### PR TITLE
Revert "[CP Staging] Revert "Surface duplicate Plaid bank account error on USD VBBA flow""

### DIFF
--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
@@ -143,6 +143,12 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy}: Reimbursemen
         return achData?.currentStep ?? CONST.BANK_ACCOUNT.STEP.COUNTRY;
     };
     const currentStep = getInitialCurrentStep();
+    const prevCurrentStep = usePrevious(currentStep);
+    const prevSubStep = usePrevious(achData?.subStep);
+    // Treat the very first effect run as a step transition. usePrevious in this codebase initializes
+    // its ref with the current value, so prev/current would match on mount and stale errors from
+    // a prior session (e.g. after a page reload while on the Plaid sub-step) would not be cleared.
+    const isFirstRenderRef = useRef(true);
     const [USDBankAccountStep, setUSDBankAccountStep] = useState<string | null>(subStepParam ?? null);
     const [isNonUSDSetup, setIsNonUSDSetup] = useState(policy ? isNonUSDWorkspace : achData?.currency !== CONST.CURRENCY.USD || reimbursementAccountDraft?.currency !== CONST.CURRENCY.USD);
 
@@ -310,11 +316,18 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy}: Reimbursemen
 
             const currentStepRouteParam = getStepToOpenFromRouteParams(route, hasConfirmedUSDCurrency);
             if (currentStepRouteParam === currentStep) {
-                // If the user is connecting online with plaid, reset any bank account errors so we don't persist old data from a potential previous connection
-                if (currentStep === CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT && achData?.subStep === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID) {
+                // If the user is connecting online with plaid, reset any bank account errors so we don't persist old data from a potential previous connection.
+                // Only clear when entering the Plaid sub-step (step transition) — clearing on every isLoading toggle would wipe fresh backend errors
+                // the instant they arrive (e.g. duplicate bank account error after re-selecting the same Plaid account).
+                const justEnteredPlaidStep =
+                    currentStep === CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT &&
+                    achData?.subStep === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID &&
+                    (isFirstRenderRef.current || prevCurrentStep !== currentStep || prevSubStep !== achData?.subStep);
+                if (justEnteredPlaidStep) {
                     hideBankAccountErrors();
                 }
 
+                isFirstRenderRef.current = false;
                 // The route is showing the correct step, no need to update the route param or clear errors.
                 return;
             }
@@ -331,6 +344,8 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy}: Reimbursemen
                 // so we don't clear it. We only want to clear the errors if we are moving between steps.
                 hideBankAccountErrors();
             }
+
+            isFirstRenderRef.current = false;
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [


### PR DESCRIPTION
Reverts Expensify/App#92733, brings back original [PR](https://github.com/Expensify/App/pull/91491) that wasn't the actual cause of regressions. QA found those issues while testing the PR, and the flow wasn't testable in production.