### PR TITLE
Decompose ReportActionsList: 9

### DIFF
--- a/src/hooks/useReportActionsVisibility.ts
+++ b/src/hooks/useReportActionsVisibility.ts
@@ -1,9 +1,11 @@
+import {reportVisibleActionsSelector} from '@selectors/ReportAction';
 import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
 import {isCreatedAction, isDeletedParentAction, isIOUActionMatchingTransactionList, isReportActionVisible} from '@libs/ReportActionsUtils';
 import {isConciergeChatReport} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {ReportAction} from '@src/types/onyx';
+import type {VisibleReportActionsDerivedValue} from '@src/types/onyx/DerivedValues';
 import useConciergeSidePanelReportActions from './useConciergeSidePanelReportActions';
 import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
 import useIsInSidePanel from './useIsInSidePanel';
@@ -58,7 +60,10 @@ function useReportActionsVisibility({
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
-    const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
+    const [reportVisibleActions] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS, {
+        selector: reportVisibleActionsSelector(reportID),
+    });
+    const visibleReportActionsData: VisibleReportActionsDerivedValue | undefined = reportID && reportVisibleActions ? {[reportID]: reportVisibleActions} : undefined;
 
     const isInSidePanel = useIsInSidePanel();
     const isConciergeSidePanel = isInSidePanel && isConciergeChatReport(report, conciergeReportID);

--- a/src/selectors/ReportAction.ts
+++ b/src/selectors/ReportAction.ts
@@ -3,6 +3,12 @@ import type {OnyxEntry} from 'react-native-onyx';
 import {filterOutDeprecatedReportActions, getLinkedTransactionID, getSortedReportActions, isActionOfType} from '@libs/ReportActionsUtils';
 import CONST from '@src/CONST';
 import type {ReportAction, ReportActions} from '@src/types/onyx';
+import type {VisibleReportActionsDerivedValue} from '@src/types/onyx/DerivedValues';
+
+/**
+ * Module-level selector factory that scopes the VISIBLE_REPORT_ACTIONS derived value to a single report
+ */
+const reportVisibleActionsSelector = (reportID: string | undefined) => (data: VisibleReportActionsDerivedValue | undefined) => (reportID ? data?.[reportID] : undefined);
 
 function getParentReportActionSelector(parentReportActions: OnyxEntry<ReportActions>, parentReportActionID?: string): OnyxEntry<ReportAction> {
     if (!parentReportActions || !parentReportActionID) {
@@ -83,4 +89,4 @@ function getReceiptScanFailedIOUActionDataSelector(
     };
 }
 
-export {getParentReportActionSelector, getLastClosedReportAction, getReportActionByIDSelector, getReceiptScanFailedIOUActionDataSelector};
+export {getParentReportActionSelector, getLastClosedReportAction, getReportActionByIDSelector, getReceiptScanFailedIOUActionDataSelector, reportVisibleActionsSelector};

--- a/tests/unit/useReportActionsVisibilityTest.tsx
+++ b/tests/unit/useReportActionsVisibilityTest.tsx
@@ -1,0 +1,124 @@
+import {act, renderHook} from '@testing-library/react-native';
+import type {ReactNode} from 'react';
+import Onyx from 'react-native-onyx';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import useReportActionsVisibility from '@hooks/useReportActionsVisibility';
+import initOnyxDerivedValues from '@userActions/OnyxDerived';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {ReportActions} from '@src/types/onyx';
+import {getFakeReportAction} from '../utils/ReportTestUtils';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+/**
+ * Guards that `useReportActionsVisibility` subscribes to VISIBLE_REPORT_ACTIONS scoped to its own
+ * report via `reportVisibleActionsSelector`. The test renders the real hook and counts how often a
+ * consumer re-renders: with the per-report selector, an unrelated report's activity must not
+ * re-render this report's consumer.
+ */
+
+const REPORT_A = 'reportA';
+const REPORT_B = 'reportB';
+
+/** Build a deterministic, visible ADD_COMMENT action keyed by its reportActionID. */
+function buildVisibleComment(reportActionID: string) {
+    return getFakeReportAction(1, {reportActionID, actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT});
+}
+
+function buildActions(...reportActionIDs: string[]): ReportActions {
+    return Object.fromEntries(reportActionIDs.map((id) => [id, buildVisibleComment(id)]));
+}
+
+function setReportActions(reportID: string, actions: ReportActions) {
+    return Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, actions);
+}
+
+type HookProps = Parameters<typeof useReportActionsVisibility>[0];
+
+function buildHookProps(reportID: string, actions: ReportActions): HookProps {
+    const actionsArray = Object.values(actions);
+    return {
+        reportID,
+        reportActions: actionsArray,
+        allReportActions: actionsArray,
+        canPerformWriteAction: true,
+        hasOlderActions: false,
+        loadOlderChats: jest.fn(),
+    };
+}
+
+const wrapper = ({children}: {children: ReactNode}) => <OnyxListItemProvider>{children}</OnyxListItemProvider>;
+
+describe('useReportActionsVisibility scopes VISIBLE_REPORT_ACTIONS per report', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+        initOnyxDerivedValues();
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        TestHelper.signInWithTestUser(1, 'test@test.com');
+        await waitForBatchedUpdates();
+    });
+
+    it('does not re-render the open report (A) when an unrelated report (B) actions change', async () => {
+        // Given reports A and B both have visible actions in the derived value, and the hook is mounted for A
+        await setReportActions(REPORT_A, buildActions('a1', 'a2'));
+        await setReportActions(REPORT_B, buildActions('b1'));
+        await waitForBatchedUpdates();
+
+        let renders = 0;
+        const {unmount} = renderHook(
+            () => {
+                renders++;
+                return useReportActionsVisibility(buildHookProps(REPORT_A, buildActions('a1', 'a2')));
+            },
+            {wrapper},
+        );
+        await waitForBatchedUpdates();
+
+        const rendersBefore = renders;
+
+        // When a new action is added to the unrelated report B
+        await act(async () => {
+            await setReportActions(REPORT_B, buildActions('b2'));
+            await waitForBatchedUpdates();
+        });
+
+        // Then the hook for report A does not re-render.
+        // (With a whole-collection subscription, report B's write would re-render A here.)
+        expect(renders).toBe(rendersBefore);
+
+        unmount();
+    });
+
+    it('re-renders the open report (A) when its own actions change (guards against over-scoping)', async () => {
+        // Given the hook is mounted for report A
+        await setReportActions(REPORT_A, buildActions('a1'));
+        await waitForBatchedUpdates();
+
+        let renders = 0;
+        const {unmount} = renderHook(
+            () => {
+                renders++;
+                return useReportActionsVisibility(buildHookProps(REPORT_A, buildActions('a1')));
+            },
+            {wrapper},
+        );
+        await waitForBatchedUpdates();
+
+        const rendersBefore = renders;
+
+        // When a new action is added to report A itself
+        await act(async () => {
+            await setReportActions(REPORT_A, buildActions('a2'));
+            await waitForBatchedUpdates();
+        });
+
+        // Then the hook reacted to its own report's visibility change
+        expect(renders).toBeGreaterThan(rendersBefore);
+
+        unmount();
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The useReportActionsVisibility hook subscribed to the entire VISIBLE_REPORT_ACTIONS derived value — a collection containing visible actions for every report. That meant any change to any report's actions re-ran the hook for all reports, causing unnecessary re-renders.

Before this change: if you're viewing Report A and Report B receives an update (e.g. a new message), Report A's visibility logic re-runs and re-renders. Now Report A only reacts to its own updates. Profiler results from such scenario below:

Before (ReportActionsList rerenders)
<img width="1220" height="1001" alt="Screenshot 2026-06-19 at 13 29 12" src="https://github.com/user-attachments/assets/9d5d857b-6d84-4e9e-b4d8-3e0591af64ec" />

After (LHN rerenders, ReportActionsList main component stays stable)
<img width="1220" height="1001" alt="Screenshot 2026-06-19 at 13 28 13" src="https://github.com/user-attachments/assets/390dfa03-6480-4bfa-b196-c80f2a48c6bd" />


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/89770
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

Prerequisites: two accounts (**A** = you, **B** = sender) signed into separate sessions/devices; at least two shared reports (Report A and Report B)

### Test 1: New message in the OPEN report
1. As account A, open Report A and keep it on screen.
2. As account B, send a message to Report A.
3. Confirm the new message appears in Report A in real time.
4. Confirm it is marked unread correctly.
5. Confirm the list scroll position / behavior matches `main` (no jump or glitch).

### Test 2: New message in a DIFFERENT report (the optimization)

Prerequisite: account A is viewing Report A; Report B is visible in the LHN.

1. As account A, stay on Report A's message list.
2. As account B, post a message in Report B.
3. Confirm Report A's list is undisturbed — no flicker, scroll jump, or reordering.
4. Confirm the LHN row for Report B updates (bold/preview/timestamp).
5. As account A, switch to Report B.
6. Confirm the new message is present and correct.

### Test 3: Rapid report switching

Prerequisite: several reports open-able from LHN, including an expense report and Concierge.

1. Open Report A and note its visible actions.
2. Quickly switch to an expense report.
3. Quickly switch to Concierge.
4. Continue rapidly switching among the reports a few times.
5. Confirm each report shows its own correct visible actions.
6. Confirm no bleed-over or stale content from a previously open report.


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/9604509c-6fa5-47b9-bc56-8625f033a13a


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a01ca835-7915-4c62-b6a5-96bf28ad6bab

> Error screen comes from known issue with android web notifications: https://github.com/Expensify/App/issues/93835

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/27fd6f0a-d4a2-4525-a6e6-6d8a34e61623


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a1c90c64-881a-4a10-a2d7-dd5ddb389935


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c2230d93-29f8-4884-a201-ccb27a8122cd


</details>
