### PR TITLE
fix: Change default columns to remove total and add amount for expense report view

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -6733,7 +6733,7 @@ const CONST = {
                     this.TABLE_COLUMNS.TITLE,
                     this.TABLE_COLUMNS.FROM,
                     this.TABLE_COLUMNS.TO,
-                    this.TABLE_COLUMNS.TOTAL,
+                    this.TABLE_COLUMNS.TOTAL_AMOUNT,
                     this.TABLE_COLUMNS.ACTION,
                 ],
                 INVOICE: [],

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -5826,12 +5826,12 @@ function getColumnsToShow({
             if (hasExchangeRate) {
                 columns[CONST.SEARCH.TABLE_COLUMNS.EXCHANGE_RATE] = true;
             }
-            // Expense report view: TOTAL (workspace currency) is always shown; add AMOUNT
-            // (transaction's own currency) when a conversion exists so both are visible.
+            // Expense report view: AMOUNT (transaction's own currency) is shown by default; add TOTAL
+            // (workspace currency) when a conversion exists so both are visible.
             // Search page: show ORIGINAL_AMOUNT column (transaction's original amount).
             if (hasExchangeRate) {
                 if (isExpenseReportView) {
-                    columns[CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT] = true;
+                    columns[CONST.SEARCH.TABLE_COLUMNS.TOTAL] = true;
                 } else {
                     columns[CONST.SEARCH.TABLE_COLUMNS.ORIGINAL_AMOUNT] = true;
                 }


### PR DESCRIPTION
### Details
Changes the default columns shown in the expense report view to use the inline-editable **amount** column instead of the non-editable **total** column.

### Fixed Issues
$ #93014

### Tests
1. Open an expense report - the amount column should be visible by default
2. If the report has transactions in a different currency, both amount and total columns should be visible
3. Verify the total column is not shown by default unless there are multi-currency transactions

### QA Steps
1. Navigate to any expense report
2. Verify the amount column is shown (not the total column)
3. If the report contains expenses in a different currency from the workspace currency, verify both amount and total columns appear

## Criterios de aceptación cubiertos
1. ✅ **Amount column shown by default**: Changed `TYPE_DEFAULT_COLUMNS.EXPENSE_REPORT` in `CONST/index.ts` from `TABLE_COLUMNS.TOTAL` to `TABLE_COLUMNS.TOTAL_AMOUNT`
2. ✅ **Keep showing both when multi-currency**: Updated `getColumnsToShow` in `SearchUIUtils.ts` to add `TABLE_COLUMNS.TOTAL` (instead of `TOTAL_AMOUNT`) when an exchange rate exists, so both columns are visible when needed