### PR TITLE
[$250] Fix email tooltip not displaying for non-admin group members

### DIFF
--- a/src/pages/ReportParticipantsPage.tsx
+++ b/src/pages/ReportParticipantsPage.tsx
@@ -243,7 +243,7 @@ function ReportParticipantsPage({report, route}: ReportParticipantsPageProps) {
             isDisabled,
             text: formatPhoneNumber(getDisplayNameOrDefault(details)),
             alternateText: formatPhoneNumber(details?.login ?? ''),
-            rightElement: isAdmin ? <Badge text={translate('common.admin')} /> : null,
+            rightElement: isAdmin ? <Badge text={translate('common.admin')} /> : <View style={[StyleUtils.getMinimumWidth(60)]} />,
             pendingAction,
             icons: [
                 {


### PR DESCRIPTION
## Problem

In the group members list (Group header > Members), hovering over a non-admin member's email doesn't show a tooltip, while hovering over an admin's email does.

## Root Cause

The email tooltip is overflow-gated — it only shows when the text is truncated (`TextWithTooltip` checks `scrollWidth > offsetWidth`). Admin rows have a `Badge` component that takes up horizontal space, causing the email text to truncate and trigger the tooltip. Non-admin members had `rightElement: null`, so their email text didn't truncate and no tooltip was shown.

## Fix

Added a spacer `<View>` with `minWidth: 60` (matching the role column header width) for non-admin members' `rightElement`. This ensures consistent email truncation across all member rows, so the `TextWithTooltip` overflow detection works uniformly.

## Files Changed

- `src/pages/ReportParticipantsPage.tsx`: Changed `rightElement` for non-admin members from `null` to `<View style={[StyleUtils.getMinimumWidth(60)]} />`

$ #93322