### PR TITLE
fix: add bottom safe area padding to Certinia prerequisites FixedFooter

### DIFF
--- a/src/pages/workspace/accounting/certinia/prerequisites/CertiniaPrerequisitesStep.tsx
+++ b/src/pages/workspace/accounting/certinia/prerequisites/CertiniaPrerequisitesStep.tsx
@@ -69,7 +69,7 @@ function CertiniaPrerequisitesStep({onNext, currentPageName, onConnect}: Certini
         <View style={styles.flex1}>
             <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mb3]}>{translate(titleKey)}</Text>
             {stepContent}
-            <FixedFooter style={[styles.mtAuto]}>
+            <FixedFooter style={[styles.mtAuto]} addBottomSafeAreaPadding>
                 <Button
                     success
                     large


### PR DESCRIPTION
## Explanation of Change

When the device goes offline, `ScreenWrapper` renders an offline indicator banner with `position: absolute; bottom: 0` that covers the bottom 25px of the screen.

The `FixedFooter` in `CertiniaPrerequisitesStep` was missing `addBottomSafeAreaPadding`, so the Connect CTA button was rendered behind the offline overlay, making it appear to disappear on Android.

Adding `addBottomSafeAreaPadding` reserves space for the offline indicator, so the CTA stays visible above it (greyed out and disabled per the existing `isDisabled={isLastStep && isOffline}` logic).

This matches the pattern used by the Sage Intacct prerequisites page.

## Fixed Issues
$ https://github.com/Expensify/App/issues/93285

## Tests
- [x] Verify the Connect CTA is visible and disabled when offline on Android
- [x] Verify the CTA is visible when online

### QA Steps
1. Open the Certinia prerequisites flow
2. Go to Step 3 (OAuth)
3. Turn off the network connection
4. Verify the Connect to CTA is visible (disabled/greyed out) and not covered by the offline banner
5. Turn the network connection back on
6. Verify the CTA is enabled and clickable