### PR TITLE
[No QA] perf: drop reportsSelector in useFilterFormValues

### DIFF
--- a/src/hooks/useFilterFormValues.tsx
+++ b/src/hooks/useFilterFormValues.tsx
@@ -8,7 +8,7 @@ import {buildFilterFormValuesFromQuery} from '@libs/SearchQueryUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {SearchAdvancedFiltersForm} from '@src/types/form';
-import type {Policy, PolicyCategories, PolicyTagLists, Report} from '@src/types/onyx';
+import type {Policy, PolicyCategories, PolicyTagLists} from '@src/types/onyx';
 import {getEmptyObject} from '@src/types/utils/EmptyObject';
 import {useCurrencyListState} from './useCurrencyList';
 import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
@@ -25,20 +25,6 @@ function policiesSelector(policies: OnyxCollection<Policy>): OnyxCollection<Poli
             continue;
         }
         result[key] = {taxRates: policy.taxRates} as Policy;
-    }
-    return result;
-}
-
-function reportsSelector(reports: OnyxCollection<Report>): OnyxCollection<Report> {
-    if (!reports) {
-        return reports;
-    }
-    const result: OnyxCollection<Report> = {};
-    for (const [key, report] of Object.entries(reports)) {
-        if (!report) {
-            continue;
-        }
-        result[key] = {reportID: report.reportID} as Report;
     }
     return result;
 }
@@ -90,7 +76,9 @@ const useFilterFormValues = (queryJSON?: SearchQueryJSON) => {
 
     const [userCardList] = useOnyx(ONYXKEYS.CARD_LIST);
     const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: policiesSelector});
-    const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: reportsSelector});
+    // Subscribe to the report collection directly. buildFilterFormValuesFromQuery only does keyed existence
+    // lookups (`in:` filter), so projecting via a selector would just waste an O(n) pass over every report.
+    const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
     const [policyTagsLists] = useOnyx(ONYXKEYS.COLLECTION.POLICY_TAGS, {selector: policyTagsSelector});
     const [policyCategories] = useOnyx(ONYXKEYS.COLLECTION.POLICY_CATEGORIES, {selector: policyCategoriesSelector});
     const [workspaceCardFeeds] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST);
@@ -119,4 +107,4 @@ const useFilterFormValues = (queryJSON?: SearchQueryJSON) => {
 };
 
 export default useFilterFormValues;
-export {policiesSelector, reportsSelector, policyCategoriesSelector, policyTagsSelector};
+export {policiesSelector, policyCategoriesSelector, policyTagsSelector};

--- a/tests/perf-test/useFilterFormValues.perf-test.tsx
+++ b/tests/perf-test/useFilterFormValues.perf-test.tsx
@@ -6,7 +6,7 @@ import {measureFunction, measureRenders} from 'reassure';
 import {typeOptionsPoliciesSelector} from '@components/Search/FilterComponents/TypeSelector';
 import {advancedSearchPoliciesSelector} from '@hooks/useAdvancedSearchFilters';
 import {exportedToPoliciesSelector} from '@hooks/useExportedToFilterOptions';
-import {policiesSelector, policyCategoriesSelector, policyTagsSelector, reportsSelector} from '@hooks/useFilterFormValues';
+import {policiesSelector, policyCategoriesSelector, policyTagsSelector} from '@hooks/useFilterFormValues';
 import {getAllTaxRates} from '@libs/PolicyUtils';
 import {buildFilterFormValuesFromQuery, buildSearchQueryJSON} from '@libs/SearchQueryUtils';
 import type {SearchQueryJSON} from '@src/components/Search/types';
@@ -58,25 +58,6 @@ describe('useFilterFormValues', () => {
             );
 
             await measureFunction(() => policiesSelector(policies));
-        });
-
-        test('reportsSelector with 500 reports', async () => {
-            const reports = createCollection<Report>(
-                (_, index) => `${ONYXKEYS.COLLECTION.REPORT}${index}`,
-                (index) =>
-                    ({
-                        reportID: `${index}`,
-                        reportName: `Report ${index}`,
-                        chatType: 'policyExpenseChat',
-                        stateNum: 1,
-                        statusNum: 1,
-                        ownerAccountID: index,
-                        participantAccountIDs: [index, index + 1],
-                    }) as unknown as Report,
-                REPORT_COUNT,
-            );
-
-            await measureFunction(() => reportsSelector(reports));
         });
 
         test('policyCategoriesSelector with 500 policy category collections', async () => {
@@ -233,7 +214,7 @@ describe('useFilterFormValues', () => {
 
             function TestComponent() {
                 const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: policiesSelector});
-                const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: reportsSelector});
+                const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
                 const [policyTagsLists] = useOnyx(ONYXKEYS.COLLECTION.POLICY_TAGS, {selector: policyTagsSelector});
                 const [policyCategories] = useOnyx(ONYXKEYS.COLLECTION.POLICY_CATEGORIES, {selector: policyCategoriesSelector});
                 const taxRates = useMemo(() => getAllTaxRates(policies), [policies]);

--- a/tests/unit/hooks/useFilterFormValues.test.ts
+++ b/tests/unit/hooks/useFilterFormValues.test.ts
@@ -2,14 +2,12 @@ import type {OnyxCollection} from 'react-native-onyx';
 import {typeOptionsPoliciesSelector} from '@components/Search/FilterComponents/TypeSelector';
 import {advancedSearchPoliciesSelector} from '@hooks/useAdvancedSearchFilters';
 import {exportedToPoliciesSelector} from '@hooks/useExportedToFilterOptions';
-import {policiesSelector, policyCategoriesSelector, policyTagsSelector, reportsSelector} from '@hooks/useFilterFormValues';
+import {policiesSelector, policyCategoriesSelector, policyTagsSelector} from '@hooks/useFilterFormValues';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Policy, PolicyCategories, PolicyTagLists, Report} from '@src/types/onyx';
+import type {Policy, PolicyCategories, PolicyTagLists} from '@src/types/onyx';
 
 const POLICY_KEY = `${ONYXKEYS.COLLECTION.POLICY}1`;
 const POLICY_KEY_2 = `${ONYXKEYS.COLLECTION.POLICY}2`;
-const REPORT_KEY = `${ONYXKEYS.COLLECTION.REPORT}1`;
-const REPORT_KEY_2 = `${ONYXKEYS.COLLECTION.REPORT}2`;
 const CATEGORIES_KEY = `${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}1`;
 const CATEGORIES_KEY_2 = `${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}2`;
 const TAGS_KEY = `${ONYXKEYS.COLLECTION.POLICY_TAGS}1`;
@@ -48,38 +46,6 @@ describe('useFilterFormValues selectors', () => {
 
             expect(result).toEqual({[POLICY_KEY]: {taxRates: {}}});
             expect(result).not.toHaveProperty(POLICY_KEY_2);
-        });
-    });
-
-    describe('reportsSelector', () => {
-        it('returns undefined input as-is', () => {
-            expect(reportsSelector(undefined)).toBeUndefined();
-        });
-
-        it('extracts only reportID from each report', () => {
-            const reports: OnyxCollection<Report> = {
-                [REPORT_KEY]: {reportID: '100', reportName: 'Expense Report', chatType: 'policyExpenseChat'} as unknown as Report,
-                [REPORT_KEY_2]: {reportID: '200', reportName: 'Invoice', chatType: 'invoice'} as unknown as Report,
-            };
-
-            const result = reportsSelector(reports);
-
-            expect(result).toEqual({
-                [REPORT_KEY]: {reportID: '100'},
-                [REPORT_KEY_2]: {reportID: '200'},
-            });
-            expect(result?.[REPORT_KEY]).not.toHaveProperty('reportName');
-        });
-
-        it('skips undefined report entries', () => {
-            const reports: OnyxCollection<Report> = {
-                [REPORT_KEY]: {reportID: '100'} as Report,
-                [REPORT_KEY_2]: undefined,
-            };
-
-            const result = reportsSelector(reports);
-
-            expect(result).toEqual({[REPORT_KEY]: {reportID: '100'}});
         });
     });
 


### PR DESCRIPTION


### Explanation of Change

`useFilterFormValues` precomputed all reports via `reportsSelector`, projecting every report down to `{reportID}`. For a 100k-report account this cost ~1.5s on **every** report-collection change: the selector ran an O(n) projection + allocation, and Onyx then deep-compared the projected map to decide on a re-render — two O(n) passes.

The only downstream consumer of that data is `buildFilterFormValuesFromQuery`&#39;s `in:` filter, which does a keyed existence lookup (`reports?.[key]?.reportID`) for the handful of report IDs typed into the query. Onyx already holds the merged collection in memory, so the projection bought nothing.

This PR drops the selector and subscribes to `ONYXKEYS.COLLECTION.REPORT` directly, eliminating the ~1.5s. The hook now re-renders when reports change, but each re-render only walks `flatFilters` (cheap) and the hook is mounted in a single place (`SearchAdvancedFiltersButton`). The now-dead `reportsSelector` function/export and its unit + perf tests were removed.

Part of the 100k-reports performance work (no dedicated issue).

### Fixed Issues



$ https://github.com/Expensify/App/issues/94170
PROPOSAL:



### Tests
No tests needed, pure refactor

- [x] Verify that no errors appear in the JS console

### Offline tests



### QA Steps



// TODO: These must be filled out, or the issue title must include &#34;[No QA].&#34;
Same as tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari




