### PR TITLE
extract DeleteWorkspaceFlow component from WorkspacesListPage

### DIFF
--- a/src/components/Tables/WorkspaceListTable/WorkspaceTableRow.tsx
+++ b/src/components/Tables/WorkspaceListTable/WorkspaceTableRow.tsx
@@ -44,7 +44,6 @@ export default function WorkspaceRow({item, shouldUseNarrowTableLayout, rowIndex
     const formattedWorkspaceType = getUserFriendlyWorkspaceType(item.type, translate);
     const narrowWorkspaceLabel = `${translate('common.owner')}: ${formattedOwnerName} • ${formattedWorkspaceType}`;
     const itemDeletedStyles = item.isDeleted ? [styles.offlineFeedbackDeleted] : [{}];
-    const resetLoadingSpinnerIconIndex = item.resetLoadingSpinnerIconIndex;
 
     const accessibilityLabel = [
         `${translate('workspace.common.workspaceName')}: ${item.title}`,
@@ -117,13 +116,11 @@ export default function WorkspaceRow({item, shouldUseNarrowTableLayout, rowIndex
             return;
         }
 
-        resetLoadingSpinnerIconIndex?.();
-
         if (!threeDotsMenuRef.current?.isPopupMenuVisible) {
             return;
         }
         threeDotsMenuRef?.current?.hidePopoverMenu();
-    }, [isLoadingBill, resetLoadingSpinnerIconIndex]);
+    }, [isLoadingBill]);
 
     return (
         <Table.Row

--- a/src/components/Tables/WorkspaceListTable/index.tsx
+++ b/src/components/Tables/WorkspaceListTable/index.tsx
@@ -40,7 +40,6 @@ type WorkspaceRowData = TableData & {
     brickRoadIndicator?: ValueOf<typeof CONST.BRICK_ROAD_INDICATOR_STATUS>;
     action: (event?: ModifiedMouseEvent) => void;
     dismissError: () => void;
-    resetLoadingSpinnerIconIndex?: () => void;
 };
 
 type WorkspaceListTableProps = {

--- a/src/hooks/useOutstandingBalanceGuard.tsx
+++ b/src/hooks/useOutstandingBalanceGuard.tsx
@@ -12,11 +12,12 @@ import useOnyx from './useOnyx';
  * a modal is shown directing them to subscription settings to settle the balance.
  *
  * @param ownedPaidPoliciesCount - The number of paid policies the current user owns
+ * @param onModalDismissed - called when the modal is dismissed (either by settling the balance or cancelling)
  * @returns shouldBlockDeletion - function that checks and shows the modal if needed (returns true if blocked)
  * @returns wouldBlockDeletion - pre-computed boolean for popover/menu configuration
  * @returns outstandingBalanceModal - React element to render in the page
  */
-function useOutstandingBalanceGuard(ownedPaidPoliciesCount: number) {
+function useOutstandingBalanceGuard(ownedPaidPoliciesCount: number, onModalDismissed?: () => void) {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const {translate} = useLocalize();
     const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
@@ -39,14 +40,18 @@ function useOutstandingBalanceGuard(ownedPaidPoliciesCount: number) {
                 onConfirm={() => {
                     setIsModalOpen(false);
                     Navigation.navigate(ROUTES.SETTINGS_SUBSCRIPTION.route);
+                    onModalDismissed?.();
                 }}
-                onCancel={() => setIsModalOpen(false)}
+                onCancel={() => {
+                    setIsModalOpen(false);
+                    onModalDismissed?.();
+                }}
                 prompt={translate('workspace.common.outstandingBalanceWarning')}
                 confirmText={translate('workspace.common.settleBalance')}
                 cancelText={translate('common.cancel')}
             />
         ),
-        [isModalOpen, translate],
+        [isModalOpen, translate, onModalDismissed],
     );
 
     return {shouldBlockDeletion, wouldBlockDeletion, outstandingBalanceModal};

--- a/src/hooks/useTransactionViolationOfWorkspace.tsx
+++ b/src/hooks/useTransactionViolationOfWorkspace.tsx
@@ -9,8 +9,8 @@ import type {Report, TransactionViolations} from '@src/types/onyx';
 import useOnyx from './useOnyx';
 
 function useTransactionViolationOfWorkspace(policyID?: string) {
-    const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
-    const [transactionsByReportID] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION, {selector: transactionsByReportIDSelector});
+    const [allReports, reportsResult] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+    const [transactionsByReportID, transactionsResult] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION, {selector: transactionsByReportIDSelector});
     const reportsToArchive = Object.values(allReports ?? {}).filter(
         (report): report is Report => report != null && isPolicyRelatedReport(report, policyID) && (isChatRoom(report) || isPolicyExpenseChat(report) || isTaskReport(report)),
     );
@@ -49,7 +49,7 @@ function useTransactionViolationOfWorkspace(policyID?: string) {
         [transactionIDSet],
     );
 
-    const [transactionViolations] = useOnyx(
+    const [transactionViolations, transactionViolationsResult] = useOnyx(
         ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS,
         {
             selector: transactionViolationSelector,
@@ -60,6 +60,9 @@ function useTransactionViolationOfWorkspace(policyID?: string) {
     return {
         reportsToArchive,
         transactionViolations,
+        reportsResult,
+        transactionsResult,
+        transactionViolationsResult,
     };
 }
 

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -2291,6 +2291,23 @@ function removeWorkspace(policyID: string) {
     Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, null);
 }
 
+/**
+ * Dismisses the errors on a workspace based on its pending action
+ */
+function dismissWorkspaceError(policyID: string, pendingAction: PendingAction | undefined) {
+    if (pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+        clearDeleteWorkspaceError(policyID);
+        return;
+    }
+
+    if (pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD) {
+        removeWorkspace(policyID);
+        return;
+    }
+
+    clearErrors(policyID);
+}
+
 function setDuplicateWorkspaceData(data: Partial<DuplicateWorkspace>) {
     Onyx.merge(ONYXKEYS.DUPLICATE_WORKSPACE, {...data});
 }
@@ -7496,6 +7513,7 @@ export {
     updateAddress,
     updateLastAccessedWorkspace,
     clearDeleteWorkspaceError,
+    dismissWorkspaceError,
     setWorkspaceDefaultSpendCategory,
     getDisplayNameForWorkspace,
     generateDefaultWorkspaceName,

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -13,7 +13,6 @@ import type {WorkspaceRowData, WorkspaceTableColumnKey} from '@components/Tables
 import WorkspaceListTable from '@components/Tables/WorkspaceListTable';
 import WorkspaceListLayout from '@components/WorkspaceListLayout';
 import useAndroidBackButtonHandler from '@hooks/useAndroidBackButtonHandler';
-import useCardFeeds from '@hooks/useCardFeeds';
 import useConfirmModal from '@hooks/useConfirmModal';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDocumentTitle from '@hooks/useDocumentTitle';
@@ -21,23 +20,17 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import useOutstandingBalanceGuard from '@hooks/useOutstandingBalanceGuard';
-import usePayAndDowngrade from '@hooks/usePayAndDowngrade';
 import usePermissions from '@hooks/usePermissions';
 import usePoliciesWithCardFeedErrors from '@hooks/usePoliciesWithCardFeedErrors';
 import usePreferredPolicy from '@hooks/usePreferredPolicy';
-import usePrivateSubscription from '@hooks/usePrivateSubscription';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
-import useTransactionViolationOfWorkspace from '@hooks/useTransactionViolationOfWorkspace';
 import {isConnectionInProgress} from '@libs/actions/connections';
 import {close} from '@libs/actions/Modal';
 import {clearCopyPolicySettings} from '@libs/actions/Policy/CopyPolicySettings';
 import {clearWorkspaceOwnerChangeFlow, requestWorkspaceOwnerChange} from '@libs/actions/Policy/Member';
-import {calculateBillNewDot, clearDeleteWorkspaceError, clearDuplicateWorkspace, clearErrors, deleteWorkspace, leaveWorkspace, removeWorkspace} from '@libs/actions/Policy/Policy';
+import {clearDuplicateWorkspace, dismissWorkspaceError, leaveWorkspace} from '@libs/actions/Policy/Policy';
 import {callFunctionIfActionIsAllowed} from '@libs/actions/Session';
-import {filterInactiveCards} from '@libs/CardUtils';
-import {getLatestErrorMessage} from '@libs/ErrorUtils';
 import {isMergeHRCompleteSetupNeeded} from '@libs/HRUtils';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import openInternalRouteInNewTab from '@libs/Navigation/helpers/openInternalRouteInNewTab';
@@ -55,46 +48,24 @@ import {
     isPolicyAdmin,
     isPolicyApprover,
     isPolicyAuditor,
-    shouldBlockWorkspaceDeletionForInvoicifyUser,
     shouldShowEmployeeListError,
     shouldShowPolicy,
 } from '@libs/PolicyUtils';
 import {getDefaultWorkspaceAvatar} from '@libs/ReportUtils';
 import shouldRenderTransferOwnerButton from '@libs/shouldRenderTransferOwnerButton';
-import {isSubscriptionTypeOfInvoicing, shouldCalculateBillNewDot as shouldCalculateBillNewDotFn} from '@libs/SubscriptionUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {setNameValuePair} from '@userActions/User';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
-import {accountIDToLoginSelector} from '@src/selectors/PersonalDetails';
-import {ownerPoliciesSelector} from '@src/selectors/Policy';
-import {reimbursementAccountErrorSelector} from '@src/selectors/ReimbursementAccount';
+import {canDowngradeSelector} from '@src/selectors/Account';
+import {createOwnedPaidPoliciesCountsSelector} from '@src/selectors/Policy';
 import type {Policy as PolicyType} from '@src/types/onyx';
-import type * as OnyxCommon from '@src/types/onyx/OnyxCommon';
 import type {PolicyDetailsForNonMembers} from '@src/types/onyx/Policy';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import CopyPolicySettingsProgressModal from './copyPolicySettings/CopyPolicySettingsProgressModal';
-
-type GetWorkspaceMenuItem = {item: WorkspaceRowData; index: number};
-
-/**
- * Dismisses the errors on one item
- */
-function dismissWorkspaceError(policyID: string, pendingAction: OnyxCommon.PendingAction | undefined) {
-    if (pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-        clearDeleteWorkspaceError(policyID);
-        return;
-    }
-
-    if (pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD) {
-        removeWorkspace(policyID);
-        return;
-    }
-
-    clearErrors(policyID);
-}
+import DeleteWorkspaceFlow from './deleteWorkspace/DeleteWorkspaceFlow';
 
 function isUserReimburserForPolicy(policies: Record<string, PolicyType | undefined> | undefined, policyID: string | undefined, userEmail: string | undefined): boolean {
     if (!policies || !policyID || !userEmail) {
@@ -111,12 +82,11 @@ function WorkspacesListPage() {
     const tableRef = useRef<TableHandle<WorkspaceRowData, WorkspaceTableColumnKey, string>>(null);
     const icons = useMemoizedLazyExpensifyIcons(['Building', 'Exit', 'Copy', 'Star', 'Trashcan', 'Transfer', 'FallbackWorkspaceAvatar', 'Plus']);
     const styles = useThemeStyles();
-    const {translate, localeCompare} = useLocalize();
+    const {translate} = useLocalize();
     useDocumentTitle(translate('common.workspaces'));
     const {isOffline} = useNetwork();
     const isFocused = useIsFocused();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
-    const privateSubscription = usePrivateSubscription();
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const [allConnectionSyncProgresses] = useOnyx(ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS);
     const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
@@ -124,124 +94,27 @@ function WorkspacesListPage() {
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
-    const [lastPaymentMethod] = useOnyx(ONYXKEYS.NVP_LAST_PAYMENT_METHOD);
     const shouldShowLoadingIndicator = isLoadingApp && !isOffline;
     const route = useRoute<PlatformStackRouteProp<WorkspaceNavigatorParamList, typeof SCREENS.WORKSPACES_LIST>>();
     const [fundList] = useOnyx(ONYXKEYS.FUND_LIST);
     const {isBetaEnabled} = usePermissions();
     const {isRestrictedToPreferredPolicy, preferredPolicyID, isRestrictedPolicyCreation} = usePreferredPolicy();
-    const [account] = useOnyx(ONYXKEYS.ACCOUNT);
-    const [reimbursementAccountError] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {selector: reimbursementAccountErrorSelector});
-    const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
     const [duplicateWorkspace] = useOnyx(ONYXKEYS.DUPLICATE_WORKSPACE);
-    const {showConfirmModal, closeModal} = useConfirmModal();
+    const {showConfirmModal} = useConfirmModal();
+    const personalDetails = usePersonalDetails();
 
-    const ownedPaidPolicies = ownerPoliciesSelector(policies, currentUserPersonalDetails?.accountID);
-    const activeOwnedPaidPoliciesCount = ownedPaidPolicies.filter((p) => !isPendingDeletePolicy(p)).length;
-    const {shouldBlockDeletion, wouldBlockDeletion, outstandingBalanceModal} = useOutstandingBalanceGuard(activeOwnedPaidPoliciesCount);
+    // Primitive-valued subscriptions configuring the Delete menu item (popover behavior and the loading spinner)
+    // before a deletion starts. The deletion itself is handled by DeleteWorkspaceFlow, mounted on demand below.
+    const [canDowngrade] = useOnyx(ONYXKEYS.ACCOUNT, {selector: canDowngradeSelector});
+    const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
+    const [isLoadingBill] = useOnyx(ONYXKEYS.IS_LOADING_BILL_WHEN_DOWNGRADE);
+    const [ownedPaidPoliciesCounts] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: createOwnedPaidPoliciesCountsSelector(currentUserPersonalDetails.accountID)}, [
+        currentUserPersonalDetails.accountID,
+    ]);
+    const shouldCalculateBillNewDot = !!canDowngrade && ownedPaidPoliciesCounts?.total === 1;
+    const wouldBlockDeletion = (amountOwed ?? 0) > 0 && ownedPaidPoliciesCounts?.active === 1;
 
     const [policyIDToDelete, setPolicyIDToDelete] = useState<string>();
-    // Set when a non-billing delete is initiated. The confirmation modal is opened from an effect (not synchronously) so that
-    // `policyIDToDelete` and all of its Onyx-derived data (card feeds, reports to archive, transaction violations, etc.) are
-    // up to date for the selected workspace before the modal and the deleteWorkspace call are built.
-    const [shouldShowDeleteConfirmModal, setShouldShowDeleteConfirmModal] = useState(false);
-    const isErrorModalShowingRef = useRef(false);
-    const {reportsToArchive, transactionViolations} = useTransactionViolationOfWorkspace(policyIDToDelete);
-
-    const [loadingSpinnerIconIndex, setLoadingSpinnerIconIndex] = useState<number | null>(null);
-
-    const policyToDelete = policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyIDToDelete}`];
-
-    // We need this to update translation for deleting a workspace when it has third party card feeds or expensify card assigned.
-    const workspaceAccountID = policyToDelete?.policyAccountID ?? CONST.DEFAULT_NUMBER_ID;
-    const [cardFeeds, , defaultCardFeeds] = useCardFeeds(policyIDToDelete);
-    const [lastSelectedFeed] = useOnyx(`${ONYXKEYS.COLLECTION.LAST_SELECTED_FEED}${policyIDToDelete}`);
-    const [lastSelectedExpensifyCardFeed] = useOnyx(`${ONYXKEYS.COLLECTION.LAST_SELECTED_EXPENSIFY_CARD_FEED}${policyIDToDelete}`);
-    const [cardsList] = useOnyx(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${workspaceAccountID}_${CONST.EXPENSIFY_CARD.BANK}`, {
-        selector: filterInactiveCards,
-    });
-    const [lastAccessedWorkspacePolicyID] = useOnyx(ONYXKEYS.LAST_ACCESSED_WORKSPACE_POLICY_ID);
-
-    const hasCardFeedOrExpensifyCard =
-        !isEmptyObject(cardFeeds) ||
-        !isEmptyObject(cardsList) ||
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        ((policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyIDToDelete}`]?.areExpensifyCardsEnabled ||
-            policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyIDToDelete}`]?.areCompanyCardsEnabled) &&
-            policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyIDToDelete}`]?.policyAccountID);
-    const hasExpensifyCard = !!policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyIDToDelete}`]?.areExpensifyCardsEnabled && !isEmptyObject(cardsList);
-    const personalDetails = usePersonalDetails();
-    const [accountIDToLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: accountIDToLoginSelector(reportsToArchive)});
-
-    const policyToDeleteLatestErrorMessage = getLatestErrorMessage(policyToDelete);
-    const isPendingDelete = isPendingDeletePolicy(policyToDelete);
-    const hasDeleteWorkspaceExpensifyCardsError = !!hasExpensifyCard && !!isOffline;
-
-    const prevIsPendingDeleteRef = useRef(isPendingDelete);
-    // Always invoked after a re-render (from the effect below for normal deletes, or from usePayAndDowngrade for billed deletes),
-    // so the workspace being deleted and its derived data are read from the latest state.
-    const continueDeleteWorkspace = () => {
-        const policyID = policyIDToDelete;
-        const policyName = policyToDelete?.name;
-
-        showConfirmModal({
-            title: translate('workspace.common.delete'),
-            prompt: hasCardFeedOrExpensifyCard ? translate('workspace.common.deleteWithCardsConfirmation') : translate('workspace.common.deleteConfirmation'),
-            confirmText: translate('common.delete'),
-            cancelText: translate('common.cancel'),
-            danger: true,
-            isConfirmLoading: isPendingDelete,
-        }).then((result) => {
-            if (!policyID || !policyName || result.action !== ModalActions.CONFIRM) {
-                return;
-            }
-
-            deleteWorkspace({
-                policies,
-                policyID,
-                activePolicyID,
-                policyName,
-                lastAccessedWorkspacePolicyID,
-                policyCardFeeds: defaultCardFeeds,
-                lastSelectedFeed,
-                lastSelectedExpensifyCardFeed,
-                reportsToArchive,
-                transactionViolations,
-                reimbursementAccountError,
-                lastUsedPaymentMethods: lastPaymentMethod,
-                localeCompare,
-                personalPolicyID,
-                hasDeleteWorkspaceExpensifyCardsError,
-                currentUserAccountID: currentUserPersonalDetails.accountID,
-                accountIDToLogin: accountIDToLogin ?? {},
-            });
-            if (isOffline) {
-                closeModal();
-                if (!hasDeleteWorkspaceExpensifyCardsError) {
-                    setPolicyIDToDelete(undefined);
-                }
-            }
-        });
-    };
-
-    const {setIsDeletingPaidWorkspace, isLoadingBill} = usePayAndDowngrade(continueDeleteWorkspace);
-
-    // Open the delete confirmation modal on the render after `policyIDToDelete` (and its derived data) have updated.
-    useEffect(() => {
-        if (!shouldShowDeleteConfirmModal) {
-            return;
-        }
-        setShouldShowDeleteConfirmModal(false);
-        continueDeleteWorkspace();
-    }, [shouldShowDeleteConfirmModal, continueDeleteWorkspace]);
-
-    const hideDeleteWorkspaceErrorModal = () => {
-        setPolicyIDToDelete(undefined);
-        if (!policyToDelete) {
-            return;
-        }
-        dismissWorkspaceError(policyToDelete.id, policyToDelete.pendingAction);
-    };
 
     const confirmLeaveAndHideModal = (policyToLeave: PolicyType | undefined) => {
         if (!policyToLeave) {
@@ -286,57 +159,6 @@ function WorkspacesListPage() {
         return translate('common.leaveWorkspaceConfirmation');
     };
 
-    const shouldCalculateBillNewDot: boolean = shouldCalculateBillNewDotFn(currentUserPersonalDetails.accountID, account?.canDowngrade, policies);
-
-    useEffect(() => {
-        const prevIsPendingDelete = prevIsPendingDeleteRef.current;
-        prevIsPendingDeleteRef.current = isPendingDelete;
-
-        // Handle showing error modal when offline and error occurs
-        if (isOffline && policyToDeleteLatestErrorMessage) {
-            if (isErrorModalShowingRef.current) {
-                return;
-            }
-            isErrorModalShowingRef.current = true;
-            showConfirmModal({
-                title: translate('workspace.common.delete'),
-                prompt: policyToDeleteLatestErrorMessage,
-                confirmText: translate('common.buttonConfirm'),
-                cancelText: translate('common.cancel'),
-                success: false,
-                shouldShowCancelButton: false,
-            }).then(() => {
-                isErrorModalShowingRef.current = false;
-                hideDeleteWorkspaceErrorModal();
-            });
-            return;
-        }
-
-        if (!prevIsPendingDelete || isPendingDelete || !policyIDToDelete) {
-            return;
-        }
-        closeModal();
-        if (!isFocused || !policyToDeleteLatestErrorMessage) {
-            return;
-        }
-
-        if (isErrorModalShowingRef.current) {
-            return;
-        }
-        isErrorModalShowingRef.current = true;
-        showConfirmModal({
-            title: translate('workspace.common.delete'),
-            prompt: policyToDeleteLatestErrorMessage,
-            confirmText: translate('common.buttonConfirm'),
-            cancelText: translate('common.cancel'),
-            success: false,
-            shouldShowCancelButton: false,
-        }).then(() => {
-            isErrorModalShowingRef.current = false;
-            hideDeleteWorkspaceErrorModal();
-        });
-    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyToDeleteLatestErrorMessage, isPendingDelete, isFocused, policyIDToDelete, closeModal]);
-
     const startChangeOwnershipFlow = (policyID: string | undefined) => {
         if (!policyID) {
             return;
@@ -375,7 +197,7 @@ function WorkspacesListPage() {
     /**
      * Gets the menu item for each workspace
      */
-    const getThreeDotMenuItems = ({item, index}: GetWorkspaceMenuItem) => {
+    const getThreeDotMenuItems = (item: WorkspaceRowData) => {
         const isDefault = activePolicyID === item.policyID;
         const isOwner = item.ownerAccountID === session?.accountID;
         const isAdmin = isPolicyAdmin(item as unknown as PolicyType, session?.email);
@@ -466,38 +288,14 @@ function WorkspacesListPage() {
             threeDotsMenuItems.push({
                 icon: icons.Trashcan,
                 text: translate('workspace.common.delete'),
-                shouldShowLoadingSpinnerIcon: loadingSpinnerIconIndex === index,
+                shouldShowLoadingSpinnerIcon: !!isLoadingBill && policyIDToDelete === item.policyID,
                 onSelected: () => {
-                    if (loadingSpinnerIconIndex !== null) {
+                    if (isLoadingBill) {
                         return;
                     }
 
-                    if (
-                        shouldBlockWorkspaceDeletionForInvoicifyUser(
-                            isSubscriptionTypeOfInvoicing(privateSubscription?.type),
-                            policies,
-                            item?.policyID,
-                            currentUserPersonalDetails?.accountID,
-                        )
-                    ) {
-                        Navigation.navigate(ROUTES.SETTINGS_SUBSCRIPTION_DOWNGRADE_BLOCKED.getRoute(Navigation.getActiveRoute()));
-                        return;
-                    }
-
+                    // All the pre-deletion checks and the confirmation modal are handled by DeleteWorkspaceFlow, which mounts when this is set.
                     setPolicyIDToDelete(item.policyID);
-
-                    if (shouldBlockDeletion()) {
-                        return;
-                    }
-
-                    if (shouldCalculateBillNewDot) {
-                        setIsDeletingPaidWorkspace(true);
-                        calculateBillNewDot();
-                        setLoadingSpinnerIconIndex(index);
-                        return;
-                    }
-
-                    setShouldShowDeleteConfirmModal(true);
                 },
                 shouldKeepModalOpen: shouldCalculateBillNewDot && !wouldBlockDeletion,
                 shouldCallAfterModalHide: !shouldCalculateBillNewDot || wouldBlockDeletion,
@@ -523,10 +321,6 @@ function WorkspacesListPage() {
         Navigation.navigate(workspaceRoute);
     };
 
-    const resetLoadingSpinnerIconIndex = () => {
-        setLoadingSpinnerIconIndex(null);
-    };
-
     const {policiesWithCardFeedErrors} = usePoliciesWithCardFeedErrors();
 
     /**
@@ -537,7 +331,7 @@ function WorkspacesListPage() {
     if (!isEmptyObject(policies)) {
         const reimbursementAccountBrickRoadIndicator = !isEmptyObject(reimbursementAccount?.errors) ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined;
 
-        for (const [index, policy] of Object.values(policies).entries()) {
+        for (const policy of Object.values(policies)) {
             if (!policy || !shouldShowPolicy(policy, true, session?.email)) {
                 continue;
             }
@@ -603,10 +397,9 @@ function WorkspacesListPage() {
                     icon: policyInfo?.avatar ? policyInfo.avatar : getDefaultWorkspaceAvatar(policy.name),
                     action: () => null,
                     dismissError: () => null,
-                    resetLoadingSpinnerIconIndex,
                 };
 
-                pendingWorkspaceRow.threeDotMenuItems = getThreeDotMenuItems({item: pendingWorkspaceRow, index});
+                pendingWorkspaceRow.threeDotMenuItems = getThreeDotMenuItems(pendingWorkspaceRow);
                 workspaceRows.push(pendingWorkspaceRow);
             } else {
                 const policyOwnerAccountID = policy.ownerAccountID;
@@ -633,12 +426,11 @@ function WorkspacesListPage() {
                     icon: policy.avatarURL ? policy.avatarURL : getDefaultWorkspaceAvatar(policy.name),
                     brickRoadIndicator,
                     pendingAction: policy.pendingAction,
-                    resetLoadingSpinnerIconIndex,
                     action: (event) => navigateToWorkspace(policy.id, event),
                     dismissError: () => dismissWorkspaceError(policy.id, policy.pendingAction),
                 };
 
-                workspaceRow.threeDotMenuItems = getThreeDotMenuItems({item: workspaceRow, index});
+                workspaceRow.threeDotMenuItems = getThreeDotMenuItems(workspaceRow);
                 workspaceRows.push(workspaceRow);
             }
         }
@@ -706,7 +498,13 @@ function WorkspacesListPage() {
                     workspaces={workspaceRows}
                 />
             )}
-            {outstandingBalanceModal}
+            {!!policyIDToDelete && (
+                <DeleteWorkspaceFlow
+                    key={policyIDToDelete}
+                    policyID={policyIDToDelete}
+                    onDismiss={() => setPolicyIDToDelete(undefined)}
+                />
+            )}
             <CopyPolicySettingsProgressModal />
         </WorkspaceListLayout>
     );

--- a/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
+++ b/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
@@ -70,10 +70,20 @@ function DeleteWorkspaceFlow({policyID, onDismiss}: DeleteWorkspaceFlowProps) {
     const [cardsList, cardsListResult] = useOnyx(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${workspaceAccountID}_${CONST.EXPENSIFY_CARD.BANK}`, {
         selector: filterInactiveCards,
     });
-    const {reportsToArchive, transactionViolations} = useTransactionViolationOfWorkspace(policyID);
+    const {reportsToArchive, transactionViolations, reportsResult, transactionsResult, transactionViolationsResult} = useTransactionViolationOfWorkspace(policyID);
     const [accountIDToLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: accountIDToLoginSelector(reportsToArchive)});
 
-    const isLoadingData = isLoadingOnyxValue(policiesResult, accountResult, amountOwedResult, privateSubscriptionResult, cardFeedsResult, cardsListResult);
+    const isLoadingData = isLoadingOnyxValue(
+        policiesResult,
+        accountResult,
+        amountOwedResult,
+        privateSubscriptionResult,
+        cardFeedsResult,
+        cardsListResult,
+        reportsResult,
+        transactionsResult,
+        transactionViolationsResult,
+    );
 
     const hasCardFeedOrExpensifyCard =
         !isEmptyObject(cardFeeds) ||
@@ -174,42 +184,7 @@ function DeleteWorkspaceFlow({policyID, onDismiss}: DeleteWorkspaceFlowProps) {
         onDismiss();
     };
 
-    useEffect(() => {
-        const prevIsPendingDelete = prevIsPendingDeleteRef.current;
-        prevIsPendingDeleteRef.current = isPendingDelete;
-
-        // Handle showing error modal when offline and error occurs
-        if (isOffline && policyLatestErrorMessage) {
-            if (isErrorModalShowingRef.current) {
-                return;
-            }
-            isErrorModalShowingRef.current = true;
-            showConfirmModal({
-                title: translate('workspace.common.delete'),
-                prompt: policyLatestErrorMessage,
-                confirmText: translate('common.buttonConfirm'),
-                cancelText: translate('common.cancel'),
-                success: false,
-                shouldShowCancelButton: false,
-            }).then(() => {
-                isErrorModalShowingRef.current = false;
-                hideDeleteWorkspaceErrorModal();
-            });
-            return;
-        }
-
-        if (!prevIsPendingDelete || isPendingDelete) {
-            return;
-        }
-        closeModal();
-        if (!isFocused || !policyLatestErrorMessage) {
-            // The deletion either succeeded or there is no error modal to show, so the flow is finished.
-            if (!isErrorModalShowingRef.current) {
-                onDismiss();
-            }
-            return;
-        }
-
+    const showErrorModal = () => {
         if (isErrorModalShowingRef.current) {
             return;
         }
@@ -225,6 +200,31 @@ function DeleteWorkspaceFlow({policyID, onDismiss}: DeleteWorkspaceFlowProps) {
             isErrorModalShowingRef.current = false;
             hideDeleteWorkspaceErrorModal();
         });
+    };
+
+    useEffect(() => {
+        const prevIsPendingDelete = prevIsPendingDeleteRef.current;
+        prevIsPendingDeleteRef.current = isPendingDelete;
+
+        // Handle showing error modal when offline and error occurs
+        if (isOffline && policyLatestErrorMessage) {
+            showErrorModal();
+            return;
+        }
+
+        if (!prevIsPendingDelete || isPendingDelete) {
+            return;
+        }
+        closeModal();
+        if (!isFocused || !policyLatestErrorMessage) {
+            // The deletion either succeeded or there is no error modal to show, so the flow is finished.
+            if (!isErrorModalShowingRef.current) {
+                onDismiss();
+            }
+            return;
+        }
+
+        showErrorModal();
     }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyLatestErrorMessage, isPendingDelete, isFocused, closeModal, onDismiss]);
 
     return outstandingBalanceModal;

--- a/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
+++ b/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
@@ -1,0 +1,233 @@
+import {useIsFocused} from '@react-navigation/native';
+import {useEffect, useRef} from 'react';
+import {ModalActions} from '@components/Modal/Global/ModalContext';
+import useCardFeeds from '@hooks/useCardFeeds';
+import useConfirmModal from '@hooks/useConfirmModal';
+import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import useOutstandingBalanceGuard from '@hooks/useOutstandingBalanceGuard';
+import usePayAndDowngrade from '@hooks/usePayAndDowngrade';
+import useTransactionViolationOfWorkspace from '@hooks/useTransactionViolationOfWorkspace';
+import {calculateBillNewDot, deleteWorkspace, dismissWorkspaceError} from '@libs/actions/Policy/Policy';
+import {filterInactiveCards} from '@libs/CardUtils';
+import {getLatestErrorMessage} from '@libs/ErrorUtils';
+import Navigation from '@libs/Navigation/Navigation';
+import {isPendingDeletePolicy, shouldBlockWorkspaceDeletionForInvoicifyUser} from '@libs/PolicyUtils';
+import {isSubscriptionTypeOfInvoicing} from '@libs/SubscriptionUtils';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import {canDowngradeSelector} from '@src/selectors/Account';
+import {accountIDToLoginSelector} from '@src/selectors/PersonalDetails';
+import {createOwnedPaidPoliciesCountsSelector} from '@src/selectors/Policy';
+import {reimbursementAccountErrorSelector} from '@src/selectors/ReimbursementAccount';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
+
+type DeleteWorkspaceFlowProps = {
+    /** ID of the workspace being deleted */
+    policyID: string;
+
+    /** Called when the flow is finished or abandoned, so the parent can unmount this component */
+    onDismiss: () => void;
+};
+
+/**
+ * Self-contained workspace deletion flow. It is mounted only while a deletion is in progress, so all of the
+ * Onyx data needed to delete a workspace (full policy and report collections, card feeds, violations, etc.)
+ * is subscribed to only for the lifetime of the flow instead of re-rendering the workspaces list in the background.
+ *
+ * On mount (once the data is ready) it runs the pre-deletion checks (Invoicify block, outstanding balance,
+ * bill calculation for the last paid workspace) and then shows the delete confirmation modal.
+ */
+function DeleteWorkspaceFlow({policyID, onDismiss}: DeleteWorkspaceFlowProps) {
+    const {translate, localeCompare} = useLocalize();
+    const {isOffline} = useNetwork();
+    const isFocused = useIsFocused();
+    const {showConfirmModal, closeModal} = useConfirmModal();
+
+    const [session] = useOnyx(ONYXKEYS.SESSION);
+    const [policies, policiesResult] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
+    const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
+    const [lastPaymentMethod] = useOnyx(ONYXKEYS.NVP_LAST_PAYMENT_METHOD);
+    const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
+    const [lastAccessedWorkspacePolicyID] = useOnyx(ONYXKEYS.LAST_ACCESSED_WORKSPACE_POLICY_ID);
+    const [reimbursementAccountError] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {selector: reimbursementAccountErrorSelector});
+    const [privateSubscription, privateSubscriptionResult] = useOnyx(ONYXKEYS.NVP_PRIVATE_SUBSCRIPTION);
+    const [canDowngrade, accountResult] = useOnyx(ONYXKEYS.ACCOUNT, {selector: canDowngradeSelector});
+    const [, amountOwedResult] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
+    const ownedPaidPoliciesCountsSelector = createOwnedPaidPoliciesCountsSelector(session?.accountID);
+    const ownedPaidPoliciesCounts = ownedPaidPoliciesCountsSelector(policies);
+
+    const policy = policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyID}`];
+
+    // We need this to update translation for deleting a workspace when it has third party card feeds or expensify card assigned.
+    const workspaceAccountID = policy?.policyAccountID ?? CONST.DEFAULT_NUMBER_ID;
+    const [cardFeeds, cardFeedsResult, defaultCardFeeds] = useCardFeeds(policyID);
+    const [lastSelectedFeed] = useOnyx(`${ONYXKEYS.COLLECTION.LAST_SELECTED_FEED}${policyID}`);
+    const [lastSelectedExpensifyCardFeed] = useOnyx(`${ONYXKEYS.COLLECTION.LAST_SELECTED_EXPENSIFY_CARD_FEED}${policyID}`);
+    const [cardsList, cardsListResult] = useOnyx(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${workspaceAccountID}_${CONST.EXPENSIFY_CARD.BANK}`, {
+        selector: filterInactiveCards,
+    });
+    const {reportsToArchive, transactionViolations} = useTransactionViolationOfWorkspace(policyID);
+    const [accountIDToLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: accountIDToLoginSelector(reportsToArchive)});
+
+    const isLoadingData = isLoadingOnyxValue(policiesResult, accountResult, amountOwedResult, privateSubscriptionResult, cardFeedsResult, cardsListResult);
+
+    const hasCardFeedOrExpensifyCard =
+        !isEmptyObject(cardFeeds) ||
+        !isEmptyObject(cardsList) ||
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        ((policy?.areExpensifyCardsEnabled || policy?.areCompanyCardsEnabled) && policy?.policyAccountID);
+    const hasExpensifyCard = !!policy?.areExpensifyCardsEnabled && !isEmptyObject(cardsList);
+    const hasDeleteWorkspaceExpensifyCardsError = !!hasExpensifyCard && !!isOffline;
+
+    const policyLatestErrorMessage = getLatestErrorMessage(policy);
+    const isPendingDelete = isPendingDeletePolicy(policy);
+    const prevIsPendingDeleteRef = useRef(isPendingDelete);
+    const isErrorModalShowingRef = useRef(false);
+
+    const shouldCalculateBillNewDot = !!canDowngrade && ownedPaidPoliciesCounts?.total === 1;
+    const {shouldBlockDeletion, outstandingBalanceModal} = useOutstandingBalanceGuard(ownedPaidPoliciesCounts?.active ?? 0, onDismiss);
+
+    // Always invoked after a re-render (from the start effect below for normal deletes, or from usePayAndDowngrade for billed deletes),
+    // so the workspace being deleted and its derived data are read from the latest state.
+    const continueDeleteWorkspace = () => {
+        const policyName = policy?.name;
+
+        showConfirmModal({
+            title: translate('workspace.common.delete'),
+            prompt: hasCardFeedOrExpensifyCard ? translate('workspace.common.deleteWithCardsConfirmation') : translate('workspace.common.deleteConfirmation'),
+            confirmText: translate('common.delete'),
+            cancelText: translate('common.cancel'),
+            danger: true,
+            isConfirmLoading: isPendingDelete,
+        }).then((result) => {
+            if (!policyName || result.action !== ModalActions.CONFIRM) {
+                onDismiss();
+                return;
+            }
+
+            deleteWorkspace({
+                policies,
+                policyID,
+                activePolicyID,
+                policyName,
+                lastAccessedWorkspacePolicyID,
+                policyCardFeeds: defaultCardFeeds,
+                lastSelectedFeed,
+                lastSelectedExpensifyCardFeed,
+                reportsToArchive,
+                transactionViolations,
+                reimbursementAccountError,
+                lastUsedPaymentMethods: lastPaymentMethod,
+                localeCompare,
+                personalPolicyID,
+                hasDeleteWorkspaceExpensifyCardsError,
+                currentUserAccountID: session?.accountID ?? 0,
+                accountIDToLogin: accountIDToLogin ?? {},
+            });
+            if (isOffline) {
+                closeModal();
+                if (!hasDeleteWorkspaceExpensifyCardsError) {
+                    onDismiss();
+                }
+            }
+        });
+    };
+
+    const {setIsDeletingPaidWorkspace} = usePayAndDowngrade(continueDeleteWorkspace);
+
+    // Runs the pre-deletion checks and opens the confirmation modal once all the Onyx data the flow depends on has loaded.
+    const hasStartedRef = useRef(false);
+    useEffect(() => {
+        if (hasStartedRef.current || isLoadingData) {
+            return;
+        }
+        hasStartedRef.current = true;
+
+        if (shouldBlockWorkspaceDeletionForInvoicifyUser(isSubscriptionTypeOfInvoicing(privateSubscription?.type), policies, policyID, session?.accountID)) {
+            Navigation.navigate(ROUTES.SETTINGS_SUBSCRIPTION_DOWNGRADE_BLOCKED.getRoute(Navigation.getActiveRoute()));
+            onDismiss();
+            return;
+        }
+
+        if (shouldBlockDeletion()) {
+            // The outstanding balance modal is now visible and will call onDismiss when it is closed.
+            return;
+        }
+
+        if (shouldCalculateBillNewDot) {
+            setIsDeletingPaidWorkspace(true);
+            calculateBillNewDot();
+            return;
+        }
+
+        continueDeleteWorkspace();
+    });
+
+    const hideDeleteWorkspaceErrorModal = () => {
+        if (policy) {
+            dismissWorkspaceError(policy.id, policy.pendingAction);
+        }
+        onDismiss();
+    };
+
+    useEffect(() => {
+        const prevIsPendingDelete = prevIsPendingDeleteRef.current;
+        prevIsPendingDeleteRef.current = isPendingDelete;
+
+        // Handle showing error modal when offline and error occurs
+        if (isOffline && policyLatestErrorMessage) {
+            if (isErrorModalShowingRef.current) {
+                return;
+            }
+            isErrorModalShowingRef.current = true;
+            showConfirmModal({
+                title: translate('workspace.common.delete'),
+                prompt: policyLatestErrorMessage,
+                confirmText: translate('common.buttonConfirm'),
+                cancelText: translate('common.cancel'),
+                success: false,
+                shouldShowCancelButton: false,
+            }).then(() => {
+                isErrorModalShowingRef.current = false;
+                hideDeleteWorkspaceErrorModal();
+            });
+            return;
+        }
+
+        if (!prevIsPendingDelete || isPendingDelete) {
+            return;
+        }
+        closeModal();
+        if (!isFocused || !policyLatestErrorMessage) {
+            // The deletion either succeeded or there is no error modal to show, so the flow is finished.
+            if (!isErrorModalShowingRef.current) {
+                onDismiss();
+            }
+            return;
+        }
+
+        if (isErrorModalShowingRef.current) {
+            return;
+        }
+        isErrorModalShowingRef.current = true;
+        showConfirmModal({
+            title: translate('workspace.common.delete'),
+            prompt: policyLatestErrorMessage,
+            confirmText: translate('common.buttonConfirm'),
+            cancelText: translate('common.cancel'),
+            success: false,
+            shouldShowCancelButton: false,
+        }).then(() => {
+            isErrorModalShowingRef.current = false;
+            hideDeleteWorkspaceErrorModal();
+        });
+    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyLatestErrorMessage, isPendingDelete, isFocused, closeModal, onDismiss]);
+
+    return outstandingBalanceModal;
+}
+
+export default DeleteWorkspaceFlow;

--- a/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
+++ b/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
@@ -135,7 +135,7 @@ function DeleteWorkspaceFlow({policyID, onDismiss}: DeleteWorkspaceFlowProps) {
                 localeCompare,
                 personalPolicyID,
                 hasDeleteWorkspaceExpensifyCardsError,
-                currentUserAccountID: session?.accountID ?? 0,
+                currentUserAccountID: session?.accountID ?? CONST.DEFAULT_NUMBER_ID,
                 accountIDToLogin: accountIDToLogin ?? {},
             });
             if (isOffline) {
@@ -225,7 +225,7 @@ function DeleteWorkspaceFlow({policyID, onDismiss}: DeleteWorkspaceFlowProps) {
         }
 
         showErrorModal();
-    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyLatestErrorMessage, isPendingDelete, isFocused, closeModal, onDismiss]);
+    }, [isOffline, hideDeleteWorkspaceErrorModal, showConfirmModal, translate, policyLatestErrorMessage, isPendingDelete, isFocused, closeModal, onDismiss, showErrorModal]);
 
     return outstandingBalanceModal;
 }

--- a/src/selectors/Account.ts
+++ b/src/selectors/Account.ts
@@ -19,6 +19,8 @@ const mfaCredentialIDsSelector = (data: OnyxEntry<Account>) => data?.multifactor
 
 const isFromInternalDomainSelector = (account: OnyxEntry<Account>) => account?.isFromInternalDomain;
 
+const canDowngradeSelector = (account: OnyxEntry<Account>) => !!account?.canDowngrade;
+
 export {
     isActingAsDelegateSelector,
     delegateEmailSelector,
@@ -29,4 +31,5 @@ export {
     accountGuideDetailsSelector,
     mfaCredentialIDsSelector,
     isFromInternalDomainSelector,
+    canDowngradeSelector,
 };

--- a/src/selectors/Policy.ts
+++ b/src/selectors/Policy.ts
@@ -2,7 +2,7 @@ import escapeRegExp from 'lodash/escapeRegExp';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import {hasSynchronizationErrorMessage, isConnectionUnverified} from '@libs/actions/connections';
 import {getDisplayNameForWorkspace} from '@libs/actions/Policy/Policy';
-import {getActiveAdminWorkspaces, getOwnedPaidPolicies, isPaidGroupPolicy} from '@libs/PolicyUtils';
+import {getActiveAdminWorkspaces, getOwnedPaidPolicies, isPaidGroupPolicy, isPendingDeletePolicy} from '@libs/PolicyUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy, PolicyReportField} from '@src/types/onyx';
@@ -16,6 +16,28 @@ type ReusablePolicyConnectionName =
 const activePolicySelector = (policy: OnyxEntry<Policy>) => (policy?.type !== CONST.POLICY.TYPE.PERSONAL ? policy : undefined);
 
 const ownerPoliciesSelector = (policies: OnyxCollection<Policy>, currentUserAccountID: number) => getOwnedPaidPolicies(policies, currentUserAccountID);
+
+type OwnedPaidPoliciesCounts = {
+    /** Number of paid policies owned by the user */
+    total: number;
+
+    /** Number of owned paid policies that are not pending deletion */
+    active: number;
+};
+
+/**
+ * Creates a selector returning only the counts of owned paid policies, so subscribers don't re-render
+ * when anything else on the policy collection changes.
+ */
+const createOwnedPaidPoliciesCountsSelector =
+    (currentUserAccountID: number | undefined) =>
+    (policies: OnyxCollection<Policy>): OwnedPaidPoliciesCounts => {
+        const ownedPaidPolicies = getOwnedPaidPolicies(policies, currentUserAccountID);
+        return {
+            total: ownedPaidPolicies.length,
+            active: ownedPaidPolicies.filter((policy) => !isPendingDeletePolicy(policy)).length,
+        };
+    };
 
 const activeAdminPoliciesSelector = (policies: OnyxCollection<Policy>, currentUserAccountLogin: string) => getActiveAdminWorkspaces(policies, currentUserAccountLogin);
 
@@ -248,6 +270,7 @@ export {
     activePolicySelector,
     createAllPolicyReportFieldsSelector,
     ownerPoliciesSelector,
+    createOwnedPaidPoliciesCountsSelector,
     activeAdminPoliciesSelector,
     hasActiveAdminPoliciesSelector,
     createPoliciesForDomainCardsSelector,

--- a/tests/unit/selectors/AccountTest.ts
+++ b/tests/unit/selectors/AccountTest.ts
@@ -1,4 +1,4 @@
-import {accountGuideDetailsSelector, primaryLoginSelector, requiresTwoFactorAuthSelector} from '@selectors/Account';
+import {accountGuideDetailsSelector, canDowngradeSelector, primaryLoginSelector, requiresTwoFactorAuthSelector} from '@selectors/Account';
 import type {OnyxEntry} from 'react-native-onyx';
 import type {Account} from '@src/types/onyx';
 
@@ -58,5 +58,26 @@ describe('requiresTwoFactorAuthSelector', () => {
     it('returns undefined when account has unrelated fields only', () => {
         const account: OnyxEntry<Account> = {primaryLogin: 'test@test.com'};
         expect(requiresTwoFactorAuthSelector(account)).toBeUndefined();
+    });
+});
+
+describe('canDowngradeSelector', () => {
+    it('returns true when canDowngrade is true', () => {
+        const account: OnyxEntry<Account> = {canDowngrade: true};
+        expect(canDowngradeSelector(account)).toBe(true);
+    });
+
+    it('returns false when canDowngrade is false', () => {
+        const account: OnyxEntry<Account> = {canDowngrade: false};
+        expect(canDowngradeSelector(account)).toBe(false);
+    });
+
+    it('returns false when canDowngrade is not set', () => {
+        const account: OnyxEntry<Account> = {};
+        expect(canDowngradeSelector(account)).toBe(false);
+    });
+
+    it('returns false when account is undefined', () => {
+        expect(canDowngradeSelector(undefined)).toBe(false);
     });
 });

--- a/tests/unit/selectors/PolicyTest.ts
+++ b/tests/unit/selectors/PolicyTest.ts
@@ -1,6 +1,7 @@
 import {
     activeAdminPoliciesSelector,
     adminPoliciesConnectedToQBDSelector,
+    createOwnedPaidPoliciesCountsSelector,
     hasMultipleOutputCurrenciesSelector,
     hasOnlyPersonalPoliciesSelector,
     hasPoliciesConnectedToQBDSelector,
@@ -11,6 +12,57 @@ import type {OnyxCollection} from 'react-native-onyx';
 import CONST from '@src/CONST';
 import type {Policy} from '@src/types/onyx';
 import createRandomPolicy from '../../utils/collections/policies';
+
+const OWNER_ACCOUNT_ID = 1;
+
+describe('createOwnedPaidPoliciesCountsSelector', () => {
+    it('returns zero counts when there are no policies', () => {
+        const selector = createOwnedPaidPoliciesCountsSelector(OWNER_ACCOUNT_ID);
+        expect(selector({})).toEqual({total: 0, active: 0});
+    });
+
+    it('returns zero counts when policies are undefined', () => {
+        const selector = createOwnedPaidPoliciesCountsSelector(OWNER_ACCOUNT_ID);
+        expect(selector(undefined)).toEqual({total: 0, active: 0});
+    });
+
+    it('returns zero counts when currentUserAccountID is undefined', () => {
+        const policies: OnyxCollection<Policy> = {
+            policy1: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.TEAM)},
+        };
+        const selector = createOwnedPaidPoliciesCountsSelector(undefined);
+        expect(selector(policies)).toEqual({total: 0, active: 0});
+    });
+
+    it('counts only paid policies owned by the user', () => {
+        const policies: OnyxCollection<Policy> = {
+            policy1: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.TEAM)},
+            policy2: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.CORPORATE)},
+            policy3: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.PERSONAL)},
+            policy4: {...createRandomPolicy(2, CONST.POLICY.TYPE.TEAM)},
+        };
+        const selector = createOwnedPaidPoliciesCountsSelector(OWNER_ACCOUNT_ID);
+        expect(selector(policies)).toEqual({total: 2, active: 2});
+    });
+
+    it('excludes policies pending deletion from active count but includes them in total', () => {
+        const policies: OnyxCollection<Policy> = {
+            policy1: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.TEAM)},
+            policy2: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.CORPORATE), pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE},
+        };
+        const selector = createOwnedPaidPoliciesCountsSelector(OWNER_ACCOUNT_ID);
+        expect(selector(policies)).toEqual({total: 2, active: 1});
+    });
+
+    it('returns zero active when all owned paid policies are pending deletion', () => {
+        const policies: OnyxCollection<Policy> = {
+            policy1: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.TEAM), pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE},
+            policy2: {...createRandomPolicy(OWNER_ACCOUNT_ID, CONST.POLICY.TYPE.CORPORATE), pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE},
+        };
+        const selector = createOwnedPaidPoliciesCountsSelector(OWNER_ACCOUNT_ID);
+        expect(selector(policies)).toEqual({total: 2, active: 0});
+    });
+});
 
 describe('hasMultipleOutputCurrenciesSelector', () => {
     it('returns false when paid group policies have the same output currency', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

This is the first in a series of smaller PRs splitting a larger `WorkspacesListPage` composition refactor (#93293) into incremental steps to catch regressions early.

This PR extracts all workspace deletion logic from `WorkspacesListPage` into a new `DeleteWorkspaceFlow` component that mounts only when a deletion is in progress. Heavy Onyx subscriptions (full policy collection, card feeds, reports, transaction violations) are now scoped to the flow's lifetime instead of living on the list page for every row. The page retains only the primitive-valued subscriptions it needs for delete menu item configuration (`canDowngrade`, `amountOwed`, `isLoadingBill`, owned-policy counts via a stable selector).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/91175
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

- [x] Verify that no errors appear in the JS console

1. Go to **Settings → Workspaces** (the workspaces list page).
2. Open the three-dots menu for any workspace you own and tap **Delete**.
3. Verify the delete confirmation modal appears and the workspace is removed after confirming.

4. With a paid workspace as the only active owned workspace, open the three-dots menu and tap **Delete**.
5. Verify the bill calculation flow runs (loading spinner appears on the delete item) and the confirmation modal opens correctly after the bill is calculated.

6. Open the three-dots menu for a workspace you don't own.
7. Verify the **Delete** option is not present and the Leave/Transfer options still appear and work normally.

### Offline tests

1. Turn off network, go to **Settings → Workspaces**.
2. Tap **Delete** on any owned workspace and confirm.
3. Verify the workspace enters a pending-delete state and the error modal appears if the deletion fails.
4. Restore network and verify the workspace is eventually deleted or the error state is cleared correctly.

### QA Steps

Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
