### PR TITLE
Add null guard in Parser.htmlToText to prevent TypeError when input is null.

### DIFF
--- a/src/libs/Parser.ts
+++ b/src/libs/Parser.ts
@@ -57,6 +57,9 @@ class ExpensiMarkWithContext extends ExpensiMark {
     }
 
     htmlToText(htmlString: string, extras?: Extras): string {
+        if (!htmlString) {
+            return '';
+        }
         return super.htmlToText(htmlString, {
             reportIDToName: extras?.reportIDToName ?? reportIDToNameMap,
             accountIDToName: extras?.accountIDToName ?? accountIDToNameMap,


### PR DESCRIPTION
Refs #92417.

Add null guard in Parser.htmlToText to prevent TypeError when input is null. The crash 'Cannot read properties of null (reading replace)' on the onboarding purpose screen is likely caused by a null string reaching Parser.replace or related methods. The simplest defense is to guard the overridden htmlToText method to return empty string when input is nullish, preventing the downstream null reference.

I ran the available lightweight check for the frontend change.