### PR TITLE
[CP Staging] Fix: Close modal once donwload and make sure file is sent in concierge

### DIFF
--- a/src/components/ExportDownloadStatusModal.tsx
+++ b/src/components/ExportDownloadStatusModal.tsx
@@ -13,7 +13,7 @@ import {getOldDotURLFromEnvironment} from '@libs/Environment/Environment';
 import fileDownload from '@libs/fileDownload';
 import Navigation from '@libs/Navigation/Navigation';
 import addTrailingForwardSlash from '@libs/UrlUtils';
-import {clearExportDownload, sendExportFileFromConcierge} from '@userActions/Export';
+import {sendExportFileFromConcierge} from '@userActions/Export';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -92,14 +92,11 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
         }
     };
 
-    const handleClose = () => {
-        clearExportDownload(exportID, displayedExport ?? undefined);
-        onClose();
-    };
-
     const handleDownloadFile = () => {
         downloadFile();
-        handleClose();
+        // Clearing the export download is owned by the parent's onClose handler (it runs on every dismissal and
+        // skips the clear for the Concierge path). Clearing here too would queue a duplicate ClearExportDownload write.
+        onClose();
     };
 
     const isNonDismissible = isPreparing;
@@ -167,7 +164,7 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
                     {!!failedBody && <Text style={styles.mb5}>{failedBody}</Text>}
                     <Button
                         text={translate('exportDownload.close')}
-                        onPress={handleClose}
+                        onPress={onClose}
                         style={styles.w100}
                     />
                 </>

--- a/src/components/ExportDownloadStatusModal.tsx
+++ b/src/components/ExportDownloadStatusModal.tsx
@@ -97,6 +97,11 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
         onClose();
     };
 
+    const handleDownloadFile = () => {
+        downloadFile();
+        handleClose();
+    };
+
     const isNonDismissible = isPreparing;
 
     const renderContent = () => {
@@ -104,7 +109,7 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
             return (
                 <>
                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mb2]}>
-                        <Text style={[styles.textHeadlineH1, styles.flexShrink1]}>{translate('exportDownload.preparingTitle')}</Text>
+                        <Text style={[styles.exportDownloadTitle, styles.flexShrink1]}>{translate('exportDownload.preparingTitle')}</Text>
                         <ActivityIndicator
                             size="small"
                             reasonAttributes={{context: 'ExportDownloadStatusModal.preparing'}}
@@ -123,7 +128,7 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
         if (isConcierge) {
             return (
                 <>
-                    <Text style={[styles.textHeadlineH1, styles.mb2]}>{translate('exportDownload.conciergeTitle')}</Text>
+                    <Text style={[styles.exportDownloadTitle, styles.mb2]}>{translate('exportDownload.conciergeTitle')}</Text>
                     <Text style={styles.mb5}>{translate('exportDownload.conciergeBody')}</Text>
                     <Button
                         success
@@ -143,18 +148,13 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
         if (isReady) {
             return (
                 <>
-                    <Text style={[styles.textHeadlineH1, styles.mb2]}>{translate('exportDownload.readyTitle')}</Text>
+                    <Text style={[styles.exportDownloadTitle, styles.mb2]}>{translate('exportDownload.readyTitle')}</Text>
                     <Text style={styles.mb5}>{translate('exportDownload.readyBody')}</Text>
                     <Button
                         success
                         text={translate('exportDownload.downloadFile')}
-                        onPress={downloadFile}
+                        onPress={handleDownloadFile}
                         style={styles.w100}
-                    />
-                    <Button
-                        text={translate('exportDownload.close')}
-                        onPress={handleClose}
-                        style={[styles.w100, styles.mt3]}
                     />
                 </>
             );
@@ -163,7 +163,7 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
         if (isFailed) {
             return (
                 <>
-                    <Text style={[styles.textHeadlineH1, styles.mb2]}>{translate('exportDownload.failedTitle')}</Text>
+                    <Text style={[styles.exportDownloadTitle, styles.mb2]}>{translate('exportDownload.failedTitle')}</Text>
                     {!!failedBody && <Text style={styles.mb5}>{failedBody}</Text>}
                     <Button
                         text={translate('exportDownload.close')}

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -2099,7 +2099,9 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         if (activeExportDownload?.state === CONST.EXPORT_DOWNLOAD.STATE.PREPARING && !activeExportDownload?.shouldSendFromConcierge) {
             return;
         }
-        if (activeExportID) {
+        // For the Concierge path the worker deletes the NVP after sending, so clearing it here would wipe
+        // shouldSendFromConcierge before the worker reads it and the file would never reach Concierge.
+        if (activeExportID && !activeExportDownload?.shouldSendFromConcierge) {
             clearExportDownload(activeExportID, activeExportDownload);
         }
         setActiveExportID(undefined);

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -622,6 +622,14 @@ const staticStyles = (theme: ThemeColors) =>
             lineHeight: variables.lineHeightSizeH1,
         },
 
+        exportDownloadTitle: {
+            ...headlineFont,
+            ...whiteSpace.preWrap,
+            color: theme.heading,
+            fontSize: variables.fontSizeLarge,
+            lineHeight: variables.lineHeightXLarge,
+        },
+
         textWhite: {
             color: theme.textLight,
         },

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -623,7 +623,7 @@ const staticStyles = (theme: ThemeColors) =>
         },
 
         exportDownloadTitle: {
-            ...headlineFont,
+            ...FontUtils.fontFamily.platform.EXP_NEUE_BOLD,
             ...whiteSpace.preWrap,
             color: theme.heading,
             fontSize: variables.fontSizeLarge,

--- a/tests/unit/ExportDownloadStatusModalTest.tsx
+++ b/tests/unit/ExportDownloadStatusModalTest.tsx
@@ -114,7 +114,7 @@ describe('ExportDownloadStatusModal', () => {
         expect(mockFileDownload).toHaveBeenCalledWith(expect.anything(), expect.stringContaining(expectedURLPart), FILE_NAME, expect.anything(), expect.anything());
     });
 
-    it('shows ready state with Download and Close buttons', async () => {
+    it('shows ready state with a Download button and no Close button', async () => {
         await Onyx.set(`${ONYXKEYS.COLLECTION.EXPORT_DOWNLOAD}${EXPORT_ID}`, {state: 'ready', fileName: FILE_NAME});
 
         renderModal();
@@ -123,7 +123,8 @@ describe('ExportDownloadStatusModal', () => {
         expect(screen.getByText('exportDownload.readyTitle')).toBeTruthy();
         expect(screen.getByText('exportDownload.readyBody')).toBeTruthy();
         expect(screen.getByText('exportDownload.downloadFile')).toBeTruthy();
-        expect(screen.getByText('exportDownload.close')).toBeTruthy();
+        // The Close button is removed in the ready state; the modal is dismissible and Download closes it.
+        expect(screen.queryByText('exportDownload.close')).toBeNull();
     });
 
     it('shows failed state with correct failedBody prop', async () => {
@@ -167,16 +168,33 @@ describe('ExportDownloadStatusModal', () => {
         expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining(conciergeReportID));
     });
 
-    it('Close button calls clearExportDownload', async () => {
+    it('Download file button downloads, clears the export and closes the modal', async () => {
         const onClose = jest.fn();
         await Onyx.set(`${ONYXKEYS.COLLECTION.EXPORT_DOWNLOAD}${EXPORT_ID}`, {state: 'ready', fileName: FILE_NAME});
 
         renderModal({onClose});
         await waitForBatchedUpdatesWithAct();
 
+        // Ignore the automatic download that fires when the export becomes ready, so we only assert the button's effect.
+        mockFileDownload.mockClear();
+
+        fireEvent.press(screen.getByText('exportDownload.downloadFile'));
+
+        expect(mockFileDownload).toHaveBeenCalled();
+        expect(mockClearExportDownload).toHaveBeenCalledWith(EXPORT_ID, expect.objectContaining({state: 'ready'}));
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('Close button in the failed state calls clearExportDownload and closes', async () => {
+        const onClose = jest.fn();
+        await Onyx.set(`${ONYXKEYS.COLLECTION.EXPORT_DOWNLOAD}${EXPORT_ID}`, {state: 'failed'});
+
+        renderModal({onClose});
+        await waitForBatchedUpdatesWithAct();
+
         fireEvent.press(screen.getByText('exportDownload.close'));
 
-        expect(mockClearExportDownload).toHaveBeenCalledWith(EXPORT_ID, expect.objectContaining({state: 'ready'}));
+        expect(mockClearExportDownload).toHaveBeenCalledWith(EXPORT_ID, expect.objectContaining({state: 'failed'}));
         expect(onClose).toHaveBeenCalled();
     });
 });

--- a/tests/unit/ExportDownloadStatusModalTest.tsx
+++ b/tests/unit/ExportDownloadStatusModalTest.tsx
@@ -168,7 +168,7 @@ describe('ExportDownloadStatusModal', () => {
         expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining(conciergeReportID));
     });
 
-    it('Download file button downloads, clears the export and closes the modal', async () => {
+    it('Download file button downloads and closes the modal, delegating the clear to the parent', async () => {
         const onClose = jest.fn();
         await Onyx.set(`${ONYXKEYS.COLLECTION.EXPORT_DOWNLOAD}${EXPORT_ID}`, {state: 'ready', fileName: FILE_NAME});
 
@@ -181,11 +181,12 @@ describe('ExportDownloadStatusModal', () => {
         fireEvent.press(screen.getByText('exportDownload.downloadFile'));
 
         expect(mockFileDownload).toHaveBeenCalled();
-        expect(mockClearExportDownload).toHaveBeenCalledWith(EXPORT_ID, expect.objectContaining({state: 'ready'}));
         expect(onClose).toHaveBeenCalled();
+        // Clearing the export download is owned by the parent's onClose handler, so the modal must not clear it itself (avoids a duplicate write).
+        expect(mockClearExportDownload).not.toHaveBeenCalled();
     });
 
-    it('Close button in the failed state calls clearExportDownload and closes', async () => {
+    it('Close button in the failed state closes the modal and delegates the clear to the parent', async () => {
         const onClose = jest.fn();
         await Onyx.set(`${ONYXKEYS.COLLECTION.EXPORT_DOWNLOAD}${EXPORT_ID}`, {state: 'failed'});
 
@@ -194,7 +195,7 @@ describe('ExportDownloadStatusModal', () => {
 
         fireEvent.press(screen.getByText('exportDownload.close'));
 
-        expect(mockClearExportDownload).toHaveBeenCalledWith(EXPORT_ID, expect.objectContaining({state: 'failed'}));
         expect(onClose).toHaveBeenCalled();
+        expect(mockClearExportDownload).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/hooks/useSearchBulkActionsTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsTest.ts
@@ -2,12 +2,18 @@ import {act, renderHook, waitFor} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
 import type {SearchQueryJSON, SelectedReports, SelectedTransactions} from '@components/Search/types';
 import useSearchBulkActions from '@hooks/useSearchBulkActions';
+import {clearExportDownload} from '@libs/actions/Export';
 import {queueExportSearchItemsToCSV, queueExportSearchWithTemplate} from '@libs/actions/Search';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 const mockQueueExportSearchItemsToCSV = jest.mocked(queueExportSearchItemsToCSV);
 const mockQueueExportSearchWithTemplate = jest.mocked(queueExportSearchWithTemplate);
+const mockClearExportDownload = jest.mocked(clearExportDownload);
+
+jest.mock('@libs/actions/Export', () => ({
+    clearExportDownload: jest.fn(),
+}));
 
 jest.mock('@libs/actions/Search', () => ({
     getExportTemplates: jest.fn(() => []),
@@ -317,5 +323,66 @@ describe('useSearchBulkActions - CSV export flow', () => {
         });
 
         expect(result.current.activeExportID).toBe('mock-export-id');
+    });
+
+    it('handleExportModalClose keeps the export NVP intact when sending via Concierge', async () => {
+        mockAreAllMatchingItemsSelected = true;
+        mockSelectedTransactions = {tx1: makeSelectedTransaction()};
+
+        const {result} = renderHook(() => useSearchBulkActions({queryJSON: baseQueryJSON}));
+
+        await waitFor(() => {
+            expect(result.current.headerButtonsOptions.length).toBeGreaterThan(0);
+        });
+
+        const exportOption = result.current.headerButtonsOptions.find((o) => o.value === CONST.SEARCH.BULK_ACTION_TYPES.EXPORT);
+        const onSelected = exportOption?.subMenuItems?.find((item) => item.text === 'export.basicExport')?.onSelected ?? exportOption?.onSelected;
+
+        await act(async () => {
+            onSelected?.();
+        });
+        expect(result.current.activeExportID).toBe('mock-export-id');
+
+        // The user chose to have the file sent from Concierge.
+        await act(async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.EXPORT_DOWNLOAD}mock-export-id`, {state: CONST.EXPORT_DOWNLOAD.STATE.READY, shouldSendFromConcierge: true});
+        });
+
+        await act(async () => {
+            result.current.handleExportModalClose();
+        });
+
+        // The NVP must not be cleared, otherwise the worker loses shouldSendFromConcierge and never delivers to Concierge.
+        expect(mockClearExportDownload).not.toHaveBeenCalled();
+        expect(result.current.activeExportID).toBeUndefined();
+    });
+
+    it('handleExportModalClose clears the export NVP for a normal (non-Concierge) close', async () => {
+        mockAreAllMatchingItemsSelected = true;
+        mockSelectedTransactions = {tx1: makeSelectedTransaction()};
+
+        const {result} = renderHook(() => useSearchBulkActions({queryJSON: baseQueryJSON}));
+
+        await waitFor(() => {
+            expect(result.current.headerButtonsOptions.length).toBeGreaterThan(0);
+        });
+
+        const exportOption = result.current.headerButtonsOptions.find((o) => o.value === CONST.SEARCH.BULK_ACTION_TYPES.EXPORT);
+        const onSelected = exportOption?.subMenuItems?.find((item) => item.text === 'export.basicExport')?.onSelected ?? exportOption?.onSelected;
+
+        await act(async () => {
+            onSelected?.();
+        });
+
+        await act(async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.EXPORT_DOWNLOAD}mock-export-id`, {state: CONST.EXPORT_DOWNLOAD.STATE.READY});
+        });
+
+        await act(async () => {
+            result.current.handleExportModalClose();
+        });
+
+        expect(mockClearExportDownload).toHaveBeenCalledWith('mock-export-id', expect.objectContaining({state: CONST.EXPORT_DOWNLOAD.STATE.READY}));
+        expect(result.current.activeExportID).toBeUndefined();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/93873
$ https://github.com/Expensify/App/issues/93874
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Test 1: Modal should be closed after clicking on "Download file"

1. Open ND.
2. Navigate to Spend > Expenses.
3.Select any expense.
4. Click the "x selected" dropdown button, then choose Export > All Data - Expense Level.
5. Verify that the Send me the file when is ready is displayed
6. Wait a few seconds until the following modal appears: Your file is ready!
7. Click Download file.
8. Your file is ready! modal should close when click Download file

Test 2: Exported file should be received in Concierge

1. Go to ND
2. Go to workspace chat.
3. Create an expense.
4. Go to Spend > Expenses.
5. Select the expense via checkbox.
6. Click dropdown button > Export > All Data - expense level.
7. Quickly click "Send me the file when it's ready", then click "Go to Concierge".
8. Verify: User will receive the exported file in Concierge chat.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Test 1: Modal should be closed after clicking on "Download file"

1. Open ND.
2. Navigate to Spend > Expenses.
3.Select any expense.
4. Click the "x selected" dropdown button, then choose Export > All Data - Expense Level.
5. Verify that the Send me the file when is ready is displayed
6. Wait a few seconds until the following modal appears: Your file is ready!
7. Click Download file.
8. Your file is ready! modal should close when click Download file

Test 2: Exported file should be received in Concierge

1. Go to ND
2. Go to workspace chat.
3. Create an expense.
4. Go to Spend > Expenses.
5. Select the expense via checkbox.
6. Click dropdown button > Export > All Data - expense level.
7. Quickly click "Send me the file when it's ready", then click "Go to Concierge".
8. Verify: User will receive the exported file in Concierge chat.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/47c14671-f7f0-4aa4-8327-fb1483bd9c87


https://github.com/user-attachments/assets/77905939-377c-4050-ab56-665089e04034


</details>
