### PR TITLE
[CP Staging] Fix selection, keyboard nav, and highlight regressions in group-by split rendering

### DIFF
--- a/src/components/Search/SearchList/BaseSearchList/index.tsx
+++ b/src/components/Search/SearchList/BaseSearchList/index.tsx
@@ -58,13 +58,15 @@ function BaseSearchList({
     onLayout,
     contentContainerStyle,
     flattenedItemsLength,
-    newTransactions,
-    selectedTransactions,
+    newTransactionsLength,
+    selectedItemsLength,
     isAttendeesEnabledForMovingPolicy,
     nonPersonalAndWorkspaceCards,
     stickyHeaderIndices,
+    stickyHeaderConfig,
     getItemType,
     disabledIndexes,
+    overrideItemLayout,
 }: BaseSearchListProps) {
     const hasKeyBeenPressed = useRef(false);
     const isFocused = useIsFocused();
@@ -164,8 +166,20 @@ function BaseSearchList({
     }, [setHasKeyBeenPressed]);
 
     const extraData = useMemo(
-        () => [focusedIndex, columns, newTransactions, selectedTransactions, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
-        [focusedIndex, columns, newTransactions, selectedTransactions, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
+        () => [focusedIndex, columns, newTransactionsLength, selectedItemsLength, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
+        [focusedIndex, columns, newTransactionsLength, selectedItemsLength, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
+    );
+
+    const defaultStickyHeaderConfig = useMemo(
+        () =>
+            stickyHeaderIndices
+                ? {
+                      hideRelatedCell: true,
+                      useNativeDriver: true,
+                      zIndex: 2,
+                  }
+                : undefined,
+        [stickyHeaderIndices],
     );
 
     return (
@@ -188,7 +202,9 @@ function BaseSearchList({
             contentContainerStyle={contentContainerStyle}
             maintainVisibleContentPosition={{disabled: true}}
             stickyHeaderIndices={stickyHeaderIndices}
+            stickyHeaderConfig={stickyHeaderConfig ?? defaultStickyHeaderConfig}
             getItemType={getItemType}
+            overrideItemLayout={overrideItemLayout}
         />
     );
 }

--- a/src/components/Search/SearchList/BaseSearchList/index.tsx
+++ b/src/components/Search/SearchList/BaseSearchList/index.tsx
@@ -64,6 +64,7 @@ function BaseSearchList({
     nonPersonalAndWorkspaceCards,
     stickyHeaderIndices,
     getItemType,
+    disabledIndexes,
 }: BaseSearchListProps) {
     const hasKeyBeenPressed = useRef(false);
     const isFocused = useIsFocused();
@@ -83,6 +84,7 @@ function BaseSearchList({
     const [focusedIndex, setFocusedIndex] = useArrowKeyFocusManager({
         initialFocusedIndex: -1,
         maxIndex: flattenedItemsLength - 1,
+        disabledIndexes,
         isActive: isFocused && !isModalVisible,
         onFocusedIndexChange: (index: number) => {
             scrollToIndex?.(index);

--- a/src/components/Search/SearchList/BaseSearchList/index.tsx
+++ b/src/components/Search/SearchList/BaseSearchList/index.tsx
@@ -58,8 +58,8 @@ function BaseSearchList({
     onLayout,
     contentContainerStyle,
     flattenedItemsLength,
-    newTransactionsLength,
-    selectedItemsLength,
+    newTransactions,
+    selectedTransactions,
     isAttendeesEnabledForMovingPolicy,
     nonPersonalAndWorkspaceCards,
     stickyHeaderIndices,
@@ -86,7 +86,6 @@ function BaseSearchList({
     const [focusedIndex, setFocusedIndex] = useArrowKeyFocusManager({
         initialFocusedIndex: -1,
         maxIndex: flattenedItemsLength - 1,
-        disabledIndexes,
         isActive: isFocused && !isModalVisible,
         onFocusedIndexChange: (index: number) => {
             scrollToIndex?.(index);
@@ -97,6 +96,7 @@ function BaseSearchList({
         setHasKeyBeenPressed,
         isFocused,
         captureOnInputs: false,
+        ...(disabledIndexes ? {disabledIndexes} : {}),
     });
 
     const handleFocusByIndex = (index: number, event: NativeSyntheticEvent<ExtendedTargetedEvent>) => {
@@ -166,20 +166,8 @@ function BaseSearchList({
     }, [setHasKeyBeenPressed]);
 
     const extraData = useMemo(
-        () => [focusedIndex, columns, newTransactionsLength, selectedItemsLength, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
-        [focusedIndex, columns, newTransactionsLength, selectedItemsLength, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
-    );
-
-    const defaultStickyHeaderConfig = useMemo(
-        () =>
-            stickyHeaderIndices
-                ? {
-                      hideRelatedCell: true,
-                      useNativeDriver: true,
-                      zIndex: 2,
-                  }
-                : undefined,
-        [stickyHeaderIndices],
+        () => [focusedIndex, columns, newTransactions, selectedTransactions, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
+        [focusedIndex, columns, newTransactions, selectedTransactions, nonPersonalAndWorkspaceCards, isAttendeesEnabledForMovingPolicy],
     );
 
     return (
@@ -202,7 +190,7 @@ function BaseSearchList({
             contentContainerStyle={contentContainerStyle}
             maintainVisibleContentPosition={{disabled: true}}
             stickyHeaderIndices={stickyHeaderIndices}
-            stickyHeaderConfig={stickyHeaderConfig ?? defaultStickyHeaderConfig}
+            stickyHeaderConfig={stickyHeaderConfig}
             getItemType={getItemType}
             overrideItemLayout={overrideItemLayout}
         />

--- a/src/components/Search/SearchList/BaseSearchList/types.ts
+++ b/src/components/Search/SearchList/BaseSearchList/types.ts
@@ -2,9 +2,9 @@ import type {FlashListProps, FlashListRef} from '@shopify/flash-list';
 import type {RefObject} from 'react';
 import type {NativeSyntheticEvent} from 'react-native';
 import type {SearchListItem} from '@components/Search/SearchList/ListItem/types';
-import type {SearchColumnType} from '@components/Search/types';
+import type {SearchColumnType, SelectedTransactions} from '@components/Search/types';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
-import type {CardList} from '@src/types/onyx';
+import type {CardList, Transaction} from '@src/types/onyx';
 
 type BaseSearchListProps = Pick<
     FlashListProps<SearchListItem>,
@@ -30,8 +30,8 @@ type BaseSearchListProps = Pick<
     /** The columns that might change to trigger re-render via extraData */
     columns: SearchColumnType[];
 
-    /** The count of new transactions that might trigger re-render via extraData */
-    newTransactionsLength: number;
+    /** The transactions that might trigger re-render via extraData */
+    newTransactions: Transaction[];
 
     /** The length of the flattened items in the list */
     flattenedItemsLength: number;
@@ -45,8 +45,8 @@ type BaseSearchListProps = Pick<
     /** The function to scroll to an index */
     scrollToIndex?: (index: number, animated?: boolean) => void;
 
-    /** Selected items count for triggering re-render via extraData */
-    selectedItemsLength?: number;
+    /** Selected transactions for triggering re-render via extraData */
+    selectedTransactions?: SelectedTransactions;
 
     /** Precomputed attendee-tracking boolean (derived from policy-for-moving-expenses) */
     isAttendeesEnabledForMovingPolicy?: boolean;

--- a/src/components/Search/SearchList/BaseSearchList/types.ts
+++ b/src/components/Search/SearchList/BaseSearchList/types.ts
@@ -2,9 +2,9 @@ import type {FlashListProps, FlashListRef} from '@shopify/flash-list';
 import type {RefObject} from 'react';
 import type {NativeSyntheticEvent} from 'react-native';
 import type {SearchListItem} from '@components/Search/SearchList/ListItem/types';
-import type {SearchColumnType, SelectedTransactions} from '@components/Search/types';
+import type {SearchColumnType} from '@components/Search/types';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
-import type {CardList, Transaction} from '@src/types/onyx';
+import type {CardList} from '@src/types/onyx';
 
 type BaseSearchListProps = Pick<
     FlashListProps<SearchListItem>,
@@ -18,6 +18,8 @@ type BaseSearchListProps = Pick<
     | 'showsVerticalScrollIndicator'
     | 'onLayout'
     | 'stickyHeaderIndices'
+    | 'stickyHeaderConfig'
+    | 'overrideItemLayout'
 > & {
     /** The data to display in the list */
     data: SearchListItem[];
@@ -28,8 +30,8 @@ type BaseSearchListProps = Pick<
     /** The columns that might change to trigger re-render via extraData */
     columns: SearchColumnType[];
 
-    /** The transactions that might trigger re-render via extraData */
-    newTransactions: Transaction[];
+    /** The count of new transactions that might trigger re-render via extraData */
+    newTransactionsLength: number;
 
     /** The length of the flattened items in the list */
     flattenedItemsLength: number;
@@ -43,8 +45,8 @@ type BaseSearchListProps = Pick<
     /** The function to scroll to an index */
     scrollToIndex?: (index: number, animated?: boolean) => void;
 
-    /** Selected transactions for triggering re-render via extraData */
-    selectedTransactions?: SelectedTransactions;
+    /** Selected items count for triggering re-render via extraData */
+    selectedItemsLength?: number;
 
     /** Precomputed attendee-tracking boolean (derived from policy-for-moving-expenses) */
     isAttendeesEnabledForMovingPolicy?: boolean;

--- a/src/components/Search/SearchList/BaseSearchList/types.ts
+++ b/src/components/Search/SearchList/BaseSearchList/types.ts
@@ -54,6 +54,9 @@ type BaseSearchListProps = Pick<
 
     /** Function to determine item type for FlashList recycling */
     getItemType?: (item: SearchListItem, index: number) => string | number | undefined;
+
+    /** Indexes to skip during keyboard arrow navigation */
+    disabledIndexes?: readonly number[];
 };
 
 export default BaseSearchListProps;

--- a/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
@@ -33,7 +33,7 @@ function GroupChildrenContainer({
 }: GroupChildrenContainerProps) {
     const theme = useTheme();
     const styles = useThemeStyles();
-    const {isRendered, animatedStyle, onLayout} = useExpandCollapseAnimation(isExpanded);
+    const {isRendered, animatedStyle, onLayout} = useExpandCollapseAnimation(isExpanded, false);
 
     if (!isExpanded && !isRendered) {
         return null;

--- a/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
@@ -47,7 +47,14 @@ function GroupChildrenContainer({
     }
 
     return (
-        <Animated.View style={[styles.mh5, {backgroundColor: isSelected ? theme.activeComponentBG : theme.highlightBG}, animatedHighlightStyle, isLastItem && [styles.tableBottomRadius, styles.overflowHidden]]}>
+        <Animated.View
+            style={[
+                styles.mh5,
+                {backgroundColor: isSelected ? theme.activeComponentBG : theme.highlightBG},
+                animatedHighlightStyle,
+                isLastItem && [styles.tableBottomRadius, styles.overflowHidden],
+            ]}
+        >
             <Animated.View style={animatedStyle}>
                 <Animated.View
                     style={[styles.stickToTop, styles.pb1]}

--- a/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
@@ -34,7 +34,8 @@ function GroupChildrenContainer({
     const theme = useTheme();
     const styles = useThemeStyles();
     const {selectedTransactions} = useSearchSelectionContext();
-    const {isRendered, animatedStyle, onLayout} = useExpandCollapseAnimation(isExpanded, false);
+    const {isRendered, animatedStyle, onLayout} = useExpandCollapseAnimation(isExpanded, false, item.keyForList);
+    const isContentVisible = isExpanded || isRendered;
 
     const isSelected = !!item.isSelected || (item.transactions.length > 0 && item.transactions.every((transaction) => selectedTransactions[transaction.transactionID]?.isSelected));
 
@@ -60,14 +61,14 @@ function GroupChildrenContainer({
             ]}
         >
             <Animated.View style={animatedStyle}>
-                <Animated.View
-                    style={[styles.stickToTop, styles.pb1]}
-                    onLayout={onLayout}
-                >
-                    {isRendered && (
+                {isContentVisible ? (
+                    <Animated.View
+                        style={[styles.stickToTop, styles.pb1]}
+                        onLayout={onLayout}
+                    >
                         <GroupChildrenContent
                             item={item}
-                            isExpanded={isExpanded}
+                            isExpanded={isContentVisible}
                             groupBy={groupBy}
                             searchType={searchType}
                             columns={columns}
@@ -82,8 +83,8 @@ function GroupChildrenContainer({
                             cardFeeds={cardFeeds}
                             conciergeReportID={conciergeReportID}
                         />
-                    )}
-                </Animated.View>
+                    </Animated.View>
+                ) : null}
             </Animated.View>
         </Animated.View>
     );

--- a/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import {View} from 'react-native';
 import Animated from 'react-native-reanimated';
+import {useSearchSelectionContext} from '@components/Search/SearchContext';
 import useAnimatedHighlightStyle from '@hooks/useAnimatedHighlightStyle';
 import useExpandCollapseAnimation from '@hooks/useExpandCollapseAnimation';
 import useTheme from '@hooks/useTheme';
@@ -9,7 +11,6 @@ import type {GroupChildrenContentProps} from './types';
 
 type GroupChildrenContainerProps = GroupChildrenContentProps & {
     isLastItem?: boolean;
-    isSelected?: boolean;
 };
 
 function GroupChildrenContainer({
@@ -25,7 +26,6 @@ function GroupChildrenContainer({
     nonPersonalAndWorkspaceCards,
     onUndelete,
     isLastItem,
-    isSelected,
     newTransactionID,
     bankAccountList,
     cardFeeds,
@@ -33,7 +33,10 @@ function GroupChildrenContainer({
 }: GroupChildrenContainerProps) {
     const theme = useTheme();
     const styles = useThemeStyles();
+    const {selectedTransactions} = useSearchSelectionContext();
     const {isRendered, animatedStyle, onLayout} = useExpandCollapseAnimation(isExpanded, false);
+
+    const isSelected = !!item.isSelected || (item.transactions.length > 0 && item.transactions.every((transaction) => selectedTransactions[transaction.transactionID]?.isSelected));
 
     const animatedHighlightStyle = useAnimatedHighlightStyle({
         shouldHighlight: item?.shouldAnimateInHighlight ?? false,
@@ -42,8 +45,9 @@ function GroupChildrenContainer({
         shouldApplyOtherStyles: false,
     });
 
+    // Rendering null in FlashList can cause heavy first-render work; use an empty placeholder instead (LHN pattern).
     if (!isExpanded && !isRendered) {
-        return null;
+        return <View />;
     }
 
     return (
@@ -60,23 +64,25 @@ function GroupChildrenContainer({
                     style={[styles.stickToTop, styles.pb1]}
                     onLayout={onLayout}
                 >
-                    <GroupChildrenContent
-                        item={item}
-                        isExpanded={isExpanded}
-                        groupBy={groupBy}
-                        searchType={searchType}
-                        columns={columns}
-                        canSelectMultiple={canSelectMultiple}
-                        onSelectRow={onSelectRow}
-                        onCheckboxPress={onCheckboxPress}
-                        onLongPressRow={onLongPressRow}
-                        nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
-                        onUndelete={onUndelete}
-                        newTransactionID={newTransactionID}
-                        bankAccountList={bankAccountList}
-                        cardFeeds={cardFeeds}
-                        conciergeReportID={conciergeReportID}
-                    />
+                    {isRendered && (
+                        <GroupChildrenContent
+                            item={item}
+                            isExpanded={isExpanded}
+                            groupBy={groupBy}
+                            searchType={searchType}
+                            columns={columns}
+                            canSelectMultiple={canSelectMultiple}
+                            onSelectRow={onSelectRow}
+                            onCheckboxPress={onCheckboxPress}
+                            onLongPressRow={onLongPressRow}
+                            nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                            onUndelete={onUndelete}
+                            newTransactionID={newTransactionID}
+                            bankAccountList={bankAccountList}
+                            cardFeeds={cardFeeds}
+                            conciergeReportID={conciergeReportID}
+                        />
+                    )}
                 </Animated.View>
             </Animated.View>
         </Animated.View>

--- a/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupChildrenContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {View} from 'react-native';
 import Animated from 'react-native-reanimated';
+import useAnimatedHighlightStyle from '@hooks/useAnimatedHighlightStyle';
 import useExpandCollapseAnimation from '@hooks/useExpandCollapseAnimation';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -35,12 +35,19 @@ function GroupChildrenContainer({
     const styles = useThemeStyles();
     const {isRendered, animatedStyle, onLayout} = useExpandCollapseAnimation(isExpanded, false);
 
+    const animatedHighlightStyle = useAnimatedHighlightStyle({
+        shouldHighlight: item?.shouldAnimateInHighlight ?? false,
+        highlightColor: theme.messageHighlightBG,
+        backgroundColor: isSelected ? theme.activeComponentBG : theme.highlightBG,
+        shouldApplyOtherStyles: false,
+    });
+
     if (!isExpanded && !isRendered) {
         return null;
     }
 
     return (
-        <View style={[styles.mh5, {backgroundColor: isSelected ? theme.activeComponentBG : theme.highlightBG}, isLastItem && [styles.tableBottomRadius, styles.overflowHidden]]}>
+        <Animated.View style={[styles.mh5, {backgroundColor: isSelected ? theme.activeComponentBG : theme.highlightBG}, animatedHighlightStyle, isLastItem && [styles.tableBottomRadius, styles.overflowHidden]]}>
             <Animated.View style={animatedStyle}>
                 <Animated.View
                     style={[styles.stickToTop, styles.pb1]}
@@ -65,7 +72,7 @@ function GroupChildrenContainer({
                     />
                 </Animated.View>
             </Animated.View>
-        </View>
+        </Animated.View>
     );
 }
 

--- a/src/components/Search/SearchList/ListItem/GroupHeader.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupHeader.tsx
@@ -165,7 +165,7 @@ function GroupHeader({
     const {isRendered: isSubHeaderRendered, animatedStyle: subHeaderAnimatedStyle, onLayout: onSubHeaderLayout} = useExpandCollapseAnimation(isExpanded);
 
     const hasSnapshotTransactions = !isExpenseReportType && !!snapshotData && Object.keys(snapshotData).some((key) => key.startsWith(ONYXKEYS.COLLECTION.TRANSACTION));
-    const isEmpty = groupItem.transactions.length === 0 && !hasSnapshotTransactions;
+    const isEmpty = groupItem.transactions.length === 0 && !hasSnapshotTransactions && !groupItem.transactionsQueryJSON;
     const isDisabled = item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
     const isDisabledOrEmpty = isEmpty || isDisabled;
 
@@ -199,11 +199,11 @@ function GroupHeader({
         const selectedTransactionIDsSet = new Set(Object.keys(selectedTransactions));
         const filteredTransactions = effectiveTransactions.filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
         const selectedCount = filteredTransactions.reduce((acc, transaction) => (selectedTransactionIDsSet.has(transaction.transactionID) ? acc + 1 : acc), 0);
-        const isEmptyReportSelected = isEmpty && originalKey && selectedTransactions[originalKey]?.isSelected;
+        const isEmptyReportSelected = effectiveTransactions.length === 0 && originalKey && selectedTransactions[originalKey]?.isSelected;
         const allChecked = !!isEmptyReportSelected || (selectedCount === filteredTransactions.length && filteredTransactions.length > 0);
         const indeterminate = selectedCount > 0 && selectedCount !== filteredTransactions.length;
         return {isSelectAllChecked: allChecked, isIndeterminate: indeterminate};
-    }, [selectedTransactions, effectiveTransactions, isEmpty, originalKey]);
+    }, [selectedTransactions, effectiveTransactions, originalKey]);
 
     const isItemSelected = isSelectAllChecked || item?.isSelected;
 

--- a/src/components/Search/SearchList/ListItem/GroupHeader.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupHeader.tsx
@@ -162,7 +162,7 @@ function GroupHeader({
         return {isSubHeaderAmountColumnWide: amountWide, isSubHeaderTaxAmountColumnWide: taxWide, shouldSubHeaderShowYear: showYear, isSubHeaderActionColumnWide: actionWide};
     }, [groupItem.transactions]);
 
-    const {isRendered: isSubHeaderRendered, animatedStyle: subHeaderAnimatedStyle, onLayout: onSubHeaderLayout} = useExpandCollapseAnimation(isExpanded, true);
+    const {isRendered: isSubHeaderRendered, animatedStyle: subHeaderAnimatedStyle, onLayout: onSubHeaderLayout} = useExpandCollapseAnimation(isExpanded, isExpanded);
 
     const hasSnapshotTransactions = !isExpenseReportType && !!snapshotData && Object.keys(snapshotData).some((key) => key.startsWith(ONYXKEYS.COLLECTION.TRANSACTION));
     const isEmpty = groupItem.transactions.length === 0 && !hasSnapshotTransactions && !groupItem.transactionsQueryJSON;

--- a/src/components/Search/SearchList/ListItem/GroupHeader.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupHeader.tsx
@@ -207,6 +207,11 @@ function GroupHeader({
 
     const isItemSelected = isSelectAllChecked || item?.isSelected;
 
+    const withOriginalKey = (rowItem: SearchListItem): SearchListItem => ({
+        ...rowItem,
+        keyForList: originalKey,
+    });
+
     const animatedHighlightStyle = useAnimatedHighlightStyle({
         shouldHighlight: item?.shouldAnimateInHighlight ?? false,
         highlightColor: theme.messageHighlightBG,
@@ -215,7 +220,7 @@ function GroupHeader({
     });
 
     const handleSelectionButtonPress = () => {
-        onCheckboxPress(item, isExpenseReportType ? undefined : effectiveTransactions);
+        onCheckboxPress(withOriginalKey(item), isExpenseReportType ? undefined : effectiveTransactions);
     };
 
     const pendingAction =
@@ -225,7 +230,7 @@ function GroupHeader({
             : undefined);
 
     const handleSelectRow = (rowItem: SearchListItem, event?: ModifiedMouseEvent) => {
-        onSelectRow(rowItem, transactionPreviewData, event);
+        onSelectRow(withOriginalKey(rowItem), transactionPreviewData, event);
     };
 
     const renderHeader = (hovered: boolean) => {
@@ -363,7 +368,7 @@ function GroupHeader({
 
     const handlePress = (event?: ModifiedMouseEvent) => {
         if (isExpenseReportType) {
-            onSelectRow(item, transactionPreviewData, event);
+            onSelectRow(withOriginalKey(item), transactionPreviewData, event);
         }
         if (!isExpenseReportType) {
             onToggle();
@@ -371,7 +376,7 @@ function GroupHeader({
     };
 
     const handleLongPress = () => {
-        onLongPressRow?.(item, isExpenseReportType ? undefined : effectiveTransactions);
+        onLongPressRow?.(withOriginalKey(item), isExpenseReportType ? undefined : effectiveTransactions);
     };
 
     return (

--- a/src/components/Search/SearchList/ListItem/GroupHeader.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupHeader.tsx
@@ -207,7 +207,7 @@ function GroupHeader({
 
     const isItemSelected = isSelectAllChecked || item?.isSelected;
 
-    const withOriginalKey = (rowItem: SearchListItem): SearchListItem => ({
+    const withOriginalKey = <T extends SearchListItem>(rowItem: T): T => ({
         ...rowItem,
         keyForList: originalKey,
     });

--- a/src/components/Search/SearchList/ListItem/GroupHeader.tsx
+++ b/src/components/Search/SearchList/ListItem/GroupHeader.tsx
@@ -162,7 +162,7 @@ function GroupHeader({
         return {isSubHeaderAmountColumnWide: amountWide, isSubHeaderTaxAmountColumnWide: taxWide, shouldSubHeaderShowYear: showYear, isSubHeaderActionColumnWide: actionWide};
     }, [groupItem.transactions]);
 
-    const {isRendered: isSubHeaderRendered, animatedStyle: subHeaderAnimatedStyle, onLayout: onSubHeaderLayout} = useExpandCollapseAnimation(isExpanded);
+    const {isRendered: isSubHeaderRendered, animatedStyle: subHeaderAnimatedStyle, onLayout: onSubHeaderLayout} = useExpandCollapseAnimation(isExpanded, true);
 
     const hasSnapshotTransactions = !isExpenseReportType && !!snapshotData && Object.keys(snapshotData).some((key) => key.startsWith(ONYXKEYS.COLLECTION.TRANSACTION));
     const isEmpty = groupItem.transactions.length === 0 && !hasSnapshotTransactions && !groupItem.transactionsQueryJSON;
@@ -442,10 +442,7 @@ function GroupHeader({
                                         style={styles.stickToTop}
                                         onLayout={onSubHeaderLayout}
                                     >
-                                        <View style={[styles.ph3, styles.pb1]}>
-                                            <View style={[styles.borderBottom, styles.borderNone]} />
-                                        </View>
-                                        <View style={[styles.searchListHeaderContainerStyle, styles.groupSearchListTableContainerStyle, styles.bgTransparent, styles.pl8, styles.borderNone]}>
+                                        <View style={[styles.searchListHeaderContainerStyle, styles.groupSearchListTableContainerStyle, styles.bgTransparent, styles.pl8]}>
                                             <SearchTableHeader
                                                 canSelectMultiple
                                                 type={CONST.SEARCH.DATA_TYPES.EXPENSE}
@@ -462,9 +459,7 @@ function GroupHeader({
                                                 isActionColumnWide={isSubHeaderActionColumnWide}
                                             />
                                         </View>
-                                        <View style={[styles.ph3, styles.groupSubHeaderBorderOverlap]}>
-                                            <View style={StyleUtils.getSelectedBorderBottomStyle(isItemSelected)} />
-                                        </View>
+                                        <View style={[StyleUtils.getSelectedBorderBottomStyle(isItemSelected), styles.ml3, styles.mr3]} />
                                     </View>
                                 )}
                             </Animated.View>

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -661,7 +661,6 @@ function SearchList({
                     )}
 
                     {SearchTableHeader}
-                    {isLargeScreenWidth && shouldSplitGroups && <View style={styles.searchListHeaderBorderCover} />}
                 </View>
             )}
             <BaseSearchList

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -325,34 +325,22 @@ function SearchList({
             return {splitData: data, stickyHeaderIndices: undefined, childrenContainerIndices: CONST.EMPTY_ARRAY as readonly number[]};
         }
 
-        const {splitData} = splitGroupsIntoPairs(data);
-        const filteredData: SearchListItem[] = [];
-        const stickyIndices: number[] = [];
+        const {splitData, stickyHeaderIndices: splitStickyIndices} = splitGroupsIntoPairs(data);
         const childrenIndices: number[] = [];
 
-        for (const item of splitData) {
-            if (isGroupChildrenContainerItem(item)) {
-                const originalKey = (item.keyForList ?? '').replace('children_', '');
-                const shouldIncludeChildren = expandedGroups.has(originalKey);
-                if (!shouldIncludeChildren) {
-                    continue;
-                }
-                childrenIndices.push(filteredData.length);
+        for (let i = 0; i < splitData.length; i++) {
+            const item = splitData.at(i);
+            if (item && isGroupChildrenContainerItem(item)) {
+                childrenIndices.push(i);
             }
-
-            if (isGroupHeaderItem(item)) {
-                stickyIndices.push(filteredData.length);
-            }
-
-            filteredData.push(item);
         }
 
         return {
-            splitData: filteredData,
-            stickyHeaderIndices: stickyIndices.length > 0 ? stickyIndices : undefined,
+            splitData,
+            stickyHeaderIndices: splitStickyIndices.length > 0 ? splitStickyIndices : undefined,
             childrenContainerIndices: childrenIndices,
         };
-    }, [data, shouldSplitGroups, expandedGroups]);
+    }, [data, shouldSplitGroups]);
 
     const getItemType = useCallback(
         (item: SearchListItem) => {
@@ -530,7 +518,6 @@ function SearchList({
             if (isGroupHeaderItem(item)) {
                 const headerItem = item;
                 const originalKey = (item.keyForList ?? '').replace('header_', '');
-                const hasChildrenInList = expandedGroups.has(originalKey);
                 return (
                     <GroupHeader
                         item={headerItem}
@@ -546,7 +533,7 @@ function SearchList({
                         onFocus={onFocus}
                         isFocused={isItemFocused}
                         isFirstItem={index === firstVisibleIndex}
-                        isLastItem={!hasChildrenInList && index === lastVisibleIndex && !ListFooterComponent}
+                        isLastItem={false}
                         originalKey={originalKey}
                         lastPaymentMethod={lastPaymentMethod}
                         personalPolicyID={personalPolicyID}

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -379,6 +379,18 @@ function SearchList({
         layout.size = variables.tableRowHeight;
     }, []);
 
+    const stickyHeaderConfig = useMemo(
+        () =>
+            shouldSplitGroups
+                ? {
+                      hideRelatedCell: true,
+                      useNativeDriver: true,
+                      zIndex: 2,
+                  }
+                : undefined,
+        [shouldSplitGroups],
+    );
+
     const [lastPaymentMethod] = useOnyx(ONYXKEYS.NVP_LAST_PAYMENT_METHOD);
     const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
     const [userBillingGracePeriodEnds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_USER_BILLING_GRACE_PERIOD_END);
@@ -693,14 +705,15 @@ function SearchList({
                 onViewableItemsChanged={onViewableItemsChanged}
                 onLayout={onLayout}
                 contentContainerStyle={contentContainerStyle}
-                newTransactionsLength={newTransactions.length}
-                selectedItemsLength={selectedItemsLength}
+                newTransactions={newTransactions}
+                selectedTransactions={selectedTransactions}
                 isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
                 nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
                 stickyHeaderIndices={stickyHeaderIndices}
                 getItemType={getItemType}
-                disabledIndexes={childrenContainerIndices}
-                overrideItemLayout={overrideItemLayout}
+                stickyHeaderConfig={stickyHeaderConfig}
+                disabledIndexes={shouldSplitGroups ? childrenContainerIndices : undefined}
+                overrideItemLayout={shouldSplitGroups ? overrideItemLayout : undefined}
             />
             <Modal
                 isVisible={isModalVisible}

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -314,12 +314,22 @@ function SearchList({
 
     const shouldSplitGroups = !!groupBy && isLargeScreenWidth;
 
-    const {splitData: listData, stickyHeaderIndices} = useMemo(() => {
+    const {
+        splitData: listData,
+        stickyHeaderIndices,
+        childrenContainerIndices,
+    } = useMemo(() => {
         if (!shouldSplitGroups) {
-            return {splitData: data, stickyHeaderIndices: undefined};
+            return {splitData: data, stickyHeaderIndices: undefined, childrenContainerIndices: CONST.EMPTY_ARRAY as readonly number[]};
         }
         const {splitData, stickyHeaderIndices: allIndices} = splitGroupsIntoPairs(data);
-        return {splitData, stickyHeaderIndices: allIndices.length > 0 ? allIndices : undefined};
+        const childrenIndices = splitData.reduce<number[]>((acc, item, idx) => {
+            if (isGroupChildrenContainerItem(item)) {
+                acc.push(idx);
+            }
+            return acc;
+        }, []);
+        return {splitData, stickyHeaderIndices: allIndices.length > 0 ? allIndices : undefined, childrenContainerIndices: childrenIndices};
     }, [data, shouldSplitGroups]);
 
     const getItemType = useCallback(
@@ -677,6 +687,7 @@ function SearchList({
                 nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
                 stickyHeaderIndices={stickyHeaderIndices}
                 getItemType={getItemType}
+                disabledIndexes={childrenContainerIndices}
             />
             <Modal
                 isVisible={isModalVisible}

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -236,11 +236,11 @@ function SearchList({
         return data;
     }, [data, groupBy, type]);
     const emptyReports = useMemo(() => {
-        if (type === CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT && isTransactionGroupListItemArray(data)) {
-            return data.filter((item) => item.transactions.length === 0);
+        if (isTransactionGroupListItemArray(data)) {
+            return data.filter((item) => item.transactions.length === 0 && item.keyForList);
         }
         return [];
-    }, [data, type]);
+    }, [data]);
 
     const selectedItemsLength = useMemo(() => {
         const selectedTransactionsCount = flattenedItems.reduce((acc, item) => {
@@ -248,7 +248,7 @@ function SearchList({
             return acc + (isTransactionSelected ? 1 : 0);
         }, 0);
 
-        if (type === CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT && isTransactionGroupListItemArray(data)) {
+        if (isTransactionGroupListItemArray(data)) {
             const selectedEmptyReports = emptyReports.reduce((acc, item) => {
                 const isEmptyReportSelected = !!(item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
                 return acc + (isEmptyReportSelected ? 1 : 0);
@@ -258,10 +258,10 @@ function SearchList({
         }
 
         return selectedTransactionsCount;
-    }, [flattenedItems, type, data, emptyReports, selectedTransactions]);
+    }, [flattenedItems, data, emptyReports, selectedTransactions]);
 
     const totalItems = useMemo(() => {
-        if (type === CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT && isTransactionGroupListItemArray(data)) {
+        if (isTransactionGroupListItemArray(data)) {
             const selectableEmptyReports = emptyReports.filter((item) => item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
             const selectableTransactions = flattenedItems.filter((item) => {
                 if ('pendingAction' in item) {
@@ -279,7 +279,7 @@ function SearchList({
             return true;
         });
         return selectableTransactions.length;
-    }, [data, type, flattenedItems, emptyReports]);
+    }, [data, flattenedItems, emptyReports]);
 
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
@@ -319,13 +319,8 @@ function SearchList({
             return {splitData: data, stickyHeaderIndices: undefined};
         }
         const {splitData, stickyHeaderIndices: allIndices} = splitGroupsIntoPairs(data);
-        const activeIndices = allIndices.filter((idx) => {
-            const item = splitData.at(idx);
-            const originalKey = item?.keyForList?.replace('header_', '') ?? '';
-            return expandedGroups.has(originalKey);
-        });
-        return {splitData, stickyHeaderIndices: activeIndices.length > 0 ? activeIndices : undefined};
-    }, [data, shouldSplitGroups, expandedGroups]);
+        return {splitData, stickyHeaderIndices: allIndices.length > 0 ? allIndices : undefined};
+    }, [data, shouldSplitGroups]);
 
     const getItemType = useCallback(
         (item: SearchListItem) => {

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -26,6 +26,7 @@ import useUndeleteTransactions from '@hooks/useUndeleteTransactions';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import {turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import DateUtils from '@libs/DateUtils';
+import getPlatform from '@libs/getPlatform';
 import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
 import navigationRef from '@libs/Navigation/navigationRef';
 import {getTableMinWidth, splitGroupsIntoPairs} from '@libs/SearchUIUtils';
@@ -312,7 +313,8 @@ function SearchList({
         });
     }, []);
 
-    const shouldSplitGroups = !!groupBy && isLargeScreenWidth;
+    const isWeb = getPlatform() === CONST.PLATFORM.WEB;
+    const shouldSplitGroups = !!groupBy && isLargeScreenWidth && isWeb;
 
     const {
         splitData: listData,
@@ -322,15 +324,35 @@ function SearchList({
         if (!shouldSplitGroups) {
             return {splitData: data, stickyHeaderIndices: undefined, childrenContainerIndices: CONST.EMPTY_ARRAY as readonly number[]};
         }
-        const {splitData, stickyHeaderIndices: allIndices} = splitGroupsIntoPairs(data);
-        const childrenIndices = splitData.reduce<number[]>((acc, item, idx) => {
+
+        const {splitData} = splitGroupsIntoPairs(data);
+        const filteredData: SearchListItem[] = [];
+        const stickyIndices: number[] = [];
+        const childrenIndices: number[] = [];
+
+        for (const item of splitData) {
             if (isGroupChildrenContainerItem(item)) {
-                acc.push(idx);
+                const originalKey = (item.keyForList ?? '').replace('children_', '');
+                const shouldIncludeChildren = expandedGroups.has(originalKey);
+                if (!shouldIncludeChildren) {
+                    continue;
+                }
+                childrenIndices.push(filteredData.length);
             }
-            return acc;
-        }, []);
-        return {splitData, stickyHeaderIndices: allIndices.length > 0 ? allIndices : undefined, childrenContainerIndices: childrenIndices};
-    }, [data, shouldSplitGroups]);
+
+            if (isGroupHeaderItem(item)) {
+                stickyIndices.push(filteredData.length);
+            }
+
+            filteredData.push(item);
+        }
+
+        return {
+            splitData: filteredData,
+            stickyHeaderIndices: stickyIndices.length > 0 ? stickyIndices : undefined,
+            childrenContainerIndices: childrenIndices,
+        };
+    }, [data, shouldSplitGroups, expandedGroups]);
 
     const getItemType = useCallback(
         (item: SearchListItem) => {
@@ -347,6 +369,15 @@ function SearchList({
         },
         [shouldSplitGroups],
     );
+
+    const overrideItemLayout = useCallback((layout: {size?: number; span?: number}, item: SearchListItem) => {
+        if (!isGroupHeaderItem(item)) {
+            return;
+        }
+        // FlashList requires mutating the layout object passed to overrideItemLayout
+        // eslint-disable-next-line no-param-reassign -- FlashList overrideItemLayout API
+        layout.size = variables.tableRowHeight;
+    }, []);
 
     const [lastPaymentMethod] = useOnyx(ONYXKEYS.NVP_LAST_PAYMENT_METHOD);
     const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
@@ -447,7 +478,7 @@ function SearchList({
      */
     const scrollToIndex = useCallback(
         (index: number, animated = true) => {
-            const item = data.at(index);
+            const item = listData.at(index);
 
             if (!listRef.current || !item || index === -1) {
                 return;
@@ -457,17 +488,9 @@ function SearchList({
                 return;
             }
 
-            let targetIndex = index;
-            if (shouldSplitGroups && item.keyForList) {
-                const splitIndex = listData.findIndex((li) => li.keyForList === `header_${item.keyForList}` || li.keyForList === item.keyForList);
-                if (splitIndex !== -1) {
-                    targetIndex = splitIndex;
-                }
-            }
-
-            listRef.current.scrollToIndex({index: targetIndex, animated, viewOffset: -variables.contentHeaderHeight});
+            listRef.current.scrollToIndex({index, animated, viewOffset: -variables.contentHeaderHeight});
         },
-        [data, isEditingCell, wasRecentlyEditingCell, shouldSplitGroups, listData],
+        [listData, isEditingCell, wasRecentlyEditingCell],
     );
 
     useFocusEffect(
@@ -495,6 +518,7 @@ function SearchList({
             if (isGroupHeaderItem(item)) {
                 const headerItem = item;
                 const originalKey = (item.keyForList ?? '').replace('header_', '');
+                const hasChildrenInList = expandedGroups.has(originalKey);
                 return (
                     <GroupHeader
                         item={headerItem}
@@ -504,20 +528,13 @@ function SearchList({
                         canSelectMultiple={canSelectMultiple}
                         isExpanded={expandedGroups.has(originalKey)}
                         onToggle={() => onToggleGroup(originalKey)}
-                        onSelectRow={(rowItem, previewData, event) => onSelectRow({...rowItem, keyForList: originalKey}, previewData, event)}
-                        onCheckboxPress={(val, itemTransactions) => onCheckboxPress({...val, keyForList: originalKey} as SearchListItem, itemTransactions)}
-                        onLongPressRow={(rowItem, itemTransactions) => {
-                            const fixedItem = {...rowItem, keyForList: originalKey} as SearchListItem;
-                            if (isMobileSelectionModeEnabled) {
-                                handleLongPressRowInMobileSelectionMode(fixedItem, itemTransactions);
-                            } else {
-                                handleLongPressRow(fixedItem, itemTransactions);
-                            }
-                        }}
+                        onSelectRow={onSelectRow}
+                        onCheckboxPress={onCheckboxPress}
+                        onLongPressRow={isMobileSelectionModeEnabled ? handleLongPressRowInMobileSelectionMode : handleLongPressRow}
                         onFocus={onFocus}
                         isFocused={isItemFocused}
                         isFirstItem={index === firstVisibleIndex}
-                        isLastItem={index + 1 >= lastVisibleIndex && !ListFooterComponent}
+                        isLastItem={!hasChildrenInList && index === lastVisibleIndex && !ListFooterComponent}
                         originalKey={originalKey}
                         lastPaymentMethod={lastPaymentMethod}
                         personalPolicyID={personalPolicyID}
@@ -533,13 +550,10 @@ function SearchList({
                 const containerItem = item;
                 const originalKey = (item.keyForList ?? '').replace('children_', '');
                 const containerNewTransactionID = item.keyForList ? newTransactionIDByItemKey.get(originalKey) : undefined;
-                const isContainerSelected =
-                    !!containerItem.isSelected || (containerItem.transactions.length > 0 && containerItem.transactions.every((t) => selectedTransactions[t.transactionID]?.isSelected));
                 return (
                     <GroupChildrenContainer
                         item={containerItem}
                         isExpanded={expandedGroups.has(originalKey)}
-                        isSelected={isContainerSelected}
                         groupBy={groupBy}
                         searchType={type}
                         columns={columns}
@@ -631,7 +645,6 @@ function SearchList({
             cardFeeds,
             conciergeReportID,
             visibleColumns,
-            selectedTransactions,
         ],
     );
 
@@ -680,13 +693,14 @@ function SearchList({
                 onViewableItemsChanged={onViewableItemsChanged}
                 onLayout={onLayout}
                 contentContainerStyle={contentContainerStyle}
-                newTransactions={newTransactions}
-                selectedTransactions={selectedTransactions}
+                newTransactionsLength={newTransactions.length}
+                selectedItemsLength={selectedItemsLength}
                 isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
                 nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
                 stickyHeaderIndices={stickyHeaderIndices}
                 getItemType={getItemType}
                 disabledIndexes={childrenContainerIndices}
+                overrideItemLayout={overrideItemLayout}
             />
             <Modal
                 isVisible={isModalVisible}

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -471,12 +471,10 @@ function SearchList({
     }, [longPressedItem, onCheckboxPress, longPressedItemTransactions]);
 
     /**
-     * Scrolls to the desired item index in the section list
-     *
-     * @param index - the index of the item to scroll to
-     * @param animated - whether to animate the scroll
+     * Scrolls to the desired item index in the FlashList (listData coordinates).
+     * Used by keyboard navigation where focused indices map directly to listData rows.
      */
-    const scrollToIndex = useCallback(
+    const scrollToListIndex = useCallback(
         (index: number, animated = true) => {
             const item = listData.at(index);
 
@@ -493,6 +491,35 @@ function SearchList({
         [listData, isEditingCell, wasRecentlyEditingCell],
     );
 
+    /**
+     * Scrolls to the desired item index in the source data array.
+     * Remaps to split listData indices when sticky group headers are active.
+     */
+    const scrollToDataIndex = useCallback(
+        (index: number, animated = true) => {
+            const item = data.at(index);
+
+            if (!listRef.current || !item || index === -1) {
+                return;
+            }
+
+            if (isEditingCell || wasRecentlyEditingCell) {
+                return;
+            }
+
+            let targetIndex = index;
+            if (shouldSplitGroups && item.keyForList) {
+                const splitIndex = listData.findIndex((listItem) => listItem.keyForList === `header_${item.keyForList}`);
+                if (splitIndex !== -1) {
+                    targetIndex = splitIndex;
+                }
+            }
+
+            listRef.current.scrollToIndex({index: targetIndex, animated, viewOffset: -variables.contentHeaderHeight});
+        },
+        [data, listData, shouldSplitGroups, isEditingCell, wasRecentlyEditingCell],
+    );
+
     useFocusEffect(
         useCallback(() => {
             const offset = getScrollOffset(route);
@@ -506,7 +533,7 @@ function SearchList({
         }, [getScrollOffset, route]),
     );
 
-    useImperativeHandle(ref, () => ({scrollToIndex}), [scrollToIndex]);
+    useImperativeHandle(ref, () => ({scrollToIndex: scrollToDataIndex}), [scrollToDataIndex]);
 
     const isItemVisible = useCallback((item: SearchListItem) => item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE || isOffline, [isOffline]);
     const firstVisibleIndex = useMemo(() => listData.findIndex(isItemVisible), [listData, isItemVisible]);
@@ -684,7 +711,7 @@ function SearchList({
                 showsVerticalScrollIndicator={false}
                 ref={listRef}
                 columns={columns}
-                scrollToIndex={scrollToIndex}
+                scrollToIndex={scrollToListIndex}
                 flattenedItemsLength={listData.length}
                 onEndReached={onEndReached}
                 onEndReachedThreshold={onEndReachedThreshold}

--- a/src/hooks/useExpandCollapseAnimation.ts
+++ b/src/hooks/useExpandCollapseAnimation.ts
@@ -58,4 +58,3 @@ function useExpandCollapseAnimation(isExpanded: boolean, shouldAddBorderHeight: 
 }
 
 export default useExpandCollapseAnimation;
-export {EXPAND_COLLAPSE_DURATION};

--- a/src/hooks/useExpandCollapseAnimation.ts
+++ b/src/hooks/useExpandCollapseAnimation.ts
@@ -6,7 +6,7 @@ import {easing} from '@components/Modal/ReanimatedModal/utils';
 
 const EXPAND_COLLAPSE_DURATION = 300;
 
-function useExpandCollapseAnimation(isExpanded: boolean) {
+function useExpandCollapseAnimation(isExpanded: boolean, shouldAddBorderHeight: boolean) {
     const contentHeight = useSharedValue(0);
     const hasExpanded = useSharedValue(isExpanded);
     const [isRendered, setIsRendered] = useState(isExpanded);
@@ -32,7 +32,7 @@ function useExpandCollapseAnimation(isExpanded: boolean) {
     }, []);
 
     const animatedStyle = useAnimatedStyle(() => ({
-        height: animatedHeight.get(),
+        height: animatedHeight.get() + (shouldAddBorderHeight ? 1 : 0),
         overflow: 'hidden',
     }));
 

--- a/src/hooks/useExpandCollapseAnimation.ts
+++ b/src/hooks/useExpandCollapseAnimation.ts
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useLayoutEffect, useRef, useState} from 'react';
 import type {LayoutChangeEvent} from 'react-native';
 import {useAnimatedStyle, useDerivedValue, useSharedValue, withTiming} from 'react-native-reanimated';
 import {scheduleOnRN} from 'react-native-worklets';
@@ -6,14 +6,25 @@ import {easing} from '@components/Modal/ReanimatedModal/utils';
 
 const EXPAND_COLLAPSE_DURATION = 300;
 
-function useExpandCollapseAnimation(isExpanded: boolean, shouldAddBorderHeight: boolean) {
+function useExpandCollapseAnimation(isExpanded: boolean, shouldAddBorderHeight: boolean, resetKey?: string) {
     const contentHeight = useSharedValue(0);
     const hasExpanded = useSharedValue(isExpanded);
     const [isRendered, setIsRendered] = useState(isExpanded);
+    const prevResetKeyRef = useRef<string | undefined>(undefined);
 
+    // FlashList may recycle this cell for a different group — reset measured height when the row identity changes.
+    useLayoutEffect(() => {
+        if (prevResetKeyRef.current !== undefined && prevResetKeyRef.current !== resetKey) {
+            contentHeight.set(0);
+            setIsRendered(isExpanded);
+        }
+        prevResetKeyRef.current = resetKey;
+    }, [resetKey, isExpanded, contentHeight]);
+
+    // Keep Reanimated shared value in sync with prop (matches AnimatedCollapsible).
     hasExpanded.set(isExpanded);
-    // Matches the pattern in AnimatedCollapsible — mount content synchronously on expand,
-    // unmount asynchronously after collapse animation via scheduleOnRN callback.
+
+    // Mount content for collapse animation once expanded; unmount after animation via scheduleOnRN callback.
     if (isExpanded && !isRendered) {
         setIsRendered(true);
     }
@@ -47,3 +58,4 @@ function useExpandCollapseAnimation(isExpanded: boolean, shouldAddBorderHeight: 
 }
 
 export default useExpandCollapseAnimation;
+export {EXPAND_COLLAPSE_DURATION};

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -3616,15 +3616,6 @@ const staticStyles = (theme: ThemeColors) =>
             zIndex: 10,
         },
 
-        searchListHeaderBorderCover: {
-            position: 'absolute',
-            bottom: -2,
-            left: 0,
-            right: 0,
-            height: 1,
-            backgroundColor: theme.highlightBG,
-        },
-
         groupSubHeaderBorderOverlap: {
             marginTop: -1,
         },

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1841,8 +1841,10 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
 
     getSearchTableGroupRowBorderStyle: (isFirstItem?: boolean, isLastItem?: boolean, isSelected?: boolean): ViewStyle => ({
         borderRadius: 0,
-        borderTopWidth: isFirstItem ? 0 : 1,
-        borderColor: isSelected ? theme.buttonHoveredBG : theme.border,
+        borderWidth: isFirstItem ? 0 : 1,
+        borderColor: theme.transparent,
+        borderTopColor: isSelected ? theme.buttonHoveredBG : theme.border,
+
         ...(isLastItem ? styles.tableBottomRadius : {}),
     }),
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
- Fixes all regressions from PR: https://github.com/Expensify/App/pull/92067

**#93526** — Only expanded headers were sticky, so the last one stayed stuck with nothing to push it off. Fix: make all group headers sticky so collapsed ones push the previous header away.

**#93527** — `SearchList` stopped counting lazy-loaded `groupBy` groups as selectable, and `GroupHeader` treated unloaded groups as empty. Fix: restore pre-#92067 selection counting and don’t disable groups that have `transactionsQueryJSON`.

**#93534** — Split rendering added invisible `children_container` rows between headers, so arrow keys needed two presses. Fix: skip those indices in keyboard nav and clean up border styling so the focus box renders fully.

**#93535** — Selection highlight/border only applied to the header after the split. Fix: align selection styling so the full group (header + children) highlights together.

**#93536** — New-expense highlight lived on the old single wrapper; after the split only `GroupHeader` animated. Fix: add `useAnimatedHighlightStyle` to `GroupChildrenContainer` so the expanded section highlights too.

### Fixed Issues
$ https://github.com/Expensify/App/issues/88926
$ https://github.com/Expensify/App/issues/93526
$ https://github.com/Expensify/App/issues/93527
$ https://github.com/Expensify/App/issues/93534
$ https://github.com/Expensify/App/issues/93535
$ https://github.com/Expensify/App/issues/93536
PROPOSAL: 

### Tests

#### Test #93526
- Precondition:
  - Account has many reports.
  

1. Go to staging.new.expensify.com
2. Go to Spend > Expenses.
3. Type group-by:from in the search field and search.
4. Expand the first report.
5. Scroll down.
6. Verify the first expanded header is not sticky when the list scrolls and the second group pushes it

#### Test #93527
- Precondition:
  - Account has many expenses from different users.
  

1. Go to staging.new.expensify.com
2. Go to Spend > Cash accruals
3. Click Select all checkbox
4. Verify it selects all items
5. Expand the first report
7. Verify checkboxes for other reports are not disabled

#### Test #93534

- Precondition:
   -Account has many expenses from different users.
   

1. Go to staging.new.expensify.com
2. Go to Spend > Cash accruals.
3. Press keyboard down arrow a few times.
4. Verify one press on keyboard down arrow navigates to the next report.
5. Verify blue boxes have complete borders.

#### Test for #93535

1. Go to staging.new.expensify.com
2. Go to workspace chat.
3. Create an expense.
4. Go to Spend > Cash accruals.
5. Expand the report.
6. Click Select all checkbox.
7. Verify the entire report group is highlighted.


#### Test for #93536
1. Go to new.expensify
2. Open Spend tab
3. Go to Cash Accruals and expand a report with an expense that is on an open report
4. Open the expense and click More > Add expense > Create expense
5. Add amount and Merchant and click Create
6. Exit the report view to see the accrual expenses page
7. Verify newly added expense causes the expanded section and header of the accrual expenses to get highlighted


- [x] Verify that no errors appear in the JS console

### Offline tests
- Same as tests

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/bce8f772-aa57-4e80-ba8b-7fb50f4791ac


https://github.com/user-attachments/assets/dd686d77-f298-4f83-b2d2-9820c3bfa478


</details>
