### PR TITLE
fix: improve Expensify Cards deletion modal copy

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -4411,7 +4411,7 @@ const translations = {
             defaultNote: `Receipts sent to ${CONST.EMAIL.RECEIPTS} will appear in this workspace.`,
             deleteConfirmation: 'Are you sure you want to delete this workspace?',
             deleteWithCardsConfirmation: 'Are you sure you want to delete this workspace? This will remove all card feeds and assigned cards.',
-            deleteOpenExpensifyCardsError: 'Your company still has open Expensify Cards.',
+            deleteOpenExpensifyCardsError: 'Your company still has Expensify Cards. Please <concierge-link>reach out to Concierge</concierge-link> to remove them.',
             outstandingBalanceWarning:
                 'You have an outstanding balance that must be settled before deleting your last workspace. Please go to your subscription settings to resolve the payment.',
             settleBalance: 'Go to subscription',

--- a/src/pages/workspace/WorkspaceOverviewPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewPage.tsx
@@ -17,6 +17,7 @@ import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import PDFThumbnail from '@components/PDFThumbnail';
 import type {PopoverMenuItem} from '@components/PopoverMenu';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
+import RenderHTML from '@components/RenderHTML';
 import Section from '@components/Section';
 import Text from '@components/Text';
 import ThreeDotsMenu from '@components/ThreeDotsMenu';
@@ -56,7 +57,7 @@ import {
     updateWorkspaceAvatar,
 } from '@libs/actions/Policy/Policy';
 import {filterInactiveCards, getCardSettings} from '@libs/CardUtils';
-import {getLatestErrorField, getLatestErrorMessage} from '@libs/ErrorUtils';
+import {getLatestErrorMessage} from '@libs/ErrorUtils';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -272,6 +273,17 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
     const prevIsPendingDeleteRef = useRef(isPendingDelete);
     const isErrorModalShowingRef = useRef(false);
     const policyLastErrorMessage = getLatestErrorMessage(policy);
+    const deleteWorkspaceErrorModalPrompt = useMemo(
+        () =>
+            policyLastErrorMessage === translate('workspace.common.deleteOpenExpensifyCardsError') ? (
+                <View style={[styles.renderHTML, styles.flexRow]}>
+                    <RenderHTML html={policyLastErrorMessage} />
+                </View>
+            ) : (
+                policyLastErrorMessage
+            ),
+        [policyLastErrorMessage, styles.flexRow, styles.renderHTML, translate],
+    );
 
     const mentionReportContextValue = useMemo(() => ({policyID, currentReportID: undefined, exactlyMatch: true}), [policyID]);
 
@@ -404,7 +416,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
             isErrorModalShowingRef.current = true;
             showConfirmModal({
                 title: translate('workspace.common.delete'),
-                prompt: policyLastErrorMessage,
+                prompt: deleteWorkspaceErrorModalPrompt,
                 confirmText: translate('common.buttonConfirm'),
                 shouldShowCancelButton: false,
                 success: false,
@@ -434,7 +446,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
         isErrorModalShowingRef.current = true;
         showConfirmModal({
             title: translate('workspace.common.delete'),
-            prompt: policyLastErrorMessage,
+            prompt: deleteWorkspaceErrorModalPrompt,
             confirmText: translate('common.buttonConfirm'),
             shouldShowCancelButton: false,
             success: false,
@@ -442,7 +454,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
             isErrorModalShowingRef.current = false;
             hideDeleteWorkspaceErrorModal();
         });
-    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyLastErrorMessage, isPendingDelete, isFocused, policyID, closeModal, hasExpensifyCard]);
+    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyLastErrorMessage, deleteWorkspaceErrorModalPrompt, isPendingDelete, isFocused, policyID, closeModal, hasExpensifyCard]);
 
     const onDeleteWorkspace = () => {
         if (shouldBlockWorkspaceDeletionForInvoicifyUser(isSubscriptionTypeOfInvoicing(subscriptionType), ownerPolicies, policyID)) {

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -8,6 +8,7 @@ import Button from '@components/Button';
 import {ModalActions} from '@components/Modal/Global/ModalContext';
 import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import type {PopoverMenuItem} from '@components/PopoverMenu';
+import RenderHTML from '@components/RenderHTML';
 import type {TableHandle} from '@components/Table';
 import type {WorkspaceRowData, WorkspaceTableColumnKey} from '@components/Tables/WorkspaceListTable';
 import WorkspaceListTable from '@components/Tables/WorkspaceListTable';
@@ -173,6 +174,17 @@ function WorkspacesListPage() {
     const [accountIDToLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: accountIDToLoginSelector(reportsToArchive)});
 
     const policyToDeleteLatestErrorMessage = getLatestErrorMessage(policyToDelete);
+    const deleteWorkspaceErrorModalPrompt = useMemo(
+        () =>
+            policyToDeleteLatestErrorMessage === translate('workspace.common.deleteOpenExpensifyCardsError') ? (
+                <View style={[styles.renderHTML, styles.flexRow]}>
+                    <RenderHTML html={policyToDeleteLatestErrorMessage} />
+                </View>
+            ) : (
+                policyToDeleteLatestErrorMessage
+            ),
+        [policyToDeleteLatestErrorMessage, styles.flexRow, styles.renderHTML, translate],
+    );
     const isPendingDelete = isPendingDeletePolicy(policyToDelete);
     const hasDeleteWorkspaceExpensifyCardsError = !!hasExpensifyCard && !!isOffline;
 
@@ -299,7 +311,7 @@ function WorkspacesListPage() {
             isErrorModalShowingRef.current = true;
             showConfirmModal({
                 title: translate('workspace.common.delete'),
-                prompt: policyToDeleteLatestErrorMessage,
+                prompt: deleteWorkspaceErrorModalPrompt,
                 confirmText: translate('common.buttonConfirm'),
                 cancelText: translate('common.cancel'),
                 success: false,
@@ -325,7 +337,7 @@ function WorkspacesListPage() {
         isErrorModalShowingRef.current = true;
         showConfirmModal({
             title: translate('workspace.common.delete'),
-            prompt: policyToDeleteLatestErrorMessage,
+            prompt: deleteWorkspaceErrorModalPrompt,
             confirmText: translate('common.buttonConfirm'),
             cancelText: translate('common.cancel'),
             success: false,
@@ -334,7 +346,7 @@ function WorkspacesListPage() {
             isErrorModalShowingRef.current = false;
             hideDeleteWorkspaceErrorModal();
         });
-    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyToDeleteLatestErrorMessage, isPendingDelete, isFocused, policyIDToDelete, closeModal]);
+    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyToDeleteLatestErrorMessage, deleteWorkspaceErrorModalPrompt, isPendingDelete, isFocused, policyIDToDelete, closeModal]);
 
     const startChangeOwnershipFlow = (policyID: string | undefined) => {
         if (!policyID) {


### PR DESCRIPTION
## Summary

$ #92511 by improving the blocked workspace deletion modal copy shown when a workspace still has active Expensify Cards.

- Updates the blocked-deletion copy to tell the user to reach out to Concierge.
- Adds a `<concierge-link>` around “reach out to Concierge” so the body opens a Concierge chat.
- Renders this specific blocked-deletion message through `RenderHTML` on both workspace surfaces:
  - Workspace overview page
  - Workspaces list page
- Leaves the initial Delete confirmation modal unchanged.

## Test Plan

1. Trigger the blocked workspace deletion flow for a workspace with active Expensify Cards.
2. Verify the secondary modal title is `Delete workspace`.
3. Verify the modal body says: `Your company still has Expensify Cards. Please reach out to Concierge to remove them.`
4. Verify tapping `reach out to Concierge` opens Concierge chat.
5. Verify the initial Delete confirmation modal for card-feed deletion is unchanged.

## Local verification

- Parsed the changed TS/TSX files with `@babel/parser` using TypeScript + JSX plugins.
- `git diff --check HEAD~1 HEAD` passed with no whitespace errors.

Full repository typecheck/lint was not runnable in this container because the repository dependencies were not fully installed and the local environment differs from the repository's required toolchain (`node 20.20.2`, `npm 10.8.2`, `bun 1.3.14`).
