### PR TITLE
Fix premature mark-as-read when browser window is visible but OS-unfocused

### DIFF
--- a/src/hooks/useMarkAsRead.ts
+++ b/src/hooks/useMarkAsRead.ts
@@ -54,6 +54,20 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
         return unsubscribe;
     }, []);
 
+    const [hasFocus, setHasFocus] = useState(Visibility.hasFocus);
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+        const updateFocus = () => setHasFocus(Visibility.hasFocus());
+        window.addEventListener('focus', updateFocus);
+        window.addEventListener('blur', updateFocus);
+        return () => {
+            window.removeEventListener('focus', updateFocus);
+            window.removeEventListener('blur', updateFocus);
+        };
+    }, []);
+
     const readActionSkippedRef = useRef(false);
     const userActiveSince = useRef<string>(DateUtils.getDBTime());
     const lastMessageTime = useRef<string | null>(null);
@@ -103,7 +117,7 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
         }
         const isFromNotification = route?.params?.referrer === CONST.REFERRER.NOTIFICATION;
 
-        if ((isVisible || isFromNotification) && !hasNewerActions && isScrolledToEnd) {
+        if (((isVisible && hasFocus) || isFromNotification) && !hasNewerActions && isScrolledToEnd) {
             readNewestAction(reportID, !!reportLoadingState?.hasOnceLoadedReportActions);
             if (isFromNotification) {
                 Navigation.setParams({referrer: undefined});
@@ -114,7 +128,7 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
 
         readActionSkippedRef.current = true;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [report?.lastVisibleActionCreated, transactionThreadReport?.lastVisibleActionCreated, reportID, isVisible, reportLoadingState?.hasOnceLoadedReportActions]);
+    }, [report?.lastVisibleActionCreated, transactionThreadReport?.lastVisibleActionCreated, reportID, isVisible, hasFocus, reportLoadingState?.hasOnceLoadedReportActions]);
 
     useEffect(() => {
         if (didMarkOnReportChangeRef.current) {
@@ -125,7 +139,7 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
             return;
         }
 
-        if (!isVisible || !isFocused) {
+        if (!isVisible || !isFocused || !hasFocus) {
             if (!lastMessageTime.current) {
                 lastMessageTime.current = lastAction?.created ?? '';
             }
@@ -151,7 +165,7 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
         readNewestAction(reportID, !!reportLoadingState?.hasOnceLoadedReportActions);
         userActiveSince.current = DateUtils.getDBTime();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isVisible, isFocused, reportLoadingState?.hasOnceLoadedReportActions]);
+    }, [isVisible, isFocused, hasFocus, reportLoadingState?.hasOnceLoadedReportActions]);
 
     return {readActionSkippedRef};
 }

--- a/tests/unit/useMarkAsReadTest.ts
+++ b/tests/unit/useMarkAsReadTest.ts
@@ -11,12 +11,14 @@ const REPORT_ID = '1';
 let mockIsUnread = true;
 let mockIsVisible = true;
 let mockIsFocused = true;
+let mockHasFocus = true;
 let mockReferrer: string | undefined;
 
 jest.mock('@libs/Visibility', () => ({
     __esModule: true,
     default: {
         isVisible: () => mockIsVisible,
+        hasFocus: () => mockHasFocus,
         onVisibilityChange: () => () => {},
     },
 }));
@@ -78,6 +80,7 @@ describe('useMarkAsRead', () => {
         mockIsUnread = true;
         mockIsVisible = true;
         mockIsFocused = true;
+        mockHasFocus = true;
         mockReferrer = undefined;
     });
 
@@ -108,5 +111,32 @@ describe('useMarkAsRead', () => {
 
         expect(readNewestAction).toHaveBeenCalledWith(REPORT_ID, false);
         expect(NavigationMock.setParams).toHaveBeenCalledWith({referrer: undefined});
+    });
+
+    it('does not mark the report as read when a new message arrives and the OS window does not have focus', () => {
+        mockIsUnread = false;
+        mockHasFocus = false;
+
+        let reportToUse: OnyxTypes.Report = REPORT;
+
+        const {rerender} = renderHook(() =>
+            useMarkAsRead({
+                reportID: REPORT_ID,
+                report: reportToUse as OnyxEntry<OnyxTypes.Report>,
+                transactionThreadReport: undefined,
+                sortedVisibleReportActions: [],
+                isScrolledToEnd: true,
+                hasNewerActions: false,
+            }),
+        );
+
+        readNewestAction.mockClear();
+
+        // Simulate new message arriving while window is visible but not OS-focused
+        mockIsUnread = true;
+        reportToUse = {...REPORT, lastVisibleActionCreated: '2023-01-01 12:00:00.000'};
+        rerender();
+
+        expect(readNewestAction).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
$ #92273

### Root cause

`useMarkAsRead` uses two mechanisms to track whether the app is "in view":
- `isVisible` -- tracks `document.visibilityState` (tab hidden/visible)
- `isFocused` -- tracks React Navigation route focus (navigation stack)

Neither tracks **OS-level window focus** (`document.hasFocus()`). When the user switches to another app (e.g., Slack), the browser tab remains visible and the navigation route stays focused -- so `isVisible` and `isFocused` stay `true`.

The first `useEffect` in `useMarkAsRead` fires when a new message arrives and checks:
```typescript
if ((isVisible || isFromNotification) && !hasNewerActions && isScrolledToEnd) {
    readNewestAction(reportID, ...);
```

Because `isVisible` is `true` when the user is in another OS app, the message is marked as read. The notification gate in `shouldShowReportActionNotification` then sees `lastReadTime >= action.created` and suppresses the desktop notification.

The `Visibility` module already implements `hasFocus()` correctly on web (`document.hasFocus()`) and returns `true` on native (always focused, so native is unaffected).

### Fix

1. Add a `hasFocus` state that subscribes to window `focus`/`blur` events (web only -- `typeof window === 'undefined'` guard makes it a no-op on native).

2. Guard the new-message mark-as-read with `hasFocus`:
```typescript
if (((isVisible && hasFocus) || isFromNotification) && !hasNewerActions && isScrolledToEnd) {
```

3. Add `hasFocus` to the visibility-change `useEffect`'s condition and dependency array so marking-as-read correctly fires when the user returns browser focus.

### Platform impact
- **Web**: fixes the bug -- messages no longer marked read when window unfocused
- **Native (iOS/Android)**: `hasFocus()` always returns `true` on native, so behavior is unchanged

### Testing
- Added `hasFocus` to the `Visibility` mock in `useMarkAsReadTest.ts`
- Added test: new message arrives while window unfocused -- `readNewestAction` not called
- Existing tests pass unchanged