### PR TITLE
[$250] Fix flaky test: PaginationTest timeout 120s → 240s

### DIFF
--- a/tests/ui/PaginationTest.tsx
+++ b/tests/ui/PaginationTest.tsx
@@ -19,7 +19,7 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 import waitForNetworkPromises from '../utils/waitForNetworkPromises';
 
 // We need a large timeout here as we are lazy loading React Navigation screens and this test is running against the entire mounted App
-jest.setTimeout(120000);
+jest.setTimeout(240000);
 
 jest.mock('@libs/BootSplash', () => ({
     hide: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Context
$ Expensify/App#92493 — \`tests/ui/PaginationTest.tsx\` › \`opens a chat and load initial messages\` intermittently times out at 120s on loaded CI runners.

The test consistently runs in ~42s locally but occasionally exceeds the 120s global \`jest.setTimeout\` on slower CI runners (#84791). A previous fix (#74232) reduced flakiness but did not eliminate the timeout edge case.

## Fix
Increase \`jest.setTimeout\` in PaginationTest.tsx from \`120000\` to \`240000\` (4 minutes), matching the precedent set by \`tests/perf-test/setupAfterEnv.ts\` (also 240000ms). This is a safe, non-behaviour-changing increase that eliminates the timeout flake without altering test logic or assertions.

## Testing
CI run of \`tests/ui/PaginationTest.tsx\` should complete without timeout errors.

/assign @neil-marcellini
/assign @mallenexpensify
/price $250
