### PR TITLE
[cp staging] Fix distance rates table regressions from #90920

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -184,7 +184,20 @@ function Table<DataType extends TableData, ColumnKey extends string = string, Fi
     });
     const sortedData = sortMiddleware(searchedData);
 
-    const {middleware: selectionMiddleware, methods: selectionMethods, mobileSelectionModalRowKey} = useSelection<DataType>({data: sortedData, selectedKeys, onRowSelectionChange});
+    const hasActiveSearchString = activeSearchString.trim().length > 0;
+    const hasAppliedFilters = filters
+        ? (Object.keys(currentFilters) as FilterKey[]).some((key) => {
+              const filterValue = currentFilters[key];
+              const defaultValue = filters[key]?.default;
+              return filterValue !== defaultValue;
+          })
+        : false;
+
+    const {
+        middleware: selectionMiddleware,
+        methods: selectionMethods,
+        mobileSelectionModalRowKey,
+    } = useSelection<DataType>({data: sortedData, isDataFiltered: hasActiveSearchString || hasAppliedFilters, selectedKeys, onRowSelectionChange});
     const processedData = selectionMiddleware(sortedData);
 
     const listRef = useRef<FlashListRef<DataType>>(null);
@@ -217,18 +230,7 @@ function Table<DataType extends TableData, ColumnKey extends string = string, Fi
     });
 
     const originalDataLength = data?.length ?? 0;
-
-    // Check if filters are applied (not default values)
-    const hasActiveFilters = filters
-        ? (Object.keys(currentFilters) as FilterKey[]).some((key) => {
-              const filterValue = currentFilters[key];
-              const defaultValue = filters[key]?.default;
-              return filterValue !== defaultValue;
-          })
-        : false;
-
-    const hasSearchString = activeSearchString.trim().length > 0;
-    const isEmptyResult = processedData.length === 0 && originalDataLength > 0 && (hasSearchString || hasActiveFilters);
+    const isEmptyResult = processedData.length === 0 && originalDataLength > 0 && (hasActiveSearchString || hasAppliedFilters);
 
     const handleMobileSelectionPress = () => {
         turnOnMobileSelectionMode();
@@ -252,8 +254,8 @@ function Table<DataType extends TableData, ColumnKey extends string = string, Fi
         activeSorting,
         activeSearchString,
         tableMethods,
-        hasActiveFilters,
-        hasSearchString,
+        hasActiveFilters: hasAppliedFilters,
+        hasSearchString: hasActiveSearchString,
         isEmptyResult,
         shouldUseNarrowTableLayout,
         selectionEnabled,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -193,11 +193,12 @@ function Table<DataType extends TableData, ColumnKey extends string = string, Fi
           })
         : false;
 
+    const originalSelectableCount = data.filter((item) => !item.disabled).length;
     const {
         middleware: selectionMiddleware,
         methods: selectionMethods,
         mobileSelectionModalRowKey,
-    } = useSelection<DataType>({data: sortedData, isDataFiltered: hasActiveSearchString || hasAppliedFilters, selectedKeys, onRowSelectionChange});
+    } = useSelection<DataType>({data: sortedData, originalSelectableCount, selectedKeys, onRowSelectionChange});
     const processedData = selectionMiddleware(sortedData);
 
     const listRef = useRef<FlashListRef<DataType>>(null);

--- a/src/components/Table/TableSearchBar.tsx
+++ b/src/components/Table/TableSearchBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import SearchBar from '@components/SearchBar';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
@@ -45,6 +45,12 @@ function TableSearchBar({label, style}: TableSearchBarProps) {
         activeSearchString,
         tableMethods: {updateSearchString},
     } = useTableContext();
+
+    useEffect(() => {
+        return () => updateSearchString('');
+        // We only want the cleanup to run on unmount to reset the search state
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
         <SearchBar

--- a/src/components/Table/middlewares/selection.ts
+++ b/src/components/Table/middlewares/selection.ts
@@ -10,8 +10,8 @@ type UseSelectionProps<DataType extends TableData> = {
     /** The data being used in the table */
     data: DataType[];
 
-    /** Whether the data is currently reduced by an active search or filter */
-    isDataFiltered: boolean;
+    /** The number of non-disabled items in the original (pre-search/filter) data */
+    originalSelectableCount: number;
 
     /** The list of selected keys */
     selectedKeys: string[];
@@ -42,7 +42,12 @@ type UseSelectionResult<DataType extends TableData> = MiddlewareHookResult<DataT
     mobileSelectionModalRowKey: string | null;
 };
 
-export default function useSelection<DataType extends TableData>({data, isDataFiltered, selectedKeys, onRowSelectionChange}: UseSelectionProps<DataType>): UseSelectionResult<DataType> {
+export default function useSelection<DataType extends TableData>({
+    data,
+    originalSelectableCount,
+    selectedKeys,
+    onRowSelectionChange,
+}: UseSelectionProps<DataType>): UseSelectionResult<DataType> {
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const isSelectionModeEnabled = useMobileSelectionMode();
     const lastSelectedRowKeyRef = useRef<string | null>(null);
@@ -65,14 +70,14 @@ export default function useSelection<DataType extends TableData>({data, isDataFi
     }, [shouldUseNarrowLayout, isSelectionModeEnabled, selectedKeys.length]);
 
     // When there are genuinely no selectable items left, turn off selection mode on mobile.
-    // Skip when data is reduced by search/filter — the items still exist, they're just hidden.
+    // Stay in selection mode as long as the original data has non-disabled items (they may be hidden by search/filter).
     useEffect(() => {
-        if (selectableKeys.length || !isSelectionModeEnabled || isDataFiltered) {
+        if (selectableKeys.length || !isSelectionModeEnabled || originalSelectableCount > 0) {
             return;
         }
 
         turnOffMobileSelectionMode();
-    }, [selectableKeys.length, isSelectionModeEnabled, isDataFiltered]);
+    }, [selectableKeys.length, isSelectionModeEnabled, originalSelectableCount]);
 
     const prevSelectionModeEnabledRef = useRef(isSelectionModeEnabled);
     useEffect(() => {

--- a/src/components/Table/middlewares/selection.ts
+++ b/src/components/Table/middlewares/selection.ts
@@ -10,6 +10,9 @@ type UseSelectionProps<DataType extends TableData> = {
     /** The data being used in the table */
     data: DataType[];
 
+    /** Whether the data is currently reduced by an active search or filter */
+    isDataFiltered: boolean;
+
     /** The list of selected keys */
     selectedKeys: string[];
 
@@ -39,7 +42,7 @@ type UseSelectionResult<DataType extends TableData> = MiddlewareHookResult<DataT
     mobileSelectionModalRowKey: string | null;
 };
 
-export default function useSelection<DataType extends TableData>({data, selectedKeys, onRowSelectionChange}: UseSelectionProps<DataType>): UseSelectionResult<DataType> {
+export default function useSelection<DataType extends TableData>({data, isDataFiltered, selectedKeys, onRowSelectionChange}: UseSelectionProps<DataType>): UseSelectionResult<DataType> {
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const isSelectionModeEnabled = useMobileSelectionMode();
     const lastSelectedRowKeyRef = useRef<string | null>(null);
@@ -61,14 +64,15 @@ export default function useSelection<DataType extends TableData>({data, selected
         }
     }, [shouldUseNarrowLayout, isSelectionModeEnabled, selectedKeys.length]);
 
-    // When there are no more items to be selected, turn off selection mode on mobile
+    // When there are genuinely no selectable items left, turn off selection mode on mobile.
+    // Skip when data is reduced by search/filter — the items still exist, they're just hidden.
     useEffect(() => {
-        if (selectableKeys.length || !isSelectionModeEnabled) {
+        if (selectableKeys.length || !isSelectionModeEnabled || isDataFiltered) {
             return;
         }
 
         turnOffMobileSelectionMode();
-    }, [selectableKeys.length, isSelectionModeEnabled]);
+    }, [selectableKeys.length, isSelectionModeEnabled, isDataFiltered]);
 
     const prevSelectionModeEnabledRef = useRef(isSelectionModeEnabled);
     useEffect(() => {

--- a/src/components/Tables/WorkspaceDistanceRatesTable/WorkspaceDistanceRatesTableRow.tsx
+++ b/src/components/Tables/WorkspaceDistanceRatesTable/WorkspaceDistanceRatesTableRow.tsx
@@ -92,7 +92,7 @@ function WorkspaceDistanceRatesTableRow({item, rowIndex, shouldUseNarrowTableLay
             accessibilityLabel={accessibilityLabel}
             skeletonReasonAttributes={reasonAttributes}
             sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.DISTANCE_RATES.ROW}
-            offlineWithFeedback={{errors, pendingAction, dismissError: item.dismissError, shouldHideOnDelete: false}}
+            offlineWithFeedback={{errors, pendingAction, dismissError: item.dismissError}}
             onPress={item.action}
         >
             {({hovered}) => (


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/89831
$ https://github.com/Expensify/App/issues/93355
$ https://github.com/Expensify/App/issues/93360
$ https://github.com/Expensify/App/issues/93391

PROPOSAL: 


### Tests
#### Test 1
- Precondition:
    - Enable Distance rates.
    - Have at least two distance rates.

1. Go to staging.new.expensify.com
2. Go to workspace settings > Distance rates.
3. Delete any rate.
4. Verify deleted rate disappears immediately.


#### Test 2

- Precondition:
   - Enable Distance rates.
   - Have at least 12 distance rates.
  
1. Launch Expensify app.
2. Go to workspace settings > Distance rates.
3. Long tap on any rate > Select.
4. Tap on the search field.
5. Type anything that will not return result.
6. Verify selection mode  persists


#### Test 3
- Prerequisite: Account has a workspace with "Distance Rates" enabled.
- Prerequisite 2: Have 12 rates created to make search input available.


1. Open the staging.new.expensify.com website.
2. Navigate to "Workspaces" > Workspace > "Distance Rates"
3. Type anything on search input that will trigger more than one rate as result.
4. Select any rate from results and delete it.
5. Note that search input disappears
6. Verify all rates are displayed

- [x] Verify that no errors appear in the JS console

### Offline tests
- Same as tests

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/1ff4caf4-e5b5-4058-b437-6c358473f7cd


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/52c2acb2-0d6e-4f3e-ad39-ca5fd489686e


https://github.com/user-attachments/assets/cf34861f-3957-46e5-8792-224c5d551857


https://github.com/user-attachments/assets/480de372-6ae1-4a4a-9b56-7d5d1439f932


</details>






