### PR TITLE
Fix "Go to room" option briefly changing to "Go to workspace" in room details RHP

### DIFF
--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -1,7 +1,7 @@
-import {StackActions} from '@react-navigation/native';
+import {StackActions, useFocusEffect} from '@react-navigation/native';
 import {delegateEmailSelector} from '@selectors/Account';
 import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
-import React, {useCallback, useEffect, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import {InteractionManager, View} from 'react-native';
@@ -43,13 +43,10 @@ import usePreferredPolicy from '@hooks/usePreferredPolicy';
 import useReportAttributes from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
-import useRootNavigationState from '@hooks/useRootNavigationState';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getBase62ReportID from '@libs/getBase62ReportID';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
-import findAllMatchingDynamicSuffixes from '@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
-import getPathWithoutDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix';
 import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -162,20 +159,6 @@ const CASES = {
 };
 
 type CaseID = ValueOf<typeof CASES>;
-
-function normalizeBasePath(path: string): string {
-    return path.replace(/^\/+/, '').replace(/\?.*$/, '').replace(/\/+$/, '');
-}
-
-/** Whether the Details page sits directly on top of its own room report, derived from the page's own route.path. */
-function isReportDetailsOnTopOfRoom(routePath: string, reportID: string | undefined): boolean {
-    const pathWithoutLeadingSlash = routePath.replace(/^\/+/, '');
-    const suffixMatch = findAllMatchingDynamicSuffixes(pathWithoutLeadingSlash).find((match) => match.pattern === DYNAMIC_ROUTES.REPORT_DETAILS.path);
-    const basePath = suffixMatch ? getPathWithoutDynamicSuffix(pathWithoutLeadingSlash, suffixMatch.actualSuffix, suffixMatch.pattern) : pathWithoutLeadingSlash;
-    const normalizedBasePath = normalizeBasePath(basePath);
-    const roomBasePath = normalizeBasePath(ROUTES.REPORT_WITH_ID.getRoute(reportID));
-    return normalizedBasePath === roomBasePath || normalizedBasePath.startsWith(`${roomBasePath}/`);
-}
 
 function DynamicReportDetailsPage({policy, report, route, reportMetadata, reportLoadingState}: DynamicReportDetailsPageProps) {
     const {translate, formatPhoneNumber} = useLocalize();
@@ -399,10 +382,12 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
 
     const shouldShowLeaveButton = canLeaveChat(report, policy, currentUserPersonalDetails?.accountID, !!reportNameValuePairs?.private_isArchived);
 
-    // Show "Go to room" only when the Details page is not on top of the room itself. Prefer the page's own route.path
-    // (stable across the RHP close and revisits); fall back to a live topmost-report check when the path is missing.
-    const liveIsRoomCurrentlyOpen = useRootNavigationState(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
-    const isRoomCurrentlyOpen = route.path ? isReportDetailsOnTopOfRoom(route.path, report?.reportID) : liveIsRoomCurrentlyOpen;
+    // Snapshot on focus whether the room is the screen behind the Details page, so the row doesn't flip while the page
+    // is closing after it's tapped, yet still reflects the correct screen on later visits.
+    const [isRoomCurrentlyOpen, setIsRoomCurrentlyOpen] = useState(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
+    useFocusEffect(() => {
+        setIsRoomCurrentlyOpen(isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
+    });
     const shouldShowGoToRoom = (isChatRoom || isPolicyExpenseChat) && !isRoomCurrentlyOpen;
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending && !shouldShowGoToRoom;
 

--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -33,7 +33,6 @@ import useDuplicateTransactionsAndViolations from '@hooks/useDuplicateTransactio
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
 import useGetIOUReportFromReportAction from '@hooks/useGetIOUReportFromReportAction';
 import useHasOutstandingChildTask from '@hooks/useHasOutstandingChildTask';
-import useInitialValue from '@hooks/useInitialValue';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
@@ -44,10 +43,13 @@ import usePreferredPolicy from '@hooks/usePreferredPolicy';
 import useReportAttributes from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useRootNavigationState from '@hooks/useRootNavigationState';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getBase62ReportID from '@libs/getBase62ReportID';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
+import findAllMatchingDynamicSuffixes from '@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
+import getPathWithoutDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix';
 import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -160,6 +162,20 @@ const CASES = {
 };
 
 type CaseID = ValueOf<typeof CASES>;
+
+function normalizeBasePath(path: string): string {
+    return path.replace(/^\/+/, '').replace(/\?.*$/, '').replace(/\/+$/, '');
+}
+
+/** Whether the Details page sits directly on top of its own room report, derived from the page's own route.path. */
+function isReportDetailsOnTopOfRoom(routePath: string, reportID: string | undefined): boolean {
+    const pathWithoutLeadingSlash = routePath.replace(/^\/+/, '');
+    const suffixMatch = findAllMatchingDynamicSuffixes(pathWithoutLeadingSlash).find((match) => match.pattern === DYNAMIC_ROUTES.REPORT_DETAILS.path);
+    const basePath = suffixMatch ? getPathWithoutDynamicSuffix(pathWithoutLeadingSlash, suffixMatch.actualSuffix, suffixMatch.pattern) : pathWithoutLeadingSlash;
+    const normalizedBasePath = normalizeBasePath(basePath);
+    const roomBasePath = normalizeBasePath(ROUTES.REPORT_WITH_ID.getRoute(reportID));
+    return normalizedBasePath === roomBasePath || normalizedBasePath.startsWith(`${roomBasePath}/`);
+}
 
 function DynamicReportDetailsPage({policy, report, route, reportMetadata, reportLoadingState}: DynamicReportDetailsPageProps) {
     const {translate, formatPhoneNumber} = useLocalize();
@@ -383,9 +399,10 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
 
     const shouldShowLeaveButton = canLeaveChat(report, policy, currentUserPersonalDetails?.accountID, !!reportNameValuePairs?.private_isArchived);
 
-    // Only show the "Go to room" row when the Details page was opened from a screen other than the room report itself (e.g. the Workspace rooms list).
-    // The check is evaluated once when the page is opened, so the menu doesn't change while the page is closing after "Go to room" makes the room the topmost report.
-    const isRoomCurrentlyOpen = useInitialValue(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
+    // Show "Go to room" only when the Details page is not on top of the room itself. Prefer the page's own route.path
+    // (stable across the RHP close and revisits); fall back to a live topmost-report check when the path is missing.
+    const liveIsRoomCurrentlyOpen = useRootNavigationState(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
+    const isRoomCurrentlyOpen = route.path ? isReportDetailsOnTopOfRoom(route.path, report?.reportID) : liveIsRoomCurrentlyOpen;
     const shouldShowGoToRoom = (isChatRoom || isPolicyExpenseChat) && !isRoomCurrentlyOpen;
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending && !shouldShowGoToRoom;
 

--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -1,7 +1,7 @@
 import {StackActions} from '@react-navigation/native';
 import {delegateEmailSelector} from '@selectors/Account';
 import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
-import React, {useCallback, useEffect, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import {InteractionManager, View} from 'react-native';
@@ -383,7 +383,8 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
     const shouldShowLeaveButton = canLeaveChat(report, policy, currentUserPersonalDetails?.accountID, !!reportNameValuePairs?.private_isArchived);
 
     // Only show the "Go to room" row when the Details page was opened from a screen other than the room report itself (e.g. the Workspace rooms list).
-    const isRoomCurrentlyOpen = isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID;
+    // The check is evaluated once when the page is opened, so the menu doesn't change while the page is closing after "Go to room" makes the room the topmost report.
+    const [isRoomCurrentlyOpen] = useState(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
     const shouldShowGoToRoom = (isChatRoom || isPolicyExpenseChat) && !isRoomCurrentlyOpen;
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending && !shouldShowGoToRoom;
 

--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -1,7 +1,7 @@
 import {StackActions} from '@react-navigation/native';
 import {delegateEmailSelector} from '@selectors/Account';
 import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import {InteractionManager, View} from 'react-native';
@@ -33,6 +33,7 @@ import useDuplicateTransactionsAndViolations from '@hooks/useDuplicateTransactio
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
 import useGetIOUReportFromReportAction from '@hooks/useGetIOUReportFromReportAction';
 import useHasOutstandingChildTask from '@hooks/useHasOutstandingChildTask';
+import useInitialValue from '@hooks/useInitialValue';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
@@ -384,7 +385,7 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
 
     // Only show the "Go to room" row when the Details page was opened from a screen other than the room report itself (e.g. the Workspace rooms list).
     // The check is evaluated once when the page is opened, so the menu doesn't change while the page is closing after "Go to room" makes the room the topmost report.
-    const [isRoomCurrentlyOpen] = useState(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
+    const isRoomCurrentlyOpen = useInitialValue(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
     const shouldShowGoToRoom = (isChatRoom || isPolicyExpenseChat) && !isRoomCurrentlyOpen;
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending && !shouldShowGoToRoom;
 

--- a/tests/ui/DynamicReportDetailsPageTest.tsx
+++ b/tests/ui/DynamicReportDetailsPageTest.tsx
@@ -25,6 +25,7 @@ jest.mock('@react-navigation/native', () => {
     return {
         ...actualNav,
         useIsFocused: jest.fn(),
+        useFocusEffect: jest.fn(),
         useRoute: jest.fn(),
         usePreventRemove: jest.fn(),
     };
@@ -34,8 +35,7 @@ jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator');
 const mockIsReportTopmostSplitNavigator = jest.mocked(isReportTopmostSplitNavigator);
 
 const navigationMock = {} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['navigation'];
-const getRouteMock = (reportID: string, path?: string) =>
-    ({params: {reportID}, path}) as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route'];
+const getRouteMock = (reportID: string) => ({params: {reportID}}) as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route'];
 
 describe('DynamicReportDetailsPage', () => {
     beforeAll(() => {
@@ -142,7 +142,7 @@ describe('DynamicReportDetailsPage', () => {
         const roomReportID = '10';
         const policyRoom: Report = createRandomReport(Number(roomReportID), CONST.REPORT.CHAT_TYPE.POLICY_ROOM);
 
-        const renderDetailsPage = (routePath?: string) =>
+        const renderDetailsPage = () =>
             render(
                 <OnyxListItemProvider>
                     <LocaleContextProvider>
@@ -154,7 +154,7 @@ describe('DynamicReportDetailsPage', () => {
                             report={policyRoom}
                             reportMetadata={undefined}
                             reportLoadingState={undefined}
-                            route={getRouteMock(roomReportID, routePath)}
+                            route={getRouteMock(roomReportID)}
                         />
                     </LocaleContextProvider>
                 </OnyxListItemProvider>,
@@ -164,40 +164,7 @@ describe('DynamicReportDetailsPage', () => {
             jest.restoreAllMocks();
         });
 
-        it('keeps showing "Go to room" derived from the page route even when the room is the topmost report (revisit flow)', async () => {
-            // The page was opened from the Workspace rooms list (route.path base is the rooms list, not the room).
-            // Simulate the reviewer's revisit flow where the GLOBAL topmost report has since become the room itself:
-            // the option must stay derived from the page's own route, not the now-stale global navigation state.
-            mockIsReportTopmostSplitNavigator.mockReturnValue(true);
-            jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(roomReportID);
-            await act(async () => {
-                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
-            });
-
-            renderDetailsPage(`workspaces/1/rooms/details?reportID=${roomReportID}`);
-            await waitForBatchedUpdatesWithAct();
-
-            expect(await screen.findByText(translateLocal('reportDetailsPage.goToRoom'))).toBeVisible();
-        });
-
-        it('does not show "Go to room" when the page route sits on top of its own room', async () => {
-            // route.path base is the room report itself, so "Go to room" is hidden regardless of the global nav state.
-            mockIsReportTopmostSplitNavigator.mockReturnValue(false);
-            jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(undefined);
-            await act(async () => {
-                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
-            });
-
-            renderDetailsPage(`r/${roomReportID}/details`);
-            await waitForBatchedUpdatesWithAct();
-
-            expect(screen.queryByText(translateLocal('reportDetailsPage.goToRoom'))).toBeNull();
-        });
-
-        it('shows "Go to room" for a path-less instance when the room is not the topmost report', async () => {
-            // A details RHP recreated by back navigation has no route.path, so the visibility falls back to the live
-            // topmost-report check. At the settled state of the reviewer's revisit flow the room is no longer the topmost
-            // report, so "Go to room" must be shown — this is the case the previous mount-time frozen check got wrong.
+        it('shows "Go to room" when the room is not the screen behind the Details page', async () => {
             mockIsReportTopmostSplitNavigator.mockReturnValue(false);
             jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(undefined);
             await act(async () => {
@@ -210,7 +177,7 @@ describe('DynamicReportDetailsPage', () => {
             expect(await screen.findByText(translateLocal('reportDetailsPage.goToRoom'))).toBeVisible();
         });
 
-        it('does not show "Go to room" for a path-less instance when the room is the topmost report', async () => {
+        it('does not show "Go to room" when the Details page is on top of its own room', async () => {
             mockIsReportTopmostSplitNavigator.mockReturnValue(true);
             jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(roomReportID);
             await act(async () => {

--- a/tests/ui/DynamicReportDetailsPageTest.tsx
+++ b/tests/ui/DynamicReportDetailsPageTest.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import Onyx from 'react-native-onyx';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
-import type Navigation from '@libs/Navigation/Navigation';
+import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
+import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {ReportDetailsNavigatorParamList} from '@libs/Navigation/types';
 import DynamicReportDetailsPage from '@pages/DynamicReportDetailsPage';
@@ -28,6 +29,12 @@ jest.mock('@react-navigation/native', () => {
         usePreventRemove: jest.fn(),
     };
 });
+
+jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator');
+const mockIsReportTopmostSplitNavigator = jest.mocked(isReportTopmostSplitNavigator);
+
+const navigationMock = {} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['navigation'];
+const getRouteMock = (reportID: string) => ({params: {reportID}}) as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route'];
 
 describe('DynamicReportDetailsPage', () => {
     beforeAll(() => {
@@ -77,12 +84,12 @@ describe('DynamicReportDetailsPage', () => {
                     <DynamicReportDetailsPage
                         betas={[]}
                         isLoadingReportData={false}
-                        navigation={{} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['navigation']}
+                        navigation={navigationMock}
                         policy={undefined}
                         report={trackExpenseReport}
                         reportMetadata={undefined}
                         reportLoadingState={undefined}
-                        route={{params: {reportID: trackExpenseReportID}} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route']}
+                        route={getRouteMock(trackExpenseReportID)}
                     />
                 </LocaleContextProvider>
             </OnyxListItemProvider>,
@@ -112,12 +119,12 @@ describe('DynamicReportDetailsPage', () => {
                     <DynamicReportDetailsPage
                         betas={[]}
                         isLoadingReportData={false}
-                        navigation={{} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['navigation']}
+                        navigation={navigationMock}
                         policy={undefined}
                         report={movedTrackExpenseReport}
                         reportMetadata={undefined}
                         reportLoadingState={undefined}
-                        route={{params: {reportID: trackExpenseReportID}} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route']}
+                        route={getRouteMock(trackExpenseReportID)}
                     />
                 </LocaleContextProvider>
             </OnyxListItemProvider>,
@@ -128,5 +135,71 @@ describe('DynamicReportDetailsPage', () => {
         // Categorize and share are temporarily disabled
         // expect(screen.queryByText(categorizeText)).not.toBeVisible();
         // expect(screen.queryByText(shareText)).not.toBeVisible();
+    });
+
+    describe('"Go to room" option visibility', () => {
+        const roomReportID = '10';
+        const policyRoom: Report = createRandomReport(Number(roomReportID), CONST.REPORT.CHAT_TYPE.POLICY_ROOM);
+        const detailsPage = (
+            <OnyxListItemProvider>
+                <LocaleContextProvider>
+                    <DynamicReportDetailsPage
+                        betas={[]}
+                        isLoadingReportData={false}
+                        navigation={navigationMock}
+                        policy={undefined}
+                        report={policyRoom}
+                        reportMetadata={undefined}
+                        reportLoadingState={undefined}
+                        route={getRouteMock(roomReportID)}
+                    />
+                </LocaleContextProvider>
+            </OnyxListItemProvider>
+        );
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('keeps showing "Go to room" while the RHP closes after the room becomes the topmost report', async () => {
+            // The Details page is opened from a screen other than the room itself (e.g. the Workspace rooms list),
+            // so the room is not the topmost report when the page mounts.
+            mockIsReportTopmostSplitNavigator.mockReturnValue(false);
+            jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(roomReportID);
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
+            });
+
+            render(detailsPage);
+            await waitForBatchedUpdatesWithAct();
+
+            const goToRoomText = translateLocal('reportDetailsPage.goToRoom');
+            expect(await screen.findByText(goToRoomText)).toBeVisible();
+
+            // Tapping "Go to room" makes the room the topmost report, and the page re-renders while the RHP is still
+            // animating closed (here driven by an Onyx update to the report, as navigation state changes would in-app).
+            mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, {lastReadTime: '2024-01-01 00:00:00.000'});
+            });
+            await waitForBatchedUpdatesWithAct();
+
+            // The check is frozen at its mount-time value, so the option must not flip to "Go to workspace".
+            expect(screen.queryByText(goToRoomText)).toBeVisible();
+        });
+
+        it('does not show "Go to room" when the Details page is opened from the room itself', async () => {
+            // The room is already the topmost report when the page mounts (Details opened from the room conversation).
+            mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+            jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(roomReportID);
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
+            });
+
+            render(detailsPage);
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.queryByText(translateLocal('reportDetailsPage.goToRoom'))).toBeNull();
+        });
     });
 });

--- a/tests/ui/DynamicReportDetailsPageTest.tsx
+++ b/tests/ui/DynamicReportDetailsPageTest.tsx
@@ -34,7 +34,8 @@ jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator');
 const mockIsReportTopmostSplitNavigator = jest.mocked(isReportTopmostSplitNavigator);
 
 const navigationMock = {} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['navigation'];
-const getRouteMock = (reportID: string) => ({params: {reportID}}) as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route'];
+const getRouteMock = (reportID: string, path?: string) =>
+    ({params: {reportID}, path}) as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route'];
 
 describe('DynamicReportDetailsPage', () => {
     beforeAll(() => {
@@ -140,63 +141,83 @@ describe('DynamicReportDetailsPage', () => {
     describe('"Go to room" option visibility', () => {
         const roomReportID = '10';
         const policyRoom: Report = createRandomReport(Number(roomReportID), CONST.REPORT.CHAT_TYPE.POLICY_ROOM);
-        const detailsPage = (
-            <OnyxListItemProvider>
-                <LocaleContextProvider>
-                    <DynamicReportDetailsPage
-                        betas={[]}
-                        isLoadingReportData={false}
-                        navigation={navigationMock}
-                        policy={undefined}
-                        report={policyRoom}
-                        reportMetadata={undefined}
-                        reportLoadingState={undefined}
-                        route={getRouteMock(roomReportID)}
-                    />
-                </LocaleContextProvider>
-            </OnyxListItemProvider>
-        );
+
+        const renderDetailsPage = (routePath?: string) =>
+            render(
+                <OnyxListItemProvider>
+                    <LocaleContextProvider>
+                        <DynamicReportDetailsPage
+                            betas={[]}
+                            isLoadingReportData={false}
+                            navigation={navigationMock}
+                            policy={undefined}
+                            report={policyRoom}
+                            reportMetadata={undefined}
+                            reportLoadingState={undefined}
+                            route={getRouteMock(roomReportID, routePath)}
+                        />
+                    </LocaleContextProvider>
+                </OnyxListItemProvider>,
+            );
 
         afterEach(() => {
             jest.restoreAllMocks();
         });
 
-        it('keeps showing "Go to room" while the RHP closes after the room becomes the topmost report', async () => {
-            // The Details page is opened from a screen other than the room itself (e.g. the Workspace rooms list),
-            // so the room is not the topmost report when the page mounts.
-            mockIsReportTopmostSplitNavigator.mockReturnValue(false);
+        it('keeps showing "Go to room" derived from the page route even when the room is the topmost report (revisit flow)', async () => {
+            // The page was opened from the Workspace rooms list (route.path base is the rooms list, not the room).
+            // Simulate the reviewer's revisit flow where the GLOBAL topmost report has since become the room itself:
+            // the option must stay derived from the page's own route, not the now-stale global navigation state.
+            mockIsReportTopmostSplitNavigator.mockReturnValue(true);
             jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(roomReportID);
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
             });
 
-            render(detailsPage);
+            renderDetailsPage(`workspaces/1/rooms/details?reportID=${roomReportID}`);
             await waitForBatchedUpdatesWithAct();
 
-            const goToRoomText = translateLocal('reportDetailsPage.goToRoom');
-            expect(await screen.findByText(goToRoomText)).toBeVisible();
-
-            // Tapping "Go to room" makes the room the topmost report, and the page re-renders while the RHP is still
-            // animating closed (here driven by an Onyx update to the report, as navigation state changes would in-app).
-            mockIsReportTopmostSplitNavigator.mockReturnValue(true);
-            await act(async () => {
-                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, {lastReadTime: '2024-01-01 00:00:00.000'});
-            });
-            await waitForBatchedUpdatesWithAct();
-
-            // The check is frozen at its mount-time value, so the option must not flip to "Go to workspace".
-            expect(screen.queryByText(goToRoomText)).toBeVisible();
+            expect(await screen.findByText(translateLocal('reportDetailsPage.goToRoom'))).toBeVisible();
         });
 
-        it('does not show "Go to room" when the Details page is opened from the room itself', async () => {
-            // The room is already the topmost report when the page mounts (Details opened from the room conversation).
+        it('does not show "Go to room" when the page route sits on top of its own room', async () => {
+            // route.path base is the room report itself, so "Go to room" is hidden regardless of the global nav state.
+            mockIsReportTopmostSplitNavigator.mockReturnValue(false);
+            jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(undefined);
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
+            });
+
+            renderDetailsPage(`r/${roomReportID}/details`);
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.queryByText(translateLocal('reportDetailsPage.goToRoom'))).toBeNull();
+        });
+
+        it('shows "Go to room" for a path-less instance when the room is not the topmost report', async () => {
+            // A details RHP recreated by back navigation has no route.path, so the visibility falls back to the live
+            // topmost-report check. At the settled state of the reviewer's revisit flow the room is no longer the topmost
+            // report, so "Go to room" must be shown — this is the case the previous mount-time frozen check got wrong.
+            mockIsReportTopmostSplitNavigator.mockReturnValue(false);
+            jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(undefined);
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
+            });
+
+            renderDetailsPage();
+            await waitForBatchedUpdatesWithAct();
+
+            expect(await screen.findByText(translateLocal('reportDetailsPage.goToRoom'))).toBeVisible();
+        });
+
+        it('does not show "Go to room" for a path-less instance when the room is the topmost report', async () => {
             mockIsReportTopmostSplitNavigator.mockReturnValue(true);
             jest.spyOn(Navigation, 'getTopmostReportId').mockReturnValue(roomReportID);
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${roomReportID}`, policyRoom);
             });
 
-            render(detailsPage);
+            renderDetailsPage();
             await waitForBatchedUpdatesWithAct();
 
             expect(screen.queryByText(translateLocal('reportDetailsPage.goToRoom'))).toBeNull();


### PR DESCRIPTION
### Explanation of Change

In the report details RHP, the `isRoomCurrentlyOpen` condition (which decides between showing `Go to room` and `Go to workspace`) was re-evaluated on every render, so tapping `Go to room` flipped it while the RHP was still closing, briefly swapping the option to `Go to workspace`. The condition is now computed once when the page is opened (lazy `useState` initializer), which is safe because `report.reportID` comes from the route params and never changes during the lifetime of a details page instance.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93257
PROPOSAL:

### Tests

1. Sign in with an account that has access to at least one workspace containing at least one room, and ensure that you are an administrator of that room.
2. Go to Workspaces > workspace > Rooms.
3. Tap on any room to open its details in the RHP.
4. Tap on "Go to room".
5. Verify that while the RHP is closing, the "Go to room" option does not change to "Go to workspace" and does not move to the bottom of the menu.
6. Verify you land in the room conversation.
7. Open the room conversation, tap the room header to open the details RHP, and verify "Go to room" is not shown (while "Go to workspace" is, for workspace members).

- [x] Verify that no errors appear in the JS console

### Offline tests

Unnecessary — the menu rendering and navigation are local, so the behavior is identical offline.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/430b865e-5ff8-46eb-a6fa-2116e0f9e654


</details>



