### PR TITLE
Fix selected workspace members disappearing after clearing search

### DIFF
--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -606,7 +606,6 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
     const [inputValue, setInputValue, filteredData] = useSearchResults(data, filterMember, sortMembers, rolePreFilter);
 
     const handleSearchChange = (value: string) => {
-        setSelectedEmployees([]);
         setInputValue(value);
     };
 


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/92959

## Summary

The workspace members search handler was clearing `selectedEmployees` on every search input change. Clearing the search field therefore removed members selected from the filtered result set before the full list rendered again.

This removes the selection reset from `handleSearchChange` so filtering the list does not implicitly clear selected members.

Explicit selection-clearing flows such as role filter changes, exiting selection mode, and back press clear selection remain unchanged.

## Test

1. Open Workspace > Members.
2. Search for a query that returns multiple members.
3. Click Select all.
4. Clear the search field.
5. Verify the previously selected members remain selected.
6. Verify explicit clear selection still clears selected members.