### PR TITLE
feat: render high-res PDF overlay on receipt hover zoom

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -1479,6 +1479,10 @@ const CONST = {
         SHUTTER_SIZE: 90,
         MAX_REPORT_PREVIEW_RECEIPTS: 3,
         FLASH_DELAY_MS: 2000,
+        // Maximum magnification applied while hover-zooming a receipt (see ReceiptHoverZoom).
+        // Remote PDFs are rendered at this multiple of their on-screen size so the magnified
+        // view shows real pixels instead of an upscaled low-resolution raster.
+        HOVER_ZOOM_SCALE: 2.5,
     },
     RECEIPT_PREVIEW_TOP_BOTTOM_MARGIN: 120,
     REPORT: {

--- a/src/components/ReceiptHoverZoom/index.web.tsx
+++ b/src/components/ReceiptHoverZoom/index.web.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import CONST from '@src/CONST';
 import type ReceiptHoverZoomProps from './types';
 import useReceiptHoverZoom from './useReceiptHoverZoom';
 
-const DEFAULT_SCALE = 2.5;
+const DEFAULT_SCALE = CONST.RECEIPT.HOVER_ZOOM_SCALE;
 
 const wrapperStyle: React.CSSProperties = {position: 'relative', overflow: 'hidden', width: '100%', height: '100%'};
 const innerStyle: React.CSSProperties = {width: '100%', height: '100%', transition: 'transform 80ms ease-out', willChange: 'transform'};

--- a/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
@@ -645,6 +645,7 @@ function MoneyRequestReceiptView({
                                         <ReportActionItemImage
                                             shouldUseThumbnailImage={!fillSpace}
                                             shouldUseFullHeight={fillSpace}
+                                            canZoomReceipt={canZoomReceipt}
                                             thumbnail={receiptURIs?.thumbnail}
                                             fileExtension={receiptURIs?.fileExtension}
                                             isThumbnail={receiptURIs?.isThumbnail}

--- a/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
@@ -269,7 +269,7 @@ function MoneyRequestReceiptView({
         receiptURIs = getThumbnailAndImageURIs(displayedTransaction);
     }
     const isEReceiptTransaction = !!displayedTransaction && !hasReceiptSource(displayedTransaction) && hasEReceipt(displayedTransaction);
-    const canZoomReceipt = hasReceipt && !isLoading && !isTransactionScanning && !isEReceiptTransaction && !!receiptURIs?.image;
+    const canZoomReceipt = hasReceipt && !isLoading && !isEReceiptTransaction && !!receiptURIs?.image;
     const pendingAction = transaction?.pendingAction;
     // Need to return undefined when we have pendingAction to avoid the duplicate pending action
     const getPendingFieldAction = (fieldPath: TransactionPendingFieldsKey) => {

--- a/src/components/ReportActionItem/ReceiptPDFOverlay/index.native.tsx
+++ b/src/components/ReportActionItem/ReceiptPDFOverlay/index.native.tsx
@@ -1,0 +1,12 @@
+import type ReceiptPDFOverlayProps from './types';
+
+/**
+ * Hover-zoom is a web-only interaction, so on native there is no high-resolution PDF overlay to render.
+ * Callers only mount this component when hover is supported, so this fallback should never actually render.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function ReceiptPDFOverlay(props: ReceiptPDFOverlayProps) {
+    return null;
+}
+
+export default ReceiptPDFOverlay;

--- a/src/components/ReportActionItem/ReceiptPDFOverlay/index.tsx
+++ b/src/components/ReportActionItem/ReceiptPDFOverlay/index.tsx
@@ -1,0 +1,87 @@
+import React, {useEffect, useState} from 'react';
+import {PDFPreviewer} from 'react-fast-pdf';
+import {View} from 'react-native';
+import useOnyx from '@hooks/useOnyx';
+import useThemeStyles from '@hooks/useThemeStyles';
+import addEncryptedAuthTokenToURL from '@libs/addEncryptedAuthTokenToURL';
+import variables from '@styles/variables';
+import {retrieveMaxCanvasArea, retrieveMaxCanvasHeight, retrieveMaxCanvasWidth} from '@userActions/CanvasSize';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type ReceiptPDFOverlayProps from './types';
+
+const oversamplePercent = `${CONST.RECEIPT.HOVER_ZOOM_SCALE * 100}%`;
+const oversampleContainerStyle = {
+    position: 'absolute' as const,
+    top: 0,
+    left: 0,
+    width: oversamplePercent,
+    height: oversamplePercent,
+    transform: `scale(${1 / CONST.RECEIPT.HOVER_ZOOM_SCALE})`,
+    transformOrigin: 'top left',
+};
+
+function ReceiptPDFOverlay({sourceURL, isAuthTokenRequired = true, onLoadFailure}: ReceiptPDFOverlayProps) {
+    const styles = useThemeStyles();
+    const [session] = useOnyx(ONYXKEYS.SESSION);
+    const [maxCanvasArea] = useOnyx(ONYXKEYS.MAX_CANVAS_AREA);
+    const [maxCanvasHeight] = useOnyx(ONYXKEYS.MAX_CANVAS_HEIGHT);
+    const [maxCanvasWidth] = useOnyx(ONYXKEYS.MAX_CANVAS_WIDTH);
+
+    useEffect(() => {
+        // Verify the per-browser canvas limits have been calculated, mirroring PDFView.
+        if (!maxCanvasArea) {
+            retrieveMaxCanvasArea();
+        }
+        if (!maxCanvasHeight) {
+            retrieveMaxCanvasHeight();
+        }
+        if (!maxCanvasWidth) {
+            retrieveMaxCanvasWidth();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- Run once on mount; canvas limits are one-time browser measurements that don't change
+    }, []);
+
+    const fileURL = isAuthTokenRequired ? addEncryptedAuthTokenToURL(sourceURL, session?.encryptedAuthToken ?? '') : sourceURL;
+
+    // Track which URL failed so hasFailed resets automatically when fileURL changes (e.g. after auth token refresh),
+    // mirroring the pattern in ThumbnailImage. No useEffect needed — the comparison runs synchronously during render.
+    const [failedURL, setFailedURL] = useState<string | null>(null);
+    const hasFailed = failedURL !== null && failedURL === fileURL;
+
+    // If the PDF can't be rendered, fall back to the thumbnail underneath by rendering nothing.
+    if (hasFailed) {
+        return null;
+    }
+
+    return (
+        <View
+            style={[styles.w100, styles.h100, styles.overflowHidden]}
+            pointerEvents="none"
+        >
+            {/* <div> is required here because `transformOrigin` is a CSS-only property unsupported by React Native's
+                View. The oversample-then-scale technique relies on it to anchor the downscale to the top-left corner. */}
+            <div style={oversampleContainerStyle}>
+                <PDFPreviewer
+                    file={fileURL}
+                    pageMaxWidth={variables.pdfPageMaxWidth}
+                    // Fit the page to the full width of the (oversized) container, matching the thumbnail framing.
+                    isSmallScreen
+                    maxCanvasWidth={maxCanvasWidth}
+                    maxCanvasHeight={maxCanvasHeight}
+                    maxCanvasArea={maxCanvasArea}
+                    containerStyle={styles.bgTransparent}
+                    contentContainerStyle={styles.bgTransparent}
+                    shouldShowErrorComponent={false}
+                    LoadingComponent={null}
+                    onLoadError={() => {
+                        setFailedURL(fileURL);
+                        onLoadFailure?.();
+                    }}
+                />
+            </div>
+        </View>
+    );
+}
+
+export default ReceiptPDFOverlay;

--- a/src/components/ReportActionItem/ReceiptPDFOverlay/types.ts
+++ b/src/components/ReportActionItem/ReceiptPDFOverlay/types.ts
@@ -1,0 +1,12 @@
+type ReceiptPDFOverlayProps = {
+    /** Resolved URL of the source PDF. The encrypted auth token is appended internally when required. */
+    sourceURL: string;
+
+    /** Whether the source requires an encrypted auth token */
+    isAuthTokenRequired?: boolean;
+
+    /** Called when the PDF fails to load so the caller can fall back to the thumbnail */
+    onLoadFailure?: () => void;
+};
+
+export default ReceiptPDFOverlayProps;

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -1,7 +1,7 @@
 import {Str} from 'expensify-common';
 import React from 'react';
 import type {ViewStyle} from 'react-native';
-import {View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import ConfirmedRoute from '@components/ConfirmedRoute';
 import type {IconSize} from '@components/EReceiptThumbnail';
@@ -12,16 +12,26 @@ import {useShowContextMenuState} from '@components/ShowContextMenuContext';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {hasHoverSupport} from '@libs/DeviceCapabilities';
 import {getReportIDForExpense} from '@libs/MergeTransactionUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {getThumbnailAndImageURIs} from '@libs/ReceiptUtils';
-import {hasEReceipt, hasPendingDistanceReceiptRegeneration, hasReceiptSource, isDistanceRequest, isManualDistanceRequest, isPerDiemRequest} from '@libs/TransactionUtils';
+import {
+    hasEReceipt,
+    hasPendingDistanceReceiptRegeneration,
+    hasReceiptSource,
+    isDistanceRequest,
+    isManualDistanceRequest,
+    isMapBasedDistanceRequest,
+    isPerDiemRequest,
+} from '@libs/TransactionUtils';
 import tryResolveUrlFromApiRoot from '@libs/tryResolveUrlFromApiRoot';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type {Report, Transaction} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import ReceiptPDFOverlay from './ReceiptPDFOverlay';
 
 type ReportActionItemImageProps = {
     /** thumbnail URI for the image */
@@ -77,6 +87,9 @@ type ReportActionItemImageProps = {
     /** Whether to use the thumbnail image instead of the full image */
     shouldUseThumbnailImage?: boolean;
 
+    /** Whether the receipt can be hover-zoomed. When true, remote PDFs render the actual PDF on top of the thumbnail so magnification stays sharp (web only). */
+    canZoomReceipt?: boolean;
+
     /** Callback to be called when the image loads */
     onLoad?: (event?: {nativeEvent: {width: number; height: number}}) => void;
 
@@ -108,6 +121,7 @@ function ReportActionItemImage({
     shouldUseFullHeight,
     report: reportProp,
     shouldUseThumbnailImage,
+    canZoomReceipt = false,
     onLoad,
     onLoadFailure,
 }: ReportActionItemImageProps) {
@@ -183,6 +197,33 @@ function ReportActionItemImage({
 
     propsObj.isPerDiemRequest = isPerDiemRequest(transaction);
 
+    // A remote PDF is shown as the server's low-resolution JPG thumbnail, which blurs when hover-zoomed.
+    // Where zooming is available (web only), render the actual PDF on top of the thumbnail so the magnified
+    // view stays sharp. The thumbnail stays underneath as an instant preview and as a fallback if the PDF fails.
+    // Map/route distance requests are excluded: their hover overlay is a DistanceEReceipt card, not the PDF.
+    // isMapBasedDistanceRequest covers map, GPS, and manual-typed transactions that still carry waypoints.
+    const pdfSourceURL = typeof originalImageSource === 'string' && !!originalImageSource ? originalImageSource : undefined;
+    const isRemotePDF = !!isPDF && !effectiveIsLocalFile && !isEReceipt && !isMapBasedDistanceRequest(transaction) && !!pdfSourceURL;
+    const shouldOverlayHighResPDF = canZoomReceipt && isRemotePDF && hasHoverSupport();
+
+    const renderReceiptContent = (receiptImage: React.ReactNode) =>
+        shouldOverlayHighResPDF ? (
+            <View style={[styles.w100, styles.h100]}>
+                {receiptImage}
+                <View
+                    style={StyleSheet.absoluteFill}
+                    pointerEvents="none"
+                >
+                    <ReceiptPDFOverlay
+                        sourceURL={pdfSourceURL}
+                        onLoadFailure={onLoadFailure}
+                    />
+                </View>
+            </View>
+        ) : (
+            receiptImage
+        );
+
     if (enablePreviewModal) {
         return (
             <PressableWithoutFocus
@@ -201,18 +242,20 @@ function ReportActionItemImage({
                 accessibilityRole={CONST.ROLE.BUTTON}
                 sentryLabel={CONST.SENTRY_LABEL.RECEIPT.IMAGE}
             >
-                <ReceiptImage
-                    {...propsObj}
-                    onLoad={onLoad}
-                    shouldUseFullHeight={shouldUseFullHeight}
-                    onLoadFailure={onLoadFailure}
-                    previewUri={previewUriSource}
-                />
+                {renderReceiptContent(
+                    <ReceiptImage
+                        {...propsObj}
+                        onLoad={onLoad}
+                        shouldUseFullHeight={shouldUseFullHeight}
+                        onLoadFailure={onLoadFailure}
+                        previewUri={previewUriSource}
+                    />,
+                )}
             </PressableWithoutFocus>
         );
     }
 
-    return (
+    return renderReceiptContent(
         <ReceiptImage
             {...propsObj}
             shouldUseFullHeight={shouldUseFullHeight}
@@ -220,7 +263,7 @@ function ReportActionItemImage({
             onLoad={onLoad}
             onLoadFailure={onLoadFailure}
             previewUri={previewUriSource}
-        />
+        />,
     );
 }
 

--- a/tests/unit/TransactionUtilsTest.ts
+++ b/tests/unit/TransactionUtilsTest.ts
@@ -3584,4 +3584,46 @@ describe('TransactionUtils', () => {
             });
         });
     });
+
+    describe('isMapBasedDistanceRequest', () => {
+        it('returns false for undefined transaction', () => {
+            expect(TransactionUtils.isMapBasedDistanceRequest(undefined)).toBe(false);
+        });
+
+        it('returns false for a non-distance (scan) request', () => {
+            const transaction = generateTransaction({iouRequestType: CONST.IOU.REQUEST_TYPE.SCAN});
+            expect(TransactionUtils.isMapBasedDistanceRequest(transaction)).toBe(false);
+        });
+
+        it('returns false for an odometer distance request', () => {
+            const transaction = generateTransaction({iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_ODOMETER});
+            expect(TransactionUtils.isMapBasedDistanceRequest(transaction)).toBe(false);
+        });
+
+        it('returns true for a map distance request', () => {
+            const transaction = generateTransaction({iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_MAP});
+            expect(TransactionUtils.isMapBasedDistanceRequest(transaction)).toBe(true);
+        });
+
+        it('returns true for a GPS distance request', () => {
+            const transaction = generateTransaction({iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_GPS});
+            expect(TransactionUtils.isMapBasedDistanceRequest(transaction)).toBe(true);
+        });
+
+        it('returns true for a manual distance request that carries waypoints', () => {
+            const transaction = generateTransaction({
+                iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_MANUAL,
+                comment: {waypoints: {waypoint0: {lat: 0, lng: 0}, waypoint1: {lat: 1, lng: 1}}},
+            });
+            expect(TransactionUtils.isMapBasedDistanceRequest(transaction)).toBe(true);
+        });
+
+        it('returns false for a manual distance request with no waypoints', () => {
+            const transaction = generateTransaction({
+                iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_MANUAL,
+                comment: {waypoints: {}},
+            });
+            expect(TransactionUtils.isMapBasedDistanceRequest(transaction)).toBe(false);
+        });
+    });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

PDF receipts are served as low-resolution JPG thumbnails by the server. When hover-zoomed, these thumbnails blur because the zoom is applied to an upscaled raster. This PR adds `ReceiptZoomablePDF` — a web-only component that renders the actual PDF at 2.5× its on-screen size (then scales it back down with CSS), so the hover-zoom layer reveals real PDF pixels. A native no-op stub keeps bundling clean. `HOVER_ZOOM_SCALE` is extracted to `CONST.RECEIPT` so both components share the value.

https://github.com/user-attachments/assets/8d978b92-863d-4537-b881-bb0e286497db


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/93627
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

Tests should be performed on web platforms

1. Open a report that has a **PDF receipt** attached (non-local, uploaded to server).
2. On web (Chrome/Safari desktop), hover over the receipt thumbnail in the report action item.
3. Verify that the hover-zoom magnification shows sharp, readable PDF text — not a blurry upscaled image.

---

1. Open a report with a PDF receipt as above.
2. Disconnect from the network (or block the PDF URL in DevTools Network tab) so the PDF fails to load.
3. Hover over the receipt thumbnail.
4. Verify that the JPG thumbnail is still visible underneath (no blank area) and no JS errors appear in the console.

---

1. Open a report with a **non-PDF receipt** (JPG/PNG image).
2. Hover over the receipt thumbnail.
3. Verify that hover-zoom behaviour is unchanged — no PDF overlay is rendered, no regressions.

- [x] Verify that no errors appear in the JS console

### Offline tests

This component fetches the PDF via the server URL. Offline behavior is covered in test 2 above: when the PDF URL is unreachable, `onLoadError` fires, `hasFailed` is set to `true`, and `ReceiptZoomablePDF` renders `null`, revealing the pre-loaded JPG thumbnail underneath. No new Onyx writes are involved.

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

