### PR TITLE
fix: back button on Confirmation page navigates to Participant page instead of Merchant page

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -578,7 +578,10 @@ function IOURequestStepConfirmation({
 
         if (transaction?.isFromGlobalCreate && !transaction.receipt?.isTestReceipt) {
             // If the participants weren't automatically added to the transaction, then we should go back to the IOURequestStepParticipants.
-            if (!transaction?.participantsAutoAssigned && participantsAutoAssignedFromRoute !== 'true') {
+            // Also check for manually assigned participants (transaction.participants.length > 0) to avoid forcing navigation to Participants page
+            // when the user has already selected a participant.
+            const hasManualParticipants = (transaction?.participants?.length ?? 0) > 0;
+            if (!transaction?.participantsAutoAssigned && participantsAutoAssignedFromRoute !== 'true' && !hasManualParticipants) {
                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 Navigation.goBack(ROUTES.MONEY_REQUEST_STEP_PARTICIPANTS.getRoute(iouType, initialTransactionID, transaction?.reportID || reportID, undefined, action), {
                     compareParams: false,


### PR DESCRIPTION
## Summary

When a user manually selects a participant (not auto-assigned), the back button on the Confirmation page incorrectly navigated to the Participants page instead of going back naturally to the previous screen (e.g., Merchant page).

## Root Cause

The `navigateBack` function in `IOURequestStepConfirmation.tsx` only checked `participantsAutoAssigned` to determine if it should force navigation to the Participants page. When a user manually selects a participant, `participantsAutoAssigned` remains `false` but `transaction.participants` has entries, causing the incorrect navigation.

## Fix

Added a check for manually assigned participants (`transaction.participants.length > 0`) before forcing navigation to the Participants page.

## Testing

1. Create a manual expense in SelfDM with Merchant
2. Click 'Submit to someone' under created expense
3. Select a workspace in Participant page
4. On Confirmation page, click back button ('<')
5. Expected: Goes back to Merchant page (not Participant page)

$ #82091