### PR TITLE
Reduce domain padding in line charts to minimum necessary for fitting labels

### DIFF
--- a/src/components/Charts/LineChart/LineChartContent.tsx
+++ b/src/components/Charts/LineChart/LineChartContent.tsx
@@ -24,8 +24,7 @@ import {
     useLabelHitTesting,
     useYAxisLabelWidth,
 } from '@components/Charts/hooks';
-import {calculateMinDomainPadding} from '@components/Charts/utils';
-import VictoryTheme, {CHART_CONTENT_MIN_HEIGHT, GLYPH_PADDING} from '@components/Charts/VictoryTheme';
+import VictoryTheme, {CHART_CONTENT_MIN_HEIGHT, GLYPH_PADDING, LABEL_PADDING} from '@components/Charts/VictoryTheme';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
@@ -37,9 +36,6 @@ const DOT_RADIUS = 4;
 
 /** Extra hover area beyond the dot radius for easier touch targeting */
 const DOT_HOVER_EXTRA_RADIUS = 2;
-
-/** Minimum safe padding to avoid clipping labels/points */
-const MIN_SAFE_PADDING = DOT_RADIUS + DOT_HOVER_EXTRA_RADIUS;
 
 /** Base domain padding applied to all sides */
 const BASE_DOMAIN_PADDING = {top: 16, bottom: 16, left: 0, right: 0};
@@ -82,33 +78,36 @@ function LineChartContentBody({data, isLoading, yAxisUnit, yAxisUnitPosition = '
 
     const measurements = useChartLabelMeasurements(data, fontMgr, variables.iconSizeExtraSmall);
 
-    const domainPadding = (() => {
-        if (chartWidth === 0 || data.length === 0) {
-            return BASE_DOMAIN_PADDING;
-        }
+    const {formatValue} = useChartLabelFormats({
+        data,
+        unit: yAxisUnit,
+        unitPosition: yAxisUnitPosition,
+    });
 
-        const geometricPadding = calculateMinDomainPadding(chartWidth, data.length);
-
-        if (!measurements.firstLabelWidth || !measurements.lastLabelWidth) {
-            return {...BASE_DOMAIN_PADDING, left: geometricPadding, right: geometricPadding};
-        }
-
-        const firstLabelNeeds = measurements.firstLabelWidth / 2;
-        const lastLabelNeeds = measurements.lastLabelWidth / 2;
-
-        const wastedLeft = geometricPadding - firstLabelNeeds;
-        const wastedRight = geometricPadding - lastLabelNeeds;
-        const reclaimablePadding = Math.min(wastedLeft, wastedRight);
-
-        if (reclaimablePadding <= 0) {
-            return {...BASE_DOMAIN_PADDING, left: geometricPadding, right: geometricPadding};
-        }
-
-        const horizontalPadding = Math.max(geometricPadding - reclaimablePadding, MIN_SAFE_PADDING);
-        return {...BASE_DOMAIN_PADDING, left: horizontalPadding, right: horizontalPadding};
-    })();
+    const yAxisLabelWidth = useYAxisLabelWidth(
+        Math.max(...data.map((p) => p.total), 0),
+        Math.min(...data.map((p) => p.total), 0),
+        VictoryTheme.axis.tickCount,
+        formatValue,
+        fontMgr,
+        variables.iconSizeExtraSmall,
+    );
 
     const tickSpacing = plotAreaWidth > 0 && data.length > 0 ? plotAreaWidth / data.length : 0;
+    const chartPaddingLeft = yAxisLabelWidth + GLYPH_PADDING;
+
+    const domainPadding = (() => {
+        if (!measurements.firstLabelWidth || !measurements.lastLabelWidth) {
+            return BASE_DOMAIN_PADDING;
+        }
+        const willRotate = tickSpacing > 0 && measurements.maxLabelWidth + LABEL_PADDING > tickSpacing;
+
+        return {
+            ...BASE_DOMAIN_PADDING,
+            left: Math.max(0, measurements.firstLabelWidth / 2 - chartPaddingLeft),
+            right: willRotate ? measurements.lineHeight / 2 : measurements.lastLabelWidth / 2,
+        };
+    })();
 
     const totalDomainPadding = domainPadding.left + domainPadding.right;
     const paddingScale = plotAreaWidth > 0 ? plotAreaWidth / (plotAreaWidth + totalDomainPadding) : 0;
@@ -125,12 +124,6 @@ function LineChartContentBody({data, isLoading, yAxisUnit, yAxisUnitPosition = '
     });
 
     const originalLabels = data.map((p) => p.label);
-
-    const {formatValue} = useChartLabelFormats({
-        data,
-        unit: yAxisUnit,
-        unitPosition: yAxisUnitPosition,
-    });
 
     const {isCursorOverLabel, findLabelCursorX, updateTickPositions} = useLabelHitTesting({
         fontMgr,
@@ -226,15 +219,11 @@ function LineChartContentBody({data, isLoading, yAxisUnit, yAxisUnitPosition = '
 
     const labelSpace = VictoryTheme.axis.labelGap + (xAxisLabelHeight ?? 0);
     const dynamicChartStyle = {height: CHART_CONTENT_MIN_HEIGHT + labelSpace};
-    const yAxisLabelWidth = useYAxisLabelWidth(
-        Math.max(...data.map((p) => p.total), 0),
-        Math.min(...data.map((p) => p.total), 0),
-        VictoryTheme.axis.tickCount,
-        formatValue,
-        fontMgr,
-        variables.iconSizeExtraSmall,
-    );
-    const chartPadding = {...VictoryTheme.axis.padding, bottom: labelSpace + VictoryTheme.axis.padding.bottom, left: yAxisLabelWidth + GLYPH_PADDING};
+    const chartPadding = {
+        ...VictoryTheme.axis.padding,
+        bottom: labelSpace + VictoryTheme.axis.padding.bottom,
+        left: chartPaddingLeft,
+    };
 
     if (isLoading || !fontMgr) {
         const reasonAttributes: SkeletonSpanReasonAttributes = {context: 'LineChartContent', isLoading, isFontLoading: !fontMgr};

--- a/src/components/Charts/LineChart/LineChartContent.tsx
+++ b/src/components/Charts/LineChart/LineChartContent.tsx
@@ -24,7 +24,8 @@ import {
     useLabelHitTesting,
     useYAxisLabelWidth,
 } from '@components/Charts/hooks';
-import VictoryTheme, {CHART_CONTENT_MIN_HEIGHT, GLYPH_PADDING, LABEL_PADDING} from '@components/Charts/VictoryTheme';
+import {labelOverhang} from '@components/Charts/utils';
+import VictoryTheme, {CHART_CONTENT_MIN_HEIGHT, GLYPH_PADDING, LABEL_PADDING, LABEL_ROTATIONS, SIN_45} from '@components/Charts/VictoryTheme';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
@@ -77,6 +78,7 @@ function LineChartContentBody({data, isLoading, yAxisUnit, yAxisUnitPosition = '
     const chartBottom = useSharedValue(0);
 
     const measurements = useChartLabelMeasurements(data, fontMgr, variables.iconSizeExtraSmall);
+    const {lineHeight, firstLabelWidth, lastLabelWidth, maxLabelWidth, labelWidths} = measurements;
 
     const {formatValue} = useChartLabelFormats({
         data,
@@ -97,15 +99,23 @@ function LineChartContentBody({data, isLoading, yAxisUnit, yAxisUnitPosition = '
     const chartPaddingLeft = yAxisLabelWidth + GLYPH_PADDING;
 
     const domainPadding = (() => {
-        if (!measurements.firstLabelWidth || !measurements.lastLabelWidth) {
+        if (!firstLabelWidth || !lastLabelWidth) {
             return BASE_DOMAIN_PADDING;
         }
-        const labelsExceedTickSpacing = tickSpacing > 0 && measurements.maxLabelWidth + LABEL_PADDING > tickSpacing;
+        const labelsExceedTickSpacing = tickSpacing > 0 && maxLabelWidth + LABEL_PADDING > tickSpacing;
+        let leftOverhang = firstLabelWidth / 2;
+        let rightOverhang = lastLabelWidth / 2;
+
+        if (labelsExceedTickSpacing) {
+            const diagTickMax = (tickSpacing - LABEL_PADDING) / SIN_45 + lineHeight;
+            leftOverhang = labelOverhang(Math.min(firstLabelWidth, diagTickMax), lineHeight, LABEL_ROTATIONS.DIAGONAL).left;
+            rightOverhang = lineHeight / 2;
+        }
 
         return {
             ...BASE_DOMAIN_PADDING,
-            left: Math.max(0, measurements.firstLabelWidth / 2 - chartPaddingLeft),
-            right: labelsExceedTickSpacing ? measurements.lineHeight / 2 : measurements.lastLabelWidth / 2,
+            left: Math.max(0, leftOverhang - chartPaddingLeft),
+            right: rightOverhang,
         };
     })();
 
@@ -187,7 +197,7 @@ function LineChartContentBody({data, isLoading, yAxisUnit, yAxisUnitPosition = '
                 {xAxisLabelHeight !== undefined && !!fontMgr && (
                     <ChartXAxisLabels
                         labels={originalLabels}
-                        labelWidths={measurements.labelWidths}
+                        labelWidths={labelWidths}
                         regularLabelMaxWidth={regularLabelMaxWidth}
                         firstLabelMaxWidth={firstLabelMaxWidth}
                         lastLabelMaxWidth={lastLabelMaxWidth}

--- a/src/components/Charts/LineChart/LineChartContent.tsx
+++ b/src/components/Charts/LineChart/LineChartContent.tsx
@@ -100,12 +100,12 @@ function LineChartContentBody({data, isLoading, yAxisUnit, yAxisUnitPosition = '
         if (!measurements.firstLabelWidth || !measurements.lastLabelWidth) {
             return BASE_DOMAIN_PADDING;
         }
-        const willRotate = tickSpacing > 0 && measurements.maxLabelWidth + LABEL_PADDING > tickSpacing;
+        const labelsExceedTickSpacing = tickSpacing > 0 && measurements.maxLabelWidth + LABEL_PADDING > tickSpacing;
 
         return {
             ...BASE_DOMAIN_PADDING,
             left: Math.max(0, measurements.firstLabelWidth / 2 - chartPaddingLeft),
-            right: willRotate ? measurements.lineHeight / 2 : measurements.lastLabelWidth / 2,
+            right: labelsExceedTickSpacing ? measurements.lineHeight / 2 : measurements.lastLabelWidth / 2,
         };
     })();
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Reduces the spacing in Spend/Home line charts between the Y axis and the first point, as well as between the chart edge and the last point to a reasonable minimum, while ensuring the labels don't get clipped or rotated prematurely because of it. It drops the idea of reserving minimum space for points so that they don't get clipped at the plot area boundaries, cause that's no longer an issue, as we've been rendering them using renderOutside prop for some time now. Also the padding symmetry is no longer enforced, the first point can make use of the space reserved for the Y axis labels more effectively this way.

| Before | After |
| :---: | :---: |
| ![](https://github.com/user-attachments/assets/83f2356c-ad32-4c83-8c21-f04b61361386) | ![](https://github.com/user-attachments/assets/5e527503-e4aa-4863-999c-28c2a4a3f0bb) |
| ![](https://github.com/user-attachments/assets/94df4e85-ab43-47b4-9042-bd3b3ce96581) | ![](https://github.com/user-attachments/assets/81325c08-1eb9-404f-a785-741c2d283031) |
| ![](https://github.com/user-attachments/assets/90cf82bc-03cb-4fe4-b1e9-7a2b3c9495ec) | ![](https://github.com/user-attachments/assets/0e03e4e4-07e6-471d-b2fc-6c47283b54ad) |
| ![](https://github.com/user-attachments/assets/db4c67f3-323f-4d7f-8c64-5f5c019d71ff) | ![](https://github.com/user-attachments/assets/6af8751d-baf3-4e9e-994a-e40422d232ab) |

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/90646
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open different line charts.
2. Verify no points or labels are ever clipped.
3. Verify there is a reduced blank space reserved for the left- and right-most labels. Due to the nature of the implementation, there could sometimes be a little extra space on the right side of the last point, especially when rotated 45 degrees, but it should be much smaller than previously.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="437" height="786" alt="Zrzut ekranu 2026-06-15 o 10 26 53" src="https://github.com/user-attachments/assets/c1313ca0-d09d-486c-85ff-30be68dc7784" />

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-15 at 10 12 39" src="https://github.com/user-attachments/assets/c0b4866f-8a44-4c3b-8bcb-1dee6fa07c04" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-15 at 10 24 27" src="https://github.com/user-attachments/assets/f060811b-900c-41e2-9b8d-429db2c548a6" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1512" height="949" alt="Zrzut ekranu 2026-06-15 o 10 39 01" src="https://github.com/user-attachments/assets/4248ad3f-a36e-446a-8085-fbb2905c0757" />

</details>
