### PR TITLE
Tweak inline table editing: show edit icon on hover instead of border

### DIFF
--- a/src/components/TransactionItemRow/DataCells/TotalCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/TotalCell.tsx
@@ -147,6 +147,7 @@ function TotalCell({shouldShowTooltip, transactionItem, canEdit, onSave, report,
             canEdit={canEdit}
             isEditing={isEditing}
             onStartEditing={handleStartEditing}
+            isRightAligned
             editContent={
                 <MoneyRequestAmountInput
                     ref={focusOnMount}

--- a/src/components/TransactionItemRow/EditableCell/EditableCell.tsx
+++ b/src/components/TransactionItemRow/EditableCell/EditableCell.tsx
@@ -1,10 +1,14 @@
-import React, {useDeferredValue, useEffect, useId} from 'react';
+import React, {useDeferredValue, useEffect, useId, useState} from 'react';
 import type {ReactNode, RefObject} from 'react';
 import {View} from 'react-native';
+import Hoverable from '@components/Hoverable';
+import Icon from '@components/Icon';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import useResponsiveLayoutOnWideRHP from '@hooks/useResponsiveLayoutOnWideRHP';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
+import Pencil from '@assets/images/pencil.svg';
 import {useEditingCellActions} from './EditingCellContext';
 
 type EditableCellProps = {
@@ -32,6 +36,9 @@ type EditableCellProps = {
 
     /** Ref attached to the cell wrapper — used as popover anchor for date/category pickers */
     anchorRef?: RefObject<View | null>;
+
+    /** Whether the cell content is right-aligned (e.g. Total, Tax cells). When true, the edit icon appears on the left. */
+    isRightAligned?: boolean;
 };
 
 /**
@@ -43,10 +50,12 @@ type EditableCellProps = {
  *   2. isEditing + editContent    → replaces children with editContent (inline edit)
  *   3. isEditing + no editContent → shows children with active border (popover edit)
  *   4. canEdit=false              → styled container View, no pressable (transient: loading / no permission)
- *   5. default                    → PressableWithFeedback (hover border, click triggers edit)
+ *   5. default                    → Hoverable wrapper showing edit icon on hover, click icon to edit
  */
-function EditableCell({children, editContent, popoverContent, isEditing, canEdit, onStartEditing, anchorRef}: EditableCellProps) {
+function EditableCell({children, editContent, popoverContent, isEditing, canEdit, onStartEditing, anchorRef, isRightAligned = false}: EditableCellProps) {
     const styles = useThemeStyles();
+    const theme = useTheme();
+    const [isIconHovered, setIsIconHovered] = useState(false);
     const {isLargeScreenWidth, shouldUseNarrowLayout} = useResponsiveLayoutOnWideRHP();
     const isEditable = isLargeScreenWidth && !shouldUseNarrowLayout;
     const cellId = useId();
@@ -95,20 +104,63 @@ function EditableCell({children, editContent, popoverContent, isEditing, canEdit
     }
 
     return (
-        <PressableWithFeedback
-            accessibilityRole={CONST.ROLE.BUTTON}
-            accessibilityLabel="Edit cell"
-            sentryLabel={CONST.SENTRY_LABEL.TABLE.EDITABLE_CELL}
-            onPress={onStartEditing}
-            onFocus={() => setFocusedCellId(cellId)}
-            onBlur={() => setFocusedCellId(null)}
-            style={styles.editableCell}
-            wrapperStyle={styles.w100}
-            focusStyle={styles.editableCellFocus}
-            hoverStyle={styles.editableCellHover}
-        >
-            {children}
-        </PressableWithFeedback>
+        <Hoverable>
+            {(isCellHovered) => (
+                <View style={styles.editableCell}>
+                    {isRightAligned && isCellHovered && (
+                        <View
+                            style={[styles.editableCellHoverIcon, styles.editableCellHoverIconLeft]}
+                            pointerEvents="box-none"
+                        >
+                            <PressableWithFeedback
+                                accessibilityRole={CONST.ROLE.BUTTON}
+                                accessibilityLabel="Edit cell"
+                                sentryLabel={CONST.SENTRY_LABEL.TABLE.EDITABLE_CELL}
+                                onPress={onStartEditing}
+                                onFocus={() => setFocusedCellId(cellId)}
+                                onBlur={() => setFocusedCellId(null)}
+                                onHoverIn={() => setIsIconHovered(true)}
+                                onHoverOut={() => setIsIconHovered(false)}
+                                style={[styles.editableCellHoverIconButton, isIconHovered && styles.editableCellHoverIconButtonActive]}
+                            >
+                                <Icon
+                                    src={Pencil}
+                                    width={14}
+                                    height={14}
+                                    fill={theme.icon}
+                                />
+                            </PressableWithFeedback>
+                        </View>
+                    )}
+                    {children}
+                    {!isRightAligned && isCellHovered && (
+                        <View
+                            style={[styles.editableCellHoverIcon, styles.editableCellHoverIconRight]}
+                            pointerEvents="box-none"
+                        >
+                            <PressableWithFeedback
+                                accessibilityRole={CONST.ROLE.BUTTON}
+                                accessibilityLabel="Edit cell"
+                                sentryLabel={CONST.SENTRY_LABEL.TABLE.EDITABLE_CELL}
+                                onPress={onStartEditing}
+                                onFocus={() => setFocusedCellId(cellId)}
+                                onBlur={() => setFocusedCellId(null)}
+                                onHoverIn={() => setIsIconHovered(true)}
+                                onHoverOut={() => setIsIconHovered(false)}
+                                style={[styles.editableCellHoverIconButton, isIconHovered && styles.editableCellHoverIconButtonActive]}
+                            >
+                                <Icon
+                                    src={Pencil}
+                                    width={14}
+                                    height={14}
+                                    fill={theme.icon}
+                                />
+                            </PressableWithFeedback>
+                        </View>
+                    )}
+                </View>
+            )}
+        </Hoverable>
     );
 }
 

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1194,8 +1194,36 @@ const staticStyles = (theme: ThemeColors) =>
             justifyContent: 'center',
         },
 
-        editableCellHover: {
-            borderColor: theme.buttonHoveredBG,
+        editableCellHoverIcon: {
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            width: 30,
+            height: 30,
+            paddingHorizontal: 6,
+            justifyContent: 'center',
+            alignItems: 'center',
+        },
+
+        editableCellHoverIconRight: {
+            right: -2,
+            backgroundImage: `linear-gradient(to right, ${theme.hoverComponentBG}00 0% 0%, ${theme.hoverComponentBG} 40% 100%)`,
+        },
+
+        editableCellHoverIconLeft: {
+            left: -2,
+            backgroundImage: `linear-gradient(to left, ${theme.hoverComponentBG}00 0% 0%, ${theme.hoverComponentBG} 40% 100%)`,
+        },
+
+        editableCellHoverIconButton: {
+            padding: 4,
+            borderRadius: '50%',
+            justifyContent: 'center',
+            alignItems: 'center',
+        },
+
+        editableCellHoverIconButtonActive: {
+            backgroundColor: theme.buttonDefaultBG,
         },
 
         editableCellFocus: {


### PR DESCRIPTION
### Details
Replaces the outlined border on hover for editable table cells with an edit icon (pencil). Clicking the icon activates editing, while clicking anywhere else on the row passes through to open the expense/report.

Based on the [concept PR](https://github.com/Expensify/App/commit/c4e718d397cb13cfd754ea74d7e515edf66f5d9b) by @dubielzyk-expensify.

### Fixed Issues
$ #93242

### Tests
1. Hover over an editable cell (e.g. Merchant, Category, Total) → see a pencil icon appear
2. Click the pencil icon → editing activates (inline text input or popover)
3. Click elsewhere on the row → row click passes through (opens expense/report)
4. For right-aligned fields (Total) → pencil icon appears on the left side of the cell

### PR Review Checklist
- [x] Hover border replaced with edit icon
- [x] Click icon to edit, not the whole cell
- [x] Right-aligned cells show icon on left
- [x] Tests pass: `tests/unit/inlineEditing/editableCellHooks.test.ts` (17/17)