### PR TITLE
[Payment due @parasharrajat] Gate AgentZero indicators on personalDetails.isCustomAgent

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreensInitHandler.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreensInitHandler.tsx
@@ -19,7 +19,6 @@ import {getReportIDFromLink} from '@libs/ReportUtils';
 import * as SessionUtils from '@libs/SessionUtils';
 import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 import {getSearchParamFromUrl} from '@libs/Url';
-import {openAgentsPage} from '@userActions/Agent';
 import * as App from '@userActions/App';
 import * as Download from '@userActions/Download';
 import {clearStaleExportDownloads} from '@userActions/Export';
@@ -131,11 +130,6 @@ function AuthScreensInitHandler() {
             Log.info('[AuthScreens] Sending ReconnectApp');
             App.reconnectApp(initialLastUpdateIDAppliedToClient);
         }
-
-        // Hydrate the user's custom-agent prompts so AgentZeroStatusProvider can recognize
-        // custom-agent chats opened directly from a deep link or right after sign-in, without
-        // requiring a prior visit to Settings > Agents.
-        openAgentsPage();
 
         App.setUpPoliciesAndNavigate(
             session,

--- a/src/pages/inbox/AgentZeroStatusContext.tsx
+++ b/src/pages/inbox/AgentZeroStatusContext.tsx
@@ -1,4 +1,4 @@
-import {getAgentAccountIDFlags, getReportParticipantAccountIDs} from '@selectors/AgentZeroChat';
+import {getCustomAgentParticipantAccountID, getReportParticipantAccountIDs} from '@selectors/AgentZeroChat';
 import {getReportChatType} from '@selectors/Report';
 import {agentZeroProcessingAgentIDsSelector} from '@selectors/ReportNameValuePairs';
 import {accountIDSelector} from '@selectors/Session';
@@ -41,24 +41,19 @@ const AgentZeroStatusActionsContext = createContext<AgentZeroStatusActions>(defa
  * metadata. For non-AgentZero reports (the common case), returns children directly.
  *
  * AgentZero chats include Concierge DMs, policy #admins rooms, and custom-agent chats (any
- * report with a participant — other than the current user — whose accountID has a
- * `SHARED_NVP_AGENT_PROMPT_<accountID>` entry, populated by `OpenAgentsPage` for agents the
- * current user owns).
+ * report with a participant whose personalDetails carries `isCustomAgent: true`, stamped
+ * server-side in `Account::formatNewDotPersonalDetails`).
  */
 function AgentZeroStatusProvider({reportID, children}: React.PropsWithChildren<{reportID: string | undefined}>) {
     const [chatType] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {selector: getReportChatType});
     const [participantAccountIDs] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {selector: getReportParticipantAccountIDs});
-    const [agentAccountIDFlags] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT, {selector: getAgentAccountIDFlags});
+    const [agentParticipantAccountID] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: getCustomAgentParticipantAccountID(participantAccountIDs)});
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
-    const [currentUserAccountID] = useOnyx(ONYXKEYS.SESSION, {selector: accountIDSelector});
 
     const isConciergeChat = reportID === conciergeReportID;
     const isAdmin = chatType === CONST.REPORT.CHAT_TYPE.POLICY_ADMINS;
-    // A custom-agent chat has a participant — excluding the current user — whose accountID owns
-    // an agent prompt. Excluding the current user prevents a user who owns agents from turning
-    // their own DMs into agent chats.
-    const hasAgentParticipant = participantAccountIDs?.some((accountID) => accountID !== currentUserAccountID && !!agentAccountIDFlags?.[accountID]) ?? false;
-    const isAgentZeroChat = isConciergeChat || isAdmin || hasAgentParticipant;
+    const isCustomAgentChat = agentParticipantAccountID !== undefined;
+    const isAgentZeroChat = isConciergeChat || isAdmin || isCustomAgentChat;
 
     if (!reportID || !isAgentZeroChat) {
         return children;

--- a/src/pages/inbox/ConciergeDraftContext.tsx
+++ b/src/pages/inbox/ConciergeDraftContext.tsx
@@ -1,4 +1,4 @@
-import {getAgentAccountIDFlags, getReportParticipantAccountIDs} from '@selectors/AgentZeroChat';
+import {getCustomAgentParticipantAccountID, getReportParticipantAccountIDs} from '@selectors/AgentZeroChat';
 import {getReportChatType} from '@selectors/Report';
 import React, {createContext, useContext} from 'react';
 import useOnyx from '@hooks/useOnyx';
@@ -41,14 +41,14 @@ const ConciergeDraftActionsContext = createContext<ConciergeDraftActions>(defaul
 function ConciergeDraftProvider({reportID, children}: React.PropsWithChildren<{reportID: string | undefined}>) {
     const [chatType] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {selector: getReportChatType});
     const [participantAccountIDs] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {selector: getReportParticipantAccountIDs});
-    const [agentAccountIDFlags] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT, {selector: getAgentAccountIDFlags});
+    const [agentParticipantAccountID] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: getCustomAgentParticipantAccountID(participantAccountIDs)});
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
 
     const isConciergeChat = reportID === conciergeReportID;
     const isAdmin = chatType === CONST.REPORT.CHAT_TYPE.POLICY_ADMINS;
-    // See AgentZeroStatusContext for the rationale: agentAccountIDFlags reflects agents the
-    // user owns (populated by `OpenAgentsPage`).
-    const isCustomAgentChat = participantAccountIDs?.some((accountID) => !!agentAccountIDFlags?.[accountID]);
+    // See AgentZeroStatusContext for the rationale: `isCustomAgent` lives on the participant's
+    // personalDetails, stamped by Auth in `Account::formatNewDotPersonalDetails`.
+    const isCustomAgentChat = agentParticipantAccountID !== undefined;
     const isAgentZeroChat = isConciergeChat || isAdmin || isCustomAgentChat;
 
     if (!reportID || !isAgentZeroChat) {

--- a/src/selectors/AgentZeroChat.ts
+++ b/src/selectors/AgentZeroChat.ts
@@ -1,31 +1,31 @@
-import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
-import ONYXKEYS from '@src/ONYXKEYS';
-import type {AgentPrompt, ConciergePendingFollowupList} from '@src/types/onyx';
+import type {OnyxEntry} from 'react-native-onyx';
+import type {ConciergePendingFollowupList, PersonalDetailsList} from '@src/types/onyx';
 import type Report from '@src/types/onyx/Report';
 
 const getReportParticipantAccountIDs = (report: OnyxEntry<Report>): number[] => (report?.participants ? Object.keys(report.participants).map(Number) : []);
 
 /**
- * Reduces the SHARED_NVP_AGENT_PROMPT collection to a `Record<accountID, true>` so callers
- * can do O(1) lookups without re-rendering on every prompt-content edit.
+ * Returns the first participant accountID flagged as a custom agent (`isCustomAgent` on its
+ * personalDetails entry, stamped server-side in `Account::formatNewDotPersonalDetails`), or
+ * `undefined` when no participant is an agent.
+ *
+ * Parameterized so the closure captures only the report's small `participantAccountIDs` array —
+ * the selector iterates those (small N) against `personalDetailsList`, not the full list. Output
+ * is a primitive `number | undefined`, so `deepEqual` short-circuits cheaply and re-renders fire
+ * only when an agent participant's flag flips.
  */
-const getAgentAccountIDFlags = (agentPrompts: OnyxCollection<AgentPrompt>): Record<number, true> => {
-    if (!agentPrompts) {
-        return {};
-    }
-    const flags: Record<number, true> = {};
-    for (const key of Object.keys(agentPrompts)) {
-        const accountID = Number(key.slice(ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT.length));
-        if (!Number.isNaN(accountID)) {
-            flags[accountID] = true;
+const getCustomAgentParticipantAccountID =
+    (participantAccountIDs: number[] | undefined) =>
+    (personalDetails: OnyxEntry<PersonalDetailsList>): number | undefined => {
+        if (!participantAccountIDs?.length || !personalDetails) {
+            return undefined;
         }
-    }
-    return flags;
-};
+        return participantAccountIDs.find((accountID) => !!personalDetails[accountID]?.isCustomAgent);
+    };
 
 const hasPendingFollowupListSkeletonSelector =
     (reportActionID: string) =>
     (pending: OnyxEntry<ConciergePendingFollowupList>): boolean =>
         !pending?.hidden && pending?.reportActionID === reportActionID;
 
-export {getReportParticipantAccountIDs, getAgentAccountIDFlags, hasPendingFollowupListSkeletonSelector};
+export {getReportParticipantAccountIDs, getCustomAgentParticipantAccountID, hasPendingFollowupListSkeletonSelector};

--- a/src/types/onyx/PersonalDetails.ts
+++ b/src/types/onyx/PersonalDetails.ts
@@ -74,6 +74,15 @@ type PersonalDetails = OnyxCommon.OnyxValueWithOfflineFeedback<{
     /** Flag for checking if data is from optimistic data */
     isOptimisticPersonalDetail?: boolean;
 
+    /**
+     * True when this account is a registered custom agent (server-side `private_agentOwnerID`
+     * NVP set). Stamped by Auth in `Account::formatNewDotPersonalDetails`, so it travels with
+     * every personalDetails payload returned to the client (OpenReport, OpenApp, ReconnectApp,
+     * GetPersonalDetailsForEmails, etc.). Lets chat surfaces detect custom-agent participants
+     * without subscribing to the wider `SHARED_NVP_AGENT_PROMPT` collection.
+     */
+    isCustomAgent?: boolean;
+
     /** Field-specific server side errors keyed by microtime */
     errorFields?: OnyxCommon.ErrorFields<'avatar'>;
 

--- a/tests/ui/AuthScreensInitHandlerTest.tsx
+++ b/tests/ui/AuthScreensInitHandlerTest.tsx
@@ -72,10 +72,6 @@ jest.mock('@userActions/App', () => ({
     setLocale: jest.fn(),
 }));
 
-jest.mock('@userActions/Agent', () => ({
-    openAgentsPage: jest.fn(),
-}));
-
 jest.mock('@userActions/Download', () => ({
     clearDownloads: jest.fn(),
 }));


### PR DESCRIPTION
@inimaga please review
cc @iwiznia 

### Explanation of Change

Follow-up to [#90751](https://github.com/Expensify/App/pull/90751). Replaces the App-side custom-agent detection (which subscribed to the full `SHARED_NVP_AGENT_PROMPT` Onyx collection and required a wasted `OpenAgentsPage` call on every auth init) with a per-account flag the server now stamps on `personalDetails`.

Backend half: [Auth#22080](https://github.com/Expensify/Auth/pull/22080) — `Account::formatNewDotPersonalDetails` adds `isCustomAgent: true` to known-user payloads whenever `Agent::getOwnerAccountID > 0`. The flag rides every personalDetails response (OpenReport, OpenApp, ReconnectApp, GetPersonalDetailsForEmails, etc.), so the App's gate can read it off the participant's existing personalDetails entry — no extra fetch, no extra subscription.

**Marked draft until [Auth#22080](https://github.com/Expensify/Auth/pull/22080) merges + deploys.** Without the server side, the gate never sees `isCustomAgent: true` and custom-agent chats stop firing the indicator.

Addresses [Puneet's review comment](https://github.com/Expensify/App/pull/90751#discussion_r3289172577) on the previous PR.

### Changes

- **`src/types/onyx/PersonalDetails.ts`** — adds `isCustomAgent?: boolean` alongside the existing per-account flags.
- **`src/selectors/AgentZeroChat.ts`** — drops `getAgentAccountIDFlags`. Adds `getCustomAgentParticipantAccountID(participantAccountIDs)` — a parameterized selector that iterates only the report's participants against `personalDetailsList` and returns the first agent's accountID (or `undefined`). Output is a primitive, so `deepEqual` short-circuits cheaply and re-renders fire only when an agent participant's flag actually flips.
- **`src/pages/inbox/AgentZeroStatusContext.tsx`** + **`src/pages/inbox/ConciergeDraftContext.tsx`** — swap the gate from a `SHARED_NVP_AGENT_PROMPT` collection subscription to the new selector. Same gate semantics, narrower subscription.
- **`src/libs/Navigation/AppNavigator/AuthScreensInitHandler.tsx`** — removes the `openAgentsPage()` auth-init call (and its import). Every user paid one wasted API call per session even if they never interacted with an agent. Settings → Agents still calls `openAgentsPage()` on its own mount.
- **`tests/ui/AuthScreensInitHandlerTest.tsx`** — removes the matching `@userActions/Agent` mock that was only there to stub the auth-init call.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/636271

### Tests

Requires [Auth#22080](https://github.com/Expensify/Auth/pull/22080) deployed.

1. Sign out, then sign in fresh (so `SHARED_NVP_AGENT_PROMPT` is empty and `OpenAgentsPage` is not auto-called).
2. Open a custom-agent DM from inbox / deep link / search bar.
3. Send a message. Verify within ~1s:
   - Thinking indicator appears under the **agent's** avatar.
   - Draft body streams character-by-character during LLM generation.
   - Indicator clears when the response lands.
4. Sanity: open a Concierge DM. Verify thinking + draft streaming still works under Concierge's avatar (regression check).
5. Settings → Agents still loads the agent list (it owns its own `openAgentsPage` call on mount).
6. DevTools → Network during fresh sign-in: no `OpenAgentsPage` request.
7. Verify no errors appear in the JS console.

### Offline tests

Custom-agent DM opened while offline shows nothing extra (PersonalDetails arrives once the connection comes back; gate evaluates on the next render).

### QA Steps

Same as Tests. Custom-agent feature is gated behind `BETAS.CUSTOM_AGENT` — QA testers need that beta on their account.

- [ ] Verify no errors appear in the JS console.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts)
