### PR TITLE
Composition of `WorkspacesListPage` 

### DIFF
--- a/src/components/Tables/WorkspaceListTable/WorkspaceRowBrickRoadIndicator.tsx
+++ b/src/components/Tables/WorkspaceListTable/WorkspaceRowBrickRoadIndicator.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {View} from 'react-native';
+import type {OnyxEntry} from 'react-native-onyx';
+import Icon from '@components/Icon';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useOnyx from '@hooks/useOnyx';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useWorkspaceAccountID from '@hooks/useWorkspaceAccountID';
+import {isConnectionInProgress} from '@libs/actions/connections';
+import {isMergeHRCompleteSetupNeeded} from '@libs/HRUtils';
+import {getPolicyBrickRoadIndicatorStatus, getUberConnectionErrorDirectlyFromPolicy, shouldShowEmployeeListError} from '@libs/PolicyUtils';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import {hasReimbursementAccountErrorsSelector} from '@src/selectors/ReimbursementAccount';
+import type {Policy, PolicyConnectionSyncProgress} from '@src/types/onyx';
+import type {CardFeedErrors} from '@src/types/onyx/DerivedValues';
+
+type WorkspaceRowBrickRoadIndicatorProps = {
+    /** ID of the policy the row represents */
+    policyID: string;
+};
+
+const createCardFeedErrorsSelector = (workspaceAccountID: number) => (cardFeedErrors: OnyxEntry<CardFeedErrors>) =>
+    !!cardFeedErrors?.shouldShowRbrForWorkspaceAccountID?.[workspaceAccountID];
+
+const createPolicyErrorsSelector = (connectionSyncProgress: OnyxEntry<PolicyConnectionSyncProgress>) => (policy: OnyxEntry<Policy>) =>
+    getUberConnectionErrorDirectlyFromPolicy(policy) ||
+    shouldShowEmployeeListError(policy) ||
+    getPolicyBrickRoadIndicatorStatus(policy, isConnectionInProgress(connectionSyncProgress, policy)) === CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR;
+
+const mergeHRCompleteSetupNeededSelector = (policy: OnyxEntry<Policy>) => isMergeHRCompleteSetupNeeded(policy);
+
+/**
+ * Error indicator of a workspaces list row. All of its subscriptions are narrow (booleans or a single
+ * small entry), so a policy write re-evaluates only this row's selectors and re-renders at most this
+ * one component instead of committing the whole workspaces list page.
+ */
+function WorkspaceRowBrickRoadIndicator({policyID}: WorkspaceRowBrickRoadIndicatorProps) {
+    const theme = useTheme();
+    const styles = useThemeStyles();
+    const icons = useMemoizedLazyExpensifyIcons(['DotIndicator']);
+    const workspaceAccountID = useWorkspaceAccountID(policyID);
+    const [hasReimbursementAccountErrors] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {selector: hasReimbursementAccountErrorsSelector});
+    const [hasCardFeedErrors] = useOnyx(ONYXKEYS.DERIVED.CARD_FEED_ERRORS, {selector: createCardFeedErrorsSelector(workspaceAccountID)}, [workspaceAccountID]);
+    const [connectionSyncProgress] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS}${policyID}`);
+    const [hasPolicyErrors] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {selector: createPolicyErrorsSelector(connectionSyncProgress)}, [connectionSyncProgress]);
+    const [isHRCompleteSetupNeeded] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {selector: mergeHRCompleteSetupNeededSelector});
+
+    // All of the error sources resolve to ERROR or undefined; the HR setup check is the only INFO source
+    // and every error takes precedence over it.
+    const hasError = !!hasReimbursementAccountErrors || !!hasCardFeedErrors || !!hasPolicyErrors;
+
+    if (!hasError && !isHRCompleteSetupNeeded) {
+        return null;
+    }
+
+    return (
+        <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2]}>
+            <Icon
+                src={icons.DotIndicator}
+                fill={hasError ? theme.danger : theme.iconSuccessFill}
+            />
+        </View>
+    );
+}
+
+export default WorkspaceRowBrickRoadIndicator;

--- a/src/components/Tables/WorkspaceListTable/WorkspaceRowBrickRoadIndicator.tsx
+++ b/src/components/Tables/WorkspaceListTable/WorkspaceRowBrickRoadIndicator.tsx
@@ -8,8 +8,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWorkspaceAccountID from '@hooks/useWorkspaceAccountID';
 import {isConnectionInProgress} from '@libs/actions/connections';
-import {isMergeHRCompleteSetupNeeded} from '@libs/HRUtils';
-import {getPolicyBrickRoadIndicatorStatus, getUberConnectionErrorDirectlyFromPolicy, shouldShowEmployeeListError} from '@libs/PolicyUtils';
+import {getPolicyBrickRoadIndicatorStatus, getUberConnectionErrorDirectlyFromPolicy, isMergeHRCompleteSetupNeededSelector, shouldShowEmployeeListError} from '@libs/PolicyUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {hasReimbursementAccountErrorsSelector} from '@src/selectors/ReimbursementAccount';
@@ -29,8 +28,6 @@ const createPolicyErrorsSelector = (connectionSyncProgress: OnyxEntry<PolicyConn
     shouldShowEmployeeListError(policy) ||
     getPolicyBrickRoadIndicatorStatus(policy, isConnectionInProgress(connectionSyncProgress, policy)) === CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR;
 
-const mergeHRCompleteSetupNeededSelector = (policy: OnyxEntry<Policy>) => isMergeHRCompleteSetupNeeded(policy);
-
 /**
  * Error indicator of a workspaces list row. All of its subscriptions are narrow (booleans or a single
  * small entry), so a policy write re-evaluates only this row's selectors and re-renders at most this
@@ -45,7 +42,7 @@ function WorkspaceRowBrickRoadIndicator({policyID}: WorkspaceRowBrickRoadIndicat
     const [hasCardFeedErrors] = useOnyx(ONYXKEYS.DERIVED.CARD_FEED_ERRORS, {selector: createCardFeedErrorsSelector(workspaceAccountID)}, [workspaceAccountID]);
     const [connectionSyncProgress] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS}${policyID}`);
     const [hasPolicyErrors] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {selector: createPolicyErrorsSelector(connectionSyncProgress)}, [connectionSyncProgress]);
-    const [isHRCompleteSetupNeeded] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {selector: mergeHRCompleteSetupNeededSelector});
+    const [isHRCompleteSetupNeeded] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {selector: isMergeHRCompleteSetupNeededSelector});
 
     // All of the error sources resolve to ERROR or undefined; the HR setup check is the only INFO source
     // and every error takes precedence over it.

--- a/src/components/Tables/WorkspaceListTable/WorkspaceTableRow.tsx
+++ b/src/components/Tables/WorkspaceListTable/WorkspaceTableRow.tsx
@@ -17,6 +17,7 @@ import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import type {CopySettingsEligibleTargets} from '@src/selectors/Policy';
 import type {WorkspaceRowData} from '.';
+import WorkspaceRowBrickRoadIndicator from './WorkspaceRowBrickRoadIndicator';
 import WorkspaceRowThreeDotsMenu from './WorkspaceRowThreeDotsMenu';
 
 type WorkspaceRowProps = {
@@ -43,7 +44,7 @@ export default function WorkspaceRow({item, shouldUseNarrowTableLayout, rowIndex
     const theme = useTheme();
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const icons = useMemoizedLazyExpensifyIcons(['ArrowRight', 'Building', 'FallbackWorkspaceAvatar', 'DotIndicator', 'Hourglass']);
+    const icons = useMemoizedLazyExpensifyIcons(['ArrowRight', 'Building', 'FallbackWorkspaceAvatar', 'Hourglass']);
 
     const formattedOwnerName = item.ownerName ?? '';
     const formattedWorkspaceType = getUserFriendlyWorkspaceType(item.type, translate);
@@ -59,15 +60,6 @@ export default function WorkspaceRow({item, shouldUseNarrowTableLayout, rowIndex
     ]
         .filter(Boolean)
         .join(', ');
-
-    const BrickRoadIndicator = !!item.brickRoadIndicator && (
-        <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2]}>
-            <Icon
-                src={icons.DotIndicator}
-                fill={item.brickRoadIndicator === CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR ? theme.danger : theme.iconSuccessFill}
-            />
-        </View>
-    );
 
     const JoinRequestPendingBadge = (
         <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
@@ -100,7 +92,7 @@ export default function WorkspaceRow({item, shouldUseNarrowTableLayout, rowIndex
 
     const ThreeDotsMenuWithBrickRoadIndicator = (
         <View style={[styles.flexRow, styles.gap1]}>
-            {item.brickRoadIndicator && BrickRoadIndicator}
+            {item.role === CONST.POLICY.ROLE.ADMIN && <WorkspaceRowBrickRoadIndicator policyID={item.policyID} />}
             <WorkspaceRowThreeDotsMenu
                 item={item}
                 onDeleteWorkspace={onDeleteWorkspace}

--- a/src/components/Tables/WorkspaceListTable/index.tsx
+++ b/src/components/Tables/WorkspaceListTable/index.tsx
@@ -35,7 +35,6 @@ type WorkspaceRowData = TableData & {
     iconType: typeof CONST.ICON_TYPE_AVATAR | typeof CONST.ICON_TYPE_ICON;
     errors?: OnyxCommon.Errors;
     pendingAction?: OnyxCommon.PendingAction;
-    brickRoadIndicator?: ValueOf<typeof CONST.BRICK_ROAD_INDICATOR_STATUS>;
     action: (event?: ModifiedMouseEvent) => void;
     dismissError: () => void;
 };

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -47,7 +47,7 @@ import addEncryptedAuthTokenToURL from './addEncryptedAuthTokenToURL';
 import {getApiRoot} from './ApiUtils';
 import {getCategoryApproverRule} from './CategoryUtils';
 import {convertToBackendAmount} from './CurrencyUtils';
-import {isAnyHRConnected} from './HRUtils';
+import {isAnyHRConnected, isMergeHRCompleteSetupNeeded} from './HRUtils';
 import Navigation from './Navigation/Navigation';
 import {getIsOffline} from './NetworkState';
 import {formatMemberForList} from './OptionsListUtils';
@@ -537,6 +537,11 @@ function getPolicyBrickRoadIndicatorStatus(policy: OnyxEntry<Policy>, isConnecti
     }
     return undefined;
 }
+
+/**
+ * Returns whether the Merge HR setup still needs to be completed for a policy.
+ */
+const isMergeHRCompleteSetupNeededSelector = (policy: OnyxEntry<Policy>) => isMergeHRCompleteSetupNeeded(policy);
 
 function getPolicyRole(policy: OnyxInputOrEntry<Policy>, currentUserLogin?: string, shouldCheckGlobalPolicyRole = true): string | undefined {
     if (shouldCheckGlobalPolicyRole && policy?.role) {
@@ -2744,6 +2749,7 @@ export {
     isSubmitPolicy,
     isSubmitterApproveBlockedOnSubmitWorkspace,
     hasAnyPaidPolicy,
+    isMergeHRCompleteSetupNeededSelector,
 };
 
 export type {MemberEmailsToAccountIDs, PolicyFeature, PolicyFeatureAccess};

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -69,17 +69,13 @@ function WorkspacesListPage() {
 
     // Narrow subscription keeping the owner name/avatar columns reactive without re-rendering the page
     // when anything else in the personal details list changes.
-    const ownerAccountIDs: number[] = [];
-    {
-        const uniqueOwnerAccountIDs = new Set<number>();
-        for (const policy of workspaceListPolicies ?? []) {
-            const ownerAccountID = policy.isJoinRequestPending && policy.nonMemberDetails ? policy.nonMemberDetails.ownerAccountID : policy.ownerAccountID;
-            if (ownerAccountID) {
-                uniqueOwnerAccountIDs.add(ownerAccountID);
-            }
-        }
-        ownerAccountIDs.push(...uniqueOwnerAccountIDs);
-    }
+    const ownerAccountIDs = [
+        ...new Set(
+            (workspaceListPolicies ?? [])
+                .map((policy) => (policy.isJoinRequestPending && policy.nonMemberDetails ? policy.nonMemberDetails.ownerAccountID : policy.ownerAccountID))
+                .filter((id): id is number => id !== undefined),
+        ),
+    ];
     const [ownerDisplayDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: createDisplayDetailsByAccountIDsSelector(ownerAccountIDs)}, [workspaceListPolicies]);
 
     const navigateToWorkspace = (policyID: string, event?: ModifiedMouseEvent) => {

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -1,7 +1,6 @@
 import {useIsFocused, useRoute} from '@react-navigation/native';
 import React, {useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
-import type {OnyxEntry} from 'react-native-onyx';
 import ActivityIndicator from '@components/ActivityIndicator';
 import Button from '@components/Button';
 import type {TableHandle} from '@components/Table';
@@ -14,13 +13,10 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePoliciesWithCardFeedErrors from '@hooks/usePoliciesWithCardFeedErrors';
 import usePreferredPolicy from '@hooks/usePreferredPolicy';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {isConnectionInProgress} from '@libs/actions/connections';
 import {clearDuplicateWorkspace, dismissWorkspaceError} from '@libs/actions/Policy/Policy';
-import {isMergeHRCompleteSetupNeeded} from '@libs/HRUtils';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import openInternalRouteInNewTab from '@libs/Navigation/helpers/openInternalRouteInNewTab';
 import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
@@ -29,14 +25,6 @@ import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigat
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import type {WorkspaceNavigatorParamList} from '@libs/Navigation/types';
 import {getDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
-import {
-    getPolicyBrickRoadIndicatorStatus,
-    getUberConnectionErrorDirectlyFromPolicy,
-    isPendingDeletePolicy,
-    isPolicyAdmin,
-    shouldShowEmployeeListError,
-    shouldShowPolicy,
-} from '@libs/PolicyUtils';
 import {getDefaultWorkspaceAvatar} from '@libs/ReportUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import CONST from '@src/CONST';
@@ -45,10 +33,7 @@ import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import {createDisplayDetailsByAccountIDsSelector} from '@src/selectors/PersonalDetails';
 import type {CopySettingsEligibleTargets} from '@src/selectors/Policy';
-import {createCopySettingsEligibleTargetsSelector} from '@src/selectors/Policy';
-import type {Policy as PolicyType} from '@src/types/onyx';
-import type {PolicyDetailsForNonMembers} from '@src/types/onyx/Policy';
-import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import {createCopySettingsEligibleTargetsSelector, createWorkspaceListPoliciesSelector} from '@src/selectors/Policy';
 import CopyPolicySettingsProgressModal from './copyPolicySettings/CopyPolicySettingsProgressModal';
 import DeleteWorkspaceFlow from './deleteWorkspace/DeleteWorkspaceFlow';
 
@@ -63,9 +48,6 @@ function WorkspacesListPage() {
     const {isOffline} = useNetwork();
     const isFocused = useIsFocused();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
-    const [allConnectionSyncProgresses] = useOnyx(ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS);
-    const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
-    const [reimbursementAccount] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT);
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
@@ -74,7 +56,12 @@ function WorkspacesListPage() {
     const {isRestrictedPolicyCreation} = usePreferredPolicy();
     const [duplicateWorkspace] = useOnyx(ONYXKEYS.DUPLICATE_WORKSPACE);
 
-    // Light projection of the policy collection passed down to the row menus, which compute their copy-settings
+    // Light, flat projection of the policy collection. Deep, frequently mutated policy fields (isLoading*
+    // flags, employeeList, connections, etc.) are excluded, so background writes to them no longer commit
+    // this page. Per-row error indicators subscribe to those fields themselves in WorkspaceRowBrickRoadIndicator.
+    const [workspaceListPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: createWorkspaceListPoliciesSelector(session?.email)}, [session?.email]);
+
+    // Projection of the policy collection passed down to the row menus, which compute their copy-settings
     // eligibility from it. Kept at the page level so it is evaluated once per policy write instead of once per row.
     const [copySettingsEligibleTargets] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: createCopySettingsEligibleTargetsSelector(session?.email)}, [session?.email]);
 
@@ -83,21 +70,17 @@ function WorkspacesListPage() {
     // Narrow subscription keeping the owner name/avatar columns reactive without re-rendering the page
     // when anything else in the personal details list changes.
     const ownerAccountIDs: number[] = [];
-    if (!isEmptyObject(policies)) {
+    {
         const uniqueOwnerAccountIDs = new Set<number>();
-        for (const policy of Object.values(policies)) {
-            if (!policy || !shouldShowPolicy(policy, true, session?.email)) {
-                continue;
-            }
-            const ownerAccountID =
-                policy.isJoinRequestPending && policy.policyDetailsForNonMembers ? Object.values(policy.policyDetailsForNonMembers).at(0)?.ownerAccountID : policy.ownerAccountID;
+        for (const policy of workspaceListPolicies ?? []) {
+            const ownerAccountID = policy.isJoinRequestPending && policy.nonMemberDetails ? policy.nonMemberDetails.ownerAccountID : policy.ownerAccountID;
             if (ownerAccountID) {
                 uniqueOwnerAccountIDs.add(ownerAccountID);
             }
         }
         ownerAccountIDs.push(...uniqueOwnerAccountIDs);
     }
-    const [ownerDisplayDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: createDisplayDetailsByAccountIDsSelector(ownerAccountIDs)}, [policies, session?.email]);
+    const [ownerDisplayDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: createDisplayDetailsByAccountIDsSelector(ownerAccountIDs)}, [workspaceListPolicies]);
 
     const navigateToWorkspace = (policyID: string, event?: ModifiedMouseEvent) => {
         const workspaceRoute = shouldUseNarrowLayout ? ROUTES.WORKSPACE_INITIAL.getRoute(policyID) : ROUTES.WORKSPACE_OVERVIEW.getRoute(policyID);
@@ -107,114 +90,66 @@ function WorkspacesListPage() {
         Navigation.navigate(workspaceRoute);
     };
 
-    const {policiesWithCardFeedErrors} = usePoliciesWithCardFeedErrors();
-
     /**
      * Add free policies (workspaces) to the list of menu items and returns the list of menu items
      */
     const workspaceRows: WorkspaceRowData[] = [];
 
-    if (!isEmptyObject(policies)) {
-        const reimbursementAccountBrickRoadIndicator = !isEmptyObject(reimbursementAccount?.errors) ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined;
+    for (const policy of workspaceListPolicies ?? []) {
+        if (policy.isJoinRequestPending && policy.nonMemberDetails) {
+            const {policyID, ownerAccountID} = policy.nonMemberDetails;
+            const ownerDetails = ownerAccountID ? ownerDisplayDetails?.[ownerAccountID] : undefined;
 
-        for (const policy of Object.values(policies)) {
-            if (!policy || !shouldShowPolicy(policy, true, session?.email)) {
-                continue;
-            }
+            const pendingWorkspaceRow: WorkspaceRowData = {
+                keyForList: policyID,
+                policyID,
+                disabled: true,
+                errors: undefined,
+                type: policy.nonMemberDetails.type,
+                title: policy.nonMemberDetails.name,
+                role: CONST.POLICY.ROLE.USER,
+                isDeleted: false,
+                isJoinRequestPending: true,
+                isDefault: activePolicyID === policyID,
+                shouldAnimateInHighlight: duplicateWorkspace?.policyID === policyID,
+                ownerAccountID,
+                ownerLogin: ownerDetails ? ownerDetails.login : undefined,
+                ownerAvatar: ownerDetails ? ownerDetails.avatar : undefined,
+                ownerName: ownerDetails ? getDisplayNameOrDefault(ownerDetails) : undefined,
+                iconType: policy.nonMemberDetails.avatar ? CONST.ICON_TYPE_AVATAR : CONST.ICON_TYPE_ICON,
+                icon: policy.nonMemberDetails.avatar ? policy.nonMemberDetails.avatar : getDefaultWorkspaceAvatar(policy.name),
+                action: () => null,
+                dismissError: () => null,
+            };
 
-            const brickRoadIndicator = (() => {
-                if (!isPolicyAdmin(policy, session?.email)) {
-                    return undefined;
-                }
+            workspaceRows.push(pendingWorkspaceRow);
+        } else {
+            const ownerDetails = policy.ownerAccountID ? ownerDisplayDetails?.[policy.ownerAccountID] : undefined;
 
-                if (reimbursementAccountBrickRoadIndicator) {
-                    return reimbursementAccountBrickRoadIndicator;
-                }
+            const workspaceRow: WorkspaceRowData = {
+                keyForList: policy.id,
+                policyID: policy.id,
+                disabled: policy.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                errors: policy.errors,
+                type: policy.type,
+                title: policy.name,
+                role: policy.role,
+                ownerAccountID: policy.ownerAccountID,
+                isJoinRequestPending: false,
+                shouldAnimateInHighlight: duplicateWorkspace?.policyID === policy.id,
+                isDefault: activePolicyID === policy.id,
+                isDeleted: policy.isPendingDelete,
+                ownerLogin: ownerDetails ? ownerDetails.login : undefined,
+                ownerAvatar: ownerDetails ? ownerDetails.avatar : undefined,
+                ownerName: ownerDetails ? getDisplayNameOrDefault(ownerDetails) : undefined,
+                iconType: policy.avatarURL ? CONST.ICON_TYPE_AVATAR : CONST.ICON_TYPE_ICON,
+                icon: policy.avatarURL ? policy.avatarURL : getDefaultWorkspaceAvatar(policy.name),
+                pendingAction: policy.pendingAction,
+                action: (event) => navigateToWorkspace(policy.id, event),
+                dismissError: () => dismissWorkspaceError(policy.id, policy.pendingAction),
+            };
 
-                const receiptUberBrickRoadIndicator = getUberConnectionErrorDirectlyFromPolicy(policy as OnyxEntry<PolicyType>) ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined;
-
-                if (receiptUberBrickRoadIndicator) {
-                    return receiptUberBrickRoadIndicator;
-                }
-
-                if (policiesWithCardFeedErrors.find((p) => p.id === policy.id)) {
-                    return CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR;
-                }
-
-                if (shouldShowEmployeeListError(policy)) {
-                    return CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR;
-                }
-
-                if (isMergeHRCompleteSetupNeeded(policy)) {
-                    return CONST.BRICK_ROAD_INDICATOR_STATUS.INFO;
-                }
-
-                return getPolicyBrickRoadIndicatorStatus(
-                    policy,
-                    isConnectionInProgress(allConnectionSyncProgresses?.[`${ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS}${policy.id}`], policy),
-                );
-            })();
-
-            if (policy?.isJoinRequestPending && policy?.policyDetailsForNonMembers) {
-                const policyID = Object.keys(policy.policyDetailsForNonMembers).at(0) ?? '';
-                const policyInfo = Object.values(policy.policyDetailsForNonMembers).at(0) as PolicyDetailsForNonMembers;
-
-                const policyOwnerAccountID = policyInfo.ownerAccountID;
-                const ownerDetails = policyOwnerAccountID ? ownerDisplayDetails?.[policyOwnerAccountID] : undefined;
-
-                const pendingWorkspaceRow: WorkspaceRowData = {
-                    keyForList: policyID,
-                    policyID,
-                    disabled: true,
-                    errors: undefined,
-                    type: policyInfo.type,
-                    title: policyInfo.name,
-                    role: CONST.POLICY.ROLE.USER,
-                    isDeleted: false,
-                    isJoinRequestPending: true,
-                    isDefault: activePolicyID === policyID,
-                    shouldAnimateInHighlight: duplicateWorkspace?.policyID === policyID,
-                    ownerAccountID: policyOwnerAccountID,
-                    ownerLogin: ownerDetails ? ownerDetails.login : undefined,
-                    ownerAvatar: ownerDetails ? ownerDetails.avatar : undefined,
-                    ownerName: ownerDetails ? getDisplayNameOrDefault(ownerDetails) : undefined,
-                    iconType: policyInfo?.avatar ? CONST.ICON_TYPE_AVATAR : CONST.ICON_TYPE_ICON,
-                    icon: policyInfo?.avatar ? policyInfo.avatar : getDefaultWorkspaceAvatar(policy.name),
-                    action: () => null,
-                    dismissError: () => null,
-                };
-
-                workspaceRows.push(pendingWorkspaceRow);
-            } else {
-                const policyOwnerAccountID = policy.ownerAccountID;
-                const ownerDetails = policyOwnerAccountID ? ownerDisplayDetails?.[policyOwnerAccountID] : undefined;
-
-                const workspaceRow: WorkspaceRowData = {
-                    keyForList: policy.id,
-                    policyID: policy.id,
-                    disabled: policy.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
-                    errors: policy.errors,
-                    type: policy.type,
-                    title: policy.name,
-                    role: policy.role,
-                    ownerAccountID: policyOwnerAccountID,
-                    isJoinRequestPending: false,
-                    shouldAnimateInHighlight: duplicateWorkspace?.policyID === policy.id,
-                    isDefault: activePolicyID === policy.id,
-                    isDeleted: isPendingDeletePolicy(policy),
-                    ownerLogin: ownerDetails ? ownerDetails.login : undefined,
-                    ownerAvatar: ownerDetails ? ownerDetails.avatar : undefined,
-                    ownerName: ownerDetails ? getDisplayNameOrDefault(ownerDetails) : undefined,
-                    iconType: policy.avatarURL ? CONST.ICON_TYPE_AVATAR : CONST.ICON_TYPE_ICON,
-                    icon: policy.avatarURL ? policy.avatarURL : getDefaultWorkspaceAvatar(policy.name),
-                    brickRoadIndicator,
-                    pendingAction: policy.pendingAction,
-                    action: (event) => navigateToWorkspace(policy.id, event),
-                    dismissError: () => dismissWorkspaceError(policy.id, policy.pendingAction),
-                };
-
-                workspaceRows.push(workspaceRow);
-            }
+            workspaceRows.push(workspaceRow);
         }
     }
 

--- a/src/selectors/Policy.ts
+++ b/src/selectors/Policy.ts
@@ -380,4 +380,4 @@ export {
     createAdminPoliciesSelector,
     isAdminForPolicyByIDSelector,
 };
-export type {ReusablePolicyConnectionName, CopySettingsEligibleTargets, WorkspaceListPolicy};
+export type {ReusablePolicyConnectionName, CopySettingsEligibleTargets};

--- a/src/selectors/Policy.ts
+++ b/src/selectors/Policy.ts
@@ -2,10 +2,11 @@ import escapeRegExp from 'lodash/escapeRegExp';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import {hasSynchronizationErrorMessage, isConnectionUnverified} from '@libs/actions/connections';
 import {getDisplayNameForWorkspace} from '@libs/actions/Policy/Policy';
-import {getActiveAdminWorkspaces, getOwnedPaidPolicies, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getActiveAdminWorkspaces, getOwnedPaidPolicies, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin, shouldShowPolicy} from '@libs/PolicyUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy, PolicyReportField} from '@src/types/onyx';
+import type {PolicyDetailsForNonMembers} from '@src/types/onyx/Policy';
 
 type ReusablePolicyConnectionName =
     | typeof CONST.POLICY.CONNECTIONS.NAME.NETSUITE
@@ -66,6 +67,64 @@ const createCopySettingsEligibleTargetsSelector =
             }
         }
         return {adminNonPersonal, corporateOnly};
+    };
+
+type WorkspaceListPolicy = Pick<Policy, 'id' | 'name' | 'type' | 'role' | 'ownerAccountID' | 'avatarURL' | 'pendingAction' | 'errors'> & {
+    /** Whether the policy is optimistically pending deletion */
+    isPendingDelete: boolean;
+
+    /** Whether the current user has a pending request to join the policy */
+    isJoinRequestPending: boolean;
+
+    /** Projection of policyDetailsForNonMembers for join-request-pending policies */
+    nonMemberDetails?: Pick<PolicyDetailsForNonMembers, 'name' | 'type' | 'ownerAccountID' | 'avatar'> & {policyID: string};
+};
+
+/**
+ * Creates a selector returning a light, flat projection of the policies shown on the workspaces list,
+ * so the page doesn't re-render when deep, frequently mutated policy fields change (isLoading* flags,
+ * employeeList, customUnits, connections, etc.).
+ */
+const createWorkspaceListPoliciesSelector =
+    (currentUserLogin: string | undefined) =>
+    (policies: OnyxCollection<Policy>): WorkspaceListPolicy[] => {
+        const result: WorkspaceListPolicy[] = [];
+        for (const policy of Object.values(policies ?? {})) {
+            if (!policy || !shouldShowPolicy(policy, true, currentUserLogin)) {
+                continue;
+            }
+
+            const isJoinRequestPending = !!policy.isJoinRequestPending && !!policy.policyDetailsForNonMembers;
+            let nonMemberDetails: WorkspaceListPolicy['nonMemberDetails'];
+            if (isJoinRequestPending) {
+                const nonMemberEntry = Object.entries(policy.policyDetailsForNonMembers ?? {}).at(0);
+                if (nonMemberEntry) {
+                    const [nonMemberPolicyID, details] = nonMemberEntry;
+                    nonMemberDetails = {
+                        policyID: nonMemberPolicyID,
+                        name: details.name,
+                        type: details.type,
+                        ownerAccountID: details.ownerAccountID,
+                        avatar: details.avatar,
+                    };
+                }
+            }
+
+            result.push({
+                id: policy.id,
+                name: policy.name,
+                type: policy.type,
+                role: policy.role,
+                ownerAccountID: policy.ownerAccountID,
+                avatarURL: policy.avatarURL,
+                pendingAction: policy.pendingAction,
+                errors: policy.errors,
+                isPendingDelete: isPendingDeletePolicy(policy),
+                isJoinRequestPending,
+                nonMemberDetails,
+            });
+        }
+        return result;
     };
 
 const activeAdminPoliciesSelector = (policies: OnyxCollection<Policy>, currentUserAccountLogin: string) => getActiveAdminWorkspaces(policies, currentUserAccountLogin);
@@ -301,6 +360,7 @@ export {
     ownerPoliciesSelector,
     createOwnedPaidPoliciesCountsSelector,
     createCopySettingsEligibleTargetsSelector,
+    createWorkspaceListPoliciesSelector,
     activeAdminPoliciesSelector,
     hasActiveAdminPoliciesSelector,
     createPoliciesForDomainCardsSelector,
@@ -320,4 +380,4 @@ export {
     createAdminPoliciesSelector,
     isAdminForPolicyByIDSelector,
 };
-export type {ReusablePolicyConnectionName, CopySettingsEligibleTargets};
+export type {ReusablePolicyConnectionName, CopySettingsEligibleTargets, WorkspaceListPolicy};

--- a/src/selectors/ReimbursementAccount.ts
+++ b/src/selectors/ReimbursementAccount.ts
@@ -1,7 +1,9 @@
 import type {OnyxEntry} from 'react-native-onyx';
 import type {ReimbursementAccount} from '@src/types/onyx';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 const reimbursementAccountErrorSelector = (reimbursementAccount: OnyxEntry<ReimbursementAccount>) => reimbursementAccount?.errors;
 
-// eslint-disable-next-line import/prefer-default-export
-export {reimbursementAccountErrorSelector};
+const hasReimbursementAccountErrorsSelector = (reimbursementAccount: OnyxEntry<ReimbursementAccount>) => !isEmptyObject(reimbursementAccount?.errors);
+
+export {reimbursementAccountErrorSelector, hasReimbursementAccountErrorsSelector};

--- a/tests/unit/PolicySelectorTest.ts
+++ b/tests/unit/PolicySelectorTest.ts
@@ -1,7 +1,14 @@
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {createAdminPoliciesSelector, createCopySettingsEligibleTargetsSelector, isAdminForPolicyByIDSelector, lastWorkspaceNumberSelector, policyNameSelector} from '@src/selectors/Policy';
+import {
+    createAdminPoliciesSelector,
+    createCopySettingsEligibleTargetsSelector,
+    createWorkspaceListPoliciesSelector,
+    isAdminForPolicyByIDSelector,
+    lastWorkspaceNumberSelector,
+    policyNameSelector,
+} from '@src/selectors/Policy';
 import type {Policy} from '@src/types/onyx';
 
 describe('lastWorkspaceNumberSelector', () => {
@@ -225,5 +232,162 @@ describe('createCopySettingsEligibleTargetsSelector', () => {
     it('returns empty arrays when policies is undefined', () => {
         const result = createCopySettingsEligibleTargetsSelector(adminLogin)(undefined);
         expect(result).toEqual({adminNonPersonal: [], corporateOnly: []});
+    });
+});
+
+describe('createWorkspaceListPoliciesSelector', () => {
+    const P = ONYXKEYS.COLLECTION.POLICY;
+    const userLogin = 'user@example.com';
+
+    const makePolicy = (overrides: Partial<Policy>): Policy =>
+        ({
+            id: 'p1',
+            name: 'Test Workspace',
+            role: CONST.POLICY.ROLE.ADMIN,
+            type: CONST.POLICY.TYPE.TEAM,
+            ownerAccountID: 1,
+            avatarURL: 'https://img/avatar.png',
+            pendingAction: undefined,
+            errors: undefined,
+            ...overrides,
+        }) as Policy;
+
+    it('returns an empty array when policies is undefined', () => {
+        expect(createWorkspaceListPoliciesSelector(userLogin)(undefined)).toEqual([]);
+    });
+
+    it('returns an empty array when no policies pass the shouldShowPolicy filter', () => {
+        const policies = {
+            [`${P}p1`]: makePolicy({type: CONST.POLICY.TYPE.PERSONAL}),
+        };
+        expect(createWorkspaceListPoliciesSelector(userLogin)(policies)).toEqual([]);
+    });
+
+    it('excludes policies where both role and employeeList entry are absent', () => {
+        const policies = {
+            [`${P}p1`]: makePolicy({role: undefined, employeeList: {}}),
+        };
+        expect(createWorkspaceListPoliciesSelector(userLogin)(policies)).toEqual([]);
+    });
+
+    it('includes a team policy where the user has an explicit role field', () => {
+        const policy = makePolicy({id: 'p1', role: CONST.POLICY.ROLE.ADMIN});
+        const result = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(result).toHaveLength(1);
+    });
+
+    it('projects only the expected fields onto each result item', () => {
+        const policy = makePolicy({
+            id: 'p1',
+            name: 'My WS',
+            type: CONST.POLICY.TYPE.CORPORATE,
+            role: CONST.POLICY.ROLE.ADMIN,
+            ownerAccountID: 42,
+            avatarURL: 'https://img/ws.png',
+            pendingAction: undefined,
+            errors: undefined,
+        });
+        const [item] = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(Object.keys(item ?? {})).toEqual([
+            'id',
+            'name',
+            'type',
+            'role',
+            'ownerAccountID',
+            'avatarURL',
+            'pendingAction',
+            'errors',
+            'isPendingDelete',
+            'isJoinRequestPending',
+            'nonMemberDetails',
+        ]);
+        expect(item?.id).toBe('p1');
+        expect(item?.name).toBe('My WS');
+        expect(item?.type).toBe(CONST.POLICY.TYPE.CORPORATE);
+        expect(item?.role).toBe(CONST.POLICY.ROLE.ADMIN);
+        expect(item?.ownerAccountID).toBe(42);
+        expect(item?.avatarURL).toBe('https://img/ws.png');
+    });
+
+    it('sets isPendingDelete=true for policies with a DELETE pendingAction', () => {
+        const policy = makePolicy({pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE});
+        const [item] = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(item?.isPendingDelete).toBe(true);
+    });
+
+    it('sets isPendingDelete=false for policies without a DELETE pendingAction', () => {
+        const policy = makePolicy({pendingAction: undefined});
+        const [item] = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(item?.isPendingDelete).toBe(false);
+    });
+
+    it('still includes a pending-delete policy because shouldShowPendingDeletePolicy is always true', () => {
+        const policy = makePolicy({pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE});
+        const result = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(result).toHaveLength(1);
+    });
+
+    it('sets isJoinRequestPending=false and omits nonMemberDetails when isJoinRequestPending is false', () => {
+        const policy = makePolicy({isJoinRequestPending: false});
+        const [item] = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(item?.isJoinRequestPending).toBe(false);
+        expect(item?.nonMemberDetails).toBeUndefined();
+    });
+
+    it('sets isJoinRequestPending=false when flag is true but policyDetailsForNonMembers is absent', () => {
+        const policy = makePolicy({isJoinRequestPending: true, policyDetailsForNonMembers: undefined});
+        const [item] = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(item?.isJoinRequestPending).toBe(false);
+        expect(item?.nonMemberDetails).toBeUndefined();
+    });
+
+    it('populates nonMemberDetails from the first policyDetailsForNonMembers entry when join request is pending', () => {
+        const policy = {
+            isJoinRequestPending: true,
+            policyDetailsForNonMembers: {
+                nonMemberPolicyID123: {
+                    name: 'External WS',
+                    type: CONST.POLICY.TYPE.CORPORATE,
+                    ownerAccountID: 99,
+                    avatar: 'https://img/ext.png',
+                },
+            },
+        } as unknown as Policy;
+        const result = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
+        expect(result).toHaveLength(1);
+        expect(result[0]?.isJoinRequestPending).toBe(true);
+        expect(result[0]?.nonMemberDetails).toEqual({
+            policyID: 'nonMemberPolicyID123',
+            name: 'External WS',
+            type: CONST.POLICY.TYPE.CORPORATE,
+            ownerAccountID: 99,
+            avatar: 'https://img/ext.png',
+        });
+    });
+
+    it('returns multiple policies sorted in insertion order', () => {
+        const policies = {
+            [`${P}p1`]: makePolicy({id: 'p1', name: 'Alpha'}),
+            [`${P}p2`]: makePolicy({id: 'p2', name: 'Beta'}),
+            [`${P}p3`]: makePolicy({id: 'p3', name: 'Gamma'}),
+        };
+        const result = createWorkspaceListPoliciesSelector(userLogin)(policies);
+        expect(result.map((p) => p.id)).toEqual(['p1', 'p2', 'p3']);
+    });
+
+    it('filters out null values in the policy collection', () => {
+        const policies = {
+            [`${P}p1`]: null,
+            [`${P}p2`]: makePolicy({id: 'p2'}),
+        } as unknown as Record<string, Policy>;
+        const result = createWorkspaceListPoliciesSelector(userLogin)(policies);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.id).toBe('p2');
+    });
+
+    it('handles undefined currentUserLogin by still including policies that have a role field', () => {
+        const policy = makePolicy({role: CONST.POLICY.ROLE.ADMIN});
+        const result = createWorkspaceListPoliciesSelector(undefined)({[`${P}p1`]: policy});
+        expect(result).toHaveLength(1);
     });
 });

--- a/tests/unit/PolicySelectorTest.ts
+++ b/tests/unit/PolicySelectorTest.ts
@@ -11,6 +11,9 @@ import {
 } from '@src/selectors/Policy';
 import type {Policy} from '@src/types/onyx';
 
+// Centralizes the single unsafe cast needed to build partial Policy fixtures for these selector tests.
+const buildPolicy = (policy: Partial<Policy>): Policy => policy as Policy;
+
 describe('lastWorkspaceNumberSelector', () => {
     const email = 'jdoe@expensify.com';
     const displayName = 'Expensify';
@@ -28,7 +31,7 @@ describe('lastWorkspaceNumberSelector', () => {
 
     it('should return 0 when there is a matching workspace without a number', () => {
         const policies = {
-            [`${ONYXKEYS.COLLECTION.POLICY}1`]: {name: workspaceName} as Policy,
+            [`${ONYXKEYS.COLLECTION.POLICY}1`]: buildPolicy({name: workspaceName}),
         };
         expect(lastWorkspaceNumberSelector(policies, email)).toBe(0);
     });
@@ -42,10 +45,10 @@ describe('lastWorkspaceNumberSelector', () => {
 
     it('should return the maximum number when there are multiple matching workspaces', () => {
         const policies = {
-            [`${ONYXKEYS.COLLECTION.POLICY}1`]: {name: workspaceName} as Policy,
+            [`${ONYXKEYS.COLLECTION.POLICY}1`]: buildPolicy({name: workspaceName}),
             [`${ONYXKEYS.COLLECTION.POLICY}2`]: {name: `${workspaceName} 2`} as Policy,
             [`${ONYXKEYS.COLLECTION.POLICY}3`]: {name: `${workspaceName} 5`} as Policy,
-            [`${ONYXKEYS.COLLECTION.POLICY}4`]: {name: 'Other Workspace'} as Policy,
+            [`${ONYXKEYS.COLLECTION.POLICY}4`]: buildPolicy({name: 'Other Workspace'}),
         };
         expect(lastWorkspaceNumberSelector(policies, email)).toBe(5);
     });
@@ -54,7 +57,7 @@ describe('lastWorkspaceNumberSelector', () => {
         const smsEmail = `+15555555555${CONST.SMS.DOMAIN}`;
         const smsDisplayName = 'My Group Workspace';
         const policies = {
-            [`${ONYXKEYS.COLLECTION.POLICY}1`]: {name: smsDisplayName} as Policy,
+            [`${ONYXKEYS.COLLECTION.POLICY}1`]: buildPolicy({name: smsDisplayName}),
             [`${ONYXKEYS.COLLECTION.POLICY}2`]: {name: `${smsDisplayName} 3`} as Policy,
         };
         expect(lastWorkspaceNumberSelector(policies, smsEmail)).toBe(3);
@@ -62,7 +65,7 @@ describe('lastWorkspaceNumberSelector', () => {
 
     it('should ignore case when matching workspace names', () => {
         const policies = {
-            [`${ONYXKEYS.COLLECTION.POLICY}1`]: {name: workspaceName.toLowerCase()} as Policy,
+            [`${ONYXKEYS.COLLECTION.POLICY}1`]: buildPolicy({name: workspaceName.toLowerCase()}),
             [`${ONYXKEYS.COLLECTION.POLICY}2`]: {name: `${workspaceName.toUpperCase()} 4`} as Policy,
         };
         expect(lastWorkspaceNumberSelector(policies, email)).toBe(4);
@@ -71,7 +74,7 @@ describe('lastWorkspaceNumberSelector', () => {
 
 describe('policyNameSelector', () => {
     it('should return the policy name', () => {
-        expect(policyNameSelector({name: 'My Workspace'} as Policy)).toBe('My Workspace');
+        expect(policyNameSelector(buildPolicy({name: 'My Workspace'}))).toBe('My Workspace');
     });
 
     it('should return undefined for undefined policy', () => {
@@ -79,16 +82,16 @@ describe('policyNameSelector', () => {
     });
 
     it('should return undefined when policy has no name', () => {
-        expect(policyNameSelector({} as Policy)).toBeUndefined();
+        expect(policyNameSelector(buildPolicy({}))).toBeUndefined();
     });
 });
 
 describe('createAdminPoliciesSelector', () => {
     const P = ONYXKEYS.COLLECTION.POLICY;
 
-    const adminPolicy = {id: '1', name: 'Admin WS', role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.TEAM, avatarURL: 'https://img/1', created: '2024-01-01'} as Policy;
-    const memberPolicy = {id: '2', name: 'Member WS', role: CONST.POLICY.ROLE.USER, type: CONST.POLICY.TYPE.TEAM} as Policy;
-    const personalPolicy = {id: '3', name: 'Personal', role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.PERSONAL} as Policy;
+    const adminPolicy = buildPolicy({id: '1', name: 'Admin WS', role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.TEAM, avatarURL: 'https://img/1', created: '2024-01-01'});
+    const memberPolicy = buildPolicy({id: '2', name: 'Member WS', role: CONST.POLICY.ROLE.USER, type: CONST.POLICY.TYPE.TEAM});
+    const personalPolicy = buildPolicy({id: '3', name: 'Personal', role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.PERSONAL});
     const allPolicies = {
         [`${P}1`]: adminPolicy,
         [`${P}2`]: memberPolicy,
@@ -117,8 +120,8 @@ describe('createAdminPoliciesSelector', () => {
 
     it('should skip policies without id or name', () => {
         const policies = {
-            [`${P}4`]: {role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.TEAM} as Policy,
-            [`${P}5`]: {id: '5', role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.TEAM} as Policy,
+            [`${P}4`]: buildPolicy({role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.TEAM}),
+            [`${P}5`]: buildPolicy({id: '5', role: CONST.POLICY.ROLE.ADMIN, type: CONST.POLICY.TYPE.TEAM}),
         };
         expect(createAdminPoliciesSelector(undefined)(policies)).toEqual({});
     });
@@ -139,7 +142,7 @@ describe('isAdminForPolicyByIDSelector', () => {
     });
 
     it('returns true when policyID is empty string', () => {
-        expect(isAdminForPolicyByIDSelector('')({[`${P}p1`]: {role: CONST.POLICY.ROLE.USER} as Policy})).toBe(true);
+        expect(isAdminForPolicyByIDSelector('')({[`${P}p1`]: buildPolicy({role: CONST.POLICY.ROLE.USER})})).toBe(true);
     });
 
     it('returns false when policies is null and policyID is provided', () => {
@@ -147,17 +150,17 @@ describe('isAdminForPolicyByIDSelector', () => {
     });
 
     it('returns false when the policy is not found in the collection', () => {
-        const policies = {[`${P}p2`]: {role: CONST.POLICY.ROLE.ADMIN} as Policy};
+        const policies = {[`${P}p2`]: buildPolicy({role: CONST.POLICY.ROLE.ADMIN})};
         expect(isAdminForPolicyByIDSelector('p1')(policies)).toBe(false);
     });
 
     it('returns false when policy exists but role is not admin', () => {
-        const policies = {[`${P}p1`]: {role: CONST.POLICY.ROLE.USER} as Policy};
+        const policies = {[`${P}p1`]: buildPolicy({role: CONST.POLICY.ROLE.USER})};
         expect(isAdminForPolicyByIDSelector('p1')(policies)).toBe(false);
     });
 
     it('returns true when policy exists and role is admin', () => {
-        const policies = {[`${P}p1`]: {role: CONST.POLICY.ROLE.ADMIN} as Policy};
+        const policies = {[`${P}p1`]: buildPolicy({role: CONST.POLICY.ROLE.ADMIN})};
         expect(isAdminForPolicyByIDSelector('p1')(policies)).toBe(true);
     });
 });
@@ -355,8 +358,8 @@ describe('createWorkspaceListPoliciesSelector', () => {
         } as unknown as Policy;
         const result = createWorkspaceListPoliciesSelector(userLogin)({[`${P}p1`]: policy});
         expect(result).toHaveLength(1);
-        expect(result[0]?.isJoinRequestPending).toBe(true);
-        expect(result[0]?.nonMemberDetails).toEqual({
+        expect(result.at(0)?.isJoinRequestPending).toBe(true);
+        expect(result.at(0)?.nonMemberDetails).toEqual({
             policyID: 'nonMemberPolicyID123',
             name: 'External WS',
             type: CONST.POLICY.TYPE.CORPORATE,
@@ -382,7 +385,7 @@ describe('createWorkspaceListPoliciesSelector', () => {
         } as unknown as Record<string, Policy>;
         const result = createWorkspaceListPoliciesSelector(userLogin)(policies);
         expect(result).toHaveLength(1);
-        expect(result[0]?.id).toBe('p2');
+        expect(result.at(0)?.id).toBe('p2');
     });
 
     it('handles undefined currentUserLogin by still including policies that have a role field', () => {

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -43,6 +43,7 @@ import {
     hasPolicyRulesError,
     hasPolicyWithXeroConnection,
     hasVendorFeature,
+    isMergeHRCompleteSetupNeededSelector,
     isPolicyMemberWithoutPendingDelete,
     isSubmitterApproveBlockedOnSubmitWorkspace,
     shouldShowPolicy,
@@ -3386,6 +3387,54 @@ describe('PolicyUtils', () => {
         it('returns only Expensify emails when the employee list is undefined', () => {
             const result = getExcludedUsers(undefined);
             expect(Object.keys(result)).toEqual([...CONST.EXPENSIFY_EMAILS]);
+        });
+    });
+
+    describe('isMergeHRCompleteSetupNeededSelector', () => {
+        const mergeHRBase = {
+            lastSync: {syncStatus: CONST.MERGE_HR.SYNC_STATUS.DONE, errorMessage: undefined, errorFields: undefined},
+            data: {groups: [{id: 'g1', name: 'Engineering', employeeCount: 5}]},
+        };
+
+        it('returns false when policy is undefined', () => {
+            expect(isMergeHRCompleteSetupNeededSelector(undefined)).toBe(false);
+        });
+
+        it('returns false when policy has no merge_hris connection', () => {
+            const policy = createRandomPolicy(1);
+            expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(false);
+        });
+
+        it('returns false when sync is not done', () => {
+            const policy = {
+                ...createRandomPolicy(2),
+                connections: {merge_hris: {...mergeHRBase, lastSync: {syncStatus: CONST.MERGE_HR.SYNC_STATUS.SYNCING, errorMessage: undefined, errorFields: undefined}}},
+            } as unknown as Policy;
+            expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(false);
+        });
+
+        it('returns false when sync is done but there are no groups', () => {
+            const policy = {
+                ...createRandomPolicy(3),
+                connections: {merge_hris: {...mergeHRBase, data: {groups: []}}},
+            } as unknown as Policy;
+            expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(false);
+        });
+
+        it('returns false when setup is already complete (groups configured)', () => {
+            const policy = {
+                ...createRandomPolicy(4),
+                connections: {merge_hris: {...mergeHRBase, config: {groups: [{id: 'g1'}]}}},
+            } as unknown as Policy;
+            expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(false);
+        });
+
+        it('returns true when sync is done, groups exist, and setup is not yet complete', () => {
+            const policy = {
+                ...createRandomPolicy(5),
+                connections: {merge_hris: mergeHRBase},
+            } as unknown as Policy;
+            expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(true);
         });
     });
 });

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -3391,9 +3391,17 @@ describe('PolicyUtils', () => {
     });
 
     describe('isMergeHRCompleteSetupNeededSelector', () => {
+        // Only the fields read by the selector are modeled here; `Object.assign` attaches the connection
+        // to a real policy without an unsafe cast.
+        type MergeHRTestConnection = {
+            lastSync?: {syncStatus?: string};
+            data?: {groups?: unknown[]};
+            config?: {groups?: unknown[] | null};
+        };
+        const buildMergeHRPolicy = (seed: number, mergeHR: MergeHRTestConnection): Policy => Object.assign(createRandomPolicy(seed), {connections: {merge_hris: mergeHR}});
         const mergeHRBase = {
-            lastSync: {syncStatus: CONST.MERGE_HR.SYNC_STATUS.DONE, errorMessage: undefined, errorFields: undefined},
-            data: {groups: [{id: 'g1', name: 'Engineering', employeeCount: 5}]},
+            lastSync: {syncStatus: CONST.MERGE_HR.SYNC_STATUS.DONE},
+            data: {groups: [{id: 'g1', name: 'Engineering'}]},
         };
 
         it('returns false when policy is undefined', () => {
@@ -3406,34 +3414,22 @@ describe('PolicyUtils', () => {
         });
 
         it('returns false when sync is not done', () => {
-            const policy = {
-                ...createRandomPolicy(2),
-                connections: {merge_hris: {...mergeHRBase, lastSync: {syncStatus: CONST.MERGE_HR.SYNC_STATUS.SYNCING, errorMessage: undefined, errorFields: undefined}}},
-            } as unknown as Policy;
+            const policy = buildMergeHRPolicy(2, {...mergeHRBase, lastSync: {syncStatus: CONST.MERGE_HR.SYNC_STATUS.SYNCING}});
             expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(false);
         });
 
         it('returns false when sync is done but there are no groups', () => {
-            const policy = {
-                ...createRandomPolicy(3),
-                connections: {merge_hris: {...mergeHRBase, data: {groups: []}}},
-            } as unknown as Policy;
+            const policy = buildMergeHRPolicy(3, {...mergeHRBase, data: {groups: []}});
             expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(false);
         });
 
         it('returns false when setup is already complete (groups configured)', () => {
-            const policy = {
-                ...createRandomPolicy(4),
-                connections: {merge_hris: {...mergeHRBase, config: {groups: [{id: 'g1'}]}}},
-            } as unknown as Policy;
+            const policy = buildMergeHRPolicy(4, {...mergeHRBase, config: {groups: ['g1']}});
             expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(false);
         });
 
         it('returns true when sync is done, groups exist, and setup is not yet complete', () => {
-            const policy = {
-                ...createRandomPolicy(5),
-                connections: {merge_hris: mergeHRBase},
-            } as unknown as Policy;
+            const policy = buildMergeHRPolicy(5, mergeHRBase);
             expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(true);
         });
     });


### PR DESCRIPTION
### Explanation of Change
Performance refactor of the Workspaces list page. The page now subscribes to a light, flat policy projection (`createWorkspaceListPoliciesSelector`) instead of the full policy collection, so deep/frequent policy writes (isLoading flags, employeeList, connections) no longer re-render the page. The per-row error dot moves into a new `WorkspaceRowBrickRoadIndicator` that subscribes narrowly to its own error sources.

The transition flow from the Overview screen to Workflows with the workspace list rendered in the background before and after composition of WorkspacesListPage:

<img width="1872" height="862" alt="image" src="https://github.com/user-attachments/assets/2a38e64e-f32d-410f-8264-f5ad9f488043" />

If we analyze the statistics of specific components, we can see that WorkspacesListPage was not re-rendering.

<img width="1884" height="897" alt="Screenshot 2026-06-15 at 12 14 14" src="https://github.com/user-attachments/assets/61c92ae6-5a78-4bea-9aac-5fd5b762ccc6" />

### Fixed Issues
$ https://github.com/Expensify/App/issues/91175
PROPOSAL:

### Tests
1. Log in with an account that owns/admins several workspaces.
2. Navigate to Settings → Workspaces.
3. Verify the list renders all workspaces with correct name, type, owner avatar/name, and default workspace indicator.
4. For a workspace that has a setup/connection/employee-list/reimbursement error, verify a red brick-road dot appears next to its three-dot menu; for a workspace needing HR merge setup verify a green/info dot appears.
5. Verify the dot only shows for workspaces where you are an admin.
6. Trigger an error on a single workspace (e.g. open and break a connection) and verify only that row's indicator updates — the rest of the list does not flicker/re-render.
7. With a pending join request workspace, verify the row shows the "pending" badge, is disabled, and shows the correct owner details.
8. Verify that no errors appear in the JS console.

### Offline tests
1. Go offline.
2. Navigate to Settings → Workspaces.
3. Verify the list still renders from cached Onyx data, including brick-road error indicators.
4. Delete a workspace while offline and verify the row shows the offline pending (greyed) state.
5. Go back online and verify the list reconciles correctly.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
