### PR TITLE
[NoQA] Add ReportActionsList perf test case

### DIFF
--- a/tests/perf-test/ReportActionsList.perf-test.tsx
+++ b/tests/perf-test/ReportActionsList.perf-test.tsx
@@ -1,20 +1,24 @@
 import {NavigationContainer} from '@react-navigation/native';
-import {screen} from '@testing-library/react-native';
-import type {ComponentType} from 'react';
+import {act, screen} from '@testing-library/react-native';
+import {useCallback} from 'react';
 import Onyx from 'react-native-onyx';
+import type {OnyxEntry} from 'react-native-onyx';
 import {measureRenders} from 'reassure';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
-import type {WithCurrentUserPersonalDetailsProps} from '@components/withCurrentUserPersonalDetails';
+import useOnyx from '@hooks/useOnyx';
 import type Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
 import {setHasRadio} from '@libs/NetworkState';
+import {getSortedReportActionsForDisplay} from '@libs/ReportActionsUtils';
 import ReportActionsList from '@pages/inbox/report/ReportActionsList';
 import {ActionListContext, ReactionListContext} from '@pages/inbox/ReportScreenContext';
 import {AttachmentModalContextProvider} from '@pages/media/AttachmentModalScreen/AttachmentModalContext';
 import ComposeProviders from '@src/components/ComposeProviders';
 import {LocaleContextProvider} from '@src/components/LocaleContextProvider';
+import CONST from '@src/CONST';
+import IntlStore from '@src/languages/IntlStore';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {PersonalDetailsList} from '@src/types/onyx';
+import type {PersonalDetailsList, ReportAction, ReportActions} from '@src/types/onyx';
 import createRandomReportAction from '../utils/collections/reportActions';
 import {createRandomReport} from '../utils/collections/reports';
 import * as ReportTestUtils from '../utils/ReportTestUtils';
@@ -24,34 +28,7 @@ import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatch
 
 const REPORT_ACTIONS_LIST_ID = 'perf-test-list';
 
-type LazyLoadLHNTestUtils = {
-    fakePersonalDetails: PersonalDetailsList;
-};
-
 const mockedNavigate = jest.fn();
-
-jest.mock('@components/withCurrentUserPersonalDetails', () => {
-    // Lazy loading of LHNTestUtils
-    const lazyLoadLHNTestUtils = () => require<LazyLoadLHNTestUtils>('../utils/LHNTestUtils');
-
-    return <TProps extends WithCurrentUserPersonalDetailsProps>(Component: ComponentType<TProps>) => {
-        function WrappedComponent(props: Omit<TProps, keyof WithCurrentUserPersonalDetailsProps>) {
-            const currentUserAccountID = 5;
-            const LHNTestUtils = lazyLoadLHNTestUtils(); // Load LHNTestUtils here
-
-            return (
-                <Component
-                    {...(props as TProps)}
-                    currentUserPersonalDetails={LHNTestUtils.fakePersonalDetails[currentUserAccountID]}
-                />
-            );
-        }
-
-        WrappedComponent.displayName = 'WrappedComponent';
-
-        return WrappedComponent;
-    };
-});
 
 jest.mock('@react-navigation/native', () => {
     const actualNav = jest.requireActual<typeof Navigation>('@react-navigation/native');
@@ -61,8 +38,6 @@ jest.mock('@react-navigation/native', () => {
         useIsFocused: () => true,
     };
 });
-
-jest.mock('@src/components/ConfirmedRoute.tsx');
 
 beforeAll(() =>
     Onyx.init({
@@ -89,21 +64,66 @@ const signUpWithTestUser = () => {
 };
 
 const report = createRandomReport(1, undefined);
+report.chatReportID = report.reportID;
+
 const parentReportAction = createRandomReportAction(1);
 
-beforeEach(() => {
+// getFakeReportAction sets actorAccountID = index, so the 500 mocked actions have actors 1..500
+const ACTOR_PERSONAL_DETAILS: PersonalDetailsList = Object.fromEntries(
+    Array.from({length: 500}, (_, i) => {
+        const accountID = i + 1;
+        return [
+            accountID,
+            {
+                accountID,
+                login: `user${accountID}@test.com`,
+                avatar: 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/avatar_7.png',
+                avatarThumbnail: 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/avatar_7.png',
+                displayName: `User ${accountID}`,
+                firstName: 'User',
+                lastName: `${accountID}`,
+                pronouns: '',
+                timezone: CONST.DEFAULT_TIME_ZONE,
+                phoneNumber: '',
+            },
+        ];
+    }),
+);
+
+const INITIAL_REPORT_ACTIONS = ReportTestUtils.getMockedSortedReportActions(500);
+const INITIAL_REPORT_ACTIONS_MAP = Object.fromEntries(INITIAL_REPORT_ACTIONS.map((action) => [action.reportActionID, action]));
+const EMPTY_REPORT_ACTIONS: ReportAction[] = [];
+
+beforeEach(async () => {
     // Initialize the network key for OfflineWithFeedback
     setHasRadio(true);
     wrapOnyxWithWaitForBatchedUpdates(Onyx);
-    signUpWithTestUser();
+    // Pre-seed the locale so LocaleContextProvider's mount effect is a no-op (setLocale/IntlStore.load
+    // early-return), avoiding post-mount Onyx writes that re-render outside act().
+    await act(async () => {
+        signUpWithTestUser();
+        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, ACTOR_PERSONAL_DETAILS);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.reportID}`, INITIAL_REPORT_ACTIONS_MAP);
+        await Onyx.merge(ONYXKEYS.NVP_PREFERRED_LOCALE, CONST.LOCALES.DEFAULT);
+        await IntlStore.load(CONST.LOCALES.DEFAULT);
+        await waitForBatchedUpdates();
+    });
 });
 
-afterEach(() => {
-    Onyx.clear();
+afterEach(async () => {
+    // Await the clear so its broadcasts settle in teardown instead of leaking into the next test.
+    await Onyx.clear();
+    await waitForBatchedUpdates();
 });
 
+// Mirror the production data flow (usePaginatedReportActions): the wrapper plays the role of the parent
+// (ReportActionsView) — it reads REPORT_ACTIONS from Onyx and sorts inside a useOnyx selector, instead of
+// holding the actions in local state. "Sending a message" is then an Onyx.merge into REPORT_ACTIONS
+// (exactly like addActions' optimistic update), so the list updates through the real subscription/selector
+// path rather than prop injection.
 function ReportActionsListWrapper() {
-    const reportActions = ReportTestUtils.getMockedSortedReportActions(500);
+    const sortedReportActionsSelector = useCallback((actions: OnyxEntry<ReportActions>) => getSortedReportActionsForDisplay(actions, true, true, undefined, report.reportID), []);
+    const [reportActions = EMPTY_REPORT_ACTIONS] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.reportID}`, {selector: sortedReportActionsSelector});
     return (
         <NavigationContainer ref={navigationRef}>
             <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, AttachmentModalContextProvider]}>
@@ -138,6 +158,51 @@ test('[ReportActionsList] should render ReportActionsList with 500 reportActions
     const scenario = async () => {
         await screen.findByTestId('report-actions-list');
     };
+    await waitForBatchedUpdates();
+    await measureRenders(<ReportActionsListWrapper />, {scenario});
+});
+
+/**
+ * Each scenario iteration simulates sending one message exactly as addActions does:
+ *  - the new report action is merged into REPORT_ACTIONS, AND
+ *  - the report's chat "heartbeat" fields (last*) are merged.
+ * Both writes flow through Onyx, so the list updates via its real subscription rather than prop injection.
+ */
+test('[ReportActionsList] should render cheaply when sending 10 new messages', async () => {
+    await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+    await waitForBatchedUpdates();
+
+    // Monotonic across reassure's repeated scenario runs so every merge writes a new value (Onyx skips no-ops).
+    let messageTick = 0;
+
+    const scenario = async () => {
+        await screen.findByTestId('report-actions-list');
+
+        // Send 10 messages back-to-back to accumulate a measurable, low-noise render duration.
+        for (let i = 0; i < 10; i++) {
+            messageTick++;
+            const tick = messageTick;
+            const stamp = `2026-06-15 00:00:00.${String(tick).padStart(3, '0')}`;
+            const newAction = ReportTestUtils.getFakeReportAction(100000 + tick, {
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                created: stamp,
+                actorAccountID: TEST_USER_ACCOUNT_ID,
+            });
+            await act(async () => {
+                // New message: merge the action into REPORT_ACTIONS AND update the report's last* fields, as a real send does.
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.reportID}`, {[newAction.reportActionID]: newAction});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, {
+                    lastMessageText: `message ${tick}`,
+                    lastMessageHtml: `<comment>message ${tick}</comment>`,
+                    lastVisibleActionCreated: stamp,
+                    lastReadTime: stamp,
+                    lastActorAccountID: TEST_USER_ACCOUNT_ID,
+                });
+                await waitForBatchedUpdates();
+            });
+        }
+    };
+
     await waitForBatchedUpdates();
     await measureRenders(<ReportActionsListWrapper />, {scenario});
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

- Depends on #93573: this guard only delivers real value once that PR is merged.
- Added a perf guard for the stable `ReportActionItem` tree: sends 10 messages and measures how expensive the re-renders are (catches the all-rows-rerender regression — ~+48% when the [optimization](https://github.com/Expensify/App/pull/93421) is reverted).
- Made it more production-faithful: actions live in Onyx and the wrapper reads them via a `useOnyx` selector (`getSortedReportActionsForDisplay`, like `usePaginatedReportActions`); "send" is an `Onyx.merge` into `REPORT_ACTIONS` + `REPORT`, like `addActions`; rows get real personal details so they render at production weight.
- Note: the plain-render test's commit count rose from 3 → 7 because actions now arrive asynchronously via `useOnyx` (empty → data)


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ 
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
