### PR TITLE
[Fix] Show Switch to Expensify Classic button on Troubleshoot page

### DIFF
--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -33,7 +33,7 @@ import ExportOnyxState from '@libs/ExportOnyxState';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
-import {shouldHideOldAppRedirect} from '@libs/TryNewDotUtils';
+import {isLockedToNewApp} from '@libs/TryNewDotUtils';
 import colors from '@styles/theme/colors';
 import {clearOnyxAndResetApp} from '@userActions/App';
 import CONFIG from '@src/CONFIG';
@@ -120,7 +120,7 @@ function TroubleshootPage() {
     const surveyCompletedWithinLastMonth = getSurveyCompletedWithinLastMonth();
 
     const getClassicRedirectMenuItem = (): BaseMenuItem | null => {
-        if (shouldHideOldAppRedirect(tryNewDot, isLoadingTryNewDot, CONFIG.IS_HYBRID_APP)) {
+        if (isLockedToNewApp(tryNewDot) || tryNewDot?.classicRedirect?.isLockedToNewDot === true || (CONFIG.IS_HYBRID_APP && isLoadingTryNewDot)) {
             return null;
         }
 


### PR DESCRIPTION
### Details

$ #93358

### Root Cause

The Troubleshoot page uses shouldHideOldAppRedirect() to decide whether to show the "Switch to Expensify Classic" button. This function includes hasBeenInNewDot30Days() which auto-hides the redirect after 30 days on NewDot. While this is appropriate for the automatic redirect nudge, it should not apply to the manual button on the Troubleshoot settings page.

This causes the button to:
1. Appear briefly after cache clear (Onyx state is null, so the 30-day check passes)
2. Disappear once Onyx state is restored (30+ day condition triggers)

### Fixed Behavior

The button now only hides when:
- The user is explicitly locked to NewDot (isLockedToNewApp or classicRedirect.isLockedToNewDot)
- Hybrid app is loading (IS_HYBRID_APP && isLoadingTryNewDot)

The 30-day time-based hide is removed from the Troubleshoot page while preserved elsewhere.

### Changes

src/pages/settings/Troubleshoot/TroubleshootPage.tsx:
- Import: shouldHideOldAppRedirect ? isLockedToNewApp
- Condition: Replace shouldHideOldAppRedirect(...) with direct checks that only block intentional locks and loading states

### Tests

- Verified the button is visible regardless of NewDot usage duration
- Verified intentional locks still hide the button correctly
- Verified no regressions in the exit survey/redirect flow

### Offline tests

N/A - this is a simple UI visibility fix.