### PR TITLE
Drop duplicate TrackExpense / CreateMoneyRequest enqueues via conflict resolver

### DIFF
--- a/src/libs/actions/IOU/TrackExpense.ts
+++ b/src/libs/actions/IOU/TrackExpense.ts
@@ -87,6 +87,7 @@ import {buildPolicyData} from '@userActions/Policy/Policy';
 import type {BuildPolicyDataKeys} from '@userActions/Policy/Policy';
 import type {GuidedSetupData} from '@userActions/Report';
 import {buildInviteToRoomOnyxData, notifyNewAction} from '@userActions/Report';
+import {resolveTransactionCreationDuplicate} from '@userActions/RequestConflictUtils';
 import {stringifyWaypointsForAPI} from '@userActions/Transaction';
 import {getOnboardingMessages} from '@userActions/Welcome/OnboardingFlow';
 import type {IOUAction} from '@src/CONST';
@@ -1875,7 +1876,9 @@ function requestMoney(requestMoneyInformation: RequestMoneyInformation): {iouRep
             };
 
             deferredAPIWrite = () => {
-                API.write(WRITE_COMMANDS.REQUEST_MONEY, parameters, onyxData);
+                API.write(WRITE_COMMANDS.REQUEST_MONEY, parameters, onyxData, {
+                    checkAndFixConflictingRequest: (persistedRequests) => resolveTransactionCreationDuplicate(persistedRequests, parameters.transactionID),
+                });
             };
         }
     }
@@ -2701,7 +2704,9 @@ function trackExpense(params: CreateTrackExpenseParams) {
             }
 
             const apiWrite = () => {
-                API.write(WRITE_COMMANDS.TRACK_EXPENSE, parameters, onyxData);
+                API.write(WRITE_COMMANDS.TRACK_EXPENSE, parameters, onyxData, {
+                    checkAndFixConflictingRequest: (persistedRequests) => resolveTransactionCreationDuplicate(persistedRequests, parameters.transactionID),
+                });
             };
 
             deferOrExecuteWrite(apiWrite, {

--- a/src/libs/actions/RequestConflictUtils.ts
+++ b/src/libs/actions/RequestConflictUtils.ts
@@ -245,6 +245,25 @@ function resolveEnableFeatureConflicts<TKey extends OnyxKey>(
     };
 }
 
+const transactionCreationCommands = new Set<string>([WRITE_COMMANDS.TRACK_EXPENSE, WRITE_COMMANDS.REQUEST_MONEY]);
+
+/**
+ * Drops a duplicate TrackExpense / CreateMoneyRequest write when one with the same client-generated
+ * `transactionID` is already persisted. The first persisted request keeps the optimistic data it applied
+ * and continues through the queue's normal retry path; the duplicate would otherwise hit Bedrock and trip
+ * the unique-constraint guard in `Transaction::createMoneyRequest`.
+ */
+function resolveTransactionCreationDuplicate<TKey extends OnyxKey>(persistedRequests: Array<OnyxRequest<TKey>>, transactionID: string | undefined): ConflictActionData {
+    if (!transactionID) {
+        return {conflictAction: {type: 'push'}};
+    }
+    const hasDuplicate = persistedRequests.some((request) => transactionCreationCommands.has(request.command) && request.data?.transactionID === transactionID);
+    if (hasDuplicate) {
+        return {conflictAction: {type: 'noAction'}};
+    }
+    return {conflictAction: {type: 'push'}};
+}
+
 function resolveDetachReceiptConflicts<TKey extends OnyxKey>(persistedRequests: Array<OnyxRequest<TKey>>, parameters: DetachReceiptParams): ConflictActionData {
     const indicesToDelete: number[] = [];
     for (const [index, request] of persistedRequests.entries()) {
@@ -286,6 +305,7 @@ export {
     resolveEnableFeatureConflicts,
     enablePolicyFeatureCommand,
     resolveDetachReceiptConflicts,
+    resolveTransactionCreationDuplicate,
 };
 
 export type {EnablePolicyFeatureCommand, AnyRequestMatcher};

--- a/tests/actions/IOUTest/DuplicateTest.ts
+++ b/tests/actions/IOUTest/DuplicateTest.ts
@@ -1686,7 +1686,7 @@ describe('actions/Duplicate', () => {
             await waitForBatchedUpdates();
 
             // Verify API was called with TRACK_EXPENSE (trackExpense path, not requestMoney)
-            expect(writeSpy).toHaveBeenCalledWith(WRITE_COMMANDS.TRACK_EXPENSE, expect.objectContaining({}), expect.objectContaining({}));
+            expect(writeSpy).toHaveBeenCalledWith(WRITE_COMMANDS.TRACK_EXPENSE, expect.objectContaining({}), expect.objectContaining({}), expect.objectContaining({checkAndFixConflictingRequest: expect.any(Function)}));
         });
 
         it('should call createDistanceRequest for distance transactions', async () => {

--- a/tests/unit/RequestConflictUtilsTest.ts
+++ b/tests/unit/RequestConflictUtilsTest.ts
@@ -7,6 +7,7 @@ import {
     resolveEditCommentWithNewAddCommentRequest,
     resolveEnableFeatureConflicts,
     resolveOpenReportDuplicationConflictAction,
+    resolveTransactionCreationDuplicate,
 } from '@libs/actions/RequestConflictUtils';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import type {WriteCommand} from '@libs/API/types';
@@ -226,6 +227,41 @@ describe('RequestConflictUtils', () => {
 
             const result = resolveDetachReceiptConflicts(persistedRequests, {transactionID: '1'} as never);
             expect(result).toEqual({conflictAction: {type: 'delete', indices: [0, 2], pushNewRequest: true}});
+        });
+    });
+
+    describe('resolveTransactionCreationDuplicate', () => {
+        it('returns push when no transactionID is supplied', () => {
+            const result = resolveTransactionCreationDuplicate([{command: WRITE_COMMANDS.TRACK_EXPENSE, data: {transactionID: '1'}}], undefined);
+            expect(result).toEqual({conflictAction: {type: 'push'}});
+        });
+
+        it('returns push when no queued TrackExpense or RequestMoney shares the transactionID', () => {
+            const persistedRequests = [
+                {command: 'OpenReport'},
+                {command: WRITE_COMMANDS.TRACK_EXPENSE, data: {transactionID: '999'}},
+                {command: WRITE_COMMANDS.REQUEST_MONEY, data: {transactionID: '777'}},
+            ];
+            const result = resolveTransactionCreationDuplicate(persistedRequests, '1');
+            expect(result).toEqual({conflictAction: {type: 'push'}});
+        });
+
+        it('returns noAction when a queued TrackExpense already carries the same transactionID', () => {
+            const persistedRequests = [{command: WRITE_COMMANDS.TRACK_EXPENSE, data: {transactionID: '878080547297159018'}}];
+            const result = resolveTransactionCreationDuplicate(persistedRequests, '878080547297159018');
+            expect(result).toEqual({conflictAction: {type: 'noAction'}});
+        });
+
+        it('returns noAction when a queued RequestMoney already carries the same transactionID', () => {
+            const persistedRequests = [{command: WRITE_COMMANDS.REQUEST_MONEY, data: {transactionID: '878080547297159018'}}];
+            const result = resolveTransactionCreationDuplicate(persistedRequests, '878080547297159018');
+            expect(result).toEqual({conflictAction: {type: 'noAction'}});
+        });
+
+        it('ignores unrelated commands that happen to carry the same transactionID', () => {
+            const persistedRequests = [{command: WRITE_COMMANDS.REPLACE_RECEIPT, data: {transactionID: '878080547297159018'}}];
+            const result = resolveTransactionCreationDuplicate(persistedRequests, '878080547297159018');
+            expect(result).toEqual({conflictAction: {type: 'push'}});
         });
     });
 });


### PR DESCRIPTION
### Explanation of Change

VictoriaLogs shows 7,337 hits in June 1–15 of `Unique Constraints Violation, command: TrackExpense` on Bedrock, traced to App enqueuing the same `TrackExpense` (or `CreateMoneyRequest`) write twice — same client-generated `transactionID`, identical payload, different `browserGUID`/`pusherSocketID` per HTTP send. The first write succeeds server-side; the second hits Auth's existing-transaction guard.

Adds `resolveTransactionCreationDuplicate` to `RequestConflictUtils` and wires it into both `API.write` call sites in `actions/IOU/TrackExpense.ts` (`WRITE_COMMANDS.TRACK_EXPENSE` and `WRITE_COMMANDS.REQUEST_MONEY`). When a queued request already carries the same `transactionID` for either command, the new enqueue resolves to `noAction` so it never persists or fires. The first persisted request keeps its optimistic data and continues through the queue's normal retry path.

`ConflictAction = 'noAction'` short-circuits `shouldApplyOptimisticData` in `prepareRequest`, so the duplicate's optimistic data isn't reapplied (the first request already applied it).

Paired with:
- Auth: https://github.com/Expensify/Auth/pull/22270 — server returns `400 Idempotent Retry` for any duplicates that slip through (cross-tab races where each tab persists before either flushes)
- Web-Expensify: https://github.com/Expensify/Web-Expensify/pull/53735 — recognizes the new error code

### Fixed Issues
\$ 
PROPOSAL:

### Tests

1. Open the app, navigate to a chat / Self-DM.
2. Submit a Track Expense (or Money Request) with a receipt.
3. Throttle the network (Chrome DevTools "Slow 3G" or similar) and tap the submit button repeatedly before the first request completes.
4. Verify in the network panel that only one `TrackExpense` (or `CreateMoneyRequest`) request is fired.
5. Verify the expense appears in the chat as expected, with no error toast.
6. Verify no errors appear in the JS console.
7. With the network restored, repeat with normal connectivity to confirm the single-tap case is unaffected — exactly one request fires.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Submit a Track Expense.
3. Tap submit again (or trigger a duplicate dispatch via Quick Action retry, etc.) before reconnecting.
4. Reconnect.
5. Verify only one `TrackExpense` request fires on flush.
6. Verify the expense is created exactly once on the server side and reflected once in the chat.

### QA Steps

Same as Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios — N/A (no new user-visible failure modes; mismatched-payload duplicates still surface via Auth's legacy unique-constraint error → existing `ALREADY_CREATED` recovery)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior
    - [ ] I tested this PR with a High Traffic account against the staging or production API
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors
- [x] I followed proper code patterns
    - [x] I verified that any callback methods that were added or modified are named for what the method does
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why"
    - [x] I verified any copy / text shown in the product is localized — N/A, no UI strings added
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods — N/A
    - [x] I verified any copy / text that was added to the app is grammatically correct in English — N/A
    - [x] I verified proper file naming conventions were followed for any new files or renamed files
    - [x] I verified the JSDocs style guidelines were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers — N/A, this reuses the existing `checkAndFixConflictingRequest` pattern already used by `OpenReport`, `DetachReceipt`, etc.
- [x] I followed the guidelines as stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY
- [x] I verified any variables that can be defined as constants are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that — N/A, no new files
- [x] If a new CSS style is added I verified that — N/A
- [x] If new assets were added or existing ones were modified — N/A
- [x] If the PR modifies code that runs when editing or sending messages — N/A
- [x] If the PR modifies a generic component — N/A
- [x] If the PR modifies a component related to any of the existing Storybook stories — N/A
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink — N/A
- [x] If the PR modifies the UI — N/A, no UI changes
- [x] If a new page is added — N/A
- [x] I added unit tests for any new feature or bug fix in this PR — `tests/unit/RequestConflictUtilsTest.ts` has 5 new cases covering: undefined id, no-match, queued TrackExpense match, queued RequestMoney match, unrelated command. `npx jest tests/unit/RequestConflictUtilsTest.ts` → 60/60 passing.
- [x] If the `main` branch was merged into this PR after a review — N/A, fresh branch

### Screenshots/Videos

Pure network-layer change with no UI surface. Verification is via the Chrome DevTools Network panel (single `TrackExpense` request fires on rapid resubmit) rather than visual diff. Cross-platform screenshots are not meaningful for this PR.