### PR TITLE
fix: iOS view of empty agent's empty state is broken

### DIFF
--- a/src/pages/settings/Agents/AgentsPage.tsx
+++ b/src/pages/settings/Agents/AgentsPage.tsx
@@ -159,7 +159,7 @@ function AgentsPage() {
                         headerMedia={illustrations.TvScreenRobot}
                         title={translate('agentsPage.emptyAgents.title')}
                         subtitleText={
-                            <View style={[styles.renderHTML, styles.agentsPageEmptyStateSubtitle]}>
+                            <View style={[styles.renderHTML, styles.textAlignCenter, styles.alignItemsCenter]}>
                                 <RenderHTML html={translate('agentsPage.emptyAgents.subtitle')} />
                             </View>
                         }

--- a/src/pages/settings/Agents/AgentsPage.tsx
+++ b/src/pages/settings/Agents/AgentsPage.tsx
@@ -16,6 +16,7 @@ import usePermissions from '@hooks/usePermissions';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSwitchToDelegator from '@hooks/useSwitchToDelegator';
 import useThemeStyles from '@hooks/useThemeStyles';
+import getPlatform from '@libs/getPlatform';
 import Navigation from '@libs/Navigation/Navigation';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import {clearAgentDeleteError, clearAgentError, clearAgentUpdateError, openAgentsPage} from '@userActions/Agent';
@@ -44,6 +45,7 @@ function AgentsPage() {
     const switchToDelegator = useSwitchToDelegator();
     const {isBetaEnabled} = usePermissions();
     const isCustomAgentEnabled = isBetaEnabled(CONST.BETAS.CUSTOM_AGENT);
+    const isWebDesktop = getPlatform(true) === CONST.PLATFORM.WEB;
     useDocumentTitle(translate('agentsPage.title'));
 
     const [agentPrompts] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT);
@@ -159,7 +161,7 @@ function AgentsPage() {
                         headerMedia={illustrations.TvScreenRobot}
                         title={translate('agentsPage.emptyAgents.title')}
                         subtitleText={
-                            <View style={[styles.renderHTML, styles.textAlignCenter, styles.alignItemsCenter]}>
+                            <View style={[styles.renderHTML, styles.textAlignCenter, styles.alignItemsCenter, isWebDesktop && styles.agentsPageForWebEmptyStateSubtitle]}>
                                 <RenderHTML html={translate('agentsPage.emptyAgents.subtitle')} />
                             </View>
                         }

--- a/src/pages/settings/Agents/AgentsPage.tsx
+++ b/src/pages/settings/Agents/AgentsPage.tsx
@@ -16,7 +16,6 @@ import usePermissions from '@hooks/usePermissions';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSwitchToDelegator from '@hooks/useSwitchToDelegator';
 import useThemeStyles from '@hooks/useThemeStyles';
-import getPlatform from '@libs/getPlatform';
 import Navigation from '@libs/Navigation/Navigation';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import {clearAgentDeleteError, clearAgentError, clearAgentUpdateError, openAgentsPage} from '@userActions/Agent';
@@ -45,7 +44,6 @@ function AgentsPage() {
     const switchToDelegator = useSwitchToDelegator();
     const {isBetaEnabled} = usePermissions();
     const isCustomAgentEnabled = isBetaEnabled(CONST.BETAS.CUSTOM_AGENT);
-    const isWebDesktop = getPlatform(true) === CONST.PLATFORM.WEB;
     useDocumentTitle(translate('agentsPage.title'));
 
     const [agentPrompts] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT);
@@ -161,7 +159,7 @@ function AgentsPage() {
                         headerMedia={illustrations.TvScreenRobot}
                         title={translate('agentsPage.emptyAgents.title')}
                         subtitleText={
-                            <View style={[styles.renderHTML, styles.textAlignCenter, styles.alignItemsCenter, isWebDesktop && styles.agentsPageForWebEmptyStateSubtitle]}>
+                            <View style={[styles.renderHTML, styles.textAlignCenter, styles.alignItemsCenter, !shouldUseNarrowLayout && styles.agentsPageEmptyStateSubtitle]}>
                                 <RenderHTML html={translate('agentsPage.emptyAgents.subtitle')} />
                             </View>
                         }

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -5595,11 +5595,6 @@ const staticStyles = (theme: ThemeColors) =>
             width: '100%',
         },
 
-        agentsPageEmptyStateSubtitle: {
-            maxWidth: 335,
-            alignSelf: 'center',
-        },
-
         emptyStateFolderWithPaperIconSize: {
             width: 160,
             height: 100,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -5595,7 +5595,7 @@ const staticStyles = (theme: ThemeColors) =>
             width: '100%',
         },
 
-        agentsPageForWebEmptyStateSubtitle: {
+        agentsPageEmptyStateSubtitle: {
             alignSelf: 'center',
             maxWidth: 335,
         },

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -5595,6 +5595,11 @@ const staticStyles = (theme: ThemeColors) =>
             width: '100%',
         },
 
+        agentsPageForWebEmptyStateSubtitle: {
+            alignSelf: 'center',
+            maxWidth: 355,
+        },
+
         emptyStateFolderWithPaperIconSize: {
             width: 160,
             height: 100,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -5597,7 +5597,7 @@ const staticStyles = (theme: ThemeColors) =>
 
         agentsPageForWebEmptyStateSubtitle: {
             alignSelf: 'center',
-            maxWidth: 355,
+            maxWidth: 335,
         },
 
         emptyStateFolderWithPaperIconSize: {


### PR DESCRIPTION
### Explanation of Change
Fixes the empty state of agents in iOS

### Fixed Issues
$ https://github.com/Expensify/App/issues/93630
PROPOSAL: https://github.com/Expensify/App/issues/93630

### Tests
1. Launch Expensify app.
2. Go to Account > Agents.
3. Empty state should be fully visible

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="346" height="707" alt="image" src="https://github.com/user-attachments/assets/a38d5abb-1962-4415-af89-b8a287276c77" />

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="340" height="715" alt="image" src="https://github.com/user-attachments/assets/8b232988-4030-47b6-9cc5-ba76a739337f" />

</details>

<details>
<summary>iOS: Native</summary>

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/5cdb0d31-3b5c-4fe2-977f-d3cfdaa88213" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/f67b8873-0e93-467b-987b-a0ae8e4754c2" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1512" height="825" alt="image" src="https://github.com/user-attachments/assets/9f8f5464-8b0a-485a-8eda-b63024470476" />

</details>
