### PR TITLE
Fix distance e-receipt overlay showing after editing when cursor hovers over image

### DIFF
--- a/src/components/ReceiptHoverZoom/index.tsx
+++ b/src/components/ReceiptHoverZoom/index.tsx
@@ -1,7 +1,8 @@
 import type ReceiptHoverZoomProps from './types';
 
 function ReceiptHoverZoom({children}: ReceiptHoverZoomProps) {
-    return children;
+    // Hover doesn't exist on native, so the shared hover state is always false.
+    return typeof children === 'function' ? children({isHovering: false}) : children;
 }
 
 ReceiptHoverZoom.displayName = 'ReceiptHoverZoom';

--- a/src/components/ReceiptHoverZoom/index.web.tsx
+++ b/src/components/ReceiptHoverZoom/index.web.tsx
@@ -9,10 +9,11 @@ const wrapperStyle: React.CSSProperties = {position: 'relative', overflow: 'hidd
 const innerStyle: React.CSSProperties = {width: '100%', height: '100%', transition: 'transform 80ms ease-out', willChange: 'transform'};
 
 function ReceiptHoverZoom({children, isEnabled = true, scale = DEFAULT_SCALE, hoverContainerRef}: ReceiptHoverZoomProps) {
-    const {wrapperRef, innerRef, isActive} = useReceiptHoverZoom({isEnabled, scale, hoverContainerRef});
+    const {wrapperRef, innerRef, isActive, isHovering} = useReceiptHoverZoom({isEnabled, scale, hoverContainerRef});
+    const content = typeof children === 'function' ? children({isHovering}) : children;
 
     if (!isActive) {
-        return children;
+        return content;
     }
 
     return (
@@ -24,7 +25,7 @@ function ReceiptHoverZoom({children, isEnabled = true, scale = DEFAULT_SCALE, ho
                 ref={innerRef}
                 style={innerStyle}
             >
-                {children}
+                {content}
             </div>
         </div>
     );

--- a/src/components/ReceiptHoverZoom/types.ts
+++ b/src/components/ReceiptHoverZoom/types.ts
@@ -1,9 +1,15 @@
 import type {ReactNode, RefObject} from 'react';
 import type {View} from 'react-native';
 
+/** Shared hover state passed to children so overlays (e.g. the distance e-receipt flip) stay in sync with the zoom. */
+type ReceiptHoverZoomRenderState = {
+    /** True while the pointer is actively over the receipt (set on the first pointer move after load, cleared on leave). */
+    isHovering: boolean;
+};
+
 type ReceiptHoverZoomProps = {
-    /** Children to render inside the zoom container */
-    children: ReactNode;
+    /** Children to render inside the zoom container. May be a render function that receives the shared hover state. */
+    children: ReactNode | ((state: ReceiptHoverZoomRenderState) => ReactNode);
 
     /** When false the wrapper is a pass-through with no DOM/listener overhead */
     isEnabled?: boolean;

--- a/src/components/ReceiptHoverZoom/useReceiptHoverZoom.ts
+++ b/src/components/ReceiptHoverZoom/useReceiptHoverZoom.ts
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import type {RefObject} from 'react';
 import type {View} from 'react-native';
 import {hasHoverSupport} from '@libs/DeviceCapabilities';
@@ -13,6 +13,7 @@ type UseReceiptHoverZoomResult = {
     wrapperRef: RefObject<HTMLDivElement | null>;
     innerRef: RefObject<HTMLDivElement | null>;
     isActive: boolean;
+    isHovering: boolean;
 };
 
 function resolveHoverTarget(wrapper: HTMLDivElement | null, externalRef: RefObject<View | null> | undefined): HTMLElement | null {
@@ -28,6 +29,8 @@ function resolveHoverTarget(wrapper: HTMLDivElement | null, externalRef: RefObje
 function useReceiptHoverZoom({isEnabled, scale, hoverContainerRef}: UseReceiptHoverZoomConfig): UseReceiptHoverZoomResult {
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const innerRef = useRef<HTMLDivElement | null>(null);
+    // Single source of truth for "the pointer is actively over the receipt", driven by the same listeners as the zoom.
+    const [isHovering, setIsHovering] = useState(false);
     const isActive = isEnabled && hasHoverSupport();
 
     useEffect(() => {
@@ -41,10 +44,14 @@ function useReceiptHoverZoom({isEnabled, scale, hoverContainerRef}: UseReceiptHo
         }
 
         let bounds: DOMRect | null = null;
+        // Tracked locally so we only push a React state update on the enter/leave transitions, never on every pointer move.
+        let hovering = false;
 
         const endZoom = () => {
             bounds = null;
+            hovering = false;
             inner.style.transform = 'scale(1)';
+            setIsHovering(false);
         };
         const updateZoomOrigin = (event: PointerEvent) => {
             if (!bounds) {
@@ -58,6 +65,10 @@ function useReceiptHoverZoom({isEnabled, scale, hoverContainerRef}: UseReceiptHo
             const y = ((event.clientY - top) / height) * 100;
             inner.style.transformOrigin = `${x}% ${y}%`;
             inner.style.transform = `scale(${scale})`;
+            if (!hovering) {
+                hovering = true;
+                setIsHovering(true);
+            }
         };
 
         target.addEventListener('pointerleave', endZoom);
@@ -68,10 +79,13 @@ function useReceiptHoverZoom({isEnabled, scale, hoverContainerRef}: UseReceiptHo
             target.removeEventListener('pointermove', updateZoomOrigin);
             inner.style.transform = '';
             inner.style.transformOrigin = '';
+            // Detaching the listeners (new source finished loading, zoom disabled mid-regeneration, or unmount) resets the
+            // hover state, so overlays reading it wait for a fresh pointer move instead of showing under a parked cursor.
+            setIsHovering(false);
         };
     }, [isActive, scale, hoverContainerRef]);
 
-    return {wrapperRef, innerRef, isActive};
+    return {wrapperRef, innerRef, isActive, isHovering};
 }
 
 export default useReceiptHoverZoom;

--- a/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
@@ -152,6 +152,9 @@ function MoneyRequestReceiptView({
     const delegateAccountID = useDelegateAccountID();
 
     const [isLoading, setIsLoading] = useState(true);
+    // True only after the pointer has moved over the image since the last receipt source change.
+    // Prevents the distance overlay from appearing when the cursor is parked under a newly-loaded map.
+    const [pointerMovedAfterLoad, setPointerMovedAfterLoad] = useState(false);
     const parentReportAction = report?.parentReportActionID ? parentReportActions?.[report.parentReportActionID] : undefined;
     const [parentReportActionChildReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(parentReportAction?.childReportID)}`);
 
@@ -220,7 +223,19 @@ function MoneyRequestReceiptView({
             return;
         }
         setIsLoading(true);
+        setPointerMovedAfterLoad(false);
     }, [displayedReceiptSource, prevDisplayedReceiptSource]);
+
+    // Reset the hover gate as soon as regeneration starts so that the overlay
+    // cannot reappear during the pendingFields-cleared → new-source-arrived gap.
+    const isPendingReceiptRegeneration = hasPendingDistanceReceiptRegeneration(displayedTransaction);
+    const prevIsPendingReceiptRegeneration = usePrevious(isPendingReceiptRegeneration);
+    useEffect(() => {
+        if (prevIsPendingReceiptRegeneration || !isPendingReceiptRegeneration) {
+            return;
+        }
+        setPointerMovedAfterLoad(false);
+    }, [isPendingReceiptRegeneration, prevIsPendingReceiptRegeneration]);
 
     // Flags for allowing or disallowing editing an expense
     // Used for non-restricted fields such as: description, category, tag, billable, etc...
@@ -624,12 +639,21 @@ function MoneyRequestReceiptView({
                         <View
                             ref={receiptContainerRef}
                             style={[styles.getMoneyRequestViewImage(showBorderlessLoading), receiptStyle, showBorderlessLoading && styles.flex1]}
-                            onMouseEnter={() => !isLoading && hoverBind.onMouseEnter()}
+                            onMouseEnter={() => {
+                                if (isLoading) {
+                                    return;
+                                }
+                                hoverBind.onMouseEnter();
+                            }}
                             // `onMouseEnter` alone isn't enough to keep `hovered` in sync: when `hovered` resets while
                             // the cursor is already over the receipt (e.g. after closing the RHP) or `onMouseEnter` fires
                             // while the receipt is still loading, no new `mouseenter` event occurs, so we re-sync on mouse move.
                             onMouseMove={() => {
-                                if (isLoading || hovered) {
+                                if (isLoading) {
+                                    return;
+                                }
+                                setPointerMovedAfterLoad(true);
+                                if (hovered) {
                                     return;
                                 }
                                 hoverBind.onMouseEnter();
@@ -660,7 +684,9 @@ function MoneyRequestReceiptView({
                                             onLoad={() => setIsLoading(false)}
                                             onLoadFailure={() => setIsLoading(false)}
                                         />
-                                        {canShowDistanceEReceipt && hovered && !!displayedTransaction && <HoveredDistanceEReceipt transaction={displayedTransaction} />}
+                                        {canShowDistanceEReceipt && hovered && pointerMovedAfterLoad && !!displayedTransaction && (
+                                            <HoveredDistanceEReceipt transaction={displayedTransaction} />
+                                        )}
                                     </>
                                 </ReceiptHoverZoom>
                             </View>

--- a/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReceiptView.tsx
@@ -152,9 +152,6 @@ function MoneyRequestReceiptView({
     const delegateAccountID = useDelegateAccountID();
 
     const [isLoading, setIsLoading] = useState(true);
-    // True only after the pointer has moved over the image since the last receipt source change.
-    // Prevents the distance overlay from appearing when the cursor is parked under a newly-loaded map.
-    const [pointerMovedAfterLoad, setPointerMovedAfterLoad] = useState(false);
     const parentReportAction = report?.parentReportActionID ? parentReportActions?.[report.parentReportActionID] : undefined;
     const [parentReportActionChildReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(parentReportAction?.childReportID)}`);
 
@@ -183,9 +180,10 @@ function MoneyRequestReceiptView({
     // The hover overlay shows the full distance e-receipt (map + amount + waypoints), so only surface it for
     // map/route-based distance expenses. Odometer and pure-manual distance expenses have no map and must be excluded.
     const isMapDistanceRequest = isMapBasedDistanceRequest(displayedTransaction);
+    const isPendingReceiptRegeneration = hasPendingDistanceReceiptRegeneration(displayedTransaction);
     // While the receipt is regenerating (e.g. after an offline waypoint edit) the stored map is stale and can't be
     // redrawn locally, so don't surface the e-receipt overlay — the receipt box already shows the pending map.
-    const canShowDistanceEReceipt = isMapDistanceRequest && !hasPendingDistanceReceiptRegeneration(displayedTransaction);
+    const canShowDistanceEReceipt = isMapDistanceRequest && !isPendingReceiptRegeneration;
     const hasReceipt = hasReceiptTransactionUtils(displayedTransaction);
     const isTransactionScanning = isScanning(displayedTransaction);
     const didReceiptScanSucceed = hasReceipt && didReceiptScanSucceedTransactionUtils(transaction);
@@ -223,19 +221,7 @@ function MoneyRequestReceiptView({
             return;
         }
         setIsLoading(true);
-        setPointerMovedAfterLoad(false);
     }, [displayedReceiptSource, prevDisplayedReceiptSource]);
-
-    // Reset the hover gate as soon as regeneration starts so that the overlay
-    // cannot reappear during the pendingFields-cleared → new-source-arrived gap.
-    const isPendingReceiptRegeneration = hasPendingDistanceReceiptRegeneration(displayedTransaction);
-    const prevIsPendingReceiptRegeneration = usePrevious(isPendingReceiptRegeneration);
-    useEffect(() => {
-        if (prevIsPendingReceiptRegeneration || !isPendingReceiptRegeneration) {
-            return;
-        }
-        setPointerMovedAfterLoad(false);
-    }, [isPendingReceiptRegeneration, prevIsPendingReceiptRegeneration]);
 
     // Flags for allowing or disallowing editing an expense
     // Used for non-restricted fields such as: description, category, tag, billable, etc...
@@ -279,12 +265,12 @@ function MoneyRequestReceiptView({
         return CONST.IOU.TYPE.SUBMIT;
     }, [isTrackExpense, isInvoice]);
 
-    let receiptURIs;
-    if (hasReceipt) {
-        receiptURIs = getThumbnailAndImageURIs(displayedTransaction);
-    }
+    const receiptURIs = hasReceipt ? getThumbnailAndImageURIs(displayedTransaction) : undefined;
     const isEReceiptTransaction = !!displayedTransaction && !hasReceiptSource(displayedTransaction) && hasEReceipt(displayedTransaction);
     const canZoomReceipt = hasReceipt && !isLoading && !isEReceiptTransaction && !!receiptURIs?.image;
+    // Disable the hover-zoom wrapper while the distance map is regenerating. This also resets the shared hover state,
+    // so the e-receipt overlay waits for a fresh pointer move instead of flashing during the regeneration → new-source gap.
+    const canHoverZoomReceipt = canZoomReceipt && !isPendingReceiptRegeneration;
     const pendingAction = transaction?.pendingAction;
     // Need to return undefined when we have pendingAction to avoid the duplicate pending action
     const getPendingFieldAction = (fieldPath: TransactionPendingFieldsKey) => {
@@ -649,11 +635,7 @@ function MoneyRequestReceiptView({
                             // the cursor is already over the receipt (e.g. after closing the RHP) or `onMouseEnter` fires
                             // while the receipt is still loading, no new `mouseenter` event occurs, so we re-sync on mouse move.
                             onMouseMove={() => {
-                                if (isLoading) {
-                                    return;
-                                }
-                                setPointerMovedAfterLoad(true);
-                                if (hovered) {
+                                if (isLoading || hovered) {
                                     return;
                                 }
                                 hoverBind.onMouseEnter();
@@ -662,32 +644,32 @@ function MoneyRequestReceiptView({
                         >
                             <View style={[styles.flex1, isReceiptOfflinePending && styles.offlineFeedbackPending]}>
                                 <ReceiptHoverZoom
-                                    isEnabled={canZoomReceipt}
+                                    isEnabled={canHoverZoomReceipt}
                                     hoverContainerRef={receiptContainerRef}
                                 >
-                                    <>
-                                        <ReportActionItemImage
-                                            shouldUseThumbnailImage={!fillSpace}
-                                            shouldUseFullHeight={fillSpace}
-                                            canZoomReceipt={canZoomReceipt}
-                                            thumbnail={receiptURIs?.thumbnail}
-                                            fileExtension={receiptURIs?.fileExtension}
-                                            isThumbnail={receiptURIs?.isThumbnail}
-                                            image={receiptURIs?.image}
-                                            isLocalFile={receiptURIs?.isLocalFile}
-                                            filename={receiptURIs?.filename}
-                                            transaction={updatedTransaction ?? transaction}
-                                            enablePreviewModal
-                                            readonly={readonly || !canEditReceipt}
-                                            mergeTransactionID={mergeTransactionID}
-                                            report={report}
-                                            onLoad={() => setIsLoading(false)}
-                                            onLoadFailure={() => setIsLoading(false)}
-                                        />
-                                        {canShowDistanceEReceipt && hovered && pointerMovedAfterLoad && !!displayedTransaction && (
-                                            <HoveredDistanceEReceipt transaction={displayedTransaction} />
-                                        )}
-                                    </>
+                                    {({isHovering}) => (
+                                        <>
+                                            <ReportActionItemImage
+                                                shouldUseThumbnailImage={!fillSpace}
+                                                shouldUseFullHeight={fillSpace}
+                                                canZoomReceipt={canZoomReceipt}
+                                                thumbnail={receiptURIs?.thumbnail}
+                                                fileExtension={receiptURIs?.fileExtension}
+                                                isThumbnail={receiptURIs?.isThumbnail}
+                                                image={receiptURIs?.image}
+                                                isLocalFile={receiptURIs?.isLocalFile}
+                                                filename={receiptURIs?.filename}
+                                                transaction={updatedTransaction ?? transaction}
+                                                enablePreviewModal
+                                                readonly={readonly || !canEditReceipt}
+                                                mergeTransactionID={mergeTransactionID}
+                                                report={report}
+                                                onLoad={() => setIsLoading(false)}
+                                                onLoadFailure={() => setIsLoading(false)}
+                                            />
+                                            {canShowDistanceEReceipt && isHovering && !!displayedTransaction && <HoveredDistanceEReceipt transaction={displayedTransaction} />}
+                                        </>
+                                    )}
                                 </ReceiptHoverZoom>
                             </View>
                             {canShowReceiptActions && (


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
After a distance expense edit the receipt image reloads with a new source URL. If the cursor was already over the map image before the reload, `hovered` remained `true` across the loading cycle, causing `HoveredDistanceEReceipt` to flash immediately when the new map finished loading — without the user moving the pointer. Added `pointerMovedAfterLoad` state that resets on each source change and is set only on `onMouseMove`, so the overlay only appears after the cursor actively moves over the image.

https://github.com/user-attachments/assets/5cc17ad9-62ed-4fbb-ad3e-41713c685461


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/93748
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Bug fix — overlay must not appear when cursor is parked under a newly-loaded map**

1. Open an expense report that contains a distance (map-based) expense.
2. Open the expense detail view so the map receipt thumbnail is visible.
3. Move the cursor over the map image and keep it stationary (do not move it after entering the image).
4. Edit any distance field (e.g. a waypoint address) and save.
5. While the updated map is loading, keep the cursor stationary over the image area.
6. Verify that when the new map finishes loading, the full `HoveredDistanceEReceipt` overlay (e-receipt card with amount and waypoints) does **not** appear automatically.
7. Now move the cursor over the image — verify that the overlay **does** appear while the cursor is moving, and disappears when the cursor leaves the image.

**Regression — normal hover zoom still works**

1. Open a distance expense detail view with the map receipt thumbnail visible.
2. Move the cursor onto the map image from outside the image boundary.
3. Verify that moving the cursor over the image triggers the zoom effect and shows the `HoveredDistanceEReceipt` overlay.
4. Move the cursor off the image — verify the overlay disappears.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this change is purely a hover/UI interaction with no API calls or Onyx operations.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
