### PR TITLE
Fix stale next step after Submit upgrade + approve

### DIFF
--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -90,7 +90,7 @@ import getWorkspaceCreatedAnalyticsEvent from '@libs/getWorkspaceCreatedAnalytic
 import GoogleTagManager from '@libs/GoogleTagManager';
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
-import {buildNextStepNew} from '@libs/NextStepUtils';
+import {buildNextStepNew, buildOptimisticNextStep} from '@libs/NextStepUtils';
 import * as NumberUtils from '@libs/NumberUtils';
 import isTrackOnboardingChoice from '@libs/OnboardingUtils';
 import Permissions from '@libs/Permissions';
@@ -5803,7 +5803,12 @@ function upgradeSubmit(
         return;
     }
 
-    type UpgradeSubmitOnyxKey = typeof ONYXKEYS.COLLECTION.POLICY | typeof ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL | typeof ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL;
+    type UpgradeSubmitOnyxKey =
+        | typeof ONYXKEYS.COLLECTION.POLICY
+        | typeof ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL
+        | typeof ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL
+        | typeof ONYXKEYS.COLLECTION.REPORT
+        | typeof ONYXKEYS.COLLECTION.NEXT_STEP;
 
     const now = new Date();
     const optimisticFirstDayFreeTrial = formatDate(subMinutes(now, 1), CONST.DATE.FNS_DATE_TIME_FORMAT_STRING);
@@ -5855,6 +5860,100 @@ function upgradeSubmit(
     } else {
         newReimbursementChoice = CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES;
     }
+
+    // When the upgrade also approves a report (the "Approve report" flow on a Submit workspace), optimistically
+    // reflect the approval on the report so its next step doesn't stay stale. UpgradeSubmit approves the report
+    // server-side but—unlike ApproveMoneyRequest—its response does not return a refreshed next step, so without
+    // this the banner stays stuck on "Waiting for you to approve" until the report is reopened/refetched.
+    const reportApprovalOptimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.NEXT_STEP>> = [];
+    const reportApprovalSuccessData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT>> = [];
+    const reportApprovalFailureData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.NEXT_STEP>> = [];
+
+    const reportToApprove = reportID ? ReportUtils.getReportOrDraftReport(reportID) : undefined;
+    if (reportID && reportToApprove && ReportUtils.isExpenseReport(reportToApprove)) {
+        // After the upgrade the upgrader becomes the workspace's sole approver, so the report is approved outright.
+        const upgradedPolicyForNextStep: OnyxEntry<Policy> = {
+            ...policy,
+            type: targetType,
+            owner: currentUserLogin || priorOwner,
+            ...(optimisticOwnerAccountID !== undefined ? {ownerAccountID: optimisticOwnerAccountID} : {}),
+            reimbursementChoice: newReimbursementChoice,
+        };
+        const approvedReportSnapshot: OnyxEntry<Report> = {
+            ...reportToApprove,
+            statusNum: CONST.REPORT.STATUS_NUM.APPROVED,
+            stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+            ...(currentUserAccountID !== undefined ? {managerID: currentUserAccountID} : {}),
+        };
+        const approvedNextStepParams = {
+            report: approvedReportSnapshot,
+            policy: upgradedPolicyForNextStep,
+            currentUserAccountIDParam: currentUserAccountID,
+            currentUserEmailParam: currentUserLogin,
+            hasViolations: false,
+            isASAPSubmitBetaEnabled: false,
+            predictedNextStatus: CONST.REPORT.STATUS_NUM.APPROVED,
+        };
+        const optimisticReportNextStep = buildOptimisticNextStep(approvedNextStepParams);
+        const optimisticNextStepDeprecated = buildNextStepNew(approvedNextStepParams);
+
+        // Rebuild the pre-approval (submitted) next step from the original report/policy so a failed upgrade rolls back cleanly.
+        const revertedNextStepDeprecated = buildNextStepNew({
+            report: reportToApprove,
+            policy,
+            currentUserAccountIDParam: currentUserAccountID,
+            currentUserEmailParam: currentUserLogin,
+            hasViolations: false,
+            isASAPSubmitBetaEnabled: false,
+            predictedNextStatus: reportToApprove.statusNum ?? CONST.REPORT.STATUS_NUM.SUBMITTED,
+        });
+
+        const reportKey = `${ONYXKEYS.COLLECTION.REPORT}${reportID}` as const;
+        const nextStepKey = `${ONYXKEYS.COLLECTION.NEXT_STEP}${reportID}` as const;
+
+        reportApprovalOptimisticData.push(
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: reportKey,
+                value: {
+                    statusNum: CONST.REPORT.STATUS_NUM.APPROVED,
+                    stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+                    ...(currentUserAccountID !== undefined ? {managerID: currentUserAccountID} : {}),
+                    nextStep: optimisticReportNextStep ?? undefined,
+                    pendingFields: {nextStep: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                },
+            },
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: nextStepKey,
+                value: optimisticNextStepDeprecated,
+            },
+        );
+        reportApprovalSuccessData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: reportKey,
+            value: {pendingFields: {nextStep: null}},
+        });
+        reportApprovalFailureData.push(
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: reportKey,
+                value: {
+                    statusNum: reportToApprove.statusNum ?? null,
+                    stateNum: reportToApprove.stateNum ?? null,
+                    managerID: reportToApprove.managerID ?? null,
+                    nextStep: reportToApprove.nextStep ?? null,
+                    pendingFields: {nextStep: null},
+                },
+            },
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: nextStepKey,
+                value: revertedNextStepDeprecated,
+            },
+        );
+    }
+
     const optimisticData: Array<OnyxUpdate<UpgradeSubmitOnyxKey>> = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
@@ -5931,6 +6030,10 @@ function upgradeSubmit(
             },
         },
     ];
+
+    optimisticData.push(...reportApprovalOptimisticData);
+    successData.push(...reportApprovalSuccessData);
+    failureData.push(...reportApprovalFailureData);
 
     API.write(WRITE_COMMANDS.UPGRADE_SUBMIT, {policyID, targetType, reportID}, {optimisticData, successData, failureData});
 }

--- a/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
+++ b/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
@@ -13,6 +13,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {updateQuickbooksOnlineSyncClasses, updateQuickbooksOnlineSyncCustomers, updateQuickbooksOnlineSyncLocations} from '@libs/actions/connections/QuickbooksOnline';
 import {updateXeroMappings} from '@libs/actions/connections/Xero';
 import {enablePolicyTravel} from '@libs/actions/Policy/Travel';
+import {openReport} from '@libs/actions/Report';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -115,6 +116,8 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
 
     const ownerPoliciesSelectorWithAccountID = useCallback((policies: OnyxCollection<Policy>) => ownerPoliciesSelector(policies, accountID), [accountID]);
     const [ownerPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: ownerPoliciesSelectorWithAccountID});
+    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
+    const [betas] = useOnyx(ONYXKEYS.BETAS);
     const qboConfig = policy?.connections?.quickbooksOnline?.config;
     const {isOffline} = useNetwork();
     const canPerformUpgrade = canModifyPlan(ownerPolicies, policy) || canAccessSubmitWorkspaceFeatures;
@@ -256,6 +259,12 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
                 setWorkspaceApprovalMode(policy, defaultApprover, CONST.POLICY.APPROVAL_MODE.ADVANCED, accountID, email);
                 break;
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.approvalSubmitReport.id:
+                // The report is approved server-side by UpgradeSubmit (via the reportID param), but that response
+                // doesn't refresh the report's next step. Refetch the report so the banner reflects the approved
+                // state immediately instead of staying stuck on "Waiting for you to approve" until a manual reopen.
+                if (reportID) {
+                    openReport({reportID, introSelected, betas});
+                }
                 break;
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.expensifyCard.id:
                 enableExpensifyCard(policyID, true);
@@ -309,6 +318,9 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
         qboConfig?.syncCustomers,
         qboConfig?.syncLocations,
         categoryId,
+        reportID,
+        introSelected,
+        betas,
     ]);
 
     useWorkspaceUpgradeConfirmation({

--- a/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
+++ b/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
@@ -13,7 +13,6 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {updateQuickbooksOnlineSyncClasses, updateQuickbooksOnlineSyncCustomers, updateQuickbooksOnlineSyncLocations} from '@libs/actions/connections/QuickbooksOnline';
 import {updateXeroMappings} from '@libs/actions/connections/Xero';
 import {enablePolicyTravel} from '@libs/actions/Policy/Travel';
-import {openReport} from '@libs/actions/Report';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -116,8 +115,6 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
 
     const ownerPoliciesSelectorWithAccountID = useCallback((policies: OnyxCollection<Policy>) => ownerPoliciesSelector(policies, accountID), [accountID]);
     const [ownerPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: ownerPoliciesSelectorWithAccountID});
-    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
-    const [betas] = useOnyx(ONYXKEYS.BETAS);
     const qboConfig = policy?.connections?.quickbooksOnline?.config;
     const {isOffline} = useNetwork();
     const canPerformUpgrade = canModifyPlan(ownerPolicies, policy) || canAccessSubmitWorkspaceFeatures;
@@ -259,12 +256,6 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
                 setWorkspaceApprovalMode(policy, defaultApprover, CONST.POLICY.APPROVAL_MODE.ADVANCED, accountID, email);
                 break;
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.approvalSubmitReport.id:
-                // The report is approved server-side by UpgradeSubmit (via the reportID param), but that response
-                // doesn't refresh the report's next step. Refetch the report so the banner reflects the approved
-                // state immediately instead of staying stuck on "Waiting for you to approve" until a manual reopen.
-                if (reportID) {
-                    openReport({reportID, introSelected, betas});
-                }
                 break;
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.expensifyCard.id:
                 enableExpensifyCard(policyID, true);
@@ -318,9 +309,6 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
         qboConfig?.syncCustomers,
         qboConfig?.syncLocations,
         categoryId,
-        reportID,
-        introSelected,
-        betas,
     ]);
 
     useWorkspaceUpgradeConfirmation({

--- a/tests/ui/WorkspaceUpgradeTest.tsx
+++ b/tests/ui/WorkspaceUpgradeTest.tsx
@@ -162,6 +162,46 @@ describe('WorkspaceUpgrade', () => {
         await waitForBatchedUpdates();
     });
 
+    it('should refetch the report after upgrading via the Approve report flow so the next step is no longer stale', async () => {
+        const policy: Policy = {...LHNTestUtils.getFakePolicy(), type: CONST.POLICY.TYPE.SUBMIT};
+        const reportID = '987654321';
+
+        // Given a Submit workspace (with the Submit 2026 beta) that has a submitted expense report awaiting approval
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.BETAS, [CONST.BETAS.SUBMIT_2026]);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
+                reportID,
+                policyID: policy.id,
+                type: CONST.REPORT.TYPE.EXPENSE,
+                stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
+                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+            });
+        });
+
+        // And the upgrade page is opened for the "Approve report" flow with the report to approve
+        const {unmount} = renderPage(SCREENS.WORKSPACE.UPGRADE, {
+            policyID: policy.id,
+            featureName: CONST.UPGRADE_FEATURE_INTRO_MAPPING.approvalSubmitReport.alias,
+            reportID,
+        });
+
+        // When the workspace is upgraded by clicking on the Upgrade button
+        fireEvent.press(screen.getByTestId('upgrade-button'));
+        await waitForBatchedUpdatesWithAct();
+        await waitForIdle();
+        await waitForBatchedUpdatesWithAct();
+
+        // Then UpgradeSubmit should target the Collect (Team) plan and pass the report to approve
+        TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.UPGRADE_SUBMIT, 0, {policyID: policy.id, targetType: CONST.POLICY.TYPE.TEAM, reportID});
+
+        // And once the upgrade succeeds, the report is refetched (OpenReport) so the stale next step refreshes
+        TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.OPEN_REPORT, 0, {reportID});
+
+        unmount();
+        await waitForBatchedUpdates();
+    });
+
     it('should render the Collect plan title and Team pricing when upgradePlanType is team', async () => {
         const policy: Policy = LHNTestUtils.getFakePolicy();
 

--- a/tests/ui/WorkspaceUpgradeTest.tsx
+++ b/tests/ui/WorkspaceUpgradeTest.tsx
@@ -16,6 +16,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
 import type {Policy} from '@src/types/onyx';
+import getOnyxValue from '../utils/getOnyxValue';
 import * as LHNTestUtils from '../utils/LHNTestUtils';
 import * as TestHelper from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
@@ -162,9 +163,10 @@ describe('WorkspaceUpgrade', () => {
         await waitForBatchedUpdates();
     });
 
-    it('should refetch the report after upgrading via the Approve report flow so the next step is no longer stale', async () => {
+    it('should optimistically approve the report and refresh its next step when upgrading via the Approve report flow', async () => {
         const policy: Policy = {...LHNTestUtils.getFakePolicy(), type: CONST.POLICY.TYPE.SUBMIT};
         const reportID = '987654321';
+        const staleNextStep = {type: 'neutral' as const, message: [{text: 'Waiting for you to approve expenses'}]};
 
         // Given a Submit workspace (with the Submit 2026 beta) that has a submitted expense report awaiting approval
         await act(async () => {
@@ -176,7 +178,11 @@ describe('WorkspaceUpgrade', () => {
                 type: CONST.REPORT.TYPE.EXPENSE,
                 stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
                 statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+                ownerAccountID: 1,
+                total: -5000,
+                currency: 'USD',
             });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.NEXT_STEP}${reportID}`, staleNextStep);
         });
 
         // And the upgrade page is opened for the "Approve report" flow with the report to approve
@@ -195,8 +201,13 @@ describe('WorkspaceUpgrade', () => {
         // Then UpgradeSubmit should target the Collect (Team) plan and pass the report to approve
         TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.UPGRADE_SUBMIT, 0, {policyID: policy.id, targetType: CONST.POLICY.TYPE.TEAM, reportID});
 
-        // And once the upgrade succeeds, the report is fetched again (OpenReport) so the stale next step refreshes
-        TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.OPEN_REPORT, 0, {reportID});
+        // And the report is optimistically approved so the next step is no longer the stale "Waiting for you to approve"
+        const updatedReport = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+        expect(updatedReport?.statusNum).toBe(CONST.REPORT.STATUS_NUM.APPROVED);
+        expect(updatedReport?.stateNum).toBe(CONST.REPORT.STATE_NUM.APPROVED);
+
+        const updatedNextStep = await getOnyxValue(`${ONYXKEYS.COLLECTION.NEXT_STEP}${reportID}`);
+        expect(updatedNextStep).not.toEqual(staleNextStep);
 
         unmount();
         await waitForBatchedUpdates();

--- a/tests/ui/WorkspaceUpgradeTest.tsx
+++ b/tests/ui/WorkspaceUpgradeTest.tsx
@@ -195,7 +195,7 @@ describe('WorkspaceUpgrade', () => {
         // Then UpgradeSubmit should target the Collect (Team) plan and pass the report to approve
         TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.UPGRADE_SUBMIT, 0, {policyID: policy.id, targetType: CONST.POLICY.TYPE.TEAM, reportID});
 
-        // And once the upgrade succeeds, the report is refetched (OpenReport) so the stale next step refreshes
+        // And once the upgrade succeeds, the report is fetched again (OpenReport) so the stale next step refreshes
         TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.OPEN_REPORT, 0, {reportID});
 
         unmount();


### PR DESCRIPTION
### Explanation of Change

When a report on a Submit-tier (`submit2026`) workspace is approved, approval goes through the new `UpgradeSubmit` server-side flow. `approveMoneyRequest` detects this and returns early (navigating to the upgrade page), so it never builds the optimistic approved action or next step. The actual approval happens server-side inside `UpgradeSubmit` (the `reportID` is passed so the backend approves the report after upgrading), but that response does not refresh the report's next step. As a result, the Next Steps banner stays stuck on "Waiting for you to approve expenses" until the report is manually reopened (e.g. via `openReport`).

This PR fills in the previously empty `approvalSubmitReport` case in the upgrade confirmation handler (`WorkspaceUpgradePage`) to call `openReport` once the Submit upgrade succeeds. Because that confirmation only fires after the upgrade completes server-side (the report is already approved by then), refetching the report returns the correct post-approval next step from the server — matching what a manual reopen does today — without fragile optimistic guessing.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93686

PROPOSAL: N/A (internal project bug fix — Bottom-Up Submit Plan)

### Tests

1. Use a Submit-tier (`submit2026`) workspace with the `SUBMIT_2026` beta enabled.
2. As a submitter, submit an expense report on the workspace.
3. As the approver, open the report and click **Approve**.
4. On the upgrade prompt, click **Upgrade**.
5. Verify the workspace upgrades to Collect and the report is approved.
6. Verify the Next Steps banner immediately updates away from "Waiting for you to approve expenses" (e.g. to "Waiting for [admin] to pay") **without** needing to navigate away or manually reopen the report.

- [x] Verify that no errors appear in the JS console

### Offline tests

Upgrading/approving is an online-only flow (consistent with the rest of the upgrade/downgrade flows), so there is no new offline behavior. While offline, the Upgrade button is disabled and no `openReport` refresh is triggered.

### QA Steps

Same as the Tests section above (requires the `SUBMIT_2026` beta and a Submit-tier workspace).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
