### PR TITLE
Fix stuck MFA cancel-confirm modal by not intercepting outside clicks

### DIFF
--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -33,8 +33,10 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
         dispatch({type: 'SET_SOFT_PROMPT_APPROVED', payload: true});
     };
 
-    // Outside-clicks and Escape route through the central cancel handler; return
-    // false to keep the focus trap intact while the confirm modal opens.
+    // Escape routes through the central cancel handler; returning false keeps the trap active.
+    // Outside clicks must keep the default behavior (deactivate the trap and pass through, like
+    // RHP screens): they reach the navigator's backdrop, which requests the cancel flow, and an
+    // intercepting trap would swallow every click aimed at the portal-rendered cancel-confirm modal.
     const interceptFocusTrapEscape = () => {
         requestCancel();
         return false;
@@ -45,8 +47,6 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
             testID={MultifactorAuthenticationPromptPage.displayName}
             focusTrapSettings={{
                 focusTrapOptions: {
-                    allowOutsideClick: interceptFocusTrapEscape,
-                    clickOutsideDeactivates: interceptFocusTrapEscape,
                     escapeDeactivates: interceptFocusTrapEscape,
                 },
             }}

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -5,7 +5,7 @@ import Button from '@components/Button';
 import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import LoadingIndicator from '@components/LoadingIndicator';
-import {useMultifactorAuthentication, useMultifactorAuthenticationActions, usePromptContent} from '@components/MultifactorAuthentication/Context';
+import {useMultifactorAuthentication, useMultifactorAuthenticationActions, useMultifactorAuthenticationState, usePromptContent} from '@components/MultifactorAuthentication/Context';
 import MultifactorAuthenticationPromptContent from '@components/MultifactorAuthentication/PromptContent';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
@@ -24,6 +24,7 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
     const styles = useThemeStyles();
     const {requestCancel} = useMultifactorAuthentication();
     const {dispatch} = useMultifactorAuthenticationActions();
+    const {isCancelConfirmVisible} = useMultifactorAuthenticationState();
     const {accountID} = useCurrentUserPersonalDetails();
 
     const {illustration, title, subtitle, shouldDisplayConfirmButton} = usePromptContent(route.params.promptType);
@@ -33,10 +34,7 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
         dispatch({type: 'SET_SOFT_PROMPT_APPROVED', payload: true});
     };
 
-    // Escape routes through the central cancel handler; returning false keeps the trap active.
-    // Outside clicks must keep the default behavior (deactivate the trap and pass through, like
-    // RHP screens): they reach the navigator's backdrop, which requests the cancel flow, and an
-    // intercepting trap would swallow every click aimed at the portal-rendered cancel-confirm modal.
+    // Escape opens the cancel confirmation; returning false keeps the trap active.
     const interceptFocusTrapEscape = () => {
         requestCancel();
         return false;
@@ -46,6 +44,9 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
         <ScreenWrapper
             testID={MultifactorAuthenticationPromptPage.displayName}
             focusTrapSettings={{
+                // Turn the trap off while the cancel confirmation modal is up so it can't swallow
+                // the modal's clicks, and back on when it closes. See https://github.com/Expensify/App/issues/93193
+                active: isCancelConfirmVisible ? false : undefined,
                 focusTrapOptions: {
                     escapeDeactivates: interceptFocusTrapEscape,
                 },

--- a/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
+++ b/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
@@ -198,8 +198,10 @@ function MultifactorAuthenticationValidateCodePage() {
         dispatch({type: 'SET_VALIDATE_CODE', payload: inputCode});
     };
 
-    // Outside-clicks and Escape route through the central cancel handler; return
-    // false to keep the focus trap intact while the confirm modal opens.
+    // Escape routes through the central cancel handler; returning false keeps the trap active.
+    // Outside clicks must keep the default behavior (deactivate the trap and pass through, like
+    // RHP screens): they reach the navigator's backdrop, which requests the cancel flow, and an
+    // intercepting trap would swallow every click aimed at the portal-rendered cancel-confirm modal.
     const interceptFocusTrapEscape = () => {
         requestCancel();
         return false;
@@ -210,8 +212,6 @@ function MultifactorAuthenticationValidateCodePage() {
             testID={MultifactorAuthenticationValidateCodePage.displayName}
             focusTrapSettings={{
                 focusTrapOptions: {
-                    allowOutsideClick: interceptFocusTrapEscape,
-                    clickOutsideDeactivates: interceptFocusTrapEscape,
                     escapeDeactivates: interceptFocusTrapEscape,
                 },
             }}

--- a/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
+++ b/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
@@ -50,7 +50,7 @@ function MultifactorAuthenticationValidateCodePage() {
     const {requestCancel} = useMultifactorAuthentication();
 
     const {dispatch} = useMultifactorAuthenticationActions();
-    const {continuableError} = useMultifactorAuthenticationState();
+    const {continuableError, isCancelConfirmVisible} = useMultifactorAuthenticationState();
 
     // Refs
     const inputRef = useRef<MagicCodeInputHandle>(null);
@@ -198,10 +198,7 @@ function MultifactorAuthenticationValidateCodePage() {
         dispatch({type: 'SET_VALIDATE_CODE', payload: inputCode});
     };
 
-    // Escape routes through the central cancel handler; returning false keeps the trap active.
-    // Outside clicks must keep the default behavior (deactivate the trap and pass through, like
-    // RHP screens): they reach the navigator's backdrop, which requests the cancel flow, and an
-    // intercepting trap would swallow every click aimed at the portal-rendered cancel-confirm modal.
+    // Escape opens the cancel confirmation; returning false keeps the trap active.
     const interceptFocusTrapEscape = () => {
         requestCancel();
         return false;
@@ -211,6 +208,9 @@ function MultifactorAuthenticationValidateCodePage() {
         <ScreenWrapper
             testID={MultifactorAuthenticationValidateCodePage.displayName}
             focusTrapSettings={{
+                // Turn the trap off while the cancel confirmation modal is up so it can't swallow
+                // the modal's clicks, and back on when it closes. See https://github.com/Expensify/App/issues/93193
+                active: isCancelConfirmVisible ? false : undefined,
                 focusTrapOptions: {
                     escapeDeactivates: interceptFocusTrapEscape,
                 },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

**Problem**

During an MFA flow (e.g. revealing virtual card details), clicking the dimmed area outside the MFA panel opens the cancel confirmation modal. After clicking outside that modal, the modal gets stuck: its buttons, backdrop and Escape stop responding, and only a page refresh recovers the app.

**Cause**

The MFA screens (magic code, prompt) overrode `allowOutsideClick` and `clickOutsideDeactivates` on their focus trap to intercept outside clicks at the document level (call `requestCancel` and swallow the event). The confirmation modal renders in a portal outside the screen trap's container, so it relies on its own `FocusTrapForModal`, which pauses the screen trap while active. Once the modal's trap deactivated (a click outside the modal does that by design), the screen trap resumed and treated every click aimed at the modal as an outside click - swallowing it before React could deliver the press.

**Solution**

The screens keep only the `escapeDeactivates` override (Escape still routes through `requestCancel`) and let outside clicks follow the default focus-trap behavior: the trap deactivates and the click passes through. The click then reaches the MFA navigator's backdrop pressable, which requests the cancel flow - so outside clicks still open the confirmation modal, and the modal stays fully interactive because no active trap can swallow its clicks anymore.

**Focus trap reactivation**

An outside click deactivates the screen's focus trap by design (same as RHP screens). Since every outside click opens the cancel confirmation modal, the screens drive the trap with `active: isCancelConfirmVisible ? false : undefined` - the trap is off while the modal is up (so it can't swallow the modal's clicks) and the prop flip on close reactivates it, keeping Tab contained in the MFA panel for the whole flow.

### Fixed Issues
$ https://github.com/Expensify/App/issues/93193
PROPOSAL:


### Tests

1. On web with a wide window, go to account > troubleshoot > Biometrics, press revoke if it is visible
2. Start the flow by pressing Biometrics > test - the MFA panel opens with the magic code screen
3. Click the dimmed area outside the MFA panel
4. Verify that the cancel confirmation modal appears
5. Click the dimmed backdrop around the confirmation modal
6. Verify that the modal closes (previously it stayed visible with unresponsive buttons)
7. Click outside the MFA panel again to reopen the confirmation modal
8. Click the modal's cancel ("No") button and verify the modal closes and the magic code screen stays interactive (typing in the input works)
9. Click outside the panel once more and click the confirm ("Yes") button - verify the whole MFA flow closes

10. With the magic code screen open, press Escape
11. Verify that the cancel confirmation modal appears and both its buttons work

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A - the change only affects focus-trap behavior on web; no API or data changes.

### QA Steps

Same as tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


https://github.com/user-attachments/assets/d39befc8-eb26-4acd-b625-e7e268c3ddcf

