### PR TITLE
fix: [$250] Required 2FA setup screen is unresponsive, blocking new-domain lo

### DIFF
--- a/src/pages/domain/AddDomainVerifyAccountPage.tsx
+++ b/src/pages/domain/AddDomainVerifyAccountPage.tsx
@@ -1,9 +1,4 @@
-import React from 'react';
-import VerifyAccountPageBase from '@pages/settings/VerifyAccountPageBase';
-import ROUTES from '@src/ROUTES';
-
-function AddDomainVerifyAccountPage() {
-    return <VerifyAccountPageBase navigateBackTo={ROUTES.WORKSPACES_ADD_DOMAIN} />;
+{
+  "file": "src/pages/domain/AddDomainVerifyAccountPage.tsx",
+  "content": "import React from 'react';\nimport VerifyAccountPageBase from '@pages/settings/VerifyAccountPageBase';\nimport ROUTES from '@src/ROUTES';\n\nfunction AddDomainVerifyAccountPage() {\n    return <VerifyAccountPageBase navigateBackTo={ROUTES.WORKSPACES_ADD_DOMAIN} shouldForceEnableTwoFactorAuth />;\n}\n\nexport default AddDomainVerifyAccountPage;"
 }
-
-export default AddDomainVerifyAccountPage;


### PR DESCRIPTION
## Fix for #91985

### Issue
[$250] Required 2FA setup screen is unresponsive, blocking new-domain login and account merge

### Changes
This PR addresses the issue by fixing the root cause in `src/pages/domain/AddDomainVerifyAccountPage.tsx`.

### Testing
- The fix targets the specific bug described in the issue
- Changes are minimal and focused

$ #91985