### PR TITLE
[TESTING] Add web crash diagnostics to detect abnormal browser session exits

### DIFF
--- a/src/Expensify.tsx
+++ b/src/Expensify.tsx
@@ -31,6 +31,7 @@ import PushNotification from './libs/Notification/PushNotification';
 import {endSpan, getSpan, startSpan} from './libs/telemetry/activeSpans';
 import type {BootsplashGateStatus} from './libs/telemetry/bootsplashTelemetry';
 import {startBootsplashMonitor} from './libs/telemetry/bootsplashTelemetry';
+import {cleanupCrashDiagnostics, initializeCrashDiagnostics} from './libs/telemetry/crashDiagnostics';
 import {cleanupMemoryTrackingTelemetry, initializeMemoryTrackingTelemetry} from './libs/telemetry/TelemetrySynchronizer';
 import Visibility from './libs/Visibility';
 import ONYXKEYS from './ONYXKEYS';
@@ -65,8 +66,10 @@ function Expensify() {
 
     useEffect(() => {
         initializeMemoryTrackingTelemetry();
+        initializeCrashDiagnostics();
         return () => {
             cleanupMemoryTrackingTelemetry();
+            cleanupCrashDiagnostics();
         };
     }, []);
 

--- a/src/libs/telemetry/crashDiagnostics/index.native.ts
+++ b/src/libs/telemetry/crashDiagnostics/index.native.ts
@@ -1,0 +1,8 @@
+/**
+ * Browser crash diagnostics are web-only — native crashes are captured by the Sentry native SDK.
+ */
+function initializeCrashDiagnostics() {}
+
+function cleanupCrashDiagnostics() {}
+
+export {initializeCrashDiagnostics, cleanupCrashDiagnostics};

--- a/src/libs/telemetry/crashDiagnostics/index.ts
+++ b/src/libs/telemetry/crashDiagnostics/index.ts
@@ -1,0 +1,281 @@
+/**
+ * Browser crash diagnostics (web only).
+ *
+ * A tab crash ("Aw, Snap!", typically an out-of-memory kill) terminates JS instantly, so nothing can be
+ * reported at crash time. Instead, every session continuously persists a heartbeat plus a ring buffer of
+ * memory/DOM samples to localStorage. On the next app start (or from another live tab), sessions that
+ * stopped heartbeating without a clean exit are reported to Sentry together with their final samples,
+ * showing what the user was doing and what was growing right before the tab died.
+ *
+ * localStorage is used instead of Onyx on purpose: the clean-exit marker must be written synchronously
+ * during pagehide, and the records must survive Onyx.clear() on sign-out.
+ */
+import * as Sentry from '@sentry/react-native';
+import {Str} from 'expensify-common';
+import type {OnyxCollection} from 'react-native-onyx';
+import Onyx from 'react-native-onyx';
+import Navigation from '@libs/Navigation/Navigation';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report} from '@src/types/onyx';
+
+const STORAGE_KEY_PREFIX = 'crashDiagnostics_session_';
+const SAMPLE_INTERVAL_MS = 15 * 1000;
+
+// ~15 minutes of history at one sample per 15 seconds
+const MAX_SAMPLES = 60;
+
+// Background tabs throttle timers to roughly one run per minute, so a live but hidden tab can be silent
+// for a while. Only sessions silent for longer than this are considered dead.
+const STALE_HEARTBEAT_MS = 5 * 60 * 1000;
+
+const BYTES_PER_MB = 1024 * 1024;
+
+type HeapSample = {
+    /** Epoch ms */
+    t: number;
+    usedJSHeapSizeMB: number | null;
+    totalJSHeapSizeMB: number | null;
+    jsHeapSizeLimitMB: number | null;
+    domNodes: number;
+    route: string;
+    reportsCount: number | null;
+    visibility: DocumentVisibilityState;
+};
+
+type SessionRecord = {
+    id: string;
+    startedAt: number;
+    lastHeartbeat: number;
+    /** True while the page is in a state where missing heartbeats are expected (pagehide/freeze) */
+    cleanExit: boolean;
+    samples: HeapSample[];
+};
+
+type PerformanceWithMemory = Performance & {
+    memory?: {
+        usedJSHeapSize?: number;
+        totalJSHeapSize?: number;
+        jsHeapSizeLimit?: number;
+    };
+};
+
+let sessionRecord: SessionRecord | undefined;
+let sampleIntervalID: ReturnType<typeof setInterval> | undefined;
+let reportsCount: number | null = null;
+let reportsConnection: ReturnType<typeof Onyx.connectWithoutView> | undefined;
+
+function markCleanExit() {
+    markExitState(true);
+}
+
+function markActive() {
+    markExitState(false);
+}
+
+function isStorageAvailable(): boolean {
+    try {
+        return typeof window !== 'undefined' && !!window.localStorage;
+    } catch {
+        // Accessing localStorage can throw (e.g. blocked by browser settings)
+        return false;
+    }
+}
+
+function isSessionRecord(value: unknown): value is SessionRecord {
+    return typeof value === 'object' && value !== null && 'id' in value && 'lastHeartbeat' in value && 'cleanExit' in value && 'samples' in value && Array.isArray(value.samples);
+}
+
+function readSessionRecord(storageKey: string): SessionRecord | undefined {
+    try {
+        const raw = window.localStorage.getItem(storageKey);
+        if (!raw) {
+            return undefined;
+        }
+        const parsed: unknown = JSON.parse(raw);
+        return isSessionRecord(parsed) ? parsed : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function persistSessionRecord() {
+    if (!sessionRecord) {
+        return;
+    }
+    try {
+        window.localStorage.setItem(`${STORAGE_KEY_PREFIX}${sessionRecord.id}`, JSON.stringify(sessionRecord));
+    } catch {
+        // Quota errors etc. — diagnostics must never break the app
+    }
+}
+
+function markExitState(cleanExit: boolean) {
+    if (!sessionRecord) {
+        return;
+    }
+    sessionRecord.cleanExit = cleanExit;
+    sessionRecord.lastHeartbeat = Date.now();
+    persistSessionRecord();
+}
+
+function getActiveRouteSafe(): string {
+    try {
+        return Navigation.getActiveRouteWithoutParams();
+    } catch {
+        return '';
+    }
+}
+
+function bytesToMB(bytes: number | undefined): number | null {
+    return bytes && bytes > 0 ? Math.round(bytes / BYTES_PER_MB) : null;
+}
+
+function takeSample(): HeapSample {
+    const perfMemory = (window.performance as PerformanceWithMemory | undefined)?.memory;
+    return {
+        t: Date.now(),
+        usedJSHeapSizeMB: bytesToMB(perfMemory?.usedJSHeapSize),
+        totalJSHeapSizeMB: bytesToMB(perfMemory?.totalJSHeapSize),
+        jsHeapSizeLimitMB: bytesToMB(perfMemory?.jsHeapSizeLimit),
+        domNodes: document.getElementsByTagName('*').length,
+        route: getActiveRouteSafe(),
+        reportsCount,
+        visibility: document.visibilityState,
+    };
+}
+
+function heartbeat() {
+    if (!sessionRecord) {
+        return;
+    }
+    sessionRecord.samples.push(takeSample());
+    if (sessionRecord.samples.length > MAX_SAMPLES) {
+        sessionRecord.samples.splice(0, sessionRecord.samples.length - MAX_SAMPLES);
+    }
+    sessionRecord.lastHeartbeat = Date.now();
+    sessionRecord.cleanExit = false;
+    persistSessionRecord();
+    reapDeadSessions();
+}
+
+function reportAbnormalExit(record: SessionRecord) {
+    const lastSample = record.samples.at(-1);
+    Sentry.captureEvent({
+        message: 'Crash diagnostics: previous browser session ended abnormally (possible tab crash)',
+        level: 'warning',
+        tags: {
+            crashDiagnostics: 'abnormal_exit',
+            lastRoute: lastSample?.route ?? 'unknown',
+        },
+        extra: {
+            sessionID: record.id,
+            sessionStartedAt: new Date(record.startedAt).toISOString(),
+            lastHeartbeatAt: new Date(record.lastHeartbeat).toISOString(),
+            sessionDurationMinutes: Math.round((record.lastHeartbeat - record.startedAt) / 60000),
+            lastUsedJSHeapSizeMB: lastSample?.usedJSHeapSizeMB,
+            lastTotalJSHeapSizeMB: lastSample?.totalJSHeapSizeMB,
+            jsHeapSizeLimitMB: lastSample?.jsHeapSizeLimitMB,
+            lastDOMNodes: lastSample?.domNodes,
+            samples: record.samples,
+        },
+    });
+}
+
+/**
+ * Removes finished session records and reports sessions that stopped heartbeating without a clean exit.
+ * Runs on startup and on every heartbeat, so a surviving tab can also report a crashed one.
+ */
+function reapDeadSessions() {
+    let storageKeys: string[];
+    try {
+        storageKeys = Object.keys(window.localStorage).filter((key) => key.startsWith(STORAGE_KEY_PREFIX));
+    } catch {
+        return;
+    }
+
+    for (const storageKey of storageKeys) {
+        if (sessionRecord && storageKey === `${STORAGE_KEY_PREFIX}${sessionRecord.id}`) {
+            continue;
+        }
+        const record = readSessionRecord(storageKey);
+        if (!record || record.cleanExit) {
+            window.localStorage.removeItem(storageKey);
+            continue;
+        }
+        // Not cleanly exited — could be another live tab, so only report once the heartbeat is stale
+        if (Date.now() - record.lastHeartbeat > STALE_HEARTBEAT_MS) {
+            reportAbnormalExit(record);
+            window.localStorage.removeItem(storageKey);
+        }
+    }
+}
+
+function reportDiscardedTab() {
+    const wasDiscarded = (document as Document & {wasDiscarded?: boolean}).wasDiscarded;
+    if (!wasDiscarded) {
+        return;
+    }
+    Sentry.captureEvent({
+        message: 'Crash diagnostics: tab was discarded by the browser to reclaim memory',
+        level: 'warning',
+        tags: {crashDiagnostics: 'tab_discarded'},
+    });
+}
+
+function initializeCrashDiagnostics() {
+    if (!isStorageAvailable() || sessionRecord) {
+        return;
+    }
+
+    reportDiscardedTab();
+    reapDeadSessions();
+
+    sessionRecord = {
+        id: Str.guid(),
+        startedAt: Date.now(),
+        lastHeartbeat: Date.now(),
+        cleanExit: false,
+        samples: [],
+    };
+
+    reportsConnection = Onyx.connectWithoutView({
+        key: ONYXKEYS.COLLECTION.REPORT,
+        waitForCollectionCallback: true,
+        callback: (value: OnyxCollection<Report>) => {
+            reportsCount = value ? Object.keys(value).length : 0;
+        },
+    });
+
+    // pagehide fires on navigation away, refresh, and tab close — all clean exits. It does NOT fire on a
+    // renderer crash, which is exactly the signal we rely on. pageshow restores the session after a
+    // back/forward-cache restore. freeze/resume cover background tabs whose timers are fully suspended,
+    // so a frozen tab isn't misreported as crashed.
+    window.addEventListener('pagehide', markCleanExit);
+    window.addEventListener('pageshow', markActive);
+    document.addEventListener('freeze', markCleanExit);
+    document.addEventListener('resume', markActive);
+
+    heartbeat();
+    sampleIntervalID = setInterval(heartbeat, SAMPLE_INTERVAL_MS);
+}
+
+function cleanupCrashDiagnostics() {
+    if (sampleIntervalID) {
+        clearInterval(sampleIntervalID);
+        sampleIntervalID = undefined;
+    }
+    if (reportsConnection) {
+        Onyx.disconnect(reportsConnection);
+        reportsConnection = undefined;
+    }
+    if (typeof window !== 'undefined') {
+        window.removeEventListener('pagehide', markCleanExit);
+        window.removeEventListener('pageshow', markActive);
+        document.removeEventListener('freeze', markCleanExit);
+        document.removeEventListener('resume', markActive);
+    }
+    markCleanExit();
+    sessionRecord = undefined;
+}
+
+export {initializeCrashDiagnostics, cleanupCrashDiagnostics};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

**What changed:** Added a web-only crash detector (src/libs/telemetry/crashDiagnostics/), initialized from Expensify.tsx.                                                
                                                                                                                                                                       
**Why:** A browser tab crash (typically out-of-memory) kills JS instantly, so Sentry can never report it from the dying session.                                         
                                                                                                                                                                       
 **How it works:** While the app runs, it writes a heartbeat plus a ring buffer of samples (used/total JS heap, heap limit, DOM node count, active route, Onyx report count) to localStorage every 15 seconds. Closing or refreshing the tab marks the session as cleanly exited via pagehide. On the next launch — or from another live tab — any session that stopped heartbeating for over 5 minutes without a clean exit is reported to Sentry with its final samples, showing what the user was doing and what was growing right before the crash. Browser tab discards (document.wasDiscarded) are reported as a separate event. Native platforms get a no-op.  

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
