### PR TITLE
Fix: Pressing Enter key now opens Confirm Details when adding workspace members

### DIFF
--- a/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
+++ b/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
@@ -224,6 +224,9 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
     const selectFocusedItem = () => {
         const focusedItem = getFocusedItem();
         if (!focusedItem || focusedItem.isInteractive === false) {
+            if (!focusedItem && canSelectMultiple && confirmButtonOptions?.onConfirm && !confirmButtonOptions?.isDisabled) {
+                confirmButtonOptions.onConfirm();
+            }
             return;
         }
         selectRow(focusedItem);


### PR DESCRIPTION
## Issue
[#92803](https://github.com/Expensify/App/issues/92803) - Pressing Enter key does not open the Confirm Details page when adding workspace members

## Root Cause
When users select workspace members by mouse click, the SelectionList moves its internal `focusedIndex` onto the clicked row but does not set `isKeyboardNavigating`. The Enter keyboard shortcut then hits the list's row-selection handler (which toggles the focused row) instead of bubbling to the footer's confirm button. If `focusedIndex` is -1 (e.g. when the search input is empty), `selectFocusedItem` early-returns with no-op and the Enter event is silently swallowed — the confirm button's `pressOnEnter` handler never gets the event.

## Fix
In `selectFocusedItem`, when there is no focused row (`getFocusedItem()` returns undefined), fall back to calling `confirmButtonOptions.onConfirm()` — the same confirm action already wired to Ctrl+Enter — provided:
- `canSelectMultiple` is true (multi-select context)
- `confirmButtonOptions.onConfirm` exists
- `confirmButtonOptions.isDisabled` is not true

This ensures that when a user has made selections and is sitting in the empty search box, pressing Enter submits the selection instead of doing nothing.

## Files Changed
- `src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx` — added fallback to `confirmButtonOptions.onConfirm()` in `selectFocusedItem`

## Testing
- Verified the fix follows the same pattern already used by Ctrl+Enter (lines 281-296)
- No impact on non-multi-select lists or lists without `confirmButtonOptions`
- Arrow-key navigation and Enter-to-toggle behavior preserved