### PR TITLE
[NO QA] Fix broken Sentry bundle-size links in deploy comments

### DIFF
--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -203,7 +203,9 @@ jobs:
         run: |
           OUTPUT=$(npx sentry-cli build upload "$ARTIFACT_PATH" --org expensify --project app --build-configuration Release --log-level debug 2>&1)
           echo "$OUTPUT"
-          SENTRY_URL=$(echo "$OUTPUT" | grep -oE 'https://expensify\.sentry\.io/[^ ]+' | head -1)
+
+          # Exclude quotes and braces so the JSON delimiters wrapping the URL in the CLI output aren't captured
+          SENTRY_URL=$(echo "$OUTPUT" | grep -oE 'https://expensify\.sentry\.io/[^ "}]+' | head -1)
           if [ -n "$SENTRY_URL" ]; then
             echo "::notice::Android Sentry size analysis: $SENTRY_URL"
             echo "SENTRY_URL=$SENTRY_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -203,8 +203,6 @@ jobs:
         run: |
           OUTPUT=$(npx sentry-cli build upload "$ARTIFACT_PATH" --org expensify --project app --build-configuration Release --log-level debug 2>&1)
           echo "$OUTPUT"
-
-          # Exclude quotes and braces so the JSON delimiters wrapping the URL in the CLI output aren't captured
           SENTRY_URL=$(echo "$OUTPUT" | grep -oE 'https://expensify\.sentry\.io/[^ "}]+' | head -1)
           if [ -n "$SENTRY_URL" ]; then
             echo "::notice::Android Sentry size analysis: $SENTRY_URL"

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -252,7 +252,9 @@ jobs:
         run: |
           OUTPUT=$(npx sentry-cli build upload "$ARTIFACT_PATH" --org expensify --project app --build-configuration Release --log-level debug 2>&1)
           echo "$OUTPUT"
-          SENTRY_URL=$(echo "$OUTPUT" | grep -oE 'https://expensify\.sentry\.io/[^ ]+' | head -1)
+
+          # Exclude quotes and braces so the JSON delimiters wrapping the URL in the CLI output aren't captured
+          SENTRY_URL=$(echo "$OUTPUT" | grep -oE 'https://expensify\.sentry\.io/[^ "}]+' | head -1)
           if [ -n "$SENTRY_URL" ]; then
             echo "::notice::iOS Sentry size analysis: $SENTRY_URL"
             echo "SENTRY_URL=$SENTRY_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -252,8 +252,6 @@ jobs:
         run: |
           OUTPUT=$(npx sentry-cli build upload "$ARTIFACT_PATH" --org expensify --project app --build-configuration Release --log-level debug 2>&1)
           echo "$OUTPUT"
-
-          # Exclude quotes and braces so the JSON delimiters wrapping the URL in the CLI output aren't captured
           SENTRY_URL=$(echo "$OUTPUT" | grep -oE 'https://expensify\.sentry\.io/[^ "}]+' | head -1)
           if [ -n "$SENTRY_URL" ]; then
             echo "::notice::iOS Sentry size analysis: $SENTRY_URL"


### PR DESCRIPTION
### Explanation of Change

Every time we deploy, a bot posts a comment on each shipped PR. That comment ends with a couple of "Bundle Size Analysis" links pointing to Sentry. Right now those links are broken — clicking one goes to an error page, because some stray characters (`"}`) got stuck onto the end of the web address.

Here's where the junk comes from. During the Android and iOS builds, we upload the app to Sentry and then pull the resulting link out of the upload tool's logs. The way we searched those logs grabbed everything up to the next space — but in the logs the link is wrapped in punctuation, and that punctuation has no spaces in it, so it got pulled in along with the link. This change makes the search stop at that punctuation, so we keep just the clean link.

You can see the broken links for yourself in [this deploy comment on App#94322](https://github.com/Expensify/App/pull/94322#issuecomment-4783982898) — the two Sentry links at the bottom are both dead.

This came up while looking into a staging deploy whose [comment-posting step failed](https://github.com/Expensify/App/actions/runs/28059583635/job/83074583773).

### Fixed Issues

$ https://github.com/Expensify/App/issues/94382
PROPOSAL:

### Tests

1. Run the command below. It mimics how the link shows up in the build logs, and should print a clean address with nothing stuck on the end:
   ```bash
   echo '{"url":"https://expensify.sentry.io/preprod/size/343209"}' | grep -oE 'https://expensify\.sentry\.io/[^ "}]+' | head -1
   ```
   Expected output: `https://expensify.sentry.io/preprod/size/343209`
2. Swap the pattern back to the old `[^ ]+` and confirm you instead get the address with `"}` stuck on the end — that's the bug this fixes.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — CI workflow change.

### QA Steps

[No QA] — this only affects the deploy-comment bot. It will check itself on the next deploy: confirm the "Bundle Size Analysis" links in the deploy comment actually open.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
