### PR TITLE
Translate empty report next step message

### DIFF
--- a/src/hooks/useOptimisticNextStep.ts
+++ b/src/hooks/useOptimisticNextStep.ts
@@ -57,7 +57,7 @@ function useOptimisticNextStep(reportID: string | undefined) {
         transactions,
     );
 
-    let optimisticNextStep = getReportNextStep(nextStep, moneyRequestReport, transactions, policy, allTransactionViolations, email ?? '', accountID);
+    let optimisticNextStep = getReportNextStep(nextStep, moneyRequestReport, transactions, policy, allTransactionViolations, email ?? '', accountID, moneyRequestReport?.nextStep);
 
     if (isDEWPolicy && (moneyRequestReport?.statusNum === CONST.REPORT.STATUS_NUM.OPEN || moneyRequestReport?.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED)) {
         if (moneyRequestReport?.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {

--- a/src/libs/NextStepUtils.ts
+++ b/src/libs/NextStepUtils.ts
@@ -384,6 +384,7 @@ function getReportNextStep(
     transactionViolations: OnyxCollection<TransactionViolations>,
     currentUserEmail: string,
     currentUserAccountID: number,
+    reportNextStep?: ReportNextStep,
 ) {
     const {reimbursableSpend} = getMoneyRequestSpendBreakdown(moneyRequestReport);
     const shouldShowNoFurtherAction =
@@ -419,6 +420,12 @@ function getReportNextStep(
             isASAPSubmitBetaEnabled: false,
             predictedNextStatus: moneyRequestReport?.statusNum ?? CONST.REPORT.STATUS_NUM.OPEN,
         });
+    }
+
+    // Prefer the new translatable next step for the empty-report case so the "Waiting for you to add expenses" message
+    // respects the user's locale. The deprecated format is kept as the fallback for every other case.
+    if (reportNextStep?.messageKey === CONST.NEXT_STEP.MESSAGE_KEY.WAITING_TO_ADD_TRANSACTIONS) {
+        return reportNextStep;
     }
 
     return currentNextStep;

--- a/tests/unit/NextStepUtilsTest.ts
+++ b/tests/unit/NextStepUtilsTest.ts
@@ -11,6 +11,7 @@ import {buildOptimisticEmptyReport, buildOptimisticExpenseReport} from '@libs/Re
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy, Report, ReportNextStepDeprecated, Transaction, TransactionViolations} from '@src/types/onyx';
+import type {ReportNextStep} from '@src/types/onyx/Report';
 import {toCollectionDataSet} from '@src/types/utils/CollectionDataSet';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
@@ -1284,6 +1285,123 @@ describe('libs/NextStepUtils', () => {
                 icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
                 actorAccountID: report.ownerAccountID,
             });
+        });
+
+        it('returns the translatable next step over the deprecated one for the empty-report waiting-to-add-transactions case', () => {
+            const report: Report = {
+                ...buildOptimisticExpenseReport({
+                    chatReportID: 'chat-5',
+                    policyID,
+                    payeeAccountID: 1,
+                    total: -500,
+                    currency: CONST.CURRENCY.USD,
+                    betas: [CONST.BETAS.ALL],
+                }),
+                ownerAccountID: currentUserAccountID,
+                managerID: currentUserAccountID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            } as Report;
+
+            const currentNextStep: ReportNextStepDeprecated = {
+                type: 'neutral',
+                icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
+                message: [{text: 'Waiting for '}, {text: 'you', type: 'strong'}, {text: ' to '}, {text: 'add'}, {text: ' %expenses.'}],
+            };
+
+            const reportNextStep: ReportNextStep = {
+                messageKey: CONST.NEXT_STEP.MESSAGE_KEY.WAITING_TO_ADD_TRANSACTIONS,
+                icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
+                actorAccountID: currentUserAccountID,
+            };
+
+            const result = getReportNextStep(currentNextStep, report, [], undefined, {}, currentUserEmail, currentUserAccountID, reportNextStep);
+            expect(result).toBe(reportNextStep);
+        });
+
+        it('falls back to the deprecated next step when the new next step has a different message key', () => {
+            const report: Report = {
+                ...buildOptimisticExpenseReport({
+                    chatReportID: 'chat-6',
+                    policyID,
+                    payeeAccountID: 1,
+                    total: -500,
+                    currency: CONST.CURRENCY.USD,
+                    betas: [CONST.BETAS.ALL],
+                }),
+                ownerAccountID: currentUserAccountID,
+                managerID: currentUserAccountID,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            } as Report;
+
+            const currentNextStep: ReportNextStepDeprecated = {
+                type: 'neutral',
+                icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
+                message: [{text: 'Current next step'}],
+            };
+
+            const reportNextStep: ReportNextStep = {
+                messageKey: CONST.NEXT_STEP.MESSAGE_KEY.WAITING_TO_SUBMIT,
+                icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
+                actorAccountID: currentUserAccountID,
+            };
+
+            const result = getReportNextStep(currentNextStep, report, [], undefined, {}, currentUserEmail, currentUserAccountID, reportNextStep);
+            expect(result).toBe(currentNextStep);
+        });
+
+        it('prioritizes a higher-priority override over the new translatable next step', async () => {
+            const overridePolicyID = 'policy-override';
+            const policy: Policy = {
+                id: overridePolicyID,
+                name: 'Policy',
+                role: CONST.POLICY.ROLE.ADMIN,
+                type: CONST.POLICY.TYPE.TEAM,
+                owner: currentUserEmail,
+                outputCurrency: CONST.CURRENCY.USD,
+                isPolicyExpenseChatEnabled: true,
+                reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
+                approvalMode: CONST.POLICY.APPROVAL_MODE.OPTIONAL,
+                approver: currentUserEmail,
+                preventSelfApproval: true,
+                employeeList: {
+                    [currentUserEmail]: {
+                        email: currentUserEmail,
+                        role: CONST.POLICY.ROLE.ADMIN,
+                        submitsTo: currentUserEmail,
+                    },
+                },
+            };
+
+            const report: Report = {
+                ...buildOptimisticExpenseReport({
+                    chatReportID: 'chat-7',
+                    policyID: overridePolicyID,
+                    payeeAccountID: 1,
+                    total: -500,
+                    currency: CONST.CURRENCY.USD,
+                    betas: [CONST.BETAS.ALL],
+                }),
+                ownerAccountID: currentUserAccountID,
+                policyID: overridePolicyID,
+                type: CONST.REPORT.TYPE.EXPENSE,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            } as Report;
+
+            const reportNextStep: ReportNextStep = {
+                messageKey: CONST.NEXT_STEP.MESSAGE_KEY.WAITING_TO_ADD_TRANSACTIONS,
+                icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
+                actorAccountID: currentUserAccountID,
+            };
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${overridePolicyID}`, policy);
+            await waitForBatchedUpdates();
+
+            // Even though a translatable next step is supplied, the prevent-self-approval override must still win.
+            const result = getReportNextStep(undefined, report, [], policy, {}, currentUserEmail, currentUserAccountID, reportNextStep);
+            expect(result).toEqual(buildOptimisticNextStepForPreventSelfApprovalsEnabled());
         });
     });
 });


### PR DESCRIPTION
### Explanation of Change

On an empty report, the next-step status message ("Waiting for you to add expenses") was always rendered in **English**, even when the user's locale was Spanish (or any other language).

The root cause is that two next-step systems exist in parallel: a deprecated one that hardcodes English text fragments, and a newer translatable one that uses a `messageKey`. For the empty-report case, `getReportNextStep` (`src/libs/NextStepUtils.ts`) fell through to returning the **deprecated** (English-only) next step, so the renderer never reached the translatable path.

This PR makes `getReportNextStep` prefer the **translatable** next step when the empty-report case applies (`messageKey === CONST.NEXT_STEP.MESSAGE_KEY.WAITING_TO_ADD_TRANSACTIONS`), so the message is rendered through `translate()` and respects the user's locale. The deprecated format remains the fallback for every other case, so no other next-step behaviour changes. `useOptimisticNextStep` (`src/hooks/useOptimisticNextStep.ts`) now passes `moneyRequestReport?.nextStep` into `getReportNextStep` so the translatable value is available.

Unit tests were added in `tests/unit/NextStepUtilsTest.ts` covering: the translatable step is preferred for the empty-report case, the deprecated step is still used for other message keys, and higher-priority overrides (e.g. prevent-self-approval) still win.

### Fixed Issues

$ https://github.com/Expensify/App/issues/85123
PROPOSAL: https://github.com/Expensify/App/issues/85123#issuecomment-4048954011

### Tests

1. Set the app language to Spanish: **Settings → Preferences → Language → Español** (or set your device/browser language to Spanish).
2. Make sure you have a workspace (create one if needed).
3. Go to **Reports → Create report** to create an empty report.
4. Look at the status bar at the top of the report.
5. Verify it reads **"Esperando a que tú añadas gastos."** (translated) and **not** "Waiting for you to add expenses." (English).
6. Switch the language back to English and verify the same message reads "Waiting for you to add expenses." (no regression for English).

- [ ] Verify that no errors appear in the JS console

### Offline tests

Same as Tests — the next step for an empty report is computed optimistically on the client, so the translated message appears identically while offline.

### QA Steps

1. Set the account/device language to Spanish.
2. Create (or open) a workspace.
3. Go to **Reports → Create report** to create an empty report.
4. Verify the status bar reads **"Esperando a que tú añadas gastos."** and not the English text.
5. Switch the language to English and verify it reads "Waiting for you to add expenses."

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<!--
Capture each platform showing the empty-report status bar reading "Esperando a que tú añadas gastos." (Spanish).
All 5 can be captured on a Mac: Web (browser), iOS Native (Simulator), iOS mWeb Safari (Simulator Safari),
Android Native (emulator), Android mWeb Chrome (emulator Chrome).
-->

<details>
<summary>Android: Native</summary>

<!-- add screenshot here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshot here -->

</details>

<details>
<summary>iOS: Native</summary>

I don't currently have the Mac disk space to build the iOS native app. Since this is a shared-JS translation change that renders identically across platforms (verified on Web, Android: Native, Android: mWeb Chrome, and iOS: mWeb Safari), the iOS native behavior is the same. Could a reviewer kindly verify iOS: Native? Happy to provide anything needed.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshot here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshot here -->

</details>
