### PR TITLE
Fix: hide illustration icon in landscape mode on iOS workspace pages

### DIFF
--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -161,7 +161,7 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
 
     // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to apply the correct modal type for the decision modal
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
-    const {shouldUseNarrowLayout, isSmallScreenWidth} = useResponsiveLayout();
+    const {shouldUseNarrowLayout, isSmallScreenWidth, isInLandscapeMode} = useResponsiveLayout();
     const isPolicyAdmin = canEditWorkspaceSettings(policy);
     // Group policies (Collect/Control + Submit) allow member management.
     const canManageMembers = isGroupPolicy(policy);
@@ -199,8 +199,14 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
             const approverAccountID = policyMemberEmailsToAccountIDs[approverEmail];
             return translate(
                 'workspace.people.removeMembersWarningPrompt',
-                getDisplayNameForParticipant({accountID: approverAccountID, formatPhoneNumber}),
-                getDisplayNameForParticipant({accountID: policy?.ownerAccountID, formatPhoneNumber}),
+                getDisplayNameForParticipant({
+                    accountID: approverAccountID,
+                    formatPhoneNumber,
+                }),
+                getDisplayNameForParticipant({
+                    accountID: policy?.ownerAccountID,
+                    formatPhoneNumber,
+                }),
             );
         }
 
@@ -210,8 +216,14 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
         if (userExporter) {
             const exporterAccountID = policyMemberEmailsToAccountIDs[userExporter];
             return translate('workspace.people.removeMemberPromptExporter', {
-                memberName: getDisplayNameForParticipant({accountID: exporterAccountID, formatPhoneNumber}),
-                workspaceOwner: getDisplayNameForParticipant({accountID: policy?.ownerAccountID, formatPhoneNumber}),
+                memberName: getDisplayNameForParticipant({
+                    accountID: exporterAccountID,
+                    formatPhoneNumber,
+                }),
+                workspaceOwner: getDisplayNameForParticipant({
+                    accountID: policy?.ownerAccountID,
+                    formatPhoneNumber,
+                }),
             });
         }
 
@@ -301,7 +313,9 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
     const askForConfirmationToRemove = useCallback(async () => {
         const result = await showConfirmModal({
             danger: true,
-            title: translate('workspace.people.removeMembersTitle', {count: selectedEmployees.length}),
+            title: translate('workspace.people.removeMembersTitle', {
+                count: selectedEmployees.length,
+            }),
             prompt: confirmModalPrompt,
             confirmText: translate('common.remove'),
             cancelText: translate('common.cancel'),
@@ -419,7 +433,12 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
 
     const filteredMembers = useMemo(() => {
         const shouldFilter = shouldFilterExpensifyTeam(policyOwner, currentUserLogin);
-        const result: Array<{email: string; policyEmployee: PolicyEmployee; accountID: number; details: PersonalDetails}> = [];
+        const result: Array<{
+            email: string;
+            policyEmployee: PolicyEmployee;
+            accountID: number;
+            details: PersonalDetails;
+        }> = [];
 
         for (const [email, policyEmployee] of Object.entries(policy?.employeeList ?? {})) {
             const accountID = Number(policyMemberEmailsToAccountIDs[email] ?? '');
@@ -562,9 +581,18 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
     }, []);
     const sortMembers = useCallback((memberOptions: MemberOption[]) => sortAlphabetically(memberOptions, 'text', localeCompare), [localeCompare]);
     const roleFilterOptions: WorkspaceMemberFilterOption[] = [
-        {text: translate('workspace.people.allMembers'), value: WORKSPACE_MEMBER_FILTER_VALUES.ALL},
-        {text: translate('workspace.people.admins'), value: WORKSPACE_MEMBER_FILTER_VALUES.ADMINS},
-        {text: translate('workspace.people.approvers'), value: WORKSPACE_MEMBER_FILTER_VALUES.APPROVERS},
+        {
+            text: translate('workspace.people.allMembers'),
+            value: WORKSPACE_MEMBER_FILTER_VALUES.ALL,
+        },
+        {
+            text: translate('workspace.people.admins'),
+            value: WORKSPACE_MEMBER_FILTER_VALUES.ADMINS,
+        },
+        {
+            text: translate('workspace.people.approvers'),
+            value: WORKSPACE_MEMBER_FILTER_VALUES.APPROVERS,
+        },
     ];
 
     if (isControlPolicy(policy)) {
@@ -794,7 +822,9 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
     const getBulkActionsButtonOptions = () => {
         const options: Array<DropdownOption<WorkspaceMemberBulkActionType>> = [
             {
-                text: translate('workspace.people.removeMembersTitle', {count: selectedEmployees.length}),
+                text: translate('workspace.people.removeMembersTitle', {
+                    count: selectedEmployees.length,
+                }),
                 value: CONST.POLICY.MEMBERS_BULK_ACTION_TYPES.REMOVE,
                 icon: icons.RemoveMembers,
                 onSelected: askForConfirmationToRemove,
@@ -810,20 +840,26 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
         });
 
         const memberOption = {
-            text: translate('workspace.people.makeMember', {count: selectedEmployees.length}),
+            text: translate('workspace.people.makeMember', {
+                count: selectedEmployees.length,
+            }),
             value: CONST.POLICY.MEMBERS_BULK_ACTION_TYPES.MAKE_MEMBER,
             icon: icons.User,
             onSelected: () => changeUserRole(CONST.POLICY.ROLE.USER),
         };
         const adminOption = {
-            text: translate('workspace.people.makeAdmin', {count: selectedEmployees.length}),
+            text: translate('workspace.people.makeAdmin', {
+                count: selectedEmployees.length,
+            }),
             value: CONST.POLICY.MEMBERS_BULK_ACTION_TYPES.MAKE_ADMIN,
             icon: icons.MakeAdmin,
             onSelected: () => changeUserRole(CONST.POLICY.ROLE.ADMIN),
         };
 
         const auditorOption = {
-            text: translate('workspace.people.makeAuditor', {count: selectedEmployees.length}),
+            text: translate('workspace.people.makeAuditor', {
+                count: selectedEmployees.length,
+            }),
             value: CONST.POLICY.MEMBERS_BULK_ACTION_TYPES.MAKE_AUDITOR,
             icon: icons.UserEye,
             onSelected: () => changeUserRole(CONST.POLICY.ROLE.AUDITOR),
@@ -948,7 +984,9 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
         return (shouldUseNarrowLayout ? canSelectMultiple : selectedEmployees.length > 0) ? (
             <ButtonWithDropdownMenu<WorkspaceMemberBulkActionType>
                 shouldAlwaysShowDropdownMenu
-                customText={translate('workspace.common.selected', {count: selectedEmployees.length})}
+                customText={translate('workspace.common.selected', {
+                    count: selectedEmployees.length,
+                })}
                 buttonSize={CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
                 onPress={() => null}
                 options={getBulkActionsButtonOptions()}
@@ -1034,7 +1072,7 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
         <WorkspacePageWithSections
             headerText={selectionModeHeader ? translate('common.selectMultiple') : translate('workspace.common.members')}
             route={route}
-            icon={!selectionModeHeader ? illustrations.ReceiptWrangler : undefined}
+            icon={!selectionModeHeader && !isInLandscapeMode ? illustrations.ReceiptWrangler : undefined}
             headerContent={!shouldDisplayButtonsInSeparateLine && getHeaderButtons()}
             testID="WorkspaceMembersPage"
             shouldShowLoading={false}

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -72,7 +72,7 @@ type WorkspaceCategoriesPageProps =
 function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to apply the correct modal type for the decision modal
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
-    const {shouldUseNarrowLayout, isSmallScreenWidth} = useResponsiveLayout();
+    const {shouldUseNarrowLayout, isSmallScreenWidth, isInLandscapeMode} = useResponsiveLayout();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const {translate, localeCompare} = useLocalize();
@@ -188,7 +188,9 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
             }
             setWorkspaceCategoryEnabled({
                 policyData,
-                categoriesToUpdate: {[categoryName]: {name: categoryName, enabled: value}},
+                categoriesToUpdate: {
+                    [categoryName]: {name: categoryName, enabled: value},
+                },
                 isSetupCategoriesTaskParentReportArchived: isSetupCategoryTaskParentReportArchived,
                 setupCategoryTaskReport,
                 setupCategoryTaskParentReport,
@@ -653,7 +655,9 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                     onPress={() => null}
                     shouldAlwaysShowDropdownMenu
                     buttonSize={CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
-                    customText={translate('workspace.common.selected', {count: selectedCategories.length})}
+                    customText={translate('workspace.common.selected', {
+                        count: selectedCategories.length,
+                    })}
                     options={options}
                     isSplitButton={false}
                     style={[shouldDisplayButtonsInSeparateLine && styles.flexGrow1, shouldDisplayButtonsInSeparateLine && styles.mb3]}
@@ -693,7 +697,11 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     };
 
     const isLoading = !isOffline && policyCategories === undefined;
-    const reasonAttributes: SkeletonSpanReasonAttributes = {context: 'WorkspaceCategoriesPage', isOffline, isPolicyCategoriesUndefined: policyCategories === undefined};
+    const reasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'WorkspaceCategoriesPage',
+        isOffline,
+        isPolicyCategoriesUndefined: policyCategories === undefined,
+    };
 
     useEffect(() => {
         if (isMobileSelectionModeEnabled) {
@@ -757,7 +765,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                 <HeaderWithBackButton
                     shouldShowBackButton={shouldUseNarrowLayout}
                     title={selectionModeHeader ? translate('common.selectMultiple') : translate('workspace.common.categories')}
-                    icon={!selectionModeHeader ? illustrations.FolderOpen : undefined}
+                    icon={!selectionModeHeader && !isInLandscapeMode ? illustrations.FolderOpen : undefined}
                     shouldUseHeadlineHeader={!selectionModeHeader}
                     shouldDisplayHelpButton
                     onBackButtonPress={() => {

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -130,7 +130,10 @@ function PolicyDistanceRatesPage({
                     }
                     return transactionsData;
                 },
-                {transactionIDs: new Set<string>(), rateIDToTransactionIDsMap: {} as Record<string, string[]>},
+                {
+                    transactionIDs: new Set<string>(),
+                    rateIDToTransactionIDsMap: {} as Record<string, string[]>,
+                },
             );
         },
         [customUnit?.customUnitID, rateIDs, policyReports],
@@ -378,7 +381,9 @@ function PolicyDistanceRatesPage({
     const getBulkActionsButtonOptions = () => {
         const options: Array<DropdownOption<WorkspaceDistanceRatesBulkActionType>> = [
             {
-                text: translate('workspace.distanceRates.deleteRates', {count: selectedDistanceRates.length}),
+                text: translate('workspace.distanceRates.deleteRates', {
+                    count: selectedDistanceRates.length,
+                }),
                 value: CONST.POLICY.BULK_ACTION_TYPES.DELETE,
                 icon: icons.Trashcan,
                 onSelected: async () => {
@@ -388,7 +393,9 @@ function PolicyDistanceRatesPage({
                     }
                     const {action} = await showConfirmModal({
                         title: translate('workspace.distanceRates.deleteDistanceRate'),
-                        prompt: translate('workspace.distanceRates.areYouSureDelete', {count: selectedDistanceRates.length}),
+                        prompt: translate('workspace.distanceRates.areYouSureDelete', {
+                            count: selectedDistanceRates.length,
+                        }),
                         confirmText: translate('common.delete'),
                         cancelText: translate('common.cancel'),
                         danger: true,
@@ -403,7 +410,9 @@ function PolicyDistanceRatesPage({
         const enabledRates = selectedDistanceRates.filter((rateID) => selectableRates[rateID].enabled);
         if (enabledRates.length > 0) {
             options.push({
-                text: translate('workspace.distanceRates.disableRates', {count: enabledRates.length}),
+                text: translate('workspace.distanceRates.disableRates', {
+                    count: enabledRates.length,
+                }),
                 value: CONST.POLICY.BULK_ACTION_TYPES.DISABLE,
                 icon: icons.Close,
                 onSelected: () => (canDisableOrDeleteSelectedRates ? disableRates() : showWarningModal()),
@@ -413,7 +422,9 @@ function PolicyDistanceRatesPage({
         const disabledRates = selectedDistanceRates.filter((rateID) => !selectableRates[rateID].enabled);
         if (disabledRates.length > 0) {
             options.push({
-                text: translate('workspace.distanceRates.enableRates', {count: disabledRates.length}),
+                text: translate('workspace.distanceRates.enableRates', {
+                    count: disabledRates.length,
+                }),
                 value: CONST.POLICY.BULK_ACTION_TYPES.ENABLE,
                 icon: icons.Checkmark,
                 onSelected: enableRates,
@@ -424,7 +435,11 @@ function PolicyDistanceRatesPage({
     };
 
     const isLoading = !isOffline && customUnit === undefined;
-    const reasonAttributes: SkeletonSpanReasonAttributes = {context: 'PolicyDistanceRatesPage', isOffline, isCustomUnitUndefined: customUnit === undefined};
+    const reasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'PolicyDistanceRatesPage',
+        isOffline,
+        isCustomUnitUndefined: customUnit === undefined,
+    };
 
     const secondaryActions = useMemo(
         () => [
@@ -467,7 +482,9 @@ function PolicyDistanceRatesPage({
                 <ButtonWithDropdownMenu<WorkspaceDistanceRatesBulkActionType>
                     shouldAlwaysShowDropdownMenu
                     pressOnEnter
-                    customText={translate('workspace.common.selected', {count: selectedDistanceRates.length})}
+                    customText={translate('workspace.common.selected', {
+                        count: selectedDistanceRates.length,
+                    })}
                     buttonSize={CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
                     onPress={() => null}
                     options={getBulkActionsButtonOptions()}
@@ -516,7 +533,7 @@ function PolicyDistanceRatesPage({
                 shouldShowOfflineIndicatorInWideScreen
             >
                 <HeaderWithBackButton
-                    icon={!selectionModeHeader ? CarIce : undefined}
+                    icon={!selectionModeHeader && !isInLandscapeMode ? CarIce : undefined}
                     shouldUseHeadlineHeader={!selectionModeHeader}
                     title={translate(!selectionModeHeader ? 'workspace.common.distanceRates' : 'common.selectMultiple')}
                     shouldShowBackButton={shouldUseNarrowLayout}

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -211,7 +211,11 @@ function WorkspaceTaxesPage({
     const [inputValue, setInputValue, filteredTaxesList] = useSearchResults(taxesList, filterTax, sortTaxes);
 
     const isLoading = !isOffline && taxesList === undefined;
-    const reasonAttributes: SkeletonSpanReasonAttributes = {context: 'WorkspaceTaxesPage', isOffline, isTaxesListUndefined: taxesList === undefined};
+    const reasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'WorkspaceTaxesPage',
+        isOffline,
+        isTaxesListUndefined: taxesList === undefined,
+    };
 
     const toggleTax = (tax: ListItem) => {
         const key = tax.keyForList;
@@ -314,7 +318,9 @@ function WorkspaceTaxesPage({
         if (selectedTaxesIDs.some((taxID) => !policy?.taxRates?.taxes[taxID]?.isDisabled)) {
             options.push({
                 icon: icons.Close,
-                text: translate('workspace.taxes.actions.disableTaxRates', {count: enabledRatesCount}),
+                text: translate('workspace.taxes.actions.disableTaxRates', {
+                    count: enabledRatesCount,
+                }),
                 value: CONST.POLICY.BULK_ACTION_TYPES.DISABLE,
                 onSelected: () => toggleTaxes(false),
             });
@@ -324,7 +330,9 @@ function WorkspaceTaxesPage({
         if (selectedTaxesIDs.some((taxID) => policy?.taxRates?.taxes[taxID]?.isDisabled)) {
             options.push({
                 icon: icons.Checkmark,
-                text: translate('workspace.taxes.actions.enableTaxRates', {count: disabledRatesCount}),
+                text: translate('workspace.taxes.actions.enableTaxRates', {
+                    count: disabledRatesCount,
+                }),
                 value: CONST.POLICY.BULK_ACTION_TYPES.ENABLE,
                 onSelected: () => toggleTaxes(true),
             });
@@ -396,7 +404,9 @@ function WorkspaceTaxesPage({
                 onPress={() => {}}
                 options={dropdownMenuOptions}
                 buttonSize={CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
-                customText={translate('workspace.common.selected', {count: selectedTaxesIDs.length})}
+                customText={translate('workspace.common.selected', {
+                    count: selectedTaxesIDs.length,
+                })}
                 shouldAlwaysShowDropdownMenu
                 isSplitButton={false}
                 style={[shouldDisplayButtonsInSeparateLine && styles.flexGrow1, shouldDisplayButtonsInSeparateLine && styles.mb3]}
@@ -450,7 +460,7 @@ function WorkspaceTaxesPage({
                 shouldShowOfflineIndicatorInWideScreen
             >
                 <HeaderWithBackButton
-                    icon={!selectionModeHeader ? illustrations.Coins : undefined}
+                    icon={!selectionModeHeader && !isInLandscapeMode ? illustrations.Coins : undefined}
                     shouldUseHeadlineHeader={!selectionModeHeader}
                     title={translate(selectionModeHeader ? 'common.selectMultiple' : 'workspace.common.taxes')}
                     shouldShowBackButton={shouldUseNarrowLayout}


### PR DESCRIPTION
## Summary

$ #90374

On iOS in landscape mode, `useShouldDisplayButtonsInSeparateLine` returns `false`, so action buttons move into the header row. The `icon` prop (illustration SVG: `ReceiptWrangler`, `FolderOpen`, `Coins`, `CarIce`) was still rendered unconditionally in `HeaderWithBackButton`, appearing as a stray circular element at the top-left of the header. This is the regression introduced by #87256.

**Root cause:** Each affected page gates `headerContent` on `!shouldDisplayButtonsInSeparateLine` but the `icon` condition only checked `!selectionModeHeader`, with no landscape awareness. In landscape mode both the illustration icon and the action buttons ended up in the header row simultaneously.

**Fix:** Add `&& !isInLandscapeMode` to each page's icon condition so the illustration is hidden in landscape mode (matching the intent of `useShouldDisplayButtonsInSeparateLine`). `isInLandscapeMode` returns `false` on web (`src/hooks/useIsInLandscapeMode/index.ts`), so desktop layout is unaffected.

**Files changed:**
- `src/pages/workspace/WorkspaceMembersPage.tsx` — add `isInLandscapeMode` to `useResponsiveLayout()` destructuring; gate icon on `!isInLandscapeMode`
- `src/pages/workspace/categories/WorkspaceCategoriesPage.tsx` — same
- `src/pages/workspace/taxes/WorkspaceTaxesPage.tsx` — already had `isInLandscapeMode`; gate icon on `!isInLandscapeMode`
- `src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx` — already had `isInLandscapeMode`; gate icon on `!isInLandscapeMode`

## Test plan

- [ ] On iOS device/simulator in landscape mode: open Workspace → Members, Categories, Taxes, Distance Rates — no circle icon visible at top-left
- [ ] On iOS in portrait mode: same pages show the illustration icon normally in the headline header
- [ ] On web/desktop: illustration icon still shows on all pages (unaffected by this change)
- [ ] In selection mode on any platform: icon still hidden (existing `selectionModeHeader` condition unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)