### PR TITLE
fix: cap group chat report name to prevent OpenReport failure with 9+ members

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -88,6 +88,8 @@ import {prunePagesToNewestWindow} from '@libs/PaginationUtils';
 import Parser from '@libs/Parser';
 import {getParsedMessageWithShortMentions} from '@libs/ParsingUtils';
 import * as PersonalDetailsUtils from '@libs/PersonalDetailsUtils';
+import {formatPhoneNumber as formatPhoneNumberPhoneUtils} from '@libs/LocalePhoneNumber';
+import {getGroupChatName} from '@libs/ReportNameUtils';
 import * as PhoneNumber from '@libs/PhoneNumber';
 import {
     getDefaultApprover,
@@ -2336,8 +2338,17 @@ function navigateToAndCreateGroupChat(
 ) {
     const participantAccountIDs = PersonalDetailsUtils.getAccountIDsByLogins(userLogins);
 
+    // Build a safe default group name (capped to REPORT_NAME_LIMIT) when the user didn't type a custom one.
+    // Without this, passing '' to the server causes Auth to auto-generate a name that can exceed the limit
+    // with 9+ members, making OpenReport fail with "Auth OpenReport returned an error".
+    const participants = userLogins.map((login, index) => ({
+        login,
+        accountID: participantAccountIDs.at(index) ?? CONST.DEFAULT_NUMBER_ID,
+    }));
+    const groupReportName = reportName || getGroupChatName(formatPhoneNumberPhoneUtils, participants) || CONST.REPORT.DEFAULT_REPORT_NAME;
+
     // If we are creating a group chat then participantAccountIDs is expected to contain currentUserAccountID
-    const newChat = buildOptimisticGroupChatReport(participantAccountIDs, reportName, avatarUri ?? '', currentUserAccountID, optimisticReportID, CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN);
+    const newChat = buildOptimisticGroupChatReport(participantAccountIDs, groupReportName, avatarUri ?? '', currentUserAccountID, optimisticReportID, CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN);
     createGroupChat(newChat.reportID, userLogins, newChat, currentUserLogin, introSelected, isSelfTourViewed, betas, avatarFile);
 
     navigateToReport(newChat.reportID);


### PR DESCRIPTION
## Problem
Creating a group chat with 9+ members using the default (empty) report name causes Auth to reject OpenReport with "Auth OpenReport returned an error". The group then disappears when the error is dismissed.

## Root Cause
When no custom name is entered, `NewChatConfirmPage.createGroup` passes `reportName: ''` through `navigateToAndCreateGroupChat` → `buildOptimisticGroupChatReport` → `createGroupChat` → `OpenReport` API. Auth then auto-generates a group name from participant display names. With 9+ members this exceeds the 100-char REPORT_NAME_LIMIT and Auth rejects the request.

## Fix
In `navigateToAndCreateGroupChat`, compute a proper default group name using `getGroupChatName` (which already caps at REPORT_NAME_LIMIT) when no custom name is provided. This is the same function already used in `AvatarAndGroupNameSection` for display.

## What changed
- `src/libs/actions/Report/index.ts`: import `formatPhoneNumber` and `getGroupChatName`; compute `groupReportName` before building the optimistic report.

$ #93275