### PR TITLE
Show agent's own avatar on thinking indicator, not the report sender

### DIFF
--- a/src/pages/home/report/ConciergeThinkingMessage.tsx
+++ b/src/pages/home/report/ConciergeThinkingMessage.tsx
@@ -51,7 +51,6 @@ function ConciergeThinkingMessage({report}: ConciergeThinkingMessageProps) {
             {candidateAgentIDs.map((agentAccountID) => (
                 <ConciergeThinkingBubble
                     key={agentAccountID}
-                    report={report}
                     reportID={reportID}
                     agentAccountID={agentAccountID}
                 />
@@ -60,7 +59,7 @@ function ConciergeThinkingMessage({report}: ConciergeThinkingMessageProps) {
     );
 }
 
-function ConciergeThinkingBubble({report, reportID, agentAccountID}: {report: OnyxEntry<Report>; reportID: string; agentAccountID: number}) {
+function ConciergeThinkingBubble({reportID, agentAccountID}: {reportID: string; agentAccountID: number}) {
     const {isProcessing, reasoningHistory, statusLabel} = useAgentZeroStatusIndicator(reportID, agentAccountID);
 
     if (!isProcessing) {
@@ -69,7 +68,6 @@ function ConciergeThinkingBubble({report, reportID, agentAccountID}: {report: On
 
     return (
         <ConciergeThinkingMessageContent
-            report={report}
             accountID={agentAccountID}
             reasoningHistory={reasoningHistory}
             statusLabel={statusLabel}
@@ -77,17 +75,7 @@ function ConciergeThinkingBubble({report, reportID, agentAccountID}: {report: On
     );
 }
 
-function ConciergeThinkingMessageContent({
-    report,
-    accountID,
-    reasoningHistory,
-    statusLabel,
-}: {
-    report: OnyxEntry<Report>;
-    accountID: number;
-    reasoningHistory: ReasoningEntry[];
-    statusLabel: string;
-}) {
+function ConciergeThinkingMessageContent({accountID, reasoningHistory, statusLabel}: {accountID: number; reasoningHistory: ReasoningEntry[]; statusLabel: string}) {
     const styles = useThemeStyles();
     const theme = useTheme();
     const StyleUtils = useStyleUtils();
@@ -177,8 +165,6 @@ function ConciergeThinkingMessageContent({
                             StyleUtils.getBackgroundAndBorderStyle(theme.appBG),
                             isHovered ? StyleUtils.getBackgroundAndBorderStyle(theme.hoverComponentBG) : undefined,
                         ]}
-                        reportID={report?.reportID}
-                        chatReportID={report?.chatReportID ?? report?.reportID}
                         accountIDs={[accountID]}
                     />
                 </OfflineWithFeedback>

--- a/tests/unit/ConciergeThinkingMessageAvatarTest.tsx
+++ b/tests/unit/ConciergeThinkingMessageAvatarTest.tsx
@@ -117,4 +117,11 @@ describe('ConciergeThinkingMessage avatar prop integration', () => {
 
         expect(mockCapturedAvatarProps.policyID).toBeUndefined();
     });
+
+    test('should not pass reportID/chatReportID to ReportActionAvatars (report context would override the agent avatar with the report-preview sender)', () => {
+        render(<ConciergeThinkingMessage report={mockAdminRoom} />);
+
+        expect(mockCapturedAvatarProps.reportID).toBeUndefined();
+        expect(mockCapturedAvatarProps.chatReportID).toBeUndefined();
+    });
 });


### PR DESCRIPTION
@JS00001 please review

### Explanation of Change

When an agent's "Thinking..." indicator shows on an expense report, the bubble was rendering the avatar of the person being talked to (the expense submitter) instead of the agent's own avatar — even though the name above it was correct.

`ReportActionAvatars` was being passed both the agent's `accountID` and the report's `reportID`. On an expense report, the report context makes it derive the report-preview sender (the submitter) and fall into the subscript branch, which silently ignores the passed `accountIDs`. The bubble only needs to show one account's avatar and doesn't use profile navigation, so dropping `reportID`/`chatReportID` makes it render the agent's avatar in every context.

Reported by Shawn here: https://expensify.slack.com/archives/C090U774ZH7/p1781552589829179

### Fixed Issues

$
PROPOSAL:

For https://github.com/Expensify/Expensify/issues/643050

### Tests

1. On a workspace with a custom agent added as an admin (with its own bot avatar), edit an expense so the agent gets triggered.
2. While the agent is working, verify the "Thinking..." bubble shows the **agent's** avatar (its bot avatar), not your own photo.
3. With two agents on the workspace, verify each bubble shows its respective agent's avatar.
4. In a Concierge DM and a workspace #admins room, verify the thinking bubble still shows the correct (Concierge / agent) avatar.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable — this is a display-only change to which avatar is rendered.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

<img width="714" height="419" alt="Screenshot 2026-06-15 at 8 36 30 PM" src="https://github.com/user-attachments/assets/5e34e6e6-f4b2-4cb4-baf9-6b96ff0946d3" />

<img width="542" height="466" alt="Screenshot 2026-06-15 at 8 39 40 PM" src="https://github.com/user-attachments/assets/91afe8c3-93c0-4557-aca5-3b8ad2dff576" />
