### PR TITLE
[CP Staging] Fix two staging deploy blockers from report-layout None feature

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -39,7 +39,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import {turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import {setOptimisticTransactionThread} from '@libs/actions/Report';
-import {getReportLayoutGroupBy, getReportLayoutSelection, isMatrixLayout, setReportLayout} from '@libs/actions/ReportLayout';
+import {getReportLayoutGroupBy, getReportLayoutSelection, setReportLayout} from '@libs/actions/ReportLayout';
 import {clearActiveTransactionIDs, setActiveTransactionIDs} from '@libs/actions/TransactionThreadNavigation';
 import {resolveTransactionCardFields} from '@libs/CardUtils';
 import {hasNonReimbursableTransactions, isBillableEnabledOnPolicy} from '@libs/MoneyRequestReportUtils';
@@ -447,9 +447,15 @@ function MoneyRequestReportTransactionList({
         horizontalScrollViewRef.current?.scrollTo({x: horizontalScrollOffsetRef.current, animated: false});
     }, [sortedTransactions, shouldScrollHorizontally]);
 
-    const currentGroupBy = getReportLayoutGroupBy(reportLayoutGroupBy);
-    const shouldGroupTransactions = shouldShowGroupedTransactions && !isMatrixLayout(reportLayoutOption);
-    const currentSelection = getReportLayoutSelection(reportLayoutOption, reportLayoutGroupBy);
+    // Latch the user's most recent selection so the popover label and grouping mode never flick through the
+    // (layoutOption=null, groupByOption=null) → CATEGORY default while the two NVPs settle in separate render passes.
+    const [pendingLayoutSelection, setPendingLayoutSelection] = useState<OnyxTypes.ReportLayoutSelection | null>(null);
+    const onyxLayoutSelection = getReportLayoutSelection(reportLayoutOption, reportLayoutGroupBy);
+    const currentSelection: OnyxTypes.ReportLayoutSelection = pendingLayoutSelection && pendingLayoutSelection !== onyxLayoutSelection ? pendingLayoutSelection : onyxLayoutSelection;
+
+    const isLayoutMatrixSelected = currentSelection === CONST.REPORT_LAYOUT.LAYOUT_OPTION.MATRIX;
+    const currentGroupBy: OnyxTypes.ReportLayoutGroupBy = currentSelection !== CONST.REPORT_LAYOUT.LAYOUT_OPTION.MATRIX ? currentSelection : getReportLayoutGroupBy(reportLayoutGroupBy);
+    const shouldGroupTransactions = shouldShowGroupedTransactions && !isLayoutMatrixSelected;
 
     const groupedTransactions = useMemo(() => {
         if (!shouldGroupTransactions) {
@@ -682,6 +688,7 @@ function MoneyRequestReportTransactionList({
                             if (!item.keyForList) {
                                 return;
                             }
+                            setPendingLayoutSelection(item.keyForList);
                             setReportLayout(item.keyForList, reportLayoutOption, reportLayoutGroupBy);
                             props.closeOverlay();
                         }}
@@ -877,7 +884,7 @@ function MoneyRequestReportTransactionList({
                 {shouldShowGroupedTransactions && (
                     <DropdownButton
                         label={translate('search.display.groupBy')}
-                        value={isMatrixLayout(reportLayoutOption) ? '' : (selectedGroupByItem?.text ?? '')}
+                        value={isLayoutMatrixSelected ? '' : (selectedGroupByItem?.text ?? '')}
                         PopoverComponent={groupByPopoverComponent}
                     />
                 )}

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -449,9 +449,18 @@ function MoneyRequestReportTransactionList({
 
     // Latch the user's most recent selection so the popover label and grouping mode never flick through the
     // (layoutOption=null, groupByOption=null) → CATEGORY default while the two NVPs settle in separate render passes.
+    // Drop the latch once Onyx reaches the clicked value, so later authoritative updates (failureData rollback,
+    // another client changing the layout) flow through instead of staying masked by stale local state.
     const [pendingLayoutSelection, setPendingLayoutSelection] = useState<OnyxTypes.ReportLayoutSelection | null>(null);
     const onyxLayoutSelection = getReportLayoutSelection(reportLayoutOption, reportLayoutGroupBy);
-    const currentSelection: OnyxTypes.ReportLayoutSelection = pendingLayoutSelection && pendingLayoutSelection !== onyxLayoutSelection ? pendingLayoutSelection : onyxLayoutSelection;
+    const currentSelection: OnyxTypes.ReportLayoutSelection = pendingLayoutSelection ?? onyxLayoutSelection;
+    useEffect(() => {
+        if (pendingLayoutSelection === null || pendingLayoutSelection !== onyxLayoutSelection) {
+            return;
+        }
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs the click latch to Onyx so subsequent authoritative updates aren't masked by stale local state
+        setPendingLayoutSelection(null);
+    }, [pendingLayoutSelection, onyxLayoutSelection]);
 
     const isLayoutMatrixSelected = currentSelection === CONST.REPORT_LAYOUT.LAYOUT_OPTION.MATRIX;
     const currentGroupBy: OnyxTypes.ReportLayoutGroupBy = currentSelection !== CONST.REPORT_LAYOUT.LAYOUT_OPTION.MATRIX ? currentSelection : getReportLayoutGroupBy(reportLayoutGroupBy);

--- a/src/libs/API/parameters/SetNameValuePairsParams.ts
+++ b/src/libs/API/parameters/SetNameValuePairsParams.ts
@@ -1,6 +1,4 @@
-type SetNameValuePairsParams = {
-    /** JSON-encoded `{[name: string]: string}` of NVPs to set in one atomic operation. An empty value deletes the NVP. */
-    nameValuePairs: string;
-};
+/** Each NVP rides as its own `nameValuePairs[<name>]` form field so PHP's `$_REQUEST` parses it as an associative array (a single JSON-encoded string is read back as empty). An empty value deletes the NVP. */
+type SetNameValuePairsParams = Record<`nameValuePairs[${string}]`, string>;
 
 export default SetNameValuePairsParams;

--- a/src/libs/actions/ReportLayout.ts
+++ b/src/libs/actions/ReportLayout.ts
@@ -70,9 +70,10 @@ function setReportLayout(selection: ReportLayoutSelection, currentLayoutOption?:
         });
     }
 
-    const parameters: SetNameValuePairsParams = {
-        nameValuePairs: JSON.stringify(nameValuePairs),
-    };
+    const parameters: SetNameValuePairsParams = {};
+    for (const [nvpName, nvpValue] of Object.entries(nameValuePairs)) {
+        parameters[`nameValuePairs[${nvpName}]`] = nvpValue;
+    }
 
     API.write(WRITE_COMMANDS.SET_NAME_VALUE_PAIRS, parameters, {optimisticData, failureData});
 }

--- a/tests/actions/ReportLayoutTest.ts
+++ b/tests/actions/ReportLayoutTest.ts
@@ -1,6 +1,5 @@
 import {getReportLayoutGroupBy, getReportLayoutSelection, isMatrixLayout, setReportLayout} from '@libs/actions/ReportLayout';
 import * as API from '@libs/API';
-import type {SetNameValuePairsParams} from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import CONST from '@src/CONST';
 
@@ -10,32 +9,31 @@ const mockWrite = jest.mocked(API.write);
 
 const LAYOUT_OPTION_NVP_NAME = 'expensify_layoutOption';
 const GROUP_BY_OPTION_NVP_NAME = 'expensify_groupByOption';
+const NAME_VALUE_PAIRS_KEY_PREFIX = 'nameValuePairs[';
 
 function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
     return typeof value === 'object' && value !== null;
-}
-
-function isSetNameValuePairsParams(value: unknown): value is SetNameValuePairsParams {
-    return isRecord(value) && 'nameValuePairs' in value && typeof value.nameValuePairs === 'string';
 }
 
 function isStringRecord(value: unknown): value is Record<string, string> {
     return isRecord(value) && Object.values(value).every((entry) => typeof entry === 'string');
 }
 
-const getWrittenNameValuePairs = (callIndex = 0) => {
-    const call = mockWrite.mock.calls.at(callIndex);
-    const params = call?.[1];
-    if (!isSetNameValuePairsParams(params)) {
+const getWrittenNameValuePairs = (callIndex = 0): Record<string, string> => {
+    const params = mockWrite.mock.calls.at(callIndex)?.[1];
+    if (!isStringRecord(params)) {
         return {};
     }
 
-    const parsed: unknown = JSON.parse(params.nameValuePairs);
-    if (!isStringRecord(parsed)) {
-        return {};
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(params)) {
+        if (!key.startsWith(NAME_VALUE_PAIRS_KEY_PREFIX) || !key.endsWith(']')) {
+            continue;
+        }
+        const nvpName = key.slice(NAME_VALUE_PAIRS_KEY_PREFIX.length, -1);
+        result[nvpName] = value;
     }
-
-    return parsed;
+    return result;
 };
 
 describe('getReportLayoutGroupBy', () => {
@@ -103,6 +101,14 @@ describe('setReportLayout', () => {
         setReportLayout(CONST.REPORT_LAYOUT.GROUP_BY.TAG, null, null);
 
         expect(mockWrite).not.toHaveBeenCalledWith(WRITE_COMMANDS.SET_NAME_VALUE_PAIR, expect.any(Object), expect.any(Object));
+    });
+
+    it('sends each NVP as its own nameValuePairs[<name>] form field so PHP parses it as an associative array', () => {
+        setReportLayout(CONST.REPORT_LAYOUT.GROUP_BY.TAG, null, null);
+
+        expect(mockWrite.mock.calls.at(0)?.[1]).toEqual({
+            [`nameValuePairs[${GROUP_BY_OPTION_NVP_NAME}]`]: CONST.REPORT_LAYOUT.GROUP_BY.TAG,
+        });
     });
 });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Two deploy blockers from App#91952:

**93133:** `SetNameValuePairs` was sent as `nameValuePairs: JSON.stringify(...)`. Web-E's `Request::getArray` returns `[]` for a non-array param, so the server persisted nothing and `expensify_layoutOption` never made it to the DB, which is why None did not survive a cache reset. Each NVP now goes out as its own `nameValuePairs[<name>]` form field so PHP parses it as an associative array.

**93130:** the popover pill is derived from two `useOnyx` reads. When toggling None → Tag the optimistic write of `(layoutOption=null, groupByOption=tag)` lands in two separate render passes, and the in-between `(null, null)` state falls through to the CATEGORY default in `getReportLayoutSelection`. Latched the last-clicked selection in local state until Onyx settles to match.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93133
$ https://github.com/Expensify/App/issues/93130
PROPOSAL:

### Tests

1. Open a workspace chat with an expense report that has 2+ expenses.
2. Open the report and click the **Group-by** pill > **None**.
3. Verify the pill shows blank (None) and the rows render flat with no group headers.
4. Refresh the page. Verify the pill still shows None and the rows are still flat.
5. Account > Troubleshoot > **Clear cache and restart** > **Reset and refresh**. Open the same report. Verify the pill still shows None and the rows are still flat.
6. Click **Group-by** > **Tag**. Verify the pill transitions None → Tag with no Category flash in between.
7. Click **Group-by** > **None**, then immediately **Group-by** > **Tag**. Repeat None ↔ Tag a few times. Verify the pill never shows Category between selections.
8. Click **Group-by** > **Category**. Verify the pill shows Category and the rows group under category headers.
9. Click **Group-by** > **None** > **Tag** > **None** > **Tag** (the exact 93130 repro). Verify no Category flash on any step.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline (DevTools > Network > Offline).
2. Toggle the Group-by pill through None > Tag > Category > None. Verify each click updates the pill immediately and the rows re-render to match, with no Category flash between selections.
3. Go back online. Refresh the page. Verify the last-chosen selection persists.

### QA Steps

1. On staging.new.expensify.com, open a workspace chat with an expense report that has 2+ expenses.
2. Open the report and click the **Group-by** pill > **None**.
3. Refresh and verify the pill still shows None.
4. Account > Troubleshoot > **Clear cache and restart** > **Reset and refresh**. Open the same report and verify the pill still shows None.
5. Toggle Group-by through None > Tag > None > Tag a few times. Verify the pill never flashes Category between selections.
6. Toggle Group-by > Category > Tag > None. Verify each transition is clean.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
