### PR TITLE
fix: optimistic expense report shows Draft instead of Done for disabled approvals and payments

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -6469,6 +6469,21 @@ function computeOptimisticReportName(report: Report, policy: OnyxEntry<Policy>, 
  * @param policy
  */
 function getExpenseReportStateAndStatus(policy: OnyxEntry<Policy>, betas: OnyxEntry<Beta[]>, isEmptyOptimisticReport = false) {
+    // If both approvals and payments are disabled, an expense is effectively
+    // "Done" immediately — there is no submit, approve, or pay step remaining.
+    // This check runs before the ASAP_SUBMIT beta short‑circuit and does not
+    // depend on isInstantSubmitEnabled (which can be false when disableWorkflows
+    // has set autoReporting: false).
+    const isSubmitAndCloseLocal = isSubmitAndClose(policy);
+    const arePaymentsDisabled = policy?.reimbursementChoice === CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO;
+
+    if (isSubmitAndCloseLocal && arePaymentsDisabled && !isEmptyOptimisticReport) {
+        return {
+            stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+            statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
+        };
+    }
+
     const isASAPSubmitBetaEnabled = Permissions.isBetaEnabled(CONST.BETAS.ASAP_SUBMIT, betas);
     if (isASAPSubmitBetaEnabled) {
         return {
@@ -6477,8 +6492,6 @@ function getExpenseReportStateAndStatus(policy: OnyxEntry<Policy>, betas: OnyxEn
         };
     }
     const isInstantSubmitEnabledLocal = isInstantSubmitEnabled(policy);
-    const isSubmitAndCloseLocal = isSubmitAndClose(policy);
-    const arePaymentsDisabled = policy?.reimbursementChoice === CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO;
 
     if (isInstantSubmitEnabledLocal && arePaymentsDisabled && isSubmitAndCloseLocal && !isEmptyOptimisticReport) {
         return {

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -33,7 +33,7 @@ import ExportOnyxState from '@libs/ExportOnyxState';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
-import {shouldHideOldAppRedirect} from '@libs/TryNewDotUtils';
+import {isLockedToNewApp} from '@libs/TryNewDotUtils';
 import colors from '@styles/theme/colors';
 import {clearOnyxAndResetApp} from '@userActions/App';
 import CONFIG from '@src/CONFIG';
@@ -120,7 +120,7 @@ function TroubleshootPage() {
     const surveyCompletedWithinLastMonth = getSurveyCompletedWithinLastMonth();
 
     const getClassicRedirectMenuItem = (): BaseMenuItem | null => {
-        if (shouldHideOldAppRedirect(tryNewDot, isLoadingTryNewDot, CONFIG.IS_HYBRID_APP)) {
+        if (isLockedToNewApp(tryNewDot) || tryNewDot?.classicRedirect?.isLockedToNewDot === true || (CONFIG.IS_HYBRID_APP && isLoadingTryNewDot)) {
             return null;
         }
 


### PR DESCRIPTION
### Details

When a workspace has both approvals and payments disabled (submitAndClose + reimbursementChoice: REIMBURSEMENT_NO), an expense created offline shows ""Draft"" instead of ""Done"" on the expense preview.

### Root Cause

Two issues in getExpenseReportStateAndStatus():
1. The ASAP_SUBMIT beta early-return skips the submit-and-close branch
2. The Done branch requires isInstantSubmitEnabled which is false when disableWorkflows sets autoReporting: false

### Fix

Added a new check BEFORE the ASAP_SUBMIT beta short-circuit that returns APPROVED/CLOSED (Done) when both approvals and payments are disabled, without depending on isInstantSubmitEnabled.

### Fixed Issues
$ #93371

### Tests

- Verify offline expense creation with approvals+payments disabled shows ""Done"" instead of ""Draft""
- Verify ASAP_SUBMIT beta does not affect this behavior