### PR TITLE
fix: #92959 - selected members disappear after clearing search

### DIFF
--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -605,11 +605,6 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
     };
     const [inputValue, setInputValue, filteredData] = useSearchResults(data, filterMember, sortMembers, rolePreFilter);
 
-    const handleSearchChange = (value: string) => {
-        setSelectedEmployees([]);
-        setInputValue(value);
-    };
-
     useEffect(() => {
         if (!isFocused) {
             return;
@@ -1005,7 +1000,7 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
                         {shouldShowSearchBar && (
                             <SearchBar
                                 inputValue={inputValue}
-                                onChangeText={handleSearchChange}
+                                onChangeText={setInputValue}
                                 label={translate('workspace.people.findMember')}
                                 shouldShowEmptyState={false}
                                 style={[styles.flex1, styles.mh0, styles.mb0]}


### PR DESCRIPTION
$ #92959

`handleSearchChange` unconditionally called `setSelectedEmployees([])` on every search input change, including when clearing the field. This wiped the selection before the unfiltered list re-rendered.

Fix: remove `handleSearchChange` and wire `SearchBar` directly to `setInputValue`. Selection is already managed by `useFilteredSelection` which stores stable logins, so clearing search should not affect it.