### PR TITLE
[NoQA] Fix flaky pushTransactionAutoSelectionsOnyxData unit tests

### DIFF
--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -5,12 +5,10 @@ import {addDays, format as formatDate} from 'date-fns';
 import type {OnyxCollection, OnyxEntry, OnyxKey, OnyxMergeCollectionInput} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import type {LocaleContextProps} from '@components/LocaleContextProvider';
-import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import type PolicyData from '@hooks/usePolicyData/types';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import * as HoldUtils from '@libs/actions/IOU/Hold';
 import {putOnHold} from '@libs/actions/IOU/Hold';
-import initOnyxDerivedValues from '@libs/actions/OnyxDerived';
 import type {TaskForParameters} from '@libs/actions/Report';
 import type {OnboardingTaskLinks} from '@libs/actions/Welcome/OnboardingFlow';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
@@ -206,7 +204,6 @@ import type {TransactionCollectionDataSet} from '@src/types/onyx/Transaction';
 import type CollectionDataSet from '@src/types/utils/CollectionDataSet';
 import {toCollectionDataSet} from '@src/types/utils/CollectionDataSet';
 import type IconAsset from '@src/types/utils/IconAsset';
-import {actionR14932 as mockIOUAction} from '../../__mocks__/reportData/actions';
 import {chatReportR14932 as mockedChatReport, iouReportR14932 as mockIOUReport} from '../../__mocks__/reportData/reports';
 import {transactionR14932 as mockTransaction} from '../../__mocks__/reportData/transactions';
 import * as NumberUtils from '../../src/libs/NumberUtils';
@@ -10217,9 +10214,9 @@ describe('ReportUtils', () => {
             return Object.fromEntries(Object.entries(createRandomPolicyCategories(numberOfCategories)).map(([name, category]) => [name, {...category, enabled: true}]));
         }
 
-        function buildPolicyData(report: Report, transaction: Transaction, policy: Policy, categories: PolicyCategories, tags: PolicyTagLists = {}): PolicyData {
+        function buildPolicyData(report: Report, transaction: Transaction, testPolicy: Policy, categories: PolicyCategories, tags: PolicyTagLists = {}): PolicyData {
             return {
-                policy,
+                policy: testPolicy,
                 categories,
                 tags,
                 reports: [report],

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -6,7 +6,7 @@ import type {OnyxCollection, OnyxEntry, OnyxKey, OnyxMergeCollectionInput} from 
 import Onyx from 'react-native-onyx';
 import type {LocaleContextProps} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
-import usePolicyData from '@hooks/usePolicyData';
+import type PolicyData from '@hooks/usePolicyData/types';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import * as HoldUtils from '@libs/actions/IOU/Hold';
 import {putOnHold} from '@libs/actions/IOU/Hold';
@@ -187,6 +187,7 @@ import type {
     PolicyCategories,
     PolicyEmployeeList,
     PolicyTag,
+    PolicyTagLists,
     Report,
     ReportAction,
     ReportActions,
@@ -10104,10 +10105,7 @@ describe('ReportUtils', () => {
     });
 
     describe('pushTransactionViolationsOnyxData', () => {
-        beforeAll(() => {
-            initOnyxDerivedValues();
-        });
-        it('should push category violation to the Onyx data when category and tag is pending deletion', async () => {
+        it('should push category violation to the Onyx data when category and tag is pending deletion', () => {
             // Given policy categories, the first is pending deletion
             const fakePolicyCategories = createRandomPolicyCategories(3);
             const fakePolicyCategoryNameToDelete = Object.keys(fakePolicyCategories).at(0) ?? '';
@@ -10144,44 +10142,37 @@ describe('ReportUtils', () => {
                 areCategoriesEnabled: true,
             };
 
-            const fakePolicyReports: Record<`${typeof ONYXKEYS.COLLECTION.REPORT}${string}`, Report> = {
-                [`${ONYXKEYS.COLLECTION.REPORT}${mockIOUReport.reportID}`]: {
-                    ...mockIOUReport,
-                    policyID: fakePolicyID,
-                },
-                [`${ONYXKEYS.COLLECTION.REPORT}${mockedChatReport.reportID}`]: {
-                    ...mockedChatReport,
-                    policyID: fakePolicyID,
+            const openIOUReport: Report = {
+                ...mockIOUReport,
+                policyID: fakePolicyID,
+            };
+
+            const transaction: Transaction = {
+                ...mockTransaction,
+                reportID: openIOUReport.reportID,
+                policyID: fakePolicyID,
+                category: fakePolicyCategoryNameToDelete,
+                tag: fakePolicyTagsToDelete.at(0)?.[0] ?? '',
+            };
+
+            const policyData: PolicyData = {
+                policy: fakePolicy,
+                categories: fakePolicyCategories,
+                tags: fakePolicyTagsLists,
+                reports: [openIOUReport],
+                transactionsAndViolations: {
+                    [openIOUReport.reportID]: {
+                        transactions: {
+                            [mockTransaction.transactionID]: transaction,
+                        },
+                        violations: {},
+                    },
                 },
             };
 
-            // Populating Onyx with required data
-            await Onyx.multiSet({
-                ...fakePolicyReports,
-                [`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicyID}`]: fakePolicyTagsLists,
-                [`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${fakePolicyID}`]: fakePolicyCategories,
-                [`${ONYXKEYS.COLLECTION.POLICY}${fakePolicyID}`]: fakePolicy,
-                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${mockIOUReport.reportID}`]: {
-                    [mockIOUAction.reportActionID]: mockIOUAction,
-                },
-                [`${ONYXKEYS.COLLECTION.TRANSACTION}${mockTransaction.transactionID}`]: {
-                    ...mockTransaction,
-                    reportID: mockIOUReport.reportID,
-                    policyID: fakePolicyID,
-                    category: fakePolicyCategoryNameToDelete,
-                    tag: fakePolicyTagsToDelete.at(0)?.[0] ?? '',
-                },
-            });
-
-            await waitForBatchedUpdates();
-
-            const {result} = renderHook(() => usePolicyData(fakePolicyID), {wrapper: OnyxListItemProvider});
-
-            await waitForBatchedUpdates();
-
             const onyxData = {optimisticData: [], failureData: []};
 
-            pushTransactionViolationsOnyxData(onyxData, result.current, {}, fakePolicyCategoriesUpdate, fakePolicyTagListsUpdate);
+            pushTransactionViolationsOnyxData(onyxData, policyData, {}, fakePolicyCategoriesUpdate, fakePolicyTagListsUpdate);
 
             const expectedOnyxData = {
                 // Expecting the optimistic data to contain the OUT_OF_POLICY violations for the deleted category and tag
@@ -10220,10 +10211,6 @@ describe('ReportUtils', () => {
     describe('pushTransactionAutoSelectionsOnyxData', () => {
         const fakePolicyID = '0';
 
-        beforeAll(() => {
-            initOnyxDerivedValues();
-        });
-
         /**
          * Builds a policy with N categories that are all enabled (the factory disables them by default).
          */
@@ -10231,14 +10218,24 @@ describe('ReportUtils', () => {
             return Object.fromEntries(Object.entries(createRandomPolicyCategories(numberOfCategories)).map(([name, category]) => [name, {...category, enabled: true}]));
         }
 
-        /**
-         * Wraps a report in a keyed collection so it can be spread into Onyx.multiSet with a precise key type.
-         */
-        function buildReportCollection(report: Report): Record<`${typeof ONYXKEYS.COLLECTION.REPORT}${string}`, Report> {
-            return {[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`]: report};
+        function buildPolicyData(report: Report, transaction: Transaction, policy: Policy, categories: PolicyCategories, tags: PolicyTagLists = {}): PolicyData {
+            return {
+                policy,
+                categories,
+                tags,
+                reports: [report],
+                transactionsAndViolations: {
+                    [report.reportID]: {
+                        transactions: {
+                            [transaction.transactionID]: transaction,
+                        },
+                        violations: {},
+                    },
+                },
+            };
         }
 
-        it('auto-selects the sole remaining enabled category when the transaction category is disabled', async () => {
+        it('auto-selects the sole remaining enabled category when the transaction category is disabled', () => {
             // Given a policy with two enabled categories, and an update that disables the first one
             const fakePolicyCategories = buildEnabledCategories(2);
             const categoryNames = Object.keys(fakePolicyCategories);
@@ -10252,27 +10249,19 @@ describe('ReportUtils', () => {
 
             // Given an open report whose transaction uses the category about to be disabled
             const openIOUReport: Report = {...mockIOUReport, policyID: fakePolicyID, stateNum: CONST.REPORT.STATE_NUM.OPEN, statusNum: CONST.REPORT.STATUS_NUM.OPEN};
+            const transaction: Transaction = {
+                ...mockTransaction,
+                reportID: openIOUReport.reportID,
+                policyID: fakePolicyID,
+                category: categoryToDisable,
+                tag: '',
+            };
 
-            await Onyx.multiSet({
-                ...buildReportCollection(openIOUReport),
-                [`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${fakePolicyID}`]: fakePolicyCategories,
-                [`${ONYXKEYS.COLLECTION.POLICY}${fakePolicyID}`]: fakePolicy,
-                [`${ONYXKEYS.COLLECTION.TRANSACTION}${mockTransaction.transactionID}`]: {
-                    ...mockTransaction,
-                    reportID: openIOUReport.reportID,
-                    policyID: fakePolicyID,
-                    category: categoryToDisable,
-                },
-            });
-            await waitForBatchedUpdates();
-
-            const {result} = renderHook(() => usePolicyData(fakePolicyID), {wrapper: OnyxListItemProvider});
-            await waitForBatchedUpdates();
-
+            const policyData = buildPolicyData(openIOUReport, transaction, fakePolicy, fakePolicyCategories);
             const onyxData = {optimisticData: [], failureData: []};
 
             // When auto-selecting after the category update
-            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, result.current, {}, fakePolicyCategoriesUpdate, {});
+            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, policyData, {}, fakePolicyCategoriesUpdate, {});
 
             // Then the transaction is moved to the sole remaining enabled category, with a matching rollback
             expect(autoSelections.get(mockTransaction.transactionID)).toEqual({category: remainingCategory});
@@ -10294,7 +10283,7 @@ describe('ReportUtils', () => {
             });
         });
 
-        it('auto-selects the sole remaining enabled tag when the transaction tag is disabled', async () => {
+        it('auto-selects the sole remaining enabled tag when the transaction tag is disabled', () => {
             // Given a single-level tag list with two enabled tags, and an update that disables the first one
             const fakePolicyTagListName = 'Tag List';
             const fakePolicyTagsLists = createRandomPolicyTags(fakePolicyTagListName, 2);
@@ -10313,27 +10302,19 @@ describe('ReportUtils', () => {
 
             // Given an open report whose transaction uses the tag about to be disabled
             const openIOUReport: Report = {...mockIOUReport, policyID: fakePolicyID, stateNum: CONST.REPORT.STATE_NUM.OPEN, statusNum: CONST.REPORT.STATUS_NUM.OPEN};
+            const transaction: Transaction = {
+                ...mockTransaction,
+                reportID: openIOUReport.reportID,
+                policyID: fakePolicyID,
+                category: '',
+                tag: tagToDisable,
+            };
 
-            await Onyx.multiSet({
-                ...buildReportCollection(openIOUReport),
-                [`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicyID}`]: fakePolicyTagsLists,
-                [`${ONYXKEYS.COLLECTION.POLICY}${fakePolicyID}`]: fakePolicy,
-                [`${ONYXKEYS.COLLECTION.TRANSACTION}${mockTransaction.transactionID}`]: {
-                    ...mockTransaction,
-                    reportID: openIOUReport.reportID,
-                    policyID: fakePolicyID,
-                    tag: tagToDisable,
-                },
-            });
-            await waitForBatchedUpdates();
-
-            const {result} = renderHook(() => usePolicyData(fakePolicyID), {wrapper: OnyxListItemProvider});
-            await waitForBatchedUpdates();
-
+            const policyData = buildPolicyData(openIOUReport, transaction, fakePolicy, {}, fakePolicyTagsLists);
             const onyxData = {optimisticData: [], failureData: []};
 
             // When auto-selecting after the tag update
-            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, result.current, {}, {}, fakePolicyTagListsUpdate);
+            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, policyData, {}, {}, fakePolicyTagListsUpdate);
 
             // Then the transaction is moved to the sole remaining enabled tag, with a matching rollback
             expect(autoSelections.get(mockTransaction.transactionID)).toEqual({tag: remainingTag});
@@ -10355,7 +10336,7 @@ describe('ReportUtils', () => {
             });
         });
 
-        it('does not auto-select when more than one enabled category remains', async () => {
+        it('does not auto-select when more than one enabled category remains', () => {
             // Given a policy with three enabled categories, and an update that disables only one (two remain)
             const fakePolicyCategories = buildEnabledCategories(3);
             const categoryToDisable = Object.keys(fakePolicyCategories).at(0) ?? '';
@@ -10365,27 +10346,19 @@ describe('ReportUtils', () => {
 
             const fakePolicy = {...createRandomPolicy(0), id: fakePolicyID, requiresCategory: true, areCategoriesEnabled: true};
             const openIOUReport: Report = {...mockIOUReport, policyID: fakePolicyID, stateNum: CONST.REPORT.STATE_NUM.OPEN, statusNum: CONST.REPORT.STATUS_NUM.OPEN};
+            const transaction: Transaction = {
+                ...mockTransaction,
+                reportID: openIOUReport.reportID,
+                policyID: fakePolicyID,
+                category: categoryToDisable,
+                tag: '',
+            };
 
-            await Onyx.multiSet({
-                ...buildReportCollection(openIOUReport),
-                [`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${fakePolicyID}`]: fakePolicyCategories,
-                [`${ONYXKEYS.COLLECTION.POLICY}${fakePolicyID}`]: fakePolicy,
-                [`${ONYXKEYS.COLLECTION.TRANSACTION}${mockTransaction.transactionID}`]: {
-                    ...mockTransaction,
-                    reportID: openIOUReport.reportID,
-                    policyID: fakePolicyID,
-                    category: categoryToDisable,
-                },
-            });
-            await waitForBatchedUpdates();
-
-            const {result} = renderHook(() => usePolicyData(fakePolicyID), {wrapper: OnyxListItemProvider});
-            await waitForBatchedUpdates();
-
+            const policyData = buildPolicyData(openIOUReport, transaction, fakePolicy, fakePolicyCategories);
             const onyxData = {optimisticData: [], failureData: []};
 
             // When auto-selecting after the category update
-            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, result.current, {}, fakePolicyCategoriesUpdate, {});
+            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, policyData, {}, fakePolicyCategoriesUpdate, {});
 
             // Then nothing is auto-selected because the remaining choice is ambiguous
             expect(autoSelections.size).toBe(0);
@@ -10393,7 +10366,7 @@ describe('ReportUtils', () => {
             expect(onyxData.failureData).toHaveLength(0);
         });
 
-        it('does not auto-select on an enable-only update that removes nothing', async () => {
+        it('does not auto-select on an enable-only update that removes nothing', () => {
             // Given a policy with two disabled categories (the factory disables them) and a transaction on the first
             const fakePolicyCategories = createRandomPolicyCategories(2);
             const categoryNames = Object.keys(fakePolicyCategories);
@@ -10407,27 +10380,19 @@ describe('ReportUtils', () => {
 
             const fakePolicy = {...createRandomPolicy(0), id: fakePolicyID, requiresCategory: true, areCategoriesEnabled: true};
             const openIOUReport: Report = {...mockIOUReport, policyID: fakePolicyID, stateNum: CONST.REPORT.STATE_NUM.OPEN, statusNum: CONST.REPORT.STATUS_NUM.OPEN};
+            const transaction: Transaction = {
+                ...mockTransaction,
+                reportID: openIOUReport.reportID,
+                policyID: fakePolicyID,
+                category: transactionCategory,
+                tag: '',
+            };
 
-            await Onyx.multiSet({
-                ...buildReportCollection(openIOUReport),
-                [`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${fakePolicyID}`]: fakePolicyCategories,
-                [`${ONYXKEYS.COLLECTION.POLICY}${fakePolicyID}`]: fakePolicy,
-                [`${ONYXKEYS.COLLECTION.TRANSACTION}${mockTransaction.transactionID}`]: {
-                    ...mockTransaction,
-                    reportID: openIOUReport.reportID,
-                    policyID: fakePolicyID,
-                    category: transactionCategory,
-                },
-            });
-            await waitForBatchedUpdates();
-
-            const {result} = renderHook(() => usePolicyData(fakePolicyID), {wrapper: OnyxListItemProvider});
-            await waitForBatchedUpdates();
-
+            const policyData = buildPolicyData(openIOUReport, transaction, fakePolicy, fakePolicyCategories);
             const onyxData = {optimisticData: [], failureData: []};
 
             // When auto-selecting after an enable-only update that leaves exactly one enabled category
-            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, result.current, {}, fakePolicyCategoriesUpdate, {});
+            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, policyData, {}, fakePolicyCategoriesUpdate, {});
 
             // Then nothing is auto-selected: the backend only auto-replaces on a delete/disable, never an enable
             expect(autoSelections.size).toBe(0);
@@ -10435,7 +10400,7 @@ describe('ReportUtils', () => {
             expect(onyxData.failureData).toHaveLength(0);
         });
 
-        it('does not auto-select on a non-open report even when a single category remains', async () => {
+        it('does not auto-select on a non-open report even when a single category remains', () => {
             // Given a policy with two enabled categories, and an update that disables the first one
             const fakePolicyCategories = buildEnabledCategories(2);
             const categoryToDisable = Object.keys(fakePolicyCategories).at(0) ?? '';
@@ -10447,27 +10412,19 @@ describe('ReportUtils', () => {
 
             // Given an approved (non-open, non-processing) report
             const approvedIOUReport: Report = {...mockIOUReport, policyID: fakePolicyID, stateNum: CONST.REPORT.STATE_NUM.APPROVED, statusNum: CONST.REPORT.STATUS_NUM.APPROVED};
+            const transaction: Transaction = {
+                ...mockTransaction,
+                reportID: approvedIOUReport.reportID,
+                policyID: fakePolicyID,
+                category: categoryToDisable,
+                tag: '',
+            };
 
-            await Onyx.multiSet({
-                ...buildReportCollection(approvedIOUReport),
-                [`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${fakePolicyID}`]: fakePolicyCategories,
-                [`${ONYXKEYS.COLLECTION.POLICY}${fakePolicyID}`]: fakePolicy,
-                [`${ONYXKEYS.COLLECTION.TRANSACTION}${mockTransaction.transactionID}`]: {
-                    ...mockTransaction,
-                    reportID: approvedIOUReport.reportID,
-                    policyID: fakePolicyID,
-                    category: categoryToDisable,
-                },
-            });
-            await waitForBatchedUpdates();
-
-            const {result} = renderHook(() => usePolicyData(fakePolicyID), {wrapper: OnyxListItemProvider});
-            await waitForBatchedUpdates();
-
+            const policyData = buildPolicyData(approvedIOUReport, transaction, fakePolicy, fakePolicyCategories);
             const onyxData = {optimisticData: [], failureData: []};
 
             // When auto-selecting after the category update
-            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, result.current, {}, fakePolicyCategoriesUpdate, {});
+            const autoSelections = pushTransactionAutoSelectionsOnyxData(onyxData, policyData, {}, fakePolicyCategoriesUpdate, {});
 
             // Then nothing is auto-selected because auto-selection is scoped to open/processing reports
             expect(autoSelections.size).toBe(0);

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -10150,7 +10150,6 @@ describe('ReportUtils', () => {
             const transaction: Transaction = {
                 ...mockTransaction,
                 reportID: openIOUReport.reportID,
-                policyID: fakePolicyID,
                 category: fakePolicyCategoryNameToDelete,
                 tag: fakePolicyTagsToDelete.at(0)?.[0] ?? '',
             };
@@ -10252,7 +10251,6 @@ describe('ReportUtils', () => {
             const transaction: Transaction = {
                 ...mockTransaction,
                 reportID: openIOUReport.reportID,
-                policyID: fakePolicyID,
                 category: categoryToDisable,
                 tag: '',
             };
@@ -10305,7 +10303,6 @@ describe('ReportUtils', () => {
             const transaction: Transaction = {
                 ...mockTransaction,
                 reportID: openIOUReport.reportID,
-                policyID: fakePolicyID,
                 category: '',
                 tag: tagToDisable,
             };
@@ -10349,7 +10346,6 @@ describe('ReportUtils', () => {
             const transaction: Transaction = {
                 ...mockTransaction,
                 reportID: openIOUReport.reportID,
-                policyID: fakePolicyID,
                 category: categoryToDisable,
                 tag: '',
             };
@@ -10383,7 +10379,6 @@ describe('ReportUtils', () => {
             const transaction: Transaction = {
                 ...mockTransaction,
                 reportID: openIOUReport.reportID,
-                policyID: fakePolicyID,
                 category: transactionCategory,
                 tag: '',
             };
@@ -10415,7 +10410,6 @@ describe('ReportUtils', () => {
             const transaction: Transaction = {
                 ...mockTransaction,
                 reportID: approvedIOUReport.reportID,
-                policyID: fakePolicyID,
                 category: categoryToDisable,
                 tag: '',
             };

--- a/tests/utils/collections/policyCategory.ts
+++ b/tests/utils/collections/policyCategory.ts
@@ -4,7 +4,9 @@ import type {PolicyCategories} from '@src/types/onyx';
 export default function createRandomPolicyCategories(numberOfCategories = 0): PolicyCategories {
     const categories: PolicyCategories = {};
     for (let i = 0; i < numberOfCategories; i++) {
-        const categoryName = randWord();
+        // Prevent the category name from being duplicated, which can happen when a lot of tests are being ran
+        // and can cause tests to fail because categories must always contain a unique set of names
+        const categoryName = `${randWord()}${i}`;
         categories[categoryName] = {
             name: categoryName,
             enabled: false,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The `pushTransactionAutoSelectionsOnyxData` tests were flaky because they populated Onyx and then read policy state through `renderHook(usePolicyData)`, which depends on async Onyx subscriptions and derived values. Under CI load, stale or incomplete hook data could make the test think only one enabled category remained, causing a spurious auto-selection.

These tests exercise pure ReportUtils logic, so they now build a `PolicyData` object inline (same approach as `tests/perf-test/ReportUtils.perf-test.ts`) instead of going through `usePolicyData`. The adjacent `pushTransactionViolationsOnyxData` test was updated the same way for consistency.

### Fixed Issues
$ https://github.com/Expensify/App/issues/93921
$ https://github.com/Expensify/App/issues/94051
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. Run `npx jest tests/unit/ReportUtilsTest.ts -t "pushTransactionAutoSelectionsOnyxData|pushTransactionViolationsOnyxData" --runInBand` and verify all 6 tests pass.
2. Run the flaky test 10 times to confirm stability: `for i in {1..10}; do npx jest tests/unit/ReportUtilsTest.ts -t "does not auto-select when more than one enabled category remains" --runInBand --silent || break; done`

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A — test-only change with no product behavior impact.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
N/A — test-only change.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
N/A — test-only change.

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
N/A — test-only change.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
N/A — test-only change.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
N/A — test-only change.

</details>