### PR TITLE
[$250] Add expand button overlay to charts for full-screen mode

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/BaseVictoryChartRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/BaseVictoryChartRenderer.tsx
@@ -4,6 +4,7 @@ import useChartFonts from '@components/Charts/hooks/useChartFonts';
 import Log from '@libs/Log';
 import VictoryChartContainer from './components/VictoryChartContainer';
 import VictoryChartContent from './components/VictoryChartContent';
+import VictoryChartWithExpand from './components/VictoryChartWithExpand';
 import {VictoryChartProvider} from './context/VictoryChartContext';
 import processVictoryChartTree from './parsers/processVictoryChartTree';
 import type {VictoryChartRendererProps} from './types';
@@ -34,9 +35,11 @@ function BaseVictoryChartRenderer({tnode}: VictoryChartRendererProps) {
                 processedResult={processedResult}
                 type={type}
             >
-                <VictoryChartContainer>
-                    <VictoryChartContent />
-                </VictoryChartContainer>
+                <VictoryChartWithExpand>
+                    <VictoryChartContainer>
+                        <VictoryChartContent />
+                    </VictoryChartContainer>
+                </VictoryChartWithExpand>
             </VictoryChartProvider>
         </ChartFontsProvider>
     );

--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartWithExpand.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartWithExpand.tsx
@@ -1,0 +1,62 @@
+import React, {useCallback, useState} from 'react';
+import {View} from 'react-native';
+import Modal from '@components/Modal';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import CONST from '@src/CONST';
+import VictoryChartContainer from './VictoryChartContainer';
+import VictoryChartContent from './VictoryChartContent';
+import IconButton from '@components/VideoPlayer/IconButton';
+
+type VictoryChartWithExpandProps = {
+    children: React.ReactNode;
+};
+
+function VictoryChartWithExpand({children}: VictoryChartWithExpandProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const [isFullScreen, setIsFullScreen] = useState(false);
+    const icons = useMemoizedLazyExpensifyIcons(['Expand']);
+
+    const openFullScreen = useCallback(() => {
+        setIsFullScreen(true);
+    }, []);
+
+    const closeFullScreen = useCallback(() => {
+        setIsFullScreen(false);
+    }, []);
+
+    return (
+        <>
+            <View style={styles.w100}>
+                {children}
+                <View style={styles.pAbsolute}>
+                    <IconButton
+                        src={icons.Expand}
+                        style={styles.videoExpandButton}
+                        tooltipText={translate('common.expand')}
+                        onPress={openFullScreen}
+                        small
+                        sentryLabel="Chart Expand Button"
+                    />
+                </View>
+            </View>
+            <Modal
+                isVisible={isFullScreen}
+                type={CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE}
+                onClose={closeFullScreen}
+            >
+                <View style={[styles.flex1, styles.alignItemsCenter, styles.justifyContentCenter]}>
+                    <VictoryChartContainer>
+                        <VictoryChartContent />
+                    </VictoryChartContainer>
+                </View>
+            </Modal>
+        </>
+    );
+}
+
+VictoryChartWithExpand.displayName = 'VictoryChartWithExpand';
+
+export default VictoryChartWithExpand;

--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartWithExpand.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartWithExpand.tsx
@@ -29,18 +29,16 @@ function VictoryChartWithExpand({children}: VictoryChartWithExpandProps) {
 
     return (
         <>
-            <View style={styles.w100}>
+            <View style={styles.pRelative}>
                 {children}
-                <View style={styles.pAbsolute}>
-                    <IconButton
-                        src={icons.Expand}
-                        style={styles.videoExpandButton}
-                        tooltipText={translate('common.expand')}
-                        onPress={openFullScreen}
-                        small
-                        sentryLabel="Chart Expand Button"
-                    />
-                </View>
+                <IconButton
+                    src={icons.Expand}
+                    style={styles.videoExpandButton}
+                    tooltipText={translate('common.expand')}
+                    onPress={openFullScreen}
+                    small
+                    sentryLabel="Chart Expand Button"
+                />
             </View>
             <Modal
                 isVisible={isFullScreen}


### PR DESCRIPTION
$ #92969

## Criterios de aceptación cubiertos

1. **Expand button overlay**: Added VictoryChartWithExpand component that wraps the chart and renders an expand button (using the existing Expand icon from the design system) overlaid on top of inline charts.

2. **Position top-right corner**: The button is positioned absolutely at the top-right corner of the chart container using the existing videoExpandButton style (position: absolute, top: 12, right: 12), overlaying the chart.

3. **Full-screen modal**: Tapping the button opens a centered full-screen modal (CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE) that renders the chart at full viewport width.

4. **Pointer events**: The button captures pointer events, suppressing chart gesture layers in that corner (acceptable since charts dont render interactive elements there).

5. **Reuses centered modal pattern**: Uses the existing centered full-screen modal pattern (not the image attachment modal), as charts arent URL-based attachments.

## Implementation

- Created VictoryChartWithExpand.tsx in the VictoryChartRenderer components directory
- Wraps VictoryChartContainer + VictoryChartContent inside a relative-positioned View with the expand button
- The modal re-renders the chart inside a VictoryChartContainer + VictoryChartContent for full-screen viewing
- Uses existing videoExpandButton style and Expand icon from Expensify design system
