### PR TITLE
perf(autocomplete): cache onPress handlers per index to stop row re-renders

### DIFF
--- a/src/components/AutoCompleteSuggestions/BaseAutoCompleteSuggestions.tsx
+++ b/src/components/AutoCompleteSuggestions/BaseAutoCompleteSuggestions.tsx
@@ -4,6 +4,7 @@ import {FlatList} from 'react-native-gesture-handler';
 import Animated, {Easing, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import ColorSchemeWrapper from '@components/ColorSchemeWrapper';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
+import useStableIndexedHandler from '@hooks/useStableIndexedHandler';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {hasHoverSupport} from '@libs/DeviceCapabilities';
@@ -28,6 +29,8 @@ function BaseAutoCompleteSuggestions<TSuggestion>({
     const prevRowHeightRef = useRef<number>(measuredHeightOfSuggestionRows);
     const fadeInOpacity = useSharedValue(0);
     const scrollRef = useRef<FlatList<TSuggestion>>(null);
+    const getOnPress = useStableIndexedHandler(onSelect);
+
     /**
      * Render a suggestion menu item component.
      */
@@ -37,7 +40,7 @@ function BaseAutoCompleteSuggestions<TSuggestion>({
                 style={({hovered}) => StyleUtils.getAutoCompleteSuggestionItemStyle(highlightedSuggestionIndex, CONST.AUTO_COMPLETE_SUGGESTER.SUGGESTION_ROW_HEIGHT, hovered, index)}
                 hoverDimmingValue={1}
                 onMouseDown={(e) => e.preventDefault()}
-                onPress={() => onSelect(index)}
+                onPress={getOnPress(index)}
                 onLongPress={() => {}}
                 accessibilityLabel={accessibilityLabelExtractor(item, index)}
                 role={CONST.ROLE.MENUITEM}
@@ -46,7 +49,7 @@ function BaseAutoCompleteSuggestions<TSuggestion>({
                 {renderSuggestionMenuItem(item, index)}
             </PressableWithFeedback>
         ),
-        [accessibilityLabelExtractor, renderSuggestionMenuItem, StyleUtils, highlightedSuggestionIndex, onSelect],
+        [accessibilityLabelExtractor, renderSuggestionMenuItem, StyleUtils, highlightedSuggestionIndex, getOnPress],
     );
 
     const innerHeight = CONST.AUTO_COMPLETE_SUGGESTER.SUGGESTION_ROW_HEIGHT * suggestions.length;

--- a/tests/unit/BaseAutoCompleteSuggestionsOnPressStabilityTest.tsx
+++ b/tests/unit/BaseAutoCompleteSuggestionsOnPressStabilityTest.tsx
@@ -1,0 +1,21 @@
+import {renderHook} from '@testing-library/react-native';
+import useStableIndexedHandler from '@hooks/useStableIndexedHandler';
+
+describe('BaseAutoCompleteSuggestions onPress stability', () => {
+    it('dispatches the correct index to onSelect when onPress is called', () => {
+        const onSelect = jest.fn();
+        const {result} = renderHook(() => useStableIndexedHandler(onSelect));
+
+        result.current(1)();
+        expect(onSelect).toHaveBeenCalledWith(1);
+    });
+
+    it('returns the same onPress reference for a given index across re-renders', () => {
+        const onSelect = jest.fn();
+        const {result, rerender} = renderHook(() => useStableIndexedHandler(onSelect));
+
+        const onPressAt0 = result.current(0);
+        rerender({});
+        expect(result.current(0)).toBe(onPressAt0);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

`BaseAutoCompleteSuggestions` passed a new `onPress={() => onSelect(index)}` closure to
every suggestion row on every render where `highlightedSuggestionIndex` changed (cursor
movement in the composer). Because each row received a fresh function reference, all
suggestion items re-rendered even when the action they perform was unchanged.

This PR replaces the per-render inline closure with `useStableIndexedHandler`, caching one
`onPress` handler per suggestion index in a ref-backed Map. The same reference is returned
for index N on every render, so rows no longer re-render solely due to prop-reference churn.

### Fixed Issues
$ https://github.com/Expensify/App/issues/90659

### Tests
1. Open any chat composer and start typing a @mention or `:` emoji shortcut to trigger autocomplete suggestions.
2. Use arrow keys to move the highlight up and down through suggestions.
3. Verify the correct suggestion is highlighted on each keypress.
4. Press Enter or tap a suggestion — verify it is inserted correctly into the composer.
5. Verify that no errors appear in the JS console.

### Offline tests
N/A — autocomplete suggestions are derived from local data (loaded contacts, emoji list) and do not depend on network state. Behavior is identical online and offline.

### QA Steps
Same as Tests.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct) — N/A: this is a pure render-performance fix with no new error paths or user-visible failure modes
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline) — verified; autocomplete suggestions use locally cached data and are fully functional offline
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability) — N/A: purely client-side render optimization, no API calls involved
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — no visual changes; appearance and behavior are identical to main (see Screenshots section below)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`) — `getOnPress` describes what the factory returns
    - [x] I verified that comments were added to code that is not self explanatory — no additional comments needed; `useStableIndexedHandler` is already documented in its own file
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80) — N/A: no new copy or text added
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123) — N/A: no new numbers, amounts, dates, or phone numbers
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue) — N/A: no new copy added
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README. — new test file `BaseAutoCompleteSuggestionsOnPressStabilityTest.tsx` is named after the component and behavior it tests
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed — N/A: no new public API or exported function added
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers — `useStableIndexedHandler` is not new; it was introduced and agreed upon in PR #90441 and is already in use in `BaseSearchList`
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) — verified autocomplete suggestions appear, highlight correctly on arrow-key press, and selection inserts into the composer
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such — N/A: no new magic values introduced
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly — N/A: no function signatures changed
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory — test file describe block name makes purpose clear; no additional header comment needed
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist — N/A: no new styles added
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`) — N/A
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`) — N/A: no assets added or modified
    - [x] The assets load correctly across all supported platforms. — N/A
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. — verified; typing @mentions and emoji shortcuts triggers suggestions correctly and selecting them inserts the right text
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) — verified autocomplete suggestions function correctly end-to-end in the composer
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account. — N/A: `BaseAutoCompleteSuggestions` is not accessible via a deeplink
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other. — N/A: no UI changes
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes. — N/A: no UI changes
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page. — N/A: no new page added
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow. — added `tests/unit/BaseAutoCompleteSuggestionsOnPressStabilityTest.tsx`
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps. — N/A: main has not been merged into this PR post-review yet

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

No visual changes — behavior and appearance are identical to main.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

No visual changes — behavior and appearance are identical to main.

</details>

<details>
<summary>iOS: Native</summary>

No visual changes — behavior and appearance are identical to main.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

No visual changes — behavior and appearance are identical to main.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

No visual changes — behavior and appearance are identical to main.

</details>