### PR TITLE
fix: pass workspace policyID only for GL-code export templates

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -1984,6 +1984,8 @@ const CONST = {
         IN_APP: 'in-app',
     },
     EXPORT_TEMPLATE: 'exportTemplate',
+    // Marker present in a template column formula (e.g. {expense:category:glcode}) that requires a workspace policyID to resolve GL codes
+    EXPORT_TEMPLATE_GL_CODE_COLUMN_MARKER: ':glcode',
     NEXT_STEP: {
         MESSAGE_KEY: {
             WAITING_TO_ADD_TRANSACTIONS: 'waitingToAddTransactions',

--- a/src/hooks/useExportActions.ts
+++ b/src/hooks/useExportActions.ts
@@ -6,7 +6,7 @@ import type {PopoverMenuItem} from '@components/PopoverMenu';
 import {useSearchSelectionActions} from '@components/Search/SearchContext';
 import {openOldDotLink} from '@libs/actions/Link';
 import {exportReportToCSV, exportReportToPDF, exportToIntegration, markAsManuallyExported} from '@libs/actions/Report';
-import {getExportTemplates, queueExportSearchWithTemplate} from '@libs/actions/Search';
+import {doesExportTemplateRequireWorkspacePolicy, getExportTemplates, queueExportSearchWithTemplate} from '@libs/actions/Search';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getConnectedIntegration, getValidConnectedIntegration} from '@libs/PolicyUtils';
 import {getFilteredReportActionsForReportView} from '@libs/ReportActionsUtils';
@@ -212,7 +212,13 @@ function useExportActions({reportID, policy, onPDFModalOpen}: UseExportActionsPa
             value: template.templateName,
             description: template.description,
             sentryLabel: CONST.SENTRY_LABEL.MORE_MENU.EXPORT_FILE,
-            onSelected: () => beginExportWithTemplate(template.templateName, template.type, transactionIDs, template.policyID),
+            onSelected: () =>
+                beginExportWithTemplate(
+                    template.templateName,
+                    template.type,
+                    transactionIDs,
+                    template.policyID ?? (doesExportTemplateRequireWorkspacePolicy(template) ? moneyRequestReport?.policyID : undefined),
+                ),
         };
     }
 

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -19,6 +19,7 @@ import {setupMergeTransactionDataAndNavigate} from '@libs/actions/MergeTransacti
 import {deleteAppReport, exportReportToPDF, markAsManuallyExported, moveIOUReportToPolicy, moveIOUReportToPolicyAndInviteSubmitter} from '@libs/actions/Report';
 import {
     approveMoneyRequestOnSearch,
+    doesExportTemplateRequireWorkspacePolicy,
     exportSearchItemsToCSV,
     exportToIntegrationOnSearch,
     getExportTemplates,
@@ -572,7 +573,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
     const {duplicateTransactions, duplicateTransactionViolations} = useDuplicateTransactionsAndViolations(selectedTransactionsKeys);
 
     const beginExportWithTemplate = useCallback(
-        (templateName: string, templateType: string, policyID: string | undefined) => {
+        (templateName: string, templateType: string, policyID: string | undefined, requiresWorkspacePolicy: boolean) => {
             const emptyReports =
                 selectedReports?.filter((selectedReport) => {
                     if (!selectedReport) {
@@ -593,6 +594,22 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 return;
             }
             const serializedQuery = queryJSON ? serializeQueryJSONForBackend(queryJSON) : JSON.stringify(queryJSON);
+
+            // Only resolve a workspace policyID for templates that reference GL codes. Account-level templates with plain
+            // {expense:category}/{expense:tag} columns must keep policyID undefined, otherwise the backend can't generate the
+            // file (see #93088). When resolving, only fall back to the selection's workspace when every selected transaction
+            // belongs to a single real workspace, so GL codes aren't resolved against the wrong workspace.
+            const resolveFallbackPolicyID = () => {
+                if (!requiresWorkspacePolicy) {
+                    return undefined;
+                }
+                if (areAllMatchingItemsSelected) {
+                    return queryJSON?.policyID?.length === 1 ? queryJSON.policyID.at(0) : undefined;
+                }
+                const allSelectedHavePolicy = Object.values(selectedTransactions).every((transaction) => !!transaction.policyID);
+                return allSelectedHavePolicy && selectedPolicyIDs.length === 1 ? selectedPolicyIDs.at(0) : undefined;
+            };
+            const exportPolicyID = policyID ?? resolveFallbackPolicyID();
             let exportID: string;
 
             if (areAllMatchingItemsSelected) {
@@ -603,7 +620,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                         jsonQuery: serializedQuery,
                         reportIDList: [],
                         transactionIDList: [],
-                        policyID,
+                        policyID: exportPolicyID,
                     },
                     true,
                 );
@@ -616,14 +633,24 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                         jsonQuery: isGroupExport ? serializeQueryJSONForBackend(addSelectedGroupsFilter(queryJSON, selectedTransactions, currentSearchResults?.data)) : '{}',
                         reportIDList: isGroupExport ? [] : selectedTransactionReportIDs,
                         transactionIDList: isGroupExport ? [] : selectedTransactionsKeys,
-                        policyID,
+                        policyID: exportPolicyID,
                     },
                     true,
                 );
             }
             setActiveExportID(exportID);
         },
-        [selectedReports, selectedTransactions, isOffline, areAllMatchingItemsSelected, currentSearchResults?.data, queryJSON, selectedTransactionReportIDs, selectedTransactionsKeys],
+        [
+            selectedReports,
+            selectedTransactions,
+            isOffline,
+            areAllMatchingItemsSelected,
+            currentSearchResults?.data,
+            queryJSON,
+            selectedTransactionReportIDs,
+            selectedTransactionsKeys,
+            selectedPolicyIDs,
+        ],
     );
 
     const policyIDsWithVBBA = useMemo(() => {
@@ -1509,7 +1536,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                         icon: isStandardTemplate ? expensifyIcons.Table : expensifyIcons.TablePencil,
                         description: template.description,
                         onSelected: () => {
-                            beginExportWithTemplate(template.templateName, template.type, template.policyID);
+                            beginExportWithTemplate(template.templateName, template.type, template.policyID, doesExportTemplateRequireWorkspacePolicy(template));
                         },
                         shouldCloseModalOnSelect: true,
                         shouldCallAfterModalHide: true,

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -1393,6 +1393,16 @@ function getExportTemplates(
 }
 
 /**
+ * Account-level export templates have no policyID by design. Only templates that reference GL codes
+ * (e.g. {expense:category:glcode}) need a workspace policyID for the backend to resolve them. Plain
+ * {expense:category}/{expense:tag} templates must keep policyID undefined — sending a workspace policyID
+ * for them prevents the backend from generating the file for account-level templates (see #93088).
+ */
+function doesExportTemplateRequireWorkspacePolicy(template: ExportTemplate): boolean {
+    return (template.columns ?? []).some((column) => column.includes(CONST.EXPORT_TEMPLATE_GL_CODE_COLUMN_MARKER));
+}
+
+/**
  * Updates the form values for the advanced filters search form.
  */
 function updateAdvancedFilters(values: Nullable<Partial<FormOnyxValues<typeof ONYXKEYS.FORMS.SEARCH_ADVANCED_FILTERS_FORM>>>, shouldUseOnyxSetMethod = false) {
@@ -1698,6 +1708,7 @@ export {
     handleBulkPayItemSelected,
     isCurrencySupportWalletBulkPay,
     getExportTemplates,
+    doesExportTemplateRequireWorkspacePolicy,
     getReportType,
     getTotalFormattedAmount,
     setOptimisticDataForTransactionThreadPreview,

--- a/src/types/onyx/ExportTemplate.ts
+++ b/src/types/onyx/ExportTemplate.ts
@@ -16,6 +16,9 @@ type ExportTemplate = OnyxCommon.OnyxValueWithOfflineFeedback<{
 
     /** Description of the template */
     description: string;
+
+    /** Column formulas the template exports (e.g. {expense:category:glcode}); present for in-app/CSV layout templates */
+    columns?: string[];
 }>;
 
 export default ExportTemplate;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

This re-raises #92131 (reverted in #93091) with a **narrowed scope** so it $ #89388 without re-introducing deploy blocker #93088.

Account-level export templates have `policyID: undefined` by design (returned by `getExportTemplates`). #92131 attached the selection's workspace `policyID` to **every** account-level template. The backend only needs a workspace `policyID` to resolve **GL codes** (e.g. `{expense:category:glcode}`); for **plain** `{expense:category}`/`{expense:tag}` account-level templates, sending a `policyID` made the backend fail to generate the file — the optimistic "Export in progress" message showed but nothing reached Concierge (#93088).

This PR scopes the workspace `policyID` to **only templates that reference GL codes** (a column containing `:glcode`):

- **GL-code templates** → resolve the workspace `policyID` ($ #89388).
- **Plain `{expense:category}`/`{expense:tag}` templates** → keep `policyID: undefined`, staying on the original working path → #93088 cannot recur.

**Changes:**

- `src/libs/actions/Search.ts`: new exported helper `doesExportTemplateRequireWorkspacePolicy(template)` — `true` only when a column contains the GL-code marker.
- `src/hooks/useSearchBulkActions.ts`: bulk path resolves the workspace `policyID` only when the template requires GL codes. The multi-workspace guard is preserved — it falls back to the selection's workspace only when every selected transaction belongs to a single real workspace, otherwise `policyID` is left undefined.
- `src/hooks/useExportActions.ts`: single-report path falls back to `moneyRequestReport.policyID` only for GL-code templates.
- `src/types/onyx/ExportTemplate.ts`: added `columns?: string[]` (already present at runtime).
- `src/CONST/index.ts`: added the `:glcode` column marker constant.

### Fixed Issues

$ https://github.com/Expensify/App/issues/89388
PROPOSAL: https://github.com/Expensify/App/issues/89388#issuecomment-4359366033

### Tests

Preconditions:

- An **account-level** custom export template (created in Classic via Settings → Account → Preferences → CSV Export Formats, or Reports → Export to → Create new CSV export layout — **not** a workspace-scoped Export Format) containing a column with the formula `{expense:category:glcode}` or `{expense:tag:glcode}` — call this the **GL-code account template**.
- A second **account-level** template with only **plain** `{expense:category}` / `{expense:tag}` columns (no `:glcode`) — call this the **plain account template**.
- A **workspace-level** export template (created inside a workspace's Export Formats) — call this the **workspace template**.
- A workspace with GL codes assigned to at least one category or tag, and expenses on that workspace categorized/tagged accordingly.

A. GL-code account template — bulk path (`useSearchBulkActions`):

1. Go to Search → Expenses, filter to the **single workspace** that has GL codes, select expenses, and Export using the **GL-code account template**.
2. Verify the export completes and the file is delivered to Concierge with the **correct GL codes** (matching Classic Expensify output).
3. (Definitive) With DevTools → Network, inspect the `QueueExportSearchWithTemplate` request body — `policyID` **is present** and matches the workspace ID.
4. Repeat with a selection that spans **multiple workspaces** and verify the export completes without errors (`policyID` is intentionally **absent**; GL codes may be unresolved by design for multi-workspace selections).

B. Plain account template — bulk path (regression guard for #93088): 5. Select expenses on the same workspace and Export using the **plain account template**. 6. Verify the file **is delivered** to Concierge (does **not** silently fail). 7. (Definitive) Inspect the `QueueExportSearchWithTemplate` request — `policyID` **is absent**.

C. Workspace template — bulk path: 8. Select expenses and Export using the **workspace template**. 9. Verify the file is delivered (`policyID` present = the template's own workspace ID — unchanged behavior).

D. Single-report path (`useExportActions`): 10. Open an expense report on the workspace with GL codes → report header menu → Export. 11. Export with the **GL-code account template** → verify the file has the correct GL codes (request includes `policyID`). 12. Export with the **plain account template** → verify the file is delivered (request has **no** `policyID`).

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Turn off network connection.
2. Attempt to export using a custom template.
3. Verify the offline modal appears and no export is triggered.

### QA Steps

Preconditions (same as Tests):

- An **account-level GL-code template** with a `{expense:category:glcode}` / `{expense:tag:glcode}` column.
- An **account-level plain template** with only `{expense:category}` / `{expense:tag}` columns.
- A **workspace-level template**.
- A workspace with GL codes set on categories/tags, and expenses categorized/tagged accordingly.

Account-level templates (Search/Expenses bulk export):

1. Go to Search → Expenses, filter to the single workspace with GL codes, select expenses.
2. Export using the **GL-code account template** → verify the file is delivered to Concierge with correct GL codes matching Classic Expensify.
3. Export using the **plain account template** → verify the file **is delivered** to Concierge (this is the #93088 regression check — it must not silently fail).
4. Repeat step 2 with a multi-workspace selection → verify the export still completes without errors.

Workspace-level template (Search/Expenses bulk export): 5. Select expenses and Export using the **workspace template** → verify the file is delivered.

Single-report export: 6. Open an expense report on the GL-code workspace → report header → Export → **GL-code account template** → verify correct GL codes. 7. Same report → Export → **plain account template** → verify the file is delivered.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

CSV files can be verified on desktop only

</details>

<details>
<summary>Android: mWeb Chrome</summary>

CSV files can be verified on desktop only

</details>

<details>
<summary>iOS: Native</summary>

CSV files can be verified on desktop only

</details>

<details>
<summary>iOS: mWeb Safari</summary>

CSV files can be verified on desktop only

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
