### PR TITLE
Fix regressions from  [Rules Revamp] Release 1

### DIFF
--- a/src/components/Tables/WorkspaceSpendRulesTable/index.tsx
+++ b/src/components/Tables/WorkspaceSpendRulesTable/index.tsx
@@ -44,6 +44,11 @@ function WorkspaceSpendRulesTable({rulesData, selectionEnabled, selectedKeys, on
     const compareItems: CompareItemsCallback<SpendRuleTableItem, SpendRulesTableColumnKey> = (a, b, activeSorting) => {
         const orderMultiplier = activeSorting.order === 'asc' ? 1 : -1;
 
+        // Keep the built-in default rule grouped so section headers stay contiguous when sorting.
+        if (a.isDefault !== b.isDefault) {
+            return a.isDefault ? -1 : 1;
+        }
+
         if (activeSorting.columnKey === 'type') {
             const aVal = a.isBlock ? 0 : 1;
             const bVal = b.isBlock ? 0 : 1;

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -251,6 +251,16 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
         openPolicyRulesPage(policyID);
     }, [policyID]);
 
+    useEffect(() => {
+        const validExpenseDefaultKeys = new Set(expenseDefaultsTableData.map((rule) => rule.keyForList));
+        setSelectedExpenseDefaultKeys((prev) => prev.filter((key) => validExpenseDefaultKeys.has(key)));
+    }, [expenseDefaultsTableData]);
+
+    useEffect(() => {
+        const validSpendRuleKeys = new Set(spendRulesTableData.map((rule) => rule.keyForList));
+        setSelectedSpendRuleKeys((prev) => prev.filter((key) => validSpendRuleKeys.has(key)));
+    }, [spendRulesTableData]);
+
     let selectedRuleKeys: string[];
     if (activeTab === RULES_TAB.CARD_RESTRICTIONS) {
         selectedRuleKeys = selectedSpendRuleKeys;

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -16,6 +16,7 @@ import WorkspaceSpendRulesTable from '@components/Tables/WorkspaceSpendRulesTabl
 import TabSelectorBase from '@components/TabSelector/TabSelectorBase';
 import TabSelectorContextProvider from '@components/TabSelector/TabSelectorContext';
 import type {TabSelectorBaseItem} from '@components/TabSelector/types';
+import useCleanupSelectedOptions from '@hooks/useCleanupSelectedOptions';
 import useConfirmModal from '@hooks/useConfirmModal';
 import useDefaultFundID from '@hooks/useDefaultFundID';
 import useExpensifyCardRules from '@hooks/useExpensifyCardRulesList';
@@ -251,15 +252,31 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
         openPolicyRulesPage(policyID);
     }, [policyID]);
 
-    useEffect(() => {
-        const validExpenseDefaultKeys = new Set(expenseDefaultsTableData.map((rule) => rule.keyForList));
-        setSelectedExpenseDefaultKeys((prev) => prev.filter((key) => validExpenseDefaultKeys.has(key)));
-    }, [expenseDefaultsTableData]);
+    const clearAllTableSelection = () => {
+        setSelectedSpendRuleKeys((prev) => (prev.length > 0 ? [] : prev));
+        setSelectedExpenseDefaultKeys((prev) => (prev.length > 0 ? [] : prev));
+        turnOffMobileSelectionMode();
+    };
+
+    useCleanupSelectedOptions(clearAllTableSelection);
 
     useEffect(() => {
+        if (selectedExpenseDefaultKeys.length === 0 || !canWriteRules) {
+            return;
+        }
+
+        const validExpenseDefaultKeys = new Set(expenseDefaultsTableData.map((rule) => rule.keyForList));
+        setSelectedExpenseDefaultKeys((prev) => prev.filter((key) => validExpenseDefaultKeys.has(key)));
+    }, [canWriteRules, expenseDefaultsTableData, selectedExpenseDefaultKeys.length]);
+
+    useEffect(() => {
+        if (selectedSpendRuleKeys.length === 0 || !canWriteRules) {
+            return;
+        }
+
         const validSpendRuleKeys = new Set(spendRulesTableData.map((rule) => rule.keyForList));
         setSelectedSpendRuleKeys((prev) => prev.filter((key) => validSpendRuleKeys.has(key)));
-    }, [spendRulesTableData]);
+    }, [canWriteRules, selectedSpendRuleKeys.length, spendRulesTableData]);
 
     let selectedRuleKeys: string[];
     if (activeTab === RULES_TAB.CARD_RESTRICTIONS) {

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -260,8 +260,8 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
 
     useCleanupSelectedOptions(clearAllTableSelection);
 
-    const validExpenseDefaultKeys = new Set(expenseDefaultsTableData.map((rule) => rule.keyForList));
-    const validSpendRuleKeys = new Set(spendRulesTableData.map((rule) => rule.keyForList));
+    const validExpenseDefaultKeys = new Set(expenseDefaultsTableData.filter((rule) => !rule.disabled).map((rule) => rule.keyForList));
+    const validSpendRuleKeys = new Set(spendRulesTableData.filter((rule) => !rule.disabled).map((rule) => rule.keyForList));
     const filteredSelectedExpenseDefaultKeys = canWriteRules ? selectedExpenseDefaultKeys.filter((key) => validExpenseDefaultKeys.has(key)) : [];
     const filteredSelectedSpendRuleKeys = canWriteRules ? selectedSpendRuleKeys.filter((key) => validSpendRuleKeys.has(key)) : [];
 

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -260,29 +260,16 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
 
     useCleanupSelectedOptions(clearAllTableSelection);
 
-    useEffect(() => {
-        if (selectedExpenseDefaultKeys.length === 0 || !canWriteRules) {
-            return;
-        }
-
-        const validExpenseDefaultKeys = new Set(expenseDefaultsTableData.map((rule) => rule.keyForList));
-        setSelectedExpenseDefaultKeys((prev) => prev.filter((key) => validExpenseDefaultKeys.has(key)));
-    }, [canWriteRules, expenseDefaultsTableData, selectedExpenseDefaultKeys.length]);
-
-    useEffect(() => {
-        if (selectedSpendRuleKeys.length === 0 || !canWriteRules) {
-            return;
-        }
-
-        const validSpendRuleKeys = new Set(spendRulesTableData.map((rule) => rule.keyForList));
-        setSelectedSpendRuleKeys((prev) => prev.filter((key) => validSpendRuleKeys.has(key)));
-    }, [canWriteRules, selectedSpendRuleKeys.length, spendRulesTableData]);
+    const validExpenseDefaultKeys = new Set(expenseDefaultsTableData.map((rule) => rule.keyForList));
+    const validSpendRuleKeys = new Set(spendRulesTableData.map((rule) => rule.keyForList));
+    const filteredSelectedExpenseDefaultKeys = canWriteRules ? selectedExpenseDefaultKeys.filter((key) => validExpenseDefaultKeys.has(key)) : [];
+    const filteredSelectedSpendRuleKeys = canWriteRules ? selectedSpendRuleKeys.filter((key) => validSpendRuleKeys.has(key)) : [];
 
     let selectedRuleKeys: string[];
     if (activeTab === RULES_TAB.CARD_RESTRICTIONS) {
-        selectedRuleKeys = selectedSpendRuleKeys;
+        selectedRuleKeys = filteredSelectedSpendRuleKeys;
     } else if (activeTab === RULES_TAB.EXPENSE_DEFAULTS) {
-        selectedRuleKeys = selectedExpenseDefaultKeys;
+        selectedRuleKeys = filteredSelectedExpenseDefaultKeys;
     } else {
         selectedRuleKeys = [];
     }
@@ -326,7 +313,7 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
             return;
         }
 
-        for (const ruleID of selectedSpendRuleKeys) {
+        for (const ruleID of filteredSelectedSpendRuleKeys) {
             if (ruleID === DEFAULT_SPEND_RULE_ID) {
                 continue;
             }
@@ -346,7 +333,7 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
             return;
         }
 
-        for (const ruleID of selectedExpenseDefaultKeys) {
+        for (const ruleID of filteredSelectedExpenseDefaultKeys) {
             deletePolicyCodingRule(policy, ruleID);
         }
         clearTableSelection();
@@ -557,7 +544,7 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
                                     <WorkspaceSpendRulesTable
                                         rulesData={areCardsEnabled ? spendRulesTableData : []}
                                         selectionEnabled={canWriteRules}
-                                        selectedKeys={selectedSpendRuleKeys}
+                                        selectedKeys={filteredSelectedSpendRuleKeys}
                                         onRowSelectionChange={handleSpendRuleSelectionChange}
                                         emptyStateContent={areCardsEnabled ? undefined : cardRulesEmptyState}
                                     />
@@ -566,7 +553,7 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
                                     <WorkspaceExpenseDefaultsTable
                                         rulesData={expenseDefaultsTableData}
                                         selectionEnabled={canWriteRules}
-                                        selectedKeys={selectedExpenseDefaultKeys}
+                                        selectedKeys={filteredSelectedExpenseDefaultKeys}
                                         onRowSelectionChange={handleExpenseDefaultSelectionChange}
                                     />
                                 )}

--- a/src/pages/workspace/rules/RulesNewPage.tsx
+++ b/src/pages/workspace/rules/RulesNewPage.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MenuItem from '@components/MenuItem';
 import ScreenWrapper from '@components/ScreenWrapper';
+import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
@@ -36,35 +37,43 @@ function RulesNewPage({route}: RulesNewPageProps) {
             policyFeatureAccess={CONST.POLICY.POLICY_FEATURE_ACCESS.WRITE}
             shouldBeBlocked={!isRulesRevampEnabled}
         >
-            <ScreenWrapper testID="RulesNewPage">
+            <ScreenWrapper
+                testID="RulesNewPage"
+                enableEdgeToEdgeBottomSafeAreaPadding
+            >
                 <HeaderWithBackButton title={translate('workspace.rules.newRule.title')} />
-                <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mv3]}>{translate('workspace.rules.newRule.subtitle')}</Text>
-                <View style={styles.mh5}>
-                    <MenuItem
-                        icon={illustrations.CardReaderAlt}
-                        title={translate('workspace.rules.newRule.restrictCardSpend')}
-                        description={translate('workspace.rules.newRule.restrictCardSpendDescription')}
-                        shouldShowRightIcon
-                        onPress={() => Navigation.navigate(ROUTES.RULES_SPEND_NEW.getRoute(policyID))}
-                        displayInDefaultIconColor
-                        iconWidth={variables.iconSizeExtraLarge}
-                        iconHeight={variables.iconSizeExtraLarge}
-                        wrapperStyle={styles.rulesNewMenuItem}
-                        sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.NEW_RULE_MENU_ITEM}
-                    />
-                    <MenuItem
-                        icon={illustrations.ReportReceipt}
-                        title={translate('workspace.rules.newRule.applyExpenseDefaults')}
-                        description={translate('workspace.rules.newRule.applyExpenseDefaultsDescription')}
-                        shouldShowRightIcon
-                        onPress={() => Navigation.navigate(ROUTES.RULES_MERCHANT_NEW.getRoute(policyID))}
-                        displayInDefaultIconColor
-                        iconWidth={variables.iconSizeExtraLarge}
-                        iconHeight={variables.iconSizeExtraLarge}
-                        wrapperStyle={styles.rulesNewMenuItem}
-                        sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.NEW_RULE_MENU_ITEM}
-                    />
-                </View>
+                <ScrollView
+                    style={[styles.flexGrow1]}
+                    addBottomSafeAreaPadding
+                >
+                    <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mv3]}>{translate('workspace.rules.newRule.subtitle')}</Text>
+                    <View style={styles.mh5}>
+                        <MenuItem
+                            icon={illustrations.CardReaderAlt}
+                            title={translate('workspace.rules.newRule.restrictCardSpend')}
+                            description={translate('workspace.rules.newRule.restrictCardSpendDescription')}
+                            shouldShowRightIcon
+                            onPress={() => Navigation.navigate(ROUTES.RULES_SPEND_NEW.getRoute(policyID))}
+                            displayInDefaultIconColor
+                            iconWidth={variables.iconSizeExtraLarge}
+                            iconHeight={variables.iconSizeExtraLarge}
+                            wrapperStyle={styles.rulesNewMenuItem}
+                            sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.NEW_RULE_MENU_ITEM}
+                        />
+                        <MenuItem
+                            icon={illustrations.ReportReceipt}
+                            title={translate('workspace.rules.newRule.applyExpenseDefaults')}
+                            description={translate('workspace.rules.newRule.applyExpenseDefaultsDescription')}
+                            shouldShowRightIcon
+                            onPress={() => Navigation.navigate(ROUTES.RULES_MERCHANT_NEW.getRoute(policyID))}
+                            displayInDefaultIconColor
+                            iconWidth={variables.iconSizeExtraLarge}
+                            iconHeight={variables.iconSizeExtraLarge}
+                            wrapperStyle={styles.rulesNewMenuItem}
+                            sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.NEW_RULE_MENU_ITEM}
+                        />
+                    </View>
+                </ScrollView>
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );

--- a/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import type {ValueOf} from 'type-fest';
 import Button from '@components/Button';
+import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -159,7 +160,11 @@ function RulesProhibitedDefaultPage({
                     })}
                 </ScrollView>
                 {isRevamp && (
-                    <View style={[styles.ph5, styles.pb5]}>
+                    <FixedFooter
+                        addBottomSafeAreaPadding
+                        addOfflineIndicatorBottomSafeAreaPadding
+                        style={styles.ph5}
+                    >
                         <Button
                             success
                             large
@@ -167,7 +172,7 @@ function RulesProhibitedDefaultPage({
                             onPress={handleSave}
                             sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.FLAG_RECEIPT_LINE_ITEMS_SAVE}
                         />
-                    </View>
+                    </FixedFooter>
                 )}
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>

--- a/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
@@ -163,7 +163,6 @@ function RulesProhibitedDefaultPage({
                     <FixedFooter
                         addBottomSafeAreaPadding
                         addOfflineIndicatorBottomSafeAreaPadding
-                        style={styles.ph5}
                     >
                         <Button
                             success

--- a/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
+++ b/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {View} from 'react-native';
 import Button from '@components/Button';
 import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';

--- a/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
+++ b/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
@@ -44,16 +44,23 @@ function RulesRequireFieldsPage({
     const hasEnabledTags = hasEnabledOptions(Object.values(policyTags ?? {}).flatMap(({tags}) => Object.values(tags)));
     const isTagToggleDisabled = !policy?.areTagsEnabled || !hasEnabledTags;
 
-    const [categoryRequired, setCategoryRequired] = useState(false);
-    const [tagRequired, setTagRequired] = useState(false);
-    const [initialCategoryRequired, setInitialCategoryRequired] = useState(false);
-    const [initialTagRequired, setInitialTagRequired] = useState(false);
+    const [categoryRequired, setCategoryRequired] = useState(() => !!policy?.requiresCategory);
+    const [tagRequired, setTagRequired] = useState(() => !!policy?.requiresTag);
+    const [initialCategoryRequired, setInitialCategoryRequired] = useState(() => !!policy?.requiresCategory);
+    const [initialTagRequired, setInitialTagRequired] = useState(() => !!policy?.requiresTag);
     const syncedPolicyIDRef = useRef<string | undefined>(undefined);
     const isSavingRef = useRef(false);
 
     useEffect(() => {
         syncedPolicyIDRef.current = undefined;
     }, [policyID]);
+
+    useEffect(
+        () => () => {
+            isSavingRef.current = false;
+        },
+        [],
+    );
 
     useEffect(() => {
         if (!policy?.id || policy.isLoading || syncedPolicyIDRef.current === policy.id) {
@@ -147,7 +154,6 @@ function RulesRequireFieldsPage({
                 <FixedFooter
                     addBottomSafeAreaPadding
                     addOfflineIndicatorBottomSafeAreaPadding
-                    style={styles.ph5}
                 >
                     <Button
                         success

--- a/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
+++ b/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
@@ -1,6 +1,7 @@
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 import Button from '@components/Button';
+import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
@@ -44,12 +45,12 @@ function RulesRequireFieldsPage({
     const hasEnabledTags = hasEnabledOptions(Object.values(policyTags ?? {}).flatMap(({tags}) => Object.values(tags)));
     const isTagToggleDisabled = !policy?.areTagsEnabled || !hasEnabledTags;
 
-    const initialCategoryRequired = !!policy?.requiresCategory;
-    const initialTagRequired = !!policy?.requiresTag;
-
-    const [categoryRequired, setCategoryRequired] = useState(initialCategoryRequired);
-    const [tagRequired, setTagRequired] = useState(initialTagRequired);
+    const [categoryRequired, setCategoryRequired] = useState(false);
+    const [tagRequired, setTagRequired] = useState(false);
+    const [initialCategoryRequired, setInitialCategoryRequired] = useState(false);
+    const [initialTagRequired, setInitialTagRequired] = useState(false);
     const syncedPolicyIDRef = useRef<string | undefined>(undefined);
+    const isSavingRef = useRef(false);
 
     useEffect(() => {
         syncedPolicyIDRef.current = undefined;
@@ -61,20 +62,28 @@ function RulesRequireFieldsPage({
         }
 
         syncedPolicyIDRef.current = policy.id;
-        setCategoryRequired(!!policy.requiresCategory);
-        setTagRequired(!!policy.requiresTag);
+        const categoryRequiredValue = !!policy.requiresCategory;
+        const tagRequiredValue = !!policy.requiresTag;
+
+        setInitialCategoryRequired(categoryRequiredValue);
+        setInitialTagRequired(tagRequiredValue);
+        setCategoryRequired(categoryRequiredValue);
+        setTagRequired(tagRequiredValue);
     }, [policy?.id, policy?.isLoading, policy?.requiresCategory, policy?.requiresTag]);
 
-    const hasChanges = useMemo(
-        () => categoryRequired !== initialCategoryRequired || tagRequired !== initialTagRequired,
-        [categoryRequired, initialCategoryRequired, tagRequired, initialTagRequired],
-    );
+    const hasChanges = categoryRequired !== initialCategoryRequired || tagRequired !== initialTagRequired;
 
     const handleSave = useCallback(() => {
+        if (isSavingRef.current) {
+            return;
+        }
+
         if (!hasChanges) {
             Navigation.goBack();
             return;
         }
+
+        isSavingRef.current = true;
 
         if (categoryRequired !== initialCategoryRequired) {
             setWorkspaceRequiresCategory(policyData, categoryRequired);
@@ -136,7 +145,11 @@ function RulesRequireFieldsPage({
                         onToggle={setTagRequired}
                     />
                 </ScrollView>
-                <View style={[styles.ph5, styles.pb5]}>
+                <FixedFooter
+                    addBottomSafeAreaPadding
+                    addOfflineIndicatorBottomSafeAreaPadding
+                    style={styles.ph5}
+                >
                     <Button
                         success
                         large
@@ -144,7 +157,7 @@ function RulesRequireFieldsPage({
                         onPress={handleSave}
                         sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.REQUIRE_FIELDS_SAVE}
                     />
-                </View>
+                </FixedFooter>
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );

--- a/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
+++ b/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import Button from '@components/Button';
 import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -44,23 +44,16 @@ function RulesRequireFieldsPage({
     const hasEnabledTags = hasEnabledOptions(Object.values(policyTags ?? {}).flatMap(({tags}) => Object.values(tags)));
     const isTagToggleDisabled = !policy?.areTagsEnabled || !hasEnabledTags;
 
-    const [categoryRequired, setCategoryRequired] = useState(() => !!policy?.requiresCategory);
-    const [tagRequired, setTagRequired] = useState(() => !!policy?.requiresTag);
-    const [initialCategoryRequired, setInitialCategoryRequired] = useState(() => !!policy?.requiresCategory);
-    const [initialTagRequired, setInitialTagRequired] = useState(() => !!policy?.requiresTag);
+    const initialCategoryRequired = !!policy?.requiresCategory;
+    const initialTagRequired = !!policy?.requiresTag;
+
+    const [categoryRequired, setCategoryRequired] = useState(initialCategoryRequired);
+    const [tagRequired, setTagRequired] = useState(initialTagRequired);
     const syncedPolicyIDRef = useRef<string | undefined>(undefined);
-    const isSavingRef = useRef(false);
 
     useEffect(() => {
         syncedPolicyIDRef.current = undefined;
     }, [policyID]);
-
-    useEffect(
-        () => () => {
-            isSavingRef.current = false;
-        },
-        [],
-    );
 
     useEffect(() => {
         if (!policy?.id || policy.isLoading || syncedPolicyIDRef.current === policy.id) {
@@ -68,28 +61,20 @@ function RulesRequireFieldsPage({
         }
 
         syncedPolicyIDRef.current = policy.id;
-        const categoryRequiredValue = !!policy.requiresCategory;
-        const tagRequiredValue = !!policy.requiresTag;
-
-        setInitialCategoryRequired(categoryRequiredValue);
-        setInitialTagRequired(tagRequiredValue);
-        setCategoryRequired(categoryRequiredValue);
-        setTagRequired(tagRequiredValue);
+        setCategoryRequired(!!policy.requiresCategory);
+        setTagRequired(!!policy.requiresTag);
     }, [policy?.id, policy?.isLoading, policy?.requiresCategory, policy?.requiresTag]);
 
-    const hasChanges = categoryRequired !== initialCategoryRequired || tagRequired !== initialTagRequired;
+    const hasChanges = useMemo(
+        () => categoryRequired !== initialCategoryRequired || tagRequired !== initialTagRequired,
+        [categoryRequired, initialCategoryRequired, tagRequired, initialTagRequired],
+    );
 
     const handleSave = useCallback(() => {
-        if (isSavingRef.current) {
-            return;
-        }
-
         if (!hasChanges) {
             Navigation.goBack();
             return;
         }
-
-        isSavingRef.current = true;
 
         if (categoryRequired !== initialCategoryRequired) {
             setWorkspaceRequiresCategory(policyData, categoryRequired);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/94352
$ https://github.com/Expensify/App/issues/94353
$ https://github.com/Expensify/App/issues/94360
$ https://github.com/Expensify/App/issues/94384
$ https://github.com/Expensify/App/issues/94473

PROPOSAL:


### Tests

### Prerequisites
- Workspace with **Rules** enabled (More features)
- `rulesRevamp` beta enabled


### [#94352](https://github.com/Expensify/App/issues/94352) — Select-all shows pointer when not clickable
**Setup:** Enable Expensify Card (with bank account). Enable Rules. Do **not** create custom card spend rules (only the built-in default row).

1. Open **Workspace settings → Rules → Card restrictions**
2. Hover the **select-all** checkbox in the table header

**Verify:** Cursor is **disabled** (`not-allowed`), not a hand/pointer. Checkbox is not clickable.

---

### [#94353](https://github.com/Expensify/App/issues/94353) — “1 selected” persists after deleting rule from edit page
**Setup:** Create an expense default rule (**Add rule → Apply expense defaults**).

1. Open **Rules → Expense defaults**
2. Select the rule via **checkbox**
3. Open the rule (tap/click row)
4. **Delete rule → Delete**

**Verify:** **“1 selected”** bulk-actions dropdown is **gone** after returning to the table.

---

### [#94360](https://github.com/Expensify/App/issues/94360) — “Custom rules” section splits when sorting by Card
**Setup:** Enable Expensify Card. Assign virtual cards to you and another member. Create **two** custom card spend rules (one per card).

1. Open **Rules → Card restrictions**
2. Click the **Card** column header to sort

**Verify:** **“Custom rules”** appears **once** as a section header (default row stays grouped; no extra “Custom rules” band in the middle of the list).

---

### [#94384](https://github.com/Expensify/App/issues/94384) — Require fields Save needs two taps
**Setup:** Enable **Tags** in More features and add tags. Enable Rules.

1. Open **Rules → Require fields for all expenses**
2. Enable the **Tag** toggle (Categories and Tags both unlocked)
3. Tap **Save rule** once

**Verify:** Rule saves and you navigate back to the **Rules** page on the **first** tap (not a no-op, and not two screens back on a second tap).






- [x] Verify that no errors appear in the JS console

### Offline tests
### [#94473](https://github.com/Expensify/App/issues/94473) — Offline indicator mid-screen on Add rule (mobile)
**Setup:** Enable Rules. Use **iOS or Android** app.

1. Open **Workspace settings → Rules**
2. Tap **Add rule**
3. Go **offline**

**Verify:** **“You appear to be offline”** is pinned to the **bottom** of the screen, not floating under the menu items.

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/f4846fbe-8257-42b5-9cc9-7c3f207cfc5c

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/850805ff-824c-4a1d-9109-ee9704a1d025


https://github.com/user-attachments/assets/677256a0-25ef-4578-bd21-18cc36a1f99e

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/ebd610d4-851c-4e9d-9688-7a8386d09bad


https://github.com/user-attachments/assets/8d3c6bbf-d69e-4f12-99e1-0f160ae2d164


https://github.com/user-attachments/assets/8582255c-ba13-46ea-96cc-2a1e3ba9d819

</details>
