### PR TITLE
fix: replace Array.toReversed() for Chrome <110 compat (#91964)

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -174,7 +174,8 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return true;
         });
 
-        return filteredActions.toReversed();
+        // Use slice().reverse() instead of toReversed() — toReversed is ES2023 and crashes on Chrome <110 / Safari <16.4 (Sentry APP-DTS).
+        return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = !isOffline && !!showReportActionsLoadingState && visibleReportActions.length === 0;


### PR DESCRIPTION
## Summary
$ #91964

## Root cause
Array.prototype.toReversed() is ES2023 and only available in Chrome 110+ / Safari 16.4+. On Chrome 103 (common on managed Chrome OS devices), this call throws TypeError which is caught by ErrorBoundary, rendering a full-page crash screen.

## Fix
Replace filteredActions.toReversed() with filteredActions.slice().reverse() which produces identical results (non-mutating reverse copy) but works on all targeted browsers.

## Testing
- [ ] Verify MoneyRequestReportActionsList renders on Chrome 103
- [ ] Verify report actions display in correct order
- [ ] Check other toReversed() occurrences in codebase