### PR TITLE
fix: #93375 - attachment fails to load after offline refresh

### DIFF
--- a/src/components/ThumbnailImage.tsx
+++ b/src/components/ThumbnailImage.tsx
@@ -115,8 +115,8 @@ function ThumbnailImage({
     const styles = useThemeStyles();
     const theme = useTheme();
     const {isOffline} = useNetwork();
-    const [failedLoadKey, setFailedLoadKey] = useState<{url: string | ImageSourcePropType; isOffline: boolean} | null>(null);
-    const failedToLoad = failedLoadKey !== null && failedLoadKey.url === previewSourceURL && failedLoadKey.isOffline === isOffline;
+    const [failedLoadKey, setFailedLoadKey] = useState<string | ImageSourcePropType | null>(null);
+    const failedToLoad = failedLoadKey !== null && failedLoadKey === previewSourceURL;
 
     const cachedDimensions = shouldDynamicallyResize && typeof previewSourceURL === 'string' ? thumbnailDimensionsCache.get(previewSourceURL) : null;
     const [imageDimensions, setImageDimensions] = useState({width: cachedDimensions?.width ?? imageWidth, height: cachedDimensions?.height ?? imageHeight});
@@ -166,7 +166,7 @@ function ThumbnailImage({
                         onMeasure?.();
                     }}
                     onLoadFailure={() => {
-                        setFailedLoadKey({url: previewSourceURL, isOffline});
+                        setFailedLoadKey(previewSourceURL);
                         onLoadFailure?.();
                     }}
                     isAuthTokenRequired={isAuthTokenRequired}


### PR DESCRIPTION
$ #93375

When a user attaches an image offline, refreshes the page, then comes back online and refreshes again, the attachment fails to load because the blob URL is dead.

Root cause: `failedLoadKey` state in `ThumbnailImage.tsx` included `isOffline` in its comparison. When the user came back online, `isOffline` changed, causing `failedToLoad` to evaluate to `false`, making the component try to reload the dead blob URL.

Fix: Remove `isOffline` from the `failedLoadKey` comparison so that once an image URL fails to load, it stays marked as failed regardless of network state changes.