### PR TITLE
Skip checklist CI checks for internal engineers regardless of org-membership visibility

### DIFF
--- a/.github/actions/javascript/isAuthorizedContributor/action.yml
+++ b/.github/actions/javascript/isAuthorizedContributor/action.yml
@@ -20,6 +20,8 @@ inputs:
 outputs:
     IS_AUTHORIZED:
         description: "'true' if the contributor is authorized, 'false' otherwise"
+    IS_INTERNAL:
+        description: "'true' if the actor is an internal Expensify engineer (engineering org team member), 'false' otherwise"
 runs:
     using: 'node24'
     main: './index.js'

--- a/.github/actions/javascript/isAuthorizedContributor/index.js
+++ b/.github/actions/javascript/isAuthorizedContributor/index.js
@@ -11582,13 +11582,16 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isAuthorizedContributor = isAuthorizedContributor;
 exports.isContributorPlusMember = isContributorPlusMember;
+exports.isInternalExpensifyEngineer = isInternalExpensifyEngineer;
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
-const request_error_1 = __nccwpck_require__(537);
 const CONST_1 = __importDefault(__nccwpck_require__(9873));
 const GithubUtils_1 = __importDefault(__nccwpck_require__(9296));
+const isTeamMember_1 = __importDefault(__nccwpck_require__(1077));
 const AUTHORIZED_ASSOCIATIONS = new Set(['MEMBER', 'OWNER', 'CONTRIBUTOR', 'COLLABORATOR']);
 const CONTRIBUTOR_PLUS_TEAM_SLUG = 'contributor-plus';
+// Internal Expensify engineers belong to this team. We can't rely on author_association, which only reports MEMBER for publicly visible org members.
+const ENGINEERING_TEAM_SLUG = 'engineering';
 const ISSUE_URL_PATTERN = /https:\/\/github\.com\/(Expensify\/[^/]+)\/issues\/(\d+)/g;
 function parseExpensifyLink(match) {
     const repoFullName = match[1];
@@ -11610,25 +11613,16 @@ function logVerificationError(repoFullName, number, error) {
 }
 async function isContributorPlusMember(username, orgToken) {
     GithubUtils_1.default.initOctokitWithToken(orgToken);
-    try {
-        await GithubUtils_1.default.octokit.teams.getMembershipForUserInOrg({
-            org: CONST_1.default.GITHUB_OWNER,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            team_slug: CONTRIBUTOR_PLUS_TEAM_SLUG,
-            username,
-        });
-        console.log(`${username} is a Contributor+ member. Authorized.`);
-        return true;
-    }
-    catch (error) {
-        if (error instanceof request_error_1.RequestError && error.status === 404) {
-            console.log(`${username} is not a Contributor+ member.`);
-            return false;
-        }
-        const message = error instanceof Error ? error.message : String(error);
-        core.warning(`Could not verify Contributor+ membership for ${username}. Assuming they are not a Contributor+: ${message}`);
-        return false;
-    }
+    const isMember = await (0, isTeamMember_1.default)(GithubUtils_1.default.octokit, CONST_1.default.GITHUB_OWNER, CONTRIBUTOR_PLUS_TEAM_SLUG, username);
+    console.log(isMember ? `${username} is a Contributor+ member. Authorized.` : `${username} is not a Contributor+ member.`);
+    return isMember;
+}
+/**
+ * Returns whether a user is an internal Expensify engineer (member of the engineering org team).
+ */
+async function isInternalExpensifyEngineer(username, orgToken) {
+    GithubUtils_1.default.initOctokitWithToken(orgToken);
+    return (0, isTeamMember_1.default)(GithubUtils_1.default.octokit, CONST_1.default.GITHUB_OWNER, ENGINEERING_TEAM_SLUG, username);
 }
 async function isAuthorizedViaLinkedIssues(prBody, actor) {
     for (const match of prBody.matchAll(ISSUE_URL_PATTERN)) {
@@ -11699,6 +11693,8 @@ async function run() {
         orgToken,
     });
     core.setOutput('IS_AUTHORIZED', isAuthorized);
+    const isInternal = await isInternalExpensifyEngineer(actor, orgToken);
+    core.setOutput('IS_INTERNAL', isInternal);
 }
 if (require.main === require.cache[eval('__filename')]) {
     run().catch((error) => {
@@ -12237,6 +12233,75 @@ class GithubUtils {
     }
 }
 exports["default"] = GithubUtils;
+
+
+/***/ }),
+
+/***/ 1077:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+/* eslint-disable @typescript-eslint/naming-convention */
+const core = __importStar(__nccwpck_require__(2186));
+const request_error_1 = __nccwpck_require__(537);
+/**
+ * Whether a user is a member of the given org team.
+ * The octokit must be authenticated with a token that has read:org scope, otherwise concealed (private) members are reported as non-members.
+ */
+async function isTeamMember(octokit, org, teamSlug, username) {
+    try {
+        await octokit.teams.getMembershipForUserInOrg({
+            org,
+            team_slug: teamSlug,
+            username,
+        });
+        return true;
+    }
+    catch (error) {
+        if (error instanceof request_error_1.RequestError && error.status === 404) {
+            return false;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        core.warning(`Could not verify ${teamSlug} membership for ${username}. Assuming they are not a member: ${message}`);
+        return false;
+    }
+}
+exports["default"] = isTeamMember;
 
 
 /***/ }),

--- a/.github/actions/javascript/isAuthorizedContributor/isAuthorizedContributor.ts
+++ b/.github/actions/javascript/isAuthorizedContributor/isAuthorizedContributor.ts
@@ -1,11 +1,14 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import {RequestError} from '@octokit/request-error';
 import CONST from '@github/libs/CONST';
 import GithubUtils from '@github/libs/GithubUtils';
+import isTeamMember from '@github/libs/isTeamMember';
 
 const AUTHORIZED_ASSOCIATIONS = new Set(['MEMBER', 'OWNER', 'CONTRIBUTOR', 'COLLABORATOR']);
 const CONTRIBUTOR_PLUS_TEAM_SLUG = 'contributor-plus';
+
+// Internal Expensify engineers belong to this team. We can't rely on author_association, which only reports MEMBER for publicly visible org members.
+const ENGINEERING_TEAM_SLUG = 'engineering';
 
 const ISSUE_URL_PATTERN = /https:\/\/github\.com\/(Expensify\/[^/]+)\/issues\/(\d+)/g;
 
@@ -49,25 +52,17 @@ function logVerificationError(repoFullName: string, number: number, error: unkno
 
 async function isContributorPlusMember(username: string, orgToken: string): Promise<boolean> {
     GithubUtils.initOctokitWithToken(orgToken);
+    const isMember = await isTeamMember(GithubUtils.octokit, CONST.GITHUB_OWNER, CONTRIBUTOR_PLUS_TEAM_SLUG, username);
+    console.log(isMember ? `${username} is a Contributor+ member. Authorized.` : `${username} is not a Contributor+ member.`);
+    return isMember;
+}
 
-    try {
-        await GithubUtils.octokit.teams.getMembershipForUserInOrg({
-            org: CONST.GITHUB_OWNER,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            team_slug: CONTRIBUTOR_PLUS_TEAM_SLUG,
-            username,
-        });
-        console.log(`${username} is a Contributor+ member. Authorized.`);
-        return true;
-    } catch (error: unknown) {
-        if (error instanceof RequestError && error.status === 404) {
-            console.log(`${username} is not a Contributor+ member.`);
-            return false;
-        }
-        const message = error instanceof Error ? error.message : String(error);
-        core.warning(`Could not verify Contributor+ membership for ${username}. Assuming they are not a Contributor+: ${message}`);
-        return false;
-    }
+/**
+ * Returns whether a user is an internal Expensify engineer (member of the engineering org team).
+ */
+async function isInternalExpensifyEngineer(username: string, orgToken: string): Promise<boolean> {
+    GithubUtils.initOctokitWithToken(orgToken);
+    return isTeamMember(GithubUtils.octokit, CONST.GITHUB_OWNER, ENGINEERING_TEAM_SLUG, username);
 }
 
 async function isAuthorizedViaLinkedIssues(prBody: string, actor: string): Promise<boolean> {
@@ -155,6 +150,9 @@ async function run(): Promise<void> {
     });
 
     core.setOutput('IS_AUTHORIZED', isAuthorized);
+
+    const isInternal = await isInternalExpensifyEngineer(actor, orgToken);
+    core.setOutput('IS_INTERNAL', isInternal);
 }
 
 if (require.main === module) {
@@ -164,5 +162,5 @@ if (require.main === module) {
     });
 }
 
-export {isAuthorizedContributor, isContributorPlusMember};
+export {isAuthorizedContributor, isContributorPlusMember, isInternalExpensifyEngineer};
 export default run;

--- a/.github/actions/javascript/reviewerChecklist/action.yml
+++ b/.github/actions/javascript/reviewerChecklist/action.yml
@@ -5,8 +5,8 @@ inputs:
     description: Auth token for New Expensify Github
     required: true
   OS_BOTIFY_TOKEN:
-    description: OSBotify token for org team membership (read:org)
-    required: true
+    description: OSBotify token for org team membership (read:org). Absent on fork-triggered runs, which don't receive org secrets.
+    required: false
 runs:
   using: 'node24'
   main: './index.js'

--- a/.github/actions/javascript/reviewerChecklist/action.yml
+++ b/.github/actions/javascript/reviewerChecklist/action.yml
@@ -4,6 +4,9 @@ inputs:
   GITHUB_TOKEN:
     description: Auth token for New Expensify Github
     required: true
+  OS_BOTIFY_TOKEN:
+    description: OSBotify token for org team membership (read:org)
+    required: true
 runs:
   using: 'node24'
   main: './index.js'

--- a/.github/actions/javascript/reviewerChecklist/index.js
+++ b/.github/actions/javascript/reviewerChecklist/index.js
@@ -11583,13 +11583,15 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const https_1 = __importDefault(__nccwpck_require__(5687));
+const CONST_1 = __importDefault(__nccwpck_require__(9873));
 const GithubUtils_1 = __importDefault(__nccwpck_require__(9296));
+const isTeamMember_1 = __importDefault(__nccwpck_require__(1077));
 const pathToReviewerChecklist = 'https://raw.githubusercontent.com/Expensify/App/main/contributingGuides/REVIEWER_CHECKLIST.md';
 const reviewerChecklistContains = '# Reviewer Checklist';
 const issue = github.context.payload.issue?.number ?? github.context.payload.pull_request?.number ?? -1;
 const combinedComments = [];
-// Org members and owners are internal Expensify engineers; external contributors (including C+) are not.
-const INTERNAL_EXPENSIFY_ASSOCIATIONS = new Set(['MEMBER', 'OWNER']);
+// Internal Expensify engineers belong to this team. We can't rely on author_association, which only reports MEMBER for publicly visible org members.
+const ENGINEERING_TEAM_SLUG = 'engineering';
 // A reviewer's standing is their latest review in one of these states; plain "commented" reviews don't change it.
 const DECISIVE_REVIEW_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
 function getNumberOfItemsFromReviewerChecklist() {
@@ -11664,7 +11666,7 @@ function checkIssueForCompletedChecklist(numberOfChecklistItems) {
 // An approval from an internal Expensify engineer means we've decided this PR doesn't need a C+ checklist, so let the check pass.
 // This workflow re-runs on every pull_request_review event, so we scan the whole review history: once an internal approval
 // stands, a later "commented" or "changes requested" review from anyone must not re-require the checklist.
-async function hasStandingInternalApproval() {
+async function hasStandingInternalApproval(orgToken) {
     const { owner, repo } = github.context.repo;
     const reviews = await GithubUtils_1.default.paginate(GithubUtils_1.default.octokit.pulls.listReviews, {
         owner,
@@ -11674,15 +11676,20 @@ async function hasStandingInternalApproval() {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         per_page: 100,
     });
+    const decisiveReviews = reviews.filter((review) => !!review.user?.login && DECISIVE_REVIEW_STATES.has(review.state ?? ''));
+    // Resolve internal status from engineering-team membership using a read:org token, since concealed members aren't reflected in author_association.
+    const orgOctokit = github.getOctokit(orgToken);
+    const reviewerLogins = [...new Set(decisiveReviews.map((review) => review.user?.login ?? ''))];
+    const membershipResults = await Promise.all(reviewerLogins.map((login) => (0, isTeamMember_1.default)(orgOctokit.rest, CONST_1.default.GITHUB_OWNER, ENGINEERING_TEAM_SLUG, login)));
+    const internalReviewerLogins = new Set(reviewerLogins.filter((_, index) => membershipResults.at(index)));
     // GitHub treats a reviewer's latest decisive review as their standing, so keep only that per internal engineer.
     const latestStateByInternalReviewer = new Map();
-    for (const review of reviews) {
-        const login = review.user?.login;
-        const state = review.state ?? '';
-        if (!login || !INTERNAL_EXPENSIFY_ASSOCIATIONS.has(review.author_association ?? '') || !DECISIVE_REVIEW_STATES.has(state)) {
+    for (const review of decisiveReviews) {
+        const login = review.user?.login ?? '';
+        if (!internalReviewerLogins.has(login)) {
             continue;
         }
-        latestStateByInternalReviewer.set(login, state);
+        latestStateByInternalReviewer.set(login, review.state ?? '');
     }
     for (const state of latestStateByInternalReviewer.values()) {
         if (state === 'APPROVED') {
@@ -11691,7 +11698,7 @@ async function hasStandingInternalApproval() {
     }
     return false;
 }
-hasStandingInternalApproval()
+hasStandingInternalApproval(core.getInput('OS_BOTIFY_TOKEN', { required: true }))
     .then((isApproved) => {
     if (isApproved) {
         console.log('PR has a standing approval from an internal Expensify engineer, so the reviewer checklist is not required 🎉');
@@ -12233,6 +12240,75 @@ class GithubUtils {
     }
 }
 exports["default"] = GithubUtils;
+
+
+/***/ }),
+
+/***/ 1077:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+/* eslint-disable @typescript-eslint/naming-convention */
+const core = __importStar(__nccwpck_require__(2186));
+const request_error_1 = __nccwpck_require__(537);
+/**
+ * Whether a user is a member of the given org team.
+ * The octokit must be authenticated with a token that has read:org scope, otherwise concealed (private) members are reported as non-members.
+ */
+async function isTeamMember(octokit, org, teamSlug, username) {
+    try {
+        await octokit.teams.getMembershipForUserInOrg({
+            org,
+            team_slug: teamSlug,
+            username,
+        });
+        return true;
+    }
+    catch (error) {
+        if (error instanceof request_error_1.RequestError && error.status === 404) {
+            return false;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        core.warning(`Could not verify ${teamSlug} membership for ${username}. Assuming they are not a member: ${message}`);
+        return false;
+    }
+}
+exports["default"] = isTeamMember;
 
 
 /***/ }),

--- a/.github/actions/javascript/reviewerChecklist/index.js
+++ b/.github/actions/javascript/reviewerChecklist/index.js
@@ -11667,6 +11667,10 @@ function checkIssueForCompletedChecklist(numberOfChecklistItems) {
 // This workflow re-runs on every pull_request_review event, so we scan the whole review history: once an internal approval
 // stands, a later "commented" or "changes requested" review from anyone must not re-require the checklist.
 async function hasStandingInternalApproval(orgToken) {
+    // Fork-triggered runs don't receive org secrets, so we can't verify engineering-team membership and must fall back to requiring the checklist.
+    if (!orgToken) {
+        return false;
+    }
     const { owner, repo } = github.context.repo;
     const reviews = await GithubUtils_1.default.paginate(GithubUtils_1.default.octokit.pulls.listReviews, {
         owner,
@@ -11698,7 +11702,7 @@ async function hasStandingInternalApproval(orgToken) {
     }
     return false;
 }
-hasStandingInternalApproval(core.getInput('OS_BOTIFY_TOKEN', { required: true }))
+hasStandingInternalApproval(core.getInput('OS_BOTIFY_TOKEN'))
     .then((isApproved) => {
     if (isApproved) {
         console.log('PR has a standing approval from an internal Expensify engineer, so the reviewer checklist is not required 🎉');

--- a/.github/actions/javascript/reviewerChecklist/reviewerChecklist.ts
+++ b/.github/actions/javascript/reviewerChecklist/reviewerChecklist.ts
@@ -99,6 +99,11 @@ function checkIssueForCompletedChecklist(numberOfChecklistItems: number) {
 // This workflow re-runs on every pull_request_review event, so we scan the whole review history: once an internal approval
 // stands, a later "commented" or "changes requested" review from anyone must not re-require the checklist.
 async function hasStandingInternalApproval(orgToken: string): Promise<boolean> {
+    // Fork-triggered runs don't receive org secrets, so we can't verify engineering-team membership and must fall back to requiring the checklist.
+    if (!orgToken) {
+        return false;
+    }
+
     const {owner, repo} = github.context.repo;
     const reviews = await GitHubUtils.paginate(GitHubUtils.octokit.pulls.listReviews, {
         owner,
@@ -135,7 +140,7 @@ async function hasStandingInternalApproval(orgToken: string): Promise<boolean> {
     return false;
 }
 
-hasStandingInternalApproval(core.getInput('OS_BOTIFY_TOKEN', {required: true}))
+hasStandingInternalApproval(core.getInput('OS_BOTIFY_TOKEN'))
     .then((isApproved) => {
         if (isApproved) {
             console.log('PR has a standing approval from an internal Expensify engineer, so the reviewer checklist is not required 🎉');

--- a/.github/actions/javascript/reviewerChecklist/reviewerChecklist.ts
+++ b/.github/actions/javascript/reviewerChecklist/reviewerChecklist.ts
@@ -1,15 +1,17 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import https from 'https';
+import CONST from '@github/libs/CONST';
 import GitHubUtils from '@github/libs/GithubUtils';
+import isTeamMember from '@github/libs/isTeamMember';
 
 const pathToReviewerChecklist = 'https://raw.githubusercontent.com/Expensify/App/main/contributingGuides/REVIEWER_CHECKLIST.md';
 const reviewerChecklistContains = '# Reviewer Checklist';
 const issue: number = github.context.payload.issue?.number ?? github.context.payload.pull_request?.number ?? -1;
 const combinedComments: string[] = [];
 
-// Org members and owners are internal Expensify engineers; external contributors (including C+) are not.
-const INTERNAL_EXPENSIFY_ASSOCIATIONS = new Set(['MEMBER', 'OWNER']);
+// Internal Expensify engineers belong to this team. We can't rely on author_association, which only reports MEMBER for publicly visible org members.
+const ENGINEERING_TEAM_SLUG = 'engineering';
 
 // A reviewer's standing is their latest review in one of these states; plain "commented" reviews don't change it.
 const DECISIVE_REVIEW_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
@@ -96,7 +98,7 @@ function checkIssueForCompletedChecklist(numberOfChecklistItems: number) {
 // An approval from an internal Expensify engineer means we've decided this PR doesn't need a C+ checklist, so let the check pass.
 // This workflow re-runs on every pull_request_review event, so we scan the whole review history: once an internal approval
 // stands, a later "commented" or "changes requested" review from anyone must not re-require the checklist.
-async function hasStandingInternalApproval(): Promise<boolean> {
+async function hasStandingInternalApproval(orgToken: string): Promise<boolean> {
     const {owner, repo} = github.context.repo;
     const reviews = await GitHubUtils.paginate(GitHubUtils.octokit.pulls.listReviews, {
         owner,
@@ -107,15 +109,22 @@ async function hasStandingInternalApproval(): Promise<boolean> {
         per_page: 100,
     });
 
+    const decisiveReviews = reviews.filter((review) => !!review.user?.login && DECISIVE_REVIEW_STATES.has(review.state ?? ''));
+
+    // Resolve internal status from engineering-team membership using a read:org token, since concealed members aren't reflected in author_association.
+    const orgOctokit = github.getOctokit(orgToken);
+    const reviewerLogins = [...new Set(decisiveReviews.map((review) => review.user?.login ?? ''))];
+    const membershipResults = await Promise.all(reviewerLogins.map((login) => isTeamMember(orgOctokit.rest, CONST.GITHUB_OWNER, ENGINEERING_TEAM_SLUG, login)));
+    const internalReviewerLogins = new Set(reviewerLogins.filter((_, index) => membershipResults.at(index)));
+
     // GitHub treats a reviewer's latest decisive review as their standing, so keep only that per internal engineer.
     const latestStateByInternalReviewer = new Map<string, string>();
-    for (const review of reviews) {
-        const login = review.user?.login;
-        const state = review.state ?? '';
-        if (!login || !INTERNAL_EXPENSIFY_ASSOCIATIONS.has(review.author_association ?? '') || !DECISIVE_REVIEW_STATES.has(state)) {
+    for (const review of decisiveReviews) {
+        const login = review.user?.login ?? '';
+        if (!internalReviewerLogins.has(login)) {
             continue;
         }
-        latestStateByInternalReviewer.set(login, state);
+        latestStateByInternalReviewer.set(login, review.state ?? '');
     }
 
     for (const state of latestStateByInternalReviewer.values()) {
@@ -126,7 +135,7 @@ async function hasStandingInternalApproval(): Promise<boolean> {
     return false;
 }
 
-hasStandingInternalApproval()
+hasStandingInternalApproval(core.getInput('OS_BOTIFY_TOKEN', {required: true}))
     .then((isApproved) => {
         if (isApproved) {
             console.log('PR has a standing approval from an internal Expensify engineer, so the reviewer checklist is not required 🎉');

--- a/.github/libs/isTeamMember.ts
+++ b/.github/libs/isTeamMember.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as core from '@actions/core';
+import type {RestEndpointMethods} from '@octokit/plugin-rest-endpoint-methods/dist-types/generated/method-types';
+import {RequestError} from '@octokit/request-error';
+
+/**
+ * Whether a user is a member of the given org team.
+ * The octokit must be authenticated with a token that has read:org scope, otherwise concealed (private) members are reported as non-members.
+ */
+async function isTeamMember(octokit: RestEndpointMethods, org: string, teamSlug: string, username: string): Promise<boolean> {
+    try {
+        await octokit.teams.getMembershipForUserInOrg({
+            org,
+            team_slug: teamSlug,
+            username,
+        });
+        return true;
+    } catch (error: unknown) {
+        if (error instanceof RequestError && error.status === 404) {
+            return false;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        core.warning(`Could not verify ${teamSlug} membership for ${username}. Assuming they are not a member: ${message}`);
+        return false;
+    }
+}
+
+export default isTeamMember;

--- a/.github/workflows/authorChecklist.yml
+++ b/.github/workflows/authorChecklist.yml
@@ -31,11 +31,10 @@ jobs:
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: authorChecklist.ts
-        # Internal Expensify engineers (org members/owners) skip the author checklist; external contributors still fill it out.
+        # Internal Expensify engineers skip the author checklist; external contributors still fill it out.
         if: |
           steps.gate.outputs.IS_AUTHORIZED == 'true'
-          && github.event.pull_request.author_association != 'MEMBER'
-          && github.event.pull_request.author_association != 'OWNER'
+          && steps.gate.outputs.IS_INTERNAL != 'true'
         uses: ./.github/actions/javascript/authorChecklist
         with:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/reviewerChecklist.yml
+++ b/.github/workflows/reviewerChecklist.yml
@@ -27,3 +27,4 @@ jobs:
         uses: ./.github/actions/javascript/reviewerChecklist
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/tests/unit/isAuthorizedContributorTest.ts
+++ b/tests/unit/isAuthorizedContributorTest.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import {RequestError} from '@octokit/request-error';
-import {isAuthorizedContributor, isContributorPlusMember} from '../../.github/actions/javascript/isAuthorizedContributor/isAuthorizedContributor';
+import {isAuthorizedContributor, isContributorPlusMember, isInternalExpensifyEngineer} from '../../.github/actions/javascript/isAuthorizedContributor/isAuthorizedContributor';
 import type {InternalOctokit} from '../../.github/libs/GithubUtils';
 import GithubUtils from '../../.github/libs/GithubUtils';
 
@@ -67,6 +67,28 @@ describe('isAuthorizedContributor', () => {
             mockGetMembershipForUserInOrg.mockRejectedValue(createRequestError(404));
 
             await expect(isContributorPlusMember('externalUser', 'org-token')).resolves.toBe(false);
+        });
+    });
+
+    describe('isInternalExpensifyEngineer', () => {
+        test('returns true for an engineering team member', async () => {
+            mockGetMembershipForUserInOrg.mockResolvedValue({data: {state: 'active'}});
+
+            await expect(isInternalExpensifyEngineer('engineerUser', 'org-token')).resolves.toBe(true);
+        });
+
+        test('returns false when not on the engineering team (404)', async () => {
+            mockGetMembershipForUserInOrg.mockRejectedValue(createRequestError(404));
+
+            await expect(isInternalExpensifyEngineer('externalUser', 'org-token')).resolves.toBe(false);
+        });
+
+        test('returns false for a Contributor+ member who is not on the engineering team', async () => {
+            mockGetMembershipForUserInOrg.mockImplementation((params: Record<string, unknown>) =>
+                params.team_slug === 'engineering' ? Promise.reject(createRequestError(404)) : Promise.resolve({data: {state: 'active'}}),
+            );
+
+            await expect(isInternalExpensifyEngineer('contributorPlusUser', 'org-token')).resolves.toBe(false);
         });
     });
 


### PR DESCRIPTION
### Explanation of Change

When an Expensify engineer opens or approves a pull request, two checklists are meant to be waived automatically so we don't fill them out by hand. [An earlier attempt](https://github.com/Expensify/App/pull/92746) at this only worked for engineers who had made their Expensify membership public, and since most of us keep it private, we were still forced to complete the checklists anyway. This change instead recognizes an Expensify engineer by checking whether they're on the `engineering` GH team, using a tool account that can see private memberships, while outside contributors still complete the checklists exactly as before. 

**💡 Note:** these checks run from the main branch, so they can't actually be tried out on this pull request itself — the real test comes after it's merged, when an engineer's next pull request should skip the checklist on its own.

Slack: https://expensify.slack.com/archives/C03TQ48KC/p1780521165839379

– written by Claude on Ben's behalf

### Fixed Issues

$ https://github.com/Expensify/App/issues/92745
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — CI workflow change.

### QA Steps

ping @blimpich and he'll test

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

N/A — CI workflow / GitHub Actions change with no UI surface.
