### PR TITLE
fix: Return image source without auth headers when offline so browser cache can serve attachments

### DIFF
--- a/src/components/Image/getImageSource.ts
+++ b/src/components/Image/getImageSource.ts
@@ -23,7 +23,13 @@ export default function getImageSource({propsSource, session, isAuthTokenRequire
 
         const authToken = session?.encryptedAuthToken ?? null;
         if (isAuthTokenRequired && authToken) {
-            if (isOffline || (!!session?.creationDate && !isExpiredSession(session.creationDate))) {
+            if (isOffline) {
+                // When offline, don't add auth headers so the browser can use its HTTP cache
+                // to serve the image if it was previously loaded. Without headers, the browser
+                // can serve from disk cache even without connectivity.
+                return {source: propsSource, shouldReauthenticate: false};
+            }
+            if (!!session?.creationDate && !isExpiredSession(session.creationDate)) {
                 return {
                     source: {
                         ...propsSource,

--- a/tests/unit/components/Image/getImageSource.test.ts
+++ b/tests/unit/components/Image/getImageSource.test.ts
@@ -56,7 +56,7 @@ describe('getImageSource', () => {
         });
     });
 
-    it('returns an authenticated source offline even when the session is expired', () => {
+    it('returns the source without auth headers when offline so the browser cache can serve the image', () => {
         const propsSource = {uri: MOCK_URI};
         const session: Session = {
             encryptedAuthToken: MOCK_TOKEN,
@@ -71,13 +71,7 @@ describe('getImageSource', () => {
                 isOffline: true,
             }),
         ).toEqual({
-            source: {
-                ...propsSource,
-                cacheKey: MOCK_URI,
-                headers: {
-                    [CONST.CHAT_ATTACHMENT_TOKEN_KEY]: MOCK_TOKEN,
-                },
-            },
+            source: propsSource,
             shouldReauthenticate: false,
         });
     });


### PR DESCRIPTION
### Details
When attaching an image while offline, the preview works because the image source is a local blob. However, after refreshing the page (while still offline), the image fails to load because `getImageSource` adds auth headers to the source. With auth headers, the browser cannot use its HTTP cache, and the fetch fails since there is no connectivity.

### Fixed Issues
$ #93375

### Tests
1. Go offline
2. Attach an image in a chat → image preview appears immediately
3. Refresh the page while still offline → image should still appear (served from browser cache)
4. Go back online and refresh → image appears normally

### PR Review Checklist
- [x] Test A: Offline attachment with page refresh works
- [x] Test B: Existing online attachment flow unchanged
- [x] Test C: All existing getImageSource tests pass

### QA Steps
Same as Tests above.