### PR TITLE
Fix Chrome <110 crash: replace Array.toReversed() in MoneyRequestReportActionsList (#91964)

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -174,7 +174,8 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        // Use slice().reverse() instead of toReversed() — toReversed is ES2023 and crashes on Chrome <110 / Safari <16.4 (Sentry APP-DTS).
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;


### PR DESCRIPTION
## Problem
On Chrome 103 / older Chromium (common on managed Chrome OS devices), opening an expense report from `/search` crashes with `TypeError: filteredActions.toReversed is not a function`. The ErrorBoundary catches this and renders a full-page crash screen.

## Root Cause
`Array.prototype.toReversed()` is ES2023 and only available in Chrome 110+ / Safari 16.4+. On Chrome 103 the method is `undefined`, causing a render-phase crash in `MoneyRequestReportActionsList.tsx:177`.

## Fix
Replace `filteredActions.toReversed()` with `filteredActions.slice().reverse()`. This produces an identical non-mutating reversed copy using only ES5 methods available in all targeted browsers.

## Files Changed
- `src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx` — 1 line change

## Test Plan
- Chrome 103 (or `delete Array.prototype.toReversed` in console): open expense report from `/search` → renders normally, no ErrorBoundary
- Modern Chrome: no regression
- Report actions still render newest-first (ordering preserved)

$ #91964