### PR TITLE
[CP staging] Fix: state field not cleared when address country changes to non-US

### DIFF
--- a/src/pages/settings/Profile/PersonalDetails/PrivatePersonalDetailsPage.tsx
+++ b/src/pages/settings/Profile/PersonalDetails/PrivatePersonalDetailsPage.tsx
@@ -381,7 +381,8 @@ function PrivatePersonalDetailsPage() {
                                 label={translate('common.stateOrProvince')}
                                 aria-label={translate('common.stateOrProvince')}
                                 role={CONST.ROLE.PRESENTATION}
-                                defaultValue={state}
+                                value={selectedState}
+                                onValueChange={(value: unknown) => setSelectedState((value ?? '') as string)}
                                 shouldSaveDraft
                                 spellCheck={false}
                             />
@@ -407,13 +408,20 @@ function PrivatePersonalDetailsPage() {
                             value={selectedCountry}
                             onValueChange={(value: unknown) => {
                                 const newCountry = (value ?? '') as Country | '';
+                                if (newCountry === selectedCountry) {
+                                    return;
+                                }
                                 setSelectedCountry(newCountry);
                                 if (newCountry === CONST.COUNTRY.US) {
                                     const resolved = resolveStateCode(selectedState);
                                     if (resolved !== selectedState) {
                                         setSelectedState(resolved);
                                     }
+                                    return;
                                 }
+                                // A previously selected US state (or another country's value) does not apply to the new country.
+                                setSelectedState('');
+                                setDraftValues(ONYXKEYS.FORMS.PERSONAL_DETAILS_FORM, {[INPUT_IDS.STATE]: ''});
                             }}
                             shouldSaveDraft
                         />


### PR DESCRIPTION
### Explanation of Change

When changing the country in `Profile > Address` from US to a non-US country, the state field was not being cleared.

`PrivatePersonalDetailsPage` renders the state input as a `StateSelector` for US and as a `TextInput` for non-US. The non-US `TextInput` used `defaultValue` (uncontrolled), so once the form's `inputValues[state]` was populated by the `StateSelector` (e.g. `"CA"`), switching the country to a non-US value couldn't clear the displayed text — the new `TextInput` would mount and immediately read the stale form-level value.

The fix:

- Make the non-US state `TextInput` controlled (`value={selectedState}` + `onValueChange`) so the parent owns the source of truth for both branches.
- In the country selector's `onValueChange`, when the country actually changes to a non-US country, clear `selectedState` and clear the saved draft for the state field so the magic-code confirmation step doesn't replay the stale value.

### Fixed Issues

$ https://github.com/Expensify/App/issues/92821
PROPOSAL:

### Tests

1. Sign in to staging.new.expensify.com.
2. Go to **Account > Profile > Address**.
3. Enter a US address (including a state, e.g. California).
4. Click **Country** and pick a non-US country (e.g. Canada).
5. Verify the **State / Province** field is now empty.
6. Type a value in the State / Province field, e.g. `Ontario`.
7. Click **Country** again and pick a different non-US country (e.g. United Kingdom).
8. Verify the State / Province field is cleared again.
9. Click **Country** and pick **United States**.
10. Verify the state selector opens cleanly (no stale free-text spillover) and accepts a fresh state selection.
11. Submit the form and confirm via magic code — verify the saved address reflects the most recent country and a blank/newly-entered state, not the previous US state.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Repeat the Tests steps 2–8 — country/state field clearing should still happen locally because it's pure UI state.
3. Go back online and submit; verify the update completes normally.

### QA Steps

1. Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all storiel working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving compoorm input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix ily prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still ex` steps.

### Screenshots/Videos

<details>
<summary>Web</summary>

https://github.com/user-attachments/assets/0350cbde-c40b-4e62-b8c7-18f5834b156c



</details>
