### PR TITLE
fix: prevent flash of hmm not here page when creating report from self DM

### DIFF
--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -48,7 +48,8 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
     const isInvalidReportPath = !!routeParams?.reportID && !isValidReportIDFromPath(routeParams.reportID);
     const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
-    const reportExists = !!reportID || isOptimisticDelete || userLeavingStatus;
+    const isOptimisticCreate = report?.pendingFields?.createReport === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD;
+    const reportExists = !!reportID || isOptimisticDelete || isOptimisticCreate || userLeavingStatus;
 
     const shouldShowNotFoundPage = !deleteTransactionNavigateBackUrl && (isInvalidReportPath || (!isLoading && !reportExists));
 


### PR DESCRIPTION
### Details
When creating a new expense report from a self DM (via Tap report -> Create report), the ReportNotFoundGuard was briefly showing the hmm not here / FullPageNotFoundView because the optimistic report data had not been written to Onyx yet when the navigation occurred.

### Fixed Issues
$ https://github.com/Expensify/App/issues/93413

### Tests
1. Launch app and login
2. Open self DM
3. Create a manual expense (enter amount)
4. Open the expense -> category -> upgrade -> create workspace and select a category
5. Tap report -> create report
6. Verify the hmm not here page does NOT flash briefly

### Analysis
The root cause was in src/pages/inbox/ReportNotFoundGuard.tsx. The reportExists variable only checked for reportID, isOptimisticDelete, and userLeavingStatus. When creating a new report optimistically via createNewReport(), the report data had not yet been written to Onyx, so reportID was undefined and reportExists was false. Since isLoading was also false (no loading state active), shouldShowNotFoundPage became true, briefly flashing the hmm not here page.

The fix adds isOptimisticCreate which checks report?.pendingFields?.createReport === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD. When this is true, the report is being optimistically created and should be treated as existing.