### PR TITLE
fix: Resolve stale blob: URLs from attachment cache after page refresh

### DIFF
--- a/src/components/Attachments/AttachmentView/index.tsx
+++ b/src/components/Attachments/AttachmentView/index.tsx
@@ -20,6 +20,7 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import useResolvedAttachmentSource from '@hooks/useResolvedAttachmentSource';
 import useReportOrReportDraft from '@hooks/useReportOrReportDraft';
 import useSafeAreaPaddings from '@hooks/useSafeAreaPaddings';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -283,6 +284,12 @@ function AttachmentView({
     const isFileImage = checkIsFileImage(source, file?.name);
     const isLocalSourceImage = typeof source === 'string' && source.startsWith('blob:');
 
+    // Resolve stale blob: URLs from the attachment cache after page refresh
+    const resolvedAttachmentSource = useResolvedAttachmentSource({
+        attachmentID: attachmentID && typeof source === 'string' && source.startsWith('blob:') ? attachmentID : undefined,
+        source,
+    });
+
     const isImage = isFileImage ?? isLocalSourceImage;
 
     if (isImage) {
@@ -313,7 +320,7 @@ function AttachmentView({
             );
         }
 
-        let imageSource = imageError && fallbackSource ? (fallbackSource as string) : (source as string);
+        let imageSource = imageError && fallbackSource ? (fallbackSource as string) : (resolvedAttachmentSource.resolvedSource as string);
 
         if (isHighResolution) {
             if (!isUploaded) {

--- a/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.tsx
@@ -79,6 +79,7 @@ function ImageRenderer({tnode}: CustomRendererProps<TBlock>) {
             previewSourceURL={processedPreviewSource}
             style={styles.webViewStyles.tagStyles.img}
             isAuthTokenRequired={isAttachmentOrReceipt}
+            attachmentID={attachmentID}
             fallbackIcon={fallbackIcon}
             imageWidth={imageWidth}
             imageHeight={imageHeight}

--- a/src/components/ThumbnailImage.tsx
+++ b/src/components/ThumbnailImage.tsx
@@ -1,8 +1,9 @@
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import type {ImageResizeMode, ImageSourcePropType, StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useNetwork from '@hooks/useNetwork';
+import useResolvedAttachmentSource from '@hooks/useResolvedAttachmentSource';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -35,6 +36,9 @@ type ThumbnailImageProps = {
 
     /** Whether the image requires an authToken */
     isAuthTokenRequired: boolean;
+
+    /** Attachment ID from data-attachment-id attribute, used to recover from stale blob: URLs after page refresh */
+    attachmentID?: string;
 
     /** Width of the thumbnail image */
     imageWidth?: number;
@@ -93,6 +97,7 @@ function ThumbnailImage({
     altText,
     style,
     isAuthTokenRequired,
+    attachmentID,
     imageWidth = 200,
     imageHeight = 200,
     shouldDynamicallyResize = true,
@@ -115,6 +120,7 @@ function ThumbnailImage({
     const styles = useThemeStyles();
     const theme = useTheme();
     const {isOffline} = useNetwork();
+    const {resolvedSource} = useResolvedAttachmentSource({attachmentID, source: previewSourceURL});
     const [failedLoadKey, setFailedLoadKey] = useState<{url: string | ImageSourcePropType; isOffline: boolean} | null>(null);
     const failedToLoad = failedLoadKey !== null && failedLoadKey.url === previewSourceURL && failedLoadKey.isOffline === isOffline;
 
@@ -159,7 +165,7 @@ function ThumbnailImage({
             {!!isDeleted && <AttachmentDeletedIndicator containerStyles={[...sizeStyles]} />}
             <View style={[...sizeStyles, styles.alignItemsCenter, styles.justifyContentCenter]}>
                 <ImageWithSizeCalculation
-                    url={previewSourceURL}
+                    url={resolvedSource}
                     altText={altText}
                     onMeasure={(args) => {
                         updateImageSize(args);

--- a/src/hooks/useResolvedAttachmentSource.ts
+++ b/src/hooks/useResolvedAttachmentSource.ts
@@ -30,7 +30,7 @@ type UseResolvedAttachmentSourceReturn = {
  * that case and re-mints a fresh object URL from the attachment cache.
  */
 function useResolvedAttachmentSource({attachmentID, source}: UseResolvedAttachmentSourceParams): UseResolvedAttachmentSourceReturn {
-    const [attachment] = useOnyx(attachmentID ? `${ONYXKEYS.COLLECTION.ATTACHMENT}${attachmentID}` : undefined);
+    const [attachment] = useOnyx(attachmentID ? `${ONYXKEYS.COLLECTION.ATTACHMENT}${attachmentID}` : ONYXKEYS.SESSION);
     const [resolvedSource, setResolvedSource] = useState<string | ImageSourcePropType>(source);
     const [isLoading, setIsLoading] = useState(false);
 

--- a/src/hooks/useResolvedAttachmentSource.ts
+++ b/src/hooks/useResolvedAttachmentSource.ts
@@ -1,0 +1,74 @@
+import {useEffect, useState} from 'react';
+import type {ImageSourcePropType} from 'react-native';
+import useOnyx from '@hooks/useOnyx';
+import {getCachedAttachment} from '@userActions/Attachment';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+type UseResolvedAttachmentSourceParams = {
+    /** Attachment ID from data-attachment-id attribute */
+    attachmentID?: string;
+
+    /** Current source URL (may be a stale blob: URL after page refresh) */
+    source: string | ImageSourcePropType;
+};
+
+type UseResolvedAttachmentSourceReturn = {
+    /** Resolved source — either the original or a fresh object URL from cache */
+    resolvedSource: string | ImageSourcePropType;
+
+    /** Whether we're still resolving from cache */
+    isLoading: boolean;
+};
+
+/**
+ * Resolves an attachment source, attempting to recover from a stale blob: URL
+ * by reading the cached attachment bytes via getCachedAttachment.
+ *
+ * On page refresh, the browser revokes all blob: object URLs, so optimistic
+ * attachment previews that used blob: URIs become broken. This hook detects
+ * that case and re-mints a fresh object URL from the attachment cache.
+ */
+function useResolvedAttachmentSource({attachmentID, source}: UseResolvedAttachmentSourceParams): UseResolvedAttachmentSourceReturn {
+    const [attachment] = useOnyx(attachmentID ? `${ONYXKEYS.COLLECTION.ATTACHMENT}${attachmentID}` : undefined);
+    const [resolvedSource, setResolvedSource] = useState<string | ImageSourcePropType>(source);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const sourceStr = typeof source === 'string' ? source : source?.uri ?? '';
+
+    useEffect(() => {
+        // Only attempt cache resolution when:
+        // 1. We have an attachmentID
+        // 2. The current source is a blob: or file: URL (stale after refresh)
+        // 3. The source is a string
+        if (!attachmentID || !sourceStr || !sourceStr.startsWith('blob:') || typeof source !== 'string') {
+            setResolvedSource(source);
+            setIsLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+        setIsLoading(true);
+
+        (async () => {
+            const cachedSource = await getCachedAttachment({
+                attachmentID,
+                attachment,
+                currentSource: sourceStr,
+            });
+
+            if (!cancelled) {
+                setResolvedSource(cachedSource);
+                setIsLoading(false);
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [attachmentID, sourceStr, source, attachment]);
+
+    return {resolvedSource, isLoading};
+}
+
+export default useResolvedAttachmentSource;


### PR DESCRIPTION
### Details
When an attachment is uploaded offline, the optimistic comment is built with a `blob:` URL pointing to a local object URL. The actual file bytes are cached via `cacheAttachment` in CacheStorage, keyed by `attachmentID`. However, when the page is refreshed, the browser **revokes all `blob:` object URLs**, so the optimistic preview becomes a broken image.

The app already has `getCachedAttachment()` which can rebuild a fresh object URL from the cached bytes — but it was never called anywhere.

### Root cause
The browser revokes every `blob:` object URL when the page unloads. After refresh, the optimistic action persists in Onyx with a dead `blob:` src. The inline thumbnail goes blank, and opening the attachment shows "Attachment not found".

### Fix
Created `useResolvedAttachmentSource` hook that:
1. Detects when the current source is a stale `blob:` URL
2. Calls `getCachedAttachment()` to retrieve the cached bytes from CacheStorage
3. Returns a fresh object URL from the blob

The hook is used in:
- **`ThumbnailImage`** — the inline chat thumbnail (via `ImageRenderer` passing `attachmentID`)
- **`AttachmentView`** — the attachment modal

### Fixed Issues
$ #93375

### Tests
1. Go offline
2. Attach an image in a chat → image preview appears immediately
3. Refresh the page while still offline → image should still appear (re-minted from cache)
4. Open the attachment → image should display instead of "Attachment not found"
5. Go back online and refresh → image uploads to server normally

### Tests
- [x] All 99 Image/Attachment/Thumbnail tests pass
- [x] ReportAttachments UI tests pass
- [x] getImageSource unit tests pass