### PR TITLE
[BOUNTY] [$250] Travel-"What's your legal name" page instead of "You'll need to use your work email" message

### DIFF
--- a/src/components/BookTravelButton.tsx
+++ b/src/components/BookTravelButton.tsx
@@ -123,12 +123,6 @@ function BookTravelButton({
             return;
         }
 
-        if (areTravelPersonalDetailsMissing(privatePersonalDetails)) {
-            shouldResumeBookingRef.current = true;
-            Navigation.navigate(ROUTES.WORKSPACE_TRAVEL_MISSING_PERSONAL_DETAILS.getRoute(policy?.id ?? String(CONST.DEFAULT_NUMBER_ID)));
-            return;
-        }
-
         // The primary login of the user is where Spotnana sends the emails with booking confirmations, itinerary etc. It can't be a phone number.
         if (!primaryContactMethod || Str.isSMSLogin(primaryContactMethod)) {
             setErrorMessage(<RenderHTML html={translate('travel.phoneError', phoneErrorMethodsRoute)} />);
@@ -138,6 +132,12 @@ function BookTravelButton({
         // Spotnana requires a private domain email for travel booking
         if (isEmailPublicDomain(primaryContactMethod)) {
             navigateToPublicDomainError();
+            return;
+        }
+
+        if (areTravelPersonalDetailsMissing(privatePersonalDetails)) {
+            shouldResumeBookingRef.current = true;
+            Navigation.navigate(ROUTES.WORKSPACE_TRAVEL_MISSING_PERSONAL_DETAILS.getRoute(policy?.id ?? String(CONST.DEFAULT_NUMBER_ID)));
             return;
         }
 


### PR DESCRIPTION
## Summary
This fix reorders the Travel booking flow validation to check for a work email requirement BEFORE requesting personal details like legal name. Previously, users with public domain emails (e.g., name@gmail.com) were incorrectly directed to the "What's your legal name?" page instead of seeing the work email requirement message.

## Changes
- Moved the personal details validation check to occur after email domain validation
- Ensures users see the correct error message (work email requirement) before being asked for legal name

## Test Plan
1. Sign up with a personal email (Gmail, Yahoo, etc.)
2. Enable Travel feature in workspace
3. Navigate to Travel > Let's Go
4. Verify that the "You'll need to use your work email" error message appears instead of the "What's your legal name?" page