### PR TITLE
perf(Search): read live feed name in CardListItemHeader for group-by-card display

### DIFF
--- a/src/components/Search/SearchList/ListItem/CardListItemHeader.tsx
+++ b/src/components/Search/SearchList/ListItem/CardListItemHeader.tsx
@@ -7,12 +7,15 @@ import type {ListItem} from '@components/SelectionList/types';
 import TextWithTooltip from '@components/TextWithTooltip';
 import UserDetailsTooltip from '@components/UserDetailsTooltip';
 import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {getFeedNameForDisplay} from '@libs/CardUtils';
 import {getDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import type {CompanyCardFeed} from '@src/types/onyx/CardFeeds';
 import ExpandCollapseArrowButton from './ExpandCollapseArrowButton';
 import TextCell from './TextCell';
@@ -69,6 +72,21 @@ function CardListItemHeader<TItem extends ListItem>({
     const StyleUtils = useStyleUtils();
     const {translate, formatPhoneNumber} = useLocalize();
     const formattedDisplayName = formatPhoneNumber(getDisplayNameOrDefault(cardItem));
+
+    // The feed name is a live-only value: it is resolved from the card feeds collection and is not part of
+    // the search snapshot. Subscribing here keeps the displayed feed name in sync as feeds/nicknames change,
+    // without forcing the screen-level getSections memo to depend on cardFeeds for display purposes.
+    // This is a group header (a few instances at most), so subscribing to the full collection is cheap.
+    const cardFeed = cardItem.bank as CompanyCardFeed;
+    const [cardFeeds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER);
+    const [cardList] = useOnyx(ONYXKEYS.CARD_LIST);
+    const cardFundID = cardList?.[cardItem.cardID]?.fundID;
+    const customFeedName = cardFundID ? cardFeeds?.[`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${cardFundID}`]?.settings?.companyCardNicknames?.[cardFeed] : undefined;
+    const liveFormattedFeedName = getFeedNameForDisplay(translate, cardFeed, cardFeeds, customFeedName, true, cardItem.feedCountry);
+    // Fall back to the snapshot value while card feeds are still loading so the feed name never flashes empty.
+    // `||` (not `??`) is intentional: an empty live name should fall through to the snapshot value.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const formattedFeedName = liveFormattedFeedName || cardItem.formattedFeedName || '';
     const backgroundColor =
         StyleUtils.getItemBackgroundColorStyle(!!cardItem.isSelected, !!isFocused, !!isDisabled, theme.activeComponentBG, theme.hoverComponentBG)?.backgroundColor ?? theme.highlightBG;
 
@@ -81,7 +99,7 @@ function CardListItemHeader<TItem extends ListItem>({
                 <UserDetailsTooltip accountID={cardItem.accountID}>
                     <View>
                         <ReportActionAvatars
-                            subscriptCardFeed={cardItem.bank as CompanyCardFeed}
+                            subscriptCardFeed={cardFeed}
                             subscriptAvatarBorderColor={backgroundColor}
                             noRightMarginOnSubscriptContainer
                             accountIDs={[cardItem.accountID]}
@@ -111,7 +129,7 @@ function CardListItemHeader<TItem extends ListItem>({
                 style={StyleUtils.getReportTableColumnStyles(CONST.SEARCH.TABLE_COLUMNS.FEED)}
             >
                 <TextWithTooltip
-                    text={cardItem.formattedFeedName ?? ''}
+                    text={formattedFeedName}
                     numberOfLines={2}
                     style={[styles.lineHeightLarge, styles.preWrap]}
                 />
@@ -155,7 +173,7 @@ function CardListItemHeader<TItem extends ListItem>({
                     {!isLargeScreenWidth && (
                         <View style={[styles.flexRow, styles.flex1, styles.gap3]}>
                             <ReportActionAvatars
-                                subscriptCardFeed={cardItem.bank as CompanyCardFeed}
+                                subscriptCardFeed={cardFeed}
                                 subscriptAvatarBorderColor={backgroundColor}
                                 noRightMarginOnSubscriptContainer
                                 accountIDs={[cardItem.accountID]}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Follow-up to the Search decomposition "slice 3" live-merge work. The goal was to stop the screen-level `getSections` memo (`src/components/Search/index.tsx`) from recomputing when `cardFeeds` changes by removing `cardFeeds` from `getSections`, moving the card feed-name **display** to the group header component instead.

**What this PR does:** moves the feed-name **display** into `CardListItemHeader`. The header now reads the feed name **live** via a narrow `useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER)` + `useOnyx(ONYXKEYS.CARD_LIST)` and computes it with `getFeedNameForDisplay`, mirroring the exact nickname-lookup logic already in `getCardSections` (`cardList[cardID].fundID` → `cardFeeds[...].settings.companyCardNicknames[bank]`). The displayed name now stays in sync as feeds/nicknames change, and falls back to the snapshot `formattedFeedName` while feeds are still loading so the value never flashes empty. `CardListItemHeader` is a group header (a handful of instances at most), so the full-collection subscription is cheap and stays well clear of the high-frequency transaction `renderItem` path.

**Honest scope re: the sort — `cardFeeds` could NOT be removed from `getSections`.** The card-group sort comparator reads the `formattedFeedName` property off each section object: `transactionCardGroupColumnNamesToSortingProperty` maps `GROUP_FEED` → `'formattedFeedName'` (`src/libs/SearchUIUtils.ts:334`), and `getSortedData` compares that string when the user sorts by the Feed column. `formattedFeedName` is produced **only** by `getCardSections` via `getFeedNameForDisplay(translate, bank, cardFeeds, ...)` (`SearchUIUtils.ts:3242`), which returns `''` when `cardFeeds` is undefined (`CardUtils.ts:829-831`). The feed name is **live-only** — it is not part of the search snapshot (`SearchCardGroup` carries only `bank`, `cardName`, `lastFourPAN`, `feedCountry`, never the resolved/localized display name). Therefore:

- Keeping a minimal `cardFeeds`-derived `formattedFeedName` "only for the comparator" still requires `cardFeeds` in `getSections`, which defeats the removal.
- Relocating the `GROUP_FEED` sort to a snapshot value is not clean: there is no snapshot field equal to the displayed (localized/custom) feed name; sorting on raw `bank` would change the observed ordering — a behavior regression, not a no-op relocation.

Per the decision rule (a smaller correct PR beats a broken one), `cardFeeds` **stays** in `getSections` for the sort, and only the display was relocated to read live. `customCardNames` is **kept** unchanged (removing it would revert the shipped fix faf0ce56e9e "Card nicknames are not showing up in group by searches"). The Search-level `cardFeeds` loading-gate subscription is also kept unchanged.

### Performance

This is a **partial** optimization, honestly scoped. `cardFeeds` was **not** removed from `getSections` — only the feed-name **display** was relocated to `CardListItemHeader` so it reads live. The `getSections` memo still depends on `cardFeeds` because the card-group feed-column sort reads `formattedFeedName`, which can only be computed from the live `cardFeeds` collection (it is not in the search snapshot). The win here is correctness/liveness of the displayed feed name without widening the screen-level memo; the targeted "stop `getSections` recomputing on `cardFeeds` change" goal is not achievable without breaking feed-name sorting.

Note on subscriptions: `getFeedNameForDisplay` iterates the entire `cardFeeds` collection (`doesCardFeedExist` / `getCustomFeedNameFromFeeds`), so a narrowing Onyx selector is not applicable here — the helper genuinely consumes the whole collection. This matches the existing convention of every other `SHARED_NVP_PRIVATE_DOMAIN_MEMBER` consumer in the repo.

### Fixed Issues
$ https://github.com/Expensify/App/issues/92079
PROPOSAL:


### Tests

1. Open Search and run a search that returns expenses, then group by **Card** (`groupBy: card`).
2. Verify each card group header shows the correct **feed name** in the Feed column (wide layout) and the correct **card name** (including custom nicknames) in the Card column.
3. Rename a company card feed / set a feed nickname elsewhere, return to the grouped-by-card search, and verify the displayed feed name updates live (no app reload needed).
4. Verify a card group with a custom card nickname still renders the nickname in the Card column (regression check for faf0ce56e9e).
5. Click the **Feed** column header to sort by feed name and verify the card groups reorder correctly by feed name (ascending/descending).

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open a grouped-by-card search and verify the feed name and card name (including nicknames) still render from cached data.
3. Verify sorting by the Feed column still orders groups correctly while offline.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
