### PR TITLE
fix: show Switch to Classic button on Troubleshoot regardless of 30-day nudge staleness

### DIFF
--- a/src/libs/TryNewDotUtils.ts
+++ b/src/libs/TryNewDotUtils.ts
@@ -35,6 +35,20 @@ function shouldHideOldAppRedirect(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryN
     return (shouldRespectMobileLock && isLoadingTryNewDot) || isOldAppRedirectBlocked(tryNewDot, shouldRespectMobileLock);
 }
 
+/**
+ * Determines whether to hide the "Switch to Expensify Classic" button on the Troubleshoot page.
+ * Unlike the generic shouldHideOldAppRedirect, this does NOT suppress the button just because
+ * the 30-day nudge has gone stale — the Troubleshoot page is a manual escape hatch that should
+ * remain available for users who are not locked to NewDot.
+ */
+function shouldHideTroubleshootOldAppRedirect(tryNewDot: OnyxEntry<TryNewDot>, isLoadingTryNewDot: boolean, shouldRespectMobileLock: boolean): boolean {
+    if (shouldRespectMobileLock && isLoadingTryNewDot) {
+        return true;
+    }
+    // Only hide for users who are genuinely locked to NewDot, not because the nudge aged out.
+    return tryNewDot?.classicRedirect?.isLockedToNewDot === true || (shouldRespectMobileLock && isLockedToNewApp(tryNewDot));
+}
+
 function shouldUseOldApp(tryNewDot: TryNewDot): boolean | undefined {
     if (isLockedToNewApp(tryNewDot)) {
         return false;
@@ -47,4 +61,4 @@ function shouldUseOldApp(tryNewDot: TryNewDot): boolean | undefined {
     return tryNewDot.classicRedirect.dismissed;
 }
 
-export {hasBeenInNewDot30Days, isLockedToNewApp, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldUseOldApp};
+export {hasBeenInNewDot30Days, isLockedToNewApp, isOldAppRedirectBlocked, shouldBlockOldAppExit, shouldHideOldAppRedirect, shouldHideTroubleshootOldAppRedirect, shouldUseOldApp};

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -33,7 +33,7 @@ import ExportOnyxState from '@libs/ExportOnyxState';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
-import {shouldHideOldAppRedirect} from '@libs/TryNewDotUtils';
+import {shouldHideTroubleshootOldAppRedirect} from '@libs/TryNewDotUtils';
 import colors from '@styles/theme/colors';
 import {clearOnyxAndResetApp} from '@userActions/App';
 import CONFIG from '@src/CONFIG';
@@ -120,7 +120,7 @@ function TroubleshootPage() {
     const surveyCompletedWithinLastMonth = getSurveyCompletedWithinLastMonth();
 
     const getClassicRedirectMenuItem = (): BaseMenuItem | null => {
-        if (shouldHideOldAppRedirect(tryNewDot, isLoadingTryNewDot, CONFIG.IS_HYBRID_APP)) {
+        if (shouldHideTroubleshootOldAppRedirect(tryNewDot, isLoadingTryNewDot, CONFIG.IS_HYBRID_APP)) {
             return null;
         }
 


### PR DESCRIPTION
## Problem

The "Switch to Expensify Classic" button on the Troubleshoot page is hidden for users who have been in NewDot for 30+ days, even though the Troubleshoot page is a manual escape hatch that should remain available.

## Root Cause

`TroubleshootPage` uses `shouldHideOldAppRedirect()` which includes `hasBeenInNewDot30Days()`. This was designed to suppress the automatic redirect nudge after 30 days, but it incorrectly hides the Troubleshoot manual button too.

The symptom: clearing cache makes the button briefly appear (tryNewDot hasn't loaded yet), then it disappears once Onyx hydrates with the stale classicRedirect timestamp.

## Fix

- Add `shouldHideTroubleshootOldAppRedirect()` in `TryNewDotUtils.ts` that checks only for genuine locks (`isLockedToNewDot` / `isLockedToNewApp`) without the 30-day staleness gate
- Use it in `TroubleshootPage` instead of `shouldHideOldAppRedirect`

$ #93358