### PR TITLE
Show date change in system message when a distance date edit also changes the rate

### DIFF
--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -291,7 +291,19 @@ function getForReportAction({
         // Only Distance edits should modify amount and merchant (which stores distance) in a single transaction.
         // We check the merchant is in distance format (includes @) as a sanity check
         if (hasModifiedMerchant && (reportActionOriginalMessage?.merchant ?? '').includes('@')) {
-            return getForDistanceRequest(translate, reportActionOriginalMessage?.merchant ?? '', reportActionOriginalMessage?.oldMerchant ?? '', amount, oldAmount);
+            const distanceMessage = getForDistanceRequest(translate, reportActionOriginalMessage?.merchant ?? '', reportActionOriginalMessage?.oldMerchant ?? '', amount, oldAmount);
+
+            // A date edit that moves the expense into a different mileage-rate window bundles the rate and the date
+            // change into a single MODIFIED_EXPENSE action. getForDistanceRequest only describes the rate/distance
+            // change, so append the date change here instead of letting it be dropped by the early return.
+            if (reportActionOriginalMessage?.oldCreated && reportActionOriginalMessage?.created) {
+                const formattedOldCreated = DateUtils.formatWithUTCTimeZone(reportActionOriginalMessage.oldCreated, CONST.DATE.FNS_FORMAT_STRING);
+                const dateChangeFragments: string[] = [];
+                buildMessageFragmentForValue(translate, reportActionOriginalMessage.created, formattedOldCreated, translate('common.date'), false, [], [], dateChangeFragments);
+                return `${distanceMessage}${getMessageLine(translate, `\n${translate('iou.changed')}`, dateChangeFragments)}`;
+            }
+
+            return distanceMessage;
         }
         buildMessageFragmentForValue(
             translate,

--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -68,6 +68,24 @@ function buildMessageFragmentForValue(
 }
 
 /**
+ * Builds the message fragment for a modified expense date, when both the old and new created dates are present.
+ */
+function buildDateChangeFragment(
+    translate: LocalizedTranslate,
+    oldCreated: string | undefined,
+    created: string | undefined,
+    setFragments: string[],
+    removalFragments: string[],
+    changeFragments: string[],
+) {
+    if (!oldCreated || !created) {
+        return;
+    }
+    const formattedOldCreated = DateUtils.formatWithUTCTimeZone(oldCreated, CONST.DATE.FNS_FORMAT_STRING);
+    buildMessageFragmentForValue(translate, created, formattedOldCreated, translate('common.date'), false, setFragments, removalFragments, changeFragments);
+}
+
+/**
  * Get the absolute value for a tax amount.
  */
 function getTaxAmountAbsValue(taxAmount: number): number {
@@ -296,10 +314,9 @@ function getForReportAction({
             // A date edit that moves the expense into a different mileage-rate window bundles the rate and the date
             // change into a single MODIFIED_EXPENSE action. getForDistanceRequest only describes the rate/distance
             // change, so append the date change here instead of letting it be dropped by the early return.
-            if (reportActionOriginalMessage?.oldCreated && reportActionOriginalMessage?.created) {
-                const formattedOldCreated = DateUtils.formatWithUTCTimeZone(reportActionOriginalMessage.oldCreated, CONST.DATE.FNS_FORMAT_STRING);
-                const dateChangeFragments: string[] = [];
-                buildMessageFragmentForValue(translate, reportActionOriginalMessage.created, formattedOldCreated, translate('common.date'), false, [], [], dateChangeFragments);
+            const dateChangeFragments: string[] = [];
+            buildDateChangeFragment(translate, reportActionOriginalMessage?.oldCreated, reportActionOriginalMessage?.created, [], [], dateChangeFragments);
+            if (dateChangeFragments.length > 0) {
                 return `${distanceMessage}${getMessageLine(translate, `\n${translate('iou.changed')}`, dateChangeFragments)}`;
             }
 
@@ -338,10 +355,7 @@ function getForReportAction({
         );
     }
 
-    if (reportActionOriginalMessage?.oldCreated && reportActionOriginalMessage?.created) {
-        const formattedOldCreated = DateUtils.formatWithUTCTimeZone(reportActionOriginalMessage.oldCreated, CONST.DATE.FNS_FORMAT_STRING);
-        buildMessageFragmentForValue(translate, reportActionOriginalMessage.created, formattedOldCreated, translate('common.date'), false, setFragments, removalFragments, changeFragments);
-    }
+    buildDateChangeFragment(translate, reportActionOriginalMessage?.oldCreated, reportActionOriginalMessage?.created, setFragments, removalFragments, changeFragments);
 
     if (hasModifiedMerchant) {
         buildMessageFragmentForValue(

--- a/tests/unit/ModifiedExpenseMessageTest.ts
+++ b/tests/unit/ModifiedExpenseMessageTest.ts
@@ -893,6 +893,35 @@ describe('ModifiedExpenseMessage', () => {
             });
         });
 
+        describe('when the date change also changes the distance rate', () => {
+            const reportAction = {
+                ...createRandomReportAction(1),
+                actionName: CONST.REPORT.ACTIONS.TYPE.MODIFIED_EXPENSE,
+                originalMessage: {
+                    oldMerchant: '56.36 mi @ $0.70 / mi',
+                    merchant: '56.36 mi @ $0.99 / mi',
+                    oldAmount: 3945,
+                    amount: 5580,
+                    oldCurrency: CONST.CURRENCY.USD,
+                    currency: CONST.CURRENCY.USD,
+                    oldCreated: '2025-06-19',
+                    created: '2026-06-19',
+                },
+            };
+
+            it('then the message reports both the rate change and the date change', () => {
+                const expectedResult = `changed the rate to ${reportAction.originalMessage.merchant} (previously ${reportAction.originalMessage.oldMerchant}), which updated the amount to $55.80 (previously $39.45)\nchanged the date to 2026-06-19 (previously 2025-06-19)`;
+                const result = getForReportAction({
+                    translate: translateLocal,
+                    reportAction,
+                    policy: undefined,
+                    policyTags: undefined,
+                    currentUserLogin: CURRENT_USER_LOGIN,
+                });
+                expect(result).toEqual(expectedResult);
+            });
+        });
+
         describe('when moving an expense', () => {
             it('returns the movedFromOrToReportMessage message when provided', () => {
                 const reportAction = {


### PR DESCRIPTION
### Explanation of Change
When a distance expense's date is edited such that the new date falls into a different mileage-rate validity window, the edit is bundled into a single `MODIFIEDEXPENSE` action carrying both the rate/merchant/amount change **and** the date change (`oldCreated`/`created`).

On the frontend, the system message text for that action is composed from `originalMessage` by `getForReportAction` in `ModifiedExpenseMessage.ts` (the backend already includes the date in both `message` and `originalMessage`). Because the merchant is in distance format (contains `@`), execution hit the early `return getForDistanceRequest(...)`, which only describes the rate/distance change and bypassed the date-fragment builder. As a result the "changed the date" part was silently dropped, so editing the date showed only a rate change and no date change.

This change captures the distance message and, when the same action also has `oldCreated`/`created`, appends the date change using the existing `buildMessageFragmentForValue`/`getMessageLine` helpers (no new copy, fully localized) before returning. Date-only and rate-only paths are unchanged.

### Fixed Issues
$ https://github.com/Expensify/App/issues/94520
PROPOSAL: https://github.com/Expensify/App/issues/94520#issuecomment-4794281432

### Tests
1. As an admin, enable Distance rates on a workspace and create two rates with non-overlapping date windows, e.g. Rate A: $0.70/mi valid Jan 1 2025 – Dec 31 2025, Rate B: $0.50/mi valid Jan 1 2026 – Dec 31 2026.
2. Go to the workspace chat and create a distance expense with a date in 2025 (so it uses Rate A).
3. Open the expense and tap Date.
4. Change the date to a day in 2026 (so it now resolves to Rate B).
5. Open the expense's thread/chat and verify the system message reports both the rate change and the date change, e.g. "changed the rate to ... (previously ...), which updated the amount to ... (previously ...)" followed by "changed the date to 2026-... (previously 2025-...)".
6. Edit the date to another day within the same rate window (no rate change) and verify the message still reads "changed the date to ... (previously ...)" as before.
7. Change only the distance rate (without changing the date) and verify the message still reads "changed the rate to ... (previously ...)" with no spurious date text.

https://github.com/user-attachments/assets/0406534c-ad34-4571-9b78-892acd4cb23f

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go offline.
2. Perform the steps in the Tests section, editing the date of a 2025 distance expense to 2026.
3. Verify the optimistic system message shows both the rate change and the date change.
4. Go back online and verify the message persists unchanged after the server response.

### QA Steps
1. As an admin, enable Distance rates on a workspace and create two rates with non-overlapping date windows (Rate A for 2025, Rate B for 2026).
2. Go to the workspace chat and create a distance expense with a date in 2025.
3. Open the expense and change the date to a day in 2026.
4. Verify the system message reports both the rate change and the date change.
5. Edit the date again within the same rate window and verify only the date change is reported, with correct previous/new values.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/0406534c-ad34-4571-9b78-892acd4cb23f

</details>
