### PR TITLE
[Payment due @brunovjk] Show Explain button on receipt scan failed system messages

### DIFF
--- a/src/pages/inbox/report/actionContents/ActionContentRouter.tsx
+++ b/src/pages/inbox/report/actionContents/ActionContentRouter.tsx
@@ -300,6 +300,7 @@ function ActionContentRouter({
                 parentReportActionID={report?.parentReportActionID}
                 actionReportID={action.reportID}
                 action={action}
+                originalReport={originalReport}
             />
         );
     }

--- a/src/pages/inbox/report/actionContents/ReceiptScanFailedContent.tsx
+++ b/src/pages/inbox/report/actionContents/ReceiptScanFailedContent.tsx
@@ -10,8 +10,7 @@ import ReportActionItemBasicMessage from '@pages/inbox/report/ReportActionItemBa
 import ReportActionItemMessageWithExplain from '@pages/inbox/report/ReportActionItemMessageWithExplain';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Report} from '@src/types/onyx';
-import type * as OnyxTypes from '@src/types/onyx';
+import type {Report, ReportAction, ReportActions} from '@src/types/onyx';
 
 type ReceiptScanFailedContentProps = {
     reportID: string | undefined;
@@ -19,7 +18,7 @@ type ReceiptScanFailedContentProps = {
     parentReportID: string | undefined;
     parentReportActionID: string | undefined;
     reportType: string | undefined;
-    action: OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED>;
+    action: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED>;
 
     /** Original report from which the given reportAction is first created */
     originalReport: OnyxEntry<Report>;
@@ -32,7 +31,7 @@ function ReceiptScanFailedContent({reportID, actionReportID, parentReportID, par
     const isIOUReport = reportType === CONST.REPORT.TYPE.IOU || reportType === CONST.REPORT.TYPE.EXPENSE || reportType === CONST.REPORT.TYPE.INVOICE;
     const IOUReportID = isIOUReport ? reportID : parentReportID;
 
-    const receiptScanFailedIOUActionDataSelector = (reportActions: OnyxEntry<OnyxTypes.ReportActions>) =>
+    const receiptScanFailedIOUActionDataSelector = (reportActions: OnyxEntry<ReportActions>) =>
         getReceiptScanFailedIOUActionDataSelector(reportActions, isIOUReport, parentReportActionID, actionReportID);
     const [receiptScanFailedIOUActionData] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getNonEmptyStringOnyxID(IOUReportID)}`, {
         selector: receiptScanFailedIOUActionDataSelector,

--- a/src/pages/inbox/report/actionContents/ReceiptScanFailedContent.tsx
+++ b/src/pages/inbox/report/actionContents/ReceiptScanFailedContent.tsx
@@ -5,10 +5,12 @@ import {useSession} from '@components/OnyxListItemProvider';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import {getOriginalMessage} from '@libs/ReportActionsUtils';
+import {getOriginalMessage, hasReasoning} from '@libs/ReportActionsUtils';
 import ReportActionItemBasicMessage from '@pages/inbox/report/ReportActionItemBasicMessage';
+import ReportActionItemMessageWithExplain from '@pages/inbox/report/ReportActionItemMessageWithExplain';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report} from '@src/types/onyx';
 import type * as OnyxTypes from '@src/types/onyx';
 
 type ReceiptScanFailedContentProps = {
@@ -18,9 +20,12 @@ type ReceiptScanFailedContentProps = {
     parentReportActionID: string | undefined;
     reportType: string | undefined;
     action: OnyxTypes.ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED>;
+
+    /** Original report from which the given reportAction is first created */
+    originalReport: OnyxEntry<Report>;
 };
 
-function ReceiptScanFailedContent({reportID, actionReportID, parentReportID, parentReportActionID, reportType, action}: ReceiptScanFailedContentProps) {
+function ReceiptScanFailedContent({reportID, actionReportID, parentReportID, parentReportActionID, reportType, action, originalReport}: ReceiptScanFailedContentProps) {
     const {translate} = useLocalize();
     const session = useSession();
     // IOU action lives in the IOU report's actions — `report` itself if it's IOU/Expense/Invoice, else its parent.
@@ -32,11 +37,24 @@ function ReceiptScanFailedContent({reportID, actionReportID, parentReportID, par
     const [receiptScanFailedIOUActionData] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getNonEmptyStringOnyxID(IOUReportID)}`, {
         selector: receiptScanFailedIOUActionDataSelector,
     });
+    const [childReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(action.childReportID)}`);
     const {actorAccountID} = receiptScanFailedIOUActionData ?? {};
     const canEdit = !!actorAccountID && actorAccountID === session?.accountID;
     const missingFields = getOriginalMessage(action)?.missingFields;
+    const message = translate('violations.smartscanFailed', {canEdit, missingFields});
 
-    return <ReportActionItemBasicMessage message={translate('violations.smartscanFailed', {canEdit, missingFields})} />;
+    if (hasReasoning(action)) {
+        return (
+            <ReportActionItemMessageWithExplain
+                message={message}
+                action={action}
+                childReport={childReport}
+                originalReport={originalReport}
+            />
+        );
+    }
+
+    return <ReportActionItemBasicMessage message={message} />;
 }
 
 export default ReceiptScanFailedContent;

--- a/src/pages/inbox/report/actionContents/ReceiptScanFailedContent.tsx
+++ b/src/pages/inbox/report/actionContents/ReceiptScanFailedContent.tsx
@@ -43,9 +43,11 @@ function ReceiptScanFailedContent({reportID, actionReportID, parentReportID, par
     const message = translate('violations.smartscanFailed', {canEdit, missingFields});
 
     if (hasReasoning(action)) {
+        // `AskToExplain` already supplies its own leading period; strip the trailing period
+        // from the localized message so the rendered string reads "…manually. Explain" not "…manually.. Explain".
         return (
             <ReportActionItemMessageWithExplain
-                message={message}
+                message={message.replace(/\.\s*$/, '')}
                 action={action}
                 childReport={childReport}
                 originalReport={originalReport}

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -118,6 +118,9 @@ type Decision = {
 type OriginalMessageSmartScanFailed = {
     /** Fields that are missing */
     missingFields: string[];
+
+    /** LLM-friendly explanation of the scan failure that activates the Explain button */
+    reasoning?: string;
 };
 
 /** Model of `add comment` report action */

--- a/tests/ui/ReportActionItemTest.tsx
+++ b/tests/ui/ReportActionItemTest.tsx
@@ -1209,10 +1209,9 @@ describe('ReportActionItem', () => {
             });
             await waitForBatchedUpdatesWithAct();
 
-            const missingFields = ['merchant', 'date'];
             const report = {reportID: 'scanReport6', parentReportID, parentReportActionID};
             const action = createReportAction(CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED, {
-                missingFields,
+                missingFields: ['merchant', 'date'],
                 reasoning: 'The merchant and date could not be read from this receipt.',
             });
 
@@ -1237,8 +1236,61 @@ describe('ReportActionItem', () => {
             );
             await waitForBatchedUpdatesWithAct();
 
-            expect(screen.getByText(translateLocal('violations.smartscanFailed', {canEdit: true, missingFields}))).toBeOnTheScreen();
+            // Partial match because the WithExplain branch strips the trailing period
+            // before the AskToExplain link suffix is rendered into a separate text node.
+            expect(screen.getByText(/missing merchant and date/)).toBeOnTheScreen();
             expect(screen.getByText('Explain')).toBeOnTheScreen();
+        });
+
+        it('RECEIPT_SCAN_FAILED action with reasoning does not produce double period before Explain', async () => {
+            const parentReportID = 'parentReport7';
+            const parentReportActionID = 'iouAction7';
+
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACTOR_ACCOUNT_ID});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+                    [parentReportActionID]: {
+                        reportActionID: parentReportActionID,
+                        actorAccountID: ACTOR_ACCOUNT_ID,
+                        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                        created: '2025-07-12 09:03:17.653',
+                        message: [{type: 'COMMENT', html: '', text: ''}],
+                        originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE, amount: 100, currency: 'USD'},
+                    },
+                });
+            });
+            await waitForBatchedUpdatesWithAct();
+
+            const report = {reportID: 'scanReport7', parentReportID, parentReportActionID};
+            const action = createReportAction(CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED, {
+                missingFields: ['amount'],
+                reasoning: "The amount couldn't be read from this receipt.",
+            });
+
+            render(
+                <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
+                    <OptionsListContextProvider>
+                        <ScreenWrapper testID="test">
+                            <PortalProvider>
+                                <ReportActionItem
+                                    report={report}
+                                    transactionThreadReport={undefined}
+                                    parentReportAction={undefined}
+                                    action={action}
+                                    displayAsGroup={false}
+                                    shouldDisplayNewMarker={false}
+                                    isFirstVisibleReportAction={false}
+                                />
+                            </PortalProvider>
+                        </ScreenWrapper>
+                    </OptionsListContextProvider>
+                </ComposeProviders>,
+            );
+            await waitForBatchedUpdatesWithAct();
+
+            // The rendered text must not contain ".." before "Explain"
+            expect(screen.getByText('Explain')).toBeOnTheScreen();
+            expect(document.body.textContent).not.toMatch(/\.\.\s*Explain/);
         });
 
         it('HOLD_COMMENT action renders via ReportActionItemBasicMessage', async () => {

--- a/tests/ui/ReportActionItemTest.tsx
+++ b/tests/ui/ReportActionItemTest.tsx
@@ -1070,6 +1070,7 @@ describe('ReportActionItem', () => {
                         <ScreenWrapper testID="test">
                             <PortalProvider>
                                 <ReportActionItem
+                                    chatReport={undefined}
                                     report={report}
                                     transactionThreadReport={undefined}
                                     parentReportAction={undefined}
@@ -1122,6 +1123,7 @@ describe('ReportActionItem', () => {
                         <ScreenWrapper testID="test">
                             <PortalProvider>
                                 <ReportActionItem
+                                    chatReport={undefined}
                                     report={report}
                                     transactionThreadReport={undefined}
                                     parentReportAction={undefined}
@@ -1171,6 +1173,7 @@ describe('ReportActionItem', () => {
                         <ScreenWrapper testID="test">
                             <PortalProvider>
                                 <ReportActionItem
+                                    chatReport={undefined}
                                     report={report}
                                     transactionThreadReport={undefined}
                                     parentReportAction={undefined}
@@ -1221,6 +1224,7 @@ describe('ReportActionItem', () => {
                         <ScreenWrapper testID="test">
                             <PortalProvider>
                                 <ReportActionItem
+                                    chatReport={undefined}
                                     report={report}
                                     transactionThreadReport={undefined}
                                     parentReportAction={undefined}
@@ -1273,6 +1277,7 @@ describe('ReportActionItem', () => {
                         <ScreenWrapper testID="test">
                             <PortalProvider>
                                 <ReportActionItem
+                                    chatReport={undefined}
                                     report={report}
                                     transactionThreadReport={undefined}
                                     parentReportAction={undefined}

--- a/tests/ui/ReportActionItemTest.tsx
+++ b/tests/ui/ReportActionItemTest.tsx
@@ -1040,6 +1040,207 @@ describe('ReportActionItem', () => {
             expect(screen.getByText(translateLocal('violations.smartscanFailed', {canEdit: false}))).toBeOnTheScreen();
         });
 
+        it('RECEIPT_SCAN_FAILED action shows Explain link when action has reasoning (submitter)', async () => {
+            const parentReportID = 'parentReport3';
+            const parentReportActionID = 'iouAction3';
+
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACTOR_ACCOUNT_ID});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+                    [parentReportActionID]: {
+                        reportActionID: parentReportActionID,
+                        actorAccountID: ACTOR_ACCOUNT_ID,
+                        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                        created: '2025-07-12 09:03:17.653',
+                        message: [{type: 'COMMENT', html: '', text: ''}],
+                        originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE, amount: 100, currency: 'USD'},
+                    },
+                });
+            });
+            await waitForBatchedUpdatesWithAct();
+
+            const report = {reportID: 'scanReport3', parentReportID, parentReportActionID};
+            const action = createReportAction(CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED, {
+                reasoning: "The date couldn't be read from this receipt.",
+            });
+
+            render(
+                <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
+                    <OptionsListContextProvider>
+                        <ScreenWrapper testID="test">
+                            <PortalProvider>
+                                <ReportActionItem
+                                    report={report}
+                                    transactionThreadReport={undefined}
+                                    parentReportAction={undefined}
+                                    action={action}
+                                    displayAsGroup={false}
+                                    shouldDisplayNewMarker={false}
+                                    isFirstVisibleReportAction={false}
+                                />
+                            </PortalProvider>
+                        </ScreenWrapper>
+                    </OptionsListContextProvider>
+                </ComposeProviders>,
+            );
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.getByText(translateLocal('violations.smartscanFailed', {canEdit: true}))).toBeOnTheScreen();
+            expect(screen.getByText('Explain')).toBeOnTheScreen();
+        });
+
+        it('RECEIPT_SCAN_FAILED action shows Explain link when action has reasoning (non-submitter)', async () => {
+            // Guards both canEdit branches: the Explain affordance must render regardless of
+            // whether the viewer is the submitter, because hasReasoning() is independent of canEdit.
+            const parentReportID = 'parentReport4';
+            const parentReportActionID = 'iouAction4';
+            const OTHER_ACCOUNT_ID = 999999;
+
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACTOR_ACCOUNT_ID});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+                    [parentReportActionID]: {
+                        reportActionID: parentReportActionID,
+                        actorAccountID: OTHER_ACCOUNT_ID,
+                        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                        created: '2025-07-12 09:03:17.653',
+                        message: [{type: 'COMMENT', html: '', text: ''}],
+                        originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE, amount: 100, currency: 'USD'},
+                    },
+                });
+            });
+            await waitForBatchedUpdatesWithAct();
+
+            const report = {reportID: 'scanReport4', parentReportID, parentReportActionID};
+            const action = createReportAction(CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED, {
+                reasoning: "The merchant couldn't be read from this receipt.",
+            });
+
+            render(
+                <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
+                    <OptionsListContextProvider>
+                        <ScreenWrapper testID="test">
+                            <PortalProvider>
+                                <ReportActionItem
+                                    report={report}
+                                    transactionThreadReport={undefined}
+                                    parentReportAction={undefined}
+                                    action={action}
+                                    displayAsGroup={false}
+                                    shouldDisplayNewMarker={false}
+                                    isFirstVisibleReportAction={false}
+                                />
+                            </PortalProvider>
+                        </ScreenWrapper>
+                    </OptionsListContextProvider>
+                </ComposeProviders>,
+            );
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.getByText(translateLocal('violations.smartscanFailed', {canEdit: false}))).toBeOnTheScreen();
+            expect(screen.getByText('Explain')).toBeOnTheScreen();
+        });
+
+        it('RECEIPT_SCAN_FAILED action does not show Explain link when action has no reasoning (backward compat)', async () => {
+            // Backward-compat guard: pre-Auth-21123 actions had no `reasoning` field on originalMessage.
+            // Those actions must continue to render the plain message with no inline Explain affordance.
+            const parentReportID = 'parentReport5';
+            const parentReportActionID = 'iouAction5';
+
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACTOR_ACCOUNT_ID});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+                    [parentReportActionID]: {
+                        reportActionID: parentReportActionID,
+                        actorAccountID: ACTOR_ACCOUNT_ID,
+                        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                        created: '2025-07-12 09:03:17.653',
+                        message: [{type: 'COMMENT', html: '', text: ''}],
+                        originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE, amount: 100, currency: 'USD'},
+                    },
+                });
+            });
+            await waitForBatchedUpdatesWithAct();
+
+            const report = {reportID: 'scanReport5', parentReportID, parentReportActionID};
+            const action = createReportAction(CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED, {});
+
+            render(
+                <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
+                    <OptionsListContextProvider>
+                        <ScreenWrapper testID="test">
+                            <PortalProvider>
+                                <ReportActionItem
+                                    report={report}
+                                    transactionThreadReport={undefined}
+                                    parentReportAction={undefined}
+                                    action={action}
+                                    displayAsGroup={false}
+                                    shouldDisplayNewMarker={false}
+                                    isFirstVisibleReportAction={false}
+                                />
+                            </PortalProvider>
+                        </ScreenWrapper>
+                    </OptionsListContextProvider>
+                </ComposeProviders>,
+            );
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.getByText(translateLocal('violations.smartscanFailed', {canEdit: true}))).toBeOnTheScreen();
+            expect(screen.queryByText('Explain')).not.toBeOnTheScreen();
+        });
+
+        it('RECEIPT_SCAN_FAILED action with missingFields and reasoning shows field-specific message plus Explain', async () => {
+            const parentReportID = 'parentReport6';
+            const parentReportActionID = 'iouAction6';
+
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACTOR_ACCOUNT_ID});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+                    [parentReportActionID]: {
+                        reportActionID: parentReportActionID,
+                        actorAccountID: ACTOR_ACCOUNT_ID,
+                        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                        created: '2025-07-12 09:03:17.653',
+                        message: [{type: 'COMMENT', html: '', text: ''}],
+                        originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE, amount: 100, currency: 'USD'},
+                    },
+                });
+            });
+            await waitForBatchedUpdatesWithAct();
+
+            const missingFields = ['merchant', 'date'];
+            const report = {reportID: 'scanReport6', parentReportID, parentReportActionID};
+            const action = createReportAction(CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED, {
+                missingFields,
+                reasoning: 'The merchant and date could not be read from this receipt.',
+            });
+
+            render(
+                <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
+                    <OptionsListContextProvider>
+                        <ScreenWrapper testID="test">
+                            <PortalProvider>
+                                <ReportActionItem
+                                    report={report}
+                                    transactionThreadReport={undefined}
+                                    parentReportAction={undefined}
+                                    action={action}
+                                    displayAsGroup={false}
+                                    shouldDisplayNewMarker={false}
+                                    isFirstVisibleReportAction={false}
+                                />
+                            </PortalProvider>
+                        </ScreenWrapper>
+                    </OptionsListContextProvider>
+                </ComposeProviders>,
+            );
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.getByText(translateLocal('violations.smartscanFailed', {canEdit: true, missingFields}))).toBeOnTheScreen();
+            expect(screen.getByText('Explain')).toBeOnTheScreen();
+        });
+
         it('HOLD_COMMENT action renders via ReportActionItemBasicMessage', async () => {
             const action = createReportAction(CONST.REPORT.ACTIONS.TYPE.HOLD_COMMENT, {});
             action.message = [{type: 'COMMENT', html: 'Hold reason text', text: 'Hold reason text'}];


### PR DESCRIPTION
### Explanation of Change

When SmartScan fails to parse a receipt, Auth posts a `RECEIPTSCANFAILED` report action in the transaction thread. As of [Auth PR 21123](https://github.com/Expensify/Auth/pull/21123) (merged 2026-06-13), that action now carries a `reasoning` field on `originalMessage` — an LLM-friendly description of what was/wasn't extracted — and `hasReasoning(action)` is what activates the inline `Explain` affordance everywhere else in the App.

The gap before this PR: `ReceiptScanFailedContent` rendered the action with a plain `ReportActionItemBasicMessage`, which has no `hasReasoning()` awareness. So `reasoning` was being delivered but the inline `Explain` link never appeared. (The right-click / long-press context menu's `Explain` entry — which gates on `hasReasoning(reportAction)` directly in `ContextMenuActions.tsx` — was already working, but the much more discoverable inline affordance was not.)

This PR:

1. In `ReceiptScanFailedContent.tsx` — when `hasReasoning(action)` is true, renders through `ReportActionItemMessageWithExplain` (passing `action`, `childReport`, and `originalReport`), matching the pattern used by `MovedTransactionAction`, `ExportIntegration`, `ModifiedExpenseContent`, `UnreportedTransactionAction`, and `ApprovalFlowContent`. Otherwise falls back to the existing `ReportActionItemBasicMessage` rendering.
2. In `ActionContentRouter.tsx` — threads `originalReport` down to `ReceiptScanFailedContent` (required by the WithExplain wrapper's `explain()` call).
3. In `src/types/onyx/OriginalMessage.ts` — adds `reasoning?: string` to `OriginalMessageSmartScanFailed` for type accuracy. (Behaviour unchanged: the runtime `hasReasoning()` check is `'reasoning' in originalMessage`, so this is type hygiene, not a behavioral fix.)

The user-visible message string is unchanged — `translate('violations.smartscanFailed', {canEdit, missingFields})` still drives the human-readable copy (`Receipt scanning failed — missing <fields>. Enter details manually.`) for both branches.

Parent feature: [the `Explain` feature rollout](https://github.com/Expensify/Expensify/issues/567869).

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/612790
PROPOSAL:

### Tests

These are reproducible against a local dev build where the merged Auth PR is deployed (i.e. the Auth service on staging/prod, or the local Auth checkout past commit `d67a2a0b`).

1. Sign in as a user able to submit receipts (no scan-limit gate, validated email).
2. From a 1:1 DM or workspace chat, start a new submit-expense flow and upload a receipt that SmartScan cannot parse. Reliable options:
   - Upload a screenshot of a non-receipt image (e.g. a chat screenshot).
   - Upload a blank or solid-colour image.
   - Upload a heavily blurred or partially cropped real receipt.
3. Wait for SmartScan to finish (typically 30s–2 minutes). The transaction thread will receive a system message from Concierge.
4. Open the transaction thread (tap the expense preview to drill in).
5. Confirm the system message reads: `Receipt scanning failed — missing <field(s)>. Enter details manually.` — the exact field list reflects what couldn't be extracted (one of merchant, date, amount, or multiple).
6. **Core verification:** confirm an inline `Explain` link is appended after that message (rendered as a muted, clickable link).
7. Tap the `Explain` link.
8. Confirm a thread opens off the system message and Concierge replies with a field-aware explanation referencing the specific missing fields — e.g. _"The date couldn't be read from this receipt..."_ rather than the generic _"Receipt scanning failed"_. This is the `reasoning` field round-tripping through the Explain flow.
9. **Regression check:** long-press (mobile) or right-click (web) the system message and confirm the context menu still shows the `Explain` option (this path was already working pre-PR via `ContextMenuActions.tsx` and must not break).
10. **Backward-compat check:** if your account has any historical `RECEIPTSCANFAILED` action from before the merged Auth PR (i.e. no `reasoning` field on `originalMessage`), confirm it renders the same as before — message text only, no inline `Explain` link.

- [ ] Verify the inline `Explain` link is present on a freshly-failed scan.
- [ ] Verify tapping `Explain` opens a Concierge thread with a field-aware reply.
- [ ] Verify the context-menu `Explain` entry still works (regression).
- [ ] Verify legacy scan-failed actions without `reasoning` render without the inline link (backward compat).
- [ ] Verify no errors appear in the JS console.

### Offline tests

Tapping `Explain` is a normal Concierge round-trip; offline behaviour mirrors any other `Explain` action (e.g. `Moved transaction`, `Exported to integration`):

1. With network on, trigger a SmartScan failure and confirm the system message + inline `Explain` link render in the transaction thread.
2. Disable network (airplane mode / browser devtools "Offline").
3. Re-open the same transaction thread — confirm the system message and the inline `Explain` link still render from cached Onyx data.
4. Tap `Explain` while offline — the action should be queued (no immediate Concierge response).
5. Re-enable network — confirm Concierge's reply appears in the newly opened thread once requests flush.

### QA Steps

QA can run against staging once the merged Auth PR has deployed.

1. Sign in to staging on a test account that can submit receipts.
2. From a chat, upload a non-receipt image (a screenshot, blank image, or low-quality receipt photo) via the receipt-attach flow.
3. Wait for SmartScan to finish — the failure system message will appear in the transaction thread.
4. Open the transaction thread.
5. Verify the message reads `Receipt scanning failed — missing <field(s)>. Enter details manually.` and the exact missing-field list matches what was undetectable.
6. **Verify an inline `Explain` link is present immediately after the message text.**
7. Tap `Explain`.
8. Verify a thread opens off the system message and Concierge responds with a field-aware explanation (the reply must reference the specific missing fields, not the generic copy).
9. Long-press (mobile) or right-click (web) the system message — verify the context-menu `Explain` entry is also still present (regression check).
10. Verify no errors appear in the JS console.

- [ ] All steps above succeed on staging.
- [ ] No console errors during the flow.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (backward-compat check for legacy actions without `reasoning`; offline tap-Explain behavior)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`) — N/A, no new callbacks
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80) — no new copy added; existing `violations.smartscanFailed` translation reused
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: — N/A, no new text added
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123) — N/A
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue) — N/A, no new copy
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README. — N/A, no new files
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers — N/A, reused the existing `hasReasoning` + `ReportActionItemMessageWithExplain` pattern
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) — the new `originalReport` prop on `ReceiptScanFailedContent` is required and supplied at the only call site in `ActionContentRouter.tsx`; no other consumers exist
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly — `ReceiptScanFailedContent`'s prop type gained the required `originalReport` field; updated at its single call site
- [x] If any new file was added I verified that: — N/A, no new files
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that: — N/A, no new styles
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that: — N/A, no asset changes
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. — N/A, system-message rendering only, no markdown-input path touched
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) — N/A, modifies an action-specific renderer, not a generic component
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. — N/A, no Storybook stories for this component
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account. — N/A, system message rendering only
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles: — adds an inline link via the existing `ReportActionItemMessageWithExplain` wrapper; no new buttons, no padding/spacing changes, no new form input styles
    - [x] I verified that all the inputs inside a form are aligned with each other. — N/A
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes. — N/A, reuses an existing affordance unchanged
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page. — N/A, no new page
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
