### PR TITLE
fix: keep multi-expense drafts submittable when a subset of receipts …

### DIFF
--- a/src/libs/ReportPrimaryActionUtils.ts
+++ b/src/libs/ReportPrimaryActionUtils.ts
@@ -130,13 +130,17 @@ function isSubmitAction(
         return false;
     }
 
-    const isAnyReceiptBeingScanned = reportTransactions?.some((transaction) => isScanning(transaction));
+    const reportTransactionsList = reportTransactions ?? [];
+    const isEveryReceiptBeingScanned = reportTransactionsList.length > 0 && reportTransactionsList.every((transaction) => isScanning(transaction));
 
-    if (isAnyReceiptBeingScanned) {
+    if (isEveryReceiptBeingScanned) {
         return false;
     }
 
-    if (hasSmartScanFailedWithMissingFields(reportTransactions ?? [], report)) {
+    const hasEverySmartScanFailedWithMissingFields =
+        reportTransactionsList.length > 0 && reportTransactionsList.every((transaction) => hasSmartScanFailedWithMissingFields([transaction], report));
+
+    if (hasEverySmartScanFailedWithMissingFields) {
         return false;
     }
 

--- a/src/libs/ReportPrimaryActionUtils.ts
+++ b/src/libs/ReportPrimaryActionUtils.ts
@@ -131,16 +131,10 @@ function isSubmitAction(
     }
 
     const reportTransactionsList = reportTransactions ?? [];
-    const isEveryReceiptBeingScanned = reportTransactionsList.length > 0 && reportTransactionsList.every((transaction) => isScanning(transaction));
+    const hasNoSubmittableTransaction =
+        reportTransactionsList.length > 0 && reportTransactionsList.every((transaction) => isScanning(transaction) || hasSmartScanFailedWithMissingFields([transaction], report));
 
-    if (isEveryReceiptBeingScanned) {
-        return false;
-    }
-
-    const hasEverySmartScanFailedWithMissingFields =
-        reportTransactionsList.length > 0 && reportTransactionsList.every((transaction) => hasSmartScanFailedWithMissingFields([transaction], report));
-
-    if (hasEverySmartScanFailedWithMissingFields) {
+    if (hasNoSubmittableTransaction) {
         return false;
     }
 

--- a/src/libs/actions/IOU/ReportWorkflow.ts
+++ b/src/libs/actions/IOU/ReportWorkflow.ts
@@ -251,8 +251,7 @@ function canSubmitReport(
     const isAdmin = policy?.role === CONST.POLICY.ROLE.ADMIN;
     const hasAllPendingRTERViolations = allHavePendingRTERViolation(transactions, allViolations, currentUserEmailParam, currentUserAccountID, report, policy);
     const hasTransactionWithoutRTERViolation = hasAnyTransactionWithoutRTERViolation(transactions, allViolations, currentUserEmailParam, currentUserAccountID, report, policy);
-    const hasScanFailTransactions = transactions.length > 0 && transactions.every((t) => isScanningTransaction(t));
-    const hasEverySmartScanFailedWithMissingFields = transactions.length > 0 && transactions.every((t) => hasSmartScanFailedWithMissingFields([t], report));
+    const hasNoSubmittableTransaction = transactions.length > 0 && transactions.every((t) => isScanningTransaction(t) || hasSmartScanFailedWithMissingFields([t], report));
     const hasAnySubmissionBlockingViolations = transactions.some((transaction) =>
         hasSubmissionBlockingViolations(transaction, allViolations, currentUserEmailParam, currentUserAccountID, report, policy),
     );
@@ -260,12 +259,11 @@ function canSubmitReport(
     return (
         isOpenExpenseReport &&
         (report?.ownerAccountID === currentUserAccountID || report?.managerID === currentUserAccountID || isAdmin) &&
-        !hasScanFailTransactions &&
+        !hasNoSubmittableTransaction &&
         !hasAllPendingRTERViolations &&
         hasTransactionWithoutRTERViolation &&
         !isReportArchived &&
         !hasAnySubmissionBlockingViolations &&
-        !hasEverySmartScanFailedWithMissingFields &&
         transactions.length > 0
     );
 }

--- a/src/libs/actions/IOU/ReportWorkflow.ts
+++ b/src/libs/actions/IOU/ReportWorkflow.ts
@@ -252,6 +252,7 @@ function canSubmitReport(
     const hasAllPendingRTERViolations = allHavePendingRTERViolation(transactions, allViolations, currentUserEmailParam, currentUserAccountID, report, policy);
     const hasTransactionWithoutRTERViolation = hasAnyTransactionWithoutRTERViolation(transactions, allViolations, currentUserEmailParam, currentUserAccountID, report, policy);
     const hasScanFailTransactions = transactions.length > 0 && transactions.every((t) => isScanningTransaction(t));
+    const hasEverySmartScanFailedWithMissingFields = transactions.length > 0 && transactions.every((t) => hasSmartScanFailedWithMissingFields([t], report));
     const hasAnySubmissionBlockingViolations = transactions.some((transaction) =>
         hasSubmissionBlockingViolations(transaction, allViolations, currentUserEmailParam, currentUserAccountID, report, policy),
     );
@@ -264,7 +265,7 @@ function canSubmitReport(
         hasTransactionWithoutRTERViolation &&
         !isReportArchived &&
         !hasAnySubmissionBlockingViolations &&
-        !hasSmartScanFailedWithMissingFields(transactions, report) &&
+        !hasEverySmartScanFailedWithMissingFields &&
         transactions.length > 0
     );
 }


### PR DESCRIPTION
### Explanation of Change

A draft expense report stopped surfacing its **Submit** affordance whenever it contained even a single receipt that failed SmartScan and was still missing required fields. The report disappeared from the **To Do "to submit" tray**, from **Spend → Drafts**, and lost its in-report **Submit** button, yet it remained findable via the manual `status:drafts` filter — exactly the reported symptom.

The root cause is that both submit predicates gate on `hasSmartScanFailedWithMissingFields`, which is a whole-report `.some(...)`: one scan-failed/missing-fields receipt among many makes it `true` for the entire report.

- `isSubmitAction` (`src/libs/ReportPrimaryActionUtils.ts`) returns `false` on that gate → no To Do tray entry, no Submit button.
- `canSubmitReport` (`src/libs/actions/IOU/ReportWorkflow.ts`) returns `false` on the same gate → the report's computed action is no longer `SUBMIT`, so it drops out of the canned `action:submit` **Drafts** search.

This change makes both submit gates block only when there is genuinely **nothing** to submit — i.e. when **every** transaction is blocked — mirroring the "all" semantics the codebase already uses for the scanning check (`transactions.every((t) => isScanningTransaction(t))`):

- In `isSubmitAction`, the scanning gate and the scan-failed gate now block only when **every** transaction is scanning / scan-failed-with-missing-fields, so a partially-blocked draft stays submittable.
- In `canSubmitReport`, the `hasSmartScanFailedWithMissingFields` term is now evaluated per-transaction with `.every`, kept aligned with the already-`every` scanning term directly above it.

Single-expense reports are unchanged (one failed receipt is the only expense → genuinely nothing to submit). `todos.ts` and the report header need no changes — both derive from `isSubmitAction`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93949
PROPOSAL: https://github.com/Expensify/App/issues/93949#issuecomment-4743831503

### Tests

1. Log in to New Expensify on a group (collect/control) workspace as the report submitter.
2. Create a draft (Open) expense report and add **multiple** expenses to it.
3. Add at least one **scan receipt** that fails SmartScan and is **missing required fields** (e.g. amount/merchant), while keeping the other expenses valid.
4. Open the home page **To Do** tray and verify the report appears under **"to submit"**.
5. Go to **Spend → Drafts** and verify the report is listed.
6. Open the report and verify the **Submit** button is shown.
7. Submit the report and verify it submits successfully (matching Expensify Classic behavior).
8. Edge case — create a draft where **every** expense is a scan-failed/missing-fields receipt, and verify the report is **not** submittable (no To Do entry, not in Spend → Drafts, no Submit button), preserving current behavior when there is genuinely nothing to submit.
9. Edge case — create a single-expense draft whose only expense is scan-failed/missing-fields, and verify it is **not** submittable (unchanged behavior).
- [x] Verify that no errors appear in the JS console

### Offline tests

1. Open a multi-expense draft (with one scan-failed/missing-fields receipt) that already shows the Submit button.
2. Turn off the network connection.
3. Verify the Submit button, To Do tray entry, and Spend → Drafts listing remain visible and consistent.
4. Tap Submit while offline and verify the optimistic submit behaves as expected, syncing when the connection is restored.

### QA Steps

1. Log in to New Expensify on a group workspace as the report submitter.
2. Create a draft expense report with **multiple** expenses, including at least one scan receipt that failed SmartScan and is missing required fields.
3. Verify the report appears in the home **To Do "to submit"** tray.
4. Verify the report appears under **Spend → Drafts**.
5. Open the report and verify the **Submit** button is present, then submit it successfully.
6. Verify a draft where **all** expenses are scan-failed/missing-fields is correctly **not** submittable.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Before fix:

https://github.com/user-attachments/assets/dea1b3b4-774f-46d3-84c8-df020b352bb5

After fix:



https://github.com/user-attachments/assets/74643673-ed42-40ba-9078-700c23720509




</details>
