### PR TITLE
Fix Review Duplicates merge navigation from Search and on browser back

### DIFF
--- a/src/pages/TransactionDuplicate/Confirmation.tsx
+++ b/src/pages/TransactionDuplicate/Confirmation.tsx
@@ -23,6 +23,7 @@ import useTransactionThreadReportIDs from '@hooks/useTransactionThreadReportIDs'
 import {mergeDuplicates, resolveDuplicates} from '@libs/actions/IOU/Duplicate';
 import {setDeleteTransactionNavigateBackUrl} from '@libs/actions/Report';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {TransactionDuplicateNavigatorParamList} from '@libs/Navigation/types';
@@ -113,7 +114,9 @@ function Confirmation() {
             return;
         }
         // Opened from Search: dismiss back to the search results instead of opening the kept report in the Inbox.
-        if (route.params.backTo) {
+        // The review flow always sets route.params.backTo (keepSelected passes getActiveRoute), so it can't be used
+        // to detect the Search entry point — check the topmost full-screen route instead.
+        if (isSearchTopmostFullScreenRoute()) {
             Navigation.dismissModal();
             return;
         }
@@ -122,7 +125,7 @@ function Confirmation() {
         Navigation.dismissModal({
             afterTransition: () => Navigation.navigate(keptReportRoute, {forceReplace: true}),
         });
-    }, [childReportID, transactionsMergeParams, taxData, currentUserAccountID, currentUserLogin, isSuperWideRHPDisplayed, route.params.backTo]);
+    }, [childReportID, transactionsMergeParams, taxData, currentUserAccountID, currentUserLogin, isSuperWideRHPDisplayed]);
 
     const handleResolveDuplicates = useCallback(() => {
         resolveDuplicates({...transactionsMergeParams, ...taxData, transactionThreadReportIDMap});

--- a/src/pages/TransactionDuplicate/Confirmation.tsx
+++ b/src/pages/TransactionDuplicate/Confirmation.tsx
@@ -113,15 +113,12 @@ function Confirmation() {
             Navigation.dismissToSuperWideRHP();
             return;
         }
-        // Opened from Search: dismiss back to the search results instead of opening the kept report in the Inbox.
-        // The review flow always sets route.params.backTo (keepSelected passes getActiveRoute), so it can't be used
-        // to detect the Search entry point — check the topmost full-screen route instead.
+        // From Search, dismiss back to the results (backTo is always set here, so it can't detect Search).
         if (isSearchTopmostFullScreenRoute()) {
             Navigation.dismissModal();
             return;
         }
-        // Opened from the discarded thread: pop the modal's history entries, then replace the now-dead
-        // thread with the kept report so browser-back can't reach its NotFound page.
+        // From the discarded thread: pop the modal entries, then replace the dead thread with the kept report.
         Navigation.dismissModal({
             afterTransition: () => Navigation.navigate(keptReportRoute, {forceReplace: true}),
         });

--- a/src/pages/TransactionDuplicate/Confirmation.tsx
+++ b/src/pages/TransactionDuplicate/Confirmation.tsx
@@ -104,9 +104,7 @@ function Confirmation() {
     const handleMergeDuplicates = useCallback(() => {
         const transactionThreadReportID = childReportID ?? generateReportID();
         const mergeParams = !childReportID ? {...transactionsMergeParams, transactionThreadReportID} : transactionsMergeParams;
-        // Server deletes the discarded transaction's now-empty expense report on merge and
-        // pushes back a "Report not found" payload for it. Hint the guard and redirect to
-        // the kept transaction's report so the user doesn't land on the discarded one.
+        // Suppress the NotFound guard for the discarded thread the server tears down on merge.
         const keptReportRoute = ROUTES.REPORT_WITH_ID.getRoute(mergeParams.reportID);
         setDeleteTransactionNavigateBackUrl(keptReportRoute);
         mergeDuplicates({...mergeParams, ...taxData, currentUserAccountID, currentUserLogin: currentUserLogin ?? ''});
@@ -114,13 +112,17 @@ function Confirmation() {
             Navigation.dismissToSuperWideRHP();
             return;
         }
-        const topmostReportID = Navigation.getTopmostReportId?.();
-        if (topmostReportID === mergeParams.reportID) {
+        // Opened from Search: dismiss back to the search results instead of opening the kept report in the Inbox.
+        if (route.params.backTo) {
             Navigation.dismissModal();
-        } else {
-            Navigation.goBack(keptReportRoute);
+            return;
         }
-    }, [childReportID, transactionsMergeParams, taxData, currentUserAccountID, currentUserLogin, isSuperWideRHPDisplayed]);
+        // Opened from the discarded thread: pop the modal's history entries, then replace the now-dead
+        // thread with the kept report so browser-back can't reach its NotFound page.
+        Navigation.dismissModal({
+            afterTransition: () => Navigation.navigate(keptReportRoute, {forceReplace: true}),
+        });
+    }, [childReportID, transactionsMergeParams, taxData, currentUserAccountID, currentUserLogin, isSuperWideRHPDisplayed, route.params.backTo]);
 
     const handleResolveDuplicates = useCallback(() => {
         resolveDuplicates({...transactionsMergeParams, ...taxData, transactionThreadReportIDMap});


### PR DESCRIPTION
### Explanation of Change

[#92838](https://github.com/Expensify/App/pull/92838) (fix for [#92302](https://github.com/Expensify/App/issues/92302)) replaced the unconditional `Navigation.dismissModal()` at the end of the Review Duplicates merge flow (`handleMergeDuplicates` in `Confirmation.tsx`) with a branch keyed on `Navigation.getTopmostReportId()`. That branch regressed two flows:

- **#93362 — lands in the Inbox instead of Spend > Expenses.** `getTopmostReportId()` only inspects the Inbox (Reports split navigator), so when the flow is opened from Search it never matches the kept transaction's expense report. The `else` branch ran `Navigation.goBack(keptReportRoute)`, opening the kept report in the Inbox instead of returning to the search results.
- **#93363 — browser back shows "Hmm… it's not here".** For a cross-report merge the kept expense report is never on the navigation stack, so `goBack(keptReportRoute)` resolves to a REPLACE rather than a pop. On web that leaves the discarded thread's history entries (`/r/<thread>`, `…/duplicates/review`) reachable; combined with the suppressor NVP being cleared when the kept report loses focus, pressing the browser Back button lands on the torn-down thread's NotFound page.

This PR replaces that branch with origin-aware navigation:

- When the flow is opened from Search (the confirmation route carries a `backTo` param), dismiss the modal back to the search results.
- Otherwise dismiss the duplicates modal (which pops its browser-history entries) and replace the now-dead discarded thread with the kept report via `forceReplace`, so the browser Back button can't reach a torn-down screen.

The original #92302 cross-report cleanup in `Duplicate.ts` is unchanged.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93362
PROPOSAL: https://github.com/Expensify/App/issues/93362#issuecomment-4686727290
$ https://github.com/Expensify/App/issues/93363
PROPOSAL: https://github.com/Expensify/App/issues/93363#issuecomment-4686727452

### Tests

1. Create a Collect workspace and open its workspace chat.
2. Create two identical expenses (same merchant, amount and date) in **two different reports** — create the first expense, submit its report, then create the second expense so it lands in a separate report.
3. Open one of the two duplicate expenses and confirm a red **Review duplicates** button appears.
4. **#93363 (opened from the Inbox):** From the workspace chat, open one of the duplicate expenses → **Review duplicates** → keep the second expense → **Confirm** → press the **browser Back** button. Verify the app lands on a live screen (the workspace chat) and the "Hmm… it's not here" page does **not** appear.
5. **#93362 (opened from Search):** Go to **Search → Spend > Expenses** → open one of the duplicate expenses → **Review duplicates** → keep the second expense → **Confirm**. Verify the app stays on **Spend > Expenses** and does **not** open a report in the Inbox.
6. Verify the duplicates are merged (only one expense remains) and the totals are correct.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as **Tests**, but enable airplane mode / disable the network before pressing **Confirm**, then re-enable the network:

1. With the device offline, complete the merge from each entry point (steps 4 and 5 above).
2. Verify the navigation behaves the same offline — Search returns to Spend > Expenses, and the Inbox flow lands on a live screen on browser Back (no NotFound page).
3. Re-enable the network and verify the merge reconciles with the server without showing the "Hmm… it's not here" page.

### QA Steps

1. Create a Collect workspace and open its workspace chat.
2. Create two identical expenses (same merchant, amount and date) in two different reports (create the first, submit its report, then create the second).
3. Open one of the duplicate expenses and confirm a **Review duplicates** button appears.
4. From the **workspace chat**, open a duplicate expense → **Review duplicates** → keep the second → **Confirm** → press the **browser Back** button → verify the "Hmm… it's not here" page does **not** appear.
5. From **Search → Spend > Expenses**, open a duplicate expense → **Review duplicates** → keep the second → **Confirm** → verify the app stays on **Spend > Expenses**.
6. Verify the duplicates are merged (only one expense remains).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/08b3e6ba-797a-4568-b047-f0ab86287d95

</details>
