### PR TITLE
fix: align report details expense columns

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -6659,26 +6659,50 @@ const CONST = {
             };
         },
         get REPORT_DETAILS_CUSTOM_COLUMNS() {
+            const reportDetailsExpenseCustomColumnsAvailability = this.REPORT_DETAILS_EXPENSE_CUSTOM_COLUMNS_AVAILABILITY;
+            const reportDetailsExpenseCustomColumns = Object.entries(this.TYPE_CUSTOM_COLUMNS.EXPENSE).filter(([column]) => {
+                const reportDetailsColumn = column as keyof typeof reportDetailsExpenseCustomColumnsAvailability;
+                return reportDetailsExpenseCustomColumnsAvailability[reportDetailsColumn];
+            });
             return {
-                RECEIPT: this.TABLE_COLUMNS.RECEIPT,
-                DATE: this.TABLE_COLUMNS.DATE,
-                MERCHANT: this.TABLE_COLUMNS.MERCHANT,
-                DESCRIPTION: this.TABLE_COLUMNS.DESCRIPTION,
-                CARD: this.TABLE_COLUMNS.CARD,
-                CATEGORY: this.TABLE_COLUMNS.CATEGORY,
-                CATEGORY_GL_CODE: this.TABLE_COLUMNS.CATEGORY_GL_CODE,
-                TAG: this.TABLE_COLUMNS.TAG,
-                EXCHANGE_RATE: this.TABLE_COLUMNS.EXCHANGE_RATE,
-                REIMBURSABLE: this.TABLE_COLUMNS.REIMBURSABLE,
-                BILLABLE: this.TABLE_COLUMNS.BILLABLE,
-                MCC: this.TABLE_COLUMNS.MCC,
-                TAX_CODE: this.TABLE_COLUMNS.TAX_CODE,
-                TAX_RATE: this.TABLE_COLUMNS.TAX_RATE,
-                TAX_AMOUNT: this.TABLE_COLUMNS.TAX_AMOUNT,
-                AMOUNT: this.TABLE_COLUMNS.TOTAL_AMOUNT,
+                ...Object.fromEntries(reportDetailsExpenseCustomColumns),
                 TOTAL: this.TABLE_COLUMNS.TOTAL,
-                WITHDRAWAL_ID: this.TABLE_COLUMNS.WITHDRAWAL_ID,
             };
+        },
+        REPORT_DETAILS_EXPENSE_CUSTOM_COLUMNS_AVAILABILITY: {
+            RECEIPT: true,
+            DATE: true,
+            STATUS: false,
+            SUBMITTED: false,
+            APPROVED: false,
+            POSTED: true,
+            EXPORTED: false,
+            MERCHANT: true,
+            DESCRIPTION: true,
+            FROM: false,
+            TO: false,
+            POLICY_NAME: false,
+            CARD: true,
+            CATEGORY: true,
+            CATEGORY_GL_CODE: true,
+            ATTENDEES: true,
+            TOTAL_PER_ATTENDEE: true,
+            TAG: true,
+            EXCHANGE_RATE: true,
+            ORIGINAL_AMOUNT: true,
+            REPORT_ID: false,
+            BASE_62_REPORT_ID: false,
+            REIMBURSABLE: true,
+            BILLABLE: true,
+            MCC: true,
+            TAX_CODE: true,
+            TAX_RATE: true,
+            TAX_AMOUNT: true,
+            TITLE: false,
+            AMOUNT: true,
+            EXPORTED_TO: false,
+            ACTION: false,
+            WITHDRAWAL_ID: true,
         },
         get GROUP_CUSTOM_COLUMNS() {
             return {

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -9110,6 +9110,37 @@ describe('SearchUIUtils', () => {
     });
 
     describe('Test getCustomColumns', () => {
+        it('should keep report details custom columns derived from explicit expense column availability', () => {
+            const expenseColumnKeys = Object.keys(CONST.SEARCH.TYPE_CUSTOM_COLUMNS.EXPENSE);
+            const reportDetailsAvailabilityKeys = Object.keys(CONST.SEARCH.REPORT_DETAILS_EXPENSE_CUSTOM_COLUMNS_AVAILABILITY);
+            expect(reportDetailsAvailabilityKeys).toEqual(expenseColumnKeys);
+
+            expect(Object.values(CONST.SEARCH.REPORT_DETAILS_CUSTOM_COLUMNS)).toEqual([
+                CONST.SEARCH.TABLE_COLUMNS.RECEIPT,
+                CONST.SEARCH.TABLE_COLUMNS.DATE,
+                CONST.SEARCH.TABLE_COLUMNS.POSTED,
+                CONST.SEARCH.TABLE_COLUMNS.MERCHANT,
+                CONST.SEARCH.TABLE_COLUMNS.DESCRIPTION,
+                CONST.SEARCH.TABLE_COLUMNS.CARD,
+                CONST.SEARCH.TABLE_COLUMNS.CATEGORY,
+                CONST.SEARCH.TABLE_COLUMNS.CATEGORY_GL_CODE,
+                CONST.SEARCH.TABLE_COLUMNS.ATTENDEES,
+                CONST.SEARCH.TABLE_COLUMNS.TOTAL_PER_ATTENDEE,
+                CONST.SEARCH.TABLE_COLUMNS.TAG,
+                CONST.SEARCH.TABLE_COLUMNS.EXCHANGE_RATE,
+                CONST.SEARCH.TABLE_COLUMNS.ORIGINAL_AMOUNT,
+                CONST.SEARCH.TABLE_COLUMNS.REIMBURSABLE,
+                CONST.SEARCH.TABLE_COLUMNS.BILLABLE,
+                CONST.SEARCH.TABLE_COLUMNS.MCC,
+                CONST.SEARCH.TABLE_COLUMNS.TAX_CODE,
+                CONST.SEARCH.TABLE_COLUMNS.TAX_RATE,
+                CONST.SEARCH.TABLE_COLUMNS.TAX_AMOUNT,
+                CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT,
+                CONST.SEARCH.TABLE_COLUMNS.WITHDRAWAL_ID,
+                CONST.SEARCH.TABLE_COLUMNS.TOTAL,
+            ]);
+        });
+
         it('should return custom columns for EXPENSE type', () => {
             const columns = SearchUIUtils.getCustomColumns(CONST.SEARCH.DATA_TYPES.EXPENSE);
             expect(columns).toEqual(Object.values(CONST.SEARCH.TYPE_CUSTOM_COLUMNS.EXPENSE));


### PR DESCRIPTION
### Details

This PR aligns the Report Details custom columns with the Search expense custom columns by deriving the Report Details list from the expense custom column list plus an explicit availability declaration.

Changes:
- Adds `REPORT_DETAILS_EXPENSE_CUSTOM_COLUMNS_AVAILABILITY` for every `TYPE_CUSTOM_COLUMNS.EXPENSE` entry.
- Derives `REPORT_DETAILS_CUSTOM_COLUMNS` from that availability map and keeps `TOTAL` as the report-details-only column.
- Enables the missing per-expense columns in Report Details: `POSTED`, `ATTENDEES`, `TOTAL_PER_ATTENDEE`, and `ORIGINAL_AMOUNT`.
- Adds a focused guard test to ensure every expense custom column has a Report Details availability decision and to verify the derived Report Details list.

### Fixed Issues

$ 250
$ #93522

### Tests

- [x] `git diff --check`
- [x] `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit --pretty false` filtered for changed files: no errors reported for `src/CONST/index.ts` or `tests/unit/Search/SearchUIUtilsTest.ts`
- [ ] `SearchUIUtilsTest.ts` targeted Jest run could not complete locally because the Windows/sparse checkout environment hit repo setup issues unrelated to this patch: npm engine mismatch (`node` 24.16.0 vs required 20.20.2), Unix-style npm scripts, and Jest runtime/module setup failures after partial dependency installation.

### Offline tests

Same as above.