### PR TITLE
[Home Page] Remove Getting started slot from Home whenever all onboarding to-dos are complete

### DIFF
--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -60,6 +60,15 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
 
     const emptyResult: UseGettingStartedItemsResult = {shouldShowSection: false, items: []};
 
+    // Hide the whole section as soon as every onboarding to-do is complete, instead of keeping it
+    // around for the full Getting Started window.
+    const buildResult = (builtItems: GettingStartedItem[]): UseGettingStartedItemsResult => {
+        if (builtItems.every((item) => item.isComplete)) {
+            return emptyResult;
+        }
+        return {shouldShowSection: true, items: builtItems};
+    };
+
     if (intent !== CONST.ONBOARDING_CHOICES.MANAGE_TEAM && intent !== CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE) {
         return emptyResult;
     }
@@ -103,7 +112,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             route: ROUTES.WORKSPACE_MEMBERS.getRoute(activePolicyID),
         });
 
-        return {shouldShowSection: true, items};
+        return buildResult(items);
     }
 
     const isDirectConnect = !!reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration);
@@ -153,7 +162,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         });
     }
 
-    return {shouldShowSection: true, items};
+    return buildResult(items);
 }
 
 export default useGettingStartedItems;

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -1125,4 +1125,83 @@ describe('useGettingStartedItems', () => {
             });
         });
     });
+
+    describe('hides the section once all to-dos are complete', () => {
+        const customCategory: PolicyCategories = {
+            'Custom Category': {
+                name: 'Custom Category',
+                enabled: true,
+                unencodedName: 'Custom Category',
+                areCommentsRequired: false,
+                'GL Code': '',
+                externalID: '',
+                origin: '',
+                previousCategoryName: undefined,
+            },
+        };
+
+        it('should stay visible for MANAGE_TEAM intent while at least one to-do is incomplete', async () => {
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            expect(result.current.shouldShowSection).toBe(true);
+            expect(result.current.items.some((item) => !item.isComplete)).toBe(true);
+        });
+
+        it('should hide the section for MANAGE_TEAM intent when every to-do is complete (within the 60-day window)', async () => {
+            const policyAccountID = 7777777;
+            // A commercial (custom) feed always counts as a linked company card feed, so the linkCompanyCards to-do is complete.
+            const commercialFeed = CONST.COMPANY_CARD.FEED_BANK_NAME.VISA;
+
+            // createWorkspace is always complete; complete categories (custom category) and company cards (a feed) so nothing is left.
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${POLICY_ID}`, customCategory);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER}${policyAccountID}`, {
+                settings: {
+                    companyCards: {
+                        [commercialFeed]: {preferredPolicy: POLICY_ID, liabilityType: 'corporate'},
+                    },
+                },
+            });
+            await setupManageTeamScenario({
+                accounting: 'none',
+                policy: {
+                    policyAccountID,
+                    areCategoriesEnabled: true,
+                    areCompanyCardsEnabled: true,
+                    areRulesEnabled: false,
+                },
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitFor(() => expect(result.current.shouldShowSection).toBe(false));
+            expect(result.current.items).toEqual([]);
+        });
+
+        it('should hide the section for TRACK_WORKSPACE intent when every to-do is complete', async () => {
+            const employeeList: PolicyEmployeeList = {
+                'owner@test.com': {email: 'owner@test.com', role: CONST.POLICY.ROLE.ADMIN},
+                'accountant@test.com': {email: 'accountant@test.com', role: CONST.POLICY.ROLE.USER},
+            };
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${POLICY_ID}`, customCategory);
+            await setupTrackWorkspaceScenario({policy: {areCategoriesEnabled: true, employeeList}});
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            expect(result.current.shouldShowSection).toBe(false);
+            expect(result.current.items).toEqual([]);
+        });
+
+        it('should stay visible for TRACK_WORKSPACE intent while at least one to-do is incomplete', async () => {
+            await setupTrackWorkspaceScenario();
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            expect(result.current.shouldShowSection).toBe(true);
+            expect(result.current.items.some((item) => !item.isComplete)).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
### Explanation of Change

- Previously the `Getting started` slot stayed on the Home page for the full 60-day onboarding window, even after a user had finished everything.
- Now the section is hidden as soon as every onboarding to-do is complete, while the 60-day window remains an upper bound for users who still have outstanding to-dos.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93106
PROPOSAL:

### Tests

### Offline tests

### QA Steps

1. Sign up / log in with an account whose onboarding intent is `Manage my team's expenses` or `Track my company's expenses` and confirm the `Getting started` section appears on Home while at least one to-do is still incomplete.
2. Complete every to-do listed in the `Getting started` section.
3. Verify the `Getting started` section disappears from Home once all to-dos are complete, instead of lingering for the rest of the 60-day window.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

[<!-- add screenshots or videos here -->](https://github.com/user-attachments/assets/5b545853-5bd7-493b-a2d9-9bf583cb549a)

</details>
