### PR TITLE
[#93322] Web - Fix email tooltip not displayed when hovering over group member

### DIFF
--- a/src/components/SelectionList/ListItem/TableListItem.tsx
+++ b/src/components/SelectionList/ListItem/TableListItem.tsx
@@ -80,6 +80,7 @@ function TableListItem<TItem extends ListItem>({
                 {!item.shouldHideAlternateText && !!item.alternateText && (
                     <TextWithTooltip
                         shouldShowTooltip={showTooltip}
+                        alwaysShowTooltip
                         text={item.alternateText}
                         style={[styles.textLabelSupporting, styles.lh16, styles.pre]}
                     />

--- a/src/components/TextWithTooltip/index.tsx
+++ b/src/components/TextWithTooltip/index.tsx
@@ -7,12 +7,15 @@ type LayoutChangeEvent = {
     target: HTMLElement;
 };
 
-function TextWithTooltip({testID, text, shouldShowTooltip, style, numberOfLines = 1, forwardedFSClass}: TextWithTooltipProps) {
+function TextWithTooltip({testID, text, shouldShowTooltip, style, numberOfLines = 1, forwardedFSClass, alwaysShowTooltip = false}: TextWithTooltipProps) {
     const [showTooltip, setShowTooltip] = useState(false);
+
+    // When alwaysShowTooltip is true, the tooltip is shown on hover regardless of text truncation
+    const isTooltipVisible = alwaysShowTooltip ? shouldShowTooltip : showTooltip;
 
     return (
         <Tooltip
-            shouldRender={showTooltip}
+            shouldRender={isTooltipVisible}
             text={text}
         >
             <Text

--- a/src/components/TextWithTooltip/types.ts
+++ b/src/components/TextWithTooltip/types.ts
@@ -16,6 +16,9 @@ type TextWithTooltipProps = ForwardedFSClassProps & {
 
     /** TestID of the Text component */
     testID?: string;
+
+    /** If true, the tooltip will always be shown on hover, regardless of text truncation */
+    alwaysShowTooltip?: boolean;
 };
 
 export default TextWithTooltipProps;


### PR DESCRIPTION
### Details
The email tooltip was not appearing when hovering over group members (non-admin) because `TextWithTooltip` only shows a tooltip when the text is truncated (scrollWidth > offsetWidth). Group admins have an "Admin" badge that reduces the available horizontal space, causing their email to truncate and the tooltip to appear. Regular members without the badge have more space, so their email never truncates and the tooltip never shows.

### Fixed Issues
$ #93322

### Tests
1. Create a group with more than 2 members
2. Navigate to the group -> click on group header -> Members
3. Hover over the email address of a group member (non-admin)
4. ✅ Verify the tooltip with the full email address is displayed
5. Hover over the email address of the group admin
6. ✅ Verify the tooltip is still displayed (regression check)

### QA Steps
Same as tests above.

### Changes
- Added `alwaysShowTooltip` prop to `TextWithTooltip` component (types.ts + index.tsx)
- Applied `alwaysShowTooltip` to the alternateText (email) rendering in `TableListItem`

When `alwaysShowTooltip` is enabled, the tooltip renders on hover regardless of text truncation. The prop defaults to `false`, so existing behavior is preserved everywhere else.