### PR TITLE
[Onyx bump] Bump react-native-onyx from 3.0.85 to 3.0.86

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
         "react-native-localize": "^3.5.4",
         "react-native-nitro-modules": "0.35.0",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.85",
+        "react-native-onyx": "3.0.86",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -36030,9 +36030,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.85",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.85.tgz",
-      "integrity": "sha512-F4rhP9IHDoXejZjMhq4HTl6+p8xih5TdrEVRaaA9SSW1dGwF08c1mUQjnDmZ1Pq81OIVWhbkYnfVhYNKwgSaIA==",
+      "version": "3.0.86",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.86.tgz",
+      "integrity": "sha512-P10auM8ZZHZrZmu/reg0EiuNq4AhZN3hmDoV5+QdEUsm2j5t2XCKWmU73ogFpL6fLCUQaxvzMmLEL84+nIhb2Q==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "react-native-localize": "^3.5.4",
     "react-native-nitro-modules": "0.35.0",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.85",
+    "react-native-onyx": "3.0.86",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",


### PR DESCRIPTION


### Explanation of Change

This PR bumps Onyx from 3.0.85 to 3.0.86 ([diff](https://github.com/Expensify/react-native-onyx/compare/3.0.85...3.0.86)), which includes the following changes:

- [react-native-onyx#792](https://github.com/Expensify/react-native-onyx/pull/792) — Make retried Onyx writes idempotent on storage retry. Two pre-existing bugs in every write path that flows through `retryOperation` (`mergeCollectionWithPatches`, `multiSetWithRetry`, `setCollectionWithRetry`, `partialSetCollection`): (1) a brand-new key was silently downgraded from `Storage.multiSet` to `Storage.multiMerge` on retry, and (2) `keysChanged`/`keyChanged` re-fired on every retry attempt, double-notifying `Onyx.connect({waitForCollectionCallback: true})` subscribers (which re-fire on every call by contract). Each write now splits into an outer orchestrator (cache + subscriber notify + storage prep, called once) and a file-private write helper that `retryOperation` re-enters — so the cache stays consistent and subscribers fire exactly once per logical write. `setWithRetry` was already safe (`broadcastUpdate` short-circuits on `hasChanged === false`).

### Fixed Issues



$ https://github.com/Expensify/App/issues/94684
PROPOSAL: N/A — Onyx version bump. The underlying fix ([react-native-onyx#792](https://github.com/Expensify/react-native-onyx/pull/792)) was a #787 review follow-up with no separate App issue; companion testing PR is [Expensify/App#91626](https://github.com/Expensify/App/pull/91626).



### Tests



The four refactored onyx write paths (`mergeCollectionWithPatches`, `multiSetWithRetry`, `setCollectionWithRetry`, `partialSetCollection`) are reached from the App via Pusher events, the `OpenApp` response, every `Onyx.update` batch that contains a `MERGE_COLLECTION` / `MULTI_SET` / `SET_COLLECTION` op, LHN refresh, Search filters, chat sends, mark-all-as-read, hold/unhold, workspace switching, etc.

**Setup**

1. Check out this branch (`bump-onyx-3.0.86`).
2. `npm install` under Node 20.20.0, then `npm run web`.
3. Open https://dev.new.expensify.com:8082/ in Chrome with DevTools open.
4. Sign in to a test account.

**Functional smoke — no regression in the refactored paths**

The fix preserves the cache-first invariant from #787, so all of these should look indistinguishable from `main` to the user:

1. **Initial hydration** — after login, LHN reports list and workspace switcher populate within a few seconds. No missing rows vs. a baseline session on `main`. _(exercises `mergeCollectionWithPatches` via Pusher / `OpenApp`)_
2. **Chat message** — open a chat, send a message. Appears immediately (optimistic merge into `reportActions_`), confirms via Pusher, persists after reload. _(`mergeCollectionWithPatches`)_
3. **Mark all as read** — click the mark-all-as-read action. All unread badges clear immediately and stay cleared after reload. _(`mergeCollectionWithPatches`)_
4. **Search & filter** — open Search, apply a filter. Results populate within a few seconds; live updates as filters change; no duplicates. _(`mergeCollectionWithPatches` + `setCollectionWithRetry`)_
5. **Hold / unhold an expense** — toggle hold on an expense in a report. Badge appears/clears immediately; persists after reload. _(`mergeCollectionWithPatches`)_
6. **Submit expense** — FAB → Submit expense. Expense appears in the report immediately, no duplicate, persists after reload. _(`mergeCollectionWithPatches`)_
7. **Switch workspaces** — switch via the workspace switcher. LHN reports filter to the new workspace within a few seconds. _(`mergeCollectionWithPatches`)_

**Storage-failure simulation — the core regression guard**

This is the test that exercises the retry path the fix targets. With the fix in place, retries on storage failure should produce **one** subscriber notification per logical operation (not one per retry attempt), and brand-new keys should stay routed through `multiSet` even when an earlier `multiMerge` retry kicks in.

1. With the App running and authenticated, open Chrome DevTools → **Application** tab → **IndexedDB**.
2. Find the database used by Onyx (typically named `OnyxDB`).
3. **Right-click → Delete database** while the App is still running and connected (do **not** reload).
4. Immediately trigger a `mergeCollection`-driven action — switch workspaces, send a chat message, or apply a search filter.
5. **Expected with this fix:** the UI updates correctly; the new state is visible to subscribers even though the underlying IDB write fails and `retryOperation` kicks in. Console shows storage error logs and retry attempts (look for `Failed to save to storage. Error: ... retryAttempt: N/5`), but **no white screen, no stale UI, no data loss within the session**, and **no duplicate `waitForCollectionCallback` subscriber invocations**.
6. Try the same with a `multiSet`-driven action and a `setCollection`-driven action (Search filter result population) to cover the other refactored paths.
7. (Optional regression check) Revert the bump to `3.0.85` locally and re-run step 4. Without the fix you'll see `Onyx.connect({waitForCollectionCallback: true})` callbacks firing twice in DevTools traces.

**Cold-cache merge — preserves the pre-warm fast path from #787**

1. Sign out and clear site data to force a cold cache.
2. Sign back in. LHN should populate within the same window as a baseline `main` session — the cache pre-warm path (existing in `mergeCollectionWithPatches`) is untouched by #792.

- [x] Verify that no errors appear in the JS console

### Offline tests



This PR is an Onyx version bump; there is no offline behavior to test that isn't already covered by the existing Onyx offline-first invariants. The fix specifically protects subscribers from going stale when a storage write fails — the user-visible behavior offline is **better** with this bump (UI reflects the merge even if IDB writes back-pressure), not worse. Spot-check the existing offline path:

1. Toggle "Offline" in DevTools Network tab.
2. Send a chat message → appears optimistically.
3. Toggle back online → message confirms via Pusher.
4. Verify no white screen, no stale UI.

### QA Steps



Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist



- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


Android: Native

N/A — Onyx storage retry path is exercised on web; no native-specific changes.




Android: mWeb Chrome






iOS: Native

N/A — Onyx storage retry path is exercised on web; no native-specific changes.




iOS: mWeb Safari






MacOS: Chrome / Safari

https://github.com/user-attachments/assets/63433562-723b-45d3-9404-0f26656d4cea

https://github.com/user-attachments/assets/0bc9a73a-3668-42bd-a926-fdffc189736d

https://github.com/user-attachments/assets/c7151e8a-fc94-47b1-b000-54bdad39938b

https://github.com/user-attachments/assets/48bd5579-3bd2-4538-9e35-804e0305eda2

https://github.com/user-attachments/assets/f8c17666-bc05-4269-a43c-d005cb7b807e

https://github.com/user-attachments/assets/828d2b39-8db8-4448-90fd-218e24d2bd19


