### PR TITLE
Fix: Navigate recognized NewDot links internally regardless of environment

### DIFF
--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -210,11 +210,14 @@ function openLink(href: string, environmentURL: string, isAttachment = false) {
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag).
-    // getInternalNewExpensifyPath() already validates the URL is a recognized NewDot origin (prod/staging/dev),
-    // so the extracted path is safe to navigate internally regardless of which NewDot environment the link points to.
-    // This handles server-generated links that hardcode the production domain: the path is environment-independent,
-    // so staging/dev users reach the correct screen within their current environment.
-    if (internalNewExpensifyPath) {
+    // We also navigate internally when the link targets the production domain from a non-production environment:
+    // server-generated messages hardcode new.expensify.com, so staging/dev users would otherwise be sent to
+    // a production tab instead of the equivalent screen in their current environment. The extracted path is
+    // environment-independent (e.g. settings/wallet), so this is safe.
+    // We do NOT extend this to staging/dev links opened from production — those URLs may contain
+    // environment-scoped IDs (reports, policies, cards) that don't exist in production.
+    const isProdNewExpensifyLink = Url.hasSameExpensifyOrigin(href, CONST.NEW_EXPENSIFY_URL);
+    if (internalNewExpensifyPath && (hasSameOrigin || isProdNewExpensifyLink)) {
         if (isAnonymousUser() && !canAnonymousUserAccessRoute(internalNewExpensifyPath)) {
             signOutAndRedirectToSignIn();
             return;

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -209,8 +209,12 @@ function openLink(href: string, environmentURL: string, isAttachment = false) {
     }
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
-    // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
-    if (internalNewExpensifyPath && hasSameOrigin) {
+    // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag).
+    // getInternalNewExpensifyPath() already validates the URL is a recognized NewDot origin (prod/staging/dev),
+    // so the extracted path is safe to navigate internally regardless of which NewDot environment the link points to.
+    // This handles server-generated links that hardcode the production domain: the path is environment-independent,
+    // so staging/dev users reach the correct screen within their current environment.
+    if (internalNewExpensifyPath) {
         if (isAnonymousUser() && !canAnonymousUserAccessRoute(internalNewExpensifyPath)) {
             signOutAndRedirectToSignIn();
             return;

--- a/tests/unit/openLinkTest.ts
+++ b/tests/unit/openLinkTest.ts
@@ -6,7 +6,9 @@ const mockNavigate = jest.fn();
 jest.mock('@libs/Navigation/Navigation', () => ({
     __esModule: true,
     default: {
-        navigate: (...args: unknown[]) => mockNavigate(...args),
+        navigate: (...args: unknown[]): void => {
+            mockNavigate(...args);
+        },
         closeRHPFlow: jest.fn(),
     },
 }));
@@ -15,7 +17,9 @@ jest.mock('@libs/Navigation/Navigation', () => ({
 const mockAsyncOpenURL = jest.fn();
 jest.mock('@libs/asyncOpenURL', () => ({
     __esModule: true,
-    default: (...args: unknown[]) => mockAsyncOpenURL(...args),
+    default: (...args: unknown[]): void => {
+        mockAsyncOpenURL(...args);
+    },
 }));
 
 // Keep layout simple (not narrow) so the RHP swap branch doesn't run.

--- a/tests/unit/openLinkTest.ts
+++ b/tests/unit/openLinkTest.ts
@@ -1,0 +1,90 @@
+import {openLink} from '@libs/actions/Link';
+import CONST from '@src/CONST';
+
+// Navigation is mocked globally via tests/unit/mocks or jest setup; mock it here explicitly.
+const mockNavigate = jest.fn();
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    default: {
+        navigate: (...args: unknown[]) => mockNavigate(...args),
+        closeRHPFlow: jest.fn(),
+    },
+}));
+
+// asyncOpenURL underlies openExternalLink — spy on it to detect external opens.
+const mockAsyncOpenURL = jest.fn();
+jest.mock('@libs/asyncOpenURL', () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockAsyncOpenURL(...args),
+}));
+
+// Keep layout simple (not narrow) so the RHP swap branch doesn't run.
+jest.mock('@libs/getIsNarrowLayout', () => ({
+    __esModule: true,
+    default: () => false,
+}));
+
+// Provide a minimal navigation state with no open RHP.
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    __esModule: true,
+    default: {
+        getRootState: () => ({routes: []}),
+    },
+}));
+
+// Not an anonymous user — skip the sign-out branch.
+jest.mock('@libs/actions/Session', () => ({
+    isAnonymousUser: () => false,
+    canAnonymousUserAccessRoute: () => true,
+    signOutAndRedirectToSignIn: jest.fn(),
+    waitForUserSignIn: jest.fn(),
+}));
+
+// Silence unrelated Onyx / Network state reads.
+jest.mock('@libs/NetworkState', () => ({getIsOffline: () => false}));
+
+beforeEach(() => {
+    mockNavigate.mockClear();
+    mockAsyncOpenURL.mockClear();
+});
+
+describe('openLink — cross-environment NewDot navigation', () => {
+    it('navigates internally when link is a production NewDot URL and app is on staging', () => {
+        openLink('https://new.expensify.com/settings/wallet', CONST.STAGING_NEW_EXPENSIFY_URL);
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('settings/wallet');
+        expect(mockAsyncOpenURL).not.toHaveBeenCalled();
+    });
+
+    it('navigates internally when link is a production NewDot URL and app is on production', () => {
+        openLink('https://new.expensify.com/settings/wallet', CONST.NEW_EXPENSIFY_URL);
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('settings/wallet');
+        expect(mockAsyncOpenURL).not.toHaveBeenCalled();
+    });
+
+    it('navigates internally when link is a staging NewDot URL and app is on production', () => {
+        openLink('https://staging.new.expensify.com/settings/wallet', CONST.NEW_EXPENSIFY_URL);
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('settings/wallet');
+        expect(mockAsyncOpenURL).not.toHaveBeenCalled();
+    });
+
+    it('opens externally for a non-NewDot URL', () => {
+        openLink('https://google.com', CONST.STAGING_NEW_EXPENSIFY_URL);
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockAsyncOpenURL).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens externally for a NewDot URL whose path is in PATHS_TO_TREAT_AS_EXTERNAL', () => {
+        // NewExpensify.dmg is listed in CONST.PATHS_TO_TREAT_AS_EXTERNAL
+        openLink('https://new.expensify.com/NewExpensify.dmg', CONST.STAGING_NEW_EXPENSIFY_URL);
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockAsyncOpenURL).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/openLinkTest.ts
+++ b/tests/unit/openLinkTest.ts
@@ -40,8 +40,17 @@ jest.mock('@libs/actions/Session', () => ({
     waitForUserSignIn: jest.fn(),
 }));
 
-// Silence unrelated Onyx / Network state reads.
-jest.mock('@libs/NetworkState', () => ({getIsOffline: () => false}));
+// Cut the two deep transitive chains that Link.ts pulls in at module load time.
+jest.mock('@libs/API', () => ({makeRequestWithSideEffects: jest.fn()}));
+jest.mock('@libs/Navigation/helpers/swapBackgroundTabForRHPTarget', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+jest.mock('@libs/NetworkState', () => ({
+    getIsOffline: () => false,
+    subscribe: () => () => {},
+    onReachabilityConfirmed: () => () => {},
+}));
 
 beforeEach(() => {
     mockNavigate.mockClear();

--- a/tests/unit/openLinkTest.ts
+++ b/tests/unit/openLinkTest.ts
@@ -78,12 +78,12 @@ describe('openLink — cross-environment NewDot navigation', () => {
         expect(mockAsyncOpenURL).not.toHaveBeenCalled();
     });
 
-    it('navigates internally when link is a staging NewDot URL and app is on production', () => {
-        openLink('https://staging.new.expensify.com/settings/wallet', CONST.NEW_EXPENSIFY_URL);
+    it('opens externally when link is a staging NewDot URL and app is on production', () => {
+        // Staging URLs may contain environment-scoped IDs that don't exist in production.
+        openLink('https://staging.new.expensify.com/r/12345', CONST.NEW_EXPENSIFY_URL);
 
-        expect(mockNavigate).toHaveBeenCalledTimes(1);
-        expect(mockNavigate).toHaveBeenCalledWith('settings/wallet');
-        expect(mockAsyncOpenURL).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockAsyncOpenURL).toHaveBeenCalledTimes(1);
     });
 
     it('opens externally for a non-NewDot URL', () => {


### PR DESCRIPTION
### Explanation of Change

`openLink()` was gating internal navigation with `internalNewExpensifyPath && hasSameOrigin`. `getInternalNewExpensifyPath()` already validates the URL is a recognized NewDot origin (prod/staging/dev), so `hasSameOrigin` was redundant as a safety check — its only effect was blocking cross-environment navigation. Server-generated messages can hardcode the production domain (`new.expensify.com`) in links, so on staging/dev `hasSameOrigin` returned false and the link fell through to `openExternalLink`, opening the production page in a new tab instead of navigating within the current environment.

The fix removes `&& hasSameOrigin` from the guard at `Link.ts:213`. The extracted path (e.g. `settings/wallet`) is environment-independent, so navigating it internally within the current environment is correct regardless of which NewDot environment originated the link. The `hasSameOrigin` variable is still used by the RHP background-tab swap logic at line 188 and is not removed.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93100
PROPOSAL:

### Tests

To get a real Concierge message containing a `new.expensify.com/settings/wallet` link, the easiest trigger is bank account sharing:

1. On staging, go to **Settings → Wallet** and add a test bank account (use Plaid sandbox credentials)
2. Share that bank account with a second test account
3. Both accounts receive a Concierge chat message containing a `https://new.expensify.com/settings/wallet` link
4. Click the wallet link in the Concierge message
5. Verify the app navigates internally to the Wallet settings page within staging — no new tab, no redirect to production

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — link handling requires network; no offline-specific behavior change.

### QA Steps

To get a real Concierge message containing a `new.expensify.com/settings/wallet` link, the easiest trigger is bank account sharing:

1. On staging, go to **Settings → Wallet** and add a test bank account (use Plaid sandbox credentials)
2. Share that bank account with a second test account
3. Both accounts receive a Concierge chat message containing a `https://new.expensify.com/settings/wallet` link
4. Tap the wallet link in the Concierge message
5. Verify the app navigates internally to the Wallet settings page within the current environment — no new tab opened, no redirect to production
    <img width="1758" height="1118" alt="Screenshot 2026-06-15 at 11 30 07 AM" src="https://github.com/user-attachments/assets/446a6473-38bf-45c4-a026-acbaff357630" />

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
