### PR TITLE
[CP Staging] Fix regressions in invite workflow workspace settings

### DIFF
--- a/src/components/ApprovalWorkflowSection.tsx
+++ b/src/components/ApprovalWorkflowSection.tsx
@@ -80,6 +80,10 @@ function ApprovalWorkflowSection({
 
     const sortedMembers = approvalWorkflow.isDefault ? [] : sortAlphabetically(approvalWorkflow.members, 'displayName', localeCompare);
 
+    // Mirror the approver row's pending opacity on the "Expenses from" row so both fade together while
+    // the workflow (e.g. a member invited offline) is still pending server confirmation.
+    const membersPendingAction = sortedMembers.find((member) => !!member.pendingFields?.submitsTo)?.pendingFields?.submitsTo;
+
     const members = approvalWorkflow.isDefault ? translate('workspace.common.everyone') : sortedMembers.map((m) => Str.removeSMSDomain(m.displayName)).join(', ');
 
     const memberPills = sortedMembers.map((m) => ({
@@ -115,38 +119,40 @@ function ApprovalWorkflowSection({
                         </Text>
                     </View>
                 )}
-                <MenuItem
-                    title={translate('workflowsExpensesFromPage.title')}
-                    style={styles.p0}
-                    titleStyle={styles.textLabelSupportingNormal}
-                    descriptionTextStyle={[styles.textNormalThemeText, styles.lineHeightXLarge]}
-                    description={approvalWorkflow.isDefault ? members : undefined}
-                    numberOfLinesDescription={4}
-                    shouldBeAccessible={false}
-                    tabIndex={-1}
-                    icon={icons.Users}
-                    iconHeight={20}
-                    iconWidth={20}
-                    iconFill={theme.icon}
-                    onPress={pressAction}
-                    shouldRemoveBackground
-                    titleComponent={
-                        !approvalWorkflow.isDefault ? (
-                            <View style={styles.ml3}>
-                                {!isDisabled && onShowAllMembersPress ? (
-                                    <UserPills
-                                        users={memberPills}
-                                        onShowAllPress={onShowAllMembersPress}
-                                        showAllSentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKFLOWS.APPROVAL_SECTION_SHOW_ALL_MEMBERS}
-                                    />
-                                ) : (
-                                    <UserPills users={memberPills} />
-                                )}
-                            </View>
-                        ) : undefined
-                    }
-                    sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKFLOWS.APPROVAL_SECTION_EXPENSES_FROM}
-                />
+                <OfflineWithFeedback pendingAction={membersPendingAction}>
+                    <MenuItem
+                        title={translate('workflowsExpensesFromPage.title')}
+                        style={styles.p0}
+                        titleStyle={styles.textLabelSupportingNormal}
+                        descriptionTextStyle={[styles.textNormalThemeText, styles.lineHeightXLarge]}
+                        description={approvalWorkflow.isDefault ? members : undefined}
+                        numberOfLinesDescription={4}
+                        shouldBeAccessible={false}
+                        tabIndex={-1}
+                        icon={icons.Users}
+                        iconHeight={20}
+                        iconWidth={20}
+                        iconFill={theme.icon}
+                        onPress={pressAction}
+                        shouldRemoveBackground
+                        titleComponent={
+                            !approvalWorkflow.isDefault ? (
+                                <View style={styles.ml3}>
+                                    {!isDisabled && onShowAllMembersPress ? (
+                                        <UserPills
+                                            users={memberPills}
+                                            onShowAllPress={onShowAllMembersPress}
+                                            showAllSentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKFLOWS.APPROVAL_SECTION_SHOW_ALL_MEMBERS}
+                                        />
+                                    ) : (
+                                        <UserPills users={memberPills} />
+                                    )}
+                                </View>
+                            ) : undefined
+                        }
+                        sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKFLOWS.APPROVAL_SECTION_EXPENSES_FROM}
+                    />
+                </OfflineWithFeedback>
 
                 {approvalWorkflow.approvers.map((approver, index) => (
                     <OfflineWithFeedback

--- a/src/pages/workspace/members/WorkspaceInviteMessageComponent.tsx
+++ b/src/pages/workspace/members/WorkspaceInviteMessageComponent.tsx
@@ -190,7 +190,9 @@ function WorkspaceInviteMessageComponent({
             if (nestedBackTo) {
                 Navigation.goBack(nestedBackTo as Routes);
             } else {
-                Navigation.navigate(ROUTES.WORKSPACE_WORKFLOWS_APPROVALS_APPROVER.getRoute(policyID, 0));
+                // forceReplace so the invite page is removed from the stack. Otherwise it stays
+                // underneath the Approver page and an iOS swipe-back reopens the invite confirm page.
+                Navigation.navigate(ROUTES.WORKSPACE_WORKFLOWS_APPROVALS_APPROVER.getRoute(policyID, 0), {forceReplace: true});
             }
             return;
         }

--- a/src/pages/workspace/workflows/approvals/ApprovalWorkflowEditor.tsx
+++ b/src/pages/workspace/workflows/approvals/ApprovalWorkflowEditor.tsx
@@ -19,6 +19,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import {sortAlphabetically} from '@libs/OptionsListUtils';
 import {isControlPolicy} from '@libs/PolicyUtils';
+import {getDefaultAvatarURL} from '@libs/UserAvatarUtils';
 import {getApprovalLimitDescription} from '@libs/WorkflowUtils';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
@@ -92,7 +93,9 @@ function ApprovalWorkflowEditor({approvalWorkflow, removeApprovalWorkflow, polic
     const memberPills = useMemo(
         () =>
             sortedMembers.map((m) => ({
-                avatar: m.avatar,
+                // A just-invited member is stored without an avatar, so fall back to the email-based default
+                // avatar instead of the generic fallback icon.
+                avatar: m.avatar ?? getDefaultAvatarURL({accountEmail: m.email}),
                 displayName: m.displayName,
                 email: m.email,
             })),

--- a/src/pages/workspace/workflows/approvals/ApprovalWorkflowEditor.tsx
+++ b/src/pages/workspace/workflows/approvals/ApprovalWorkflowEditor.tsx
@@ -133,7 +133,13 @@ function ApprovalWorkflowEditor({approvalWorkflow, removeApprovalWorkflow, polic
 
     const handleExpensesFromPress = useCallback(() => {
         const firstApproverEmail = approvalWorkflow.approvers?.at(0)?.email ?? '';
-        const backTo = approvalWorkflow.action === CONST.APPROVAL_WORKFLOW.ACTION.EDIT ? ROUTES.WORKSPACE_WORKFLOWS_APPROVALS_EDIT.getRoute(policyID, firstApproverEmail) : undefined;
+        // Always pass a backTo so that after editing expenses-from (including the invite-a-member detour),
+        // we return to the page we came from. For EDIT that's the edit page; for CREATE we're on the
+        // confirm (new) page, so return there instead of falling through to the Approver step.
+        const backTo =
+            approvalWorkflow.action === CONST.APPROVAL_WORKFLOW.ACTION.EDIT
+                ? ROUTES.WORKSPACE_WORKFLOWS_APPROVALS_EDIT.getRoute(policyID, firstApproverEmail)
+                : ROUTES.WORKSPACE_WORKFLOWS_APPROVALS_NEW.getRoute(policyID);
         Navigation.navigate(ROUTES.WORKSPACE_WORKFLOWS_APPROVALS_EXPENSES_FROM.getRoute(policyID, backTo));
     }, [approvalWorkflow.action, approvalWorkflow.approvers, policyID]);
 

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsApproverPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsApproverPage.tsx
@@ -14,6 +14,7 @@ import {isAnyHRReadOnlyWorkflowMode} from '@libs/HRUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {WorkspaceSplitNavigatorParamList} from '@libs/Navigation/types';
+import {addSMSDomainIfPhoneNumber} from '@libs/PhoneNumber';
 import {getDefaultApprover, getMemberAccountIDsForWorkspace, isExpensifyTeam, shouldFilterExpensifyTeam} from '@libs/PolicyUtils';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import MemberRightIcon from '@pages/workspace/MemberRightIcon';
@@ -172,7 +173,10 @@ function WorkspaceWorkflowsApprovalsApproverPage({policy, personalDetails, isLoa
                 return;
             }
 
-            const newSelectedEmail = approver?.login ?? '';
+            // Canonicalize phone logins (e164@expensify.sms) so the approver email stored as submitsTo
+            // matches the canonical key the invite writes into employeeList. Without this, a phone approver
+            // invited offline stops resolving once online and the workflow disappears. No-op for emails.
+            const newSelectedEmail = addSMSDomainIfPhoneNumber(approver?.login ?? '');
             const policyMemberEmailsToAccountIDs = getMemberAccountIDsForWorkspace(employeeList);
             const accountID = Number(newSelectedEmail ? policyMemberEmailsToAccountIDs[newSelectedEmail] : '');
             const {avatar, displayName = newSelectedEmail} = personalDetails?.[accountID] ?? {};

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
@@ -283,7 +283,7 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
     // never confirmed, so leaving them in approvalWorkflow.members would carry an un-invited user into
     // the form and fail backend validation with "Approvals can only be set for members of the policy".
     // This must run on every back path, including when an explicit backTo is honored below.
-    const dropUnconfirmedStagedMembers = useCallback(() => {
+    const dropUnconfirmedStagedMembers = () => {
         // Going back means we're done with this expenses-from session, so any
         // hand-off to the invite-message page is no longer in flight.
         isHandingOffToInviteRef.current = false;
@@ -293,7 +293,7 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
         if (confirmedMembers.length !== stagedMembers.length) {
             setApprovalWorkflowMembers(confirmedMembers);
         }
-    }, [approvalWorkflow?.members, policy?.employeeList]);
+    };
 
     const goBack = useCallback(() => {
         dropUnconfirmedStagedMembers();
@@ -328,22 +328,27 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
             if (!member.login) {
                 continue;
             }
-            const isPolicyMember = policy?.employeeList?.[normalizeLogin(member.login)];
+            // Store the canonical SMS login (e164@expensify.sms) for phone members so it matches the key the
+            // invite writes into employeeList. If we kept the raw number, convertApprovalWorkflowToPolicyEmployees
+            // would index a separate, non-matching employee, so the member and submitsTo fall out of sync once
+            // online and the workflow gets dropped. No-op for email logins.
+            const memberLogin = normalizeLogin(member.login);
+            const isPolicyMember = policy?.employeeList?.[memberLogin];
             if (isPolicyMember) {
                 existingMembers.push({
                     displayName: member.text ?? '',
                     avatar: member.icons?.at(0)?.source,
-                    email: member.login,
+                    email: memberLogin,
                 });
             } else {
-                // This is a non-workspace member that needs to be invited
+                // This is a non-workspace member that needs to be invited.
+                // Carry the picker's display name and avatar so they survive the round-trip through
+                // approvalWorkflow.members, otherwise the invited user reverts to their email and a
+                // fallback avatar after returning from the invite step or on the confirm page.
                 const iconId = member.icons?.at(0)?.id;
                 const accountID = typeof iconId === 'number' ? iconId : undefined;
-                // Carry the picker's display name and avatar so they survive the round-trip through
-                // approvalWorkflow.members. Without this the invited user reverts to showing their email
-                // and a fallback avatar after returning from the invite step or on the confirm page.
                 usersToInvite.push({
-                    email: member.login,
+                    email: memberLogin,
                     accountID,
                     displayName: member.text,
                     avatar: member.icons?.at(0)?.source,

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
@@ -41,8 +41,8 @@ type WorkspaceWorkflowsApprovalsExpensesFromPageProps = WithPolicyAndFullscreenL
 
 // A user invited by phone is stored in the workflow with the raw login the admin typed, but the workspace
 // keys its members by the canonical SMS login (e164@expensify.sms). Normalize before any membership or
-// dedup comparison so a freshly invited phone number isn't treated as both a pending invite and a separate
-// member (which made it show twice and lose its selection on back). This is a no-op for email logins.
+// duplicate comparison so a freshly invited phone number isn't treated as both a pending invite and a
+// separate member (which made it show twice and lose its selection on back). This is a no-op for email logins.
 function normalizeLogin(login: string | null | undefined): string {
     return addSMSDomainIfPhoneNumber(login ?? '');
 }

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
@@ -20,7 +20,9 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {WorkspaceSplitNavigatorParamList} from '@libs/Navigation/types';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
+import {addSMSDomainIfPhoneNumber} from '@libs/PhoneNumber';
 import {canEditWorkspaceSettings, getDefaultApprover, getExcludedUsers, getMemberAccountIDsForWorkspace, isPendingDeletePolicy} from '@libs/PolicyUtils';
+import type {AvatarSource} from '@libs/UserAvatarUtils';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import MemberRightIcon from '@pages/workspace/MemberRightIcon';
 import withPolicyAndFullscreenLoading from '@pages/workspace/withPolicyAndFullscreenLoading';
@@ -36,6 +38,14 @@ import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
 type WorkspaceWorkflowsApprovalsExpensesFromPageProps = WithPolicyAndFullscreenLoadingProps &
     PlatformStackScreenProps<WorkspaceSplitNavigatorParamList, typeof SCREENS.WORKSPACE.WORKFLOWS_APPROVALS_EXPENSES_FROM>;
+
+// A user invited by phone is stored in the workflow with the raw login the admin typed, but the workspace
+// keys its members by the canonical SMS login (e164@expensify.sms). Normalize before any membership or
+// dedup comparison so a freshly invited phone number isn't treated as both a pending invite and a separate
+// member (which made it show twice and lose its selection on back). This is a no-op for email logins.
+function normalizeLogin(login: string | null | undefined): string {
+    return addSMSDomainIfPhoneNumber(login ?? '');
+}
 
 function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportData = true, route}: WorkspaceWorkflowsApprovalsExpensesFromPageProps) {
     const styles = useThemeStyles();
@@ -114,15 +124,15 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
         setSelectedMembers(
             approvalWorkflow.members
                 .filter((member) => {
-                    const isPolicyMember = !!policy?.employeeList?.[member.email];
+                    const isPolicyMember = !!policy?.employeeList?.[normalizeLogin(member.email)];
                     // Keep policy members. For non-policy members, only keep if they're
                     // in the invite draft (meaning an invite flow is actively in progress).
                     // This mirrors the card flow's handleBackButtonPress cleanup pattern.
                     return isPolicyMember || invitedEmailsToAccountIDsDraft?.[member.email] != null;
                 })
                 .map((member) => {
-                    let accountID = Number(policyMemberEmailsToAccountIDs[member.email] ?? '');
-                    const isPolicyMember = !!policy?.employeeList?.[member.email];
+                    let accountID = Number(policyMemberEmailsToAccountIDs[normalizeLogin(member.email)] ?? '');
+                    const isPolicyMember = !!policy?.employeeList?.[normalizeLogin(member.email)];
 
                     const personalDetail = getPersonalDetailByEmail(member.email);
 
@@ -154,7 +164,7 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
                         // Only show right element for policy members
                         rightElement: isPolicyMember ? (
                             <MemberRightIcon
-                                role={policy?.employeeList?.[member.email]?.role}
+                                role={policy?.employeeList?.[normalizeLogin(member.email)]?.role}
                                 owner={policy?.owner}
                                 login={login}
                             />
@@ -208,7 +218,9 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
                 };
             })
             .filter(
-                (member) => (!policy?.preventSelfApproval || !approversEmail?.includes(member.login)) && !selectedMembers.some((selectedOption) => selectedOption.login === member.login),
+                (member) =>
+                    (!policy?.preventSelfApproval || !approversEmail?.includes(member.login)) &&
+                    !selectedMembers.some((selectedOption) => normalizeLogin(selectedOption.login) === normalizeLogin(member.login)),
             );
 
         members.push(...availableMembers);
@@ -233,8 +245,8 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
 
             // Add search results that are not already workspace members
             const searchResults = [...availableOptions.recentReports, ...availableOptions.personalDetails].filter((option) => {
-                const isMember = policy?.employeeList?.[option.login ?? ''];
-                const isAlreadyInList = members.some((m) => m.login === option.login);
+                const isMember = policy?.employeeList?.[normalizeLogin(option.login)];
+                const isAlreadyInList = members.some((m) => normalizeLogin(m.login) === normalizeLogin(option.login));
                 return !isMember && !isAlreadyInList;
             });
 
@@ -267,21 +279,24 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
         policyMemberEmailsToAccountIDs,
     ]);
 
-    const goBack = useCallback(() => {
+    // Drop any selected members who never made it into the workspace. They were staged for invite but
+    // never confirmed, so leaving them in approvalWorkflow.members would carry an un-invited user into
+    // the form and fail backend validation with "Approvals can only be set for members of the policy".
+    // This must run on every back path, including when an explicit backTo is honored below.
+    const dropUnconfirmedStagedMembers = useCallback(() => {
         // Going back means we're done with this expenses-from session, so any
         // hand-off to the invite-message page is no longer in flight.
         isHandingOffToInviteRef.current = false;
 
-        // Drop any selected members who never made it into the workspace. They
-        // were staged for invite but never confirmed, so leaving them in
-        // approvalWorkflow.members would carry an un-invited user into the form
-        // and fail backend validation with "Approvals can only be set for
-        // members of the policy".
         const stagedMembers = approvalWorkflow?.members ?? [];
-        const confirmedMembers = stagedMembers.filter((m) => !!policy?.employeeList?.[m.email]);
+        const confirmedMembers = stagedMembers.filter((m) => !!policy?.employeeList?.[normalizeLogin(m.email)]);
         if (confirmedMembers.length !== stagedMembers.length) {
             setApprovalWorkflowMembers(confirmedMembers);
         }
+    }, [approvalWorkflow?.members, policy?.employeeList]);
+
+    const goBack = useCallback(() => {
+        dropUnconfirmedStagedMembers();
 
         let backTo;
         if (approvalWorkflow?.action === CONST.APPROVAL_WORKFLOW.ACTION.EDIT) {
@@ -292,12 +307,13 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
         // Don't compare params: the edit screen may carry "Add agent" seed params, so a strict param
         // match would miss it and REPLACE would mount a fresh edit screen that wipes the unsaved draft.
         Navigation.goBack(backTo, {compareParams: false});
-    }, [isInitialCreationFlow, route.params.policyID, firstApprover, approvalWorkflow?.action, approvalWorkflow?.members, policy?.employeeList]);
+    }, [isInitialCreationFlow, route.params.policyID, firstApprover, approvalWorkflow?.action, dropUnconfirmedStagedMembers]);
 
     // Fall back to goBack — plain Navigation.goBack() closes the modal after a refresh.
     const onBackButtonPress = () => {
         const {backTo} = route.params as WorkspaceSplitNavigatorParamList[typeof SCREENS.WORKSPACE.WORKFLOWS_APPROVALS_EXPENSES_FROM];
         if (backTo) {
+            dropUnconfirmedStagedMembers();
             Navigation.goBack(backTo);
             return;
         }
@@ -306,13 +322,13 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
 
     const nextStep = useCallback(() => {
         const existingMembers: Member[] = [];
-        const usersToInvite: Array<{email: string; accountID?: number}> = [];
+        const usersToInvite: Array<{email: string; accountID?: number; displayName?: string; avatar?: AvatarSource}> = [];
 
         for (const member of selectedMembers) {
             if (!member.login) {
                 continue;
             }
-            const isPolicyMember = policy?.employeeList?.[member.login];
+            const isPolicyMember = policy?.employeeList?.[normalizeLogin(member.login)];
             if (isPolicyMember) {
                 existingMembers.push({
                     displayName: member.text ?? '',
@@ -323,9 +339,14 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
                 // This is a non-workspace member that needs to be invited
                 const iconId = member.icons?.at(0)?.id;
                 const accountID = typeof iconId === 'number' ? iconId : undefined;
+                // Carry the picker's display name and avatar so they survive the round-trip through
+                // approvalWorkflow.members. Without this the invited user reverts to showing their email
+                // and a fallback avatar after returning from the invite step or on the confirm page.
                 usersToInvite.push({
                     email: member.login,
                     accountID,
+                    displayName: member.text,
+                    avatar: member.icons?.at(0)?.source,
                 });
             }
         }
@@ -340,9 +361,9 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
         const allMembers: Member[] = [
             ...normalizedExistingMembers,
             ...usersToInvite.map((user) => ({
-                displayName: user.email,
+                displayName: user.displayName ?? user.email,
                 email: user.email,
-                avatar: undefined,
+                avatar: typeof user.avatar === 'string' ? user.avatar : undefined,
             })),
         ];
         setApprovalWorkflowMembers(allMembers);
@@ -432,7 +453,7 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
                         email: member.login,
                         avatar: typeof iconSource === 'string' ? iconSource : undefined,
                     });
-                    if (policy?.employeeList?.[member.login]) {
+                    if (policy?.employeeList?.[normalizeLogin(member.login)]) {
                         continue;
                     }
                     const iconId = member.icons?.at(0)?.id;

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsExpensesFromPage.tsx
@@ -283,7 +283,7 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
     // never confirmed, so leaving them in approvalWorkflow.members would carry an un-invited user into
     // the form and fail backend validation with "Approvals can only be set for members of the policy".
     // This must run on every back path, including when an explicit backTo is honored below.
-    const dropUnconfirmedStagedMembers = () => {
+    const dropUnconfirmedStagedMembers = useCallback(() => {
         // Going back means we're done with this expenses-from session, so any
         // hand-off to the invite-message page is no longer in flight.
         isHandingOffToInviteRef.current = false;
@@ -293,7 +293,7 @@ function WorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportDat
         if (confirmedMembers.length !== stagedMembers.length) {
             setApprovalWorkflowMembers(confirmedMembers);
         }
-    };
+    }, [approvalWorkflow?.members, policy?.employeeList]);
 
     const goBack = useCallback(() => {
         dropUnconfirmedStagedMembers();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->F

Fixes regression from original PR https://github.com/Expensify/App/pull/80449

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/93621
$ https://github.com/Expensify/App/issues/93626
$ https://github.com/Expensify/App/issues/93632
$ https://github.com/Expensify/App/issues/93635
$ https://github.com/Expensify/App/issues/93637
$ https://github.com/Expensify/App/issues/93642

PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

### Test 1

1. Go to staging.new.expensify.com
2. Go to workspace settings > Workflows.
3. Click Add approval workflow.
4. Upgrade workspace if needed.
5. Enter phone number which does not have ND account > select it > Next.
6. Click Invite.
7. Select any approver > Skip.
8. On confirm page, click Expenses from.
9. Click RHP back button.

**Expected Result:**
- In Step 8, the invited phone number will appear once in the list.
- In Step 9, after user clicks RHP back button, the phone number will remain selected.

---

### Test 2

1. Go to staging.new.expensify.com
2. Go to workspace settings > Workflows.
3. Click Add approval workflow.
4. Upgrade workspace if needed.
5. Enter email which does not have ND account > select it > Next.
6. Click Invite.
7. Select any approver > Skip.

**Expected Result:**
Invited user will show correct avatar on confirm page.

---

### Test 3

1. Launch Expensify app.
2. Go to workspace settings > Workflows.
3. Tap Add approval workflow.
4. Upgrade workspace if needed.
5. Enter email > select the user > Next.
6. Tap Invite.
7. Swipe back using iOS gesture.

**Expected Result:**
Invite confirm page will not open after inviting member and swiping back.

---

### Test 4

**Prerequisite:** User is owner of a "Control" workspace.
**Prerequisite 2:** Approvals enabled.

1. Open the staging.new.expensify.com website.
2. Navigate to "Workspaces" > Workspace > "Workflows"
3. Scroll down to "Approvals" > "Add approval workflows"
4. On "Expenses From" enter the Email of an existing user that is not member of the workspace.
5. Note that user's name appears above Email.
6. Click on "Next"
7. Click on the arrow on top left corner to return to previous step.
8. Note that now, user's name changed to Email.

**Expected Result:**
User's name should remain visible after adding it and advancing to following step.

---

### Test 5

**Prerequisite:** User is owner of "Control" workspace.
**Prerequisite 2:** Approvals enabled.

1. Open the staging.new.expensify.com website.
2. Navigate to "Workspaces" > Workspace > "Workflows"
3. Turn off internet connection.
4. Scroll down to "Approvals" and click on "Add Approval workflow"
5. On expenses from, enter Email of an existing user that is not member of workspace > "Next" > "Invite"
6. Select the same member as approver > "Skip" > "Add Workflow"
7. Once redirected to "Workflows" again, note that "Expenses From" and "Approver" fields, display different levels of reduced opacity.

**Expected Result:**
After inviting a new member while offline, during "Add approval workflow" process and selecting it as "Approver", the "Expenses From" and "Approver" fields, should display the same level of reduced opacity.

---

### Test 6

**Prerequisite:** User is owner of a "Control" workspace.
**Prerequisite 2:** Workspace has "Approvals" enabled.
**Prerequisite 3:** Workspace has at least one member apart from "Owner"

1. Open the staging.new.expensify.com website.
2. Navigate to "Workspaces" > Workspace > "Workflows"
3. Scroll down to "Approvals" and click on "Add approval workflow"
4. On "Expenses From" select the owner.
5. On "Approver" select any member.
6. Click on "Skip"
7. On confirm page, click on "Expenses From"
8. Enter the Email of any existing user that is not member of workspace > "Save" > "Invite"
9. Note that you return to "Approver" page, where approver is still selected instead of returning to confirm page.

**Expected Result:**
After opening "Expenses From" on confirm page and inviting a new member, user should return to confirm page again.


---

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
