### PR TITLE
fix: make Subscription settings row read-only with Edit subscription button

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -9367,6 +9367,7 @@ const translations = {
         },
         subscriptionSettings: {
             title: 'Subscription settings',
+            editSubscription: 'Edit subscription',
             summary: (subscriptionType: string, subscriptionSize: string, expensifyCode: string, autoRenew: string, autoIncrease: string) =>
                 `Subscription type: ${subscriptionType}, Subscription size: ${subscriptionSize}${expensifyCode ? `, Expensify code: ${expensifyCode}` : ''}, Auto renew: ${autoRenew}, Auto increase annual seats: ${autoIncrease}`,
             none: 'none',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -9477,6 +9477,7 @@ ${amount} para ${merchant} - ${date}`,
         },
         subscriptionSettings: {
             title: 'Configuración de suscripción',
+            editSubscription: 'Editar suscripción',
             summary: (subscriptionType, subscriptionSize, expensifyCode, autoRenew, autoIncrease) =>
                 `Tipo de suscripción: ${subscriptionType}, Tamaño de suscripción: ${subscriptionSize}${expensifyCode ? `, Código Expensify: ${expensifyCode}` : ''}, Renovación automática: ${autoRenew}, Aumento automático de asientos anuales: ${autoIncrease}`,
             none: 'ninguno',

--- a/src/pages/settings/Subscription/SubscriptionPlan/SubscriptionPlanCardActionButton.tsx
+++ b/src/pages/settings/Subscription/SubscriptionPlan/SubscriptionPlanCardActionButton.tsx
@@ -137,14 +137,19 @@ function SubscriptionPlanCardActionButton({subscriptionPlan, isFromComparisonMod
     const expensifyCode = isSecretPromoCode ? '' : (privatePromoCode ?? '');
 
     return (
-        <MenuItemWithTopDescription
-            description={translate('subscription.subscriptionSettings.title')}
-            style={style}
-            shouldShowRightIcon
-            onPress={() => Navigation.navigate(ROUTES.SETTINGS_SUBSCRIPTION_SETTINGS_DETAILS)}
-            numberOfLinesTitle={3}
-            title={translate('subscription.subscriptionSettings.summary', subscriptionType, subscriptionSize, expensifyCode, autoRenew, autoIncrease)}
-        />
+        <View style={style}>
+            <MenuItemWithTopDescription
+                description={translate('subscription.subscriptionSettings.title')}
+                interactive={false}
+                numberOfLinesTitle={3}
+                title={translate('subscription.subscriptionSettings.summary', subscriptionType, subscriptionSize, expensifyCode, autoRenew, autoIncrease)}
+            />
+            <Button
+                text={translate('subscription.subscriptionSettings.editSubscription')}
+                onPress={() => Navigation.navigate(ROUTES.SETTINGS_SUBSCRIPTION_SETTINGS_DETAILS)}
+                style={styles.mt3}
+            />
+        </View>
     );
 }
 


### PR DESCRIPTION
## Summary

- Converts the Subscription settings push row from an interactive `MenuItemWithTopDescription` to a **read-only** row by removing `shouldShowRightIcon` and `onPress`, and setting `interactive={false}`
- Adds an explicit **"Edit subscription"** button below the row that navigates to the existing `ROUTES.SETTINGS_SUBSCRIPTION_SETTINGS_DETAILS` route
- Adds the `subscription.subscriptionSettings.editSubscription` translation key in `en.ts` and `es.ts`

## Motivation

Users were having trouble discovering that the Subscription settings row was tappable. This change keeps the existing summary display intact while providing a clear, labeled call-to-action to reach the subscription settings RHP.

## Files changed

- `src/pages/settings/Subscription/SubscriptionPlan/SubscriptionPlanCardActionButton.tsx` — read-only row + Edit subscription button
- `src/languages/en.ts` — new `editSubscription` key
- `src/languages/es.ts` — new `editSubscription` key

## Test plan

- [ ] Open Subscription settings page
- [ ] Verify the Subscription settings row is displayed as read-only (no chevron, not tappable)
- [ ] Verify the "Edit subscription" button appears below the row
- [ ] Tap "Edit subscription" and confirm the subscription settings RHP opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)