### PR TITLE
fix: #93371 - action button shows Draft for offline expense when approvals/payments disabled

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -959,6 +959,7 @@ type BuildOptimisticExpenseReportParams = {
     optimisticIOUReportID?: string;
     reportTransactions?: Record<string, Transaction>;
     createdTimestamp?: string;
+    shouldMarkAsDone?: boolean;
 };
 
 type ReportByPolicyMap = Record<string, OnyxCollection<Report>>;
@@ -6468,9 +6469,9 @@ function computeOptimisticReportName(report: Report, policy: OnyxEntry<Policy>, 
  * Returns the stateNum and statusNum for an expense report based on the policy settings
  * @param policy
  */
-function getExpenseReportStateAndStatus(policy: OnyxEntry<Policy>, betas: OnyxEntry<Beta[]>, isEmptyOptimisticReport = false) {
+function getExpenseReportStateAndStatus(policy: OnyxEntry<Policy>, betas: OnyxEntry<Beta[]>, isEmptyOptimisticReport = false, shouldMarkAsDone = false) {
     const isASAPSubmitBetaEnabled = Permissions.isBetaEnabled(CONST.BETAS.ASAP_SUBMIT, betas);
-    if (isASAPSubmitBetaEnabled) {
+    if (isASAPSubmitBetaEnabled && !shouldMarkAsDone) {
         return {
             stateNum: CONST.REPORT.STATE_NUM.OPEN,
             statusNum: CONST.REPORT.STATUS_NUM.OPEN,
@@ -6480,7 +6481,7 @@ function getExpenseReportStateAndStatus(policy: OnyxEntry<Policy>, betas: OnyxEn
     const isSubmitAndCloseLocal = isSubmitAndClose(policy);
     const arePaymentsDisabled = policy?.reimbursementChoice === CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO;
 
-    if (isInstantSubmitEnabledLocal && arePaymentsDisabled && isSubmitAndCloseLocal && !isEmptyOptimisticReport) {
+    if ((isInstantSubmitEnabledLocal || shouldMarkAsDone) && arePaymentsDisabled && isSubmitAndCloseLocal && !isEmptyOptimisticReport) {
         return {
             stateNum: CONST.REPORT.STATE_NUM.APPROVED,
             statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
@@ -6524,6 +6525,7 @@ function buildOptimisticExpenseReport({
     optimisticIOUReportID,
     reportTransactions,
     createdTimestamp,
+    shouldMarkAsDone,
 }: BuildOptimisticExpenseReportParams): OptimisticExpenseReport {
     // The amount for Expense reports are stored as negative value in the database
     const storedTotal = total * -1;
@@ -6536,7 +6538,7 @@ function buildOptimisticExpenseReport({
     const policyDraft = allPolicyDrafts?.[`${ONYXKEYS.COLLECTION.POLICY_DRAFTS}${policyID}`];
     const policy = policyReal ?? policyDraft;
 
-    const {stateNum, statusNum} = getExpenseReportStateAndStatus(policy, betas);
+    const {stateNum, statusNum} = getExpenseReportStateAndStatus(policy, betas, false, shouldMarkAsDone);
 
     const created = createdTimestamp ?? DateUtils.getDBTime();
 

--- a/src/libs/actions/IOU/MoneyRequestBuilder.ts
+++ b/src/libs/actions/IOU/MoneyRequestBuilder.ts
@@ -1354,6 +1354,7 @@ function getMoneyRequestInformation(moneyRequestInformation: MoneyRequestInforma
                   optimisticIOUReportID: optimisticReportID,
                   reportTransactions,
                   betas,
+                  shouldMarkAsDone: action === CONST.IOU.ACTION.SUBMIT,
               })
             : buildOptimisticIOUReport(payeeAccountID, payerAccountID, amount, chatReport.reportID, currency, undefined, undefined, optimisticReportID);
     } else if (isPolicyExpenseChat) {


### PR DESCRIPTION
$ #93371

When a tracked expense is submitted to a workspace with approvals and payments disabled, the optimistic expense report was created as OPEN/OPEN (Draft) instead of APPROVED/CLOSED (Done).

Root cause: `getExpenseReportStateAndStatus` didn't know the user was explicitly submitting, so the ASAP_SUBMIT beta check short-circuited to OPEN/OPEN before the submit-and-close check could run.

Fix:
- Add `shouldMarkAsDone` param to `buildOptimisticExpenseReport` and `getExpenseReportStateAndStatus`
- When `shouldMarkAsDone` is true, skip the ASAP beta OPEN/OPEN fallback
- From `MoneyRequestBuilder`, pass `shouldMarkAsDone: action === CONST.IOU.ACTION.SUBMIT`