### PR TITLE
Argent pr qa poc

### DIFF
--- a/.claude/skills/argent-find-testable-prs/SKILL.md
+++ b/.claude/skills/argent-find-testable-prs/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: argent-find-testable-prs
+description: Scans open Expensify App PRs and filters to the mobile-native ones (the platforms the argent-qa-pr skill can actually drive), outputting a candidate shortlist with raw signals. It does NOT rate difficulty — the agent judges difficulty + setup/feasibility per candidate by reading the full PR. Use when asked "what PRs can I test/QA", "find PRs to test on mobile", "list QA candidates", or to pick the next PR for argent-qa-pr.
+allowed-tools: Bash, Read, Write, Edit
+---
+
+# argent-find-testable-prs
+
+The **scout** for the `[[argent-qa-pr]]` skill. Its job is the cheap, high-volume part: scan
+open `Expensify/App` PRs and **filter to the ones `argent-qa-pr` can actually run** (mobile-native),
+so you don't read 100 issue bodies by hand. It does **not** rate difficulty or decide testability —
+**that judgment is yours** (the agent's), made per candidate from the full PR context. Scout filters;
+you judge.
+
+## When to use / not use
+- **Use** to get the mobile-native candidate shortlist, then judge + pick the next one for `argent-qa-pr`.
+- **Not** for actually testing a PR (that's `argent-qa-pr`), and not for web-only work.
+
+## How to run
+
+```bash
+node .claude/skills/argent-find-testable-prs/helpers/scan-prs.mjs --limit 100 --json ai-qa-poc/triage-scan.json
+```
+Requires the `gh` CLI authenticated. Prints a markdown table of candidates (factual columns +
+raw signals), then a collapsed skipped section, and writes JSON. Rows are **identified by PR number**
+— the scout does **no** ranking or numbering (that's yours, after judging). One issue fetch per PR,
+so a large `--limit` takes a little while — start at `--limit 80–120`.
+
+**What the scout does (mechanical only — no judgment):**
+1. Skip drafts, `[No QA]`, `[WIP]`/`[HOLD]`/revert.
+2. Resolve the **linked issue** and read its **`## Platforms`** checkboxes.
+3. Keep only PRs where **iOS App and/or Android App** is reproduced (mWeb is a browser → doesn't
+   count). Web/mWeb-only → `SKIPPED_WEB_ONLY`; no Platforms checklist → `SKIPPED_OTHER`; no linked
+   issue → `UNKNOWN`.
+4. Emit each candidate's **platforms**, **repro step count**, and **raw keyword signals** (e.g.
+   `accounting`, `offline`, `signup`, `rooms`). **Signals are factual hints to prioritize reading
+   order — NOT a difficulty/feasibility verdict** (they over/under-fire: e.g. a stray "onboarding").
+
+## Then YOU judge each candidate (the part that isn't a script)
+
+For each candidate worth considering, **pull the full context and judge it yourself** — this is
+where project knowledge beats keyword matching:
+
+```bash
+gh pr view <n> --repo Expensify/App --json title,body,headRefName
+gh issue view <issue> --repo Expensify/App --json body   # + follow the PROPOSAL link in the body
+gh pr diff <n> --repo Expensify/App                       # pin the exact element + any beta/layout gate
+```
+
+Then rate **how hard to TEST** (not how hard to fix) and **plan the setup**, using the same lens as
+`argent-qa-pr` Phase 1.5 (surmountable prep vs real blocker):
+
+| | What it usually means |
+| --- | --- |
+| 🟢 **Easy** | pure UI / visual / navigation; logged-out or few steps; no data/state setup |
+| 🟡 **Medium** | needs some state you can prepare — offline toggle, native share, a workspace/room/expense, a `+tag` fresh account, onboarding, a deep-link/gated entry |
+| 🔴 **Hard** | heavy but still doable setup — multi-account (copilot/delegate via `+tag`), roles/workflows |
+| **NOT_TESTABLE** | a **live external integration you can't stand up locally** — accounting (QBO/Xero/NetSuite/Sage/Certinia), bank/Plaid, card issuing, real payments — or a **backend-gated** beta |
+
+Reason about **surmountable vs blocker** (don't treat prep as a wall): a fresh account is a `+tag`
+alias, a missing workspace/room is created in-app, a UI-gating beta is an Onyx override, a hard-to-reach
+screen is a deep link, a web precondition (OldDot signup) is done in a browser. Only genuine external
+integrations are `NOT_TESTABLE`. Full recipes: `argent-qa-pr` → `references/methodology.md`.
+
+## Output & next step
+
+**Always present your judged candidates as a markdown table** (this is the required output format —
+not a prose list). Sort rows by your verdict (testable easiest-first → harder-but-doable →
+`NOT_TESTABLE` → already-done) and number them `1..N` in that order in a leading **`#`** column so the
+user can pick by `#`. The scout itself does no numbering; you add it here. Use exactly these columns:
+
+```
+| # | PR | Title | Platforms | Difficulty | Setup |
+| --- | --- | --- | --- | --- | --- |
+| 1 | #93425 | avatar discard-changes guard | iOS | 🟢 best pick | change own avatar → back; self-contained |
+| 2 | #93200 | scroll workspace list to top | Android | 🟡 clean | `+tag` fresh acct (no workspaces) + landscape |
+| … | … | … | … | … | … |
+| 7 | #93217 | Certinia export status | Android+iOS+web | ⛔ NOT_TESTABLE | needs Certinia connection |
+```
+
+- `#` = your rank (user picks by it); **PR number** stays as the stable id (`argent-qa-pr` takes it).
+- Under the table, **recommend the top picks** — favor single-platform, self-contained, read-only
+  flows (least flaky), and call out which need prep vs which are blocked.
+- Optionally fold the rows + your verdicts into **`ai-qa-poc/triage-log.md`** so reasons persist.
+- To test a chosen PR: run **`argent-qa-pr <PR-number>`**.
+
+## References
+- Pairs with **`[[argent-qa-pr]]`** — same mobile-only scope, same surmountable-vs-blocker lens, same
+  `ai-qa-poc/` outputs. Scout filters; `argent-qa-pr` (and your judgment) does the rest.
+- Helper: `helpers/scan-prs.mjs` (zero extra deps — only needs `gh` + Node).

--- a/.claude/skills/argent-find-testable-prs/helpers/scan-prs.mjs
+++ b/.claude/skills/argent-find-testable-prs/helpers/scan-prs.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * scan-prs.mjs — scan open Expensify/App PRs, keep the mobile-native ones, and rate how
+ * hard each would be to QA with the `argent-qa-pr` skill (🟢 Easy / 🟡 Medium / 🔴 Hard).
+ *
+ *   node scan-prs.mjs [--limit 80] [--json <path>]
+ *
+ * Prints a markdown table (candidates easy→hard, then a collapsed skipped section).
+ * Requires the `gh` CLI to be authenticated. One issue fetch per PR, so it's a bit slow.
+ *
+ * The rating is a heuristic first pass from the linked issue's reproduced platforms +
+ * keyword flags + step count. It is meant to be sanity-checked by a human/agent, not
+ * trusted blindly — see SKILL.md.
+ */
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+
+const arg = (n, d) => {
+    const i = process.argv.indexOf(`--${n}`);
+    return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : d;
+};
+const LIMIT = parseInt(arg('limit', '80'), 10);
+const JSON_OUT = arg('json', '');
+const REPO = 'Expensify/App';
+const gh = (c) => {
+    try {
+        return execSync(c, {maxBuffer: 1e8, stdio: ['ignore', 'pipe', 'ignore']}).toString();
+    } catch (e) {
+        return e.stdout ? e.stdout.toString() : '';
+    }
+};
+const sec = (b, s, e) => {
+    const i = b.search(new RegExp(s, 'i'));
+    if (i < 0) return '';
+    const x = b.slice(i + s.length);
+    const j = e ? x.search(new RegExp(e, 'i')) : -1;
+    return (j < 0 ? x : x.slice(0, j)).trim();
+};
+
+console.error(`Scanning up to ${LIMIT} open PRs in ${REPO}...`);
+const prs = JSON.parse(gh(`gh pr list --repo ${REPO} --state open --limit ${LIMIT} --json number,title,body,isDraft`) || '[]');
+const rows = [];
+const counts = {webOnly: 0, other: 0, noIssue: 0, drafts: 0};
+
+for (const p of prs) {
+    if (p.isDraft) {
+        counts.drafts++;
+        continue;
+    }
+    if (/\[no ?qa\]/i.test(p.title)) {
+        counts.other++;
+        continue;
+    }
+    if (/\[(wip|hold)\]|\b(revert|do not merge|dnm)\b/i.test(p.title)) {
+        rows.push({pr: p.number, issue: '', title: p.title, plat: '', diff: '—', status: 'SKIPPED_OTHER', note: 'WIP / hold / revert'});
+        counts.other++;
+        continue;
+    }
+    const m = (p.body || '').match(/issues\/(\d+)/);
+    if (!m) {
+        counts.noIssue++;
+        rows.push({pr: p.number, issue: '', title: p.title, plat: '?', diff: '?', status: 'UNKNOWN', note: 'no linked issue — triage by hand'});
+        continue;
+    }
+    const issue = m[1];
+    const ij = JSON.parse(gh(`gh issue view ${issue} --repo ${REPO} --json body`) || '{}');
+    const b = ij.body || '';
+    const checked = b
+        .split('\n')
+        .filter((l) => /\[x\]/i.test(l) && /(Android|iOS|mWeb|MacOS|Windows)/i.test(l))
+        .map((l) => l.replace(/^\s*-?\s*\[x\]\s*/i, '').trim());
+    const native = checked.filter((c) => /^(Android: App|iOS: App)/i.test(c)).map((c) => c.split(':')[0].trim());
+    const hasWeb = checked.some((c) => /Windows|MacOS|mWeb/i.test(c));
+    if (native.length === 0) {
+        if (hasWeb) {
+            counts.webOnly++;
+            rows.push({pr: p.number, issue, title: p.title, plat: 'web/mWeb', diff: '—', status: 'SKIPPED_WEB_ONLY', note: 'only web/mWeb reproduced'});
+        } else {
+            counts.other++;
+            rows.push({pr: p.number, issue, title: p.title, plat: '—', diff: '—', status: 'SKIPPED_OTHER', note: 'no Platforms checklist (refactor/chore/tracking?) — triage by hand'});
+        }
+        continue;
+    }
+    const action = sec(b, '## Action Performed:?', '## Expected');
+    const steps = action.split('\n').filter((l) => /^\s*\d+\./.test(l)).length;
+    const lo = b.toLowerCase();
+    // Raw keyword SIGNALS — factual hints only (NOT a verdict). They help the agent decide which
+    // candidates to deep-dive first. The scout does NOT rate difficulty or setup: the agent judges
+    // that per candidate by reading the full PR + linked issue/PROPOSAL + `gh pr diff` (see SKILL.md).
+    const sig = [];
+    if (/qbo|quickbooks|xero|netsuite|sage|intacct|certinia|accounting/.test(lo)) sig.push('accounting');
+    if (/plaid|bank account|company card|expensify card|reimburs/.test(lo)) sig.push('bank/card');
+    if (/copilot|delegate/.test(lo)) sig.push('copilot/delegate');
+    if (/invite member|approver|workflow|submit workspace|\badmin\b/.test(lo)) sig.push('ws/roles');
+    if (/offline|airplane/.test(lo)) sig.push('offline');
+    if (/4 finger|four finger|test tool|biometric/.test(lo)) sig.push('test-tool');
+    if (/share (a )?(photo|image)|share sheet|native share/.test(lo)) sig.push('native-share');
+    if (/deep ?link|\/r\//.test(lo)) sig.push('deeplink');
+    if (/sign ?up|new gmail|new account/.test(lo)) sig.push('signup');
+    if (/onboarding|employee step/.test(lo)) sig.push('onboarding');
+    if (/\brooms?\b/.test(lo)) sig.push('rooms');
+    if (/(log|sign) ?out|logged ?out|anonymous|anon user/.test(lo)) sig.push('logged-out');
+
+    rows.push({pr: p.number, issue, title: p.title, plat: native.join('+') + (hasWeb ? '+web' : ''), status: 'CANDIDATE', signals: [...new Set(sig)].join(', '), steps});
+}
+
+const cands = rows.filter((r) => r.status === 'CANDIDATE');
+const skipped = rows.filter((r) => r.status !== 'CANDIDATE');
+const esc = (s) => (s || '').replace(/\|/g, '\\|').slice(0, 70);
+// No row numbering here — PRs are identified by PR number. The agent re-ranks/numbers after judging.
+const line = (r) => `| [#${r.pr}](https://github.com/Expensify/App/pull/${r.pr}) | ${r.issue || '—'} | ${esc(r.title)} | ${r.plat || ''} | ${r.status} | ${esc(r.note)} |`;
+// Candidate line: FACTUAL columns only (platforms, step count, raw signals) — no verdict.
+const cline = (r) => `| [#${r.pr}](https://github.com/Expensify/App/pull/${r.pr}) | ${r.issue || '—'} | ${esc(r.title)} | ${r.plat || ''} | ${r.steps || '?'} | ${esc(r.signals) || '—'} |`;
+
+let out = `## Mobile-native QA candidates (${cands.length}) — agent judges each\n\n`;
+out += "_The scout only filters to **mobile-native** PRs. **Difficulty + setup/feasibility is the agent's call**:\n";
+out += 'for each candidate, read the full PR body + linked issue/PROPOSAL + `gh pr diff <n>`, then rate it and\n';
+out += 'plan the setup (see `argent-qa-pr` SKILL.md → Phase 1.5). "Signals" below are raw keyword hits to help\n';
+out += 'prioritize which to open first — they are NOT a verdict._\n\n';
+out += '| PR | Issue | Title | Platforms | Steps | Signals (raw hints) |\n|---|---|---|---|---|---|\n';
+out += cands.map((r) => cline(r)).join('\n') + '\n\n';
+out += `<details><summary>Skipped / web-only / other (${skipped.length})</summary>\n\n`;
+out += '| PR | Issue | Title | Platforms | Status | Note |\n|---|---|---|---|---|---|\n';
+out += skipped.map((r) => line(r)).join('\n') + '\n</details>\n';
+console.log(out);
+console.error(`\nScanned ${prs.length} PRs → ${cands.length} candidates, ${counts.webOnly} web-only, ${counts.other} chore/WIP/NoQA, ${counts.noIssue} no-issue, ${counts.drafts} drafts.`);
+if (JSON_OUT) {
+    fs.writeFileSync(JSON_OUT, JSON.stringify({generatedAt: new Date().toISOString(), candidates: cands, skipped}, null, 2));
+    console.error('Wrote ' + JSON_OUT);
+}

--- a/.claude/skills/argent-qa-pr/.gitignore
+++ b/.claude/skills/argent-qa-pr/.gitignore
@@ -1,0 +1,11 @@
+# Never commit real secrets. Each user fills in their own gitignored .env
+# (from .env.example). These patterns are a safety net.
+.env
+.env.*
+# ...but DO commit the template:
+!.env.example
+*.secret
+**/credentials*
+
+# Helper deps (installed locally, not committed)
+node_modules/

--- a/.claude/skills/argent-qa-pr/SKILL.md
+++ b/.claude/skills/argent-qa-pr/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: argent-qa-pr
+description: Tests an Expensify App PR on mobile by reproducing the bug on `main` and verifying the fix on the PR branch, then posts a before/after report (screenshots AND a before/after GIF+MP4 per branch embedded, PASS/FAIL verdict) as a comment on the PR. Recording a video on each branch is a standard deliverable, not optional. Mobile-native (iOS/Android simulators via Argent) only — skips web/mWeb-only PRs. Use when asked to "test PR #X", "verify PR #X works on mobile", "QA PR #X", or given a PR URL to validate.
+allowed-tools: Bash, Read, Write, Edit, Agent
+---
+
+# argent-qa-pr
+
+Verify whether an Expensify `App` PR **actually fixes its bug**, on real mobile
+devices, by running the issue's repro on **`main` (bug) vs the PR branch (fix)** and
+**posting a documented before/after report — screenshots embedded, explicit verdict — as a
+comment on the PR**.
+
+This skill **composes** the existing **Argent** device tooling rather than reinventing it:
+- the **Argent MCP** tools + skills (`argent-test-ui-flow`, `argent-device-interact`) drive
+  the simulator/emulator;
+- `argent-screenshot-diff` compares before/after;
+- this skill adds the layer they don't: **context gathering, mobile-only triage,
+  branch-to-branch before/after orchestration, and the PASS/FAIL verdict.**
+
+> **Core principle:** a PR's `### Tests` section is **not enough**. A test is only
+> meaningful if it runs the *actual scenario* the PR fixes, on the *platform the issue
+> reproduces on*, against the *exact element*, and compares **`main` vs the PR branch**.
+> A look-alike flow on the wrong platform is a confident but worthless "pass".
+
+The full reasoning, the hard-won environment gotchas, and the report format live in
+**[`references/methodology.md`](references/methodology.md)** — read it before a run.
+
+## When to use / not use
+
+- **Use** when given a PR number/URL to test or verify on mobile.
+- **Not** for: web-only behavior (no native automation here — `SKIPPED_WEB_ONLY`),
+  pure unit/type checks, or `[No QA]` PRs.
+
+## Inputs
+
+| Input | Form | Required |
+| --- | --- | --- |
+| PR | number or URL, e.g. `<number>` / `https://github.com/Expensify/App/pull/<number>` | Yes |
+| Platforms override | `ios`, `android`, or both | No (default: derived from the issue) |
+| Test account / workspace | the agreed disposable test account | assumed |
+
+## Step 0 — Preflight: get the test bed ready (run FIRST, before triage)
+
+Front-load the slow/blocking setup — **app installed, running, and logged in** on each
+in-scope simulator — so the actual test run is never interrupted by a build or the
+one-time login. Set up **one device at a time** (log into iOS, then Android); both can stay
+**booted** — the constraint during testing is one *app* live on Metro, not co-resident
+devices (see "Multi-platform & host limits"). **Login persists across reboots**, so each
+device only needs logging in once.
+
+For each target platform (default **both iOS + Android**; or just the in-scope one):
+
+1. **Metro running?** `lsof -iTCP:8081 -sTCP:LISTEN -n -P` — else start it:
+   `NODE_OPTIONS="--max-old-space-size=8192" npm run start &` (12288 only if you must
+   drive both at once — usually don't).
+2. **Boot the device** (skip if already booted):
+   - iOS: pick an iPhone from `xcrun simctl list devices available`; `xcrun simctl boot <udid>`.
+   - Android: `~/Library/Android/sdk/emulator/emulator -avd <name> &`; `adb wait-for-device`;
+     wait for `getprop sys.boot_completed = 1`; `adb reverse tcp:8081 tcp:8081`.
+3. **App installed?** else install (first time is a slow Rock build):
+   - check: `xcrun simctl listapps <udid> | grep com.expensify.chat.dev` /
+     `adb shell pm list packages | grep expensify`
+   - install: `npm run ios-standalone` / `npm run android-standalone`.
+4. **Launch + verify state:** open the app, screenshot, and determine whether it's on
+   **Home (logged in)** or the **login screen**.
+5. **If logged out → log in (autonomous via the email helper):**
+   - Enter the test account email → Continue (via Argent).
+   - **Fetch the magic code automatically** instead of asking a human — run the vendored
+     reader, which reads it from the test Gmail inbox over IMAP and prints just the code:
+     ```bash
+     # first run only: (cd .claude/skills/argent-qa-pr/helpers && npm install)
+     node .claude/skills/argent-qa-pr/helpers/fetch-magic-code.mjs --timeout 90
+     ```
+     (Credentials come from `helpers/.env` — gitignored — so no Keychain prompt; see
+     `helpers/README.md`.) Type the printed 6-digit code into the sim's code field → logged
+     in, **no human**. The **session then persists** across runs.
+   - **Fallback:** if the helper isn't set up (no App Password yet) or errors, ask the
+     human for the emailed code once.
+   - `000000` does **not** work here — that's dev-VM-only; production and staging both use
+     real emailed codes (which is exactly what the helper reads).
+   - If Continue **hangs** (rare — only seen under heavy automated traffic, likely
+     transient rate-limiting), **wait and retry**. It is **not** a hard wall, so don't
+     pivot away on the first spin. (A bare host-side `curl`/`node` probe of
+     `BeginSignIn` returns a Cloudflare `403 cf-mitigated: challenge`, but that challenges
+     a *non-browser* client and is **not representative of the app** — ignore it.)
+   - Either backend is fine: **production or staging** (staging shares the prod DB — same
+     data — so it's effectively equivalent; we keep the sim on staging via the "Use
+     Staging Server" Test Preferences toggle).
+   - Do **not** proceed until the app is at **Home, logged in**.
+   - ⚠️ For resets prefer **"Clear cache and restart"** (keeps the login). A full
+     **reinstall wipes the login** (and the staging toggle) → you'd have to log in again.
+6. **Preflight gate:** Metro up **and** each in-scope device has the app installed and is
+   logged in. Only then continue to Phase 0. (If a device can't be made ready — build
+   fails, login blocked with no human/staging available — report that and stop; don't
+   half-run.)
+
+## Process (summary — full detail in `references/methodology.md`)
+
+**Phase 0 — Triage & scope.** Skip `[No QA]`. Resolve the **linked issue** and read its
+**`## Platforms:` checkboxes**. Decide status and record a row in `ai-qa-poc/triage-log.md`
+with a 🟢/🟡/🔴 difficulty-to-test rating:
+- mobile-native reproduced → `CANDIDATE` → test it;
+- **web/mWeb only → `SKIPPED_WEB_ONLY`** (Argent can't drive browsers; mWeb is a browser);
+- needs a **live external integration you can't stand up locally** (accounting QBO/Xero/NetSuite/
+  Sage/Certinia, bank/Plaid, card issuing, real payments) → `NOT_TESTABLE`. (Note: a *fresh account*,
+  *onboarding state*, *OldDot web signup*, *missing data/room/workspace*, or a *UI-gating beta* are
+  **not** blockers — they're surmountable setup; see **Phase 1.5**.)
+- WIP/revert/chore → `SKIPPED_OTHER`.
+- **If both iOS App and Android App are checked → test BOTH.**
+
+**Phase 1 — Gather full context.** PR body (`### Tests`/`### Offline tests`/`### QA`) **plus**
+the linked issue (exact repro, **Expected vs Actual**, platforms) **plus** the **code diff**
+(`gh pr diff <n>`) to pin the **exact element** and any layout/platform condition. **Also read the
+issue's `Precondition`/`Prerequisite` lines** — they reveal setup walls the Platforms checkboxes
+hide (e.g. "Sign up via staging.expensify.com" = OldDot signup + fresh account; "Account has at
+least one workspace / be an admin / has a room" = data/role setup).
+
+**Phase 1.5 — Feasibility pre-check (identify setup EARLY, then prepare it — don't just bail).**
+The point isn't to list blockers; it's to surface what the repro needs *before* a long run and
+**prepare the surmountable stuff**. Two prior "easy" PRs each burned a run hitting setup we could
+have prepped up front. Cheap checks first:
+- read the issue `Precondition`/`Prerequisite`;
+- **`grep -rn "isBetaEnabled" src/pages/<feature>`** to find the entry screen's beta gate (e.g. the
+  "Go to room" list was gated by `CONST.BETAS.WORKSPACE_ROOMS_PAGE`);
+- once the app is up, **probe the account**: `globalThis.Onyx.get('betas')` + the workspace list via
+  `debugger-evaluate`, and compare against what the repro needs.
+
+(These are deterministic. *Don't* rely on a deep-link 404 as a "is it gated?" test — a failed deep
+link is ambiguous: it can also be navigation-not-ready-on-cold-boot, or a wrong route/scheme/domain.
+Deep links are an **unblocker** to *reach* a screen, not a feasibility diagnostic.) Then classify:
+
+- **Surmountable → prepare it, then test (NOT a blocker):**
+  - *Fresh account / onboarding state* → use a **`+tag` alias** of the test inbox
+    (`…+pr<n>@gmail.com`); the magic-code helper reads its code from the base inbox.
+  - *Account/data state* (a workspace, a room, an expense, a report) → **create it** in-app first.
+  - *UI/navigation behind a beta the account lacks* → **client-side Onyx beta override** (apply to
+    both branches, note the deviation).
+  - *Hard-to-navigate / gated entry screen* → **deep link** to its route.
+  - *Web precondition* (e.g. OldDot signup) → do it in a **browser**; only the *verification* must
+    be on mobile.
+- **Genuinely `NOT_TESTABLE` locally (real blockers):** live external integrations you can't stand
+  up — accounting (QBO/Xero/NetSuite/Sage/Certinia), bank/Plaid, card issuing, real payments — or a
+  beta that gates **backend** behavior (a client override won't change server responses). Say so and
+  stop; don't half-run.
+
+Recipes for every "prepare it" item (with exact commands) are in `references/methodology.md` →
+"Recipes / unblockers".
+
+**Phase 2 — Environment.** Start Metro; bring up the target simulator(s) via Argent; ensure
+the right account/data state (create disposable test data if the flow needs it). If the app
+misbehaves, **"Clear cache and restart" first** (it keeps the login + staging toggle);
+**reinstall only if that fails** — a reinstall wipes the login. If connectivity/auth still
+fails after that, **pause & probe**, don't thrash.
+
+**Phase 3 — Before/after (mandatory).** Reproduce on **`main`** (capture the bug) → `gh pr
+checkout <n>` → reload (JS-only) or rebuild (native) → re-run the identical steps on the **PR
+branch** (capture the fixed behavior). The branch switch is a **barrier**: git + Metro are
+shared, so never have one device on `main` while another is on the PR branch.
+
+**Phase 4 — Execute robustly.** Drive the **exact element**; loop interact→screenshot→verify;
+**recognize and report blocker states** (offline, error boundary, stuck skeletons, wrong
+layout) instead of faking a pass.
+
+**Phase 5 — Report → post as a PR comment.** Build the before/after report and **post it as
+a comment on the PR**, with screenshots **and a before/after GIF per branch** embedded inline
+(record a video on each branch — see step 3, it's a standard deliverable). Because GitHub renders comment images
+only from public URLs (local paths and base64 don't render, and the native drag-drop upload is
+browser-cookie-only — not automatable), screenshots are first pushed to an **evidence repo** and
+embedded via its `raw.githubusercontent.com` URLs. Steps:
+
+1. **Save screenshots locally** under `ai-qa-poc/PR-<n>/screens/` (named `ios-main-*`,
+   `ios-pr-*`, `android-main-*`, `android-pr-*` — the upload source).
+2. **Publish them** and get the base raw URL:
+   ```bash
+   BASE=$(bash .claude/skills/argent-qa-pr/helpers/publish-evidence.sh <n> ai-qa-poc/PR-<n>/screens)
+   # BASE e.g. https://raw.githubusercontent.com/<your-evidence-repo>/main/PR-<n>
+   ```
+   (Target repo/branch come from `EVIDENCE_REPO`/`EVIDENCE_BRANCH` — process env, else
+   `helpers/.env` — each user sets their **own** evidence repo there; it's never hardcoded.
+   The auth identity needs `contents:write` on that repo.)
+3. **Record a video of the full flow on EACH branch — this is a standard deliverable, not optional.**
+   Capture **one recording per `main`/PR × platform** (so a 1-platform PR yields 2 videos: `*-main-*`
+   and `*-pr-*`; a both-platform PR yields 4), each showing the **whole repro flow** end-to-end
+   (navigate → act → result), started **after the app is at the ready state**. Every run ships the
+   **before/after stills AND the before/after GIFs+MP4s** — the stills pin the decisive end-state, the
+   GIFs make the cause→effect legible (you just did X and Y happened).
+   **RECORD LONG, CUT LATER — two artifacts per branch, different lengths:** keep the recording rolling
+   through the *whole* session (lead-in nav → repro → settle), don't start/stop around just the key tap.
+   Then the helper emits **two** things from that one raw: a **tight inline GIF** (just the repro action,
+   ~6–10s) and a **longer linked MP4** that keeps **~20s of context on each side of the repro**
+   (`repro ± CLIP_CONTEXT_SEC`, default 20s). The GIF is the inline preview (a 40s GIF is 5–10 MB and
+   won't load inline); the MP4 is *linked* and carries the context so a reviewer sees the repro in situ,
+   not an isolated 10s snippet. **If the relevant state is largely static** (nothing animates), don't film
+   a frozen screen — drive a short flow that *exercises* the behaviour so the take has real motion, and
+   repeat it if needed for natural length.
+   ```bash
+   # Android raw capture (screenrecord is slow to init — wait ~4s before the first action; --time-limit caps it):
+   adb shell screenrecord --bit-rate 8000000 --time-limit 60 /sdcard/c.mp4 &   # run the WHOLE flow …
+   adb shell pkill -INT screenrecord; adb pull /sdcard/c.mp4 ai-qa-poc/PR-<n>/videos/android-main-raw.mp4
+   # iOS: xcrun simctl io <udid> recordVideo --codec h264 <raw> &  … then  pkill -INT -f "simctl io.*recordVideo"
+   #
+   # 1) Pick the repro window on the NORMALIZED timeline (iOS recordVideo is VFR — see note below):
+   bash .claude/skills/argent-qa-pr/helpers/clip-to-evidence.sh --contact ai-qa-poc/PR-<n>/videos/android-main-raw.mp4
+   #    → Read /tmp/_clip_contact.png, find where the repro action happens (e.g. 13s..21s).
+   # 2) Emit GIF (tight action) + MP4 (auto-padded to ±20s of context) from that one raw:
+   bash .claude/skills/argent-qa-pr/helpers/clip-to-evidence.sh \
+     ai-qa-poc/PR-<n>/videos/android-main-raw.mp4 ai-qa-poc/PR-<n>/videos/android-main 13 8 320
+   ```
+   This writes `android-main.mp4` (~40s, repro + ~20s context each side) + `android-main.gif` (the tight
+   action loop); repeat for `android-pr-*` (and `ios-*` if in scope). **GIFs embed inline and auto-loop in
+   a comment; raw/blob MP4 URLs do NOT play inline** — so embed the GIF and *link* the MP4 with a caption
+   noting its length + that it's the repro with lead-in/aftermath context.
+   - ⚠️ **iOS `recordVideo` writes VARIABLE frame rate** — on a static screen it captures almost no frames,
+     so a naive GIF of a settled "after" state is a ~7-frame flicker and raw `-ss` seeks are off. The helper
+     **CFR-normalizes** the raw (30fps) before clipping, which fixes both — but it means you must read the
+     window timestamps off the **normalized** clip (`--contact` / `/tmp/_clip_norm.mp4`), not the raw.
+   - The only case to skip a branch's video is a genuine impossibility (e.g. the flow can't be driven on
+     that platform) — say so in the report; "the bug is static, stills are enough" is **not** a reason to
+     skip. When the bug *is* motion/flicker, the GIF is the primary evidence, not a supplement.
+   - **The clip MUST show the whole repro THROUGH the final confirmation** (the settled result that
+     proves it works / doesn't work) — not just up to the last tap. **Verify the last frame** before
+     publishing: `ffmpeg -sseof -0.1 -i <gif> -frames:v 1 /tmp/last.png` and look at it. A mid-animation
+     end frame = re-do. Don't claim "full quality" for the MP4 — `clip-to-evidence.sh` compresses it
+     (≈540px, crf 28); caption it like "▶️ Full video — ~40s, repro with lead-in & aftermath (compressed)".
+   - **`adb screenrecord` can DIE at a navigation surface-change** (e.g. backing out of a full-screen
+     RHP/detail to a list) — it stops ~1s into the transition, so the settled result never lands in the
+     file (don't rely on `--time-limit` or a post-tap hold). It's flaky (sometimes survives). If a clip
+     cuts at the nav: record/screenshot the **settled result separately** and concatenate — e.g. grab a
+     full-res still of the result (`adb exec-out screencap`), make a 3.5s clip from it
+     (`ffmpeg -loop 1 -t 3.5 -i result.png -vf scale=W:H,fps=24 -pix_fmt yuv420p B.mp4`), then
+     `ffmpeg -i flow.mp4 -i B.mp4 -filter_complex "[0:v]scale=W:H,fps=24,setsar=1[a];[1:v]scale=W:H,fps=24,setsar=1[b];[a][b]concat=n=2:v=1[o]" -map "[o]" full.mp4`,
+     and clip `full.mp4`. Use a **versioned filename** (`android-pr-v2.gif`) when replacing an already-posted
+     asset — GitHub caches comment images by URL, so overwriting the same name shows the stale one.
+4. **Write the report** to `ai-qa-poc/PR-<n>/report.md` (kept as the local source-of-truth and
+   backup) with context, environment, a per-platform **Before/After** section, and a **PASS/FAIL
+   verdict** + caveats. Embed each screenshot/GIF with its **raw URL** — `![caption]($BASE/<file>.png|.gif)`
+   — *not* a relative path; link MP4s as `[MP4]($BASE/<file>.mp4)`. Lead the body with a marker
+   line `<!-- argent-qa-pr -->` and a footer noting it's an automated mobile QA run.
+   - Publish videos/gifs too: `publish-evidence.sh <n> ai-qa-poc/PR-<n>/screens ai-qa-poc/PR-<n>/videos`
+     (multi-dir; auto-skips `*-raw.*`). For inline video *players*, the only path is the human
+     drag-dropping the compressed MP4s into the comment (cookie-auth upload) — offer this.
+5. **Post the PR comment** from that file. To **update** instead of duplicate, PATCH the existing
+   comment: `gh api --method PATCH repos/Expensify/App/issues/comments/<id> -F body=@ai-qa-poc/PR-<n>/report.md`
+   (the `<id>` is the trailing number in the comment's `#issuecomment-<id>` URL). First post:
+   ```bash
+   gh pr comment <n> --repo Expensify/App --body-file ai-qa-poc/PR-<n>/report.md
+   ```
+6. **Update the triage-log** row to `TESTED` + result, linking the posted comment URL.
+
+## Multi-platform & host limits (read before a both-platform run)
+
+- **Keep both simulators booted; run the app on only ONE at a time.** Having an iOS sim
+  *and* an Android emulator **both booted** is fine and expected — do **not** shut one down
+  to bring up the other, and never skip the reported platform for "resource" reasons. The
+  rule is about the **app/Metro**, not the device: only the platform **currently under test**
+  should have the Expensify app running and connected to Metro.
+- **When you switch platforms, kill the app on the one you're leaving — but leave its
+  emulator running (idle, no app).** Terminate the app so Metro is only ever serving **one
+  bundle** at a time:
+  - iOS: `xcrun simctl terminate <udid> com.expensify.chat.dev` (the sim stays booted).
+  - Android: `adb -s <serial> shell am force-stop com.expensify.chat.dev` (the emulator stays running).
+- **Why:** the real failure mode isn't two booted devices — it's **two live app bundles on
+  one Metro** (especially two concurrent full bundle builds after a branch switch, which can
+  OOM-crash Metro). One app resident at a time keeps Metro to a single bundle and avoids it.
+- Give Metro adequate heap: `NODE_OPTIONS="--max-old-space-size=12288"`. Quick health gate
+  before a heavy run: `memory_pressure` (free %) and `sysctl -n vm.loadavg` — but a healthy
+  reading with both sims booted is the norm, not a reason to drop a platform.
+- True parallel (a subagent per device, both apps live) is only for **light read-only
+  flows**; for heavier or data-mutating flows drive **sequentially**, one app live at a time.
+- **Shared-account hazard:** both devices share one test account — for data-mutating flows
+  give each device a **distinct value** and verify only its own delta (or use separate
+  accounts), else results confound.
+
+## Hard rules (the expensive lessons — never skip)
+
+1. **Mobile-native only.** Web/mWeb → `SKIPPED_WEB_ONLY`. Don't mis-test a wide-screen
+   (desktop/RHP) bug on a phone.
+2. **Always test on the platform(s) the issue actually reproduces on — no substitutions.**
+   Read the issue's `## Platforms` checkboxes and test **exactly those** native platforms:
+   Android-only → test **Android**; iOS-only → test **iOS**; both → test **both** (separate
+   Before/After + screenshots each). **Never swap in the other platform because it's already
+   booted or easier**, even when the fix is "shared JS" — boot the reported platform and run
+   it there. (Both sims can be resident at once, so there's no resource excuse to skip one —
+   see "Multi-platform & host limits".) If the reported platform genuinely cannot be run
+   (build fails, integration unavailable), say so and mark it `NOT_TESTABLE` — do not pass it
+   off on a different platform and call it tested.
+3. **Always before/after** (`main` vs PR) — a single branch validates nothing.
+4. **Drive the exact element** from the issue + diff, not a look-alike.
+5. **Prefer what a real user would do; reach the scenario the way a user/tester would.**
+   Favor genuine interactions — tap, **long-press**, double-tap, swipe, scroll, type. You
+   *may* use tool-level helpers (`adb input`, and even `adb am start` / deep links / CDP)
+   when they unblock you, but treat them as a **fallback, not the default**: the closer the
+   repro is to the real user path, the stronger the evidence. A result that only works via a
+   shortcut a user couldn't perform is weak — note the deviation if you rely on one.
+6. **When one way to accomplish the goal fails, find another *way to accomplish the same
+   goal* — don't just retry micro-variations of the same gesture.** Reason about the user's
+   intent (e.g. "share an image into the app"), and if the obvious path is blocked,
+   enumerate **alternative routes to the same outcome**: a different gesture (e.g.
+   long-press instead of tap), a different entry point, a different app that reaches the same
+   screen, a different feature that lands in the same flow. **When you don't know what
+   options exist, search the web** for how a real user does *X* on that platform/app, then
+   try the options you find. Apply this generically to any blocked step — only report a
+   blocker once you've actually exhausted the alternative *ways*, not just nudged coordinates.
+7. **Never fake a pass.** Report blockers and how far you got; verify the app is actually
+   running the PR's JS before declaring a result.
+
+## Outputs
+
+**Primary output: a comment on the PR** — the before/after report with inline screenshots **and
+before/after GIFs** and the PASS/FAIL verdict. Local artifacts are the source/backup that produce it:
+
+```
+ai-qa-poc/
+  triage-log.md                 # one row per PR triaged (status + difficulty + comment link)
+  PR-<number>/
+    report.md                   # exact body posted to the PR (images = raw evidence-repo URLs)
+    screens/                    # upload source: ios-main-*, ios-pr-*, android-main-*, android-pr-*
+    videos/                     # standard: one recording per branch×platform — *-raw.mp4 (local),
+                                #   <name>.mp4 (compressed, linked), <name>.gif (inline). e.g.
+                                #   android-main.gif/.mp4 + android-pr.gif/.mp4
+
+evidence repo (per-user, set via EVIDENCE_REPO in helpers/.env):
+  PR-<number>/                  # screenshots + GIFs (inline) + compressed MP4s, over raw.githubusercontent.com
+```
+
+## References
+
+- **[`references/methodology.md`](references/methodology.md)** — full phased methodology,
+  anti-patterns, report format, Expensify environment gotchas, and **Recipes / unblockers**
+  (feasibility pre-check, `+tag` fresh accounts, Onyx beta override, deep-link entry, Metro OOM
+  recovery, Android magic-code/keyboard fixes, screen-recording → inline GIF).
+- **Helpers** (`helpers/`, see `helpers/README.md`): `fetch-magic-code.mjs` (autonomous login),
+  `publish-evidence.sh` (push screenshots/GIFs/MP4s → evidence repo, multi-dir),
+  `clip-to-evidence.sh` (raw recording → compressed MP4 + looping GIF).
+- Drives devices via the **Argent MCP** tooling (`argent-test-ui-flow`,
+  `argent-device-interact`, `argent-screenshot-diff`, `argent-create-flow`). Sibling skill
+  `agent-device-evidence` captures MP4/screenshot *evidence* of a flow (no branch
+  comparison) — use it when you only need artifacts, this skill when you need a **verdict**.
+
+## CI note
+
+Keep every run **autonomous and non-interactive** (no mid-run prompts) so the same logic
+ports to a headless GitHub Action later — the stated end goal if the POC proves out.

--- a/.claude/skills/argent-qa-pr/helpers/.env.example
+++ b/.claude/skills/argent-qa-pr/helpers/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to `.env` (same dir) and fill in YOUR throwaway test account.
+#   cp .env.example .env
+# `.env` is gitignored — your real creds never get committed.
+#
+# Requirements for the Gmail account:
+#   - 2-Step Verification ON, then create a 16-char App Password:
+#     https://myaccount.google.com/apppasswords
+#   - IMAP is always on in modern Gmail (no toggle).
+#
+# The helper resolves credentials in order: process env vars → this .env → macOS Keychain.
+
+GMAIL_USER=your-test-account@gmail.com
+GMAIL_APP_PASSWORD=your16charapppassword
+
+# --- Evidence repo (for publish-evidence.sh) ---
+# Public repo YOU can push to; hosts the QA screenshots that get embedded into the PR
+# comment via raw.githubusercontent.com URLs. `gh`/git must be authed with contents:write.
+# Process env vars override these (set them as CI secrets/vars to retarget without edits).
+EVIDENCE_REPO=your-username/qa-evidence
+EVIDENCE_BRANCH=main

--- a/.claude/skills/argent-qa-pr/helpers/README.md
+++ b/.claude/skills/argent-qa-pr/helpers/README.md
@@ -1,0 +1,112 @@
+# Helpers — autonomous mobile login & evidence publishing
+
+## `fetch-magic-code.mjs`
+Fetches the latest **Expensify login code** from a Gmail inbox over IMAP and prints
+**only** the 6-digit code to stdout. Used by the skill's Step-0 preflight so mobile login
+is autonomous (no human reads the email). Idea/credit: `adamgrzybowski/expensify-auto-login`
+(we reuse its Gmail-reading half; the device driving is ours, via Argent).
+
+Uses **`imap` + `mailparser`** — the code lives in a **quoted-printable HTML email body**
+that needs real MIME decoding (a raw zero-dep parse couldn't extract it reliably).
+
+> ⚠️ The current Expensify email is **subject "Your Expensify security code"** (sender
+> `concierge@expensify.com`) with the **code in the body** — *not* the old
+> `Expensify magic code: NNNNNN` subject. The helper searches broadly (unseen, from
+> *expensify*) and pulls the 6-digit code out of the decoded body, so it's robust to the
+> subject wording.
+
+### One-time setup
+1. **Install deps** (once):
+   ```bash
+   cd .claude/skills/argent-qa-pr/helpers && npm install
+   ```
+2. On the **test Gmail account**, enable **2-Step Verification**
+   (https://myaccount.google.com/security) — required for an App Password.
+3. Create a **16-char App Password**: https://myaccount.google.com/apppasswords
+   (IMAP is always on in modern Gmail — no toggle to flip.)
+4. Give the helper **your own** credentials (each user has their own test account). It
+   resolves them in order: **process env vars → `.env` → macOS Keychain**.
+   - **Local, no prompts (recommended):** copy the template and fill it in —
+     ```bash
+     cd .claude/skills/argent-qa-pr/helpers
+     cp .env.example .env      # then edit .env: GMAIL_USER + GMAIL_APP_PASSWORD
+     ```
+     `.env` is **gitignored** (your real creds never get committed); `.env.example` is the
+     committed template.
+   - **Headless / CI:** export `GMAIL_USER` + `GMAIL_APP_PASSWORD` from a CI secret.
+   - **Secure local (but prompts):** macOS Keychain —
+     `security add-generic-password -s "expensify-auto-login" -a "<gmail>" -w "<app-pw>"`.
+
+### Usage
+```bash
+node fetch-magic-code.mjs --timeout 90
+# Credentials resolved from env → .env → Keychain (above). Override with --user / --from / --timeout.
+# → prints the 6-digit code on stdout; exit 0 ok / 1 timeout / 2 bad config / 3 IMAP error.
+```
+
+Then type the printed code into the sim's code field (via Argent) → logged in.
+
+### Notes
+- **Each user supplies their own test account** in their gitignored `helpers/.env` — nothing
+  is shared or hardcoded. The `+tag` trick (`you+acct1@gmail.com`) lets one inbox back many
+  Expensify accounts; the helper strips the tag for the IMAP login.
+- Works for **production/staging** codes (real emailed codes). Not needed for the dev VM
+  (which uses `000000`, no email).
+- **Never commit** real creds or `node_modules/` (both gitignored); only `.env.example` is
+  committed.
+- Verified end-to-end on iOS: sim email → helper fetched the real code → typed it → Home.
+
+## `publish-evidence.sh`
+Pushes a PR's QA evidence (screenshots, GIFs, MP4s) to the **evidence repo** and prints the
+**base raw URL** the report comment embeds from (Phase 5). GitHub renders comment images/GIFs only
+from public URLs — local paths don't render, base64 is stripped, and the native drag-drop upload is
+browser-cookie-only (not automatable) — so evidence must live somewhere with a public URL.
+
+### Usage
+```bash
+BASE=$(bash publish-evidence.sh <pr-number> ai-qa-poc/PR-<n>/screens ai-qa-poc/PR-<n>/videos)
+# → https://raw.githubusercontent.com/<owner>/<repo>/main/PR-<n>
+# embed screenshots/GIFs inline: ![caption]($BASE/<file>.png)  /  ![caption]($BASE/<file>.gif)
+# link MP4s (NOT inline-playable in a comment): [MP4]($BASE/<file>.mp4)
+```
+Accepts **one or more dirs**. Clones the repo to `EVIDENCE_CACHE` (default `/tmp/qa-evidence`,
+reused), copies `*.png *.jpg *.gif *.mp4` from each (flattened into `PR-<n>/`, **skipping
+`*-raw.*`** so raw captures stay local), commits, pushes, and prints the URL.
+
+### Config (resolved: process env > `helpers/.env` > built-in default)
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `EVIDENCE_REPO` | _(none — required)_ | `owner/name` of YOUR public repo hosting screenshots |
+| `EVIDENCE_BRANCH` | `main` | branch the images live on |
+| `EVIDENCE_CACHE` | `/tmp/qa-evidence` | local working clone path |
+
+- Put non-secret overrides in `helpers/.env`; in **CI** set them as env vars / secrets instead
+  (process env always wins), so retargeting to e.g. an org repo needs no file edit.
+- **Auth:** the active `gh`/git identity needs **`contents:write`** on `EVIDENCE_REPO`. Locally
+  that's your `gh` login; in CI use a **fine-grained PAT** or a **GitHub App installation token**
+  scoped to just that repo (no broad `gist`/account scopes needed).
+- **One-time:** the repo must exist and be **public** (so `raw.githubusercontent.com` serves the
+  images) with at least one commit on `EVIDENCE_BRANCH`. Create with
+  `gh repo create <owner>/qa-evidence --public` and push a README.
+
+## `clip-to-evidence.sh`
+Turns a raw screen recording into a **looping GIF** (embeds inline + auto-plays in a comment) plus a
+**compressed MP4** (linked for full quality). GitHub does NOT inline-play a raw/blob MP4 URL in a
+comment — a GIF is the only automatable inline-motion format.
+
+### Usage
+```bash
+bash clip-to-evidence.sh <raw-video> <out-basename> [gif-start-sec] [gif-dur-sec] [gif-width]
+# e.g. clip-to-evidence.sh ai-qa-poc/PR-<n>/videos/android-main-raw.mp4 \
+#        ai-qa-poc/PR-<n>/videos/android-main 3.6 3.0 320
+# → writes android-main.mp4 (compressed) + android-main.gif (trimmed to the action window)
+```
+Trim the GIF to the moment that matters (start/dur) so it loops tightly. Needs `ffmpeg`.
+
+### Recording the raw video first (start AFTER the app is at the ready state)
+- **Android:** `adb shell screenrecord --bit-rate 8000000 /sdcard/c.mp4 &` → run the flow →
+  `adb shell pkill -INT screenrecord` → `adb pull /sdcard/c.mp4 <raw>`.
+  ⚠️ `screenrecord` is **slow to init on a loaded emulator — wait ~4s after starting it before the
+  first tap**, or the start gets clipped (re-take if so). 180s max per file.
+- **iOS:** `xcrun simctl io <udid> recordVideo --codec h264 <raw> &` → run the flow →
+  `kill -INT %1` (SIGINT finalizes the .mp4).

--- a/.claude/skills/argent-qa-pr/helpers/clip-to-evidence.sh
+++ b/.claude/skills/argent-qa-pr/helpers/clip-to-evidence.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Turn a raw screen recording into publishable QA evidence:
+#   - a LONG context MP4 (the repro PLUS lead-in & aftermath — repro ± ~20s — linked for full quality)
+#   - an optimized, looping GIF of the key action window (embedded INLINE in the comment)
+#
+# Why two artifacts:
+#   * GitHub renders GIFs inline from a raw URL and auto-loops them, but a 40s GIF is 5-10 MB and
+#     won't load inline — so the GIF stays SHORT (just the action), as the inline preview.
+#   * A raw/blob MP4 URL does NOT inline-play in a comment, so the MP4 is *linked* — and because it's
+#     only a click away it carries the LONGER context (the reviewer sees the repro in situ, not an
+#     isolated 10s snippet). Default MP4 window = [gif_start - CTX, gif_end + CTX], CTX=20s.
+#
+# Why CFR-normalize first (the hard-won lesson): iOS `xcrun simctl io recordVideo` writes a
+# VARIABLE frame rate — on a static screen it captures almost no frames, so a GIF of a settled
+# "after" state comes out as a 7-frame flicker, and -ss/-t seeks on the raw are unreliable. We first
+# transcode the raw to constant 30fps; then both clips seek accurately and static stretches still
+# have frames. (For a CFR Android `screenrecord` mp4 this is a cheap no-op re-encode.)
+#
+# Usage:
+#   # 1) Find your windows on the NORMALIZED clip (timestamps are accurate there):
+#   clip-to-evidence.sh --contact <raw-video>          # writes /tmp/_clip_contact.png (1fps, timestamped)
+#   # 2) Produce the evidence (gif window = the action; mp4 auto-pads to ±CTX unless you override):
+#   clip-to-evidence.sh <raw-video> <out-basename> [gif-start] [gif-dur] [gif-width] [mp4-start] [mp4-dur]
+#   # e.g. clip-to-evidence.sh ai-qa-poc/PR-93399/videos/ios-pr-raw.mov \
+#   #        ai-qa-poc/PR-93399/videos/ios-pr 13 7 360      # gif = 13..20s; mp4 = 0..40s (13-20 ±20, clamped)
+#
+# Produces <out-basename>.mp4 (long, ~repro±20s) and <out-basename>.gif (tight action window).
+# Override the context with CLIP_CONTEXT_SEC=NN, or pin the mp4 window with the 6th/7th args.
+#
+# RECORD LONG, CUT LATER: start the recording BEFORE the lead-in and stop it AFTER the aftermath, so
+# there is genuinely ~20s of context on each side of the repro to cut to. Record the WHOLE flow
+# continuously (navigate in → repro → settle), don't start/stop around just the key tap.
+#   Android: adb shell screenrecord --bit-rate 8000000 --time-limit 60 /sdcard/c.mp4 &   # then run the flow
+#            adb shell pkill -INT screenrecord ; adb pull /sdcard/c.mp4 <raw>
+#            ^ screenrecord is SLOW to init on a loaded emulator — wait ~4s after starting it before the
+#              first action. It can also DIE at a navigation surface-change; if so, re-record (or drive
+#              the flow so the repro repeats a few times mid-recording, so a clean cycle survives).
+#   iOS:     xcrun simctl io <udid> recordVideo --codec h264 <raw> &      # then run the flow
+#            pkill -INT -f "simctl io.*recordVideo"   (SIGINT finalizes the .mov)
+set -euo pipefail
+
+# --- contact-sheet mode: CFR-normalize + emit a timestamped 1fps grid for picking windows ---
+if [ "${1:-}" = "--contact" ]; then
+  RAW="${2:?usage: clip-to-evidence.sh --contact <raw-video>}"
+  command -v ffmpeg >/dev/null || { echo "clip-to-evidence: ffmpeg not found" >&2; exit 3; }
+  ffmpeg -y -i "$RAW" -vf "fps=30,scale=540:-2" -c:v libx264 -crf 23 -preset veryfast -an /tmp/_clip_norm.mp4 >/dev/null 2>&1
+  ffmpeg -y -i /tmp/_clip_norm.mp4 -vf "fps=1,scale=120:-1,drawtext=text='%{pts\:hms}':x=3:y=3:fontsize=13:fontcolor=red,tile=8x5" /tmp/_clip_contact.png >/dev/null 2>&1
+  echo "wrote /tmp/_clip_norm.mp4 ($(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 /tmp/_clip_norm.mp4)s) and /tmp/_clip_contact.png — Read the PNG, pick the gif window (the repro action) on THIS timeline."
+  exit 0
+fi
+
+RAW="${1:?usage: clip-to-evidence.sh <raw-video> <out-basename> [gif-start] [gif-dur] [gif-width] [mp4-start] [mp4-dur]}"
+OUT="${2:?usage: clip-to-evidence.sh <raw-video> <out-basename> [gif-start] [gif-dur] [gif-width] [mp4-start] [mp4-dur]}"
+GIF_START="${3:-0}"
+GIF_DUR="${4:-}"            # empty = whole clip
+GIF_W="${5:-320}"
+MP4_START_IN="${6:-}"      # empty = auto (gif_start - CTX)
+MP4_DUR_IN="${7:-}"       # empty = auto (gif_dur + 2*CTX)
+CTX="${CLIP_CONTEXT_SEC:-20}"   # seconds of context to keep each side of the repro in the MP4
+MP4_W=540
+
+command -v ffmpeg >/dev/null || { echo "clip-to-evidence: ffmpeg not found" >&2; exit 3; }
+[ -f "$RAW" ] || { echo "clip-to-evidence: raw video not found: $RAW" >&2; exit 1; }
+
+# 1) CFR-normalize the raw (fixes iOS VFR: static screens keep frames, seeks become accurate).
+NORM=/tmp/_clip_norm.mp4
+ffmpeg -y -i "$RAW" -vf "fps=30,scale=${MP4_W}:-2" -c:v libx264 -crf 23 -preset veryfast -an "$NORM" >/dev/null 2>&1
+DUR=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$NORM")
+
+# 2) MP4 = LONG context window around the repro (repro ± CTX), from the normalized clip.
+if [ -n "$MP4_START_IN" ]; then
+  MP4_START="$MP4_START_IN"; MP4_DUR="${MP4_DUR_IN:-$(awk "BEGIN{print $DUR-$MP4_START_IN}")}"
+elif [ -n "$GIF_DUR" ]; then
+  MP4_START=$(awk "BEGIN{s=$GIF_START-$CTX; if(s<0)s=0; print s}")
+  MP4_DUR=$(awk "BEGIN{d=$GIF_DUR+2*$CTX; m=$DUR-$MP4_START; if(d>m)d=m; print d}")
+else
+  MP4_START=0; MP4_DUR="$DUR"   # no gif window given → whole clip
+fi
+ffmpeg -y -ss "$MP4_START" -t "$MP4_DUR" -i "$NORM" -c:v libx264 -crf 28 -preset veryfast \
+  -movflags +faststart -an "${OUT}.mp4" >/dev/null 2>&1
+
+# 3) Optimized looping GIF of the TIGHT action window (palettegen/paletteuse for clean colors).
+DUR_ARGS=()
+[ -n "$GIF_DUR" ] && DUR_ARGS=(-t "$GIF_DUR")
+# Safe expansion of a possibly-empty array under `set -u` (macOS bash 3.2 errors on "${arr[@]}" when empty).
+ffmpeg -y -ss "$GIF_START" ${DUR_ARGS[@]+"${DUR_ARGS[@]}"} -i "$NORM" \
+  -vf "fps=15,scale=${GIF_W}:-1:flags=lanczos,palettegen=stats_mode=diff" "/tmp/_clip_pal.png" >/dev/null 2>&1
+ffmpeg -y -ss "$GIF_START" ${DUR_ARGS[@]+"${DUR_ARGS[@]}"} -i "$NORM" -i "/tmp/_clip_pal.png" \
+  -lavfi "fps=15,scale=${GIF_W}:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=3" \
+  "${OUT}.gif" >/dev/null 2>&1
+
+mp4sz=$(wc -c < "${OUT}.mp4"); gifsz=$(wc -c < "${OUT}.gif")
+mp4dur=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${OUT}.mp4")
+gifdur=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${OUT}.gif")
+echo "wrote ${OUT}.mp4 (${mp4dur}s, $((mp4sz/1024))KB — context window) and ${OUT}.gif (${gifdur}s, $((gifsz/1024))KB — tight action)"

--- a/.claude/skills/argent-qa-pr/helpers/fetch-magic-code.mjs
+++ b/.claude/skills/argent-qa-pr/helpers/fetch-magic-code.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * fetch-magic-code.mjs — fetch the latest Expensify login code from a Gmail inbox.
+ *
+ * Uses `imap` + `mailparser` (run `npm install` in this dir once) because the code lives
+ * in a quoted-printable HTML email body that needs real MIME decoding.
+ *   node fetch-magic-code.mjs [--from expensify] [--timeout 90]
+ *
+ * Prints ONLY the 6-digit code to stdout. Exit 0 ok / 1 timeout / 2 bad config / 3 IMAP.
+ *
+ * Credentials — a Gmail **App Password** (needs 2FA + IMAP). Resolved in order:
+ *   env GMAIL_USER + GMAIL_APP_PASSWORD  →  local .env (see .env.example)  →  macOS Keychain
+ *   (security add-generic-password -s "expensify-auto-login" -a "<gmail>" -w "<app-pw>")
+ *
+ * NOTE: Expensify's email subject is "Your Expensify security code" (sender
+ * concierge@expensify.com) and the 6-digit code is in the BODY — so we search broadly
+ * (unseen, from expensify) and extract the code from the decoded text/html.
+ * Idea/credit: adamgrzybowski/expensify-auto-login.
+ */
+import Imap from 'imap';
+import {simpleParser} from 'mailparser';
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const arg = (n, d) => {
+    const i = process.argv.indexOf(`--${n}`);
+    return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : d;
+};
+
+// Credentials precedence: process env → local .env (gitignored) → macOS Keychain.
+// The .env path means no Keychain access prompt for a throwaway test account.
+const fileEnv = {};
+try {
+    const envPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '.env');
+    for (const l of fs.readFileSync(envPath, 'utf8').split('\n')) {
+        const m = l.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*?)\s*$/);
+        if (m) fileEnv[m[1]] = m[2].replace(/^["']|["']$/g, '');
+    }
+} catch {
+    /* no .env file — fine */
+}
+
+const USER = process.env.GMAIL_USER || fileEnv.GMAIL_USER || arg('user', '');
+const FROM = arg('from', 'expensify');
+const TIMEOUT = parseInt(arg('timeout', '90'), 10) * 1000;
+const imapUser = USER.replace(/\+[^@]+@/, '@');
+let PASS = process.env.GMAIL_APP_PASSWORD || fileEnv.GMAIL_APP_PASSWORD || '';
+if (!PASS) {
+    try {
+        PASS = execSync(`security find-generic-password -s "expensify-auto-login" -a "${imapUser}" -w`, {stdio: ['ignore', 'pipe', 'ignore']})
+            .toString()
+            .trim();
+    } catch {
+        /* not in keychain */
+    }
+}
+if (!USER || !PASS) {
+    console.error('ERR(2): need GMAIL_USER + App Password (env GMAIL_APP_PASSWORD or Keychain service "expensify-auto-login").');
+    process.exit(2);
+}
+
+const imap = new Imap({user: imapUser, password: PASS, host: 'imap.gmail.com', port: 993, tls: true, tlsOptions: {servername: 'imap.gmail.com'}});
+const openInbox = () => new Promise((res, rej) => imap.openBox('INBOX', false, (e, b) => (e ? rej(e) : res(b))));
+const search = (crit) => new Promise((res, rej) => imap.search(crit, (e, r) => (e ? rej(e) : res(r || []))));
+
+function extractCodeFromMatches(uids) {
+    return new Promise((resolve, reject) => {
+        const f = imap.fetch(uids, {bodies: ''});
+        const found = [];
+        let pending = uids.length;
+        const done = () => {
+            if (pending > 0) return;
+            if (!found.length) return resolve(null);
+            found.sort((a, b) => b.date - a.date);
+            const best = found[0];
+            imap.addFlags(best.uid, '\\Seen', () => {});
+            resolve(best.code);
+        };
+        f.on('message', (msg) => {
+            let uid;
+            msg.once('attributes', (a) => (uid = a.uid));
+            msg.on('body', async (stream) => {
+                try {
+                    const p = await simpleParser(stream);
+                    const hay = `${p.subject || ''}\n${p.text || ''}\n${p.html || ''}`;
+                    const m = hay.match(/(?:code|magic)[^\d]{0,40}(\d{6})/i) || hay.match(/\b(\d{6})\b/);
+                    if (m) found.push({uid, code: m[1], date: p.date || new Date(0)});
+                } catch {
+                    /* skip unparseable */
+                }
+                pending--;
+                done();
+            });
+        });
+        f.once('error', reject);
+    });
+}
+
+(async () => {
+    const start = Date.now();
+    await new Promise((res, rej) => {
+        imap.once('ready', res);
+        imap.once('error', rej);
+        imap.connect();
+    }).catch((e) => {
+        console.error('ERR(3): IMAP login failed —', e.message, '(check App Password / IMAP enabled).');
+        process.exit(3);
+    });
+    await openInbox();
+    console.error(`⏳ waiting for Expensify code email from *${FROM}* (up to ${TIMEOUT / 1000}s)...`);
+    while (Date.now() - start < TIMEOUT) {
+        try {
+            const uids = await search(['UNSEEN', ['FROM', FROM]]);
+            if (uids.length) {
+                const code = await extractCodeFromMatches(uids);
+                if (code) {
+                    process.stdout.write(code + '\n');
+                    imap.end();
+                    process.exit(0);
+                }
+            }
+        } catch (e) {
+            console.error('(search retry:', e.message + ')');
+        }
+        await new Promise((r) => setTimeout(r, 3000));
+    }
+    console.error('ERR(1): timed out waiting for the code email.');
+    imap.end();
+    process.exit(1);
+})();

--- a/.claude/skills/argent-qa-pr/helpers/package-lock.json
+++ b/.claude/skills/argent-qa-pr/helpers/package-lock.json
@@ -1,0 +1,409 @@
+{
+  "name": "expensify-magic-code-helper",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "expensify-magic-code-helper",
+      "dependencies": {
+        "imap": "^0.8.19",
+        "mailparser": "^3.7.1"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.12.0.tgz",
+      "integrity": "sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "~2.3.0",
+        "domhandler": "~5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      },
+      "peerDependencies": {
+        "selderee": "~0.12.0"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.12.tgz",
+      "integrity": "sha512-w7Gy+NvjZ0MiXm8F6zfjImAqcTONKDImgWVBjDKQVFUXWuz3VFM5levNArkL2M877ajql5+bkS2pDV56injlmg==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.8",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
+      "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "~0.12.0",
+        "deepmerge-ts": "^7.1.5",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^10.1.0",
+        "selderee": "~0.12.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/imap": {
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/imap/-/imap-0.8.19.tgz",
+      "integrity": "sha512-z5DxEA1uRnZG73UcPA4ES5NSCGnPuuouUx43OPX7KZx1yzq3N8/vx2mtXEShT5inxB3pRgnfG1hijfu7XN2YMw==",
+      "dependencies": {
+        "readable-stream": "1.1.x",
+        "utf7": ">=1.0.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/leac": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.7.0.tgz",
+      "integrity": "sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
+      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/mailparser": {
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.9.tgz",
+      "integrity": "sha512-ulZi7h1eKm8WQmXibIgj8dmMQGDQCUS/g+XHkxxjcLDq4Dwn2ppo+0hz5Fi+ltvu4eN7mh3ykIp5RcpiWWav1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.12",
+        "encoding-japanese": "2.2.0",
+        "he": "1.2.0",
+        "html-to-text": "10.0.0",
+        "iconv-lite": "0.7.2",
+        "libmime": "5.3.8",
+        "linkify-it": "5.0.1",
+        "nodemailer": "8.0.10",
+        "punycode.js": "2.3.1",
+        "tlds": "1.261.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/parseley": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.13.1.tgz",
+      "integrity": "sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.7.0",
+        "peberminta": "^0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.10.0.tgz",
+      "integrity": "sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/selderee": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz",
+      "integrity": "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "~0.13.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/utf7": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utf7/-/utf7-1.0.2.tgz",
+      "integrity": "sha512-qQrPtYLLLl12NF4DrM9CvfkxkYI97xOb5dsnGZHE3teFr0tWiEZ9UdgMPczv24vl708cYMpe6mGXGHrotIp3Bw==",
+      "dependencies": {
+        "semver": "~5.3.0"
+      }
+    }
+  }
+}

--- a/.claude/skills/argent-qa-pr/helpers/package.json
+++ b/.claude/skills/argent-qa-pr/helpers/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "expensify-magic-code-helper",
+  "private": true,
+  "type": "module",
+  "description": "Fetches the Expensify login code from Gmail over IMAP (used by the argent-qa-pr skill preflight).",
+  "dependencies": {
+    "imap": "^0.8.19",
+    "mailparser": "^3.7.1"
+  }
+}

--- a/.claude/skills/argent-qa-pr/helpers/publish-evidence.sh
+++ b/.claude/skills/argent-qa-pr/helpers/publish-evidence.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Publish QA evidence (screenshots, GIFs, MP4s) to the evidence repo and print the
+# base raw URL the report comment embeds images from.
+#
+# Usage:
+#   publish-evidence.sh <pr-number> <dir> [<dir> ...]
+#   # e.g. publish-evidence.sh 93296 ai-qa-poc/PR-93296/screens ai-qa-poc/PR-93296/videos
+#
+# Copies *.png *.jpg *.gif *.mp4 from each given dir (flattened into PR-<n>/), EXCLUDING
+# any *-raw.* files (keep raw captures local; publish only the compressed/derived ones).
+#
+# Output (stdout, LAST line): the base raw URL, e.g.
+#   https://raw.githubusercontent.com/<owner>/<repo>/main/PR-93059
+# Embed in the report: screenshots/GIFs as ![](<base>/<file>.png|.gif) (render inline);
+# MP4s as a [link](<base>/<file>.mp4) — GitHub does NOT inline-play raw MP4s in comments,
+# so use a GIF for inline motion and link the MP4 for full quality (see methodology.md).
+#
+# Config — resolved as: process env > sibling .env > built-in default.
+#   EVIDENCE_REPO    owner/name of the evidence repo   (REQUIRED — set in helpers/.env)
+#   EVIDENCE_BRANCH  branch images live on             (default: main)
+#   EVIDENCE_CACHE   local working clone path          (default: /tmp/qa-evidence)
+# EVIDENCE_REPO is per-user (each user owns their own evidence repo) and lives in the
+# gitignored helpers/.env — never hardcoded here. In CI set it as an env var / secret
+# (process env always wins). Auth: the active `gh`/git identity needs `contents:write`
+# on EVIDENCE_REPO (a fine-grained PAT or a GitHub App installation token in CI).
+set -euo pipefail
+
+PR="${1:?usage: publish-evidence.sh <pr-number> <dir> [<dir> ...]}"
+shift
+SRCS=("$@")
+if [ "${#SRCS[@]}" -eq 0 ]; then
+  echo "publish-evidence: give at least one source dir" >&2; exit 2
+fi
+
+# Load config defaults from sibling .env WITHOUT clobbering anything already in the
+# environment (so CI-provided env vars take precedence over the committed/local .env).
+ENV_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.env"
+if [ -f "$ENV_FILE" ]; then
+  while IFS='=' read -r key val; do
+    case "$key" in ''|'#'*) continue ;; esac
+    key="$(printf '%s' "$key" | tr -d '[:space:]')"
+    [ -z "$key" ] && continue
+    if [ -z "${!key:-}" ]; then export "$key=$val"; fi
+  done < "$ENV_FILE"
+fi
+
+EVIDENCE_BRANCH="${EVIDENCE_BRANCH:-main}"
+EVIDENCE_CACHE="${EVIDENCE_CACHE:-/tmp/qa-evidence}"
+
+if [ -z "${EVIDENCE_REPO:-}" ]; then
+  echo "publish-evidence: EVIDENCE_REPO is not set. Set it (owner/name of YOUR public" >&2
+  echo "  evidence repo) in $ENV_FILE, or export it as an env var / CI secret." >&2
+  exit 2
+fi
+
+
+# Clone once; reuse and hard-reset to the remote on later runs.
+if [ -d "$EVIDENCE_CACHE/.git" ]; then
+  git -C "$EVIDENCE_CACHE" fetch -q origin "$EVIDENCE_BRANCH"
+  git -C "$EVIDENCE_CACHE" checkout -q "$EVIDENCE_BRANCH"
+  git -C "$EVIDENCE_CACHE" reset -q --hard "origin/$EVIDENCE_BRANCH"
+else
+  rm -rf "$EVIDENCE_CACHE"
+  gh repo clone "$EVIDENCE_REPO" "$EVIDENCE_CACHE" -- -q --branch "$EVIDENCE_BRANCH"
+fi
+
+DEST="$EVIDENCE_CACHE/PR-$PR"
+mkdir -p "$DEST"
+# Copy png/jpg/gif/mp4 from each source dir (flat), overwriting so re-runs refresh.
+# Skip *-raw.* (raw captures stay local; only publish compressed/derived files).
+copied=0
+for d in "${SRCS[@]}"; do
+  [ -d "$d" ] || continue
+  while IFS= read -r -d '' f; do
+    case "$f" in *-raw.*) continue ;; esac
+    cp -f "$f" "$DEST"/ && copied=$((copied+1))
+  done < <(find "$d" -maxdepth 1 -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.gif' -o -iname '*.mp4' \) -print0)
+done
+if [ "$copied" -eq 0 ]; then
+  echo "publish-evidence: no publishable files (png/jpg/gif/mp4) found in: ${SRCS[*]}" >&2
+  exit 1
+fi
+
+git -C "$EVIDENCE_CACHE" add "PR-$PR"
+if git -C "$EVIDENCE_CACHE" diff --cached --quiet; then
+  echo "publish-evidence: evidence already up to date, nothing to push" >&2
+else
+  git -C "$EVIDENCE_CACHE" \
+      -c user.name="argent-qa-pr" \
+      -c user.email="argent-qa-pr@users.noreply.github.com" \
+      commit -q -m "PR-$PR: QA evidence"
+  git -C "$EVIDENCE_CACHE" push -q origin "$EVIDENCE_BRANCH"
+fi
+
+echo "https://raw.githubusercontent.com/$EVIDENCE_REPO/$EVIDENCE_BRANCH/PR-$PR"

--- a/.claude/skills/argent-qa-pr/references/methodology.md
+++ b/.claude/skills/argent-qa-pr/references/methodology.md
@@ -1,0 +1,432 @@
+# AI PR Testing Methodology — Expensify App (POC)
+
+How an AI agent should test an Expensify `App` pull request by reproducing its
+fixed bug and verifying the fix, end-to-end, on a real running app.
+
+> **Core principle:** The PR's "Tests" section is **not enough**. A test is only
+> meaningful if it runs the *actual scenario* the PR addresses, on the *right
+> platform/layout*, against the *exact UI element*, and compares **`main` (bug)
+> vs the PR branch (fix)**. Reproducing a look-alike flow on the wrong platform
+> produces a confident but worthless "pass".
+
+---
+
+## Phase 0 — Triage (decide if it's testable at all)
+
+1. Skip if the PR title contains **`[No QA]`**.
+2. Read the PR body. If the steps require **external integrations you cannot set
+   up** (QBO/Xero/NetSuite/Sage, Plaid/bank, card issuing, real payments), record
+   `NOT_TESTABLE` in `triage-log.md` with the reason. Don't fake it.
+3. **Record every triaged PR in `ai-qa-poc/triage-log.md`** — a single table that is
+   the home for all triage "marks". For each PR log: PR#, issue#, title, native
+   platforms, a **difficulty rating** (🟢 Easy / 🟡 Medium / 🔴 Hard — difficulty to
+   *test*, from data/setup/interaction needs, not difficulty to fix), and a **status**
+   (`TESTED` / `CANDIDATE` / `NOT_TESTABLE` / `SKIPPED_WEB_ONLY` / `SKIPPED_OTHER`).
+   `TESTED` rows link to their `PR-<n>/report.md`. This way skips and not-testables
+   are visible with their reason, not silently dropped.
+
+### MVP scope: MOBILE ONLY (Argent covers iOS/Android simulators, NOT web)
+
+Argent drives iOS/Android simulators only — there is **no desktop-browser
+automation** in this setup. So scope every candidate by the platforms in the
+linked issue's "Platforms reproduced" checkboxes:
+
+- **Mobile-only** (iOS App and/or Android App — native; **mWeb does not count**, it's
+  a browser) → **TEST IT** on the simulator.
+  - **If BOTH iOS App and Android App are reproduced → test BOTH platforms.** Boot
+    the iOS simulator *and* the Android emulator, run the full before/after on each,
+    confirm the fix works on both, and include **before/after screenshots for both
+    platforms** in the report. Don't generalize from one platform to the other —
+    layout, gestures, and native behavior differ. If only one mobile platform is
+    checked, test just that one.
+- **Web-only** (only Windows: Chrome and/or macOS: Chrome/Safari, or only **mWeb** —
+  mWeb is a mobile *browser*, which Argent's native driving can't test) → **SKIP**.
+  Record it in `triage-log.md` with status `SKIPPED_WEB_ONLY`.
+- **Both mobile and web** (a mobile box AND a desktop box are checked) → **test the
+  MOBILE path only**, and put a **prominent disclaimer at the top of the report**:
+
+  > ⚠️ **Tested on mobile (iOS/Android simulator via Argent) only. The web/desktop
+  > path was NOT tested.** This bug is also reported on web (Windows Chrome /
+  > macOS Chrome-Safari); that platform is out of scope for this Argent-based run.
+
+## Phase 1 — Gather the FULL context (this is where the real signal is)
+
+Do **all** of these before touching the app. Each one changes how/where you test.
+
+1. **PR body** — extract `### Tests`, `### Offline tests`, `### QA Steps`.
+2. **Follow every reference in the PR**, especially:
+   - the **linked GitHub issue** (the `$ https://github.com/.../issues/<id>` line),
+   - the **PROPOSAL** comment link.
+   Use `gh issue view <id> --repo Expensify/App --json title,body,labels`.
+3. **From the linked issue, extract the decisive details the PR body usually omits:**
+   - **Platforms reproduced** (the checkbox list: Android App / iOS App / mWeb /
+     Windows Chrome / macOS Chrome-Safari). → **This dictates the environment.**
+   - **Exact reproduction steps** (often more precise than the PR's "Tests").
+   - **Expected Result vs Actual Result** — read literally. They often reference
+     **layout concepts** ("super-wide modal", "RHP", "Inbox page", "LHN") that
+     only exist on a specific screen width.
+   - Version, and any attached screenshots/videos of the bug.
+4. **Read the PR code diff** — `gh pr diff <n> --repo Expensify/App` and
+   `gh pr view <n> --json files`. The changed files/functions tell you:
+   - the **exact component/element** involved (e.g. a fix in
+     `ParentNavigationSubtitle.tsx` means the element under test is the
+     "From <report> in <workspace>" parent link — *not* some other field that
+     looks similar),
+   - the **layout/platform conditions** the logic branches on
+     (`shouldUseNarrowLayout`, `isSmallScreenWidth`, RHP navigators,
+     `SEARCH_FULLSCREEN_NAVIGATOR`, etc.) — these confirm whether it's a
+     wide-screen or narrow-screen behavior.
+
+Output of this phase: a short **context brief** = {platforms, exact steps,
+expected, actual, exact element, layout condition, files touched}.
+
+## Phase 2 — Choose the right environment (derived from Phase 1, not guessed)
+
+- **Platform:** pick the native simulator(s) from the issue's reproduced platforms —
+  iOS App and/or Android App (both, if both are checked). Behavior that only exists
+  on wide screens (desktop/tablet layouts) is out of scope; such PRs are `SKIPPED_WEB_ONLY`.
+- **How to run:** start Metro first (`npm run start`, see gotchas below), then launch
+  and drive the app on the iOS simulator / Android emulator via the device-automation
+  tooling (Argent).
+- **Account/data:** ensure backend connectivity and the **right data state**
+  (e.g. an expense/report must actually exist in the view the steps start from).
+  Create disposable test data if needed, on the agreed test account/workspace.
+- **Login is autonomous.** A fresh install is logged out; log in with the test account and
+  **fetch the emailed code automatically** via the skill's helper
+  (`helpers/fetch-magic-code.mjs`, Gmail/IMAP — no human code entry). Full steps in
+  **SKILL.md → Step 0**. (`000000` only works on the dev VM; prod/staging use real emailed codes.)
+- **Repro hygiene — escalate least-destructive first.** The app should be runnable
+  out of the box. If it misbehaves (stuck spinners, "offline", jammed queue, weird
+  state), reset in this order:
+  1. **Clear cache and restart FIRST** (in-app: Account → Troubleshoot → "Clear cache
+     and restart"). This wipes stale Onyx state but **keeps the login session AND the
+     "Use Staging Server" toggle** — most weird states are fixed here, non-destructively.
+  2. **Only if that doesn't fix it → uninstall + reinstall.** A fresh install wipes the
+     whole data container, which **also wipes the login + the staging toggle** — you'll
+     drop back to logged out and have to log in again (and re-toggle staging if you use
+     it). So it's the heavier fallback, not the first move. Preserve
+     the binary and reinstall it:
+     ```bash
+     APP=$(xcrun simctl get_app_container <udid> <bundleId> app)
+     cp -R "$APP" /tmp/app.app && xcrun simctl uninstall <udid> <bundleId>
+     xcrun simctl install <udid> /tmp/app.app && xcrun simctl launch <udid> <bundleId>
+     ```
+  **Only if a fresh reinstall still fails** is it a deeper problem (network/backend/
+  edge) — then investigate (see gotchas) and report what makes it untestable.
+- **If login hangs, PAUSE and ease off — don't thrash.** A hung `BeginSignIn` under
+  heavy automated traffic is most likely **transient rate-limiting**; hammering it makes
+  it worse. Reduce request volume, wait a bit, and **retry** — it normally clears (login
+  works fine in the app under normal conditions). Don't pivot away on the first spin.
+
+## Phase 3 — Before/after: reproduce on `main`, then verify on the PR branch
+
+This is mandatory — a single-branch result can't prove a fix.
+
+1. **`main` first** — run the exact steps and **capture the bug** (the "Actual
+   Result" from the issue). Screenshot every step.
+2. **Switch to the PR branch** — `gh pr checkout <n>`.
+   - **JS-only** change (most navigation/UI fixes) ⇒ just reload the app (relaunch to
+     re-fetch the bundle from Metro); no native rebuild.
+   - Native change (ios/android/Podfile/package.json/native deps) ⇒ rebuild.
+3. **Re-run the identical steps** on the PR branch and capture the **"Expected
+   Result"**. Screenshot every step.
+4. **Compare**: did Actual→Expected actually change? That's the verdict.
+
+### Testing both platforms (default: one app live at a time)
+
+Both an iOS simulator **and** an Android emulator can be **booted at once** — that's the
+normal setup, works fine here, and is **never** a reason to skip a reported platform. The
+limit isn't co-resident *devices*, it's co-resident *app bundles on Metro*: the genuine
+failure mode is **two live app bundles on one Metro** — most sharply, **two concurrent full
+bundle builds** (both apps reloading right after a branch switch) OOM-crashing Metro (exit
+134) even at a 12 GB heap. So run the **app on only one platform at a time**.
+
+The default for a both-platform PR is therefore **sequential within each branch**:
+
+1. On **`main`**: test one platform, then the other — capture BEFORE screenshots for each
+   (`ios-main-*.png`, `android-main-*.png`). Only the platform under test runs the app;
+   **kill the app on the other but leave its device booted** (terminate, don't shut down):
+   - iOS: `xcrun simctl terminate <udid> com.expensify.chat.dev` (sim stays booted)
+   - Android: `adb -s <serial> shell am force-stop com.expensify.chat.dev` (emulator stays running)
+2. **The branch switch is the barrier** (git + Metro are shared across both devices) — you
+   can never have one device on `main` while the other is on the PR branch. Move both to the
+   PR branch together with `gh pr checkout <n>`; only the platform under test relaunches /
+   rebuilds its bundle.
+3. On the **PR branch**: test each platform again for the AFTER screenshots.
+4. Synthesize the combined two-platform report.
+
+- Give Metro headroom for a both-platform session: `NODE_OPTIONS="--max-old-space-size=12288"`.
+- Health gate before a heavy run: `memory_pressure` free % and `sysctl -n vm.loadavg` — a
+  healthy reading with both sims booted (one app live) is normal; treat a problem as a reason
+  to **sequence** work, not to drop a platform.
+
+**Exception — true parallel** (a subagent per device, **both apps live at once**) is only
+worth it for **light, read-only flows** (search, navigation). Even then, mind the
+**shared-account hazard:** both devices use the **same test account**, so two parallel
+subagents that **create/edit data** can confound each other. For any data-mutating flow,
+drive **sequentially** — or give each device a **distinct, identifiable value** (e.g.
+different amounts) and verify only its own delta, or use **separate accounts**.
+
+## Phase 4 — Execute the steps robustly
+
+- Drive the **exact element** identified in Phase 1 (from the issue + diff), not a
+  visually similar one.
+- Loop **interact → screenshot → verify** for each step and each "Verify…" assertion.
+- **Prefer what a real user would do.** Favor genuine interactions — tap, **long-press**,
+  double-tap, swipe, scroll, type. Tool helpers (`adb input`, `adb am start`, deep links,
+  CDP) are fine as a **fallback to unblock**, but the closer the repro is to the real user
+  path the stronger the evidence; if you rely on a shortcut a user couldn't perform, note
+  the deviation.
+- **When one way to accomplish the goal fails, find another *way to accomplish the same
+  goal* — don't just nudge coordinates.** Reason about the user's intent (e.g. "share an
+  image into the app") and enumerate alternative routes to the same outcome: a different
+  gesture (long-press vs tap), a different entry point, a different app that reaches the same
+  screen, a different feature that lands in the same flow. **When you don't know the
+  options, search the web** for how a real user does *X* on that platform/app, then try
+  them. Only report a blocker once the alternative *ways* are genuinely exhausted.
+- **Recognize and report blocker/failure states instead of faking a pass:**
+  offline banner, error boundary ("Something went wrong"), stuck loading
+  skeletons, wrong layout, missing element. But first run the ladder above — most
+  "missing/undrivable element" dead-ends are really "wrong gesture tried once."
+
+## Phase 5 — Document the report & post it as a PR comment
+
+The deliverable is a **comment on the PR** carrying the full before/after report with
+**inline screenshots**. GitHub renders comment images only from public URLs — local paths
+don't render, base64 data URIs are stripped, and the native drag-drop upload
+(`user-attachments`) is browser-cookie-only and **cannot be automated**. So screenshots are
+pushed to a small **evidence repo** and embedded via its `raw.githubusercontent.com` URLs.
+
+Flow:
+1. Save the per-step screenshots locally under `ai-qa-poc/PR-<n>/screens/` (the upload source),
+   named with a platform prefix: `ios-main-2-*.png`, `ios-pr-2-*.png`, `android-main-2-*.png`, …
+2. Publish them and capture the base raw URL:
+   `BASE=$(bash .claude/skills/argent-qa-pr/helpers/publish-evidence.sh <n> ai-qa-poc/PR-<n>/screens)`.
+   The target repo/branch come from `EVIDENCE_REPO`/`EVIDENCE_BRANCH` (process env, else
+   `helpers/.env`) — each user sets their **own** public evidence repo there; it's never
+   hardcoded in the skill. The active `gh`/git identity needs `contents:write` on that repo
+   (a fine-grained PAT or a GitHub App token in CI).
+3. **Record a video of the full flow on EACH branch (standard, not optional). Record long, cut later.**
+   One screen recording per `main`/PR × platform (1-platform PR → 2 videos; both-platform → 4). Keep the
+   recording rolling through the whole session (lead-in → repro → settle) so there's context on each side
+   of the repro; don't start/stop around just the key action. `helpers/clip-to-evidence.sh` then emits
+   **two artifacts** from one raw: a **tight inline GIF** (just the repro action) and a **longer linked
+   MP4** padded to **repro ± `CLIP_CONTEXT_SEC`** (default 20s). Workflow: run it with `--contact <raw>`,
+   Read `/tmp/_clip_contact.png`, find the repro window on the normalized timeline, then
+   `clip-to-evidence.sh <raw> <out> <gif_start> <gif_dur> 320` (the MP4 auto-pads). Named `android-main`,
+   `android-pr`, `ios-main`, `ios-pr`. `adb screenrecord` is slow to init — wait ~4s before the first
+   action (`--time-limit` caps the file). The **stills + GIFs** ship inline (stills pin the end-state,
+   GIFs make cause→effect legible); the **MP4 link** carries the context. Only skip a branch's video if
+   the flow genuinely can't be driven on that platform (say so) — "the bug is static" is not a reason to
+   skip; if nothing animates, drive a short flow that exercises the behaviour so the take has real motion.
+4. Publish screenshots **and** videos/GIFs and capture the base raw URL (multi-dir, auto-skips `*-raw.*`):
+   `BASE=$(bash .claude/skills/argent-qa-pr/helpers/publish-evidence.sh <n> ai-qa-poc/PR-<n>/screens ai-qa-poc/PR-<n>/videos)`.
+5. Write `ai-qa-poc/PR-<n>/report.md` (kept as the local source/backup) — embed each screenshot **and
+   each branch's GIF** as `![caption]($BASE/<file>.png|.gif)` (the **raw URL**, never a relative path)
+   and **link the MP4s** as `[MP4]($BASE/<file>.mp4)` (raw MP4 URLs don't inline-play; GIFs auto-loop).
+   Start the body with `<!-- argent-qa-pr -->` and end with a footer noting it's an automated mobile QA run.
+6. Post it: `gh pr comment <n> --repo Expensify/App --body-file ai-qa-poc/PR-<n>/report.md`. To **update**
+   an existing comment instead of duplicating, PATCH it:
+   `gh api --method PATCH repos/Expensify/App/issues/comments/<id> -F body=@ai-qa-poc/PR-<n>/report.md`.
+7. Update the `triage-log.md` row to `TESTED` + result and link the posted comment.
+
+The report body must contain:
+- **Context**: issue link + summary, PR link, platforms, exact steps,
+  Expected vs Actual, files touched + one-line "what the diff does".
+- **Environment**: platform/device(s), account/workspace, branch + commit.
+- **Before (`main`)**: numbered steps, ending in the bug.
+- **After (PR branch)**: same steps, ending in the fix.
+- **Per platform when testing more than one.** If both iOS and Android are in
+  scope, give each its **own Before/After section** with its own screenshots
+  (don't reuse one platform's shots for the other), and a per-platform verdict.
+  Name screenshots with a platform prefix: `ios-main-2-*.png`, `ios-pr-2-*.png`,
+  `android-main-2-*.png`, `android-pr-2-*.png`.
+- **One directory per PR.** Layout (the methodology itself lives in the skill at
+  `.claude/skills/argent-qa-pr/references/methodology.md`; `ai-qa-poc/` holds only the local
+  source/backup — the published artifact is the PR comment):
+  ```
+  ai-qa-poc/
+    triage-log.md
+    PR-<number>/
+      report.md     # exact body posted to the PR (images = raw evidence-repo URLs)
+      screens/      # upload source: ios-main-2-*.png, ios-pr-2-*.png, android-main-2-*.png, …
+  ```
+- **Embed screenshots inline** with Markdown image syntax — `![caption]($BASE/<file>.png)` using
+  the **raw evidence-repo URL** from `publish-evidence.sh` (step 2 above), **never a relative
+  `screens/<file>.png` path** — relative paths render in a local file but show as broken images in
+  the GitHub comment, which is the actual deliverable.
+- **Verdict**: PASS/FAIL with the explicit Actual→Expected delta, plus any caveats.
+
+---
+
+## Anti-patterns (do not do these)
+
+1. **Wrong platform / platform substitution.** Testing a bug on a platform/layout where it
+   can't appear (e.g. a wide-screen "super-wide modal"/RHP bug on a narrow phone) yields a
+   meaningless "pass". Pick the platform from the issue's reproduced checkboxes — and test
+   **exactly** those. **Never substitute the other native platform** because it's already
+   booted, faster, or because the fix "is just shared JS": an Android-reported bug is tested
+   on **Android**. Both sims can run at once, so there is no resource excuse. If the reported
+   platform truly can't be run, mark it `NOT_TESTABLE` — don't pass it off on another platform.
+2. **Look-alike element.** Acting on an element that merely resembles the one in the
+   issue (different element ⇒ different behavior). Confirm the exact element from the
+   issue + the code diff.
+3. **Single branch.** Testing only `main` or only the PR branch — no before/after
+   means nothing is actually validated.
+4. **Trusting the PR "Tests" alone** without the linked issue's platform +
+   Expected/Actual context.
+5. **Faking a pass** when the real scenario wasn't reproduced.
+
+## Expensify-specific environment gotchas (observed)
+
+- **Android emulator (hard-won, this host):**
+  - **Boot:** argent `boot-device` may fail (`-gpu auto` → `exited code 1`; corrupt AVD
+    snapshots). Workaround: **manual cold boot** —
+    `~/Library/Android/sdk/emulator/emulator -avd <name> -no-snapshot -no-boot-anim -gpu swiftshader_indirect -memory 6144 &`
+    then `adb wait-for-device`, wait for `getprop sys.boot_completed = 1`,
+    `adb reverse tcp:8081 tcp:8081`. argent's `list-devices`/`describe`/gestures then attach
+    to the running `emulator-<port>` fine.
+  - **`-memory 6144` is essential.** At the AVD default (~2 GB) the *guest's*
+    `lowmemorykiller` OOM-kills the heavy dev build mid-run (`thrashing 343%`, app silently
+    dies → drops to launcher). Host RAM is usually not the problem; the **guest** allocation is.
+  - **Driving the UI:** `adb input` is more reliable than argent gestures on a
+    software-rendered emulator. Plain taps on cross-app surfaces (e.g. a Google Photos
+    thumbnail) often **don't register**; a **long-press via `adb shell input swipe X Y X Y 1000`**
+    (same point, 1 s hold) does. Read coordinates with argent `describe` (normalized) but
+    **multiply by the real pixel size** (`adb shell wm size`) for `adb input` taps.
+  - **Native share repro:** drive the **real** flow (gallery → long-press → Share →
+    "New Expensify Dev" → Share tab). A synthetic `adb am start -a SEND` reaches
+    `FileIntentHandler` but `copyUriToStorage` returns null for an `am`-injected MediaStore
+    URI (no real URI grant), so the share object is never persisted → "No data found".
+  - Screenshots: `adb exec-out screencap -p > x.png` then downscale for viewing
+    (`sips -Z 1100 x.png --out x-s.png`) — full-res Android frames exceed the image read limit.
+
+- **Metro OOM:** the bundle is large; start Metro with a bigger heap or it crashes
+  with `JavaScript heap out of memory`:
+  `NODE_OPTIONS="--max-old-space-size=8192" npm run start`. **Testing both iOS and
+  Android off one Metro roughly doubles memory** — bump to `--max-old-space-size=12288`
+  or Metro can crash mid-session (exit 134 / SIGABRT) and both apps lose their bundle server.
+- **Dev build hits production** by default (no `.env`). Cloudflare returns **403**
+  to requests with a missing/`node` User-Agent, but the app's own requests carry a
+  real UA and get 200 — so a bare host-side `curl` is misleading; reproduce network
+  calls **inside the app runtime** (Metro CDP) to judge real connectivity.
+- **Stuck `SequentialQueue`:** poisoned optimistic writes (`RequestMoney`/
+  `SubmitReport`/`OpenReport`) that fail (403/499/666) and retry can deadlock the
+  queue; reads (`Search`) block behind them → Spend > Expenses hangs forever and
+  the state **survives relaunches** (persisted in Onyx). Fix: Account → Troubleshoot
+  → **Clear cache and restart**.
+- **Login can transiently hang under heavy automated traffic — but it is NOT a wall.**
+  Login normally works in the app (real emailed magic code). Under heavy automated request
+  volume `BeginSignIn` can hang (Continue spins; logs show
+  `[Network] Making API request - BeginSignIn` with no "Finished") — most likely transient
+  rate-limiting that clears on its own. **Remedy: wait and retry**, and ease off request
+  volume. Three easy-to-make wrong conclusions to avoid: (1) a bare host-side `node`/`curl`
+  probe of `POST .../api?command=BeginSignIn` returns `403 cf-mitigated: challenge`, but
+  that's just Cloudflare challenging a *non-browser* client — **not representative of the
+  app** (the app's requests log in fine), so never conclude the app is "walled" from it;
+  (2) magic code `000000` works **only** on the local dev VM — production and staging both
+  use real emailed codes; (3) **staging shares the production database** (same data — not
+  a clean sandbox), so it's effectively the same as production for testing.
+- **Inspecting app internals:** connect to Metro CDP (`ws` to
+  `http://localhost:8081/json/list`) and `Runtime.evaluate` to read console logs /
+  run fetches in the app's own context — invaluable for telling "offline" apart from
+  "request failing" apart from "queue stuck".
+
+---
+
+## Recipes / unblockers (hard-won — reach for these before declaring a wall)
+
+- **Feasibility pre-check (do FIRST — saves whole runs). Goal: detect setup early so you can
+  *prepare* it, not just bail.** Use **deterministic** signals: (1) read the issue
+  `Precondition`/`Prerequisite`; (2) `grep -rn "isBetaEnabled" src/pages/<feature>` — the changed
+  screen's *entry point* is often beta-gated; (3) once the app is up, probe the account (one CDP
+  call) and compare its `betas`/workspaces against what the repro needs. **Don't use a deep-link 404
+  as a gate test** — a failed deep link is ambiguous (navigation-not-ready on cold boot, wrong
+  route/scheme/domain, bad param), so it's an *unblocker*, not a diagnostic. Then split setup into
+  **surmountable** (prepare it) vs **real blocker** (`NOT_TESTABLE`):
+  - Surmountable: *fresh account / onboarding* → `+tag` alias (below); *missing data* → create it
+    in-app; *UI-gating beta* → Onyx override (below); *gated/hard screen* → deep link (below); *web
+    precondition* → do it in a browser, verify on mobile.
+  - Real blocker (stop): live external integrations (accounting/bank/Plaid/card/payments) or a beta
+    that gates **backend** behavior (a client override won't change server responses).
+
+- **Fresh account in any state via a `+tag` alias (NOT a blocker).** Sign up / log in with
+  `<testinbox>+pr<n>@gmail.com` — Expensify treats `+tag` as a distinct account, but Gmail delivers
+  the validation/magic-code email to the **base inbox**, which `fetch-magic-code.mjs` reads (it
+  strips the tag for IMAP login). Entering the magic code validates the account, so onboarding /
+  validated-account / new-user states are all reproducible. Use a **distinct tag per
+  platform/branch** to avoid the shared-account hazard.
+
+- **Read account state via Metro CDP.** Onyx is exposed at `globalThis.Onyx`.
+  `debugger-evaluate` doesn't await promises, so stash-then-read:
+  ```js
+  // call 1: (function(){ globalThis.__x='p'; globalThis.Onyx.get('betas').then(b=>{globalThis.__x=b;}); return 'ok'; })()
+  // call 2: JSON.stringify(globalThis.__x)
+  ```
+  Note: with both an iOS sim and Android emulator on one Metro, CDP attaches to whichever app is
+  connected. To target the other, **terminate the app you don't want** (e.g.
+  `xcrun simctl terminate <udid> com.expensify.chat.dev`) so only your target stays on Metro.
+
+- **Enable a missing beta client-side (for UI/navigation-only bugs).** When the repro's entry is
+  gated by a beta the account lacks, and the fix is pure client-side render/nav logic, you can
+  surface the entry by injecting the beta into Onyx — applied **identically to both branches**, and
+  noted as a deviation in the report:
+  ```js
+  // after reading current betas into globalThis.__x (above):
+  (function(){var b=globalThis.__x; if(!b.includes('workspaceRoomsPage')) globalThis.Onyx.set('betas', b.concat(['workspaceRoomsPage'])); return 'done';})()
+  ```
+  Betas come from the server on `OpenApp`, so re-inject after a reload/branch-switch.
+
+- **Reach a hard-to-navigate / gated screen via deep link (UNBLOCKER, not a diagnostic).** Find the
+  route in `src/ROUTES.ts`, get the id from logs (`adb logcat -d | grep -aoiE '"policyID":"[A-F0-9]+"'`),
+  then: `adb shell am start -a android.intent.action.VIEW -d "https://staging.new.expensify.com/<route>" com.expensify.chat.dev`
+  (delivers to the running app). Best **after** you've enabled any required beta. Don't read a 404
+  ("Hmm… it's not here") as proof of a beta gate — it's ambiguous (it also happens when the link
+  arrives before navigation is ready on a cold boot, or the route/scheme/domain/param is wrong);
+  confirm gating with the `isBetaEnabled` grep + account `betas` instead.
+
+- **Metro OOM (the bundle is huge).** Symptoms: app shows "Unable to load script" / JS thread
+  `SIGABRT`; `grep -i heap /tmp/metro-qa.log` shows V8 GC frames. Fix: kill Metro
+  (`pkill -9 -f "react-native start"`) and restart with a big heap + reset cache:
+  `NODE_OPTIONS="--max-old-space-size=12288" npm run start -- --reset-cache &`. Then `adb reverse
+  tcp:8081 tcp:8081` and relaunch the app.
+
+- **Slow Android cold boots are NORMAL — don't panic or nuke the login.** On this host the dev build
+  routinely takes **2–3 min** to get past the green splash (heavy bundle + Onyx migrations; logcat
+  shows `BootsplashVisibleOnyxMigrations` then `useSidebarOrderedReports building reportsToDisplay`).
+  The clock advancing + JS logs ticking = it's progressing, just slow. **Wait it out**; only treat it
+  as broken if logcat shows a `SIGABRT`/`Unable to load script` (→ Metro OOM, above) or it's clearly
+  idle for minutes. `adb shell pm clear` / reinstall (which wipes the login) is a LAST resort, not a
+  reaction to a slow boot.
+
+- **Android magic-code login is flaky — the field corrupts injected keys.** The 6-box code field
+  drops/duplicates `adb`/IME input and ignores backspace under the emulator's floating Gboard.
+  **Fix that worked: force-stop + relaunch the app** (`adb shell am force-stop …; monkey -p … 1`) to
+  reset the keyboard state, then type the code once into the fresh field. For normal text fields,
+  input is usually fine but **verify the field value** (re-dump uiautomator) and **append missing
+  chars** rather than retype; **never `input keycombination 113 29` (CTRL+A)** — it can switch apps.
+
+- **Screen recording → inline GIF + linked context MP4.** GitHub renders a GIF inline from a raw URL
+  and auto-loops it; it will NOT inline-play a raw/blob MP4 (only its cookie-auth drag-drop upload does).
+  So record the whole flow, then `helpers/clip-to-evidence.sh` makes a **tight looping GIF** (embed
+  inline, just the repro action) + a **longer MP4** padded to repro ± `CLIP_CONTEXT_SEC` (default 20s,
+  link it). Pick the window with `clip-to-evidence.sh --contact <raw>` (reads on the normalized timeline).
+  `adb screenrecord` is slow to init — wait ~4s after starting it before the first action (start gets
+  clipped otherwise); 180s max per file. **iOS `recordVideo` is variable-frame-rate** so a GIF of a
+  static screen flickers and raw seeks drift — the helper CFR-normalizes (30fps) before clipping, so read
+  window timestamps off the normalized clip, not the raw.
+
+---
+
+## Checklist (paste into the agent prompt)
+
+- [ ] PR is not `[No QA]` and is testable locally (no unavailable integrations).
+- [ ] **Platform scope (MVP): mobile box checked?** Web-only → SKIP. Both → mobile + disclaimer.
+- [ ] Read PR body + **opened the linked issue** + read the **PROPOSAL**.
+- [ ] Extracted **platforms reproduced**, exact steps, **Expected vs Actual**.
+- [ ] Read the **code diff**; identified the **exact element** and **layout condition**.
+- [ ] Chose the simulator(s) to **match the reproduced native platform(s)**.
+- [ ] Reproduced the bug on **`main`** with per-step screenshots.
+- [ ] `gh pr checkout <n>`; reloaded (or rebuilt if native).
+- [ ] Re-ran identical steps on the **PR branch**; per-step screenshots.
+- [ ] Wrote the **before/after report** with an explicit verdict + caveats.


### PR DESCRIPTION
I’ve been working on a POC of using Argent to reproduce issues and test PRs locally (for now). I opened a PR that adds two skills:
• `argent-find-testable-prs` (helper) — scans open PRs that need to be tested on mobile and rates how hard each one will be to test with AI.
• `argent-qa-pr` — tests a specific PR. It gathers as much context about the PR as it can, reproduces the original issue on the main branch, then runs the same steps on the PR branch to confirm the issue is fixed.
`argent-qa-pr` knows which platforms to check based on the issue description (whichever platforms were selected there). If both Android and iOS are selected, it tests both and includes them in the report.

When it finishes, it outputs a report and posts it as a comment on the PR. Examples:
Early versions (no videos/gifs yet):
https://github.com/Expensify/App/pull/93164#issuecomment-4685578632
https://github.com/Expensify/App/pull/93059#issuecomment-4685043213
Latest versions:
https://github.com/Expensify/App/pull/93200#issuecomment-4692679393
https://github.com/Expensify/App/pull/93399#issuecomment-4693700191
I’ve been improving the reports with each iteration, so the last one reflects the current version.

I also built two helpers around this:
• Auto-login, to avoid a human in the loop — used https://github.com/adamgrzybowski/expensify-auto-login, which Adam originally created for this :pray:
• Uploading images/gifs/videos so they can be added to GitHub comments via CLI — Claude flagged that we can’t add these to comments programmatically without hosting them somewhere first.
To use these automations, whoever runs the skill needs the env vars set up from `.claude/skills/argent-qa-pr/helpers/.env`. - you can find instructions what needs to be done in README

For now each run of argent-find-testable-prs and argent-qa-pr creates reports and triage-log locally (in ai-qa-poc) so we know which PRs were already tested and which we tried to test