### PR TITLE
perf: Search S5 ExpenseFlatSearchView + primitives

### DIFF
--- a/src/components/Search/ExpenseFlatSearchView.tsx
+++ b/src/components/Search/ExpenseFlatSearchView.tsx
@@ -4,6 +4,7 @@ import type {ForwardedRef} from 'react';
 import {View} from 'react-native';
 import type {NativeScrollEvent, NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
+import {useEditingCellState} from '@components/TransactionItemRow/EditableCell';
 import useKeyboardState from '@hooks/useKeyboardState';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -145,6 +146,7 @@ function ExpenseFlatSearchView({
     // See https://github.com/Expensify/App/issues/48675 for more details
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth, isLargeScreenWidth} = useResponsiveLayout();
+    const {isEditingCell, wasRecentlyEditingCell} = useEditingCellState();
 
     const listRef = useRef<FlashListRef<SearchListItem>>(null);
     const prevDataLength = usePrevious(data.length);
@@ -186,6 +188,10 @@ function ExpenseFlatSearchView({
     const scrollToListIndex = (index: number, animated = true) => {
         const item = data.at(index);
         if (!listRef.current || !item || index === -1) {
+            return;
+        }
+        // Mirror SearchList: don't scroll while a row's cell is being inline-edited, which would blur/move it mid-edit.
+        if (isEditingCell || wasRecentlyEditingCell) {
             return;
         }
         listRef.current.scrollToIndex({index, animated, viewOffset: -variables.contentHeaderHeight});

--- a/src/components/Search/ExpenseFlatSearchView.tsx
+++ b/src/components/Search/ExpenseFlatSearchView.tsx
@@ -287,4 +287,3 @@ function ExpenseFlatSearchView({
 ExpenseFlatSearchView.displayName = 'ExpenseFlatSearchView';
 
 export default ExpenseFlatSearchView;
-export type {ExpenseFlatSearchViewProps, SearchListHandle};

--- a/src/components/Search/ExpenseFlatSearchView.tsx
+++ b/src/components/Search/ExpenseFlatSearchView.tsx
@@ -101,16 +101,15 @@ const keyExtractor = (item: SearchListItem, index: number) => item.keyForList ??
 const isRowDeleted = (item: SearchListItem) => item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
 
 /**
- * The flat-expense Search list (Slice S5, callstack-internal/expensify-issues#2547).
+ * The flat-expense Search list.
  *
- * The first real consumer of the S4 data layer. `<Search>` keeps the snapshot, lifecycle and selection
- * providers; this view is rendered as a provider child (so it reads the real `toggle`/`toggleAll`/
- * `selectedTransactions`) and composes the S5 primitives directly around `BaseSearchList` — no
- * `SearchList` shell, no `ListItem` prop, no factory. `TransactionListItem` is the only row renderer for
- * the flat-expense path, and rows always animate, so the group/sticky/chat/task branches of `SearchList`
- * collapse away. KeyboardListNavigation is inherited from `BaseSearchList`; RowHighlight stays in the
- * router (the snapshot already stamps `shouldAnimateInHighlight`, and `newTransactions` flows into
- * `extraData`).
+ * Consumes `useSearchSnapshot` and is rendered by `<Search>` as a child of the selection providers (so it
+ * reads the real `toggle`/`toggleAll`/`selectedTransactions`). It composes the reusable Search list
+ * primitives directly around `BaseSearchList` — no `SearchList` shell, no `ListItem` prop, no factory.
+ * `TransactionListItem` is the only row renderer for the flat-expense path, and rows always animate, so the
+ * group/sticky/chat/task branches of `SearchList` do not apply here. Keyboard navigation is inherited from
+ * `BaseSearchList`; the post-create highlight stays in the router (the snapshot stamps
+ * `shouldAnimateInHighlight`, and `newTransactions` flows into `extraData`).
  */
 function ExpenseFlatSearchView({
     queryJSON,

--- a/src/components/Search/ExpenseFlatSearchView.tsx
+++ b/src/components/Search/ExpenseFlatSearchView.tsx
@@ -1,0 +1,317 @@
+import type {FlashListRef} from '@shopify/flash-list';
+import React, {useCallback, useImperativeHandle, useMemo, useRef} from 'react';
+import type {ForwardedRef} from 'react';
+import {View} from 'react-native';
+import type {NativeScrollEvent, NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
+import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
+import useKeyboardState from '@hooks/useKeyboardState';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import usePrevious from '@hooks/usePrevious';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useSafeAreaPaddings from '@hooks/useSafeAreaPaddings';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useUndeleteTransactions from '@hooks/useUndeleteTransactions';
+import type {TransactionPreviewData} from '@libs/actions/Search';
+import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
+import variables from '@styles/variables';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {CardList, Transaction} from '@src/types/onyx';
+import AnimatedExitRow from './primitives/AnimatedExitRow';
+import HorizontalTableScroll from './primitives/HorizontalTableScroll';
+import SelectionTopBar from './primitives/SelectionTopBar';
+import useRowLongPressMenu from './primitives/useRowLongPressMenu';
+import useScrollRestoration from './primitives/useScrollRestoration';
+import {useSearchRowSelectionActions, useSearchSelectionContext} from './SearchContext';
+import BaseSearchList from './SearchList/BaseSearchList';
+import TransactionListItem from './SearchList/ListItem/TransactionListItem';
+import type {SearchListItem} from './SearchList/ListItem/types';
+import type {SearchColumnType, SearchQueryJSON} from './types';
+
+/** Imperative handle the router uses for highlight-driven scrolling (mirrors SearchList's handle). */
+type SearchListHandle = {
+    scrollToIndex: (index: number, animated?: boolean) => void;
+};
+
+type ExpenseFlatSearchViewProps = {
+    /** The flat-expense search query. */
+    queryJSON: SearchQueryJSON;
+
+    /** The sorted, optimistic-stabilized rows to render (from the router's useSearchSnapshot). */
+    data: SearchListItem[];
+
+    /** The columns to render in the list (fade-stabilized by the router). */
+    columns: SearchColumnType[];
+
+    /** Whether the list supports multi-select. */
+    canSelectMultiple: boolean;
+
+    /** Whether the action column uses its wider variant (a deleted transaction is present). */
+    isActionColumnWide: boolean;
+
+    /** Precomputed attendee-tracking boolean (derived from policy-for-moving-expenses). */
+    isAttendeesEnabledForMovingPolicy?: boolean;
+
+    /** Non-personal and workspace cards for row rendering (subscribed once by the router). */
+    nonPersonalAndWorkspaceCards?: CardList;
+
+    /** Whether mobile selection mode is on. */
+    isMobileSelectionModeEnabled: boolean;
+
+    /** The column header element for the flat table (undefined on narrow layouts). */
+    SearchTableHeader?: React.JSX.Element;
+
+    /** Whether a table header bar is shown above the list. */
+    tableHeaderVisible: boolean;
+
+    /** Whether every transaction has been loaded (gates the fully-checked select-all state). */
+    hasLoadedAllTransactions?: boolean;
+
+    /** Transactions flagged for the post-create highlight animation (feeds BaseSearchList extraData). */
+    newTransactions: Transaction[];
+
+    /** The navigation/thread-creation handler for a row tap (owned by the router). */
+    onSelectRow: (item: SearchListItem, transactionPreviewData?: TransactionPreviewData, event?: ModifiedMouseEvent) => void;
+
+    /** The list footer (pagination / pending-expense skeleton). */
+    ListFooterComponent?: React.JSX.Element;
+
+    /** Fires when the list scrolls near its end (router's fetchMoreResults). */
+    onEndReached: () => void;
+
+    /** Fires on the list's first layout and on layout changes. */
+    onLayout: () => void;
+
+    /** Scroll handler forwarded to the list. */
+    onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+
+    /** Content container style for the list. */
+    contentContainerStyle: StyleProp<ViewStyle>;
+
+    /** Outer container style for the list wrapper. */
+    containerStyle: StyleProp<ViewStyle>;
+
+    /** Imperative handle for highlight-driven scrolling, set by the router. */
+    ref?: ForwardedRef<SearchListHandle>;
+};
+
+const keyExtractor = (item: SearchListItem, index: number) => item.keyForList ?? `${index}`;
+
+/**
+ * The flat-expense Search list (Slice S5, callstack-internal/expensify-issues#2547).
+ *
+ * The first real consumer of the S4 data layer. `<Search>` keeps the snapshot, lifecycle and selection
+ * providers; this view is rendered as a provider child (so it reads the real `toggle`/`toggleAll`/
+ * `selectedTransactions`) and composes the S5 primitives directly around `BaseSearchList` — no
+ * `SearchList` shell, no `ListItem` prop, no factory. `TransactionListItem` is the only row renderer for
+ * the flat-expense path, and rows always animate, so the group/sticky/chat/task branches of `SearchList`
+ * collapse away. KeyboardListNavigation is inherited from `BaseSearchList`; RowHighlight stays in the
+ * router (the snapshot already stamps `shouldAnimateInHighlight`, and `newTransactions` flows into
+ * `extraData`).
+ */
+function ExpenseFlatSearchView({
+    queryJSON,
+    data,
+    columns,
+    canSelectMultiple,
+    isActionColumnWide,
+    isAttendeesEnabledForMovingPolicy,
+    nonPersonalAndWorkspaceCards,
+    isMobileSelectionModeEnabled,
+    SearchTableHeader: searchTableHeader,
+    tableHeaderVisible,
+    hasLoadedAllTransactions,
+    newTransactions,
+    onSelectRow,
+    ListFooterComponent,
+    onEndReached,
+    onLayout,
+    onScroll,
+    contentContainerStyle,
+    containerStyle,
+    ref,
+}: ExpenseFlatSearchViewProps) {
+    const styles = useThemeStyles();
+    const {type} = queryJSON;
+    const {toggle, toggleAll} = useSearchRowSelectionActions();
+    const {selectedTransactions} = useSearchSelectionContext();
+
+    const {isOffline} = useNetwork();
+    const {isKeyboardShown} = useKeyboardState();
+    const {safeAreaPaddingBottomStyle} = useSafeAreaPaddings();
+    // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout here because there is a race condition that causes shouldUseNarrowLayout to change indefinitely in this component
+    // See https://github.com/Expensify/App/issues/48675 for more details
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
+    const {isSmallScreenWidth, isLargeScreenWidth} = useResponsiveLayout();
+
+    const listRef = useRef<FlashListRef<SearchListItem>>(null);
+    const prevDataLength = usePrevious(data.length);
+    const hasItemsBeingRemoved = !!prevDataLength && prevDataLength > data.length;
+
+    const [lastPaymentMethod] = useOnyx(ONYXKEYS.NVP_LAST_PAYMENT_METHOD);
+    const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
+    const [userBillingGracePeriodEnds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_USER_BILLING_GRACE_PERIOD_END);
+    const [ownerBillingGracePeriodEnd] = useOnyx(ONYXKEYS.NVP_PRIVATE_OWNER_BILLING_GRACE_PERIOD_END);
+    const undeleteTransactions = useUndeleteTransactions();
+
+    const handleUndelete = useCallback((transaction: Transaction) => undeleteTransactions([transaction]), [undeleteTransactions]);
+
+    // Flat lists have no group children to skip, so visibility is computed straight off the rendered rows.
+    const isItemVisible = useCallback((item: SearchListItem) => item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE || isOffline, [isOffline]);
+    const firstVisibleIndex = useMemo(() => data.findIndex(isItemVisible), [data, isItemVisible]);
+    const lastVisibleIndex = useMemo(() => data.findLastIndex(isItemVisible), [data, isItemVisible]);
+
+    // Flat-expense selection counts: no empty groups, no group flattening — a single pass over the rows.
+    const selectedItemsLength = useMemo(
+        () => data.reduce((acc, item) => acc + (item?.keyForList && selectedTransactions[item.keyForList]?.isSelected ? 1 : 0), 0),
+        [data, selectedTransactions],
+    );
+    const totalItems = useMemo(() => data.filter((item) => !('pendingAction' in item) || item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE).length, [data]);
+
+    const {onLongPressRow, modal} = useRowLongPressMenu({shouldPreventLongPressRow: false, isSmallScreenWidth, isMobileSelectionModeEnabled});
+
+    // In mobile selection mode a row tap toggles selection. This must live inside the providers (not in the
+    // router) because the `toggle` it reads is the default no-op outside SearchWriteActionsProvider; here it
+    // resolves to the real action.
+    const handleSelectRow = useCallback(
+        (item: SearchListItem, transactionPreviewData?: TransactionPreviewData, event?: ModifiedMouseEvent) => {
+            if (isMobileSelectionModeEnabled) {
+                if (item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+                    return;
+                }
+                toggle(item);
+                return;
+            }
+            onSelectRow(item, transactionPreviewData, event);
+        },
+        [isMobileSelectionModeEnabled, toggle, onSelectRow],
+    );
+
+    const scrollToListIndex = useCallback(
+        (index: number, animated = true) => {
+            const item = data.at(index);
+            if (!listRef.current || !item || index === -1) {
+                return;
+            }
+            listRef.current.scrollToIndex({index, animated, viewOffset: -variables.contentHeaderHeight});
+        },
+        [data],
+    );
+
+    useScrollRestoration(listRef);
+
+    // Flat data maps 1:1 to the rendered list, so highlight-scroll-to-index is the same as scroll-to-data-index.
+    useImperativeHandle(ref, () => ({scrollToIndex: scrollToListIndex}), [scrollToListIndex]);
+
+    const renderItem = useCallback(
+        (item: SearchListItem, index: number, isItemFocused: boolean, onFocus?: (event: NativeSyntheticEvent<ExtendedTargetedEvent>) => void) => {
+            const isDisabled = item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
+            // Flat view always animates row exits, so the only gate is excluding the last row.
+            const shouldApplyAnimation = index < data.length - 1;
+
+            return (
+                <AnimatedExitRow
+                    shouldApplyAnimation={shouldApplyAnimation}
+                    hasItemsBeingRemoved={hasItemsBeingRemoved}
+                >
+                    <TransactionListItem
+                        showTooltip
+                        isFocused={isItemFocused}
+                        onSelectRow={handleSelectRow}
+                        onLongPressRow={onLongPressRow}
+                        onSelectionButtonPress={toggle}
+                        canSelectMultiple={canSelectMultiple}
+                        item={item}
+                        columns={columns}
+                        isDisabled={isDisabled}
+                        lastPaymentMethod={lastPaymentMethod}
+                        personalPolicyID={personalPolicyID}
+                        userBillingGracePeriodEnds={userBillingGracePeriodEnds}
+                        ownerBillingGracePeriodEnd={ownerBillingGracePeriodEnd}
+                        nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                        onFocus={onFocus}
+                        onUndelete={handleUndelete}
+                        keyForList={item.keyForList}
+                        isFirstItem={index === firstVisibleIndex}
+                        isLastItem={index === lastVisibleIndex && !ListFooterComponent}
+                    />
+                </AnimatedExitRow>
+            );
+        },
+        [
+            data.length,
+            hasItemsBeingRemoved,
+            handleSelectRow,
+            onLongPressRow,
+            toggle,
+            canSelectMultiple,
+            columns,
+            lastPaymentMethod,
+            personalPolicyID,
+            userBillingGracePeriodEnds,
+            ownerBillingGracePeriodEnd,
+            nonPersonalAndWorkspaceCards,
+            handleUndelete,
+            firstVisibleIndex,
+            lastVisibleIndex,
+            ListFooterComponent,
+        ],
+    );
+
+    const isSelectAllChecked = selectedItemsLength > 0 && selectedItemsLength === totalItems && hasLoadedAllTransactions;
+    const selectAllButtonVisible = canSelectMultiple && !searchTableHeader;
+
+    return (
+        <HorizontalTableScroll
+            columns={columns}
+            type={type}
+            isActionColumnWide={isActionColumnWide}
+            isHeaderVisible={!!searchTableHeader}
+            dataKey={data}
+        >
+            <View style={[styles.flex1, !isKeyboardShown && safeAreaPaddingBottomStyle, containerStyle]}>
+                {tableHeaderVisible && (
+                    <SelectionTopBar
+                        isLargeScreenWidth={isLargeScreenWidth}
+                        shouldSplitGroups={false}
+                        canSelectMultiple={canSelectMultiple}
+                        isSelectAllChecked={isSelectAllChecked}
+                        selectedItemsLength={selectedItemsLength}
+                        totalItems={totalItems}
+                        hasLoadedAllTransactions={hasLoadedAllTransactions}
+                        selectAllButtonVisible={selectAllButtonVisible}
+                        onAllCheckboxPress={toggleAll}
+                        SearchTableHeader={searchTableHeader}
+                    />
+                )}
+                <BaseSearchList
+                    data={data}
+                    renderItem={renderItem}
+                    onSelectRow={handleSelectRow}
+                    keyExtractor={keyExtractor}
+                    onScroll={onScroll}
+                    showsVerticalScrollIndicator={false}
+                    ref={listRef}
+                    columns={columns}
+                    scrollToIndex={scrollToListIndex}
+                    flattenedItemsLength={data.length}
+                    onEndReached={onEndReached}
+                    onEndReachedThreshold={0.75}
+                    ListFooterComponent={ListFooterComponent}
+                    onLayout={onLayout}
+                    contentContainerStyle={contentContainerStyle}
+                    newTransactions={newTransactions}
+                    isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
+                    nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                />
+                {modal}
+            </View>
+        </HorizontalTableScroll>
+    );
+}
+
+ExpenseFlatSearchView.displayName = 'ExpenseFlatSearchView';
+
+export default ExpenseFlatSearchView;
+export type {ExpenseFlatSearchViewProps, SearchListHandle};

--- a/src/components/Search/ExpenseFlatSearchView.tsx
+++ b/src/components/Search/ExpenseFlatSearchView.tsx
@@ -1,5 +1,5 @@
 import type {FlashListRef} from '@shopify/flash-list';
-import React, {useCallback, useImperativeHandle, useMemo, useRef} from 'react';
+import React, {useImperativeHandle, useRef} from 'react';
 import type {ForwardedRef} from 'react';
 import {View} from 'react-native';
 import type {NativeScrollEvent, NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
@@ -98,6 +98,8 @@ type ExpenseFlatSearchViewProps = {
 
 const keyExtractor = (item: SearchListItem, index: number) => item.keyForList ?? `${index}`;
 
+const isRowDeleted = (item: SearchListItem) => item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
+
 /**
  * The flat-expense Search list (Slice S5, callstack-internal/expensify-issues#2547).
  *
@@ -155,109 +157,80 @@ function ExpenseFlatSearchView({
     const [ownerBillingGracePeriodEnd] = useOnyx(ONYXKEYS.NVP_PRIVATE_OWNER_BILLING_GRACE_PERIOD_END);
     const undeleteTransactions = useUndeleteTransactions();
 
-    const handleUndelete = useCallback((transaction: Transaction) => undeleteTransactions([transaction]), [undeleteTransactions]);
+    const handleUndelete = (transaction: Transaction) => undeleteTransactions([transaction]);
 
     // Flat lists have no group children to skip, so visibility is computed straight off the rendered rows.
-    const isItemVisible = useCallback((item: SearchListItem) => item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE || isOffline, [isOffline]);
-    const firstVisibleIndex = useMemo(() => data.findIndex(isItemVisible), [data, isItemVisible]);
-    const lastVisibleIndex = useMemo(() => data.findLastIndex(isItemVisible), [data, isItemVisible]);
+    const isItemVisible = (item: SearchListItem) => !isRowDeleted(item) || isOffline;
+    const firstVisibleIndex = data.findIndex(isItemVisible);
+    const lastVisibleIndex = data.findLastIndex(isItemVisible);
 
     // Flat-expense selection counts: no empty groups, no group flattening — a single pass over the rows.
-    const selectedItemsLength = useMemo(
-        () => data.reduce((acc, item) => acc + (item?.keyForList && selectedTransactions[item.keyForList]?.isSelected ? 1 : 0), 0),
-        [data, selectedTransactions],
-    );
-    const totalItems = useMemo(() => data.filter((item) => !('pendingAction' in item) || item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE).length, [data]);
+    const selectedItemsLength = data.reduce((acc, item) => acc + (item.keyForList && selectedTransactions[item.keyForList]?.isSelected ? 1 : 0), 0);
+    const totalItems = data.filter((item) => !isRowDeleted(item)).length;
 
     const {onLongPressRow, modal} = useRowLongPressMenu({shouldPreventLongPressRow: false, isSmallScreenWidth, isMobileSelectionModeEnabled});
 
     // In mobile selection mode a row tap toggles selection. This must live inside the providers (not in the
     // router) because the `toggle` it reads is the default no-op outside SearchWriteActionsProvider; here it
     // resolves to the real action.
-    const handleSelectRow = useCallback(
-        (item: SearchListItem, transactionPreviewData?: TransactionPreviewData, event?: ModifiedMouseEvent) => {
-            if (isMobileSelectionModeEnabled) {
-                if (item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-                    return;
-                }
-                toggle(item);
+    const handleSelectRow = (item: SearchListItem, transactionPreviewData?: TransactionPreviewData, event?: ModifiedMouseEvent) => {
+        if (isMobileSelectionModeEnabled) {
+            if (item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
                 return;
             }
-            onSelectRow(item, transactionPreviewData, event);
-        },
-        [isMobileSelectionModeEnabled, toggle, onSelectRow],
-    );
+            toggle(item);
+            return;
+        }
+        onSelectRow(item, transactionPreviewData, event);
+    };
 
-    const scrollToListIndex = useCallback(
-        (index: number, animated = true) => {
-            const item = data.at(index);
-            if (!listRef.current || !item || index === -1) {
-                return;
-            }
-            listRef.current.scrollToIndex({index, animated, viewOffset: -variables.contentHeaderHeight});
-        },
-        [data],
-    );
+    const scrollToListIndex = (index: number, animated = true) => {
+        const item = data.at(index);
+        if (!listRef.current || !item || index === -1) {
+            return;
+        }
+        listRef.current.scrollToIndex({index, animated, viewOffset: -variables.contentHeaderHeight});
+    };
 
     useScrollRestoration(listRef);
 
     // Flat data maps 1:1 to the rendered list, so highlight-scroll-to-index is the same as scroll-to-data-index.
     useImperativeHandle(ref, () => ({scrollToIndex: scrollToListIndex}), [scrollToListIndex]);
 
-    const renderItem = useCallback(
-        (item: SearchListItem, index: number, isItemFocused: boolean, onFocus?: (event: NativeSyntheticEvent<ExtendedTargetedEvent>) => void) => {
-            const isDisabled = item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
-            // Flat view always animates row exits, so the only gate is excluding the last row.
-            const shouldApplyAnimation = index < data.length - 1;
+    const renderItem = (item: SearchListItem, index: number, isItemFocused: boolean, onFocus?: (event: NativeSyntheticEvent<ExtendedTargetedEvent>) => void) => {
+        const isDisabled = isRowDeleted(item);
+        // Flat view always animates row exits, so the only gate is excluding the last row.
+        const shouldApplyAnimation = index < data.length - 1;
 
-            return (
-                <AnimatedExitRow
-                    shouldApplyAnimation={shouldApplyAnimation}
-                    hasItemsBeingRemoved={hasItemsBeingRemoved}
-                >
-                    <TransactionListItem
-                        showTooltip
-                        isFocused={isItemFocused}
-                        onSelectRow={handleSelectRow}
-                        onLongPressRow={onLongPressRow}
-                        onSelectionButtonPress={toggle}
-                        canSelectMultiple={canSelectMultiple}
-                        item={item}
-                        columns={columns}
-                        isDisabled={isDisabled}
-                        lastPaymentMethod={lastPaymentMethod}
-                        personalPolicyID={personalPolicyID}
-                        userBillingGracePeriodEnds={userBillingGracePeriodEnds}
-                        ownerBillingGracePeriodEnd={ownerBillingGracePeriodEnd}
-                        nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
-                        onFocus={onFocus}
-                        onUndelete={handleUndelete}
-                        keyForList={item.keyForList}
-                        isFirstItem={index === firstVisibleIndex}
-                        isLastItem={index === lastVisibleIndex && !ListFooterComponent}
-                    />
-                </AnimatedExitRow>
-            );
-        },
-        [
-            data.length,
-            hasItemsBeingRemoved,
-            handleSelectRow,
-            onLongPressRow,
-            toggle,
-            canSelectMultiple,
-            columns,
-            lastPaymentMethod,
-            personalPolicyID,
-            userBillingGracePeriodEnds,
-            ownerBillingGracePeriodEnd,
-            nonPersonalAndWorkspaceCards,
-            handleUndelete,
-            firstVisibleIndex,
-            lastVisibleIndex,
-            ListFooterComponent,
-        ],
-    );
+        return (
+            <AnimatedExitRow
+                shouldApplyAnimation={shouldApplyAnimation}
+                hasItemsBeingRemoved={hasItemsBeingRemoved}
+            >
+                <TransactionListItem
+                    showTooltip
+                    isFocused={isItemFocused}
+                    onSelectRow={handleSelectRow}
+                    onLongPressRow={onLongPressRow}
+                    onSelectionButtonPress={toggle}
+                    canSelectMultiple={canSelectMultiple}
+                    item={item}
+                    columns={columns}
+                    isDisabled={isDisabled}
+                    lastPaymentMethod={lastPaymentMethod}
+                    personalPolicyID={personalPolicyID}
+                    userBillingGracePeriodEnds={userBillingGracePeriodEnds}
+                    ownerBillingGracePeriodEnd={ownerBillingGracePeriodEnd}
+                    nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                    onFocus={onFocus}
+                    onUndelete={handleUndelete}
+                    keyForList={item.keyForList}
+                    isFirstItem={index === firstVisibleIndex}
+                    isLastItem={index === lastVisibleIndex && !ListFooterComponent}
+                />
+            </AnimatedExitRow>
+        );
+    };
 
     const isSelectAllChecked = selectedItemsLength > 0 && selectedItemsLength === totalItems && hasLoadedAllTransactions;
     const selectAllButtonVisible = canSelectMultiple && !searchTableHeader;

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -5,10 +5,10 @@ import type {ForwardedRef} from 'react';
 import {View} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import type {NativeScrollEvent, NativeSyntheticEvent, ScrollView as RNScrollView, StyleProp, ViewStyle} from 'react-native';
-import Animated, {Easing, FadeOutUp, LinearTransition} from 'react-native-reanimated';
 import MenuItem from '@components/MenuItem';
 import Modal from '@components/Modal';
 import ScrollView from '@components/ScrollView';
+import AnimatedExitRow from '@components/Search/primitives/AnimatedExitRow';
 import useScrollRestoration from '@components/Search/primitives/useScrollRestoration';
 import {useSearchRowSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
 import type {SearchColumnType, SearchGroupBy, SearchQueryJSON} from '@components/Search/types';
@@ -60,8 +60,6 @@ import type {
 } from './ListItem/types';
 import {isGroupChildrenContainerItem, isGroupHeaderItem} from './ListItem/types';
 import SearchSelectAllMenu from './SearchSelectAllMenu';
-
-const easing = Easing.bezier(0.76, 0.0, 0.24, 1.0);
 
 // Keep a ref to the horizontal scroll offset so we can restore it if users change the search query
 let savedHorizontalScrollOffset = 0;
@@ -600,11 +598,9 @@ function SearchList({
             const newTransactionID = item.keyForList ? newTransactionIDByItemKey.get(item.keyForList) : undefined;
 
             return (
-                <Animated.View
-                    exiting={shouldApplyAnimation ? FadeOutUp.duration(CONST.SEARCH.EXITING_ANIMATION_DURATION).easing(easing) : undefined}
-                    entering={undefined}
-                    style={styles.overflowHidden}
-                    layout={shouldApplyAnimation && hasItemsBeingRemoved ? LinearTransition.easing(easing).duration(CONST.SEARCH.EXITING_ANIMATION_DURATION) : undefined}
+                <AnimatedExitRow
+                    shouldApplyAnimation={!!shouldApplyAnimation}
+                    hasItemsBeingRemoved={!!hasItemsBeingRemoved}
                 >
                     <ListItem
                         showTooltip
@@ -630,7 +626,7 @@ function SearchList({
                         isFirstItem={index === firstVisibleIndex}
                         isLastItem={index === lastVisibleIndex && !ListFooterComponent}
                     />
-                </Animated.View>
+                </AnimatedExitRow>
             );
         },
         [
@@ -639,7 +635,6 @@ function SearchList({
             newTransactionIDByItemKey,
             shouldAnimate,
             listData.length,
-            styles.overflowHidden,
             hasItemsBeingRemoved,
             ListItem,
             handleSelectRow,

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -1,21 +1,17 @@
-import {useRoute} from '@react-navigation/native';
 import type {FlashListProps, FlashListRef, ViewToken} from '@shopify/flash-list';
 import React, {useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react';
 import type {ForwardedRef} from 'react';
 import {View} from 'react-native';
 import type {NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
-import MenuItem from '@components/MenuItem';
-import Modal from '@components/Modal';
 import AnimatedExitRow from '@components/Search/primitives/AnimatedExitRow';
 import HorizontalTableScroll from '@components/Search/primitives/HorizontalTableScroll';
+import useRowLongPressMenu from '@components/Search/primitives/useRowLongPressMenu';
 import useScrollRestoration from '@components/Search/primitives/useScrollRestoration';
 import {useSearchRowSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
 import type {SearchColumnType, SearchGroupBy, SearchQueryJSON} from '@components/Search/types';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
 import {useEditingCellState} from '@components/TransactionItemRow/EditableCell';
 import useKeyboardState from '@hooks/useKeyboardState';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
-import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePrevious from '@hooks/usePrevious';
@@ -23,11 +19,9 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSafeAreaPaddings from '@hooks/useSafeAreaPaddings';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useUndeleteTransactions from '@hooks/useUndeleteTransactions';
-import {turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import DateUtils from '@libs/DateUtils';
 import getPlatform from '@libs/getPlatform';
 import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
-import navigationRef from '@libs/Navigation/navigationRef';
 import {splitGroupsIntoPairs} from '@libs/SearchUIUtils';
 import variables from '@styles/variables';
 import type {TransactionPreviewData} from '@userActions/Search';
@@ -205,7 +199,6 @@ function SearchList({
     ref,
 }: SearchListProps) {
     const styles = useThemeStyles();
-    const expensifyIcons = useMemoizedLazyExpensifyIcons(['CheckSquare']);
     const {toggle, toggleAll} = useSearchRowSelectionActions();
     const {selectedTransactions} = useSearchSelectionContext();
 
@@ -265,7 +258,6 @@ function SearchList({
         return selectableTransactions.length;
     }, [data, flattenedItems, emptyReports]);
 
-    const {translate} = useLocalize();
     const {isOffline} = useNetwork();
     const listRef = useRef<FlashListRef<SearchListItem>>(null);
     const {isKeyboardShown} = useKeyboardState();
@@ -275,9 +267,6 @@ function SearchList({
     // See https://github.com/Expensify/App/issues/48675 for more details
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth, isLargeScreenWidth} = useResponsiveLayout();
-
-    const [isModalVisible, setIsModalVisible] = useState(false);
-    const [longPressedItem, setLongPressedItem] = useState<SearchListItem>();
 
     const hasItemsBeingRemoved = prevDataLength && prevDataLength > data.length;
     const {isEditingCell, wasRecentlyEditingCell} = useEditingCellState();
@@ -374,10 +363,6 @@ function SearchList({
 
     const handleUndelete = (transaction: Transaction) => undeleteTransactions([transaction]);
 
-    const route = useRoute();
-
-    const [longPressedItemTransactions, setLongPressedItemTransactions] = useState<TransactionListItemType[]>();
-
     const newTransactionIDByItemKey = (() => {
         if (newTransactions.length === 0) {
             return CONST.EMPTY_MAP;
@@ -394,45 +379,7 @@ function SearchList({
         return mappedTransactionIDs;
     })();
 
-    const handleLongPressRowInMobileSelectionMode = (item: SearchListItem, itemTransactions?: TransactionListItemType[]) => {
-        const currentRoute = navigationRef.current?.getCurrentRoute();
-        if (currentRoute && route.key !== currentRoute.key) {
-            return;
-        }
-
-        if (shouldPreventLongPressRow || !isSmallScreenWidth || item?.isDisabled || item?.isDisabledCheckbox || item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-            return;
-        }
-
-        toggle(item, itemTransactions);
-    };
-
-    const handleLongPressRow = useCallback(
-        (item: SearchListItem, itemTransactions?: TransactionListItemType[]) => {
-            const currentRoute = navigationRef.current?.getCurrentRoute();
-            if (currentRoute && route.key !== currentRoute.key) {
-                return;
-            }
-
-            if (shouldPreventLongPressRow || !isSmallScreenWidth || item?.isDisabled || item?.isDisabledCheckbox || item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-                return;
-            }
-
-            setLongPressedItem(item);
-            setLongPressedItemTransactions(itemTransactions);
-            setIsModalVisible(true);
-        },
-        [route.key, shouldPreventLongPressRow, isSmallScreenWidth],
-    );
-
-    const turnOnSelectionMode = useCallback(() => {
-        turnOnMobileSelectionMode();
-        setIsModalVisible(false);
-
-        if (longPressedItem) {
-            toggle(longPressedItem, longPressedItemTransactions);
-        }
-    }, [longPressedItem, toggle, longPressedItemTransactions]);
+    const {onLongPressRow, modal} = useRowLongPressMenu({shouldPreventLongPressRow, isSmallScreenWidth, isMobileSelectionModeEnabled});
 
     // In mobile selection mode a row tap toggles selection. This must live here (not in <Search>) because
     // <Search> renders SearchWriteActionsProvider as its child, so the `toggle` it reads is the default no-op;
@@ -526,7 +473,7 @@ function SearchList({
                         onToggle={() => onToggleGroup(originalKey)}
                         onSelectRow={handleSelectRow}
                         onCheckboxPress={toggle}
-                        onLongPressRow={isMobileSelectionModeEnabled ? handleLongPressRowInMobileSelectionMode : handleLongPressRow}
+                        onLongPressRow={onLongPressRow}
                         onFocus={onFocus}
                         isFocused={isItemFocused}
                         isFirstItem={index === firstVisibleIndex}
@@ -556,7 +503,7 @@ function SearchList({
                         canSelectMultiple={canSelectMultiple}
                         onSelectRow={handleSelectRow}
                         onCheckboxPress={toggle}
-                        onLongPressRow={isMobileSelectionModeEnabled ? handleLongPressRowInMobileSelectionMode : handleLongPressRow}
+                        onLongPressRow={onLongPressRow}
                         nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
                         onUndelete={handleUndelete}
                         isLastItem={index === lastVisibleIndex && !ListFooterComponent}
@@ -583,7 +530,7 @@ function SearchList({
                         showTooltip
                         isFocused={isItemFocused}
                         onSelectRow={handleSelectRow}
-                        onLongPressRow={isMobileSelectionModeEnabled ? handleLongPressRowInMobileSelectionMode : handleLongPressRow}
+                        onLongPressRow={onLongPressRow}
                         onSelectionButtonPress={toggle}
                         canSelectMultiple={canSelectMultiple}
                         item={item}
@@ -615,9 +562,7 @@ function SearchList({
             hasItemsBeingRemoved,
             ListItem,
             handleSelectRow,
-            handleLongPressRow,
-            handleLongPressRowInMobileSelectionMode,
-            isMobileSelectionModeEnabled,
+            onLongPressRow,
             toggle,
             canSelectMultiple,
             columns,
@@ -693,19 +638,7 @@ function SearchList({
                 disabledIndexes={shouldSplitGroups ? childrenContainerIndices : undefined}
                 overrideItemLayout={shouldSplitGroups ? overrideItemLayout : undefined}
             />
-            <Modal
-                isVisible={isModalVisible}
-                type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
-                onClose={() => setIsModalVisible(false)}
-                shouldPreventScrollOnFocus
-            >
-                <MenuItem
-                    title={translate('common.select')}
-                    icon={expensifyIcons.CheckSquare}
-                    onPress={turnOnSelectionMode}
-                    sentryLabel={CONST.SENTRY_LABEL.SEARCH.SELECTION_MODE_MENU_ITEM}
-                />
-            </Modal>
+            {modal}
         </View>
     );
 

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -1,6 +1,6 @@
-import {useFocusEffect, useRoute} from '@react-navigation/native';
+import {useRoute} from '@react-navigation/native';
 import type {FlashListProps, FlashListRef, ViewToken} from '@shopify/flash-list';
-import React, {useCallback, useContext, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {ForwardedRef} from 'react';
 import {View} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
@@ -8,8 +8,8 @@ import type {NativeScrollEvent, NativeSyntheticEvent, ScrollView as RNScrollView
 import Animated, {Easing, FadeOutUp, LinearTransition} from 'react-native-reanimated';
 import MenuItem from '@components/MenuItem';
 import Modal from '@components/Modal';
-import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
 import ScrollView from '@components/ScrollView';
+import useScrollRestoration from '@components/Search/primitives/useScrollRestoration';
 import {useSearchRowSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
 import type {SearchColumnType, SearchGroupBy, SearchQueryJSON} from '@components/Search/types';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
@@ -382,7 +382,6 @@ function SearchList({
     const handleUndelete = (transaction: Transaction) => undeleteTransactions([transaction]);
 
     const route = useRoute();
-    const {getScrollOffset} = useContext(ScrollOffsetContext);
 
     const [longPressedItemTransactions, setLongPressedItemTransactions] = useState<TransactionListItemType[]>();
 
@@ -527,18 +526,7 @@ function SearchList({
         [data, listData, shouldSplitGroups, isEditingCell, wasRecentlyEditingCell],
     );
 
-    useFocusEffect(
-        useCallback(() => {
-            const offset = getScrollOffset(route);
-            requestAnimationFrame(() => {
-                if (!offset || !listRef.current) {
-                    return;
-                }
-
-                listRef.current.scrollToOffset({offset, animated: false});
-            });
-        }, [getScrollOffset, route]),
-    );
+    useScrollRestoration(listRef);
 
     useImperativeHandle(ref, () => ({scrollToIndex: scrollToDataIndex}), [scrollToDataIndex]);
 

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -1,14 +1,13 @@
 import {useRoute} from '@react-navigation/native';
 import type {FlashListProps, FlashListRef, ViewToken} from '@shopify/flash-list';
-import React, {useCallback, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react';
 import type {ForwardedRef} from 'react';
 import {View} from 'react-native';
-// eslint-disable-next-line no-restricted-imports
-import type {NativeScrollEvent, NativeSyntheticEvent, ScrollView as RNScrollView, StyleProp, ViewStyle} from 'react-native';
+import type {NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
 import MenuItem from '@components/MenuItem';
 import Modal from '@components/Modal';
-import ScrollView from '@components/ScrollView';
 import AnimatedExitRow from '@components/Search/primitives/AnimatedExitRow';
+import HorizontalTableScroll from '@components/Search/primitives/HorizontalTableScroll';
 import useScrollRestoration from '@components/Search/primitives/useScrollRestoration';
 import {useSearchRowSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
 import type {SearchColumnType, SearchGroupBy, SearchQueryJSON} from '@components/Search/types';
@@ -24,13 +23,12 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSafeAreaPaddings from '@hooks/useSafeAreaPaddings';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useUndeleteTransactions from '@hooks/useUndeleteTransactions';
-import useWindowDimensions from '@hooks/useWindowDimensions';
 import {turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import DateUtils from '@libs/DateUtils';
 import getPlatform from '@libs/getPlatform';
 import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
 import navigationRef from '@libs/Navigation/navigationRef';
-import {getTableMinWidth, splitGroupsIntoPairs} from '@libs/SearchUIUtils';
+import {splitGroupsIntoPairs} from '@libs/SearchUIUtils';
 import variables from '@styles/variables';
 import type {TransactionPreviewData} from '@userActions/Search';
 import CONST from '@src/CONST';
@@ -60,9 +58,6 @@ import type {
 } from './ListItem/types';
 import {isGroupChildrenContainerItem, isGroupHeaderItem} from './ListItem/types';
 import SearchSelectAllMenu from './SearchSelectAllMenu';
-
-// Keep a ref to the horizontal scroll offset so we can restore it if users change the search query
-let savedHorizontalScrollOffset = 0;
 
 type SearchListItem = TransactionListItemType | TransactionGroupListItemType | ReportActionListItemType | TaskListItemType;
 type SearchListItemComponentType = typeof TransactionListItem | typeof ChatListItem | typeof TransactionGroupListItem | typeof TaskListItem | typeof ExpenseReportListItem;
@@ -399,24 +394,6 @@ function SearchList({
         return mappedTransactionIDs;
     })();
 
-    const {windowWidth} = useWindowDimensions();
-    const minTableWidth = getTableMinWidth(columns, queryJSON.type, isActionColumnWide);
-    const shouldScrollHorizontally = !!SearchTableHeader && minTableWidth > windowWidth;
-
-    const horizontalScrollViewRef = useRef<RNScrollView>(null);
-
-    const handleHorizontalScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-        savedHorizontalScrollOffset = event.nativeEvent.contentOffset.x;
-    }, []);
-
-    // Restore horizontal scroll position synchronously before paint using useLayoutEffect to avoid a visible shift on the table
-    useLayoutEffect(() => {
-        if (!shouldScrollHorizontally || savedHorizontalScrollOffset <= 0) {
-            return;
-        }
-        horizontalScrollViewRef.current?.scrollTo({x: savedHorizontalScrollOffset, animated: false});
-    }, [data, shouldScrollHorizontally]);
-
     const handleLongPressRowInMobileSelectionMode = (item: SearchListItem, itemTransactions?: TransactionListItemType[]) => {
         const currentRoute = navigationRef.current?.getCurrentRoute();
         if (currentRoute && route.key !== currentRoute.key) {
@@ -732,24 +709,17 @@ function SearchList({
         </View>
     );
 
-    if (shouldScrollHorizontally) {
-        return (
-            <ScrollView
-                ref={horizontalScrollViewRef}
-                horizontal
-                showsHorizontalScrollIndicator
-                style={styles.flex1}
-                contentContainerStyle={{width: minTableWidth}}
-                contentOffset={{x: savedHorizontalScrollOffset, y: 0}}
-                onScroll={handleHorizontalScroll}
-                scrollEventThrottle={CONST.TIMING.MIN_SMOOTH_SCROLL_EVENT_THROTTLE}
-            >
-                {content}
-            </ScrollView>
-        );
-    }
-
-    return content;
+    return (
+        <HorizontalTableScroll
+            columns={columns}
+            type={queryJSON.type}
+            isActionColumnWide={isActionColumnWide}
+            isHeaderVisible={!!SearchTableHeader}
+            dataKey={data}
+        >
+            {content}
+        </HorizontalTableScroll>
+    );
 }
 
 export default SearchList;

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -5,6 +5,7 @@ import {View} from 'react-native';
 import type {NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
 import AnimatedExitRow from '@components/Search/primitives/AnimatedExitRow';
 import HorizontalTableScroll from '@components/Search/primitives/HorizontalTableScroll';
+import SelectionTopBar from '@components/Search/primitives/SelectionTopBar';
 import useRowLongPressMenu from '@components/Search/primitives/useRowLongPressMenu';
 import useScrollRestoration from '@components/Search/primitives/useScrollRestoration';
 import {useSearchRowSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
@@ -51,7 +52,6 @@ import type {
     TransactionYearGroupListItemType,
 } from './ListItem/types';
 import {isGroupChildrenContainerItem, isGroupHeaderItem} from './ListItem/types';
-import SearchSelectAllMenu from './SearchSelectAllMenu';
 
 type SearchListItem = TransactionListItemType | TransactionGroupListItemType | ReportActionListItemType | TaskListItemType;
 type SearchListItemComponentType = typeof TransactionListItem | typeof ChatListItem | typeof TransactionGroupListItem | typeof TaskListItem | typeof ExpenseReportListItem;
@@ -591,26 +591,18 @@ function SearchList({
     const content = (
         <View style={[styles.flex1, !isKeyboardShown && safeAreaPaddingBottomStyle, containerStyle]}>
             {tableHeaderVisible && (
-                <View
-                    style={[
-                        styles.searchListHeaderContainerStyle,
-                        isLargeScreenWidth ? [styles.listTableHeaderCompact, styles.searchListHeaderTableStyle, styles.mh5] : styles.listTableHeader,
-                        isLargeScreenWidth && shouldSplitGroups && styles.searchListHeaderTableStickyOverlap,
-                    ]}
-                >
-                    {canSelectMultiple && (
-                        <SearchSelectAllMenu
-                            isSelectAllChecked={isSelectAllChecked}
-                            isIndeterminate={selectedItemsLength > 0 && (selectedItemsLength !== totalItems || !hasLoadedAllTransactions)}
-                            selectedItemsLength={selectedItemsLength}
-                            totalItems={totalItems}
-                            shouldShowTextButton={selectAllButtonVisible}
-                            onAllCheckboxPress={toggleAll}
-                        />
-                    )}
-
-                    {SearchTableHeader}
-                </View>
+                <SelectionTopBar
+                    isLargeScreenWidth={isLargeScreenWidth}
+                    shouldSplitGroups={shouldSplitGroups}
+                    canSelectMultiple={canSelectMultiple}
+                    isSelectAllChecked={isSelectAllChecked}
+                    selectedItemsLength={selectedItemsLength}
+                    totalItems={totalItems}
+                    hasLoadedAllTransactions={hasLoadedAllTransactions}
+                    selectAllButtonVisible={selectAllButtonVisible}
+                    onAllCheckboxPress={toggleAll}
+                    SearchTableHeader={SearchTableHeader}
+                />
             )}
             <BaseSearchList
                 data={listData}

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -81,6 +81,7 @@ import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import type SearchResults from '@src/types/onyx/SearchResults';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
+import ExpenseFlatSearchView from './ExpenseFlatSearchView';
 import useSearchSnapshot from './hooks/useSearchSnapshot';
 import SearchChartView from './SearchChartView';
 import SearchChartWrapper from './SearchChartWrapper';
@@ -1037,6 +1038,12 @@ function Search({
             />
         ) : undefined;
 
+    // Flat-expense (a plain transaction list) renders through the dedicated ExpenseFlatSearchView (S5,
+    // callstack-internal/expensify-issues#2547), which composes the S5 primitives directly over
+    // BaseSearchList. Every other variant (chat, task, report, grouped) keeps the legacy SearchList shell
+    // until S6. The snapshot, lifecycle and selection providers stay here so the data layer runs once.
+    const isFlatExpenseView = type === CONST.SEARCH.DATA_TYPES.EXPENSE && !validGroupBy;
+
     return (
         <SearchScopeProvider>
             <SearchWriteActionsProvider
@@ -1051,31 +1058,56 @@ function Search({
                 isSearchResultsEmpty={isSearchResultsEmpty}
             >
                 <Animated.View style={[styles.flex1, animatedStyle]}>
-                    <SearchList
-                        ref={searchListRef}
-                        data={stableSortedData}
-                        ListItem={ListItem}
-                        onSelectRow={onSelectRow}
-                        canSelectMultiple={canSelectMultiple}
-                        shouldPreventLongPressRow={isChat || isTask}
-                        SearchTableHeader={searchTableHeader}
-                        contentContainerStyle={[styles.pb3, contentContainerStyle]}
-                        containerStyle={[styles.pv0, !tableHeaderVisible && !isSmallScreenWidth && styles.pt3]}
-                        onScroll={onSearchListScroll}
-                        onEndReachedThreshold={0.75}
-                        onEndReached={fetchMoreResults}
-                        ListFooterComponent={listFooterComponent}
-                        queryJSON={queryJSON}
-                        columns={columnsToShow}
-                        onLayout={onLayout}
-                        isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                        shouldAnimate={type === CONST.SEARCH.DATA_TYPES.EXPENSE}
-                        newTransactions={newTransactions}
-                        hasLoadedAllTransactions={hasLoadedAllTransactions}
-                        isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
-                        nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
-                        isActionColumnWide={isTask || hasDeletedTransaction}
-                    />
+                    {isFlatExpenseView ? (
+                        <ExpenseFlatSearchView
+                            ref={searchListRef}
+                            queryJSON={queryJSON}
+                            data={stableSortedData}
+                            columns={columnsToShow}
+                            onSelectRow={onSelectRow}
+                            canSelectMultiple={canSelectMultiple}
+                            SearchTableHeader={searchTableHeader}
+                            tableHeaderVisible={tableHeaderVisible}
+                            contentContainerStyle={[styles.pb3, contentContainerStyle]}
+                            containerStyle={[styles.pv0, !tableHeaderVisible && !isSmallScreenWidth && styles.pt3]}
+                            onScroll={onSearchListScroll}
+                            onEndReached={fetchMoreResults}
+                            ListFooterComponent={listFooterComponent}
+                            onLayout={onLayout}
+                            isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                            newTransactions={newTransactions}
+                            hasLoadedAllTransactions={hasLoadedAllTransactions}
+                            isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
+                            nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                            isActionColumnWide={isTask || hasDeletedTransaction}
+                        />
+                    ) : (
+                        <SearchList
+                            ref={searchListRef}
+                            data={stableSortedData}
+                            ListItem={ListItem}
+                            onSelectRow={onSelectRow}
+                            canSelectMultiple={canSelectMultiple}
+                            shouldPreventLongPressRow={isChat || isTask}
+                            SearchTableHeader={searchTableHeader}
+                            contentContainerStyle={[styles.pb3, contentContainerStyle]}
+                            containerStyle={[styles.pv0, !tableHeaderVisible && !isSmallScreenWidth && styles.pt3]}
+                            onScroll={onSearchListScroll}
+                            onEndReachedThreshold={0.75}
+                            onEndReached={fetchMoreResults}
+                            ListFooterComponent={listFooterComponent}
+                            queryJSON={queryJSON}
+                            columns={columnsToShow}
+                            onLayout={onLayout}
+                            isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                            shouldAnimate={type === CONST.SEARCH.DATA_TYPES.EXPENSE}
+                            newTransactions={newTransactions}
+                            hasLoadedAllTransactions={hasLoadedAllTransactions}
+                            isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
+                            nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                            isActionColumnWide={isTask || hasDeletedTransaction}
+                        />
+                    )}
                 </Animated.View>
             </SearchWriteActionsProvider>
         </SearchScopeProvider>

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1038,10 +1038,10 @@ function Search({
             />
         ) : undefined;
 
-    // Flat-expense (a plain transaction list) renders through the dedicated ExpenseFlatSearchView (S5,
-    // callstack-internal/expensify-issues#2547), which composes the S5 primitives directly over
-    // BaseSearchList. Every other variant (chat, task, report, grouped) keeps the legacy SearchList shell
-    // until S6. The snapshot, lifecycle and selection providers stay here so the data layer runs once.
+    // Flat-expense (a plain transaction list) renders through the dedicated ExpenseFlatSearchView, which
+    // composes the reusable Search list primitives directly over BaseSearchList. Every other variant
+    // (chat, task, report, grouped) keeps the legacy SearchList shell. The snapshot, lifecycle and
+    // selection providers stay here so the data layer runs once.
     const isFlatExpenseView = type === CONST.SEARCH.DATA_TYPES.EXPENSE && !validGroupBy;
 
     return (

--- a/src/components/Search/primitives/AnimatedExitRow.tsx
+++ b/src/components/Search/primitives/AnimatedExitRow.tsx
@@ -18,9 +18,9 @@ type AnimatedExitRowProps = {
 
 /**
  * Wraps a Search row in the FadeOutUp exit + LinearTransition layout animation that plays when an
- * expense is deleted from the list. Extracted from SearchList so ExpenseFlatSearchView can reuse it
- * without the god-component (Slice S5). Kept byte-identical to the original wrapper because FlashList
- * v2 + reanimated exit animations are timing-sensitive.
+ * expense is deleted from the list. Extracted from SearchList so ExpenseFlatSearchView can reuse it.
+ * Kept byte-identical to the original wrapper because FlashList v2 + reanimated exit animations are
+ * timing-sensitive.
  */
 function AnimatedExitRow({shouldApplyAnimation, hasItemsBeingRemoved, children}: AnimatedExitRowProps) {
     const styles = useThemeStyles();

--- a/src/components/Search/primitives/AnimatedExitRow.tsx
+++ b/src/components/Search/primitives/AnimatedExitRow.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Animated, {Easing, FadeOutUp, LinearTransition} from 'react-native-reanimated';
+import useThemeStyles from '@hooks/useThemeStyles';
+import CONST from '@src/CONST';
+
+const easing = Easing.bezier(0.76, 0.0, 0.24, 1.0);
+
+type AnimatedExitRowProps = {
+    /** Whether the FadeOutUp exit animation applies to this row (the caller excludes the last row). */
+    shouldApplyAnimation: boolean;
+
+    /** Whether the list shrank this render, so the remaining rows slide up via LinearTransition. */
+    hasItemsBeingRemoved: boolean;
+
+    /** The row content to wrap. */
+    children: React.ReactNode;
+};
+
+/**
+ * Wraps a Search row in the FadeOutUp exit + LinearTransition layout animation that plays when an
+ * expense is deleted from the list. Extracted from SearchList so ExpenseFlatSearchView can reuse it
+ * without the god-component (Slice S5). Kept byte-identical to the original wrapper because FlashList
+ * v2 + reanimated exit animations are timing-sensitive.
+ */
+function AnimatedExitRow({shouldApplyAnimation, hasItemsBeingRemoved, children}: AnimatedExitRowProps) {
+    const styles = useThemeStyles();
+
+    return (
+        <Animated.View
+            exiting={shouldApplyAnimation ? FadeOutUp.duration(CONST.SEARCH.EXITING_ANIMATION_DURATION).easing(easing) : undefined}
+            entering={undefined}
+            style={styles.overflowHidden}
+            layout={shouldApplyAnimation && hasItemsBeingRemoved ? LinearTransition.easing(easing).duration(CONST.SEARCH.EXITING_ANIMATION_DURATION) : undefined}
+        >
+            {children}
+        </Animated.View>
+    );
+}
+
+export default AnimatedExitRow;

--- a/src/components/Search/primitives/HorizontalTableScroll.tsx
+++ b/src/components/Search/primitives/HorizontalTableScroll.tsx
@@ -1,0 +1,79 @@
+import React, {useCallback, useLayoutEffect, useRef} from 'react';
+// eslint-disable-next-line no-restricted-imports
+import type {NativeScrollEvent, NativeSyntheticEvent, ScrollView as RNScrollView} from 'react-native';
+import ScrollView from '@components/ScrollView';
+import type {SearchColumnType, SearchQueryJSON} from '@components/Search/types';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useWindowDimensions from '@hooks/useWindowDimensions';
+import {getTableMinWidth} from '@libs/SearchUIUtils';
+import CONST from '@src/CONST';
+
+// Keep a ref to the horizontal scroll offset so we can restore it if users change the search query
+let savedHorizontalScrollOffset = 0;
+
+type HorizontalTableScrollProps = {
+    /** The table/list content to wrap. */
+    children: React.ReactNode;
+
+    /** Columns to render, drives the minimum table width. */
+    columns: SearchColumnType[];
+
+    /** Search data type, drives the action-column sizing in getTableMinWidth. */
+    type: SearchQueryJSON['type'];
+
+    /** Whether the action column uses its wider variant (e.g. a deleted transaction is present). */
+    isActionColumnWide?: boolean;
+
+    /** Whether a table header is shown. Horizontal scroll only engages when the header is visible. */
+    isHeaderVisible: boolean;
+
+    /** Re-restores the saved horizontal offset whenever this value changes (typically the list data). */
+    dataKey: unknown;
+};
+
+/**
+ * Wraps the Search table in a horizontal ScrollView when it is wider than the viewport, and restores
+ * the saved horizontal offset across query changes (before paint, to avoid a visible shift). Extracted
+ * from SearchList so ExpenseFlatSearchView can reuse it without the god-component (Slice S5).
+ */
+function HorizontalTableScroll({children, columns, type, isActionColumnWide, isHeaderVisible, dataKey}: HorizontalTableScrollProps) {
+    const styles = useThemeStyles();
+    const {windowWidth} = useWindowDimensions();
+    const minTableWidth = getTableMinWidth(columns, type, isActionColumnWide);
+    const shouldScrollHorizontally = isHeaderVisible && minTableWidth > windowWidth;
+
+    const horizontalScrollViewRef = useRef<RNScrollView>(null);
+
+    const handleHorizontalScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+        savedHorizontalScrollOffset = event.nativeEvent.contentOffset.x;
+    }, []);
+
+    // Restore horizontal scroll position synchronously before paint using useLayoutEffect to avoid a visible shift on the table
+    useLayoutEffect(() => {
+        if (!shouldScrollHorizontally || savedHorizontalScrollOffset <= 0) {
+            return;
+        }
+        horizontalScrollViewRef.current?.scrollTo({x: savedHorizontalScrollOffset, animated: false});
+    }, [dataKey, shouldScrollHorizontally]);
+
+    if (!shouldScrollHorizontally) {
+        return children;
+    }
+
+    return (
+        <ScrollView
+            ref={horizontalScrollViewRef}
+            horizontal
+            showsHorizontalScrollIndicator
+            style={styles.flex1}
+            contentContainerStyle={{width: minTableWidth}}
+            contentOffset={{x: savedHorizontalScrollOffset, y: 0}}
+            onScroll={handleHorizontalScroll}
+            scrollEventThrottle={CONST.TIMING.MIN_SMOOTH_SCROLL_EVENT_THROTTLE}
+        >
+            {children}
+        </ScrollView>
+    );
+}
+
+export default HorizontalTableScroll;

--- a/src/components/Search/primitives/HorizontalTableScroll.tsx
+++ b/src/components/Search/primitives/HorizontalTableScroll.tsx
@@ -34,7 +34,7 @@ type HorizontalTableScrollProps = {
 /**
  * Wraps the Search table in a horizontal ScrollView when it is wider than the viewport, and restores
  * the saved horizontal offset across query changes (before paint, to avoid a visible shift). Extracted
- * from SearchList so ExpenseFlatSearchView can reuse it without the god-component (Slice S5).
+ * from SearchList so ExpenseFlatSearchView can reuse it.
  */
 function HorizontalTableScroll({children, columns, type, isActionColumnWide, isHeaderVisible, dataKey}: HorizontalTableScrollProps) {
     const styles = useThemeStyles();

--- a/src/components/Search/primitives/SelectionTopBar.tsx
+++ b/src/components/Search/primitives/SelectionTopBar.tsx
@@ -37,7 +37,7 @@ type SelectionTopBarProps = {
 
 /**
  * The Search list's sticky header bar: an optional select-all control plus the column header.
- * Extracted from SearchList so ExpenseFlatSearchView can reuse it (Slice S5). Purely presentational,
+ * Extracted from SearchList so ExpenseFlatSearchView can reuse it. Purely presentational,
  * the consumer computes the selection counts and passes them in so a checkbox press does not re-render
  * the whole bar subtree through a selection subscription here.
  */

--- a/src/components/Search/primitives/SelectionTopBar.tsx
+++ b/src/components/Search/primitives/SelectionTopBar.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {View} from 'react-native';
+import SearchSelectAllMenu from '@components/Search/SearchList/SearchSelectAllMenu';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+type SelectionTopBarProps = {
+    /** Wide-layout flag, drives the compact header style. */
+    isLargeScreenWidth: boolean;
+
+    /** Whether grouped rows are split into sticky pairs (adds the sticky-overlap style). Always false in the flat view. */
+    shouldSplitGroups: boolean;
+
+    /** Whether the list supports multi-select (renders the select-all menu). */
+    canSelectMultiple: boolean;
+
+    /** Whether every selectable row is selected. */
+    isSelectAllChecked: boolean | undefined;
+
+    /** Count of currently-selected rows. */
+    selectedItemsLength: number;
+
+    /** Count of selectable rows. */
+    totalItems: number;
+
+    /** Whether all transactions are loaded (gates the fully-checked state in grouped views). */
+    hasLoadedAllTransactions: boolean | undefined;
+
+    /** Whether to render the textual select-all button (no column header present). */
+    selectAllButtonVisible: boolean;
+
+    /** Fired when the header checkbox / select-all button is pressed. */
+    onAllCheckboxPress: () => void;
+
+    /** The column header element rendered to the right of the select-all control. */
+    SearchTableHeader?: React.JSX.Element;
+};
+
+/**
+ * The Search list's sticky header bar: an optional select-all control plus the column header.
+ * Extracted from SearchList so ExpenseFlatSearchView can reuse it (Slice S5). Purely presentational,
+ * the consumer computes the selection counts and passes them in so a checkbox press does not re-render
+ * the whole bar subtree through a selection subscription here.
+ */
+function SelectionTopBar({
+    isLargeScreenWidth,
+    shouldSplitGroups,
+    canSelectMultiple,
+    isSelectAllChecked,
+    selectedItemsLength,
+    totalItems,
+    hasLoadedAllTransactions,
+    selectAllButtonVisible,
+    onAllCheckboxPress,
+    SearchTableHeader,
+}: SelectionTopBarProps) {
+    const styles = useThemeStyles();
+
+    return (
+        <View
+            style={[
+                styles.searchListHeaderContainerStyle,
+                isLargeScreenWidth ? [styles.listTableHeaderCompact, styles.searchListHeaderTableStyle, styles.mh5] : styles.listTableHeader,
+                isLargeScreenWidth && shouldSplitGroups && styles.searchListHeaderTableStickyOverlap,
+            ]}
+        >
+            {canSelectMultiple && (
+                <SearchSelectAllMenu
+                    isSelectAllChecked={isSelectAllChecked}
+                    isIndeterminate={selectedItemsLength > 0 && (selectedItemsLength !== totalItems || !hasLoadedAllTransactions)}
+                    selectedItemsLength={selectedItemsLength}
+                    totalItems={totalItems}
+                    shouldShowTextButton={selectAllButtonVisible}
+                    onAllCheckboxPress={onAllCheckboxPress}
+                />
+            )}
+
+            {SearchTableHeader}
+        </View>
+    );
+}
+
+export default SelectionTopBar;

--- a/src/components/Search/primitives/useRowLongPressMenu.tsx
+++ b/src/components/Search/primitives/useRowLongPressMenu.tsx
@@ -34,7 +34,7 @@ type UseRowLongPressMenuResult = {
 /**
  * Owns the row long-press affordance: in mobile selection mode a long press toggles the row, otherwise
  * it opens a bottom-docked menu whose single action turns on selection mode for the pressed row.
- * Extracted from SearchList so ExpenseFlatSearchView can reuse it (Slice S5). Must be used inside
+ * Extracted from SearchList so ExpenseFlatSearchView can reuse it. Must be used inside
  * SearchWriteActionsProvider so `toggle` resolves to the real action rather than the no-op default.
  */
 function useRowLongPressMenu({shouldPreventLongPressRow, isSmallScreenWidth, isMobileSelectionModeEnabled}: UseRowLongPressMenuParams): UseRowLongPressMenuResult {

--- a/src/components/Search/primitives/useRowLongPressMenu.tsx
+++ b/src/components/Search/primitives/useRowLongPressMenu.tsx
@@ -1,0 +1,111 @@
+import {useRoute} from '@react-navigation/native';
+import React, {useCallback, useState} from 'react';
+import MenuItem from '@components/MenuItem';
+import Modal from '@components/Modal';
+import {useSearchRowSelectionActions} from '@components/Search/SearchContext';
+import type {SearchListItem, TransactionListItemType} from '@components/Search/SearchList/ListItem/types';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import {turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
+import navigationRef from '@libs/Navigation/navigationRef';
+import CONST from '@src/CONST';
+
+type UseRowLongPressMenuParams = {
+    /** Whether long press should be suppressed entirely. */
+    shouldPreventLongPressRow?: boolean;
+
+    /** Narrow-layout flag. Long press is a narrow-only affordance. Uses isSmallScreenWidth (not
+     *  shouldUseNarrowLayout) to dodge the issue #48675 race, so the caller passes it through. */
+    isSmallScreenWidth: boolean;
+
+    /** When mobile selection mode is already on, a long press toggles the row directly instead of
+     *  opening the "select" menu. */
+    isMobileSelectionModeEnabled: boolean;
+};
+
+type UseRowLongPressMenuResult = {
+    /** The resolved long-press handler to hand to each row (mobile-mode toggle vs open-menu). */
+    onLongPressRow: (item: SearchListItem, itemTransactions?: TransactionListItemType[]) => void;
+
+    /** The bottom-docked "select" menu element. Render it as a sibling of the list. */
+    modal: React.JSX.Element;
+};
+
+/**
+ * Owns the row long-press affordance: in mobile selection mode a long press toggles the row, otherwise
+ * it opens a bottom-docked menu whose single action turns on selection mode for the pressed row.
+ * Extracted from SearchList so ExpenseFlatSearchView can reuse it (Slice S5). Must be used inside
+ * SearchWriteActionsProvider so `toggle` resolves to the real action rather than the no-op default.
+ */
+function useRowLongPressMenu({shouldPreventLongPressRow, isSmallScreenWidth, isMobileSelectionModeEnabled}: UseRowLongPressMenuParams): UseRowLongPressMenuResult {
+    const {translate} = useLocalize();
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['CheckSquare']);
+    const {toggle} = useSearchRowSelectionActions();
+    const route = useRoute();
+
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const [longPressedItem, setLongPressedItem] = useState<SearchListItem>();
+    const [longPressedItemTransactions, setLongPressedItemTransactions] = useState<TransactionListItemType[]>();
+
+    const handleLongPressRowInMobileSelectionMode = (item: SearchListItem, itemTransactions?: TransactionListItemType[]) => {
+        const currentRoute = navigationRef.current?.getCurrentRoute();
+        if (currentRoute && route.key !== currentRoute.key) {
+            return;
+        }
+
+        if (shouldPreventLongPressRow || !isSmallScreenWidth || item?.isDisabled || item?.isDisabledCheckbox || item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+            return;
+        }
+
+        toggle(item, itemTransactions);
+    };
+
+    const handleLongPressRow = useCallback(
+        (item: SearchListItem, itemTransactions?: TransactionListItemType[]) => {
+            const currentRoute = navigationRef.current?.getCurrentRoute();
+            if (currentRoute && route.key !== currentRoute.key) {
+                return;
+            }
+
+            if (shouldPreventLongPressRow || !isSmallScreenWidth || item?.isDisabled || item?.isDisabledCheckbox || item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+                return;
+            }
+
+            setLongPressedItem(item);
+            setLongPressedItemTransactions(itemTransactions);
+            setIsModalVisible(true);
+        },
+        [route.key, shouldPreventLongPressRow, isSmallScreenWidth],
+    );
+
+    const turnOnSelectionMode = useCallback(() => {
+        turnOnMobileSelectionMode();
+        setIsModalVisible(false);
+
+        if (longPressedItem) {
+            toggle(longPressedItem, longPressedItemTransactions);
+        }
+    }, [longPressedItem, toggle, longPressedItemTransactions]);
+
+    const onLongPressRow = isMobileSelectionModeEnabled ? handleLongPressRowInMobileSelectionMode : handleLongPressRow;
+
+    const modal = (
+        <Modal
+            isVisible={isModalVisible}
+            type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+            onClose={() => setIsModalVisible(false)}
+            shouldPreventScrollOnFocus
+        >
+            <MenuItem
+                title={translate('common.select')}
+                icon={expensifyIcons.CheckSquare}
+                onPress={turnOnSelectionMode}
+                sentryLabel={CONST.SENTRY_LABEL.SEARCH.SELECTION_MODE_MENU_ITEM}
+            />
+        </Modal>
+    );
+
+    return {onLongPressRow, modal};
+}
+
+export default useRowLongPressMenu;

--- a/src/components/Search/primitives/useScrollRestoration.ts
+++ b/src/components/Search/primitives/useScrollRestoration.ts
@@ -9,7 +9,7 @@ import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
  *
  * The offset is saved per route in ScrollOffsetContext by the page wrappers; on focus we read it back
  * and apply it to the FlashList on the next frame, so a back-navigation lands at the prior position
- * instead of the top. Extracted from SearchList so ExpenseFlatSearchView can reuse it (Slice S5).
+ * instead of the top. Extracted from SearchList so ExpenseFlatSearchView can reuse it.
  */
 function useScrollRestoration<TItem>(listRef: RefObject<FlashListRef<TItem> | null>) {
     const route = useRoute();

--- a/src/components/Search/primitives/useScrollRestoration.ts
+++ b/src/components/Search/primitives/useScrollRestoration.ts
@@ -1,0 +1,32 @@
+import {useFocusEffect, useRoute} from '@react-navigation/native';
+import type {FlashListRef} from '@shopify/flash-list';
+import {useCallback, useContext} from 'react';
+import type {RefObject} from 'react';
+import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
+
+/**
+ * Restores the Search list's vertical scroll position when the screen regains focus.
+ *
+ * The offset is saved per route in ScrollOffsetContext by the page wrappers; on focus we read it back
+ * and apply it to the FlashList on the next frame, so a back-navigation lands at the prior position
+ * instead of the top. Extracted from SearchList so ExpenseFlatSearchView can reuse it (Slice S5).
+ */
+function useScrollRestoration<TItem>(listRef: RefObject<FlashListRef<TItem> | null>) {
+    const route = useRoute();
+    const {getScrollOffset} = useContext(ScrollOffsetContext);
+
+    useFocusEffect(
+        useCallback(() => {
+            const offset = getScrollOffset(route);
+            requestAnimationFrame(() => {
+                if (!offset || !listRef.current) {
+                    return;
+                }
+
+                listRef.current.scrollToOffset({offset, animated: false});
+            });
+        }, [getScrollOffset, route, listRef]),
+    );
+}
+
+export default useScrollRestoration;

--- a/tests/unit/Search/ExpenseFlatSearchViewTest.tsx
+++ b/tests/unit/Search/ExpenseFlatSearchViewTest.tsx
@@ -149,7 +149,7 @@ function createMockData(length: number, deletedKeys = new Set<string>()): Search
     }) as unknown as SearchListItem[];
 }
 
-/** Max render count for the view subtree on initial mount with stable props. Also the #3 memo-cleanup benchmark. */
+/** Max render count for the view subtree on initial mount with stable props. Also guards against re-render regressions from the memoization cleanup. */
 const MAX_INITIAL_RENDER_COUNT = 15;
 
 function ThemeProviderWithLight({children}: {children: React.ReactNode}) {

--- a/tests/unit/Search/ExpenseFlatSearchViewTest.tsx
+++ b/tests/unit/Search/ExpenseFlatSearchViewTest.tsx
@@ -1,0 +1,306 @@
+import {act, render, screen} from '@testing-library/react-native';
+import React, {Profiler, useCallback, useMemo} from 'react';
+import Onyx from 'react-native-onyx';
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import ScrollOffsetContextProvider from '@components/ScrollOffsetContextProvider';
+import ExpenseFlatSearchView from '@components/Search/ExpenseFlatSearchView';
+import type {SearchListItem} from '@components/Search/SearchList/ListItem/types';
+import type {SearchColumnType, SearchQueryJSON} from '@components/Search/types';
+import ThemeProvider from '@components/ThemeProvider';
+import ThemeStylesProvider from '@components/ThemeStylesContextProvider';
+import {setHasRadio} from '@libs/NetworkState';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import * as TestHelper from '../../utils/TestHelper';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+import wrapOnyxWithWaitForBatchedUpdates from '../../utils/wrapOnyxWithWaitForBatchedUpdates';
+
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: jest.fn((key: string) => key),
+        numberFormat: jest.fn(),
+    })),
+);
+
+jest.mock('@hooks/useNetwork', () =>
+    jest.fn(() => ({
+        isOffline: false,
+    })),
+);
+
+jest.mock('@hooks/useKeyboardState', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({isKeyboardShown: false, keyboardHeight: 0})),
+}));
+
+jest.mock('@hooks/useResponsiveLayout', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({isSmallScreenWidth: false, isLargeScreenWidth: true, shouldUseNarrowLayout: false})),
+}));
+
+jest.mock('@hooks/useSafeAreaPaddings', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({safeAreaPaddingBottomStyle: {}})),
+}));
+
+jest.mock('@hooks/useWindowDimensions', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({windowWidth: 1200, windowHeight: 800})),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+    useFocusEffect: jest.fn((callback: () => void) => {
+        queueMicrotask(() => callback());
+        return () => {};
+    }),
+    useRoute: jest.fn(() => ({key: 'search-test-route'})),
+    useIsFocused: () => true,
+    createNavigationContainerRef: jest.fn(() => ({
+        getCurrentRoute: jest.fn(),
+        addListener: jest.fn(() => jest.fn()),
+        removeListener: jest.fn(),
+        isReady: jest.fn(() => true),
+        getState: jest.fn(),
+    })),
+}));
+
+jest.mock('@src/components/ConfirmedRoute.tsx');
+
+// Capture each row's tap handler so the mobile-selection-mode toggle can be exercised without the heavy
+// real TransactionListItem.
+const mockRowSelect: Record<string, () => void> = {};
+jest.mock('@components/Search/SearchList/ListItem/TransactionListItem', () => {
+    const ReactLocal = jest.requireActual<typeof React>('react');
+    const {View: RNView} = jest.requireActual<{View: React.ComponentType<{testID?: string}>}>('react-native');
+    return {
+        __esModule: true,
+        default: (props: {item: SearchListItem; onSelectRow: (item: SearchListItem) => void}) => {
+            mockRowSelect[props.item?.keyForList ?? ''] = () => props.onSelectRow?.(props.item);
+            return ReactLocal.createElement(RNView, {testID: `row-${props.item?.keyForList ?? 'unknown'}`});
+        },
+    };
+});
+
+// Capture SelectionTopBar props so the selection-count math can be asserted directly.
+type CapturedTopBarProps = {selectedItemsLength: number; totalItems: number; isSelectAllChecked: boolean | undefined};
+const mockTopBar: {current: CapturedTopBarProps | null} = {current: null};
+jest.mock('@components/Search/primitives/SelectionTopBar', () => ({
+    __esModule: true,
+    default: (props: CapturedTopBarProps) => {
+        mockTopBar.current = {selectedItemsLength: props.selectedItemsLength, totalItems: props.totalItems, isSelectAllChecked: props.isSelectAllChecked};
+        return null;
+    },
+}));
+
+const mockToggle = jest.fn();
+const mockToggleAll = jest.fn();
+const mockSelectedTransactions: {current: Record<string, {isSelected: boolean}>} = {current: {}};
+jest.mock('@components/Search/SearchContext', () => ({
+    useSearchRowSelectionActions: () => ({toggle: mockToggle, toggleAll: mockToggleAll}),
+    useSearchSelectionContext: () => ({selectedTransactions: mockSelectedTransactions.current}),
+}));
+
+function selectKeys(...keys: string[]): Record<string, {isSelected: boolean}> {
+    return Object.fromEntries(keys.map((key) => [key, {isSelected: true}]));
+}
+
+const STABLE_QUERY_JSON: SearchQueryJSON = {
+    hash: 0,
+    recentSearchHash: 0,
+    similarSearchHash: 0,
+    groupBy: undefined,
+    type: CONST.SEARCH.DATA_TYPES.EXPENSE,
+    status: CONST.SEARCH.STATUS.EXPENSE.ALL,
+    sortBy: CONST.SEARCH.TABLE_COLUMNS.DATE,
+    sortOrder: 'desc',
+    view: CONST.SEARCH.VIEW.TABLE,
+    flatFilters: [],
+    inputQuery: '',
+    filters: {operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, left: CONST.SEARCH.SYNTAX_FILTER_KEYS.STATUS, right: ''},
+    policyID: undefined,
+    columns: undefined,
+    limit: undefined,
+    rawFilterList: undefined,
+};
+
+const STABLE_COLUMNS: SearchColumnType[] = [CONST.SEARCH.TABLE_COLUMNS.DATE, CONST.SEARCH.TABLE_COLUMNS.MERCHANT, CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT, CONST.SEARCH.TABLE_COLUMNS.ACTION];
+
+function createMockData(length: number, deletedKeys = new Set<string>()): SearchListItem[] {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test fixtures are intentionally partial SearchListItem rows
+    return Array.from({length}, (_, i) => {
+        const keyForList = `transaction-${i}`;
+        return {
+            keyForList,
+            transactionID: `${i}`,
+            reportID: '1',
+            policyID: 'policy-1',
+            amount: 100,
+            currency: 'USD',
+            created: '2025-01-01',
+            merchant: `Merchant ${i}`,
+            formattedMerchant: `Merchant ${i}`,
+            formattedTotal: 100,
+            date: '2025-01-01',
+            action: CONST.SEARCH.ACTION_TYPES.VIEW,
+            pendingAction: deletedKeys.has(keyForList) ? CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE : undefined,
+        };
+    }) as unknown as SearchListItem[];
+}
+
+/** Max render count for the view subtree on initial mount with stable props. Also the #3 memo-cleanup benchmark. */
+const MAX_INITIAL_RENDER_COUNT = 15;
+
+function ThemeProviderWithLight({children}: {children: React.ReactNode}) {
+    return <ThemeProvider theme="light">{children}</ThemeProvider>;
+}
+ThemeProviderWithLight.displayName = 'ThemeProviderWithLight';
+
+type RenderOverrides = {
+    data?: SearchListItem[];
+    canSelectMultiple?: boolean;
+    tableHeaderVisible?: boolean;
+    isMobileSelectionModeEnabled?: boolean;
+    hasLoadedAllTransactions?: boolean;
+    onSelectRow?: (item: SearchListItem) => void;
+    onRenderCount?: () => void;
+};
+
+function renderView(overrides: RenderOverrides = {}) {
+    const data = overrides.data ?? createMockData(3);
+
+    function Wrapper() {
+        const onSelectRow = useCallback((item: SearchListItem) => overrides.onSelectRow?.(item), []);
+        const onEndReached = useCallback(() => {}, []);
+        const onLayout = useCallback(() => {}, []);
+        const queryJSON = useMemo(() => STABLE_QUERY_JSON, []);
+        const columns = useMemo(() => STABLE_COLUMNS, []);
+        const contentContainerStyle = useMemo(() => ({}), []);
+        const containerStyle = useMemo(() => ({}), []);
+
+        const view = (
+            <ExpenseFlatSearchView
+                queryJSON={queryJSON}
+                data={data}
+                columns={columns}
+                canSelectMultiple={overrides.canSelectMultiple ?? false}
+                isActionColumnWide={false}
+                isMobileSelectionModeEnabled={overrides.isMobileSelectionModeEnabled ?? false}
+                tableHeaderVisible={overrides.tableHeaderVisible ?? false}
+                hasLoadedAllTransactions={overrides.hasLoadedAllTransactions ?? true}
+                newTransactions={[]}
+                onSelectRow={onSelectRow}
+                onEndReached={onEndReached}
+                onLayout={onLayout}
+                contentContainerStyle={contentContainerStyle}
+                containerStyle={containerStyle}
+            />
+        );
+
+        if (!overrides.onRenderCount) {
+            return view;
+        }
+        return (
+            <Profiler
+                id="expense-flat-search-view"
+                onRender={overrides.onRenderCount}
+            >
+                {view}
+            </Profiler>
+        );
+    }
+
+    return render(
+        <ComposeProviders components={[ThemeProviderWithLight, ThemeStylesProvider, OnyxListItemProvider, LocaleContextProvider, ScrollOffsetContextProvider]}>
+            <Wrapper />
+        </ComposeProviders>,
+    );
+}
+
+beforeAll(() => Onyx.init({keys: ONYXKEYS, evictableKeys: [ONYXKEYS.COLLECTION.REPORT]}));
+
+beforeEach(() => {
+    global.fetch = TestHelper.getGlobalFetchMock();
+    wrapOnyxWithWaitForBatchedUpdates(Onyx);
+    setHasRadio(true);
+    mockToggle.mockClear();
+    mockToggleAll.mockClear();
+    mockSelectedTransactions.current = {};
+    mockTopBar.current = null;
+    for (const key of Object.keys(mockRowSelect)) {
+        delete mockRowSelect[key];
+    }
+    Onyx.merge(ONYXKEYS.COLLECTION.REPORT, {});
+    Onyx.merge(ONYXKEYS.COLLECTION.POLICY, {});
+});
+
+afterEach(() => Onyx.clear());
+
+describe('ExpenseFlatSearchView', () => {
+    it('does not exceed the max render count on initial mount with stable props', async () => {
+        let renderCount = 0;
+        renderView({data: createMockData(100), onRenderCount: () => (renderCount += 1)});
+        await waitForBatchedUpdates();
+        expect(renderCount).toBeLessThanOrEqual(MAX_INITIAL_RENDER_COUNT);
+    });
+
+    it('renders one row per data item', async () => {
+        renderView({data: createMockData(3)});
+        await waitForBatchedUpdates();
+        expect(screen.queryAllByTestId(/^row-transaction-/)).toHaveLength(3);
+    });
+
+    it('computes selection counts excluding deleted rows and reflects select-all state', async () => {
+        // 3 rows, one pending-delete -> 2 selectable. One selected -> not all-checked.
+        mockSelectedTransactions.current = selectKeys('transaction-0');
+        renderView({
+            data: createMockData(3, new Set(['transaction-2'])),
+            canSelectMultiple: true,
+            tableHeaderVisible: true,
+            hasLoadedAllTransactions: true,
+        });
+        await waitForBatchedUpdates();
+
+        expect(mockTopBar.current?.selectedItemsLength).toBe(1);
+        expect(mockTopBar.current?.totalItems).toBe(2);
+        expect(mockTopBar.current?.isSelectAllChecked).toBe(false);
+    });
+
+    it('marks select-all checked when every selectable row is selected', async () => {
+        mockSelectedTransactions.current = selectKeys('transaction-0', 'transaction-1');
+        renderView({
+            data: createMockData(3, new Set(['transaction-2'])),
+            canSelectMultiple: true,
+            tableHeaderVisible: true,
+            hasLoadedAllTransactions: true,
+        });
+        await waitForBatchedUpdates();
+
+        expect(mockTopBar.current?.selectedItemsLength).toBe(2);
+        expect(mockTopBar.current?.totalItems).toBe(2);
+        expect(mockTopBar.current?.isSelectAllChecked).toBe(true);
+    });
+
+    it('toggles selection on row tap while in mobile selection mode, instead of navigating', async () => {
+        const onSelectRow = jest.fn();
+        renderView({data: createMockData(2), isMobileSelectionModeEnabled: true, onSelectRow});
+        await waitForBatchedUpdates();
+
+        act(() => mockRowSelect['transaction-0']?.());
+
+        expect(mockToggle).toHaveBeenCalledTimes(1);
+        expect(onSelectRow).not.toHaveBeenCalled();
+    });
+
+    it('navigates on row tap when not in mobile selection mode', async () => {
+        const onSelectRow = jest.fn();
+        renderView({data: createMockData(2), isMobileSelectionModeEnabled: false, onSelectRow});
+        await waitForBatchedUpdates();
+
+        act(() => mockRowSelect['transaction-0']?.());
+
+        expect(onSelectRow).toHaveBeenCalledTimes(1);
+        expect(mockToggle).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION


### Explanation of Change
This changes how the flat expenses list renders on the Search screen. The expenses view (a plain, ungrouped transaction list) now renders through a new dedicated `ExpenseFlatSearchView`, which composes the reusable Search list building blocks (scroll restoration, horizontal table scroll, row exit animation, the selection header, and the row long-press menu) directly on top of `BaseSearchList`, instead of going through the larger shared `SearchList`.

`` still owns the data (a single `useSearchSnapshot` call), the screen lifecycle, and the selection providers — it just routes the flat-expenses view to the new component, while every other view (chat, task, report, grouped) keeps using `SearchList`. There is no intended user-facing change; behavior should be identical. This is an internal refactor to slim the expenses render path so it can evolve on its own.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94455
PROPOSAL:




### Tests


1. Go to the **Search** tab and open the **Expenses** view (a flat, ungrouped list of expenses).
2. Verify the expenses list loads with its table header and rows.
3. Tap an expense row → it opens the expense details. Go back → the list returns to the same scroll position.
4. Select a few expenses with the checkboxes, then use **Select all** → the header shows the correct selected count and bulk actions appear.
5. On a wide screen, if the table is wider than the window, scroll horizontally → the columns scroll smoothly.
6. Create a new expense from this page → it appears in the list with no crash.
7. Delete an expense → the row animates out and the list updates.
8. (Mobile) Long-press a row → it enters selection mode.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native



https://github.com/user-attachments/assets/24b87602-86d8-4e28-80e1-4b97e284c02c





iOS: mWeb Safari






MacOS: Chrome / Safari



https://github.com/user-attachments/assets/d2718d0d-a41f-4e1c-905b-6ef4dbac231b




