### PR TITLE
Revert "fix: pass workspace policyID when exporting with account-level custom templates"

### DIFF
--- a/src/hooks/useExportActions.ts
+++ b/src/hooks/useExportActions.ts
@@ -133,7 +133,7 @@ function useExportActions({reportID, policy, onPDFModalOpen}: UseExportActionsPa
             jsonQuery: '{}',
             reportIDList: [moneyRequestReport.reportID],
             transactionIDList,
-            policyID: policyID ?? moneyRequestReport.policyID,
+            policyID,
         });
     };
 

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -551,14 +551,6 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
             }
             const serializedQuery = queryJSON ? serializeQueryJSONForBackend(queryJSON) : JSON.stringify(queryJSON);
 
-            // Only fall back to the selection's policyID when every selected transaction belongs to the same real workspace.
-            // selectedPolicyIDs filters out falsy policyIDs, so a mix of one workspace expense and policy-less (personal/unreported)
-            // expenses would otherwise collapse to a single ID and incorrectly resolve GL codes against that workspace.
-            const allSelectedHavePolicy = Object.values(selectedTransactions).every((transaction) => !!transaction.policyID);
-            const selectedPolicyID = allSelectedHavePolicy && selectedPolicyIDs.length === 1 ? selectedPolicyIDs.at(0) : undefined;
-            const queryPolicyID = queryJSON?.policyID?.length === 1 ? queryJSON.policyID.at(0) : undefined;
-            const exportPolicyID = policyID ?? (areAllMatchingItemsSelected ? queryPolicyID : selectedPolicyID);
-
             if (areAllMatchingItemsSelected) {
                 queueExportSearchWithTemplate({
                     templateName,
@@ -566,7 +558,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                     jsonQuery: serializedQuery,
                     reportIDList: [],
                     transactionIDList: [],
-                    policyID: exportPolicyID,
+                    policyID,
                 });
             } else {
                 const isGroupExport = !!queryJSON?.groupBy && selectedTransactionsKeys.some((key) => key.startsWith(CONST.SEARCH.GROUP_PREFIX));
@@ -576,7 +568,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                     jsonQuery: isGroupExport ? serializeQueryJSONForBackend(addSelectedGroupsFilter(queryJSON, selectedTransactions, currentSearchResults?.data)) : '{}',
                     reportIDList: isGroupExport ? [] : selectedTransactionReportIDs,
                     transactionIDList: isGroupExport ? [] : selectedTransactionsKeys,
-                    policyID: exportPolicyID,
+                    policyID,
                 });
             }
 
@@ -603,7 +595,6 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
             queryJSON,
             selectedTransactionReportIDs,
             selectedTransactionsKeys,
-            selectedPolicyIDs,
         ],
     );
 


### PR DESCRIPTION
Reverts Expensify/App#92131


That PR caused a deploy blocker: https://github.com/Expensify/App/issues/93088

So we're doing a straight revert