### PR TITLE
fix: navigate to quick action exit route after Hybrid App login

### DIFF
--- a/src/pages/LogOutPreviousUserPage.tsx
+++ b/src/pages/LogOutPreviousUserPage.tsx
@@ -70,8 +70,8 @@ function LogOutPreviousUserPage({route}: LogOutPreviousUserPageProps) {
         // We don't want to navigate to the exitTo route when creating a new workspace from a deep link,
         // because we already handle creating the optimistic policy and navigating to it in App.setUpPoliciesAndNavigate,
         // which is already called when AuthScreens mounts.
-        // For HybridApp we have separate logic to handle transitions.
-        if (!CONFIG.IS_HYBRID_APP && exitTo !== ROUTES.WORKSPACE_NEW && !isAccountLoading && !isLoggingInAsNewUser) {
+        const shouldNavigateToExitTo = exitTo !== ROUTES.WORKSPACE_NEW && !isAccountLoading && !isLoggingInAsNewUser;
+        if (shouldNavigateToExitTo) {
             Navigation.isNavigationReady().then(() => {
                 // remove this screen and navigate to exit route
                 Navigation.goBack(ROUTES.HOME);


### PR DESCRIPTION
## Summary

Fixes the Hybrid App transition flow after login when the user enters NewDot from a quick action.

Previously, `LogOutPreviousUserPage` skipped navigation to `exitTo` whenever `CONFIG.IS_HYBRID_APP` was true, so after authentication the NewDot create flow did not open from the quick action. This keeps the existing `WORKSPACE_NEW` exception, but otherwise allows the transition page to navigate to `exitTo`.

## Test plan

1. In Hybrid App, log out.
2. Long-press the app icon.
3. Select the Manual Create quick action.
4. Log in.
5. Verify NewDot opens the create flow instead of staying on the loading/transition path.

## Safety

Local-only patch before PR creation. No wallet, payout, claim, payment, or unrelated files changed.
