### PR TITLE
[No QA] Add support for dynamic routes that host an onyx tab navigator

### DIFF
--- a/src/hooks/useDynamicBackPath.ts
+++ b/src/hooks/useDynamicBackPath.ts
@@ -33,7 +33,7 @@ function useDynamicBackPath(dynamicRouteSuffix: DynamicRouteSuffix): Route {
     const pathWithoutLeadingSlash = path.replaceAll(/^\/+/g, '');
     const match = findAllMatchingDynamicSuffixes(pathWithoutLeadingSlash).find((m) => m.pattern === dynamicRouteSuffix);
     if (match) {
-        return getPathWithoutDynamicSuffix(pathWithoutLeadingSlash, match.actualSuffix, match.pattern);
+        return getPathWithoutDynamicSuffix(match.pathUsedForMatching, match.actualSuffix, match.pattern);
     }
 
     return pathWithoutLeadingSlash as Route;

--- a/src/libs/Navigation/helpers/collectScreensWithTabNavigator.ts
+++ b/src/libs/Navigation/helpers/collectScreensWithTabNavigator.ts
@@ -1,25 +1,52 @@
 import NAVIGATORS from '@src/NAVIGATORS';
+import isDynamicRouteSuffix from './dynamicRoutesUtils/isDynamicRouteSuffix';
 
 type ScreenConfigEntry = string | {path?: string; screens?: Record<string, ScreenConfigEntry>};
 
 const navigatorNames = new Set(Object.values(NAVIGATORS) as string[]);
 
+type CollectResult = {
+    screensWithTabNavigator: Set<string>;
+
+    /** Maps dynamic-route pattern - tab-child paths of that screen's tab navigator.
+     * Used by findAllMatchingDynamicSuffixes to safely strip trailing tab segments. */
+    dynamicTabPatternToTabPaths: Map<string, Set<string>>;
+};
+
 /**
- * Recursively walks the linking config tree and collects screen names that host
- * an OnyxTabNavigator. These screens are identified by having both a `path` and
- * nested `screens` - a pattern unique to tab-hosting screens in the config.
- * Navigator entries (from NAVIGATORS) are excluded to avoid false positives.
+ * Recursively walks the linking config tree and collects:
+ * 1. `screensWithTabNavigator` - screen names that host an OnyxTabNavigator
+ *    (identified by having both a `path` and nested `screens`, navigators excluded).
+ * 2. `dynamicTabPatternToTabPaths` - for each tab-host screen that is also a dynamic
+ *    route, a mapping from its route pattern to the path values of its tab children.
  *
  * @param screens - The linking config screens object (or a nested `screens` subtree)
- * @param result - Accumulator set passed through recursive calls
- * @returns Set of screen names that contain an OnyxTabNavigator
+ * @param result - Accumulator passed through recursive calls
+ * @returns Collected data
  */
-function collectScreensWithTabNavigator(screens: Record<string, ScreenConfigEntry>, result: Set<string> = new Set<string>()): Set<string> {
+function collectScreensWithTabNavigator(
+    screens: Record<string, ScreenConfigEntry>,
+    result: CollectResult = {screensWithTabNavigator: new Set(), dynamicTabPatternToTabPaths: new Map()},
+): CollectResult {
     const screenConfigEntries = Object.entries(screens);
     for (const [screenName, screenConfig] of screenConfigEntries) {
         if (typeof screenConfig === 'object' && screenConfig !== null) {
             if (screenConfig.path !== undefined && screenConfig.screens && !navigatorNames.has(screenName)) {
-                result.add(screenName);
+                result.screensWithTabNavigator.add(screenName);
+
+                // For dynamic tab-host screens, map the route pattern - tab paths for findAllMatchingDynamicSuffixes.
+                if (isDynamicRouteSuffix(screenConfig.path)) {
+                    const tabPaths = new Set<string>();
+                    for (const tabConfig of Object.values(screenConfig.screens)) {
+                        const tabPath = typeof tabConfig === 'string' ? tabConfig : tabConfig?.path;
+                        if (tabPath) {
+                            tabPaths.add(tabPath);
+                        }
+                    }
+                    if (tabPaths.size > 0) {
+                        result.dynamicTabPatternToTabPaths.set(screenConfig.path, tabPaths);
+                    }
+                }
             }
             if (screenConfig.screens) {
                 collectScreensWithTabNavigator(screenConfig.screens, result);
@@ -29,5 +56,5 @@ function collectScreensWithTabNavigator(screens: Record<string, ScreenConfigEntr
     return result;
 }
 
-export type {ScreenConfigEntry};
+export type {ScreenConfigEntry, CollectResult};
 export default collectScreensWithTabNavigator;

--- a/src/libs/Navigation/helpers/collectScreensWithTabNavigator.ts
+++ b/src/libs/Navigation/helpers/collectScreensWithTabNavigator.ts
@@ -56,5 +56,5 @@ function collectScreensWithTabNavigator(
     return result;
 }
 
-export type {ScreenConfigEntry, CollectResult};
+export type {ScreenConfigEntry};
 export default collectScreensWithTabNavigator;

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
@@ -1,3 +1,4 @@
+import {dynamicTabPatternToTabPaths} from '@libs/Navigation/linkingConfig/config';
 import type {CompiledEntry} from './compileDynamicRoutePattern';
 import {compiledOptionalParametricDynamicRoutes, compiledStrictParametricDynamicRoutes} from './compileDynamicRoutePattern';
 import {dynamicRoutePaths} from './isDynamicRouteSuffix';
@@ -10,6 +11,8 @@ type DynamicSuffixMatch = {
     actualSuffix: string;
     /** Extracted path params, e.g. {reportID: '456', reportActionID: 'abc'} */
     pathParams: Record<string, string>;
+    /** The path to pass to getPathWithoutDynamicSuffix. Equal to the original path unless a trailing tab segment was stripped. */
+    pathUsedForMatching: string;
 };
 
 /**
@@ -18,7 +21,7 @@ type DynamicSuffixMatch = {
  *
  * @private - Internal helper. Do not export or use outside this file.
  */
-function tryMatchParametric(candidate: string, candidateSegmentCount: number, patterns: CompiledEntry[]): DynamicSuffixMatch | undefined {
+function tryMatchParametric(candidate: string, candidateSegmentCount: number, patterns: CompiledEntry[]): Omit<DynamicSuffixMatch, 'pathUsedForMatching'> | undefined {
     const normalized = candidate.endsWith('/') ? candidate : `${candidate}/`;
 
     for (const {compiled} of patterns) {
@@ -48,8 +51,35 @@ function tryMatchParametric(candidate: string, candidateSegmentCount: number, pa
 }
 
 /**
- * Collects all registered dynamic route suffixes that syntactically match the end of the given path,
- * across all three phases and in priority order:
+ * Strips the trailing tab segment from a path and retries matching against Phases 1–3.
+ * Returns an empty array if stripping is not applicable.
+ * Calls `findAllMatchingDynamicSuffixes` recursively with an empty map to prevent double-stripping.
+ *
+ * @private - Internal helper. Do not export or use outside this file.
+ */
+function tryStripTabSuffix(normalizedPath: string, query: string, tabPatternMap: Map<string, Set<string>>): DynamicSuffixMatch[] {
+    if (tabPatternMap.size === 0) {
+        return [];
+    }
+    const lastSlash = normalizedPath.lastIndexOf('/');
+    if (lastSlash <= 0) {
+        return [];
+    }
+    const lastSegment = normalizedPath.slice(lastSlash + 1);
+    const pathWithoutTab = normalizedPath.slice(0, lastSlash);
+    const fullPathWithoutTab = query ? `${pathWithoutTab}?${query}` : pathWithoutTab;
+    const retriedResults = findAllMatchingDynamicSuffixes(pathWithoutTab, new Map());
+
+    // Keep only matches whose pattern owns the stripped segment as a registered tab-child path.
+    const validResults = retriedResults.filter((match) => tabPatternMap.get(match.pattern)?.has(lastSegment));
+    return validResults.map((match) => ({...match, pathUsedForMatching: fullPathWithoutTab}));
+}
+
+/**
+ * Collects all registered dynamic route suffixes that syntactically match the end of the given path.
+ * First checks whether the path ends with a tab-navigator segment (i.e. the matched dynamic route
+ * hosts a nested tab navigator), if so, strips the tab segment and returns the match immediately.
+ * Otherwise collects matches across three phases in priority order:
  *   1. Static matches (`dynamicRoutePaths` Set lookup), longest to shortest.
  *   2. Strict parametric patterns (no optional params), longest to shortest.
  *   3. Optional parametric patterns (has at least one `:param?`), longest to shortest.
@@ -63,12 +93,21 @@ function tryMatchParametric(candidate: string, candidateSegmentCount: number, pa
  * to what `findMatchingDynamicSuffix` would return for the same path.
  *
  * @param path - The path to find all matching dynamic suffixes for
+ * @param tabPatternMap - Override for the tab-pattern map (defaults to the app-wide
+ *   `dynamicTabPatternToTabPaths`).
  * @returns Array of all matching dynamic suffixes in priority order (may be empty)
  */
-function findAllMatchingDynamicSuffixes(path = ''): DynamicSuffixMatch[] {
-    const [normalizedPath] = splitPathAndQuery(path);
+function findAllMatchingDynamicSuffixes(path = '', tabPatternMap: Map<string, Set<string>> = dynamicTabPatternToTabPaths): DynamicSuffixMatch[] {
+    const [normalizedPath, query] = splitPathAndQuery(path);
     if (!normalizedPath) {
         return [];
+    }
+
+    // Handles dynamic routes that host a tab navigator: if the URL ends with a tab segment,
+    // strip it and return the match immediately.
+    const tabResults = tryStripTabSuffix(normalizedPath, query ?? '', tabPatternMap);
+    if (tabResults.length > 0) {
+        return tabResults;
     }
 
     const segments = normalizedPath.split('/').filter(Boolean);
@@ -79,7 +118,7 @@ function findAllMatchingDynamicSuffixes(path = ''): DynamicSuffixMatch[] {
     for (let i = 0; i < segments.length; i++) {
         const candidate = segments.slice(i).join('/');
         if (dynamicRoutePaths.has(candidate)) {
-            results.push({pattern: candidate, actualSuffix: candidate, pathParams: {}});
+            results.push({pattern: candidate, actualSuffix: candidate, pathParams: {}, pathUsedForMatching: path});
             seenPatterns.add(candidate);
         }
     }
@@ -88,7 +127,7 @@ function findAllMatchingDynamicSuffixes(path = ''): DynamicSuffixMatch[] {
     for (let i = 0; i < segments.length; i++) {
         const match = tryMatchParametric(segments.slice(i).join('/'), segments.length - i, compiledStrictParametricDynamicRoutes);
         if (match && !seenPatterns.has(match.pattern)) {
-            results.push(match);
+            results.push({...match, pathUsedForMatching: path});
             seenPatterns.add(match.pattern);
         }
     }
@@ -97,7 +136,7 @@ function findAllMatchingDynamicSuffixes(path = ''): DynamicSuffixMatch[] {
     for (let i = 0; i < segments.length; i++) {
         const match = tryMatchParametric(segments.slice(i).join('/'), segments.length - i, compiledOptionalParametricDynamicRoutes);
         if (match && !seenPatterns.has(match.pattern)) {
-            results.push(match);
+            results.push({...match, pathUsedForMatching: path});
             seenPatterns.add(match.pattern);
         }
     }

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes.ts
@@ -51,7 +51,7 @@ function tryMatchParametric(candidate: string, candidateSegmentCount: number, pa
 }
 
 /**
- * Strips the trailing tab segment from a path and retries matching against Phases 1–3.
+ * Strips the trailing tab segment from a path and retries matching.
  * Returns an empty array if stripping is not applicable.
  * Calls `findAllMatchingDynamicSuffixes` recursively with an empty map to prevent double-stripping.
  *

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteAdaptedState.ts
@@ -85,7 +85,7 @@ function getDynamicRouteAdaptedState(state: PartialState<NavigationState>, focus
         const allSuffixMatches = findAllMatchingDynamicSuffixes(currentPath);
 
         for (const candidate of allSuffixMatches) {
-            const candidateBasePath = getPathWithoutDynamicSuffix(currentPath, candidate.actualSuffix, candidate.pattern);
+            const candidateBasePath = getPathWithoutDynamicSuffix(candidate.pathUsedForMatching, candidate.actualSuffix, candidate.pattern);
             if (!candidateBasePath || candidateBasePath === currentPath) {
                 continue;
             }

--- a/src/libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard.ts
+++ b/src/libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard.ts
@@ -1,5 +1,7 @@
-import type {NavigationRoute, NavigationState, ParamListBase, PartialState} from '@react-navigation/native';
 import {screensWithOnyxTabNavigator} from '@libs/Navigation/linkingConfig/config';
+import type {State} from '@libs/Navigation/types';
+
+type RouteFromState = State['routes'][number];
 
 /**
  * Works like React Navigation's {@link findFocusedRoute} but stops recursing when it reaches
@@ -7,18 +9,18 @@ import {screensWithOnyxTabNavigator} from '@libs/Navigation/linkingConfig/config
  * tab navigator's internal state and return the individual tab name (e.g. "amount", "scan")
  * instead of the parent screen (e.g. "Money_Request_Split_Expense").
  */
-function findFocusedRouteWithOnyxTabGuard(state: NavigationState | PartialState<NavigationState>): NavigationRoute<ParamListBase> | undefined {
+function findFocusedRouteWithOnyxTabGuard(state: State): RouteFromState | undefined {
     const route = state.routes[state.index ?? state.routes.length - 1];
     if (route === undefined) {
         return undefined;
     }
     if (screensWithOnyxTabNavigator.has(route.name)) {
-        return route as NavigationRoute<ParamListBase>;
+        return route;
     }
     if (route.state) {
-        return findFocusedRouteWithOnyxTabGuard(route.state);
+        return findFocusedRouteWithOnyxTabGuard(route.state as State);
     }
-    return route as NavigationRoute<ParamListBase>;
+    return route;
 }
 
 export default findFocusedRouteWithOnyxTabGuard;

--- a/src/libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard.ts
+++ b/src/libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard.ts
@@ -1,4 +1,4 @@
-import type {findFocusedRoute, NavigationState, PartialState} from '@react-navigation/native';
+import type {NavigationRoute, NavigationState, ParamListBase, PartialState} from '@react-navigation/native';
 import {screensWithOnyxTabNavigator} from '@libs/Navigation/linkingConfig/config';
 
 /**
@@ -7,18 +7,18 @@ import {screensWithOnyxTabNavigator} from '@libs/Navigation/linkingConfig/config
  * tab navigator's internal state and return the individual tab name (e.g. "amount", "scan")
  * instead of the parent screen (e.g. "Money_Request_Split_Expense").
  */
-function findFocusedRouteWithOnyxTabGuard(state: PartialState<NavigationState>): ReturnType<typeof findFocusedRoute> {
+function findFocusedRouteWithOnyxTabGuard(state: NavigationState | PartialState<NavigationState>): NavigationRoute<ParamListBase> | undefined {
     const route = state.routes[state.index ?? state.routes.length - 1];
     if (route === undefined) {
         return undefined;
     }
     if (screensWithOnyxTabNavigator.has(route.name)) {
-        return route as ReturnType<typeof findFocusedRoute>;
+        return route as NavigationRoute<ParamListBase>;
     }
     if (route.state) {
         return findFocusedRouteWithOnyxTabGuard(route.state);
     }
-    return route as ReturnType<typeof findFocusedRoute>;
+    return route as NavigationRoute<ParamListBase>;
 }
 
 export default findFocusedRouteWithOnyxTabGuard;

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -235,9 +235,7 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
     if (route.path) {
         const allSuffixMatches = findAllMatchingDynamicSuffixes(route.path);
         for (const suffixMatch of allSuffixMatches) {
-            // Strip the suffix from the URL. For parametric routes we pass both the actual URL
-            // suffix and the registered pattern so query params can be resolved correctly.
-            const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(route.path, suffixMatch.actualSuffix, suffixMatch.pattern);
+            const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(suffixMatch.pathUsedForMatching, suffixMatch.actualSuffix, suffixMatch.pattern);
 
             if (!pathWithoutDynamicSuffix) {
                 continue;

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -3,7 +3,7 @@ import pick from 'lodash/pick';
 import getInitialSplitNavigatorState from '@libs/Navigation/AppNavigator/createSplitNavigator/getInitialSplitNavigatorState';
 import TAB_SCREENS from '@libs/Navigation/AppNavigator/Navigators/TAB_SCREENS';
 import {RHP_TO_DOMAIN, RHP_TO_HOME, RHP_TO_SEARCH, RHP_TO_SETTINGS, RHP_TO_SIDEBAR, RHP_TO_WORKSPACE, RHP_TO_WORKSPACES_LIST} from '@libs/Navigation/linkingConfig/RELATIONS';
-import type {NavigationPartialRoute, RootNavigatorParamList} from '@libs/Navigation/types';
+import type {NavigationPartialRoute, NavigationRoute, RootNavigatorParamList} from '@libs/Navigation/types';
 import {getReportOrDraftReport} from '@libs/ReportUtils';
 import {getSearchParamFromPath} from '@libs/Url';
 import CONST from '@src/CONST';
@@ -69,11 +69,11 @@ function getTabNavigatorState(selectedTabRoute: NavigationPartialRoute): Navigat
     return {name: NAVIGATORS.TAB_NAVIGATOR, state: {routes, index}};
 }
 
-function isRouteWithBackToParam(route: NavigationPartialRoute): route is Route<string, {backTo: string}> {
+function isRouteWithBackToParam(route: NavigationRoute): route is Route<string, {backTo: string}> {
     return route.params !== undefined && 'backTo' in route.params && typeof route.params.backTo === 'string';
 }
 
-function isRouteWithReportID(route: NavigationPartialRoute): route is Route<string, {reportID: string}> {
+function isRouteWithReportID(route: NavigationRoute): route is Route<string, {reportID: string}> {
     return route.params !== undefined && 'reportID' in route.params && typeof route.params.reportID === 'string';
 }
 
@@ -83,7 +83,7 @@ function isRouteWithReportID(route: NavigationPartialRoute): route is Route<stri
  * When a split tab route is accessed from search context (path contains '/search'),
  * we use SPLIT_EXPENSE_SEARCH for the mapping lookup instead of the tab name.
  */
-function getSearchScreenNameForRoute(route: NavigationPartialRoute): string {
+function getSearchScreenNameForRoute(route: NavigationRoute): string {
     const splitTabNames = Object.values(CONST.TAB.SPLIT) as string[];
     const isSplitTabRoute = splitTabNames.includes(route.name);
 
@@ -94,7 +94,7 @@ function getSearchScreenNameForRoute(route: NavigationPartialRoute): string {
     return route.name;
 }
 
-function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
+function getMatchingFullScreenRoute(route: NavigationRoute) {
     const isDynamicScreen = isDynamicRouteScreen(route.name as Screen);
 
     // Check for backTo param. One screen with different backTo value may need different screens visible under the overlay.
@@ -274,7 +274,7 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
 // It is the reports split navigator with report. If the reportID is defined in the focused route, we want to use it for the default report.
 // This is separated from getMatchingFullScreenRoute because we want to use it only for the initial state.
 // We don't want to make this route mandatory e.g. after deep linking or opening a specific flow.
-function getDefaultFullScreenRoute(route?: NavigationPartialRoute) {
+function getDefaultFullScreenRoute(route?: NavigationRoute) {
     if (route && isRouteWithReportID(route)) {
         const reportID = route.params.reportID;
 

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -1,13 +1,11 @@
 import {getPathFromState as RNGetPathFromState} from '@react-navigation/native';
-import type {NavigationState, PartialState} from '@react-navigation/routers';
 import {config, normalizedConfigs, screensWithOnyxTabNavigator} from '@libs/Navigation/linkingConfig/config';
+import type {State} from '@libs/Navigation/types';
 import type {Screen} from '@src/SCREENS';
 import getDynamicRouteQueryParams from './dynamicRoutesUtils/getDynamicRouteQueryParams';
 import isDynamicRouteScreen from './dynamicRoutesUtils/isDynamicRouteScreen';
 import splitPathAndQuery from './dynamicRoutesUtils/splitPathAndQuery';
 import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
-
-type State = NavigationState | Omit<PartialState<NavigationState>, 'stale'>;
 
 function isScreen(name: string): name is Screen {
     return name in normalizedConfigs;
@@ -73,19 +71,12 @@ function buildSuffixFromPattern(pattern: string, params: Record<string, unknown>
  * Pops the deepest focused route from a navigation state tree.
  * Returns the reduced state, or undefined if the tree becomes empty.
  *
- * Screens listed in `isLeaf` are treated as atomic leaves - the function will
- * not recurse into their nested state (e.g. tab navigators), so the entire
- * screen is removed as a unit rather than popping an individual tab.
- *
  * @param state - The navigation state tree to pop from
- * @param isLeaf - Optional guard: return true for screen names that should be
- *                 treated as leaves (not recursed into). Used to prevent drilling
- *                 into tab navigators hosted by dynamic screens.
  * @returns The reduced state, or undefined if the tree becomes empty
  *
  * @private - Internal helper. Do not export or use outside this file.
  */
-function popFocusedRoute(state: State, isLeaf?: (name: string) => boolean): State | undefined {
+function popFocusedRoute(state: State): State | undefined {
     const index = state.index ?? state.routes.length - 1;
     const focusedRoute = state.routes[index];
 
@@ -95,9 +86,9 @@ function popFocusedRoute(state: State, isLeaf?: (name: string) => boolean): Stat
     }
 
     // the focused route has nested state - try to pop from deeper levels first,
-    // unless it is a leaf screen (e.g. a tab-hosting dynamic screen).
-    if (focusedRoute.state && !isLeaf?.(focusedRoute.name ?? '')) {
-        const nestedResult = popFocusedRoute(focusedRoute.state as State, isLeaf);
+    // unless it hosts an OnyxTabNavigator (treat it as a leaf).
+    if (focusedRoute.state && !screensWithOnyxTabNavigator.has(focusedRoute.name ?? '')) {
+        const nestedResult = popFocusedRoute(focusedRoute.state as State);
 
         // A deeper route was successfully popped - rebuild the current level with the updated nested state.
         if (nestedResult) {
@@ -121,10 +112,6 @@ function popFocusedRoute(state: State, isLeaf?: (name: string) => boolean): Stat
 /**
  * Builds a URL path for a dynamic route screen.
  * Recursively peels off dynamic suffixes and resolves the base path underneath.
- *
- * When the focused dynamic screen hosts a tab navigator (i.e. it is in
- * `screensWithOnyxTabNavigator`), the focused tab's path segment is appended
- * to the dynamic suffix before the base path is resolved.
  *
  * @param state - The navigation state tree to build the path from
  * @returns The resolved path for the focused dynamic route screen
@@ -155,7 +142,7 @@ function getPathFromStateWithDynamicRoute(state: State): string {
         }
     }
 
-    const reducedState = popFocusedRoute(state, (name) => screensWithOnyxTabNavigator.has(name));
+    const reducedState = popFocusedRoute(state);
 
     if (!reducedState) {
         return `/${actualSuffix}`;

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -1,12 +1,17 @@
-import {findFocusedRoute, getPathFromState as RNGetPathFromState} from '@react-navigation/native';
+import {getPathFromState as RNGetPathFromState} from '@react-navigation/native';
 import type {NavigationState, PartialState} from '@react-navigation/routers';
-import {config, normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
+import {config, normalizedConfigs, screensWithOnyxTabNavigator} from '@libs/Navigation/linkingConfig/config';
 import type {Screen} from '@src/SCREENS';
 import getDynamicRouteQueryParams from './dynamicRoutesUtils/getDynamicRouteQueryParams';
 import isDynamicRouteScreen from './dynamicRoutesUtils/isDynamicRouteScreen';
 import splitPathAndQuery from './dynamicRoutesUtils/splitPathAndQuery';
+import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
 
 type State = NavigationState | Omit<PartialState<NavigationState>, 'stale'>;
+
+function isScreen(name: string): name is Screen {
+    return name in normalizedConfigs;
+}
 
 /**
  * Resolves a single path segment: if it's a `:param` placeholder, replaces it
@@ -68,12 +73,19 @@ function buildSuffixFromPattern(pattern: string, params: Record<string, unknown>
  * Pops the deepest focused route from a navigation state tree.
  * Returns the reduced state, or undefined if the tree becomes empty.
  *
+ * Screens listed in `isLeaf` are treated as atomic leaves - the function will
+ * not recurse into their nested state (e.g. tab navigators), so the entire
+ * screen is removed as a unit rather than popping an individual tab.
+ *
  * @param state - The navigation state tree to pop from
+ * @param isLeaf - Optional guard: return true for screen names that should be
+ *                 treated as leaves (not recursed into). Used to prevent drilling
+ *                 into tab navigators hosted by dynamic screens.
  * @returns The reduced state, or undefined if the tree becomes empty
  *
  * @private - Internal helper. Do not export or use outside this file.
  */
-function popFocusedRoute(state: State): State | undefined {
+function popFocusedRoute(state: State, isLeaf?: (name: string) => boolean): State | undefined {
     const index = state.index ?? state.routes.length - 1;
     const focusedRoute = state.routes[index];
 
@@ -82,9 +94,10 @@ function popFocusedRoute(state: State): State | undefined {
         return undefined;
     }
 
-    // the focused route has nested state — try to pop from deeper levels first.
-    if (focusedRoute.state) {
-        const nestedResult = popFocusedRoute(focusedRoute.state as State);
+    // the focused route has nested state - try to pop from deeper levels first,
+    // unless it is a leaf screen (e.g. a tab-hosting dynamic screen).
+    if (focusedRoute.state && !isLeaf?.(focusedRoute.name ?? '')) {
+        const nestedResult = popFocusedRoute(focusedRoute.state as State, isLeaf);
 
         // A deeper route was successfully popped - rebuild the current level with the updated nested state.
         if (nestedResult) {
@@ -106,8 +119,12 @@ function popFocusedRoute(state: State): State | undefined {
 }
 
 /**
- * Builds a URL path for a dynamic route screen that has no `path` in state.
+ * Builds a URL path for a dynamic route screen.
  * Recursively peels off dynamic suffixes and resolves the base path underneath.
+ *
+ * When the focused dynamic screen hosts a tab navigator (i.e. it is in
+ * `screensWithOnyxTabNavigator`), the focused tab's path segment is appended
+ * to the dynamic suffix before the base path is resolved.
  *
  * @param state - The navigation state tree to build the path from
  * @returns The resolved path for the focused dynamic route screen
@@ -115,7 +132,7 @@ function popFocusedRoute(state: State): State | undefined {
  * @private - Internal helper. Do not export or use outside this file.
  */
 function getPathFromStateWithDynamicRoute(state: State): string {
-    const focusedRoute = findFocusedRoute(state);
+    const focusedRoute = findFocusedRouteWithOnyxTabGuard(state);
     const screenName = focusedRoute?.name ?? '';
     const suffixPattern = normalizedConfigs[screenName as Screen]?.path;
 
@@ -123,8 +140,22 @@ function getPathFromStateWithDynamicRoute(state: State): string {
         return RNGetPathFromState(state, config);
     }
 
-    const actualSuffix = buildSuffixFromPattern(suffixPattern, focusedRoute?.params as Record<string, unknown> | undefined);
-    const reducedState = popFocusedRoute(state);
+    let actualSuffix = buildSuffixFromPattern(suffixPattern, focusedRoute?.params as Record<string, unknown> | undefined);
+
+    // If this dynamic screen hosts a tab navigator, append the focused tab's path segment.
+    if (screensWithOnyxTabNavigator.has(screenName)) {
+        const tabState = focusedRoute?.state;
+        if (tabState) {
+            const tabIndex = tabState.index ?? tabState.routes.length - 1;
+            const focusedTab = tabState.routes[tabIndex];
+            const tabPath = focusedTab && isScreen(focusedTab.name) ? normalizedConfigs[focusedTab.name]?.path : undefined;
+            if (tabPath) {
+                actualSuffix = `${actualSuffix}/${tabPath}`;
+            }
+        }
+    }
+
+    const reducedState = popFocusedRoute(state, (name) => screensWithOnyxTabNavigator.has(name));
 
     if (!reducedState) {
         return `/${actualSuffix}`;
@@ -145,7 +176,7 @@ function getPathFromStateWithDynamicRoute(state: State): string {
 }
 
 function getPathFromState(state: State): string {
-    const focusedRoute = findFocusedRoute(state);
+    const focusedRoute = findFocusedRouteWithOnyxTabGuard(state);
     const screenName = focusedRoute?.name ?? '';
 
     if (isDynamicRouteScreen(screenName as Screen)) {

--- a/src/libs/Navigation/helpers/getStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getStateFromPath.ts
@@ -29,8 +29,8 @@ function getStateFromPath(path: Route): PartialState<NavigationState> {
     const dynamicRouteKeys = Object.keys(DYNAMIC_ROUTES) as DynamicRouteKey[];
 
     for (const suffixMatch of allSuffixMatches) {
-        const {pattern, actualSuffix, pathParams} = suffixMatch;
-        const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(normalizedPathAfterRedirection, actualSuffix, pattern);
+        const {pattern, actualSuffix, pathParams, pathUsedForMatching} = suffixMatch;
+        const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(pathUsedForMatching, actualSuffix, pattern);
 
         // Find the DYNAMIC_ROUTES config key whose path matches the extracted pattern.
         const dynamicRoute = dynamicRouteKeys.find((key) => DYNAMIC_ROUTES[key].path === pattern) ?? '';

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -980,16 +980,13 @@ const config: LinkingOptions<RootNavigatorParamList>['config'] = {
                             path: ROUTES.WORKSPACE_RECEIPT_PARTNERS_INVITE_EDIT.route,
                             screens: {
                                 [CONST.TAB.RECEIPT_PARTNERS.ALL]: {
-                                    path: ROUTES.WORKSPACE_RECEIPT_PARTNERS_INVITE_EDIT_ALL,
-                                    exact: true,
+                                    path: CONST.TAB.RECEIPT_PARTNERS.ALL,
                                 },
                                 [CONST.TAB.RECEIPT_PARTNERS.LINKED]: {
-                                    path: ROUTES.WORKSPACE_RECEIPT_PARTNERS_INVITE_EDIT_LINKED,
-                                    exact: true,
+                                    path: CONST.TAB.RECEIPT_PARTNERS.LINKED,
                                 },
                                 [CONST.TAB.RECEIPT_PARTNERS.OUTSTANDING]: {
-                                    path: ROUTES.WORKSPACE_RECEIPT_PARTNERS_INVITE_EDIT_OUTSTANDING,
-                                    exact: true,
+                                    path: CONST.TAB.RECEIPT_PARTNERS.OUTSTANDING,
                                 },
                             },
                         },
@@ -2374,6 +2371,6 @@ const normalizedConfigs = Object.keys(config.screens)
         {} as Record<Screen, RouteConfig>,
     );
 
-const screensWithOnyxTabNavigator = collectScreensWithTabNavigator(config.screens as Record<string, ScreenConfigEntry>);
+const {screensWithTabNavigator: screensWithOnyxTabNavigator, dynamicTabPatternToTabPaths} = collectScreensWithTabNavigator(config.screens as Record<string, ScreenConfigEntry>);
 
-export {normalizedConfigs, config, screensWithOnyxTabNavigator};
+export {normalizedConfigs, config, screensWithOnyxTabNavigator, dynamicTabPatternToTabPaths};

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -981,12 +981,15 @@ const config: LinkingOptions<RootNavigatorParamList>['config'] = {
                             screens: {
                                 [CONST.TAB.RECEIPT_PARTNERS.ALL]: {
                                     path: CONST.TAB.RECEIPT_PARTNERS.ALL,
+                                    exact: true,
                                 },
                                 [CONST.TAB.RECEIPT_PARTNERS.LINKED]: {
                                     path: CONST.TAB.RECEIPT_PARTNERS.LINKED,
+                                    exact: true,
                                 },
                                 [CONST.TAB.RECEIPT_PARTNERS.OUTSTANDING]: {
                                     path: CONST.TAB.RECEIPT_PARTNERS.OUTSTANDING,
+                                    exact: true,
                                 },
                             },
                         },

--- a/tests/navigation/collectScreensWithTabNavigatorTests.ts
+++ b/tests/navigation/collectScreensWithTabNavigatorTests.ts
@@ -19,7 +19,7 @@ describe('collectScreensWithTabNavigator', () => {
 
         const result = collectScreensWithTabNavigator(screens);
 
-        expect(result.size).toBe(0);
+        expect(result.screensWithTabNavigator.size).toBe(0);
     });
 
     it('should collect a screen that has both path and screens', () => {
@@ -29,7 +29,7 @@ describe('collectScreensWithTabNavigator', () => {
 
         const result = collectScreensWithTabNavigator(screens);
 
-        expect(result).toEqual(new Set(['TabScreen']));
+        expect(result.screensWithTabNavigator).toEqual(new Set(['TabScreen']));
     });
 
     it('should exclude navigator names even if they have both path and screens', () => {
@@ -40,7 +40,7 @@ describe('collectScreensWithTabNavigator', () => {
 
         const result = collectScreensWithTabNavigator(screens);
 
-        expect(result.size).toBe(0);
+        expect(result.screensWithTabNavigator.size).toBe(0);
     });
 
     it('should collect a nested tab screen inside a navigator', () => {
@@ -54,7 +54,7 @@ describe('collectScreensWithTabNavigator', () => {
 
         const result = collectScreensWithTabNavigator(screens);
 
-        expect(result).toEqual(new Set(['NestedTabScreen']));
+        expect(result.screensWithTabNavigator).toEqual(new Set(['NestedTabScreen']));
     });
 
     it('should collect tab screens at all depth levels in a 3-level structure', () => {
@@ -73,7 +73,7 @@ describe('collectScreensWithTabNavigator', () => {
 
         const result = collectScreensWithTabNavigator(screens);
 
-        expect(result).toEqual(new Set(['Level1Tab', 'Level3Tab']));
+        expect(result.screensWithTabNavigator).toEqual(new Set(['Level1Tab', 'Level3Tab']));
     });
 
     it('should collect only matching screens from a mixed config', () => {
@@ -88,6 +88,6 @@ describe('collectScreensWithTabNavigator', () => {
 
         const result = collectScreensWithTabNavigator(screens);
 
-        expect(result).toEqual(new Set(['ValidTab', 'AnotherTab']));
+        expect(result.screensWithTabNavigator).toEqual(new Set(['ValidTab', 'AnotherTab']));
     });
 });

--- a/tests/navigation/findAllMatchingDynamicSuffixesTests.ts
+++ b/tests/navigation/findAllMatchingDynamicSuffixesTests.ts
@@ -22,18 +22,20 @@ jest.mock('@src/ROUTES', () => ({
 
 describe('findMatchingDynamicSuffix', () => {
     it('should match a single-segment dynamic suffix', () => {
-        expect(findMatchingDynamicSuffix('settings/wallet/verify-account')).toMatchObject({
+        expect(findMatchingDynamicSuffix('settings/wallet/verify-account')).toEqual({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
+            pathUsedForMatching: 'settings/wallet/verify-account',
         });
     });
 
     it('should match when the path has a leading slash', () => {
-        expect(findMatchingDynamicSuffix('/settings/wallet/verify-account')).toMatchObject({
+        expect(findMatchingDynamicSuffix('/settings/wallet/verify-account')).toEqual({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
+            pathUsedForMatching: '/settings/wallet/verify-account',
         });
     });
 
@@ -50,18 +52,20 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should ignore query parameters when matching', () => {
-        expect(findMatchingDynamicSuffix('settings/wallet/verify-account?sortBy=date')).toMatchObject({
+        expect(findMatchingDynamicSuffix('settings/wallet/verify-account?sortBy=date')).toEqual({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
+            pathUsedForMatching: 'settings/wallet/verify-account?sortBy=date',
         });
     });
 
     it('should handle trailing slashes', () => {
-        expect(findMatchingDynamicSuffix('settings/wallet/verify-account/')).toMatchObject({
+        expect(findMatchingDynamicSuffix('settings/wallet/verify-account/')).toEqual({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
+            pathUsedForMatching: 'settings/wallet/verify-account/',
         });
     });
 
@@ -70,34 +74,38 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should match a suffix when path has suffix-specific query params', () => {
-        expect(findMatchingDynamicSuffix('settings/profile/address/country?country=US')).toMatchObject({
+        expect(findMatchingDynamicSuffix('settings/profile/address/country?country=US')).toEqual({
             pattern: 'country',
             actualSuffix: 'country',
             pathParams: {},
+            pathUsedForMatching: 'settings/profile/address/country?country=US',
         });
     });
 
     it('should prefer longer multi-segment static match over shorter', () => {
-        expect(findMatchingDynamicSuffix('/settings/wallet/add-bank-account/verify-account')).toMatchObject({
+        expect(findMatchingDynamicSuffix('/settings/wallet/add-bank-account/verify-account')).toEqual({
             pattern: 'add-bank-account/verify-account',
             actualSuffix: 'add-bank-account/verify-account',
             pathParams: {},
+            pathUsedForMatching: '/settings/wallet/add-bank-account/verify-account',
         });
     });
 
     it('should match parametric suffix and extract params', () => {
-        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc')).toMatchObject({
+        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc')).toEqual({
             pattern: 'flag/:reportID/:reportActionID',
             actualSuffix: 'flag/456/abc',
             pathParams: {reportID: '456', reportActionID: 'abc'},
+            pathUsedForMatching: '/r/123/flag/456/abc',
         });
     });
 
     it('should match single-param suffix', () => {
-        expect(findMatchingDynamicSuffix('/r/123/members/member-details/456')).toMatchObject({
+        expect(findMatchingDynamicSuffix('/r/123/members/member-details/456')).toEqual({
             pattern: 'member-details/:accountID',
             actualSuffix: 'member-details/456',
             pathParams: {accountID: '456'},
+            pathUsedForMatching: '/r/123/members/member-details/456',
         });
     });
 
@@ -110,67 +118,75 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should handle query params alongside parametric suffix', () => {
-        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc?tab=details')).toMatchObject({
+        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc?tab=details')).toEqual({
             pattern: 'flag/:reportID/:reportActionID',
             actualSuffix: 'flag/456/abc',
             pathParams: {reportID: '456', reportActionID: 'abc'},
+            pathUsedForMatching: '/r/123/flag/456/abc?tab=details',
         });
     });
 
     it('should match keyboard-shortcuts dynamic suffix', () => {
-        expect(findMatchingDynamicSuffix('settings/about/keyboard-shortcuts')).toMatchObject({
+        expect(findMatchingDynamicSuffix('settings/about/keyboard-shortcuts')).toEqual({
             pattern: 'keyboard-shortcuts',
             actualSuffix: 'keyboard-shortcuts',
             pathParams: {},
+            pathUsedForMatching: 'settings/about/keyboard-shortcuts',
         });
     });
 
     describe('optional path params', () => {
         it('should match trailing-optional pattern when optional is absent', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page')).toMatchObject({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page')).toEqual({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page',
                 pathParams: {},
+                pathUsedForMatching: '/r/123/opt-page',
             });
         });
 
         it('should match trailing-optional pattern when optional is present', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page/789')).toMatchObject({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page/789')).toEqual({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page/789',
                 pathParams: {id: '789'},
+                pathUsedForMatching: '/r/123/opt-page/789',
             });
         });
 
         it('should match middle-optional pattern when optional is absent', () => {
-            expect(findMatchingDynamicSuffix('/r/123/wrap/end')).toMatchObject({
+            expect(findMatchingDynamicSuffix('/r/123/wrap/end')).toEqual({
                 pattern: 'wrap/:p?/end',
                 actualSuffix: 'wrap/end',
                 pathParams: {},
+                pathUsedForMatching: '/r/123/wrap/end',
             });
         });
 
         it('should match middle-optional pattern when optional is present', () => {
-            expect(findMatchingDynamicSuffix('/r/123/wrap/x/end')).toMatchObject({
+            expect(findMatchingDynamicSuffix('/r/123/wrap/x/end')).toEqual({
                 pattern: 'wrap/:p?/end',
                 actualSuffix: 'wrap/x/end',
                 pathParams: {p: 'x'},
+                pathUsedForMatching: '/r/123/wrap/x/end',
             });
         });
 
         it('should ignore query params when matching trailing-optional present-form', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page/789?tab=details')).toMatchObject({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page/789?tab=details')).toEqual({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page/789',
                 pathParams: {id: '789'},
+                pathUsedForMatching: '/r/123/opt-page/789?tab=details',
             });
         });
 
         it('should ignore query params when matching trailing-optional absent-form', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page?tab=details')).toMatchObject({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page?tab=details')).toEqual({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page',
                 pathParams: {},
+                pathUsedForMatching: '/r/123/opt-page?tab=details',
             });
         });
     });
@@ -190,16 +206,19 @@ describe('findAllMatchingDynamicSuffixes', () => {
     });
 
     it('should return a single-element array for an unambiguous static path', () => {
-        expect(findAllMatchingDynamicSuffixes('settings/wallet/verify-account')).toMatchObject([{pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}}]);
+        expect(findAllMatchingDynamicSuffixes('settings/wallet/verify-account')).toEqual([
+            {pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}, pathUsedForMatching: 'settings/wallet/verify-account'},
+        ]);
     });
 
     it('should return both a static and a parametric candidate when a tag name matches a static suffix (gl-code collision)', () => {
-        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/gl-code')).toMatchObject([
-            {pattern: 'gl-code', actualSuffix: 'gl-code', pathParams: {}},
+        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/gl-code')).toEqual([
+            {pattern: 'gl-code', actualSuffix: 'gl-code', pathParams: {}, pathUsedForMatching: '/settings/tags/tag-settings/0/gl-code'},
             {
                 pattern: 'tag-settings/:orderWeight/:tagName',
                 actualSuffix: 'tag-settings/0/gl-code',
                 pathParams: {orderWeight: '0', tagName: 'gl-code'},
+                pathUsedForMatching: '/settings/tags/tag-settings/0/gl-code',
             },
         ]);
     });
@@ -207,35 +226,35 @@ describe('findAllMatchingDynamicSuffixes', () => {
     it('should place static candidates before strict parametric candidates (priority order)', () => {
         const results = findAllMatchingDynamicSuffixes('/base/flag/123/verify-account');
         expect(results).toHaveLength(2);
-        expect(results.at(0)).toMatchObject({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
-        expect(results.at(1)).toMatchObject({
+        expect(results.at(0)).toEqual({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}, pathUsedForMatching: '/base/flag/123/verify-account'});
+        expect(results.at(1)).toEqual({
             pattern: 'flag/:reportID/:reportActionID',
             actualSuffix: 'flag/123/verify-account',
             pathParams: {reportID: '123', reportActionID: 'verify-account'},
+            pathUsedForMatching: '/base/flag/123/verify-account',
         });
     });
 
     it('should place static candidates before optional parametric candidates (priority order)', () => {
         const results = findAllMatchingDynamicSuffixes('/base/opt-page/verify-account');
         expect(results).toHaveLength(2);
-        expect(results.at(0)).toMatchObject({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
-        expect(results.at(1)).toMatchObject({
+        expect(results.at(0)).toEqual({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}, pathUsedForMatching: '/base/opt-page/verify-account'});
+        expect(results.at(1)).toEqual({
             pattern: 'opt-page/:id?',
             actualSuffix: 'opt-page/verify-account',
             pathParams: {id: 'verify-account'},
+            pathUsedForMatching: '/base/opt-page/verify-account',
         });
     });
 
     it('should return a single-element array when only one candidate exists (tag-approver at the end)', () => {
-        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/tagname/tag-approver')).toMatchObject([{pattern: 'tag-approver', actualSuffix: 'tag-approver', pathParams: {}}]);
+        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/tagname/tag-approver')).toEqual([
+            {pattern: 'tag-approver', actualSuffix: 'tag-approver', pathParams: {}, pathUsedForMatching: '/settings/tags/tag-settings/0/tagname/tag-approver'},
+        ]);
     });
 });
 
-describe('findAllMatchingDynamicSuffixes – Phase 4 (tab-suffix stripping)', () => {
-    // 'flag/:reportID/:reportActionID' → tabs: 'AllTab', 'LinkedTab'
-    // URLs ending with .../flag/456/abc/AllTab should be recognised as the flag route with tab stripped.
-    // 'keyboard-shortcuts' is registered as a dynamic route but NOT in the tabMap, so Phase 4
-    // must not fire even when the URL ends with a seemingly tab-like segment.
+describe('findAllMatchingDynamicSuffixes - tab-suffix stripping', () => {
     const tabMap = new Map<string, Set<string>>([['flag/:reportID/:reportActionID', new Set(['AllTab', 'LinkedTab'])]]);
 
     it('strips the trailing tab segment and returns match with pathUsedForMatching', () => {
@@ -267,9 +286,6 @@ describe('findAllMatchingDynamicSuffixes – Phase 4 (tab-suffix stripping)', ()
     });
 
     it('does NOT strip when the last segment is a tab of a different (non-matched) pattern', () => {
-        // After stripping 'AllTab', the retry on '/base/about/keyboard-shortcuts' finds the
-        // static 'keyboard-shortcuts' pattern. But tabMap.get('keyboard-shortcuts') is undefined,
-        // so the scoped check fails and the result is empty.
         const results = findAllMatchingDynamicSuffixes('/base/about/keyboard-shortcuts/AllTab', tabMap);
         expect(results).toEqual([]);
     });
@@ -283,9 +299,6 @@ describe('findAllMatchingDynamicSuffixes – Phase 4 (tab-suffix stripping)', ()
     });
 
     it('recursive retry does not receive tabMap so stripping stops after one level', () => {
-        // '/base/flag/456/AllTab/LinkedTab' → Phase 4 strips 'LinkedTab' →
-        // retry '/base/flag/456/AllTab' → 'flag/456/AllTab' matches flag pattern
-        // (reportID='456', reportActionID='AllTab') → tabMap.get(pattern)?.has('LinkedTab') → true.
         const results = findAllMatchingDynamicSuffixes('/base/flag/456/AllTab/LinkedTab', tabMap);
         expect(results).toHaveLength(1);
         expect(results.at(0)).toMatchObject({

--- a/tests/navigation/findAllMatchingDynamicSuffixesTests.ts
+++ b/tests/navigation/findAllMatchingDynamicSuffixesTests.ts
@@ -1,5 +1,9 @@
 import findAllMatchingDynamicSuffixes, {findMatchingDynamicSuffix} from '@libs/Navigation/helpers/dynamicRoutesUtils/findAllMatchingDynamicSuffixes';
 
+jest.mock('@libs/Navigation/linkingConfig/config', () => ({
+    dynamicTabPatternToTabPaths: new Map(),
+}));
+
 jest.mock('@src/ROUTES', () => ({
     DYNAMIC_ROUTES: {
         VERIFY_ACCOUNT: {path: 'verify-account'},
@@ -18,7 +22,7 @@ jest.mock('@src/ROUTES', () => ({
 
 describe('findMatchingDynamicSuffix', () => {
     it('should match a single-segment dynamic suffix', () => {
-        expect(findMatchingDynamicSuffix('settings/wallet/verify-account')).toEqual({
+        expect(findMatchingDynamicSuffix('settings/wallet/verify-account')).toMatchObject({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
@@ -26,7 +30,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should match when the path has a leading slash', () => {
-        expect(findMatchingDynamicSuffix('/settings/wallet/verify-account')).toEqual({
+        expect(findMatchingDynamicSuffix('/settings/wallet/verify-account')).toMatchObject({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
@@ -46,7 +50,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should ignore query parameters when matching', () => {
-        expect(findMatchingDynamicSuffix('settings/wallet/verify-account?sortBy=date')).toEqual({
+        expect(findMatchingDynamicSuffix('settings/wallet/verify-account?sortBy=date')).toMatchObject({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
@@ -54,7 +58,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should handle trailing slashes', () => {
-        expect(findMatchingDynamicSuffix('settings/wallet/verify-account/')).toEqual({
+        expect(findMatchingDynamicSuffix('settings/wallet/verify-account/')).toMatchObject({
             pattern: 'verify-account',
             actualSuffix: 'verify-account',
             pathParams: {},
@@ -66,7 +70,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should match a suffix when path has suffix-specific query params', () => {
-        expect(findMatchingDynamicSuffix('settings/profile/address/country?country=US')).toEqual({
+        expect(findMatchingDynamicSuffix('settings/profile/address/country?country=US')).toMatchObject({
             pattern: 'country',
             actualSuffix: 'country',
             pathParams: {},
@@ -74,7 +78,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should prefer longer multi-segment static match over shorter', () => {
-        expect(findMatchingDynamicSuffix('/settings/wallet/add-bank-account/verify-account')).toEqual({
+        expect(findMatchingDynamicSuffix('/settings/wallet/add-bank-account/verify-account')).toMatchObject({
             pattern: 'add-bank-account/verify-account',
             actualSuffix: 'add-bank-account/verify-account',
             pathParams: {},
@@ -82,7 +86,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should match parametric suffix and extract params', () => {
-        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc')).toEqual({
+        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc')).toMatchObject({
             pattern: 'flag/:reportID/:reportActionID',
             actualSuffix: 'flag/456/abc',
             pathParams: {reportID: '456', reportActionID: 'abc'},
@@ -90,7 +94,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should match single-param suffix', () => {
-        expect(findMatchingDynamicSuffix('/r/123/members/member-details/456')).toEqual({
+        expect(findMatchingDynamicSuffix('/r/123/members/member-details/456')).toMatchObject({
             pattern: 'member-details/:accountID',
             actualSuffix: 'member-details/456',
             pathParams: {accountID: '456'},
@@ -106,7 +110,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should handle query params alongside parametric suffix', () => {
-        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc?tab=details')).toEqual({
+        expect(findMatchingDynamicSuffix('/r/123/flag/456/abc?tab=details')).toMatchObject({
             pattern: 'flag/:reportID/:reportActionID',
             actualSuffix: 'flag/456/abc',
             pathParams: {reportID: '456', reportActionID: 'abc'},
@@ -114,7 +118,7 @@ describe('findMatchingDynamicSuffix', () => {
     });
 
     it('should match keyboard-shortcuts dynamic suffix', () => {
-        expect(findMatchingDynamicSuffix('settings/about/keyboard-shortcuts')).toEqual({
+        expect(findMatchingDynamicSuffix('settings/about/keyboard-shortcuts')).toMatchObject({
             pattern: 'keyboard-shortcuts',
             actualSuffix: 'keyboard-shortcuts',
             pathParams: {},
@@ -123,7 +127,7 @@ describe('findMatchingDynamicSuffix', () => {
 
     describe('optional path params', () => {
         it('should match trailing-optional pattern when optional is absent', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page')).toEqual({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page')).toMatchObject({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page',
                 pathParams: {},
@@ -131,7 +135,7 @@ describe('findMatchingDynamicSuffix', () => {
         });
 
         it('should match trailing-optional pattern when optional is present', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page/789')).toEqual({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page/789')).toMatchObject({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page/789',
                 pathParams: {id: '789'},
@@ -139,7 +143,7 @@ describe('findMatchingDynamicSuffix', () => {
         });
 
         it('should match middle-optional pattern when optional is absent', () => {
-            expect(findMatchingDynamicSuffix('/r/123/wrap/end')).toEqual({
+            expect(findMatchingDynamicSuffix('/r/123/wrap/end')).toMatchObject({
                 pattern: 'wrap/:p?/end',
                 actualSuffix: 'wrap/end',
                 pathParams: {},
@@ -147,7 +151,7 @@ describe('findMatchingDynamicSuffix', () => {
         });
 
         it('should match middle-optional pattern when optional is present', () => {
-            expect(findMatchingDynamicSuffix('/r/123/wrap/x/end')).toEqual({
+            expect(findMatchingDynamicSuffix('/r/123/wrap/x/end')).toMatchObject({
                 pattern: 'wrap/:p?/end',
                 actualSuffix: 'wrap/x/end',
                 pathParams: {p: 'x'},
@@ -155,7 +159,7 @@ describe('findMatchingDynamicSuffix', () => {
         });
 
         it('should ignore query params when matching trailing-optional present-form', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page/789?tab=details')).toEqual({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page/789?tab=details')).toMatchObject({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page/789',
                 pathParams: {id: '789'},
@@ -163,7 +167,7 @@ describe('findMatchingDynamicSuffix', () => {
         });
 
         it('should ignore query params when matching trailing-optional absent-form', () => {
-            expect(findMatchingDynamicSuffix('/r/123/opt-page?tab=details')).toEqual({
+            expect(findMatchingDynamicSuffix('/r/123/opt-page?tab=details')).toMatchObject({
                 pattern: 'opt-page/:id?',
                 actualSuffix: 'opt-page',
                 pathParams: {},
@@ -186,11 +190,11 @@ describe('findAllMatchingDynamicSuffixes', () => {
     });
 
     it('should return a single-element array for an unambiguous static path', () => {
-        expect(findAllMatchingDynamicSuffixes('settings/wallet/verify-account')).toEqual([{pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}}]);
+        expect(findAllMatchingDynamicSuffixes('settings/wallet/verify-account')).toMatchObject([{pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}}]);
     });
 
     it('should return both a static and a parametric candidate when a tag name matches a static suffix (gl-code collision)', () => {
-        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/gl-code')).toEqual([
+        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/gl-code')).toMatchObject([
             {pattern: 'gl-code', actualSuffix: 'gl-code', pathParams: {}},
             {
                 pattern: 'tag-settings/:orderWeight/:tagName',
@@ -203,8 +207,8 @@ describe('findAllMatchingDynamicSuffixes', () => {
     it('should place static candidates before strict parametric candidates (priority order)', () => {
         const results = findAllMatchingDynamicSuffixes('/base/flag/123/verify-account');
         expect(results).toHaveLength(2);
-        expect(results.at(0)).toEqual({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
-        expect(results.at(1)).toEqual({
+        expect(results.at(0)).toMatchObject({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
+        expect(results.at(1)).toMatchObject({
             pattern: 'flag/:reportID/:reportActionID',
             actualSuffix: 'flag/123/verify-account',
             pathParams: {reportID: '123', reportActionID: 'verify-account'},
@@ -214,8 +218,8 @@ describe('findAllMatchingDynamicSuffixes', () => {
     it('should place static candidates before optional parametric candidates (priority order)', () => {
         const results = findAllMatchingDynamicSuffixes('/base/opt-page/verify-account');
         expect(results).toHaveLength(2);
-        expect(results.at(0)).toEqual({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
-        expect(results.at(1)).toEqual({
+        expect(results.at(0)).toMatchObject({pattern: 'verify-account', actualSuffix: 'verify-account', pathParams: {}});
+        expect(results.at(1)).toMatchObject({
             pattern: 'opt-page/:id?',
             actualSuffix: 'opt-page/verify-account',
             pathParams: {id: 'verify-account'},
@@ -223,6 +227,71 @@ describe('findAllMatchingDynamicSuffixes', () => {
     });
 
     it('should return a single-element array when only one candidate exists (tag-approver at the end)', () => {
-        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/tagname/tag-approver')).toEqual([{pattern: 'tag-approver', actualSuffix: 'tag-approver', pathParams: {}}]);
+        expect(findAllMatchingDynamicSuffixes('/settings/tags/tag-settings/0/tagname/tag-approver')).toMatchObject([{pattern: 'tag-approver', actualSuffix: 'tag-approver', pathParams: {}}]);
+    });
+});
+
+describe('findAllMatchingDynamicSuffixes – Phase 4 (tab-suffix stripping)', () => {
+    // 'flag/:reportID/:reportActionID' → tabs: 'AllTab', 'LinkedTab'
+    // URLs ending with .../flag/456/abc/AllTab should be recognised as the flag route with tab stripped.
+    // 'keyboard-shortcuts' is registered as a dynamic route but NOT in the tabMap, so Phase 4
+    // must not fire even when the URL ends with a seemingly tab-like segment.
+    const tabMap = new Map<string, Set<string>>([['flag/:reportID/:reportActionID', new Set(['AllTab', 'LinkedTab'])]]);
+
+    it('strips the trailing tab segment and returns match with pathUsedForMatching', () => {
+        const results = findAllMatchingDynamicSuffixes('/base/flag/456/abc/AllTab', tabMap);
+        expect(results).toHaveLength(1);
+        expect(results.at(0)).toEqual({
+            pattern: 'flag/:reportID/:reportActionID',
+            actualSuffix: 'flag/456/abc',
+            pathParams: {reportID: '456', reportActionID: 'abc'},
+            pathUsedForMatching: '/base/flag/456/abc',
+        });
+    });
+
+    it('strips the non-default tab segment and sets pathUsedForMatching', () => {
+        const results = findAllMatchingDynamicSuffixes('/base/flag/456/abc/LinkedTab', tabMap);
+        expect(results).toHaveLength(1);
+        expect(results.at(0)).toMatchObject({
+            pattern: 'flag/:reportID/:reportActionID',
+            pathUsedForMatching: '/base/flag/456/abc',
+        });
+    });
+
+    it('preserves query string in pathUsedForMatching when stripping tab segment', () => {
+        const results = findAllMatchingDynamicSuffixes('/base/flag/456/abc/AllTab?foo=bar', tabMap);
+        expect(results).toHaveLength(1);
+        expect(results.at(0)).toMatchObject({
+            pathUsedForMatching: '/base/flag/456/abc?foo=bar',
+        });
+    });
+
+    it('does NOT strip when the last segment is a tab of a different (non-matched) pattern', () => {
+        // After stripping 'AllTab', the retry on '/base/about/keyboard-shortcuts' finds the
+        // static 'keyboard-shortcuts' pattern. But tabMap.get('keyboard-shortcuts') is undefined,
+        // so the scoped check fails and the result is empty.
+        const results = findAllMatchingDynamicSuffixes('/base/about/keyboard-shortcuts/AllTab', tabMap);
+        expect(results).toEqual([]);
+    });
+
+    it('does NOT strip when tabMap is not provided', () => {
+        expect(findAllMatchingDynamicSuffixes('/base/flag/456/abc/AllTab')).toEqual([]);
+    });
+
+    it('does NOT strip when tabMap is empty', () => {
+        expect(findAllMatchingDynamicSuffixes('/base/flag/456/abc/AllTab', new Map())).toEqual([]);
+    });
+
+    it('recursive retry does not receive tabMap so stripping stops after one level', () => {
+        // '/base/flag/456/AllTab/LinkedTab' → Phase 4 strips 'LinkedTab' →
+        // retry '/base/flag/456/AllTab' → 'flag/456/AllTab' matches flag pattern
+        // (reportID='456', reportActionID='AllTab') → tabMap.get(pattern)?.has('LinkedTab') → true.
+        const results = findAllMatchingDynamicSuffixes('/base/flag/456/AllTab/LinkedTab', tabMap);
+        expect(results).toHaveLength(1);
+        expect(results.at(0)).toMatchObject({
+            pattern: 'flag/:reportID/:reportActionID',
+            pathParams: {reportID: '456', reportActionID: 'AllTab'},
+            pathUsedForMatching: '/base/flag/456/AllTab',
+        });
     });
 });

--- a/tests/navigation/getDynamicRouteAdaptedStateTests.ts
+++ b/tests/navigation/getDynamicRouteAdaptedStateTests.ts
@@ -21,6 +21,7 @@ jest.mock('@libs/Navigation/linkingConfig/config', () => ({
         DynCrossStack: {path: 'suffix-cross'},
     },
     screensWithOnyxTabNavigator: new Set(),
+    dynamicTabPatternToTabPaths: new Map(),
 }));
 
 jest.mock('@src/ROUTES', () => ({

--- a/tests/navigation/getMatchingFullScreenRouteTests.ts
+++ b/tests/navigation/getMatchingFullScreenRouteTests.ts
@@ -9,6 +9,7 @@ jest.mock('@libs/Navigation/linkingConfig/config', () => ({
         DynamicScreen: {path: 'suffix-a'},
     },
     screensWithOnyxTabNavigator: new Set(),
+    dynamicTabPatternToTabPaths: new Map(),
 }));
 
 jest.mock('@libs/ReportUtils', () => ({

--- a/tests/navigation/getPathFromStateTests.ts
+++ b/tests/navigation/getPathFromStateTests.ts
@@ -9,75 +9,30 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('@libs/Navigation/linkingConfig/config', () => ({
     config: {},
     normalizedConfigs: {
-        TestDynamicScreen: {
-            path: 'test-dynamic',
-        },
-        StandardScreen: {
-            path: 'standard',
-        },
-        VerifyAccountScreen: {
-            path: 'verify-account',
-        },
-        CountryScreen: {
-            path: 'country',
-        },
-        FlagScreen: {
-            path: 'flag/:reportID/:reportActionID',
-        },
-        ConstantPickerScreen: {
-            path: 'constant-picker',
-        },
-        WalletScreen: {
-            path: 'settings/wallet',
-        },
-        ReportScreen: {
-            path: 'r/:reportID',
-        },
-        // Tab-hosting dynamic screen and its tab children
-        TabHostDynamicScreen: {
-            path: ':integration/edit',
-        },
-        TabAll: {
-            path: 'all',
-        },
-        TabLinked: {
-            path: 'linked',
-        },
-    },
-    // Screens that host an OnyxTabNavigator — findFocusedRouteWithOnyxTabGuard stops here
-    screensWithOnyxTabNavigator: new Set(['TabHostDynamicScreen']),
-    // Pattern-to-tabs map used by findAllMatchingDynamicSuffixes Phase 4 (not used in getPathFromState tests)
-    dynamicTabPatternToTabPaths: new Map(),
-}));
+        TestDynamicScreen: {path: 'test-dynamic'},
+        StandardScreen: {path: 'standard'},
+        VerifyAccountScreen: {path: 'verify-account'},
+        CountryScreen: {path: 'country'},
+        FlagScreen: {path: 'flag/:reportID/:reportActionID'},
+        ConstantPickerScreen: {path: 'constant-picker'},
+        WalletScreen: {path: 'settings/wallet'},
+        ReportScreen: {path: 'r/:reportID'},
+        SplitExpenseScreen: {path: 'split-expense/:reportID'},
 
-jest.mock('@libs/Navigation/linkingConfig', () => ({
-    linkingConfig: {
-        config: {},
+        AmountTab: {path: 'amount'},
+        ScanTab: {path: 'scan'},
     },
+    screensWithOnyxTabNavigator: new Set(['SplitExpenseScreen']),
 }));
 
 jest.mock('@src/ROUTES', () => ({
     DYNAMIC_ROUTES: {
-        TEST_DYNAMIC: {
-            path: 'test-dynamic',
-        },
-        VERIFY_ACCOUNT: {
-            path: 'verify-account',
-        },
-        ADDRESS_COUNTRY: {
-            path: 'country',
-            queryParams: ['country'],
-        },
-        FLAG: {
-            path: 'flag/:reportID/:reportActionID',
-        },
-        CONSTANT_PICKER: {
-            path: 'constant-picker',
-            queryParams: ['formType', 'fieldName', 'fieldValue'],
-        },
-        TAB_HOST_DYNAMIC: {
-            path: ':integration/edit',
-        },
+        TEST_DYNAMIC: {path: 'test-dynamic'},
+        VERIFY_ACCOUNT: {path: 'verify-account'},
+        ADDRESS_COUNTRY: {path: 'country', queryParams: ['country']},
+        FLAG: {path: 'flag/:reportID/:reportActionID'},
+        CONSTANT_PICKER: {path: 'constant-picker', queryParams: ['formType', 'fieldName', 'fieldValue']},
+        SPLIT_EXPENSE: {path: 'split-expense/:reportID'},
     },
 }));
 
@@ -100,8 +55,8 @@ function buildState(routes: RouteEntry[], index?: number): TestState {
     } as TestState;
 }
 
-function realFindFocusedRoute(state: TestState | RouteEntry['state']): RouteEntry | undefined {
-    let current: TestState | RouteEntry['state'] = state;
+function realFindFocusedRoute(s: TestState | RouteEntry['state']): RouteEntry | undefined {
+    let current: TestState | RouteEntry['state'] = s;
     while (current?.routes?.[current.index ?? 0]?.state != null) {
         current = current.routes[current.index ?? 0].state;
     }
@@ -310,7 +265,7 @@ describe('getPathFromState', () => {
         });
     });
 
-    describe('dynamic screen with tab navigator inside', () => {
+    describe('tab navigator integration (OnyxTabNavigator)', () => {
         beforeEach(() => {
             mockRNGetPathFromState.mockImplementation((s: TestState) => {
                 const route = realFindFocusedRoute(s);
@@ -319,98 +274,80 @@ describe('getPathFromState', () => {
             });
         });
 
-        it('resolves default tab (index 0) when tab-host dynamic screen is focused', () => {
+        it('appends focused tab path segment when first tab is focused', () => {
             const state = buildState([
                 {name: 'WalletScreen'},
                 {
-                    name: 'TabHostDynamicScreen',
-                    params: {integration: 'brex'},
-                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
+                    name: 'SplitExpenseScreen',
+                    params: {reportID: '123'},
+                    state: buildState([{name: 'AmountTab'}, {name: 'ScanTab'}], 0),
                 },
             ]);
 
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/all');
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/split-expense/123/amount');
         });
 
-        it('resolves non-default tab (index 1) when tab-host dynamic screen is focused', () => {
+        it('appends focused tab path segment when second tab is focused', () => {
             const state = buildState([
                 {name: 'WalletScreen'},
                 {
-                    name: 'TabHostDynamicScreen',
-                    params: {integration: 'brex'},
-                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 1),
+                    name: 'SplitExpenseScreen',
+                    params: {reportID: '123'},
+                    state: buildState([{name: 'AmountTab'}, {name: 'ScanTab'}], 1),
                 },
             ]);
 
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/linked');
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/split-expense/123/scan');
         });
 
-        it('resolves tab path when tab-host dynamic screen is the only screen (no base)', () => {
-            const state = buildState([
-                {
-                    name: 'TabHostDynamicScreen',
-                    params: {integration: 'brex'},
-                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
-                },
-            ]);
+        it('omits tab segment when tab-hosting screen has no nested state', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'SplitExpenseScreen', params: {reportID: '123'}}]);
 
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/brex/edit/all');
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/split-expense/123');
         });
 
-        it('resolves tab path inside a nested navigator', () => {
+        it('tab-hosting screen inside a nested navigator', () => {
             const state = buildState([
                 {
                     name: 'RHPNavigator',
                     state: buildState([
                         {name: 'WalletScreen'},
                         {
-                            name: 'TabHostDynamicScreen',
-                            params: {integration: 'lyft'},
-                            state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
+                            name: 'SplitExpenseScreen',
+                            params: {reportID: '789'},
+                            state: buildState([{name: 'AmountTab'}, {name: 'ScanTab'}], 1),
                         },
                     ]),
                 },
             ]);
 
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/lyft/edit/all');
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/split-expense/789/scan');
         });
 
-        it('resolves tab-host dynamic screen in backstack under another focused dynamic screen', () => {
-            // Stack: WalletScreen → TabHostDynamicScreen[TabAll] → VerifyAccountScreen (focused)
-            // Expected: basePath(WalletScreen) / tabHostSuffix / tabPath / verifyAccountSuffix
+        it('tab-hosting screen is the only route (no base)', () => {
+            const state = buildState([
+                {
+                    name: 'SplitExpenseScreen',
+                    params: {reportID: '42'},
+                    state: buildState([{name: 'AmountTab'}, {name: 'ScanTab'}], 0),
+                },
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/split-expense/42/amount');
+        });
+
+        it('popFocusedRoute treats tab-hosting screen as a leaf (removes whole screen, not individual tab)', () => {
             const state = buildState([
                 {name: 'WalletScreen'},
                 {
-                    name: 'TabHostDynamicScreen',
-                    params: {integration: 'brex'},
-                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
+                    name: 'SplitExpenseScreen',
+                    params: {reportID: '123'},
+                    state: buildState([{name: 'AmountTab'}, {name: 'ScanTab'}], 0),
                 },
                 {name: 'VerifyAccountScreen'},
             ]);
 
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/all/verify-account');
-        });
-
-        it('tab-host in backstack uses the currently focused tab, not always default', () => {
-            // Non-default tab (linked) is focused inside the tab-host that sits under another dynamic screen
-            const state = buildState([
-                {name: 'WalletScreen'},
-                {
-                    name: 'TabHostDynamicScreen',
-                    params: {integration: 'brex'},
-                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 1),
-                },
-                {name: 'VerifyAccountScreen'},
-            ]);
-
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/linked/verify-account');
-        });
-
-        it('does not append tab path when tab-host dynamic screen has no nested tab state', () => {
-            // Edge case: tab state is absent (e.g. partially initialised navigation state)
-            const state = buildState([{name: 'WalletScreen'}, {name: 'TabHostDynamicScreen', params: {integration: 'brex'}}]);
-
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit');
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/split-expense/123/amount/verify-account');
         });
     });
 });

--- a/tests/navigation/getPathFromStateTests.ts
+++ b/tests/navigation/getPathFromStateTests.ts
@@ -1,9 +1,8 @@
-import {findFocusedRoute, getPathFromState as RNGetPathFromState} from '@react-navigation/native';
+import {getPathFromState as RNGetPathFromState} from '@react-navigation/native';
 import type {NavigationState, PartialState} from '@react-navigation/routers';
 import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
 
 jest.mock('@react-navigation/native', () => ({
-    findFocusedRoute: jest.fn(),
     getPathFromState: jest.fn(),
 }));
 
@@ -34,7 +33,21 @@ jest.mock('@libs/Navigation/linkingConfig/config', () => ({
         ReportScreen: {
             path: 'r/:reportID',
         },
+        // Tab-hosting dynamic screen and its tab children
+        TabHostDynamicScreen: {
+            path: ':integration/edit',
+        },
+        TabAll: {
+            path: 'all',
+        },
+        TabLinked: {
+            path: 'linked',
+        },
     },
+    // Screens that host an OnyxTabNavigator — findFocusedRouteWithOnyxTabGuard stops here
+    screensWithOnyxTabNavigator: new Set(['TabHostDynamicScreen']),
+    // Pattern-to-tabs map used by findAllMatchingDynamicSuffixes Phase 4 (not used in getPathFromState tests)
+    dynamicTabPatternToTabPaths: new Map(),
 }));
 
 jest.mock('@libs/Navigation/linkingConfig', () => ({
@@ -61,6 +74,9 @@ jest.mock('@src/ROUTES', () => ({
         CONSTANT_PICKER: {
             path: 'constant-picker',
             queryParams: ['formType', 'fieldName', 'fieldValue'],
+        },
+        TAB_HOST_DYNAMIC: {
+            path: ':integration/edit',
         },
     },
 }));
@@ -98,7 +114,6 @@ const staticBasePaths: Record<string, (params?: Record<string, unknown>) => stri
 };
 
 describe('getPathFromState', () => {
-    const mockFindFocusedRoute = findFocusedRoute as jest.Mock;
     const mockRNGetPathFromState = RNGetPathFromState as jest.Mock;
 
     beforeEach(() => {
@@ -106,7 +121,6 @@ describe('getPathFromState', () => {
     });
 
     it('should resolve dynamic screen from pattern and params', () => {
-        mockFindFocusedRoute.mockImplementation(realFindFocusedRoute);
         mockRNGetPathFromState.mockImplementation(staticBasePaths.WalletScreen);
 
         const state = buildState([{name: 'WalletScreen'}, {name: 'TestDynamicScreen'}]);
@@ -117,26 +131,21 @@ describe('getPathFromState', () => {
     });
 
     it('should use RN getPathFromState for standard screens', () => {
-        const state = {} as PartialState<NavigationState>;
         const expectedPath = '/standard/path';
-
-        mockFindFocusedRoute.mockReturnValue({
-            name: 'StandardScreen',
-        });
         mockRNGetPathFromState.mockReturnValue(expectedPath);
 
-        const result = getPathFromState(state);
+        const state = buildState([{name: 'StandardScreen'}]);
+        const result = getPathFromState(state as PartialState<NavigationState>);
 
         expect(result).toBe(expectedPath);
         expect(mockRNGetPathFromState).toHaveBeenCalledWith(state, expect.anything());
     });
 
     it('should handle state where no route is focused', () => {
-        const state = {} as PartialState<NavigationState>;
-        mockFindFocusedRoute.mockReturnValue(undefined);
         mockRNGetPathFromState.mockReturnValue('/fallback');
 
-        const result = getPathFromState(state);
+        const state = buildState([{name: 'StandardScreen'}]);
+        const result = getPathFromState(state as PartialState<NavigationState>);
 
         expect(result).toBe('/fallback');
         expect(mockRNGetPathFromState).toHaveBeenCalled();
@@ -144,8 +153,6 @@ describe('getPathFromState', () => {
 
     describe('dynamic route resolution from pattern and params', () => {
         beforeEach(() => {
-            mockFindFocusedRoute.mockImplementation(realFindFocusedRoute);
-
             mockRNGetPathFromState.mockImplementation((s: TestState) => {
                 const route = realFindFocusedRoute(s);
                 const builder = staticBasePaths[route?.name ?? ''];
@@ -300,6 +307,110 @@ describe('getPathFromState', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen'}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country');
+        });
+    });
+
+    describe('dynamic screen with tab navigator inside', () => {
+        beforeEach(() => {
+            mockRNGetPathFromState.mockImplementation((s: TestState) => {
+                const route = realFindFocusedRoute(s);
+                const builder = staticBasePaths[route?.name ?? ''];
+                return builder ? builder(route?.params) : '/unknown';
+            });
+        });
+
+        it('resolves default tab (index 0) when tab-host dynamic screen is focused', () => {
+            const state = buildState([
+                {name: 'WalletScreen'},
+                {
+                    name: 'TabHostDynamicScreen',
+                    params: {integration: 'brex'},
+                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
+                },
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/all');
+        });
+
+        it('resolves non-default tab (index 1) when tab-host dynamic screen is focused', () => {
+            const state = buildState([
+                {name: 'WalletScreen'},
+                {
+                    name: 'TabHostDynamicScreen',
+                    params: {integration: 'brex'},
+                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 1),
+                },
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/linked');
+        });
+
+        it('resolves tab path when tab-host dynamic screen is the only screen (no base)', () => {
+            const state = buildState([
+                {
+                    name: 'TabHostDynamicScreen',
+                    params: {integration: 'brex'},
+                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
+                },
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/brex/edit/all');
+        });
+
+        it('resolves tab path inside a nested navigator', () => {
+            const state = buildState([
+                {
+                    name: 'RHPNavigator',
+                    state: buildState([
+                        {name: 'WalletScreen'},
+                        {
+                            name: 'TabHostDynamicScreen',
+                            params: {integration: 'lyft'},
+                            state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
+                        },
+                    ]),
+                },
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/lyft/edit/all');
+        });
+
+        it('resolves tab-host dynamic screen in backstack under another focused dynamic screen', () => {
+            // Stack: WalletScreen → TabHostDynamicScreen[TabAll] → VerifyAccountScreen (focused)
+            // Expected: basePath(WalletScreen) / tabHostSuffix / tabPath / verifyAccountSuffix
+            const state = buildState([
+                {name: 'WalletScreen'},
+                {
+                    name: 'TabHostDynamicScreen',
+                    params: {integration: 'brex'},
+                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 0),
+                },
+                {name: 'VerifyAccountScreen'},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/all/verify-account');
+        });
+
+        it('tab-host in backstack uses the currently focused tab, not always default', () => {
+            // Non-default tab (linked) is focused inside the tab-host that sits under another dynamic screen
+            const state = buildState([
+                {name: 'WalletScreen'},
+                {
+                    name: 'TabHostDynamicScreen',
+                    params: {integration: 'brex'},
+                    state: buildState([{name: 'TabAll'}, {name: 'TabLinked'}], 1),
+                },
+                {name: 'VerifyAccountScreen'},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit/linked/verify-account');
+        });
+
+        it('does not append tab path when tab-host dynamic screen has no nested tab state', () => {
+            // Edge case: tab state is absent (e.g. partially initialised navigation state)
+            const state = buildState([{name: 'WalletScreen'}, {name: 'TabHostDynamicScreen', params: {integration: 'brex'}}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/brex/edit');
         });
     });
 });

--- a/tests/navigation/getStateFromPathTests.ts
+++ b/tests/navigation/getStateFromPathTests.ts
@@ -20,6 +20,7 @@ jest.mock('@libs/Navigation/linkingConfig', () => ({
 
 jest.mock('@libs/Navigation/linkingConfig/config', () => ({
     screensWithOnyxTabNavigator: new Set(),
+    dynamicTabPatternToTabPaths: new Map(),
 }));
 
 jest.mock('@src/ROUTES', () => ({

--- a/tests/navigation/useDynamicBackPathTests.ts
+++ b/tests/navigation/useDynamicBackPathTests.ts
@@ -5,6 +5,9 @@ import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 
 jest.mock('@hooks/useRootNavigationState', () => jest.fn());
 jest.mock('@libs/Navigation/helpers/getPathFromState', () => jest.fn());
+jest.mock('@libs/Navigation/linkingConfig/config', () => ({
+    dynamicTabPatternToTabPaths: new Map(),
+}));
 jest.mock('@src/ROUTES', () => ({
     default: {
         HOME: 'home',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Extends dynamic route resolution to handle routes that host a tab navigator. When a URL ends with a trailing tab segment (e.g. `/some-dynamic-route/tabName`), `findAllMatchingDynamicSuffixes` now strips the tab segment and retries matching, returning `pathUsedForMatching` so `getMatchingFullScreenRoute` strips the suffix from the correct path. `collectScreensWithTabNavigator` is refactored to also build a `dynamicTabPatternToTabPaths` map used for this lookup. `getPathFromState` is also updated to correctly serialize screens that contain a nested Onyx tab navigator, so the generated URL includes the active tab segment.

### Fixed Issues
$
PROPOSAL:


### Tests

No QA

### Offline tests

N/A

### QA Steps

No QA

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
