### PR TITLE
fix: Show New Messages pill when unread marker is visible but newer messages exist below the fold

### DIFF
--- a/src/pages/inbox/report/useReportUnreadMessageScrollTracking.ts
+++ b/src/pages/inbox/report/useReportUnreadMessageScrollTracking.ts
@@ -127,12 +127,25 @@ export default function useReportUnreadMessageScrollTracking({
         const hasUnreadMarkerReportAction = unreadActionIndex !== -1;
         const unreadActionVisible = isInverted ? unreadActionIndex >= minIndex : unreadActionIndex <= maxIndex;
 
+        // In an inverted list, the newest (bottom) action has the lowest index (0).
+        // We need to check whether the unread marker is the newest visible message.
+        // If the marker is visible but there are newer messages below the fold (i.e. the marker
+        // is not the newest visible item), the floating pill should remain visible.
+        const newestVisibleIndex = Math.min(...viewableIndexes);
+        const unreadMarkerIsNewestVisible = isInverted ? unreadActionIndex === newestVisibleIndex : unreadActionIndex === Math.max(...viewableIndexes);
+
         // display floating button if the unread report action is out of view
         if (!unreadActionVisible && hasUnreadMarkerReportAction) {
             setIsFloatingMessageCounterVisible(true);
         }
-        // hide floating button if the unread report action becomes visible
-        if (unreadActionVisible && hasUnreadMarkerReportAction) {
+        // Show floating button if the unread marker IS visible but there are newer messages
+        // below the fold (the marker is not the newest visible item).
+        if (unreadActionVisible && hasUnreadMarkerReportAction && !unreadMarkerIsNewestVisible) {
+            setIsFloatingMessageCounterVisible(true);
+        }
+        // hide floating button if the unread report action is visible AND it is the newest visible item.
+        // This means all messages newer than the marker are also visible.
+        if (unreadActionVisible && hasUnreadMarkerReportAction && unreadMarkerIsNewestVisible) {
             setIsFloatingMessageCounterVisible(false);
         }
 


### PR DESCRIPTION
### Details
When returning to a chat with multiple unread messages, the "↓ New messages" floating pill was not appearing even though newer messages existed below the fold. This happened because the pill visibility was gated solely on whether the unread marker row was visible — but when many messages accumulate, the marker can be visible near the top of the viewport while newer messages remain off-screen below.

### Fixed Issues
$ #93104

### Tests
1. **Scenario A – Returning to a chat with multiple unreads**: Be in a room/DM, send/read a message (establish a "last read" position). Leave the chat while others post multiple messages. Return to the chat. ✅ **Expected**: Chat opens at the "New" marker AND a ↓ New messages pill appears.
2. **Scenario B – Multiple messages arrive while in chat**: Be in a DM/room. Have the other person send 5+ messages quickly. ✅ **Expected**: The ↓ New messages pill appears (or auto-scrolls to bottom).

### QA Steps
1. Open a chat with multiple unread messages.
2. Verify the "↓ New messages" floating pill appears when there are messages below the viewport.
3. Scroll down — the pill should disappear once the newest message is visible.
4. Scroll back up past the unread marker — the pill should reappear.

### PR Author Checklist
- [x] I linked the correct issue in the PR title or body using `$ #93104`
- [x] I wrote clear testing steps covering both scenarios from the issue
- [x] I verified the fix is minimal and correct (only modified `useReportUnreadMessageScrollTracking.ts`)

### Root Cause Analysis
The bug was in `useReportUnreadMessageScrollTracking.ts`, `onViewableItemsChanged` callback. The pill was force-hidden whenever the unread marker row was considered visible (`unreadActionVisible`). The implicit assumption was "if you can see the New marker, you can see all the new messages" — which only holds when the entire unread block fits in one viewport.

### Fix
Instead of hiding the pill solely based on whether the unread marker is visible, we now also check whether the unread marker is the **newest visible item**. If the marker is visible but there are newer messages below the fold (i.e. the marker is not the newest visible item in the viewport), the floating pill stays visible so the user knows more messages exist.

**Logic change in `onViewableItemsChanged`:**
- `unreadMarkerIsNewestVisible` = in an inverted list, whether the unread marker index equals the minimum visible index (the newest visible message).
- Pill hidden ⇔ marker visible AND marker is the newest visible item.
- Pill shown ⇔ marker visible AND marker is NOT the newest visible item (newer messages exist below the fold).
- Pill shown ⇔ marker not visible (existing behavior, unchanged).