### PR TITLE
Fix #92564: Remove forceReplace in 2FA download codes navigation

### DIFF
--- a/src/pages/settings/Security/TwoFactorAuth/DynamicTwoFactorAuthPage.tsx
+++ b/src/pages/settings/Security/TwoFactorAuth/DynamicTwoFactorAuthPage.tsx
@@ -185,7 +185,7 @@ function DynamicTwoFactorAuthPage() {
                                 setError('');
                                 setCodesAreCopied();
                                 announceStatus(translate('fileDownload.success.title'));
-                                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.TWO_FACTOR_AUTH_VERIFY.path, backPath), {forceReplace: true});
+                                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.TWO_FACTOR_AUTH_VERIFY.path, backPath));
                             }}
                         />
                     )}


### PR DESCRIPTION
## Root cause
The 2FA download codes flow navigated back to the verify page with `forceReplace: true`. In Chrome, that forced replacement causes the right-hand panel (RHP) to close instead of preserving the expected navigation state.

## What changed
Removed the `forceReplace: true` option from the navigation call after backup codes are downloaded/copied, allowing the normal navigation behavior to keep the RHP open.

## Issue
$ #92564