### PR TITLE
Fix/92672 anon public room lhn

### DIFF
--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -24,6 +24,7 @@ import type Policy from '@src/types/onyx/Policy';
 import type PriorityMode from '@src/types/onyx/PriorityMode';
 import type Report from '@src/types/onyx/Report';
 import type ReportAction from '@src/types/onyx/ReportAction';
+import {isAnonymousUser} from './actions/Session';
 import {formatPhoneNumber as formatPhoneNumberPhoneUtils} from './LocalePhoneNumber';
 import {formatList} from './Localize';
 import {
@@ -185,6 +186,7 @@ import {
     isOneOnOneChat,
     isOneTransactionThread,
     isPolicyExpenseChat,
+    isPublicRoom,
     isSelfDM,
     isSystemChat as isSystemChatUtil,
     isTaskReport,
@@ -328,6 +330,10 @@ function shouldDisplayReportInLHN({
         !!draftComment ||
         hasErrorsOtherThanFailedReceipt ||
         isFocused ||
+        // An anonymous user can only access public rooms, and such a room's notification preference
+        // defaults to `hidden`. Without this, opening a thread inside the room (which steals focus)
+        // drops the room from the LHN, leaving the anon user unable to return to it. See #92672.
+        (isPublicRoom(report) && isAnonymousUser()) ||
         isSystemChat ||
         !!report.isPinned ||
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/src/pages/ReimbursementAccount/NonUSD/BeneficialOwnerInfo/BeneficialOwnerDetailsFormPages.tsx
+++ b/src/pages/ReimbursementAccount/NonUSD/BeneficialOwnerInfo/BeneficialOwnerDetailsFormPages.tsx
@@ -6,11 +6,12 @@ import useOnyx from '@hooks/useOnyx';
 import useSubPage from '@hooks/useSubPage';
 import type {SubPageProps} from '@hooks/useSubPage/types';
 import Navigation from '@libs/Navigation/Navigation';
+import getCurrencyForNonUSDBankAccount from '@pages/ReimbursementAccount/NonUSD/utils/getCurrencyForNonUSDBankAccount';
+import getNeededDocumentsStatusForBeneficialOwner from '@pages/ReimbursementAccount/NonUSD/utils/getNeededDocumentsStatusForBeneficialOwner';
 import {clearErrors, setDraftValues} from '@userActions/FormActions';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import INPUT_IDS from '@src/types/form/ReimbursementAccountForm';
 import SafeString from '@src/utils/SafeString';
 import Address from './BeneficialOwnerDetailsFormSubSteps/Address';
 import Confirmation from './BeneficialOwnerDetailsFormSubSteps/Confirmation';
@@ -59,6 +60,8 @@ type BeneficialOwnerDetailsFormPagesProps = {
 function BeneficialOwnerDetailsFormPages({stepNames, policyID, onFinished, backTo}: BeneficialOwnerDetailsFormPagesProps) {
     const {translate} = useLocalize();
     const [reimbursementAccountDraft] = useOnyx(ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM_DRAFT);
+    const [reimbursementAccount] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT);
+    const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
 
     const ownerBeingModifiedID = reimbursementAccountDraft?.ownerBeingModifiedID ?? CONST.NON_USD_BANK_ACCOUNT.CURRENT_USER_KEY;
     const isUserEnteringHisOwnData = ownerBeingModifiedID === CONST.NON_USD_BANK_ACCOUNT.CURRENT_USER_KEY;
@@ -67,9 +70,9 @@ function BeneficialOwnerDetailsFormPages({stepNames, policyID, onFinished, backT
 
     const beneficialOwnerNationalityInputID = `${PREFIX}_${ownerBeingModifiedID}_${NATIONALITY}` as const;
     const beneficialOwnerNationality = SafeString(reimbursementAccountDraft?.[beneficialOwnerNationalityInputID]);
+    const {country: countryStepCountryValue, currency} = getCurrencyForNonUSDBankAccount(policy, reimbursementAccountDraft, reimbursementAccount);
     const beneficialOwnerAddressCountryInputID = `${PREFIX}_${ownerBeingModifiedID}_${COUNTRY}` as const;
     const beneficialOwnerAddressCountry = SafeString(reimbursementAccountDraft?.[beneficialOwnerAddressCountryInputID]);
-    const countryStepCountryValue = reimbursementAccountDraft?.[INPUT_IDS.ADDITIONAL_DATA.COUNTRY] ?? '';
 
     const totalOwnedPercentage = Object.fromEntries(
         ownerKeys.map((key) => {
@@ -83,11 +86,12 @@ function BeneficialOwnerDetailsFormPages({stepNames, policyID, onFinished, backT
         if (beneficialOwnerNationality !== CONST.COUNTRY.US) {
             pagesToSkip.push(SUB_PAGE_NAMES.LAST_4_SSN);
         }
-        if (countryStepCountryValue === CONST.COUNTRY.GB && beneficialOwnerAddressCountry === CONST.COUNTRY.GB) {
+        const documentsStatus = getNeededDocumentsStatusForBeneficialOwner(currency, countryStepCountryValue, beneficialOwnerAddressCountry);
+        if (!documentsStatus.isProofOfOwnershipNeeded && !documentsStatus.isCopyOfIDNeeded && !documentsStatus.isProofOfAddressNeeded && !documentsStatus.isCodiceFiscaleNeeded) {
             pagesToSkip.push(SUB_PAGE_NAMES.DOCUMENTS);
         }
         return pagesToSkip;
-    }, [beneficialOwnerNationality, beneficialOwnerAddressCountry, countryStepCountryValue]);
+    }, [beneficialOwnerNationality, beneficialOwnerAddressCountry, countryStepCountryValue, currency]);
 
     const buildRoute = useCallback(
         (pageName: string, action?: 'edit') => ROUTES.BANK_ACCOUNT_NON_USD_SETUP.getRoute({policyID, page: PAGE_NAME.BENEFICIAL_OWNER_INFO, subPage: pageName, action, backTo}),


### PR DESCRIPTION
### Explanation of Change

An anonymous session can only ever access public rooms, and such a room's notification preference defaults to `hidden`. In the LHN filter (`shouldDisplayReportInLHN` in `SidebarUtils`), a `hidden` report only survives when one of the `shouldOverrideHidden` conditions is true — and for an anonymous user the only one that ever applied was `isFocused`. So the public room stayed in the Inbox only while it was the focused report. The moment the anon user opened a thread inside the room, the thread became the focused report, the public room was no longer focused, `isHidden && !shouldOverrideHidden` became true, and the room was dropped from the Inbox — collapsing it to the "Woohoo! All caught up" empty state and leaving the anon user unable to return to the room.

This PR adds a new `shouldOverrideHidden` condition so a public room is never hidden from an anonymous user's LHN just because it isn't the focused report:

```ts
(isPublicRoom(report) && isAnonymousUser())
```

This pairs `isPublicRoom` with `isAnonymousUser()` exactly the way `ReportUtils` already gates anon-only public-room behaviour elsewhere (e.g. `canLeaveChat`). It is a display-only predicate — it does not mutate any report/Onyx data or notification preference — so there are no side effects on unread/GBR or leave-room logic. After sign-in `isAnonymousUser()` becomes `false`, the override no longer applies, and the existing flow (#91931) re-fetches the room with a real notification preference, so there is no regression and no double-handling.

### Fixed Issues

$ https://github.com/Expensify/App/issues/92672
PROPOSAL: https://github.com/Expensify/App/issues/92672#issuecomment-4622321842

### Tests

1. Log out of the app so you are an **anonymous** user.
2. Open a public room as the anonymous user (e.g. open the public room deep link / URL `…/r/<publicRoomID>`).
3. Verify the public room appears in the Inbox/LHN.
4. Inside the public room, open a thread (tap a message that has replies, e.g. "1 Reply").
5. Verify the public room **remains** in the Inbox/LHN and the Inbox does **not** collapse to the "Woohoo! All caught up" empty state.
6. Tap the public room in the LHN and verify you can navigate back to it.
7. Sign in and verify the Inbox/LHN still behaves normally (no duplicate or stuck public room).

- [x] Verify that no errors appear in the JS console

### Offline tests

This change is a purely client-side display predicate, so it behaves identically offline.

1. As an anonymous user, open a public room and confirm it shows in the Inbox/LHN.
2. Turn off your network connection.
3. Open a thread inside the public room.
4. Verify the public room is still present in the Inbox/LHN while offline.

### QA Steps

1. On staging, log out so you are an **anonymous** user.
2. Open this public room link as the anonymous user: https://staging.new.expensify.com/r/1540486774487195
3. Verify the public room appears in the Inbox.
4. Open a thread inside the public room (tap a message with replies).
5. Verify the public room **remains** in the Inbox and you do **not** see the "Woohoo! All caught up" empty state.
6. Verify you can still navigate back to the public room from the Inbox.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Before fix:


https://github.com/user-attachments/assets/f2eddab1-d620-4a55-8e2e-e1cf39df3cf8

After fix:

https://github.com/user-attachments/assets/46c8865b-a279-47c4-bb97-984483431fc8



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Before fix:

https://github.com/user-attachments/assets/ff9c7219-b877-4979-815f-86f3b8cd6663

After fix:


https://github.com/user-attachments/assets/bfa65a05-f1e5-4cb2-840c-5e3e9aa3d052



</details>
