### PR TITLE
fix: update zip code validation when address country changes

### DIFF
--- a/src/components/SubStepForms/AddressStep.tsx
+++ b/src/components/SubStepForms/AddressStep.tsx
@@ -1,3 +1,4 @@
+import {CONST as COMMON_CONST} from 'expensify-common/dist/CONST';
 import React, {useCallback, useEffect, useRef} from 'react';
 import {View} from 'react-native';
 import FormProvider from '@components/Form/FormProvider';
@@ -8,7 +9,7 @@ import useLocalize from '@hooks/useLocalize';
 import type {SubStepProps} from '@hooks/useSubStep/types';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {ForwardedFSClassProps} from '@libs/Fullstory/types';
-import {getFieldRequiredErrors, isValidAddress, isValidZipCode, isValidZipCodeInternational} from '@libs/ValidationUtils';
+import {getFieldRequiredErrors, isValidAddress, isValidZipCode} from '@libs/ValidationUtils';
 import AddressFormFields from '@pages/ReimbursementAccount/AddressFormFields';
 import HelpLinks from '@pages/ReimbursementAccount/USD/Requestor/PersonalInfo/HelpLinks';
 import {setDraftValues} from '@userActions/FormActions';
@@ -30,6 +31,11 @@ type AddressInputIDs = {
     state: string;
     zipCode: string;
     country?: string;
+};
+
+type CountryZipRegex = {
+    regex?: RegExp;
+    samples?: string;
 };
 
 type AddressStepProps<TFormID extends keyof OnyxFormValuesMapping> = SubStepProps &
@@ -145,14 +151,28 @@ function AddressStep<TFormID extends keyof OnyxFormValuesMapping>({
             }
 
             const zipCode = values[inputFieldsIDs.zipCode as keyof typeof values];
-            if (shouldValidateZipCodeFormat && zipCode && (shouldDisplayCountrySelector ? !isValidZipCodeInternational(zipCode as string) : !isValidZipCode(zipCode as string))) {
+            const selectedCountry = inputFieldsIDs.country ? (values[inputFieldsIDs.country as keyof typeof values] as Country | undefined) : undefined;
+            const countryRegexDetails = selectedCountry ? (COMMON_CONST.COUNTRY_ZIP_REGEX_DATA?.[selectedCountry] as CountryZipRegex) : undefined;
+            const countrySpecificZipRegex = countryRegexDetails?.regex;
+            const trimmedZipCode = (zipCode as string | undefined)?.trim().toUpperCase() ?? '';
+
+            const isInvalidZipCode =
+                !!zipCode &&
+                shouldValidateZipCodeFormat &&
+                (shouldDisplayCountrySelector
+                    ? countrySpecificZipRegex
+                        ? !countrySpecificZipRegex.test(trimmedZipCode)
+                        : !COMMON_CONST.GENERIC_ZIP_CODE_REGEX.test(trimmedZipCode)
+                    : !isValidZipCode(zipCode as string));
+
+            if (isInvalidZipCode) {
                 // @ts-expect-error type mismatch to be fixed
                 errors[inputFieldsIDs.zipCode] = translate('bankAccount.error.zipCode');
             }
 
             return errors;
         },
-        [inputFieldsIDs.street, inputFieldsIDs.zipCode, shouldDisplayCountrySelector, shouldValidateZipCodeFormat, stepFields, translate],
+        [inputFieldsIDs.country, inputFieldsIDs.street, inputFieldsIDs.zipCode, shouldDisplayCountrySelector, shouldValidateZipCodeFormat, stepFields, translate],
     );
 
     return (

--- a/src/pages/ReimbursementAccount/AddressFormFields.tsx
+++ b/src/pages/ReimbursementAccount/AddressFormFields.tsx
@@ -10,8 +10,14 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {ForwardedFSClassProps} from '@libs/Fullstory/types';
 import CONST from '@src/CONST';
+import type {Country} from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import type {Address} from '@src/types/onyx/PrivatePersonalDetails';
+
+type CountryZipRegex = {
+    regex?: RegExp;
+    samples?: string;
+};
 
 type AddressInputKeys = {
     street: string;
@@ -119,6 +125,7 @@ function AddressFormFields({
     const [countryInEditMode, setCountryInEditMode] = useState<string>(defaultValues?.country ?? CONST.COUNTRY.US);
     // When draft values are not being saved we need to relay on local state to determine the currently selected country
     const currentlySelectedCountry = shouldSaveDraft ? defaultValues?.country : countryInEditMode;
+    const zipSampleFormat = (currentlySelectedCountry && (COMMON_CONST.COUNTRY_ZIP_REGEX_DATA[currentlySelectedCountry as Country] as CountryZipRegex)?.samples) ?? '';
 
     const handleCountryChange = (country: unknown) => {
         if (typeof country === 'string' && country !== '') {
@@ -186,11 +193,11 @@ function AddressFormFields({
                 label={translate('common.zip')}
                 accessibilityLabel={translate('common.zip')}
                 role={CONST.ROLE.PRESENTATION}
-                inputMode={shouldValidateZipCodeFormat ? CONST.INPUT_MODE.NUMERIC : undefined}
+                inputMode={shouldValidateZipCodeFormat && currentlySelectedCountry === CONST.COUNTRY.US ? CONST.INPUT_MODE.NUMERIC : undefined}
                 value={values?.zipCode}
                 defaultValue={defaultValues?.zipCode}
                 errorText={errors?.zipCode ? translate('bankAccount.error.zipCode') : ''}
-                hint={translate('common.zipCodeExampleFormat', COMMON_CONST.COUNTRY_ZIP_REGEX_DATA.US.samples)}
+                hint={translate('common.zipCodeExampleFormat', zipSampleFormat)}
                 containerStyles={styles.mt3}
                 forwardedFSClass={forwardedFSClass}
                 autoComplete="postal-code"

--- a/tests/unit/components/SubStepForms/AddressStep.test.tsx
+++ b/tests/unit/components/SubStepForms/AddressStep.test.tsx
@@ -1,0 +1,138 @@
+import {CONST as COMMON_CONST} from 'expensify-common/dist/CONST';
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+import type {FormInputErrors, FormOnyxKeys, FormOnyxValues} from '@components/Form/types';
+import AddressStep from '@components/SubStepForms/AddressStep';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+type InputWrapperProps = {
+    inputID: string;
+    hint?: string;
+    inputMode?: string;
+    onValueChange?: (value: string) => void;
+};
+
+type FormProviderProps = {
+    children: React.ReactNode;
+    validate: (values: FormOnyxValues<typeof ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM>) => FormInputErrors<typeof ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM>;
+    ref?: React.Ref<{resetFormFieldError: jest.Mock}>;
+};
+
+const mockInputWrapperProps: InputWrapperProps[] = [];
+let mockValidateForm: FormProviderProps['validate'] = jest.fn();
+
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: (key: string, value?: string) => (key === 'common.zipCodeExampleFormat' ? `e.g. ${value ?? ''}` : key),
+    })),
+);
+
+jest.mock('@hooks/useThemeStyles', () =>
+    jest.fn(
+        () =>
+            new Proxy(
+                {},
+                {
+                    get: () => ({}),
+                },
+            ),
+    ),
+);
+
+jest.mock('@components/Form/FormProvider', () => {
+    const ReactActual = jest.requireActual('react');
+
+    function MockFormProvider({children, validate, ref}: FormProviderProps) {
+        mockValidateForm = validate;
+        ReactActual.useImperativeHandle(ref, () => ({resetFormFieldError: jest.fn()}));
+        return children;
+    }
+
+    return MockFormProvider;
+});
+
+jest.mock('@components/Form/InputWrapper', () => {
+    const {Text} = jest.requireActual('react-native');
+
+    function MockInputWrapper(props: InputWrapperProps) {
+        mockInputWrapperProps.push(props);
+        return <Text>{props.inputID}</Text>;
+    }
+
+    return MockInputWrapper;
+});
+
+jest.mock('@components/AddressSearch', () => 'AddressSearch');
+jest.mock('@components/PushRowWithModal', () => 'PushRowWithModal');
+jest.mock('@components/TextInput', () => 'TextInput');
+jest.mock('@components/PatriotActLink', () => 'PatriotActLink');
+jest.mock('@pages/ReimbursementAccount/USD/Requestor/PersonalInfo/HelpLinks', () => 'HelpLinks');
+jest.mock('@userActions/FormActions', () => ({
+    setDraftValues: jest.fn(),
+}));
+
+const inputFieldsIDs = {
+    street: 'ownerStreet',
+    city: 'ownerCity',
+    state: 'ownerState',
+    zipCode: 'ownerZipCode',
+    country: 'ownerCountry',
+};
+
+const defaultValues = {
+    street: '1 Main Street',
+    city: 'New York',
+    state: 'NY',
+    zipCode: '10001',
+    country: CONST.COUNTRY.US,
+};
+
+function renderAddressStep() {
+    return render(
+        <AddressStep<typeof ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM>
+            formID={ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM}
+            formTitle="Owner info"
+            onSubmit={jest.fn()}
+            onNext={jest.fn()}
+            isEditing
+            stepFields={Object.values(inputFieldsIDs) as Array<FormOnyxKeys<typeof ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM>>}
+            inputFieldsIDs={inputFieldsIDs}
+            defaultValues={defaultValues}
+            shouldDisplayCountrySelector
+        />,
+    );
+}
+
+function getLastInputProps(inputID: string) {
+    const matchingProps = mockInputWrapperProps.filter((props) => props.inputID === inputID);
+    return matchingProps[matchingProps.length - 1];
+}
+
+describe('AddressStep', () => {
+    beforeEach(() => {
+        mockInputWrapperProps.length = 0;
+    });
+
+    it('uses the current edit-mode country for ZIP validation and hint text', () => {
+        renderAddressStep();
+
+        expect(getLastInputProps(inputFieldsIDs.zipCode)?.hint).toBe(`e.g. ${COMMON_CONST.COUNTRY_ZIP_REGEX_DATA.US.samples}`);
+        expect(getLastInputProps(inputFieldsIDs.zipCode)?.inputMode).toBe(CONST.INPUT_MODE.NUMERIC);
+
+        act(() => {
+            getLastInputProps(inputFieldsIDs.country)?.onValueChange?.(CONST.COUNTRY.GB);
+        });
+
+        expect(getLastInputProps(inputFieldsIDs.zipCode)?.hint).toBe(`e.g. ${COMMON_CONST.COUNTRY_ZIP_REGEX_DATA.GB.samples}`);
+        expect(getLastInputProps(inputFieldsIDs.zipCode)?.inputMode).toBeUndefined();
+
+        const errors = mockValidateForm({
+            ...defaultValues,
+            [inputFieldsIDs.country]: CONST.COUNTRY.GB,
+            [inputFieldsIDs.zipCode]: 'SW1W 9SH',
+        });
+
+        expect(errors[inputFieldsIDs.zipCode]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This change makes the address form react immediately when a user changes the selected country, especially in edit-mode reimbursement account flows where draft values are not saved until confirmation.

Previously, the ZIP/postal-code field could still behave like a US ZIP field after switching to another country. That meant users could see the wrong example format, get US-style validation errors for valid international postcodes, or be restricted to numeric input when the selected country allows letters.

With this update, the currently selected country becomes the source of truth for ZIP/postal-code guidance and validation. The form now shows the right example format, allows alphanumeric postcodes for countries like the UK and Canada, and validates against country-specific postal-code rules when available. This reduces confusing false errors and makes the owner address step match what users expect after changing countries.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ #90491
PROPOSAL: [#90491 (comment)](https://github.com/Expensify/App/issues/90491#issuecomment-4441193986)


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
