### PR TITLE
fix: backport RN scheduler delegate UAF guard

### DIFF
--- a/patches/react-native/details.md
+++ b/patches/react-native/details.md
@@ -305,3 +305,10 @@
 - Upstream PR/issue: 🛑
 - E/App issue: https://github.com/Expensify/App/issues/78873
 - PR introducing patch: https://github.com/Expensify/App/pull/84556
+
+### [react-native+0.83.1+040+fix-runtime-scheduler-delegate-uaf-APP-25V.patch](react-native+0.83.1+040+fix-runtime-scheduler-delegate-uaf-APP-25V.patch)
+
+- Reason: Fixes a fatal iOS HybridApp crash (APP-25V) where `RuntimeScheduler_Modern::runEventLoopTick` can drain deferred Fabric rendering updates after the captured `SchedulerDelegate` has been torn down. RN 0.83.1 queues `Scheduler::uiManagerDidFinishTransaction` and `Scheduler::uiManagerDidDispatchCommand` callbacks with lambdas that capture the raw `delegate_` pointer by value. During OldDot↔NewDot lifecycle churn, the delegate can be replaced or destroyed before the scheduled rendering update runs, causing `EXC_BAD_ACCESS` when the lambda dereferences stale native memory. This patch backports the upstream RN scheduler-delegate invalidation guard by adding a per-delegate `shared_ptr<atomic<bool>>` token, invalidating the old token on delegate changes and Scheduler destruction, and making already-queued lambdas no-op before touching a stale delegate.
+- Upstream PR/issue: https://github.com/facebook/react-native/pull/56680 / https://github.com/facebook/react-native/commit/aadbe965792bd900ca70412d6704b76e339d1aca
+- E/App issue: https://github.com/Expensify/App/issues/92412
+- PR introducing patch: 🛑

--- a/patches/react-native/react-native+0.83.1+040+fix-runtime-scheduler-delegate-uaf-APP-25V.patch
+++ b/patches/react-native/react-native+0.83.1+040+fix-runtime-scheduler-delegate-uaf-APP-25V.patch
@@ -15,7 +15,8 @@ index bfbff89..8287bb1 100644
 @@ -151,6 +152,11 @@ Scheduler::~Scheduler() {
    LOG(WARNING) << "Scheduler::~Scheduler() was called (address: " << this
                 << ").";
- 
+-
++
 +  // Invalidate any deferred rendering-update lambdas that captured the current
 +  // raw delegate_ pointer. Scheduler is being destroyed, so those lambdas must
 +  // no-op instead of dereferencing a delegate that may have been torn down.
@@ -24,9 +25,7 @@ index bfbff89..8287bb1 100644
    auto weakRuntimeScheduler =
        contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
            RuntimeSchedulerKey);
-@@ -239,6 +246,14 @@ Scheduler::findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
- #pragma mark - Delegate
- 
+@@ -243,2 +249,10 @@ void Scheduler::setDelegate(SchedulerDelegate* delegate) {
  void Scheduler::setDelegate(SchedulerDelegate* delegate) {
 +  if (delegate_ != delegate) {
 +    // Queued lambdas capture this shared token by value. Invalidate the old
@@ -37,12 +36,11 @@ index bfbff89..8287bb1 100644
 +  }
 +
    delegate_ = delegate;
- }
- 
 @@ -270,10 +285,15 @@ void Scheduler::uiManagerDidFinishTransaction(
      if (!mountSynchronously) {
        auto surfaceId = mountingCoordinator->getSurfaceId();
- 
+-
++
        runtimeScheduler_->scheduleRenderingUpdate(
            surfaceId,
            [delegate = delegate_,
@@ -75,16 +73,20 @@ index 26e2943..c317c77 100644
 --- a/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
 +++ b/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
 @@ -7,6 +7,7 @@
- 
+-
++
  #pragma once
- 
+-
++
 +#include <atomic>
  #include <memory>
- 
+-
++
  #include <ReactCommon/RuntimeExecutor.h>
 @@ -120,6 +121,11 @@ class Scheduler final : public UIManagerDelegate {
    friend class SurfaceHandler;
- 
+-
++
    SchedulerDelegate *delegate_;
 +  // Captured by deferred RuntimeScheduler rendering-update lambdas. The token
 +  // is invalidated when the delegate changes or Scheduler is destroyed so

--- a/patches/react-native/react-native+0.83.1+040+fix-runtime-scheduler-delegate-uaf-APP-25V.patch
+++ b/patches/react-native/react-native+0.83.1+040+fix-runtime-scheduler-delegate-uaf-APP-25V.patch
@@ -1,0 +1,96 @@
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp b/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+index bfbff89..8287bb1 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
++++ b/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+@@ -29,7 +29,8 @@ Scheduler::Scheduler(
+     const SchedulerToolbox& schedulerToolbox,
+     UIManagerAnimationDelegate* animationDelegate,
+     SchedulerDelegate* delegate)
+-    : runtimeExecutor_(schedulerToolbox.runtimeExecutor),
++    : delegateInvalidated_(std::make_shared<std::atomic<bool>>(false)),
++      runtimeExecutor_(schedulerToolbox.runtimeExecutor),
+       contextContainer_(schedulerToolbox.contextContainer) {
+   // Creating a container for future `EventDispatcher` instance.
+   eventDispatcher_ = std::make_shared<std::optional<const EventDispatcher>>();
+@@ -151,6 +152,11 @@ Scheduler::~Scheduler() {
+   LOG(WARNING) << "Scheduler::~Scheduler() was called (address: " << this
+                << ").";
+ 
++  // Invalidate any deferred rendering-update lambdas that captured the current
++  // raw delegate_ pointer. Scheduler is being destroyed, so those lambdas must
++  // no-op instead of dereferencing a delegate that may have been torn down.
++  delegateInvalidated_->store(true, std::memory_order_release);
++
+   auto weakRuntimeScheduler =
+       contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
+           RuntimeSchedulerKey);
+@@ -239,6 +246,14 @@ Scheduler::findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
+ #pragma mark - Delegate
+ 
+ void Scheduler::setDelegate(SchedulerDelegate* delegate) {
++  if (delegate_ != delegate) {
++    // Queued lambdas capture this shared token by value. Invalidate the old
++    // token before installing a fresh one so work captured against a previous
++    // delegate cannot be re-armed by a later delegate assignment.
++    delegateInvalidated_->store(true, std::memory_order_release);
++    delegateInvalidated_ = std::make_shared<std::atomic<bool>>(false);
++  }
++
+   delegate_ = delegate;
+ }
+ 
+@@ -270,10 +285,15 @@ void Scheduler::uiManagerDidFinishTransaction(
+     if (!mountSynchronously) {
+       auto surfaceId = mountingCoordinator->getSurfaceId();
+ 
+       runtimeScheduler_->scheduleRenderingUpdate(
+           surfaceId,
+           [delegate = delegate_,
++           delegateInvalidated = delegateInvalidated_,
+            mountingCoordinator = std::move(mountingCoordinator)]() {
++            if (delegateInvalidated->load(std::memory_order_acquire)) {
++              return;
++            }
++
+             delegate->schedulerShouldRenderTransactions(mountingCoordinator);
+           });
+     } else {
+@@ -297,9 +317,14 @@ void Scheduler::uiManagerDidDispatchCommand(
+     runtimeScheduler_->scheduleRenderingUpdate(
+         shadowNode->getSurfaceId(),
+         [delegate = delegate_,
++         delegateInvalidated = delegateInvalidated_,
+          shadowView = std::move(shadowView),
+          commandName,
+          args]() {
++          if (delegateInvalidated->load(std::memory_order_acquire)) {
++            return;
++          }
++
+           delegate->schedulerDidDispatchCommand(shadowView, commandName, args);
+         });
+   }
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h b/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+index 26e2943..c317c77 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
++++ b/node_modules/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+@@ -7,6 +7,7 @@
+ 
+ #pragma once
+ 
++#include <atomic>
+ #include <memory>
+ 
+ #include <ReactCommon/RuntimeExecutor.h>
+@@ -120,6 +121,11 @@ class Scheduler final : public UIManagerDelegate {
+   friend class SurfaceHandler;
+ 
+   SchedulerDelegate *delegate_;
++  // Captured by deferred RuntimeScheduler rendering-update lambdas. The token
++  // is invalidated when the delegate changes or Scheduler is destroyed so
++  // already-queued lambdas cannot dereference a stale raw delegate pointer.
++  std::shared_ptr<std::atomic<bool>> delegateInvalidated_;
++
+   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
+   RuntimeExecutor runtimeExecutor_;
+   std::shared_ptr<UIManager> uiManager_;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Backports the upstream React Native scheduler delegate invalidation guard from RN 0.86 into the RN 0.83.1 patch layer.

RN 0.83.1 schedules deferred Fabric rendering-update lambdas that capture the raw `SchedulerDelegate*`. During HybridApp lifecycle churn, the delegate can be torn down before `RuntimeScheduler_Modern` drains the queued rendering update, so this patch adds a per-delegate invalidation token and makes already-queued lambdas no-op before dereferencing a stale delegate.

The guard is intentionally unconditional in this backport. Upstream RN gates it behind `enableSchedulerDelegateInvalidation()`, but this branch does not backport RN's feature-flag plumbing and follows the approved proposal's unconditional option because calling a destroyed delegate is never valid.

### Fixed Issues
$ https://github.com/Expensify/App/issues/92412
PROPOSAL: https://github.com/Expensify/App/issues/92412#issuecomment-4606225484


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. Build and run the iOS HybridApp from this branch.
2. Sign in to a test account.
3. From Expensify Classic, open New Expensify.
4. Navigate between several chats/reports and scroll quickly.
5. Background the app for a few seconds, then foreground it.
6. Switch back to Expensify Classic.
7. Repeat the Classic -> New Expensify -> Classic transition several times.
8. Verify the app does not crash, especially with `RuntimeScheduler_Modern::runEventLoopTick`.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A. This is a native React Native scheduler lifetime patch and does not change app network/offline behavior.

### QA Steps
1. On iOS Native HybridApp, sign in to a test account.
2. From Expensify Classic, open New Expensify.
3. Navigate between chats/reports, scroll quickly, and background/foreground the app.
4. Switch back to Expensify Classic.
5. Repeat the Classic -> New Expensify -> Classic transition several times.
6. Verify the app does not crash.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A. This PR does not change the UI.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A. This PR does not change the UI.

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/2ff14c61-9d27-44bb-a5e5-85e46b11d95b



</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A. This PR does not change the UI.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A. This PR does not change the UI.

</details>

