### PR TITLE
[Payment due @hoangzinh] Fix real author shown in type:chat search results for automatic actions

### DIFF
--- a/src/components/ReportActionAvatars/index.tsx
+++ b/src/components/ReportActionAvatars/index.tsx
@@ -76,6 +76,9 @@ type ReportActionAvatarsProps = {
 
     /** chatReportID needed for the avatars logic. When provided, this will be used as a fallback if the snapshot is undefined */
     chatReportID?: string;
+
+    /** Whether to show the real actor instead of Concierge for automatic actions (e.g. in search results) */
+    shouldUseRealActor?: boolean;
 };
 
 /**
@@ -110,6 +113,7 @@ function ReportActionAvatars({
     invitedEmailsToAccountIDs,
     shouldUseCustomFallbackAvatar = false,
     chatReportID,
+    shouldUseRealActor = false,
 }: ReportActionAvatarsProps) {
     const accountIDs = passedAccountIDs.filter((accountID) => accountID !== CONST.DEFAULT_NUMBER_ID);
 
@@ -145,6 +149,7 @@ function ReportActionAvatars({
         invitedEmailsToAccountIDs,
         shouldUseCustomFallbackAvatar,
         chatReportID,
+        shouldUseRealActor,
     });
 
     let avatarType: ValueOf<typeof CONST.REPORT_ACTION_AVATARS.TYPE> = notPreciseAvatarType;

--- a/src/components/ReportActionAvatars/useReportActionAvatars.ts
+++ b/src/components/ReportActionAvatars/useReportActionAvatars.ts
@@ -48,6 +48,7 @@ function useReportActionAvatars({
     invitedEmailsToAccountIDs,
     shouldUseCustomFallbackAvatar = false,
     chatReportID: passedChatReportID,
+    shouldUseRealActor = false,
 }: {
     report: OnyxEntry<Report>;
     action: OnyxEntry<ReportAction>;
@@ -60,6 +61,8 @@ function useReportActionAvatars({
     invitedEmailsToAccountIDs?: InvitedEmailsToAccountIDs;
     shouldUseCustomFallbackAvatar?: boolean;
     chatReportID?: string;
+    /** When true, returns the action's real author instead of the Concierge display override used in inbox timelines. */
+    shouldUseRealActor?: boolean;
 }) {
     const defaultAvatars = useDefaultAvatars();
     /* Get avatar type */
@@ -119,7 +122,7 @@ function useReportActionAvatars({
 
     const delegateAccountID = getDelegateAccountIDFromReportAction(action);
     const delegatePersonalDetails = delegateAccountID ? personalDetails?.[delegateAccountID] : undefined;
-    const actorAccountID = getReportActionActorAccountID(action, iouReport, chatReport, delegatePersonalDetails);
+    const actorAccountID = getReportActionActorAccountID(action, iouReport, chatReport, delegatePersonalDetails, shouldUseRealActor);
     const humanAgentAccountID = getHumanAgentAccountIDFromReportAction(action);
 
     const isAInvoiceReport = isInvoiceReport(iouReport ?? null);

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -960,6 +960,9 @@ function getReportActionActorAccountID(
     iouReport: OnyxEntry<Report>,
     report: OnyxEntry<Report>,
     delegatePersonalDetails?: PersonalDetails | undefined | null,
+    // When true (e.g. in search results) the actual author is returned instead of the Concierge
+    // display override used in inbox timelines for automated actions.
+    shouldUseRealActor = false,
 ): number | undefined {
     switch (reportAction?.actionName) {
         case CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW: {
@@ -975,7 +978,7 @@ function getReportActionActorAccountID(
 
         case CONST.REPORT.ACTIONS.TYPE.CREATED: {
             const reportNameValuePairs = allReportNameValuePair?.[`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${iouReport?.reportID}`];
-            if (isHarvestCreatedExpenseReport(reportNameValuePairs?.origin, reportNameValuePairs?.originalID)) {
+            if (!shouldUseRealActor && isHarvestCreatedExpenseReport(reportNameValuePairs?.origin, reportNameValuePairs?.originalID)) {
                 return CONST.ACCOUNT_ID.CONCIERGE;
             }
             return reportAction?.actorAccountID;
@@ -1000,7 +1003,7 @@ function getReportActionActorAccountID(
             // - Harvesting (delayed submissions)
             // - Automatic approvals/forwards via workspace rules
             // - Automatic payments via workspace rules
-            if (wasSubmittedViaHarvesting || (wasAutomatic && actionName !== CONST.REPORT.ACTIONS.TYPE.IOU) || (wasAutomatic && isPayment)) {
+            if (!shouldUseRealActor && (wasSubmittedViaHarvesting || (wasAutomatic && actionName !== CONST.REPORT.ACTIONS.TYPE.IOU) || (wasAutomatic && isPayment))) {
                 return CONST.ACCOUNT_ID.CONCIERGE;
             }
 

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -6,6 +6,7 @@ import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import ReportActionAvatars from '@components/ReportActionAvatars';
 import useReportActionAvatars from '@components/ReportActionAvatars/useReportActionAvatars';
+import {useIsOnSearch} from '@components/Search/SearchScopeProvider';
 import Text from '@components/Text';
 import Tooltip from '@components/Tooltip';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
@@ -78,8 +79,9 @@ function ReportActionItemSingle({
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
+    const isOnSearch = useIsOnSearch();
 
-    const {avatarType, avatars, details, source, reportPreviewSenderID} = useReportActionAvatars({report: potentialIOUReport ?? report, action});
+    const {avatarType, avatars, details, source, reportPreviewSenderID} = useReportActionAvatars({report: potentialIOUReport ?? report, action, shouldUseRealActor: isOnSearch});
 
     const reportID = source.chatReport?.reportID;
     const iouReportID = source.iouReport?.reportID;

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -167,6 +167,7 @@ function ReportActionItemSingle({
                         reportID={iouReportID}
                         chatReportID={source.iouReport?.chatReportID ?? reportID}
                         action={action}
+                        shouldUseRealActor={isOnSearch}
                     />
                 </OfflineWithFeedback>
             </PressableWithoutFeedback>

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -4252,6 +4252,57 @@ describe('ReportActionsUtils', () => {
             const actorAccountID = getReportActionActorAccountID(reportAction, iouReport, report);
             expect(actorAccountID).toBe(9999);
         });
+
+        it('returns CONCIERGE for automatic DEW_APPROVE_FAILED when shouldUseRealActor is false', () => {
+            const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.DEW_APPROVE_FAILED> = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.DEW_APPROVE_FAILED,
+                reportActionID: '1',
+                created: '1',
+                message: [],
+                actorAccountID: 2701545,
+                originalMessage: {automaticAction: true, message: 'failed'},
+            };
+            const iouReport: Report = {...createRandomReport(0, undefined)};
+            const report: Report = {...createRandomReport(1, undefined)};
+
+            const actorAccountID = getReportActionActorAccountID(reportAction, iouReport, report, undefined, false);
+            expect(actorAccountID).toBe(CONST.ACCOUNT_ID.CONCIERGE);
+        });
+
+        it('returns real actorAccountID for automatic DEW_APPROVE_FAILED when shouldUseRealActor is true', () => {
+            const reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.DEW_APPROVE_FAILED> = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.DEW_APPROVE_FAILED,
+                reportActionID: '1',
+                created: '1',
+                message: [],
+                actorAccountID: 2701545,
+                originalMessage: {automaticAction: true, message: 'failed'},
+            };
+            const iouReport: Report = {...createRandomReport(0, undefined)};
+            const report: Report = {...createRandomReport(1, undefined)};
+
+            const actorAccountID = getReportActionActorAccountID(reportAction, iouReport, report, undefined, true);
+            expect(actorAccountID).toBe(2701545);
+        });
+
+        it('returns real actorAccountID for harvest-created CREATED action when shouldUseRealActor is true', async () => {
+            const reportAction: ReportAction = {
+                ...createRandomReportAction(0),
+                actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
+                actorAccountID: 9999,
+            };
+            const iouReport: Report = {...createRandomReport(0, undefined)};
+            const report: Report = {...createRandomReport(3, undefined), reportID: 'harvest-report-shouldUseRealActor'};
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${iouReport.reportID}`, {
+                origin: 'harvest',
+                originalID: 'orig-456',
+            });
+            await waitForBatchedUpdates();
+
+            const actorAccountID = getReportActionActorAccountID(reportAction, iouReport, report, undefined, true);
+            expect(actorAccountID).toBe(9999);
+        });
     });
 
     describe('getInvoiceCompanyNameUpdateMessage', () => {


### PR DESCRIPTION
### Explanation of Change

When you search `type:chat from:`, the App filters chat results to messages authored by that account. The backend does this correctly — but the App has a display rule that shows **Concierge** as the author for any automatic workspace action (auto-submit, auto-approve, auto-pay, or "failed to approve via workspace rules"), regardless of who actually triggered it.

So if the searched account is a workspace approver or submitter, its automatic actions show up in results with Concierge's name and avatar — even though the filter chip correctly says "From: Expense Team". Confusing.

The fix: when rendering a chat result row inside Search, use the action's real author instead of the Concierge display override. The override is still used everywhere else (inbox timeline), so nothing changes outside of search.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/637862
PROPOSAL:

### Tests

This bug reproduces with **any** automatic action, so DEW is not required. The fastest self-serve flow uses **auto-approval**, where the automatic Approved action is created instantly on submit (no cron/scheduled job to wait for):

1. Use a **Collect or Control** group workspace.
2. **Workflows → Add approvals**: set an approver who is **not** the submitter (auto-approval refuses self-approval). Easiest: a second account submits, the workspace owner approves.
3. Enable **Auto-approve compliant reports** with a limit comfortably **above** the test expense amount.
4. Set the **auto-approval audit rate to 0%** (otherwise reports are randomly diverted to manual approval and may not auto-approve).
5. As the submitting member, create a small **compliant** expense (no violations) and **Submit** the report. It auto-approves instantly; the **Approved** action shows **Concierge** as the author in the chat timeline (inbox) — expected, unchanged behavior.
6. Search `type:chat from:APPROVER_EMAIL` (the **approver's** account — the auto-Approved action is authored by the approver).
7. Verify the result row shows the approver's real name/avatar — **not** Concierge.
8. Open the report directly and confirm the same Approved action **still shows Concierge** in the timeline (inbox behavior unchanged).
    <img width="1758" height="1118" alt="Screenshot 2026-06-15 at 12 31 32 PM" src="https://github.com/user-attachments/assets/59c88d0b-ccd7-4006-9fdc-06b734bdbc84" />
    <img width="1758" height="1203" alt="Screenshot 2026-06-16 at 11 39 21 AM" src="https://github.com/user-attachments/assets/d08ab171-9a28-4af7-bd5e-3b993f3144ab" />

Equivalent flows that also reproduce it: **Scheduled Submit (Delay submissions)** auto-submit (waits on the daily harvest cron) or **DEW** ("failed to approve via workspace rules"). Any of them work — auto-approval is just the quickest with no waiting.

- [x] Verify that no errors appear in the JS console

### Offline tests

Only affects rendering of already-loaded search results. No offline behavior changes.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native

Android: mWeb Chrome

iOS: Native

iOS: mWeb Safari

MacOS: Chrome / Safari