### PR TITLE
Fix approve button flicker in workspace chat report preview

### DIFF
--- a/src/libs/ReportPreviewActionUtils.ts
+++ b/src/libs/ReportPreviewActionUtils.ts
@@ -82,6 +82,10 @@ function canApprove(report: Report, currentUserAccountID: number, reportMetadata
         return false;
     }
 
+    if (reportMetadata?.pendingExpenseAction === CONST.EXPENSE_PENDING_ACTION.APPROVE) {
+        return false;
+    }
+
     const isPreventSelfApprovalEnabled = policy?.preventSelfApproval;
     const isReportSubmitter = isCurrentUserSubmitter(report);
 

--- a/src/libs/actions/IOU/ReportWorkflow.ts
+++ b/src/libs/actions/IOU/ReportWorkflow.ts
@@ -533,15 +533,13 @@ function approveMoneyRequest(params: ApproveMoneyRequestFunctionParams) {
         });
     }
 
-    if (isDEWPolicy) {
-        optimisticData.push({
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
-            value: {
-                pendingExpenseAction: CONST.EXPENSE_PENDING_ACTION.APPROVE,
-            },
-        });
-    }
+    optimisticData.push({
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
+        value: {
+            pendingExpenseAction: CONST.EXPENSE_PENDING_ACTION.APPROVE,
+        },
+    });
 
     const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT_METADATA>> = [];
 
@@ -570,15 +568,13 @@ function approveMoneyRequest(params: ApproveMoneyRequestFunctionParams) {
         });
     }
 
-    if (isDEWPolicy) {
-        successData.push({
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
-            value: {
-                pendingExpenseAction: null,
-            },
-        });
-    }
+    successData.push({
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
+        value: {
+            pendingExpenseAction: null,
+        },
+    });
 
     const failureData: Array<
         OnyxUpdate<
@@ -642,15 +638,13 @@ function approveMoneyRequest(params: ApproveMoneyRequestFunctionParams) {
         }
     }
 
-    if (isDEWPolicy) {
-        failureData.push({
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
-            value: {
-                pendingExpenseAction: null,
-            },
-        });
-    }
+    failureData.push({
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
+        value: {
+            pendingExpenseAction: null,
+        },
+    });
 
     // Clear hold reason of all transactions if we approve all requests
     if (full && hasHeldExpenses) {


### PR DESCRIPTION
## Problem
When approving a non-DEW report from workspace chat preview, the approve button disappears → reappears → disappears (flicker). This is a race condition between `isApprovedAnimationRunning` (React state) and the Onyx optimistic status update.

## Root Cause
`getReportPreviewAction` decides which button to show from two unsynchronized sources:
1. `isApprovedAnimationRunning` (React state) — while true, shows PAY/animated button
2. `canApprove` (reads report status from Onyx) — when status is SUBMITTED, returns true

The animation flag is set synchronously but the Onyx optimistic update arrives asynchronously. When the animation ends before Onyx propagates, `canApprove` briefly returns true → Approve button reappears.

DEW policies don't have this bug because they use `reportMetadata.pendingExpenseAction = APPROVE` as an atomic Onyx guard that persists until the server responds.

## Fix
Two changes:

### File 1: `src/libs/actions/IOU/ReportWorkflow.ts`
In `approveMoneyRequest()`, extend the `pendingExpenseAction = APPROVE` pattern to ALL policies, not just DEW. Previously gated behind `isDEWPolicy` — removed the gate so all policies set it in `optimisticData` and clear it in `successData`/`failureData`.

### File 2: `src/libs/ReportPreviewActionUtils.ts`
In `canApprove()\), added a guard that checks `reportMetadata?.pendingExpenseAction === CONST.EXPENSE_PENDING_ACTION.APPROVE` and returns false, regardless of DEW status.

$ #93067