### PR TITLE
fix: show routed Concierge action for manual Approve-and-Forward from OldDot

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -391,7 +391,7 @@ function hasPendingDEWApprove(reportMetadata: OnyxEntry<ReportMetadata>, isDEWPo
 }
 
 function isDynamicExternalWorkflowForwardedAction(reportAction: OnyxInputOrEntry<ReportAction>): reportAction is ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.FORWARDED> {
-    return isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.FORWARDED) && getOriginalMessage(reportAction)?.workflow === CONST.POLICY.APPROVAL_MODE.DYNAMICEXTERNAL;
+    return isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.FORWARDED) && !!getOriginalMessage(reportAction)?.to;
 }
 
 function isModifiedExpenseAction(reportAction: OnyxInputOrEntry<ReportAction>): reportAction is ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.MODIFIED_EXPENSE> {


### PR DESCRIPTION
## Problem

After an admin uses "Approve and Forward" in OldDot (entering a next approver + memo), NewDot shows the forwarded action as "approved, saying <memo>" but never shows the routed Concierge action ("report routed to <approver> because <memo>").

## Root Cause

`isDynamicExternalWorkflowForwardedAction` requires `originalMessage.workflow === DYNAMIC_EXTERNAL`, but OldDot's manual Approve-and-Forward sets `to` and `message` without the `workflow` tag. The routed Concierge action synthesis is skipped.

## Fix

Changed `isDynamicExternalWorkflowForwardedAction` to check for the presence of `originalMessage.to` instead of the `workflow` enum. This is the actual signal that a forward was routed to a specific approver.

The existing `&& getOriginalMessage(reportAction)?.to` guard in `withDEWRoutedActionsArray`/`withDEWRoutedActionsObject` already prevents false positives for plain forwards without a target.

$ #93278