### PR TITLE
Restore IOUReportID fallback for IOU action report resolution

### DIFF
--- a/src/hooks/useGetIOUReportFromReportAction.ts
+++ b/src/hooks/useGetIOUReportFromReportAction.ts
@@ -10,8 +10,10 @@ function useGetIOUReportFromReportAction(reportAction: OnyxTypes.ReportAction | 
     chatReport: OnyxTypes.Report | undefined;
     isChatIOUReportArchived: boolean;
 } {
-    // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
-    const iouReportID = isMoneyRequestAction(reportAction) ? (getOriginalMessage(reportAction)?.IOUReportID ?? reportAction?.reportID) : undefined;
+    // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
+    // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
+    // Temporary until the backend reliably sends reportID on IOU actions.
+    const iouReportID = isMoneyRequestAction(reportAction) ? reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID : undefined;
     const [candidateIOUReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`) ?? null;
     // For self-DM tracks and split bills, action.reportID resolves to a chat report, not an IOU/expense report.
     const iouReport = isIOUReport(candidateIOUReport) || isExpenseReport(candidateIOUReport) ? candidateIOUReport : undefined;

--- a/src/hooks/useGetIOUReportFromReportAction.ts
+++ b/src/hooks/useGetIOUReportFromReportAction.ts
@@ -12,7 +12,7 @@ function useGetIOUReportFromReportAction(reportAction: OnyxTypes.ReportAction | 
 } {
     // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
     // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
-    // Temporary until the backend reliably sends reportID on IOU actions.
+    // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882.
     const iouReportID = isMoneyRequestAction(reportAction) ? reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID : undefined;
     const [candidateIOUReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`) ?? null;
     // For self-DM tracks and split bills, action.reportID resolves to a chat report, not an IOU/expense report.

--- a/src/hooks/useGetIOUReportFromReportAction.ts
+++ b/src/hooks/useGetIOUReportFromReportAction.ts
@@ -13,7 +13,7 @@ function useGetIOUReportFromReportAction(reportAction: OnyxTypes.ReportAction | 
     // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
     // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
     // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882.
-    const iouReportID = isMoneyRequestAction(reportAction) ? reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID : undefined;
+    const iouReportID = isMoneyRequestAction(reportAction) ? (reportAction?.reportID ?? getOriginalMessage(reportAction)?.IOUReportID) : undefined;
     const [candidateIOUReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`) ?? null;
     // For self-DM tracks and split bills, action.reportID resolves to a chat report, not an IOU/expense report.
     const iouReport = isIOUReport(candidateIOUReport) || isExpenseReport(candidateIOUReport) ? candidateIOUReport : undefined;

--- a/src/hooks/useGetIOUReportFromReportAction.ts
+++ b/src/hooks/useGetIOUReportFromReportAction.ts
@@ -1,4 +1,4 @@
-import {isMoneyRequestAction} from '@libs/ReportActionsUtils';
+import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {isExpenseReport, isIOUReport} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
@@ -10,7 +10,8 @@ function useGetIOUReportFromReportAction(reportAction: OnyxTypes.ReportAction | 
     chatReport: OnyxTypes.Report | undefined;
     isChatIOUReportArchived: boolean;
 } {
-    const iouReportID = isMoneyRequestAction(reportAction) ? reportAction?.reportID : undefined;
+    // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
+    const iouReportID = isMoneyRequestAction(reportAction) ? (getOriginalMessage(reportAction)?.IOUReportID ?? reportAction?.reportID) : undefined;
     const [candidateIOUReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`) ?? null;
     // For self-DM tracks and split bills, action.reportID resolves to a chat report, not an IOU/expense report.
     const iouReport = isIOUReport(candidateIOUReport) || isExpenseReport(candidateIOUReport) ? candidateIOUReport : undefined;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4870,8 +4870,10 @@ function canEditMoneyRequest(
         return true;
     }
 
-    // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
-    const moneyRequestReportID = originalMessage?.IOUReportID ?? reportAction?.reportID;
+    // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
+    // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
+    // Temporary until the backend reliably sends reportID on IOU actions.
+    const moneyRequestReportID = reportAction?.reportID || originalMessage?.IOUReportID;
     const isRequestor = deprecatedCurrentUserAccountID === reportAction?.actorAccountID;
 
     if (!moneyRequestReportID) {
@@ -5088,8 +5090,10 @@ function canEditFieldOfMoneyRequest({
         return true;
     }
 
-    // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
-    const iouReportID = getOriginalMessage(reportAction)?.IOUReportID ?? reportAction?.reportID;
+    // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
+    // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
+    // Temporary until the backend reliably sends reportID on IOU actions.
+    const iouReportID = reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID;
     const moneyRequestReport = report ?? (iouReportID ? (getReport(iouReportID, deprecatedAllReports) ?? ({} as Report)) : ({} as Report));
 
     if (fieldToEdit === CONST.EDIT_REQUEST_FIELD.BILLABLE && isInvoiceReport(moneyRequestReport) && isReportApproved({report: moneyRequestReport})) {
@@ -5238,8 +5242,10 @@ function canEditReportAction(reportAction: OnyxInputOrEntry<ReportAction>, linke
     // canEditMoneyRequest has an admin/manager bypass for field-level edits (via canEditFieldOfMoneyRequest),
     // but that bypass should not allow the "Edit expense" action on finalized reports.
     if (isMoneyRequestAction(reportAction)) {
-        // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
-        const moneyRequestReportID = getOriginalMessage(reportAction)?.IOUReportID ?? reportAction?.reportID;
+        // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
+        // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
+        // Temporary until the backend reliably sends reportID on IOU actions.
+        const moneyRequestReportID = reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID;
         if (moneyRequestReportID) {
             const moneyRequestReport = getReportOrDraftReport(String(moneyRequestReportID));
             if (isSettled(moneyRequestReport?.reportID) || isReportApproved({report: moneyRequestReport}) || isClosedReport(moneyRequestReport)) {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4872,7 +4872,7 @@ function canEditMoneyRequest(
 
     // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
     // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
-    // Temporary until the backend reliably sends reportID on IOU actions.
+    // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882.
     const moneyRequestReportID = reportAction?.reportID || originalMessage?.IOUReportID;
     const isRequestor = deprecatedCurrentUserAccountID === reportAction?.actorAccountID;
 
@@ -5092,7 +5092,7 @@ function canEditFieldOfMoneyRequest({
 
     // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
     // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
-    // Temporary until the backend reliably sends reportID on IOU actions.
+    // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882.
     const iouReportID = reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID;
     const moneyRequestReport = report ?? (iouReportID ? (getReport(iouReportID, deprecatedAllReports) ?? ({} as Report)) : ({} as Report));
 
@@ -5244,7 +5244,7 @@ function canEditReportAction(reportAction: OnyxInputOrEntry<ReportAction>, linke
     if (isMoneyRequestAction(reportAction)) {
         // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
         // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
-        // Temporary until the backend reliably sends reportID on IOU actions.
+        // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882. See https://github.com/Expensify/App/issues/93882.
         const moneyRequestReportID = reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID;
         if (moneyRequestReportID) {
             const moneyRequestReport = getReportOrDraftReport(String(moneyRequestReportID));

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4873,7 +4873,7 @@ function canEditMoneyRequest(
     // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
     // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
     // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882.
-    const moneyRequestReportID = reportAction?.reportID || originalMessage?.IOUReportID;
+    const moneyRequestReportID = reportAction?.reportID ?? originalMessage?.IOUReportID;
     const isRequestor = deprecatedCurrentUserAccountID === reportAction?.actorAccountID;
 
     if (!moneyRequestReportID) {
@@ -5093,7 +5093,7 @@ function canEditFieldOfMoneyRequest({
     // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
     // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
     // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882.
-    const iouReportID = reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID;
+    const iouReportID = reportAction?.reportID ?? getOriginalMessage(reportAction)?.IOUReportID;
     const moneyRequestReport = report ?? (iouReportID ? (getReport(iouReportID, deprecatedAllReports) ?? ({} as Report)) : ({} as Report));
 
     if (fieldToEdit === CONST.EDIT_REQUEST_FIELD.BILLABLE && isInvoiceReport(moneyRequestReport) && isReportApproved({report: moneyRequestReport})) {
@@ -5245,7 +5245,7 @@ function canEditReportAction(reportAction: OnyxInputOrEntry<ReportAction>, linke
         // Prefer the action's own reportID; fall back to originalMessage.IOUReportID only when the backend omits reportID.
         // Preferring reportID keeps moved expenses correct (the moved action carries a stale IOUReportID from the source report).
         // Temporary until the backend reliably sends reportID on IOU actions. See https://github.com/Expensify/App/issues/93882. See https://github.com/Expensify/App/issues/93882.
-        const moneyRequestReportID = reportAction?.reportID || getOriginalMessage(reportAction)?.IOUReportID;
+        const moneyRequestReportID = reportAction?.reportID ?? getOriginalMessage(reportAction)?.IOUReportID;
         if (moneyRequestReportID) {
             const moneyRequestReport = getReportOrDraftReport(String(moneyRequestReportID));
             if (isSettled(moneyRequestReport?.reportID) || isReportApproved({report: moneyRequestReport}) || isClosedReport(moneyRequestReport)) {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4870,7 +4870,8 @@ function canEditMoneyRequest(
         return true;
     }
 
-    const moneyRequestReportID = reportAction?.reportID;
+    // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
+    const moneyRequestReportID = originalMessage?.IOUReportID ?? reportAction?.reportID;
     const isRequestor = deprecatedCurrentUserAccountID === reportAction?.actorAccountID;
 
     if (!moneyRequestReportID) {
@@ -5087,7 +5088,8 @@ function canEditFieldOfMoneyRequest({
         return true;
     }
 
-    const iouReportID = reportAction?.reportID;
+    // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
+    const iouReportID = getOriginalMessage(reportAction)?.IOUReportID ?? reportAction?.reportID;
     const moneyRequestReport = report ?? (iouReportID ? (getReport(iouReportID, deprecatedAllReports) ?? ({} as Report)) : ({} as Report));
 
     if (fieldToEdit === CONST.EDIT_REQUEST_FIELD.BILLABLE && isInvoiceReport(moneyRequestReport) && isReportApproved({report: moneyRequestReport})) {
@@ -5236,7 +5238,8 @@ function canEditReportAction(reportAction: OnyxInputOrEntry<ReportAction>, linke
     // canEditMoneyRequest has an admin/manager bypass for field-level edits (via canEditFieldOfMoneyRequest),
     // but that bypass should not allow the "Edit expense" action on finalized reports.
     if (isMoneyRequestAction(reportAction)) {
-        const moneyRequestReportID = reportAction?.reportID;
+        // Temporary fallback to originalMessage.IOUReportID while the backend is updated to reliably send reportID on IOU actions.
+        const moneyRequestReportID = getOriginalMessage(reportAction)?.IOUReportID ?? reportAction?.reportID;
         if (moneyRequestReportID) {
             const moneyRequestReport = getReportOrDraftReport(String(moneyRequestReportID));
             if (isSettled(moneyRequestReport?.reportID) || isReportApproved({report: moneyRequestReport}) || isClosedReport(moneyRequestReport)) {

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -39,6 +39,7 @@ type OriginalMessageIOU = {
     /**
      * ID of the IOU/expense report the action belongs to. Temporary fallback for resolving the report when the
      * backend omits `reportID` on hydrated IOU actions. Remove once the backend reliably sends `reportID`.
+     * See https://github.com/Expensify/App/issues/93882.
      */
     IOUReportID?: string;
 

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -36,6 +36,12 @@ type OriginalMessageIOU = {
     /** The ID of the `IOU` transaction */
     IOUTransactionID?: string;
 
+    /**
+     * ID of the IOU/expense report the action belongs to. Temporary fallback for resolving the report when the
+     * backend omits `reportID` on hydrated IOU actions. Remove once the backend reliably sends `reportID`.
+     */
+    IOUReportID?: string;
+
     /** ID of the expense report */
     expenseReportID?: string;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

[#87530](https://github.com/Expensify/App/pull/87530) ("Remove usage of IOUReportID completely", shipped in v9.4.8) stopped resolving the report an `IOU` action belongs to via the `getOriginalMessage(reportAction)?.IOUReportID ?? reportAction?.reportID` fallback and switched to using `reportAction?.reportID` directly. The premise was that for `CREATE`/`TRACK` `IOU` actions `reportID` always equals the IOU/expense report ID.

That premise does not hold for backend-hydrated actions: the backend does not reliably include `reportID` on `IOU` actions, so the lookup resolves the wrong report (or none). When that happens, `getPolicy()` cannot find the policy, the admin/manager bypass in `canEditMoneyRequest` / `canEditFieldOfMoneyRequest` never fires, and execution falls through to the requestor-only branch. The result is that an admin or manager viewing someone else's submitted expense report sees every field as read-only — and because the edit is blocked client-side, no request is ever sent to the API. The code already documents this divergence in `useGetIOUReportFromReportAction` ("For self-DM tracks and split bills, action.reportID resolves to a chat report, not an IOU/expense report").

This PR restores the `originalMessage.IOUReportID ?? reportAction?.reportID` fallback in the report-resolution paths used for editability:

- `canEditMoneyRequest`
- `canEditFieldOfMoneyRequest`
- `canEditReportAction`
- `useGetIOUReportFromReportAction`

It also re-adds the `IOUReportID` field to the `OriginalMessageIOU` type (it had been removed) so the fallback typechecks.

This is a **temporary** client-side fallback. The real fix is on the backend, which must reliably include `reportID` on `IOU` actions; once that ships, the fallback (and the `IOUReportID` field) should be removed. Tracked in [#93882](https://github.com/Expensify/App/issues/93882).

### Fixed Issues

$ https://github.com/Expensify/App/issues/93864
PROPOSAL:

### Tests

1. Sign in to New Expensify as a workspace admin who is **not** the submitter of the expenses below.
2. Ensure the workspace has a submitted (Processing/Outstanding) expense report owned by another member with at least one expense.
3. Open that expense report (e.g. from Spend > Reports) and click an expense.
4. Open the **Category** field (and other coding fields such as Tag/Description).
5. Verify the field is editable, that selecting a new value saves it, and that the change persists after refresh.
6. Verify no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Complete steps 1-3 from the Tests section while online.
2. Disable your network connection.
3. Open an expense on the submitted report as the admin.
4. Verify the coding fields (Category, Tag, etc.) still render as editable for the admin.
5. Verify edits are queued optimistically and reconcile correctly once back online.

### QA Steps

1. Sign in to New Expensify as a workspace admin who is **not** the submitter.
2. Ensure the workspace has a submitted expense report owned by another member with at least one expense.
3. Open that expense report and click an expense.
4. Open the Category field and change it.
5. Verify the category updates and persists, and the change is reflected after refresh.
6. Verify no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
