### PR TITLE
Refactor: remove deprecatedAllTransactions in getTransactionReportName

### DIFF
--- a/src/libs/ReportNameUtils.ts
+++ b/src/libs/ReportNameUtils.ts
@@ -175,7 +175,7 @@ type ComputeReportName = {
     report?: Report;
     reports?: OnyxCollection<Report>;
     policies?: OnyxCollection<Policy>;
-    transactions?: OnyxCollection<Transaction>;
+    transactions: OnyxCollection<Transaction>;
     allReportNameValuePairs?: OnyxCollection<ReportNameValuePairs>;
     allPolicyTags?: OnyxCollection<PolicyTagLists>;
     personalDetailsList?: PersonalDetailsList;
@@ -839,10 +839,10 @@ function computeChatThreadReportName(
     report: Report,
     reports: OnyxCollection<Report>,
     currentUserLogin: string,
-    parentReportAction?: ReportAction,
-    policyTags?: OnyxEntry<PolicyTagLists>,
+    transactions: OnyxCollection<Transaction>,
+    parentReportAction?: ReportAction ,
+    policyTags?: OnyxEntry<PolicyTagLists> ,
     policy?: OnyxEntry<Policy>,
-    transactions?: OnyxCollection<Transaction>,
 ): string | undefined {
     if (!isChatThread(report)) {
         return undefined;
@@ -857,15 +857,11 @@ function computeChatThreadReportName(
     if (!isEmptyObject(parentReportAction) && isTransactionThread(parentReportAction)) {
         const linkedTransactionID = getLinkedTransactionID(parentReportAction);
         const linkedTransaction = linkedTransactionID ? transactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${linkedTransactionID}`] : undefined;
-        let linkedTransactions: Transaction[] | undefined;
-        if (transactions) {
-            linkedTransactions = linkedTransaction ? [linkedTransaction] : [];
-        }
         const linkedTransactionReport = linkedTransaction?.reportID ? reports?.[`${ONYXKEYS.COLLECTION.REPORT}${linkedTransaction.reportID}`] : undefined;
         let formattedName = getTransactionReportName({
             translate,
             reportAction: parentReportAction,
-            transactions: linkedTransactions,
+            linkedTransaction,
             report: linkedTransactionReport,
         });
 
@@ -999,10 +995,10 @@ function computeReportName({
         report,
         reports ?? {},
         currentUserLogin ?? '',
+        transactions,
         parentReportAction,
         policyTags,
         reportPolicy,
-        transactions,
     );
     if (chatThreadReportName) {
         return chatThreadReportName;

--- a/src/libs/ReportNameUtils.ts
+++ b/src/libs/ReportNameUtils.ts
@@ -840,8 +840,8 @@ function computeChatThreadReportName(
     reports: OnyxCollection<Report>,
     currentUserLogin: string,
     transactions: OnyxCollection<Transaction>,
-    parentReportAction?: ReportAction ,
-    policyTags?: OnyxEntry<PolicyTagLists> ,
+    parentReportAction?: ReportAction,
+    policyTags?: OnyxEntry<PolicyTagLists>,
     policy?: OnyxEntry<Policy>,
 ): string | undefined {
     if (!isChatThread(report)) {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -5481,12 +5481,12 @@ function shouldShowRBRForMissingSmartscanFields(iouReport: OnyxEntry<Report>, io
 function getTransactionReportName({
     translate,
     reportAction,
-    transactions,
+    linkedTransaction,
     report,
 }: {
     translate: LocalizedTranslate;
     reportAction: OnyxEntry<ReportAction | OptimisticIOUReportAction>;
-    transactions?: Transaction[];
+    linkedTransaction: OnyxEntry<Transaction>;
     report: OnyxEntry<Report>;
 }): string {
     if (reportAction && isReversedTransaction(reportAction)) {
@@ -5497,36 +5497,34 @@ function getTransactionReportName({
         return translate('parentReportAction.deletedExpense');
     }
 
-    const transaction = reportAction ? getLinkedTransaction(reportAction, transactions) : transactions?.at(0);
-
-    if (isEmptyObject(transaction)) {
+    if (isEmptyObject(linkedTransaction)) {
         // Transaction data might be empty on app's first load, if so we fallback to Expense/Track Expense
         return isTrackExpenseAction(reportAction) ? translate('iou.createExpense') : translate('iou.expense');
     }
 
-    if (isScanning(transaction)) {
+    if (isScanning(linkedTransaction)) {
         return translate('iou.receiptScanning', {count: 1});
     }
 
-    if (hasMissingSmartscanFieldsTransactionUtils(transaction, report)) {
+    if (hasMissingSmartscanFieldsTransactionUtils(linkedTransaction, report)) {
         return translate('iou.receiptMissingDetails');
     }
-    if (isFetchingWaypointsFromServer(transaction) && getMerchant(transaction) === translate('iou.fieldPending')) {
+    if (isFetchingWaypointsFromServer(linkedTransaction) && getMerchant(linkedTransaction) === translate('iou.fieldPending')) {
         return translate('iou.fieldPending');
     }
 
     // The unit does not matter as we are only interested in whether the distance is zero or not
-    if (isMapDistanceRequest(transaction) && !getDistanceInMeters(transaction, CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS) && !hasReceiptTransactionUtils(transaction)) {
+    if (isMapDistanceRequest(linkedTransaction) && !getDistanceInMeters(linkedTransaction, CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS) && !hasReceiptTransactionUtils(linkedTransaction)) {
         return translate('violations.noRoute');
     }
 
     if (isSentMoneyReportAction(reportAction)) {
-        return getIOUReportActionDisplayMessage(translate, reportAction as ReportAction, transaction);
+        return getIOUReportActionDisplayMessage(translate, reportAction as ReportAction, linkedTransaction);
     }
 
-    const amount = getTransactionAmount(transaction, !isEmptyObject(report) && isExpenseReport(report), transaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID) ?? 0;
-    const formattedAmount = convertToDisplayString(amount, getCurrency(transaction)) ?? '';
-    const comment = getMerchantOrDescription(transaction);
+    const amount = getTransactionAmount(linkedTransaction, !isEmptyObject(report) && isExpenseReport(report), linkedTransaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID) ?? 0;
+    const formattedAmount = convertToDisplayString(amount, getCurrency(linkedTransaction)) ?? '';
+    const comment = getMerchantOrDescription(linkedTransaction);
     return translate('iou.threadExpenseReportName', formattedAmount, Parser.htmlToText(comment));
 }
 

--- a/src/pages/TransactionMerge/MergeTransactionsListContent.tsx
+++ b/src/pages/TransactionMerge/MergeTransactionsListContent.tsx
@@ -130,7 +130,7 @@ function MergeTransactionsListContent({transactionID, mergeTransaction}: MergeTr
         ? getTransactionReportName({
               translate,
               reportAction: undefined,
-              transactions: [targetTransaction],
+              linkedTransaction: targetTransaction,
               report: getReportOrDraftReport(targetTransaction?.reportID, targetTransactionReport ? [targetTransactionReport] : [], undefined, undefined, targetTransactionReport),
           })
         : '';

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -18,6 +18,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {PersonalDetailsList, Policy, PolicyTagLists, Report, ReportAction, ReportActions, ReportAttributesDerivedValue, ReportNameValuePairs, Transaction} from '@src/types/onyx';
 import createRandomPolicy from '../utils/collections/policies';
 import {createAdminRoom, createExpenseReport, createPolicyExpenseChat, createRegularChat, createRegularTaskReport, createSelfDM, createWorkspaceThread} from '../utils/collections/reports';
+import createRandomTransaction from '../utils/collections/transaction';
 import {fakePersonalDetails} from '../utils/LHNTestUtils';
 import {formatPhoneNumber} from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
@@ -1322,6 +1323,7 @@ describe('ReportNameUtils', () => {
             } as ReportAction;
 
             const transaction: Transaction = {
+                ...createRandomTransaction(1),
                 transactionID,
                 reportID: expenseReportID,
                 merchant: 'Coffee Shop',
@@ -1329,23 +1331,7 @@ describe('ReportNameUtils', () => {
                 amount: -2500,
                 currency: CONST.CURRENCY.USD,
                 comment: {comment: ''},
-                created: '2024-01-01',
-                modifiedCreated: '',
-                modifiedCurrency: '',
-                originalAmount: 0,
-                originalCurrency: '',
-                tag: '',
-                category: '',
-                billable: false,
-                reimbursable: true,
-                cardID: 0,
-                bank: '',
-                hasEReceipt: false,
-                modifiedAmount: '',
-                receipt: {},
-                parentTransactionID: '',
-                status: CONST.TRANSACTION.STATUS.POSTED,
-            } as unknown as Transaction;
+            };
 
             const reportActionsCollection: Record<string, ReportActions> = {
                 [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`]: {

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -549,6 +549,7 @@ describe('ReportNameUtils', () => {
                 report: thread,
                 reports: emptyCollections.reports,
                 policies: emptyCollections.policies,
+                transactions: {},
                 personalDetailsList: participantsPersonalDetails,
                 reportActions: reportActionsCollection,
                 currentUserAccountID,

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -1289,4 +1289,147 @@ describe('ReportNameUtils', () => {
             expect(reportName).not.toBe('');
         });
     });
+
+    describe('computeReportName - Transaction thread with linkedTransaction', () => {
+        test('returns formatted expense name for transaction thread', () => {
+            const transactionID = '999';
+            const parentReportID = '100';
+            const parentReportActionID = '200';
+            const expenseReportID = '300';
+
+            const thread: Report = {
+                ...createWorkspaceThread(60),
+                parentReportID,
+                parentReportActionID,
+            };
+
+            const parentAction: ReportAction = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                reportActionID: parentReportActionID,
+                message: [{type: 'TEXT', text: 'test'}],
+                created: '2024-01-01 00:00:00',
+                lastModified: '',
+                actorAccountID: 1,
+                person: [],
+                originalMessage: {
+                    type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+                    IOUTransactionID: transactionID,
+                    IOUReportID: expenseReportID,
+                    amount: 2500,
+                    currency: CONST.CURRENCY.USD,
+                    participantAccountIDs: [1, 2],
+                },
+            } as unknown as ReportAction;
+
+            const transaction: Transaction = {
+                transactionID,
+                reportID: expenseReportID,
+                merchant: 'Coffee Shop',
+                modifiedMerchant: '',
+                amount: -2500,
+                currency: CONST.CURRENCY.USD,
+                comment: {comment: ''},
+                created: '2024-01-01',
+                modifiedCreated: '',
+                modifiedCurrency: '',
+                originalAmount: 0,
+                originalCurrency: '',
+                tag: '',
+                category: '',
+                billable: false,
+                reimbursable: true,
+                cardID: 0,
+                bank: '',
+                hasEReceipt: false,
+                modifiedAmount: '',
+                receipt: {},
+                parentTransactionID: '',
+                status: CONST.TRANSACTION.STATUS.POSTED,
+            } as unknown as Transaction;
+
+            const reportActionsCollection: Record<string, ReportActions> = {
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`]: {
+                    [parentReportActionID]: parentAction,
+                },
+            };
+
+            const transactionsCollection: Record<string, Transaction> = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`]: transaction,
+            };
+
+            const expenseReport: Report = {
+                ...createExpenseReport(300),
+                reportID: expenseReportID,
+                type: CONST.REPORT.TYPE.EXPENSE,
+            };
+
+            const reportsCollection: Record<string, Report> = {
+                [`${ONYXKEYS.COLLECTION.REPORT}${parentReportID}`]: createRegularChat(100, [1, 2]),
+                [`${ONYXKEYS.COLLECTION.REPORT}${expenseReportID}`]: expenseReport,
+            };
+
+            const name = computeReportName(
+                thread,
+                reportsCollection,
+                emptyCollections.policies,
+                transactionsCollection,
+                undefined,
+                participantsPersonalDetails,
+                reportActionsCollection,
+                currentUserAccountID,
+            );
+
+            expect(name).toContain('$25.00');
+            expect(name).toContain('Coffee Shop');
+        });
+
+        test('returns expense fallback when transaction is not in collection', () => {
+            const transactionID = '888';
+            const parentReportID = '101';
+            const parentReportActionID = '201';
+
+            const thread: Report = {
+                ...createWorkspaceThread(61),
+                parentReportID,
+                parentReportActionID,
+            };
+
+            const parentAction: ReportAction = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                reportActionID: parentReportActionID,
+                message: [{type: 'TEXT', text: 'test'}],
+                created: '2024-01-01 00:00:00',
+                lastModified: '',
+                actorAccountID: 1,
+                person: [],
+                originalMessage: {
+                    type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+                    IOUTransactionID: transactionID,
+                    IOUReportID: '301',
+                    amount: 1000,
+                    currency: CONST.CURRENCY.USD,
+                    participantAccountIDs: [1, 2],
+                },
+            } as unknown as ReportAction;
+
+            const reportActionsCollection: Record<string, ReportActions> = {
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`]: {
+                    [parentReportActionID]: parentAction,
+                },
+            };
+
+            const name = computeReportName(
+                thread,
+                emptyCollections.reports,
+                emptyCollections.policies,
+                {},
+                undefined,
+                participantsPersonalDetails,
+                reportActionsCollection,
+                currentUserAccountID,
+            );
+
+            expect(name).toBe(translate(CONST.LOCALES.EN, 'iou.expense'));
+        });
+    });
 });

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -1319,7 +1319,7 @@ describe('ReportNameUtils', () => {
                     currency: CONST.CURRENCY.USD,
                     participantAccountIDs: [1, 2],
                 },
-            } as unknown as ReportAction;
+            } as ReportAction;
 
             const transaction: Transaction = {
                 transactionID,
@@ -1410,7 +1410,7 @@ describe('ReportNameUtils', () => {
                     currency: CONST.CURRENCY.USD,
                     participantAccountIDs: [1, 2],
                 },
-            } as unknown as ReportAction;
+            } as ReportAction;
 
             const reportActionsCollection: Record<string, ReportActions> = {
                 [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`]: {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -13004,6 +13004,87 @@ describe('ReportUtils', () => {
             expect(result).toBeDefined();
             expect(typeof result).toBe('string');
         });
+
+        test('returns expense fallback when linkedTransaction is empty and reportAction is not track expense', () => {
+            const result = getTransactionReportName({
+                translate: translateLocal,
+                reportAction: undefined,
+                linkedTransaction: undefined,
+                report: mockTransactionReport,
+            });
+
+            expect(result).toBe(translateLocal('iou.expense'));
+        });
+
+        test('returns create expense fallback when linkedTransaction is empty and reportAction is track expense', () => {
+            const reportAction = createRandomReportAction(1);
+            jest.spyOn(require('@libs/ReportActionsUtils'), 'isTrackExpenseAction').mockReturnValueOnce(true);
+
+            const result = getTransactionReportName({
+                translate: translateLocal,
+                reportAction,
+                linkedTransaction: undefined,
+                report: mockTransactionReport,
+            });
+
+            expect(result).toBe(translateLocal('iou.createExpense'));
+        });
+
+        test('returns scanning message when transaction is being scanned', () => {
+            const transaction: Transaction = {
+                ...createRandomTransaction(1),
+                reportID: mockReportID,
+            };
+            jest.spyOn(require('@libs/TransactionUtils'), 'isScanning').mockReturnValueOnce(true);
+
+            const result = getTransactionReportName({
+                translate: translateLocal,
+                reportAction: undefined,
+                linkedTransaction: transaction,
+                report: mockTransactionReport,
+            });
+
+            expect(result).toBe(translateLocal('iou.receiptScanning', {count: 1}));
+        });
+
+        test('returns missing details message when smartscan fields are missing', () => {
+            const transaction: Transaction = {
+                ...createRandomTransaction(1),
+                reportID: mockReportID,
+            };
+            jest.spyOn(require('@libs/TransactionUtils'), 'hasMissingSmartscanFields').mockReturnValueOnce(true);
+
+            const result = getTransactionReportName({
+                translate: translateLocal,
+                reportAction: undefined,
+                linkedTransaction: transaction,
+                report: mockTransactionReport,
+            });
+
+            expect(result).toBe(translateLocal('iou.receiptMissingDetails'));
+        });
+
+        test('returns formatted amount and merchant for normal expense', () => {
+            const transaction: Transaction = {
+                ...createRandomTransaction(1),
+                reportID: mockReportID,
+                merchant: 'Coffee Shop',
+                modifiedMerchant: '',
+                comment: {comment: ''},
+                amount: -2500,
+                currency: CONST.CURRENCY.USD,
+            };
+
+            const result = getTransactionReportName({
+                translate: translateLocal,
+                reportAction: undefined,
+                linkedTransaction: transaction,
+                report: mockTransactionReport,
+            });
+
+            expect(result).toContain('Coffee Shop');
+            expect(result).toContain('$25.00');
+        });
     });
 
     describe('buildOptimisticExpenseReport', () => {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -12927,7 +12927,7 @@ describe('ReportUtils', () => {
             const result = getTransactionReportName({
                 translate: translateLocal,
                 reportAction: undefined,
-                transactions: [transaction],
+                linkedTransaction: transaction,
                 report: mockTransactionReport,
             });
 
@@ -12947,7 +12947,7 @@ describe('ReportUtils', () => {
             const result = getTransactionReportName({
                 translate: translateLocal,
                 reportAction: undefined,
-                transactions: [transaction],
+                linkedTransaction: transaction,
                 report: mockTransactionReport,
             });
 
@@ -12963,6 +12963,7 @@ describe('ReportUtils', () => {
             const result = getTransactionReportName({
                 translate: translateLocal,
                 reportAction,
+                linkedTransaction: undefined,
                 report: mockTransactionReport,
             });
 
@@ -12977,6 +12978,7 @@ describe('ReportUtils', () => {
             const result = getTransactionReportName({
                 translate: translateLocal,
                 reportAction,
+                linkedTransaction: undefined,
                 report: mockTransactionReport,
             });
 
@@ -12995,7 +12997,7 @@ describe('ReportUtils', () => {
             const result = getTransactionReportName({
                 translate: translateLocal,
                 reportAction: undefined,
-                transactions: [transaction],
+                linkedTransaction: transaction,
                 report: mockTransactionReport,
             });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Refactors `getTransactionReportName` to accept a single `linkedTransaction` object instead of a `transactions` array. This is part of the effort to remove `deprecatedAllTransactions` (issue #66418).

**Key changes:**

- `getTransactionReportName`: renamed `transactions?: Transaction[]` → `linkedTransaction: OnyxEntry<Transaction>`. Removes the internal call to `getLinkedTransaction()` (which used `deprecatedAllTransactions` as fallback) since callers now pass the transaction directly.
- `computeChatThreadReportName`: made `transactions` param required and moved it before optional params. The O(1) lookup (`transactions?.[key]`) was already happening at the call site — we now pass the result directly as `linkedTransaction` instead of wrapping it in an array.
- `ComputeReportName.transactions`: made required since `reportAttributes.ts` always provides it.

**Performance improvement:** Previously, `computeChatThreadReportName` wrapped a single transaction into an array, passed it to `getTransactionReportName`, which then called `getLinkedTransaction` to `.find()` on that array — an unnecessary round-trip. Now it passes the transaction object directly.

### Fixed Issues

$ https://github.com/Expensify/App/issues/66418
PROPOSAL: N/A

### Tests
#### Test 1
- Log in to the app
- Submit two manual expense (e.g., $25.00 at "Coffee Shop") to another user or a workspace
- Open the chat where the expense was submitted
- Click the expense to open the transaction thread
- Verify the transaction thread tittle shows the correct name format (e.g., "$25.00 for Coffee Shop")


#### Test 2

- Create two similar expenses (same merchant or similar amount)
- Navigate to merge transactions flow (select an expense > three-dot menu > Merge)
- Check the transaction display name at the top of the merge list
- Verify that the target transaction name displays correctly (e.g., "$25.00 for Coffee Shop")

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests

### QA Steps

Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="576" height="1280" alt="photo_2026-06-22 14 43 29" src="https://github.com/user-attachments/assets/4bc24d97-e344-4434-a509-95cc4f7dd52f" />

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="576" height="1280" alt="photo_2026-06-22 14 43 26" src="https://github.com/user-attachments/assets/e031084a-629d-463d-9ae3-7cd55ba3286e" />

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-06-22 at 14 44 26" src="https://github.com/user-attachments/assets/2f951472-a359-4e45-9311-7f5c06fbc229" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/72dda55b-fd1f-409a-b90c-e77557e11b41


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1914" height="963" alt="Screenshot 2026-06-22 at 14 14 18" src="https://github.com/user-attachments/assets/683edc7e-2486-4c1e-8ee5-2f8dd38fdf27" />



https://github.com/user-attachments/assets/be0f4a3d-f256-4762-981d-def2e1565004



</details>