### PR TITLE
Implement escape key suppression for focus trap in icationPromptPage

### DIFF
--- a/src/components/MultifactorAuthentication/useMFACancelOnEscape/index.ts
+++ b/src/components/MultifactorAuthentication/useMFACancelOnEscape/index.ts
@@ -1,0 +1,31 @@
+import {useCallback} from 'react';
+import {useMultifactorAuthentication} from '@components/MultifactorAuthentication/Context';
+
+/**
+ * Returns a focus-trap `escapeDeactivates` callback that opens the MFA cancel-confirmation modal.
+ *
+ * `focus-trap` listens on `keydown`, but `ReanimatedModal` listens on `keyup`. Without intervention,
+ * the same ESC press that opens the modal would also trigger the keyup listener that just got
+ * attached, closing the modal immediately. We swallow that one keyup via a one-shot capture-phase
+ * listener registered on `document` before `requestCancel` runs.
+ *
+ * Returning `false` keeps the trap active so focus stays inside the MFA screen while the
+ * confirmation modal is up.
+ */
+function useMFACancelOnEscape(): () => boolean {
+    const {requestCancel} = useMultifactorAuthentication();
+
+    return useCallback(() => {
+        const suppressEscapeKeyup = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.stopImmediatePropagation();
+            }
+            document.removeEventListener('keyup', suppressEscapeKeyup, true);
+        };
+        document.addEventListener('keyup', suppressEscapeKeyup, true);
+        requestCancel();
+        return false;
+    }, [requestCancel]);
+}
+
+export default useMFACancelOnEscape;

--- a/src/components/MultifactorAuthentication/useMFACancelOnEscape/index.ts
+++ b/src/components/MultifactorAuthentication/useMFACancelOnEscape/index.ts
@@ -1,4 +1,3 @@
-import {useCallback} from 'react';
 import {useMultifactorAuthentication} from '@components/MultifactorAuthentication/Context';
 
 /**
@@ -15,7 +14,7 @@ import {useMultifactorAuthentication} from '@components/MultifactorAuthenticatio
 function useMFACancelOnEscape(): () => boolean {
     const {requestCancel} = useMultifactorAuthentication();
 
-    return useCallback(() => {
+    return () => {
         const suppressEscapeKeyup = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 event.stopImmediatePropagation();
@@ -25,7 +24,7 @@ function useMFACancelOnEscape(): () => boolean {
         document.addEventListener('keyup', suppressEscapeKeyup, true);
         requestCancel();
         return false;
-    }, [requestCancel]);
+    };
 }
 
 export default useMFACancelOnEscape;

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -7,6 +7,7 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import LoadingIndicator from '@components/LoadingIndicator';
 import {useMultifactorAuthentication, useMultifactorAuthenticationActions, useMultifactorAuthenticationState, usePromptContent} from '@components/MultifactorAuthentication/Context';
 import MultifactorAuthenticationPromptContent from '@components/MultifactorAuthentication/PromptContent';
+import useMFACancelOnEscape from '@components/MultifactorAuthentication/useMFACancelOnEscape';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useLocalize from '@hooks/useLocalize';
@@ -28,25 +29,11 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
     const {accountID} = useCurrentUserPersonalDetails();
 
     const {illustration, title, subtitle, shouldDisplayConfirmButton} = usePromptContent(route.params.promptType);
+    const interceptFocusTrapEscape = useMFACancelOnEscape();
 
     const onConfirm = () => {
         markHasAcceptedSoftPrompt(accountID);
         dispatch({type: 'SET_SOFT_PROMPT_APPROVED', payload: true});
-    };
-
-    // Escape opens the cancel confirmation; returning false keeps the trap active.
-    // focus-trap fires on keydown, but the confirm modal mounts a `keyup` listener via useEffect
-    // that catches the matching ESC keyup and instantly closes the modal. Swallow that keyup once.
-    const interceptFocusTrapEscape = () => {
-        const suppressEscapeKeyup = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                event.stopImmediatePropagation();
-            }
-            document.removeEventListener('keyup', suppressEscapeKeyup, true);
-        };
-        document.addEventListener('keyup', suppressEscapeKeyup, true);
-        requestCancel();
-        return false;
     };
 
     return (

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -35,7 +35,16 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
     };
 
     // Escape opens the cancel confirmation; returning false keeps the trap active.
+    // focus-trap fires on keydown, but the confirm modal mounts a `keyup` listener via useEffect
+    // that catches the matching ESC keyup and instantly closes the modal. Swallow that keyup once.
     const interceptFocusTrapEscape = () => {
+        const suppressEscapeKeyup = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.stopImmediatePropagation();
+            }
+            document.removeEventListener('keyup', suppressEscapeKeyup, true);
+        };
+        document.addEventListener('keyup', suppressEscapeKeyup, true);
         requestCancel();
         return false;
     };

--- a/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
+++ b/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
@@ -8,6 +8,7 @@ import MagicCodeInput from '@components/MagicCodeInput';
 import type {MagicCodeInputHandle} from '@components/MagicCodeInput';
 import {useMultifactorAuthentication, useMultifactorAuthenticationActions, useMultifactorAuthenticationState} from '@components/MultifactorAuthentication/Context';
 import addMFABreadcrumb from '@components/MultifactorAuthentication/observability/breadcrumbs';
+import useMFACancelOnEscape from '@components/MultifactorAuthentication/useMFACancelOnEscape';
 import MultifactorAuthenticationValidateCodeResendButton from '@components/MultifactorAuthentication/ValidateCodeResendButton';
 import type {MultifactorAuthenticationValidateCodeResendButtonHandle} from '@components/MultifactorAuthentication/ValidateCodeResendButton';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -198,11 +199,7 @@ function MultifactorAuthenticationValidateCodePage() {
         dispatch({type: 'SET_VALIDATE_CODE', payload: inputCode});
     };
 
-    // Escape opens the cancel confirmation; returning false keeps the trap active.
-    const interceptFocusTrapEscape = () => {
-        requestCancel();
-        return false;
-    };
+    const interceptFocusTrapEscape = useMFACancelOnEscape();
 
     return (
         <ScreenWrapper

--- a/tests/unit/components/MultifactorAuthentication/useMFACancelOnEscape.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/useMFACancelOnEscape.test.ts
@@ -1,0 +1,91 @@
+import {renderHook} from '@testing-library/react-native';
+import useMFACancelOnEscape from '@components/MultifactorAuthentication/useMFACancelOnEscape';
+
+const mockRequestCancel = jest.fn();
+
+jest.mock('@components/MultifactorAuthentication/Context', () => ({
+    useMultifactorAuthentication: () => ({requestCancel: mockRequestCancel}),
+}));
+
+function dispatchKeyup(key: string): jest.SpyInstance {
+    const event = new KeyboardEvent('keyup', {key, cancelable: true, bubbles: true});
+    const stopImmediatePropagationSpy = jest.spyOn(event, 'stopImmediatePropagation');
+    document.dispatchEvent(event);
+    return stopImmediatePropagationSpy;
+}
+
+describe('useMFACancelOnEscape', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns false so the focus trap stays active', () => {
+        // Given the hook is rendered
+        // When the returned handler is invoked
+        // Then it returns false so focus-trap does not deactivate
+        const {result} = renderHook(() => useMFACancelOnEscape());
+
+        expect(result.current()).toBe(false);
+    });
+
+    it('invokes requestCancel so the cancel-confirmation modal opens', () => {
+        // Given the hook is rendered
+        // When the returned handler is invoked
+        // Then requestCancel runs, which dispatches SET_CANCEL_CONFIRM_VISIBLE: true
+        const {result} = renderHook(() => useMFACancelOnEscape());
+
+        result.current();
+
+        expect(mockRequestCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses the matching ESC keyup so the modal does not close immediately', () => {
+        // Given the focus-trap escape handler has just run on keydown
+        // When the matching ESC keyup arrives moments later
+        // Then propagation is stopped so the modal's keyup listener cannot fire
+        const {result} = renderHook(() => useMFACancelOnEscape());
+
+        result.current();
+        const stopImmediatePropagationSpy = dispatchKeyup('Escape');
+
+        expect(stopImmediatePropagationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not stop propagation for a non-ESC keyup that races in', () => {
+        // Given another key is released between the focus-trap keydown and the ESC keyup
+        // When that keyup fires first
+        // Then we let it propagate normally — only ESC is special
+        const {result} = renderHook(() => useMFACancelOnEscape());
+
+        result.current();
+        const stopImmediatePropagationSpy = dispatchKeyup('Enter');
+
+        expect(stopImmediatePropagationSpy).not.toHaveBeenCalled();
+    });
+
+    it('self-removes after one keyup so subsequent ESC presses are not silently swallowed', () => {
+        // Given the suppressor consumed its one keyup
+        // When a later, unrelated ESC keyup happens
+        // Then the suppressor is gone and propagation continues normally
+        const {result} = renderHook(() => useMFACancelOnEscape());
+
+        result.current();
+        dispatchKeyup('Escape');
+        const stopImmediatePropagationSpy = dispatchKeyup('Escape');
+
+        expect(stopImmediatePropagationSpy).not.toHaveBeenCalled();
+    });
+
+    it('self-removes even when the first keyup is not ESC', () => {
+        // Given a non-ESC key was released first (rare but possible with chorded keys)
+        // When a later ESC keyup happens
+        // Then the listener has already cleaned itself up
+        const {result} = renderHook(() => useMFACancelOnEscape());
+
+        result.current();
+        dispatchKeyup('Enter');
+        const stopImmediatePropagationSpy = dispatchKeyup('Escape');
+
+        expect(stopImmediatePropagationSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION





### Explanation of Change

## Root cause

Two libraries handle ESC at different event phases:

| Component | Event  |
|---|---|
| `focus-trap` library | `keydown` | 
| `ReanimatedModal` | `keyup` | 

A single ESC press generates **both** events. When the user presses ESC on `PromptPage`:

1. **`keydown`** → `focus-trap` calls `interceptFocusTrapEscape` → `requestCancel()` dispatches `SET_CANCEL_CONFIRM_VISIBLE: true`.
2. React commits the state change → `ConfirmModal` mounts → its `useEffect` attaches the `keyup` listener on `document.body`.
3. **`keyup`** (same key press, ~milliseconds later) → the brand-new listener fires → calls `closeTop()` → invokes the modal's `onCancel` (`hideCancelConfirm`) → modal closes instantly.

The modal essentially intercepts the tail end of the *same* keystroke that opened it.

## Solution

Before triggering `requestCancel()`, we register a one-shot **capture-phase** `keyup` listener on `document`. When the matching ESC `keyup` arrives, `stopImmediatePropagation()` prevents `ReanimatedModal`'s listener from ever seeing it, so the modal stays open. The listener self-removes on the next keyup of any kind, so it never affects subsequent keystrokes.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/93304
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Begin the passkey registration flow (e.g. via the troubleshoot/test page or virtual card reveal).
2. On the prompt page, press the Escape key.
3. The cancel confirmation modal opens and stays open, mirroring the click-outside behavior.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Begin the passkey registration flow (e.g. via the troubleshoot/test page or virtual card reveal).
2. On the prompt page, press the Escape key.
3. The cancel confirmation modal opens and stays open, mirroring the click-outside behavior.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


https://github.com/user-attachments/assets/3db890a9-3a46-49f7-8a6f-c77c6df0c08a

