### PR TITLE
fix: use location.replace to prevent blank page on browser back after delegate connect/disconnect

### DIFF
--- a/src/libs/actions/Delegate.ts
+++ b/src/libs/actions/Delegate.ts
@@ -215,6 +215,13 @@ function connect({email, delegatedAccess, credentials, session, activePolicyID, 
                 .then(() => {
                     confirmReadyToOpenApp();
                     return openApp().then(() => {
+                        // Replace the entire browser history entry so the back button cannot navigate
+                        // to a route from the previous account context (which would result in a blank
+                        // page since Onyx was cleared during the transition).
+                        // eslint-disable-next-line no-restricted-globals
+                        if (typeof window !== 'undefined' && window.location.replace) {
+                            window.location.replace(window.location.href);
+                        }
                         if (!CONFIG.IS_HYBRID_APP || !policyID) {
                             return true;
                         }
@@ -320,6 +327,13 @@ function disconnect({stashedCredentials, stashedSession}: DisconnectParams) {
                     Onyx.set(ONYXKEYS.STASHED_SESSION, {});
                     confirmReadyToOpenApp();
                     openApp().then(() => {
+                        // Replace the entire browser history entry so the back button cannot navigate
+                        // to a route from the previous account context (which would result in a blank
+                        // page since Onyx was cleared during the transition).
+                        // eslint-disable-next-line no-restricted-globals
+                        if (typeof window !== 'undefined' && window.location.replace) {
+                            window.location.replace(window.location.href);
+                        }
                         if (!CONFIG.IS_HYBRID_APP) {
                             return;
                         }


### PR DESCRIPTION
### Details

After connecting as a delegate (Copilot into account), the browser history still contains routes from the previous account context. When the user presses the browser back button, React Navigation tries to restore a route (`/settings/agents/{id}`) that no longer has valid Onyx data since `clearOnyxForDelegateTransition()` was called during the transition. This results in a blank page.

The fix uses `window.location.replace(window.location.href)` after `openApp()` completes in both `connect()` and `disconnect()`. This replaces the current browser history entry so the back button cannot navigate to routes from the previous account context.

### Fixed Issues

$ Expensify/App#93089

### Tests

1. Open Settings → Account → Agents
2. Click "Edit" on an agent
3. Click "Copilot into account"
4. After landing on Profile, press browser back button
5. Verify the page does NOT become blank

### QA Steps

Same as tests above.

### Acceptance Criteria

* Browser back button after Copilot into account does NOT result in a blank page
* The fix applies to both `connect` (copilot into account) and `disconnect` (return from delegation)