### PR TITLE
Migrate useSearchSelector.base.ts from useOptionsList to usePersonalDetailOptions (part 4)

### DIFF
--- a/src/components/BaseVacationDelegateSelectionComponent.tsx
+++ b/src/components/BaseVacationDelegateSelectionComponent.tsx
@@ -3,11 +3,11 @@ import {View} from 'react-native';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import useSearchSelector from '@hooks/useSearchSelector';
+import usePersonalDetailSearchSelector from '@hooks/usePersonalDetailSearchSelector';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {searchUserInServer} from '@libs/actions/Report';
 import {formatPhoneNumber} from '@libs/LocalePhoneNumber';
-import {getHeaderMessage} from '@libs/OptionsListUtils';
+import {filterOption, getHeaderMessage} from '@libs/PersonalDetailOptionsListUtils';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -67,95 +67,107 @@ function BaseVacationDelegateSelectionComponent({
         ...additionalExcludeLogins,
     };
 
-    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, areOptionsInitialized, onListEndReached} = useSearchSelector({
+    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, areOptionsInitialized} = usePersonalDetailSearchSelector({
         selectionMode: CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE,
         maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
-        searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
         excludeLogins,
+        includeUserToInvite: true,
         includeRecentReports: true,
-        getValidOptionsConfig: {
-            excludeLogins,
-            includeCurrentUser,
-        },
+        includeCurrentUser,
     });
 
     useEffect(() => {
         searchUserInServer(debouncedSearchTerm);
     }, [debouncedSearchTerm]);
 
-    const sectionsList = [];
+    const sectionsList = (() => {
+        const list = [];
 
-    if (currentVacationDelegate && delegatePersonalDetails) {
-        sectionsList.push({
-            title: undefined,
-            sectionIndex: 0,
-            data: [
-                {
-                    ...delegatePersonalDetails,
-                    text: delegatePersonalDetails?.displayName ?? currentVacationDelegate,
-                    alternateText: delegatePersonalDetails?.login ?? currentVacationDelegate,
-                    login: delegatePersonalDetails.login ?? currentVacationDelegate,
-                    keyForList: `vacationDelegate-${delegatePersonalDetails.login}`,
-                    isDisabled: false,
-                    isSelected: true,
-                    shouldShowSubscript: undefined,
-                    icons: [
-                        {
-                            source: delegatePersonalDetails?.avatar ?? icons.FallbackAvatar,
-                            name: formatPhoneNumber(delegatePersonalDetails?.login ?? ''),
-                            type: CONST.ICON_TYPE_AVATAR,
-                            id: delegatePersonalDetails?.accountID,
-                        },
-                    ],
-                },
-            ],
-        });
-    }
+        const delegateOption =
+            currentVacationDelegate && delegatePersonalDetails
+                ? {
+                      ...delegatePersonalDetails,
+                      text: delegatePersonalDetails?.displayName ?? currentVacationDelegate,
+                      alternateText: delegatePersonalDetails?.login ?? currentVacationDelegate,
+                      login: delegatePersonalDetails.login ?? currentVacationDelegate,
+                      keyForList: `vacationDelegate-${delegatePersonalDetails.login}`,
+                      isDisabled: false,
+                      isSelected: true,
+                      shouldShowSubscript: undefined,
+                      icons: [
+                          {
+                              source: delegatePersonalDetails?.avatar ?? icons.FallbackAvatar,
+                              name: formatPhoneNumber(delegatePersonalDetails?.login ?? ''),
+                              type: CONST.ICON_TYPE_AVATAR,
+                              id: delegatePersonalDetails?.accountID,
+                          },
+                      ],
+                  }
+                : undefined;
 
-    sectionsList.push({
-        title: translate('common.recents'),
-        sectionIndex: 1,
-        data: availableOptions.recentReports,
-    });
-    sectionsList.push({
-        title: translate('common.contacts'),
-        sectionIndex: 2,
-        data: availableOptions.personalDetails,
-    });
+        // Only pin the current delegate when it matches the search term, mirroring how the hook filters the other sections
+        if (delegateOption && filterOption(delegateOption, debouncedSearchTerm)) {
+            list.push({
+                title: undefined,
+                sectionIndex: 0,
+                data: [delegateOption],
+            });
+        }
 
-    if (availableOptions.userToInvite) {
-        sectionsList.push({
-            title: undefined,
-            sectionIndex: 3,
-            data: [availableOptions.userToInvite],
-        });
-    }
+        if (availableOptions.recentOptions.length) {
+            list.push({
+                title: translate('common.recents'),
+                sectionIndex: 1,
+                data: availableOptions.recentOptions,
+            });
+        }
+
+        if (availableOptions.personalDetails.length) {
+            list.push({
+                title: translate('common.contacts'),
+                sectionIndex: 2,
+                data: availableOptions.personalDetails,
+            });
+        }
+
+        if (availableOptions.userToInvite) {
+            list.push({
+                title: undefined,
+                sectionIndex: 3,
+                data: [availableOptions.userToInvite],
+            });
+        }
+
+        return list;
+    })();
 
     const sections = sectionsList.map((section) => ({
         ...section,
         data: (section.data ?? []).map((option) => ({
             ...option,
-            text: option.text ?? option.displayName ?? '',
+            text: option.text ?? '',
             alternateText: option.alternateText ?? option.login ?? undefined,
             keyForList: option.keyForList ?? '',
             isDisabled: option.isDisabled ?? undefined,
             isSelected: option.isSelected ?? undefined,
             login: option.login ?? undefined,
-            shouldShowSubscript: option.shouldShowSubscript ?? undefined,
+            shouldShowSubscript: undefined,
         })),
     }));
+
+    const searchValue = debouncedSearchTerm.trim().toLowerCase();
+    const headerMessage = (() => {
+        if (sections.length > 0) {
+            return '';
+        }
+        return getHeaderMessage(translate, searchValue, countryCode);
+    })();
 
     const textInputOptions = {
         value: searchTerm,
         onChangeText: setSearchTerm,
         label: translate('selectionList.nameEmailOrPhoneNumber'),
-        headerMessage: getHeaderMessage(
-            (availableOptions.recentReports?.length || 0) + (availableOptions.personalDetails?.length || 0) !== 0,
-            !!availableOptions.userToInvite,
-            debouncedSearchTerm.trim(),
-            countryCode,
-            false,
-        ),
+        headerMessage,
     };
 
     return (
@@ -186,7 +198,6 @@ function BaseVacationDelegateSelectionComponent({
                             textInputOptions={textInputOptions}
                             shouldShowLoadingPlaceholder={!areOptionsInitialized}
                             isLoadingNewOptions={!!isSearchingForReports}
-                            onEndReached={onListEndReached}
                             shouldSingleExecuteRowSelect
                             shouldShowTextInput
                         />

--- a/src/pages/settings/Security/AddDelegate/AddDelegatePage.tsx
+++ b/src/pages/settings/Security/AddDelegate/AddDelegatePage.tsx
@@ -7,12 +7,12 @@ import UserListItem from '@components/SelectionList/ListItem/UserListItem';
 import SelectionListWithSections from '@components/SelectionList/SelectionListWithSections';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import useSearchSelector from '@hooks/useSearchSelector';
+import usePersonalDetailSearchSelector from '@hooks/usePersonalDetailSearchSelector';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {searchUserInServer} from '@libs/actions/Report';
 import Navigation from '@libs/Navigation/Navigation';
-import {getHeaderMessage} from '@libs/OptionsListUtils';
-import type {OptionData} from '@libs/ReportUtils';
+import {getHeaderMessage} from '@libs/PersonalDetailOptionsListUtils';
+import type {OptionData} from '@libs/PersonalDetailOptionsListUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -33,47 +33,60 @@ function AddDelegatePage() {
             {} as Record<string, boolean>,
         ) ?? {};
 
-    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, areOptionsInitialized, setSelectedOptions, onListEndReached} = useSearchSelector({
+    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, selectedNonExistingOptions, areOptionsInitialized, toggleSelection} = usePersonalDetailSearchSelector({
         selectionMode: CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE,
-        searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
         includeUserToInvite: true,
         excludeLogins: {...CONST.EXPENSIFY_EMAILS_OBJECT, ...existingDelegates},
         includeRecentReports: true,
         maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
         shouldKeepSelectedInAvailableOptions: true,
+        shouldUpdateSelectedOptionsOnSingleSelect: true,
     });
 
     const handleSelectRow = (option: OptionData) => {
-        setSelectedOptions([option]);
+        // toggleSelection would deselect an already-selected row on re-tap, so only select when it isn't selected yet
+        if (!option.isSelected) {
+            toggleSelection(option);
+        }
         Navigation.navigate(ROUTES.SETTINGS_DELEGATE_ROLE.getRoute(option.login ?? ''));
     };
 
-    const headerMessage = getHeaderMessage(
-        (availableOptions.recentReports?.length || 0) + (availableOptions.personalDetails?.length || 0) !== 0,
-        !!availableOptions.userToInvite,
-        debouncedSearchTerm,
-        countryCode,
-    );
-    const sectionsList = [
-        {
-            title: translate('common.recents'),
-            sectionIndex: 0,
-            data: availableOptions.recentReports,
-        },
-        {
-            title: translate('common.contacts'),
-            sectionIndex: 1,
-            data: availableOptions.personalDetails,
-        },
-    ];
+    const sectionsList = (() => {
+        const list = [];
+        if (selectedNonExistingOptions.length > 0) {
+            list.push({
+                title: undefined,
+                sectionIndex: 0,
+                data: selectedNonExistingOptions,
+            });
+        }
 
-    if (availableOptions.userToInvite) {
-        sectionsList.push({
-            sectionIndex: 2,
-            title: '',
-            data: [availableOptions.userToInvite],
-        });
-    }
+        if (availableOptions.recentOptions?.length) {
+            list.push({
+                title: translate('common.recents'),
+                sectionIndex: 1,
+                data: availableOptions.recentOptions,
+            });
+        }
+
+        if (availableOptions.personalDetails?.length) {
+            list.push({
+                title: translate('common.contacts'),
+                sectionIndex: 2,
+                data: availableOptions.personalDetails,
+            });
+        }
+
+        if (availableOptions.userToInvite) {
+            list.push({
+                sectionIndex: 3,
+                title: '',
+                data: [availableOptions.userToInvite],
+            });
+        }
+
+        return list;
+    })();
 
     const sections = sectionsList.map((section) => ({
         ...section,
@@ -84,9 +97,17 @@ function AddDelegatePage() {
             keyForList: `${option.keyForList}-${index}`,
             isDisabled: option.isDisabled ?? undefined,
             login: option.login ?? undefined,
-            shouldShowSubscript: option.shouldShowSubscript ?? undefined,
+            shouldShowSubscript: undefined,
         })),
     }));
+
+    const searchValue = debouncedSearchTerm.trim().toLowerCase();
+    const headerMessage = (() => {
+        if (sections.length > 0) {
+            return '';
+        }
+        return getHeaderMessage(translate, searchValue, countryCode);
+    })();
 
     useEffect(() => {
         searchUserInServer(debouncedSearchTerm);
@@ -117,7 +138,6 @@ function AddDelegatePage() {
                         shouldShowLoadingPlaceholder={!areOptionsInitialized}
                         isLoadingNewOptions={!!isSearchingForReports}
                         shouldShowTextInput
-                        onEndReached={onListEndReached}
                     />
                 </View>
             </DelegateNoAccessWrapper>

--- a/src/pages/tasks/TaskAssigneeSelectorModal.tsx
+++ b/src/pages/tasks/TaskAssigneeSelectorModal.tsx
@@ -10,15 +10,13 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import UserListItem from '@components/SelectionList/ListItem/UserListItem';
 import SelectionListWithSections from '@components/SelectionList/SelectionListWithSections';
 import type {ListItem} from '@components/SelectionList/types';
-import withCurrentUserPersonalDetails from '@components/withCurrentUserPersonalDetails';
-import withNavigationTransitionEnd from '@components/withNavigationTransitionEnd';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
 import useHasOutstandingChildTask from '@hooks/useHasOutstandingChildTask';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
+import usePersonalDetailSearchSelector from '@hooks/usePersonalDetailSearchSelector';
 import useReportIsArchived from '@hooks/useReportIsArchived';
-import useSearchSelector from '@hooks/useSearchSelector';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {searchUserInServer} from '@libs/actions/Report';
 import {canModifyTask, editTaskAssignee, setAssigneeValue} from '@libs/actions/Task';
@@ -26,9 +24,8 @@ import {READ_COMMANDS} from '@libs/API/types';
 import HttpUtils from '@libs/HttpUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import {getHeaderMessage, isCurrentUser} from '@libs/OptionsListUtils';
+import {getHeaderMessage} from '@libs/PersonalDetailOptionsListUtils';
 import {isOpenTaskReport, isTaskReport} from '@libs/ReportUtils';
-import {expensifyLoginsSelector} from '@libs/UserUtils';
 import type {NewTaskNavigatorParamList, TaskDetailsNavigatorParamList} from '@navigation/types';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -52,38 +49,15 @@ function TaskAssigneeSelectorModal() {
     const [countryCode = CONST.DEFAULT_COUNTRY_CODE] = useOnyx(ONYXKEYS.COUNTRY_CODE);
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const currentUserEmail = currentUserPersonalDetails.email ?? '';
-    const [loginList] = useOnyx(ONYXKEYS.LOGINS, {selector: expensifyLoginsSelector});
     const [delegateEmail] = useOnyx(ONYXKEYS.ACCOUNT, {selector: delegateEmailSelector});
 
-    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, areOptionsInitialized} = useSearchSelector({
+    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, areOptionsInitialized} = usePersonalDetailSearchSelector({
         selectionMode: CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE,
-        searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
         includeUserToInvite: true,
         excludeLogins: CONST.EXPENSIFY_EMAILS_OBJECT,
         maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
-        getValidOptionsConfig: {
-            includeCurrentUser: true,
-        },
+        includeRecentReports: true,
     });
-
-    const optionsWithoutCurrentUser = !currentUserPersonalDetails?.accountID
-        ? availableOptions
-        : {
-              ...availableOptions,
-              personalDetails: availableOptions.personalDetails.filter((detail) => detail.accountID !== currentUserPersonalDetails.accountID),
-              recentReports: availableOptions.recentReports.filter((report) => report.accountID !== currentUserPersonalDetails.accountID),
-          };
-
-    const recentReportsLength = optionsWithoutCurrentUser.recentReports?.length || 0;
-    const personalDetailsLength = optionsWithoutCurrentUser.personalDetails?.length || 0;
-
-    const headerMessage = getHeaderMessage(
-        recentReportsLength + personalDetailsLength !== 0 || !!optionsWithoutCurrentUser.currentUserOption,
-        !!optionsWithoutCurrentUser.userToInvite,
-        debouncedSearchTerm,
-        countryCode,
-        false,
-    );
 
     const allPersonalDetails = usePersonalDetails();
 
@@ -104,35 +78,43 @@ function TaskAssigneeSelectorModal() {
 
     const hasOutstandingChildTask = useHasOutstandingChildTask(report);
 
-    const sectionsList = [];
+    const sectionsList = (() => {
+        const list = [];
 
-    if (optionsWithoutCurrentUser.currentUserOption) {
-        sectionsList.push({
-            title: translate('newTaskPage.assignMe'),
-            data: [optionsWithoutCurrentUser.currentUserOption],
-            sectionIndex: 0,
-        });
-    }
+        if (availableOptions.currentUserOption) {
+            list.push({
+                title: translate('newTaskPage.assignMe'),
+                data: [availableOptions.currentUserOption],
+                sectionIndex: 0,
+            });
+        }
 
-    sectionsList.push({
-        title: translate('common.recents'),
-        data: optionsWithoutCurrentUser.recentReports,
-        sectionIndex: 1,
-    });
+        if (availableOptions.recentOptions.length) {
+            list.push({
+                title: translate('common.recents'),
+                data: availableOptions.recentOptions,
+                sectionIndex: 1,
+            });
+        }
 
-    sectionsList.push({
-        title: translate('common.contacts'),
-        data: optionsWithoutCurrentUser.personalDetails,
-        sectionIndex: 2,
-    });
+        if (availableOptions.personalDetails.length) {
+            list.push({
+                title: translate('common.contacts'),
+                data: availableOptions.personalDetails,
+                sectionIndex: 2,
+            });
+        }
 
-    if (optionsWithoutCurrentUser.userToInvite) {
-        sectionsList.push({
-            title: '',
-            data: [optionsWithoutCurrentUser.userToInvite],
-            sectionIndex: 3,
-        });
-    }
+        if (availableOptions.userToInvite) {
+            list.push({
+                title: '',
+                data: [availableOptions.userToInvite],
+                sectionIndex: 3,
+            });
+        }
+
+        return list;
+    })();
 
     const sections = sectionsList.map((section) => ({
         ...section,
@@ -143,7 +125,7 @@ function TaskAssigneeSelectorModal() {
             keyForList: option.keyForList ?? '',
             isDisabled: option.isDisabled ?? undefined,
             login: option.login ?? undefined,
-            shouldShowSubscript: option.shouldShowSubscript ?? undefined,
+            shouldShowSubscript: undefined,
             isSelected: task?.assigneeAccountID === option.accountID || task?.report?.managerID === option.accountID,
         })),
     }));
@@ -171,7 +153,7 @@ function TaskAssigneeSelectorModal() {
                     assigneePersonalDetails,
                     report.reportID,
                     undefined, // passing null as report because for editing task the report will be task details report page not the actual report where task was created
-                    isCurrentUser({...option, accountID: option?.accountID ?? CONST.DEFAULT_NUMBER_ID, login: option?.login ?? ''}, loginList, currentUserEmail),
+                    option.accountID === currentUserPersonalDetails.accountID,
                 );
                 // Pass through the selected assignee
                 editTaskAssignee({
@@ -196,7 +178,7 @@ function TaskAssigneeSelectorModal() {
                 assigneePersonalDetails,
                 task?.shareDestination ?? '',
                 undefined, // passing null as report is null in this condition
-                isCurrentUser({...option, accountID: option?.accountID ?? CONST.DEFAULT_NUMBER_ID, login: option?.login ?? undefined}, loginList, currentUserEmail),
+                option.accountID === currentUserPersonalDetails.accountID,
             );
             Navigation.goBack(ROUTES.NEW_TASK.getRoute(backTo));
         }
@@ -218,6 +200,14 @@ function TaskAssigneeSelectorModal() {
     useEffect(() => {
         searchUserInServer(debouncedSearchTerm);
     }, [debouncedSearchTerm]);
+
+    const searchValue = debouncedSearchTerm.trim().toLowerCase();
+    const headerMessage = (() => {
+        if (sections.length > 0) {
+            return '';
+        }
+        return getHeaderMessage(translate, searchValue, countryCode);
+    })();
 
     const textInputOptions = {
         value: searchTerm,
@@ -256,4 +246,4 @@ function TaskAssigneeSelectorModal() {
     );
 }
 
-export default withNavigationTransitionEnd(withCurrentUserPersonalDetails(TaskAssigneeSelectorModal));
+export default TaskAssigneeSelectorModal;

--- a/src/pages/workspace/WorkspaceConfirmationOwnerSelectorPage.tsx
+++ b/src/pages/workspace/WorkspaceConfirmationOwnerSelectorPage.tsx
@@ -1,132 +1,96 @@
-import React, {useCallback, useEffect, useMemo} from 'react';
+import React, {useEffect} from 'react';
 import {View} from 'react-native';
+import FullscreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import UserListItem from '@components/SelectionList/ListItem/UserListItem';
 import SelectionListWithSections from '@components/SelectionList/SelectionListWithSections';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import useSearchSelector from '@hooks/useSearchSelector';
+import usePersonalDetailSearchSelector from '@hooks/usePersonalDetailSearchSelector';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {setDraftValues} from '@libs/actions/FormActions';
 import {searchInServer} from '@libs/actions/Report';
-import {formatPhoneNumber} from '@libs/LocalePhoneNumber';
 import Navigation from '@libs/Navigation/Navigation';
-import {getHeaderMessage} from '@libs/OptionsListUtils';
-import type {OptionWithKey} from '@libs/OptionsListUtils/types';
+import {getHeaderMessage, getUserToInviteOption} from '@libs/PersonalDetailOptionsListUtils';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
-import {generateAccountID} from '@libs/UserUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import INPUT_IDS from '@src/types/form/WorkspaceConfirmationForm';
 import type {Participant} from '@src/types/onyx/IOU';
-import type IconAsset from '@src/types/utils/IconAsset';
+import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
-/**
- * Helper function to create a formatted user list item
- */
-function createUserListItem(
-    personalDetails: ReturnType<typeof getPersonalDetailByEmail>,
-    login: string,
-    keyPrefix: string,
-    isSelected: boolean,
-    fallBackAvatarIcon: IconAsset,
-): OptionWithKey {
-    const accountID = personalDetails?.accountID ?? generateAccountID(login);
-    return {
-        ...(personalDetails ?? {}),
-        text: personalDetails?.displayName ?? login,
-        alternateText: personalDetails?.login ?? login,
-        login: personalDetails?.login ?? login,
-        keyForList: `${keyPrefix}-${personalDetails?.login ?? login}`,
-        accountID,
-        isSelected,
-        shouldShowSubscript: undefined,
-        icons: [
-            {
-                source: personalDetails?.avatar ?? fallBackAvatarIcon,
-                name: formatPhoneNumber(personalDetails?.login ?? login),
-                type: CONST.ICON_TYPE_AVATAR,
-                id: accountID,
-            },
-        ],
-    };
-}
+type WorkspaceConfirmationOwnerSelectorPageContentProps = {
+    /** The currently selected workspace owner login (from the draft, falling back to the current user) */
+    currentOwner: string;
+};
 
-function WorkspaceConfirmationOwnerSelectorPage() {
-    const {translate} = useLocalize();
+function WorkspaceConfirmationOwnerSelectorPageContent({currentOwner}: WorkspaceConfirmationOwnerSelectorPageContentProps) {
+    const {translate, formatPhoneNumber} = useLocalize();
     const styles = useThemeStyles();
-    const icons = useMemoizedLazyExpensifyIcons(['FallbackAvatar']);
-    const {login: currentUserLogin} = useCurrentUserPersonalDetails();
     const [countryCode = CONST.DEFAULT_COUNTRY_CODE] = useOnyx(ONYXKEYS.COUNTRY_CODE);
-
     const [isSearchingForReports] = useOnyx(ONYXKEYS.RAM_ONLY_IS_SEARCHING_FOR_REPORTS);
-    const [draftValues] = useOnyx(ONYXKEYS.FORMS.WORKSPACE_CONFIRMATION_FORM_DRAFT);
-    const currentOwner = draftValues?.owner ?? currentUserLogin ?? '';
-    const ownerPersonalDetails = getPersonalDetailByEmail(currentOwner);
     const backPath = useDynamicBackPath(DYNAMIC_ROUTES.OWNER_SELECTOR.path);
 
-    const excludeLogins = useMemo(
-        () => ({
-            ...CONST.EXPENSIFY_EMAILS_OBJECT,
-        }),
-        [],
-    );
+    const ownerPersonalDetails = getPersonalDetailByEmail(currentOwner);
 
-    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, areOptionsInitialized, onListEndReached} = useSearchSelector({
+    // When the current owner isn't in the personal details list (e.g. an external email), build an optimistic option to seed the selection
+    const ownerExtraOption =
+        !currentOwner || ownerPersonalDetails ? undefined : (getUserToInviteOption({searchValue: currentOwner, countryCode, formatPhoneNumber, loginList: {}}) ?? undefined);
+
+    const ownerAccountID = ownerPersonalDetails?.accountID ?? ownerExtraOption?.accountID;
+    const initialSelected = new Set(ownerAccountID ? [String(ownerAccountID)] : []);
+    const initialExtraOptions = ownerExtraOption ? [{...ownerExtraOption, isSelected: true}] : [];
+
+    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, areOptionsInitialized} = usePersonalDetailSearchSelector({
         selectionMode: CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE,
         maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
-        searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
-        excludeLogins,
+        excludeLogins: CONST.EXPENSIFY_EMAILS_OBJECT,
         includeRecentReports: true,
-        getValidOptionsConfig: {
-            excludeLogins,
-        },
+        includeUserToInvite: true,
+        initialSelected,
+        initialExtraOptions,
     });
 
-    const sections = useMemo(() => {
+    const sections = (() => {
         const sectionsList = [];
-        const currentUserPersonalDetails = getPersonalDetailByEmail(currentUserLogin ?? '');
 
-        if (currentOwner) {
-            const ownerItem = createUserListItem(ownerPersonalDetails, currentOwner, 'currentOwner', true, icons.FallbackAvatar);
+        // Current owner (always pinned at the top) — sourced from the hook's selected option
+        if (availableOptions.selectedOptions.length > 0) {
             sectionsList.push({
-                data: [ownerItem],
+                data: availableOptions.selectedOptions,
                 sectionIndex: 0,
             });
         }
 
-        if (currentUserLogin && currentUserLogin !== currentOwner) {
-            const currentUserItem = createUserListItem(currentUserPersonalDetails, currentUserLogin, 'currentUser', false, icons.FallbackAvatar);
+        // "Switch back to me" quick-pick — only when the current user isn't already the owner
+        if (availableOptions.currentUserOption) {
             sectionsList.push({
-                data: [currentUserItem],
+                data: [availableOptions.currentUserOption],
                 sectionIndex: 1,
             });
         }
 
-        const filteredRecentReports = availableOptions.recentReports?.filter((report) => report.login !== currentOwner) ?? [];
-        if (filteredRecentReports.length > 0) {
+        if (availableOptions.recentOptions.length > 0) {
             sectionsList.push({
                 title: translate('common.recents'),
-                data: filteredRecentReports,
+                data: availableOptions.recentOptions,
                 sectionIndex: 2,
             });
         }
 
-        const filteredPersonalDetails = availableOptions.personalDetails?.filter((contact) => contact.login !== currentOwner) ?? [];
-        if (filteredPersonalDetails.length > 0) {
+        if (availableOptions.personalDetails.length > 0) {
             sectionsList.push({
                 title: translate('common.contacts'),
-                data: filteredPersonalDetails,
+                data: availableOptions.personalDetails,
                 sectionIndex: 3,
             });
         }
 
-        if (availableOptions.userToInvite && availableOptions.userToInvite.login !== currentOwner) {
+        if (availableOptions.userToInvite) {
             sectionsList.push({
                 data: [availableOptions.userToInvite],
                 sectionIndex: 4,
@@ -134,47 +98,37 @@ function WorkspaceConfirmationOwnerSelectorPage() {
         }
 
         return sectionsList;
-    }, [
-        currentOwner,
-        currentUserLogin,
-        ownerPersonalDetails,
-        translate,
-        availableOptions.recentReports,
-        availableOptions.personalDetails,
-        availableOptions.userToInvite,
-        icons.FallbackAvatar,
-    ]);
+    })();
 
-    const onSelectRow = useCallback(
-        (option: Participant) => {
-            // Clear search to prevent "No results found" after selection
-            setSearchTerm('');
+    const onSelectRow = (option: Participant) => {
+        // Clear search to prevent "No results found" after selection
+        setSearchTerm('');
 
-            setDraftValues(ONYXKEYS.FORMS.WORKSPACE_CONFIRMATION_FORM, {
-                [INPUT_IDS.OWNER]: option?.login,
-            });
+        setDraftValues(ONYXKEYS.FORMS.WORKSPACE_CONFIRMATION_FORM, {
+            [INPUT_IDS.OWNER]: option?.login,
+        });
 
-            // Navigate back to the confirmation form
-            Navigation.goBack(backPath);
-        },
-        [setSearchTerm, backPath],
-    );
+        // Navigate back to the confirmation form
+        Navigation.goBack(backPath);
+    };
 
     useEffect(() => {
         searchInServer(debouncedSearchTerm);
     }, [debouncedSearchTerm]);
 
+    const searchValue = debouncedSearchTerm.trim().toLowerCase();
+    const headerMessage = (() => {
+        if (sections.length > 0) {
+            return '';
+        }
+        return getHeaderMessage(translate, searchValue, countryCode);
+    })();
+
     const textInputOptions = {
         onChangeText: setSearchTerm,
         value: searchTerm,
         label: translate('selectionList.nameEmailOrPhoneNumber'),
-        headerMessage: getHeaderMessage(
-            (availableOptions.recentReports?.length || 0) + (availableOptions.personalDetails?.length || 0) !== 0,
-            !!availableOptions.userToInvite,
-            debouncedSearchTerm.trim(),
-            countryCode,
-            false,
-        ),
+        headerMessage,
     };
 
     return (
@@ -195,12 +149,23 @@ function WorkspaceConfirmationOwnerSelectorPage() {
                     textInputOptions={textInputOptions}
                     shouldShowLoadingPlaceholder={!areOptionsInitialized}
                     isLoadingNewOptions={!!isSearchingForReports}
-                    onEndReached={onListEndReached}
                     shouldSingleExecuteRowSelect
                 />
             </View>
         </ScreenWrapper>
     );
+}
+
+function WorkspaceConfirmationOwnerSelectorPage() {
+    const {login: currentUserLogin} = useCurrentUserPersonalDetails();
+    const [draftValues, draftValuesMetadata] = useOnyx(ONYXKEYS.FORMS.WORKSPACE_CONFIRMATION_FORM_DRAFT);
+
+    // Wait for the draft to load so the initial owner selection is seeded correctly on mount
+    if (isLoadingOnyxValue(draftValuesMetadata)) {
+        return <FullscreenLoadingIndicator reasonAttributes={{context: 'WorkspaceConfirmationOwnerSelectorPage', isLoadingDraftValues: true}} />;
+    }
+
+    return <WorkspaceConfirmationOwnerSelectorPageContent currentOwner={draftValues?.owner ?? currentUserLogin ?? ''} />;
 }
 
 export default WorkspaceConfirmationOwnerSelectorPage;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/82191

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Test 1:

1. Open App
2. Open any chat where you can add tasks.
3. Click on + > Assign Task
4. Enter title and go next.
5. Click on Assignee menu.
6. Verify that all options are displayed correctly and searching and selecting works fine.

Test 2:

1. Open App
2. Go to Account Tab > Profile.
3. Click on Status > Vacation Delegate
4. Verify that all options are displayed correctly and searching and selecting works fine.

Test 3:

1. Open App
2. Go to Account Tab > Copilot.
3. Click on Add copilot.
4. Verify that all options are displayed correctly and searching and selecting works fine.

Test 4:

Pre-req: Do `Onyx.merge('account', {isApprovedAccountant: true});` on the console before proceeding.

1. Open App
2. Go to Workspace tab
3. Click on New > Owner menu.
4. Verify that all options are displayed correctly and searching and selecting works fine.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
15. Upload an image via copy paste
16. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/04042a57-6c91-4803-9b9c-1d70ec38fe3c

https://github.com/user-attachments/assets/309ce760-9be1-4d96-b2f0-76db087ec8db

https://github.com/user-attachments/assets/a70d9719-a627-4378-8db0-af154ff89b40

https://github.com/user-attachments/assets/fbb44eac-3fa6-414a-a8d7-fd82f1260e8a
