### PR TITLE
fix: Action button shows "Draft" for offline expense when approvals/payments are disabled

### DIFF
--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -31,7 +31,7 @@ import type {SearchFullscreenNavigatorParamList} from '@libs/Navigation/types';
 import enhanceParameters from '@libs/Network/enhanceParameters';
 import {rand64} from '@libs/NumberUtils';
 import {getActivePaymentType} from '@libs/PaymentUtils';
-import {getSubmitReportManagerAccountID, getValidConnectedIntegration, isDelayedSubmissionEnabled} from '@libs/PolicyUtils';
+import {getSubmitReportManagerAccountID, getValidConnectedIntegration, isDelayedSubmissionEnabled, isSubmitAndClose} from '@libs/PolicyUtils';
 import type {OptimisticExportIntegrationAction} from '@libs/ReportUtils';
 import {
     buildOptimisticExportIntegrationAction,
@@ -840,12 +840,23 @@ function search({
 
 function submitMoneyRequestOnSearch(hash: number, reportList: Report[], policy: Policy[], currentSearchKey?: SearchKey) {
     const firstReport = (reportList.at(0) ?? {}) as Report;
-    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE>> = [
+    const isSubmitAndClosePolicy = isSubmitAndClose(policy.at(0));
+    const optimisticData: Array<
+        OnyxUpdate<typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE | typeof ONYXKEYS.COLLECTION.REPORT>
+    > = [
         {
             onyxMethod: Onyx.METHOD.MERGE_COLLECTION,
             key: ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE,
             value: Object.fromEntries(reportList.map((report) => [`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${report?.reportID}`, {isActionLoading: true}])),
         },
+        ...reportList.map((report) => ({
+            onyxMethod: Onyx.METHOD.MERGE as const,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${report?.reportID}`,
+            value: {
+                stateNum: isSubmitAndClosePolicy ? CONST.REPORT.STATE_NUM.APPROVED : CONST.REPORT.STATE_NUM.SUBMITTED,
+                statusNum: isSubmitAndClosePolicy ? CONST.REPORT.STATUS_NUM.CLOSED : CONST.REPORT.STATUS_NUM.SUBMITTED,
+            },
+        })),
     ];
 
     const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE | typeof ONYXKEYS.COLLECTION.SNAPSHOT>> = [


### PR DESCRIPTION
### Details
When submitting an expense offline from the Search view (Reports > Expenses), the action button shows "Draft" instead of "Done" on workspaces with approvals and payments disabled. This happens because `submitMoneyRequestOnSearch` does not include an optimistic update for the report state (stateNum/statusNum).

### Fixed Issues
$ #93371

### Tests
1. Select "Track expenses for my business" during onboarding
2. Have a workspace with approvals and payments disabled
3. Go offline
4. Navigate to Reports > Expenses
5. Create a manual expense and submit it to workspace
6. Verify the action button shows "Done" instead of "Draft"

### QA Steps
Same as tests above.

### Root Cause
`submitMoneyRequestOnSearch` in `src/libs/actions/Search.ts` calls `API.write(SUBMIT_REPORT)` without an optimistic update for the report state. When offline, the report remains OPEN/OPEN ("Draft") instead of transitioning to APPROVED/CLOSED ("Done") for submit-and-close policies.

### Fix
Added optimistic data entries in `submitMoneyRequestOnSearch` that update each report's `stateNum` and `statusNum` to APPROVED/CLOSED (or SUBMITTED/SUBMITTED for non-submit-and-close policies) immediately in Onyx, before the API call completes. This ensures the UI reflects the correct status even when offline.