### PR TITLE
Fix Okta SAML double login on native session resume

### DIFF
--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -838,6 +838,20 @@ function signInWithShortLivedAuthToken(authToken: string, isSAML = false) {
 }
 
 /**
+ * Marks (or clears) that a short-lived-token sign-in is in progress.
+ *
+ * Native SAML sign-in opens an in-app browser, which backgrounds the app. On resume, `reconnectApp()` fires
+ * with the now-expired authToken and gets a 407; if this guard isn't already set, `reauthenticate()` takes
+ * the `isSAMLRequired` branch and calls `redirectToSignIn()`, wiping the session before the SAML callback can
+ * sign the user back in. Setting it `true` before opening the browser makes `reauthenticate()` abort while the
+ * SAML sign-in is in progress. `signInWithShortLivedAuthToken` clears it on completion; the cancel/error paths
+ * clear it explicitly.
+ */
+function setIsAuthenticatingWithShortLivedToken(isAuthenticating: boolean) {
+    Onyx.set(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN, isAuthenticating);
+}
+
+/**
  * Sign the user into the application. This will first authenticate their account
  * then it will create a temporary login for them which is used when re-authenticating
  * after an authToken expires.
@@ -1686,6 +1700,7 @@ export {
     signInWithValidateCodeAndNavigate,
     initAutoAuthState,
     signInWithShortLivedAuthToken,
+    setIsAuthenticatingWithShortLivedToken,
     cleanupSession,
     signOut,
     signOutAndRedirectToSignIn,

--- a/src/pages/signin/SAMLSignInPage/index.native.tsx
+++ b/src/pages/signin/SAMLSignInPage/index.native.tsx
@@ -11,7 +11,7 @@ import getPlatform from '@libs/getPlatform';
 import Log from '@libs/Log';
 import {handleSAMLLoginError, postSAMLLogin} from '@libs/LoginUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {clearSignInData, setAccountError, signInWithShortLivedAuthToken} from '@userActions/Session';
+import {clearSignInData, setAccountError, setIsAuthenticatingWithShortLivedToken, signInWithShortLivedAuthToken} from '@userActions/Session';
 import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -26,6 +26,8 @@ function SAMLSignInPage() {
     const hasOpenedAuthSession = useRef(false);
 
     const handleExitSAMLFlow = useCallback(() => {
+        // Clear the guard we set before opening the in-app browser so we don't block future reauthentication
+        setIsAuthenticatingWithShortLivedToken(false);
         Navigation.isNavigationReady().then(() => {
             Navigation.goBack();
             clearSignInData();
@@ -67,6 +69,8 @@ function SAMLSignInPage() {
                 return;
             }
 
+            // The browser returned but we couldn't sign in, so clear the guard we set before opening it
+            setIsAuthenticatingWithShortLivedToken(false);
             clearSignInData();
             setAccountError(translate('common.error.login'));
             Navigation.isNavigationReady().then(() => {
@@ -84,6 +88,12 @@ function SAMLSignInPage() {
             return;
         }
         hasOpenedAuthSession.current = true;
+        // Opening the in-app browser backgrounds the app. When it returns, the app resumes and fires
+        // reconnectApp() with the expired authToken, which 407s and would trigger reauthenticate() ->
+        // redirectToSignIn(), wiping the session before the SAML callback can sign the user back in. Setting
+        // this guard up front makes reauthenticate() abort while the SAML sign-in is in progress. It is cleared
+        // by signInWithShortLivedAuthToken() on success, and on the cancel/error paths below.
+        setIsAuthenticatingWithShortLivedToken(true);
         openAuthSessionAsync(SAMLUrl, CONST.SAML_REDIRECT_URL)
             .then((response: WebBrowserAuthSessionResult) => {
                 if (response.type !== 'success') {

--- a/tests/unit/SAMLSignInPageTest.tsx
+++ b/tests/unit/SAMLSignInPageTest.tsx
@@ -1,0 +1,100 @@
+import {act, render} from '@testing-library/react-native';
+import {openAuthSessionAsync} from 'expo-web-browser';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import type {OnyxEntry} from 'react-native-onyx';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import * as Session from '@libs/actions/Session';
+import SAMLSignInPage from '@pages/signin/SAMLSignInPage';
+import ONYXKEYS from '@src/ONYXKEYS';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('expo-web-browser', () => ({
+    openAuthSessionAsync: jest.fn(() => Promise.resolve({type: 'cancel'})),
+}));
+
+jest.mock('@libs/LoginUtils', () => ({
+    postSAMLLogin: jest.fn(() => Promise.resolve({url: 'https://idp.example.com/saml'})),
+    handleSAMLLoginError: jest.fn(),
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    isNavigationReady: jest.fn(() => Promise.resolve()),
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+}));
+
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: (key: string) => key,
+    })),
+);
+
+// Stub the presentational wrappers — SAMLSignInPage's effects (which is what we're testing) run on mount
+// regardless of what these render, and stubbing them avoids pulling in the navigation-heavy render tree.
+jest.mock('@components/ScreenWrapper', () => ({__esModule: true, default: () => null}));
+jest.mock('@components/BlockingViews/FullPageOfflineBlockingView', () => ({__esModule: true, default: () => null}));
+jest.mock('@components/HeaderWithBackButton', () => ({__esModule: true, default: () => null}));
+jest.mock('@components/SAMLLoadingIndicator', () => ({__esModule: true, default: () => null}));
+
+const mockedOpenAuthSessionAsync = jest.mocked(openAuthSessionAsync);
+
+async function setCredentials() {
+    await act(async () => {
+        await Onyx.set(ONYXKEYS.CREDENTIALS, {login: 'test@example.com'});
+        await Onyx.set(ONYXKEYS.ACCOUNT, {isLoading: false});
+        await Onyx.set(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN, false);
+    });
+    await waitForBatchedUpdatesWithAct();
+}
+
+describe('SAMLSignInPage (native)', () => {
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await act(async () => {
+            await Onyx.clear();
+        });
+    });
+
+    test('sets the short-lived-token guard before opening the SAML browser (prevents the resume-after-idle teardown)', async () => {
+        const setGuardSpy = jest.spyOn(Session, 'setIsAuthenticatingWithShortLivedToken');
+        await setCredentials();
+
+        render(
+            <OnyxListItemProvider>
+                <SAMLSignInPage />
+            </OnyxListItemProvider>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        // The in-app browser was opened, and the guard was set to true BEFORE that call, so a reconnectApp()
+        // 407 firing while the app is backgrounded aborts reauthenticate() instead of tearing down the session.
+        expect(mockedOpenAuthSessionAsync).toHaveBeenCalledTimes(1);
+        expect(setGuardSpy).toHaveBeenCalledWith(true);
+        const setTrueOrder = setGuardSpy.mock.calls.findIndex((call) => call.at(0) === true);
+        expect(setGuardSpy.mock.invocationCallOrder.at(setTrueOrder)).toBeLessThan(mockedOpenAuthSessionAsync.mock.invocationCallOrder.at(0) ?? Infinity);
+    });
+
+    test('clears the guard when the SAML browser is cancelled so future reauthentication is not blocked', async () => {
+        let guard: OnyxEntry<boolean>;
+        Onyx.connect({
+            key: ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN,
+            callback: (value) => {
+                guard = value;
+            },
+        });
+        // openAuthSessionAsync is mocked to resolve as a cancellation by default (see top of file)
+        await setCredentials();
+
+        render(
+            <OnyxListItemProvider>
+                <SAMLSignInPage />
+            </OnyxListItemProvider>,
+        );
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockedOpenAuthSessionAsync).toHaveBeenCalledTimes(1);
+        // After the user cancels, the guard must be cleared (otherwise reauthenticate stays blocked forever)
+        expect(guard).toBe(false);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

On native, SAML sign-in opens an in-app browser (`openAuthSessionAsync`), which backgrounds the app. When the browser returns and the app resumes, `reconnectApp()` fires with the now-expired authToken and gets a `407`. At that moment `reauthenticate()` runs, and because `account.isSAMLRequired` is `true` it takes the SAML branch and calls `redirectToSignIn(undefined, true)` — tearing the session down before the SAML callback (`signInWithShortLivedAuthToken`) can sign the user back in. That is the reported "double login": after returning from the IdP the user is bounced back to the SSO login screen.

The `isAuthenticatingWithShortLivedToken` guard already exists to make `reauthenticate()` abort while a short-lived-token sign-in is in flight — but it was only set once the browser *returned* with the token, which is too late for the resume race. This PR sets the guard **before** opening the in-app browser, so it is already in place when the app resumes and `reauthenticate()` aborts instead of wiping the session. The guard is cleared by `signInWithShortLivedAuthToken()` on success and explicitly on the cancel/error paths, so it can never get stuck.

- `Session.setIsAuthenticatingWithShortLivedToken(value)` — small setter for the RAM-only guard key.
- `SAMLSignInPage` (native) — set the guard `true` before `openAuthSessionAsync`; clear it on cancel/error and on the no-token callback path.

### Fixed Issues

$ https://github.com/Expensify/App/issues/86705
PROPOSAL: https://github.com/Expensify/App/issues/86705#issuecomment-4585742802

### Tests

Validated on a real Okta → Expensify SAML environment (the resume-after-idle race needs a real IdP):

1. Configure an Okta SAML domain and sign into the native app via SSO.
2. Leave the app idle until the authToken expires (or shorten the Okta session/idle timeout to force it quickly), then background and resume the app.
3. **Before this change:** on resume the app drops the session and returns to the SSO sign-in screen (double login). Logs show `[Reauthenticate] Redirecting to Sign In because SAML is required`.
4. **After this change:** the session is preserved — the app stays signed in and `reauthenticate()` aborts (`[Reauthenticate] Authentication with shortLivedToken is in progress`); there is no redirect to sign-in.

Automated coverage (`tests/unit/SAMLSignInPageTest.tsx`):
- `SAMLSignInPage` sets the guard to `true` before `openAuthSessionAsync` is called.
- The guard is cleared when the browser is cancelled, so future reauthentication is not blocked.

The complementary contract — that `reauthenticate()` aborts while the guard is set — is already covered by `tests/actions/SessionTest.ts`.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this is a session-resume / re-authentication change that only manifests with connectivity (the resume `reconnectApp` 407). Offline, the request queue is paused and `reauthenticate()` does not run.

### QA Steps

1. On a native build, sign in to an account that uses Okta/SAML SSO.
2. Background the app and leave it idle long enough for the auth token to expire, then reopen it.
3. Verify the app stays signed in and lands on the user's inbox — it should **not** bounce back to the SSO login screen.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Bug reproduction on a real Okta SAML session — the app boots with a SAML session, then on the resume-time `reconnectApp` 407 it tears the session down and bounces to the Okta re-login (the "double login"):

![86705 bug repro](https://github.com/trasnake87/App/releases/download/saml-repro/86705_poster.png)

[Bug reproduction recording](https://github.com/trasnake87/App/releases/download/saml-repro/86705_repro.mp4)

<!-- after-fix recording to be added -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — this change only touches `SAMLSignInPage/index.native.tsx`; mWeb uses a separate SAML path and is unaffected.

</details>

<details>
<summary>iOS: Native</summary>

<!-- iOS native recording to be added -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — native-only change; mWeb is unaffected.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — native-only change; desktop is unaffected.

</details>
