### PR TITLE
[No QA] Fix ESLint failures in OnboardingPersonalTrackGoal test

### DIFF
--- a/tests/ui/OnboardingPersonalTrackGoal.tsx
+++ b/tests/ui/OnboardingPersonalTrackGoal.tsx
@@ -3,6 +3,7 @@ import {NavigationContainer} from '@react-navigation/native';
 import {act, render, screen, userEvent, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
+import type {ValueOf} from 'type-fest';
 import ComposeProviders from '@components/ComposeProviders';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
@@ -16,7 +17,6 @@ import OnboardingPersonalTrackGoal from '@pages/OnboardingPersonalTrackGoal';
 import {completeOnboarding} from '@userActions/Report';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
-import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
@@ -50,7 +50,7 @@ jest.mock('@userActions/Policy/Policy', () => {
 
 TestHelper.setupGlobalFetchMock();
 
-const translateGoal = (goal: string) => TestHelper.translateLocal(`onboarding.personalTrackGoal.${goal}` as TranslationPaths);
+const translateGoal = (goal: ValueOf<typeof CONST.ONBOARDING_PERSONAL_TRACK_GOALS>) => TestHelper.translateLocal(`onboarding.personalTrackGoal.${goal}`);
 
 const Stack = createPlatformStackNavigator<OnboardingModalNavigatorParamList>();
 
@@ -89,7 +89,16 @@ describe('OnboardingPersonalTrackGoal Page', () => {
         jest.spyOn(useResponsiveLayoutModule, 'default').mockReturnValue({
             isSmallScreenWidth: false,
             shouldUseNarrowLayout: false,
-        } as ResponsiveLayoutResult);
+            isInNarrowPaneModal: false,
+            isExtraSmallScreenHeight: false,
+            isMediumScreenWidth: false,
+            isLargeScreenWidth: false,
+            isExtraLargeScreenWidth: false,
+            isExtraSmallScreenWidth: false,
+            isSmallScreen: false,
+            onboardingIsMediumOrLargerScreenWidth: false,
+            isInLandscapeMode: false,
+        } satisfies ResponsiveLayoutResult);
     });
 
     afterEach(async () => {


### PR DESCRIPTION
### Explanation of Change
Fixes the ESLint check failure on main caused by unsafe type assertions in the newly merged `OnboardingPersonalTrackGoal` UI test.

- Typed `translateGoal` with `ValueOf<typeof CONST.ONBOARDING_PERSONAL_TRACK_GOALS>` so the translation path is inferred without casting.
- Replaced the partial `ResponsiveLayoutResult` cast with a complete mock object using `satisfies ResponsiveLayoutResult`.

### Fixed Issues
$

### Tests
1. Ran `npx eslint tests/ui/OnboardingPersonalTrackGoal.tsx` — passes with no errors.
2. Ran `npm test -- tests/ui/OnboardingPersonalTrackGoal.tsx` — both tests pass.

### Offline tests
N/A — test-only change.

### QA Steps
N/A — test-only change.


Made with [Cursor](https://cursor.com)