### PR TITLE
Fix #93144: Use ISO currency code instead of locale symbol in rate change log

### DIFF
--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -212,6 +212,111 @@ function convertAmountToDisplayString(amount = 0, currency: string = CONST.CURRE
     });
 }
 
+function getAmountWithoutCurrencyIdentifier(value: string, currencyIdentifier: string): string | undefined {
+    const trimmedValue = value.trim();
+    if (!currencyIdentifier) {
+        return undefined;
+    }
+
+    if (trimmedValue.startsWith(currencyIdentifier)) {
+        return trimmedValue.slice(currencyIdentifier.length).trim();
+    }
+
+    if (trimmedValue.endsWith(currencyIdentifier)) {
+        return trimmedValue.slice(0, -currencyIdentifier.length).trim();
+    }
+
+    return undefined;
+}
+
+function getCurrencyCodeFromAmountString(value: string): {currency: string; amount: string} | undefined {
+    const trimmedValue = value.trim();
+    const possibleCurrencyCode = trimmedValue.slice(0, 3).toUpperCase();
+    if (isValidCurrencyCode(possibleCurrencyCode)) {
+        const amount = getAmountWithoutCurrencyIdentifier(trimmedValue, possibleCurrencyCode);
+        if (amount) {
+            return {currency: possibleCurrencyCode, amount};
+        }
+    }
+
+    const matchingCurrencySymbols = Object.entries(currencyList ?? {})
+        .filter(([, currency]) => !!currency?.symbol)
+        .sort(([, firstCurrency], [, secondCurrency]) => (secondCurrency?.symbol?.length ?? 0) - (firstCurrency?.symbol?.length ?? 0));
+
+    for (const [currencyCode, currency] of matchingCurrencySymbols) {
+        const symbol = currency?.symbol;
+        if (!symbol || matchingCurrencySymbols.filter(([, otherCurrency]) => otherCurrency?.symbol === symbol).length > 1) {
+            continue;
+        }
+        const amount = getAmountWithoutCurrencyIdentifier(trimmedValue, symbol);
+        if (amount) {
+            return {currency: currencyCode, amount};
+        }
+    }
+
+    return undefined;
+}
+
+function getNormalizedAmountString(amount: string): string | undefined {
+    const numericAmount = amount.replaceAll(/[^\d.,+-]/g, '');
+    if (!/\d/.test(numericAmount)) {
+        return undefined;
+    }
+
+    const isNegative = numericAmount.startsWith('-');
+    const unsignedAmount = numericAmount.replaceAll(/[+-]/g, '');
+    const lastCommaIndex = unsignedAmount.lastIndexOf(',');
+    const lastPeriodIndex = unsignedAmount.lastIndexOf('.');
+    let normalizedAmount = unsignedAmount;
+
+    if (lastCommaIndex !== -1 && lastPeriodIndex !== -1) {
+        const decimalSeparator = lastCommaIndex > lastPeriodIndex ? ',' : '.';
+        const thousandsSeparator = decimalSeparator === ',' ? '.' : ',';
+        normalizedAmount = unsignedAmount.replaceAll(thousandsSeparator, '').replace(decimalSeparator, '.');
+    } else if (lastCommaIndex !== -1) {
+        normalizedAmount = unsignedAmount.replaceAll('.', '').replace(',', '.');
+    } else if (lastPeriodIndex !== -1) {
+        normalizedAmount = unsignedAmount.replaceAll(',', '');
+    }
+
+    return `${isNegative ? '-' : ''}${normalizedAmount}`;
+}
+
+/**
+ * Backend-generated policy change-log amount strings can contain the currency-list symbol (e.g. "AR$1,40").
+ * Convert those strings back through the App currency formatter so rate changes match rate creation logs.
+ */
+function convertPolicyChangelogAmountToDisplayString(value: string, currency?: string): string {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+        return value;
+    }
+
+    const sanitizedCurrency = currency ? sanitizeCurrencyCode(currency) : undefined;
+    const currencySymbol = sanitizedCurrency ? getCurrencySymbol(sanitizedCurrency) : undefined;
+    const amount = sanitizedCurrency
+        ? (getAmountWithoutCurrencyIdentifier(trimmedValue, sanitizedCurrency) ??
+          (currencySymbol ? getAmountWithoutCurrencyIdentifier(trimmedValue, currencySymbol) : undefined) ??
+          trimmedValue)
+        : undefined;
+    const parsedCurrencyAmount = amount ? {currency: sanitizedCurrency, amount} : getCurrencyCodeFromAmountString(trimmedValue);
+    if (!parsedCurrencyAmount) {
+        return value;
+    }
+
+    const normalizedAmount = getNormalizedAmountString(parsedCurrencyAmount.amount);
+    if (!normalizedAmount) {
+        return value;
+    }
+
+    const amountAsFloat = Number(normalizedAmount);
+    if (!Number.isFinite(amountAsFloat)) {
+        return value;
+    }
+
+    return convertAmountToDisplayString(convertToBackendAmount(amountAsFloat), parsedCurrencyAmount.currency);
+}
+
 /**
  * Acts the same as `convertAmountToDisplayString` but the result string does not contain currency
  */
@@ -248,6 +353,7 @@ export {
     convertToFrontendAmountAsString,
     convertToDisplayString,
     convertAmountToDisplayString,
+    convertPolicyChangelogAmountToDisplayString,
     convertToDisplayStringWithoutCurrency,
     convertToDisplayStringWithExplicitCurrency,
     convertToShortDisplayString,

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -46,7 +46,14 @@ import type ReportActionName from '@src/types/onyx/ReportActionName';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import {getBankName, isCardPendingActivate} from './CardUtils';
 import {getDecodedCategoryName} from './CategoryUtils';
-import {convertAmountToDisplayString, convertToBackendAmount, convertToDisplayString, convertToDisplayStringWithExplicitCurrency, convertToShortDisplayString} from './CurrencyUtils';
+import {
+    convertAmountToDisplayString,
+    convertPolicyChangelogAmountToDisplayString,
+    convertToBackendAmount,
+    convertToDisplayString,
+    convertToDisplayStringWithExplicitCurrency,
+    convertToShortDisplayString,
+} from './CurrencyUtils';
 import DateUtils from './DateUtils';
 import {getEnvironmentURL, getOldDotEnvironmentURL} from './Environment/Environment';
 import getBase62ReportID from './getBase62ReportID';
@@ -3257,8 +3264,22 @@ function getCustomUnitRateDateRangeForMessage(translate: LocalizedTranslate, sta
 }
 
 function getWorkspaceCustomUnitRateUpdatedMessage(translate: LocalizedTranslate, action: ReportAction): string {
-    const {customUnitName, customUnitRateName, updatedField, oldValue, newValue, newTaxPercentage, oldTaxPercentage, newStartDate, newEndDate, oldStartDate, oldEndDate} =
-        getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CUSTOM_UNIT_RATE>) ?? {};
+    const {
+        customUnitName,
+        customUnitRateName,
+        updatedField,
+        oldValue,
+        newValue,
+        newTaxPercentage,
+        oldTaxPercentage,
+        newStartDate,
+        newEndDate,
+        oldStartDate,
+        oldEndDate,
+        oldRate,
+        newRate,
+        currency,
+    } = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CUSTOM_UNIT_RATE>) ?? {};
 
     const {RATE_CHANGELOG_UPDATED_FIELD} = CONST.CUSTOM_UNITS;
 
@@ -3267,7 +3288,25 @@ function getWorkspaceCustomUnitRateUpdatedMessage(translate: LocalizedTranslate,
     }
 
     if (customUnitName && customUnitRateName && updatedField === RATE_CHANGELOG_UPDATED_FIELD.RATE && typeof oldValue === 'string' && typeof newValue === 'string') {
-        return translate('workspaceActions.updatedCustomUnitRate', customUnitName, customUnitRateName, updatedField, newValue, oldValue);
+        if (typeof oldRate === 'number' && typeof newRate === 'number' && currency) {
+            return translate(
+                'workspaceActions.updatedCustomUnitRate',
+                customUnitName,
+                customUnitRateName,
+                updatedField,
+                convertAmountToDisplayString(newRate, currency),
+                convertAmountToDisplayString(oldRate, currency),
+            );
+        }
+
+        return translate(
+            'workspaceActions.updatedCustomUnitRate',
+            customUnitName,
+            customUnitRateName,
+            updatedField,
+            convertPolicyChangelogAmountToDisplayString(newValue, currency),
+            convertPolicyChangelogAmountToDisplayString(oldValue, currency),
+        );
     }
 
     if (customUnitRateName && updatedField === RATE_CHANGELOG_UPDATED_FIELD.TAX_RATE_EXTERNAL_ID && typeof newValue === 'string' && newTaxPercentage) {

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -66,6 +66,7 @@ import {getFakeReportAction} from '../utils/ReportTestUtils';
 import {translateLocal} from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
+import currencyList from './currencyList.json';
 
 describe('ReportActionsUtils', () => {
     beforeAll(() =>
@@ -4101,6 +4102,26 @@ describe('ReportActionsUtils', () => {
             };
             const actual = ReportActionsUtils.getWorkspaceCustomUnitRateUpdatedMessage(translateLocal, action);
             expect(actual).toBe('renamed the Distance rate "Default Rate" to "Custom Rate"');
+        });
+
+        it('should format rate changes with the currency code when the backend sends a currency symbol', async () => {
+            await Onyx.set(ONYXKEYS.CURRENCY_LIST, currencyList);
+            await waitForBatchedUpdates();
+
+            const action: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CUSTOM_UNIT_RATE> = {
+                reportActionID: '1',
+                actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CUSTOM_UNIT_RATE,
+                created: '',
+                originalMessage: {
+                    customUnitName: 'Distance',
+                    customUnitRateName: 'Default Rate',
+                    updatedField: 'rate',
+                    oldValue: 'AR$1,30',
+                    newValue: 'AR$1,40',
+                },
+            };
+            const actual = ReportActionsUtils.getWorkspaceCustomUnitRateUpdatedMessage(translateLocal, action);
+            expect(actual).toBe('changed the rate of the Distance rate "Default Rate" to "ARS 1.40" (previously "ARS 1.30")');
         });
 
         it('should return the correct message when a start date is set on a rate without dates', () => {


### PR DESCRIPTION
## Root cause
Custom unit rate change-log messages used backend-provided string values directly for rate updates. Those values can include currency-list symbols such as `AR$`, so rate update logs could display locale symbols instead of the ISO currency code used by rate creation logs.

## What changed
- Added currency change-log amount normalization that parses backend amount strings, resolves unambiguous currency symbols to ISO codes, and formats them through the existing app currency display formatter.
- Updated custom unit rate update messages to prefer numeric `oldRate`/`newRate` plus `currency` when present, and otherwise normalize legacy `oldValue`/`newValue` strings.
- Added a unit test covering ARS rate changes received as `AR$` values.

## Test results
- `npm test -- tests/unit/ReportActionsUtilsTest.ts -t "should format rate changes with the currency code" --runInBand`
- `npm run lint -- src/libs/CurrencyUtils.ts src/libs/ReportActionsUtils.ts tests/unit/ReportActionsUtilsTest.ts`

## Issue
$ #93144