### PR TITLE
[Payment due @ZhenjaHorbach] fix(ReceiptImage): render local PDF receipts via LocalPDFReceiptPreview

### DIFF
--- a/src/components/PDFThumbnail/PDFThumbnailError.tsx
+++ b/src/components/PDFThumbnail/PDFThumbnailError.tsx
@@ -6,16 +6,23 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import variables from '@styles/variables';
 
+import type {StyleProp, ViewStyle} from 'react-native';
+
 import React from 'react';
 import {View} from 'react-native';
 
-function PDFThumbnailError() {
+type PDFThumbnailErrorProps = {
+    /** Additional styles applied to the placeholder container (e.g. to widen it past its default max width) */
+    style?: StyleProp<ViewStyle>;
+};
+
+function PDFThumbnailError({style}: PDFThumbnailErrorProps) {
     const styles = useThemeStyles();
     const theme = useTheme();
     const icons = useMemoizedLazyExpensifyIcons(['ReceiptSlash']);
 
     return (
-        <View style={[styles.justifyContentCenter, styles.pdfErrorPlaceholder, styles.alignItemsCenter]}>
+        <View style={[styles.justifyContentCenter, styles.pdfErrorPlaceholder, styles.alignItemsCenter, style]}>
             <Icon
                 src={icons.ReceiptSlash}
                 width={variables.receiptPlaceholderIconWidth}

--- a/src/components/PDFThumbnail/index.tsx
+++ b/src/components/PDFThumbnail/index.tsx
@@ -2,6 +2,8 @@ import LoadingIndicator from '@components/LoadingIndicator';
 
 import useThemeStyles from '@hooks/useThemeStyles';
 
+import type {PDFDocumentProxy} from 'pdfjs-dist';
+
 // eslint-disable-next-line import/extensions
 import pdfWorkerSource from 'pdfjs-dist/legacy/build/pdf.worker.min.mjs';
 import React, {useMemo, useState} from 'react';
@@ -58,7 +60,16 @@ function PDFThumbnail({previewSourceURL, style, enabled = true, onPassword, onLo
 
     return (
         <View style={[style, styles.overflowHidden, failedToLoad && styles.h100]}>
-            <View style={[styles.w100, styles.h100, !failedToLoad && {...styles.alignItemsCenter, ...styles.justifyContentCenter}]}>
+            <View
+                style={[
+                    styles.w100,
+                    styles.h100,
+                    !failedToLoad && {
+                        ...styles.alignItemsCenter,
+                        ...styles.justifyContentCenter,
+                    },
+                ]}
+            >
                 {enabled && !failedToLoad && thumbnail}
                 {failedToLoad && <PDFThumbnailError />}
             </View>
@@ -69,3 +80,8 @@ function PDFThumbnail({previewSourceURL, style, enabled = true, onPassword, onLo
 PDFThumbnail.displayName = 'PDFThumbnail';
 
 export default React.memo(PDFThumbnail);
+
+// Re-exported so other PDF-rendering components reuse this file's worker setup
+// instead of importing pdfjs-dist/react-pdf directly.
+export {Document, Thumbnail};
+export type {PDFDocumentProxy};

--- a/src/components/ReceiptImage/index.tsx
+++ b/src/components/ReceiptImage/index.tsx
@@ -4,8 +4,8 @@ import type {IconSize} from '@components/EReceiptThumbnail';
 import EReceiptWithSizeCalculation from '@components/EReceiptWithSizeCalculation';
 import type {FullScreenLoadingIndicatorIconSize} from '@components/FullscreenLoadingIndicator';
 import ImageWithLoading from '@components/ImageWithLoading';
-import PDFThumbnail from '@components/PDFThumbnail';
 import ReceiptEmptyState from '@components/ReceiptEmptyState';
+import LocalPDFReceiptPreview from '@components/ReportActionItem/LocalPDFReceiptPreview';
 import type {TransactionListItemType} from '@components/Search/SearchList/ListItem/types';
 import ThumbnailImage from '@components/ThumbnailImage';
 
@@ -191,10 +191,11 @@ function ReceiptImage({
 
     if (isPDFThumbnail) {
         return (
-            <PDFThumbnail
-                previewSourceURL={source ?? ''}
-                style={[styles.w100, styles.h100]}
+            <LocalPDFReceiptPreview
+                sourceURL={source ?? ''}
+                shouldUseFullHeight={shouldUseFullHeight}
                 onLoadSuccess={onLoad}
+                onLoadFailure={onLoadFailure}
             />
         );
     }

--- a/src/components/ReportActionItem/LocalPDFReceiptPreview/index.native.tsx
+++ b/src/components/ReportActionItem/LocalPDFReceiptPreview/index.native.tsx
@@ -1,0 +1,22 @@
+import PDFThumbnail from '@components/PDFThumbnail';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import React from 'react';
+
+import type LocalPDFReceiptPreviewProps from './types';
+
+// `shouldUseFullHeight` only affects the web zoom-mode container sizing; on native the non-zoom PDFThumbnail is used.
+function LocalPDFReceiptPreview({sourceURL, onLoadFailure, onLoadSuccess}: LocalPDFReceiptPreviewProps) {
+    const styles = useThemeStyles();
+    return (
+        <PDFThumbnail
+            previewSourceURL={sourceURL}
+            style={[styles.w100, styles.h100]}
+            onLoadError={onLoadFailure}
+            onLoadSuccess={onLoadSuccess}
+        />
+    );
+}
+
+export default LocalPDFReceiptPreview;

--- a/src/components/ReportActionItem/LocalPDFReceiptPreview/index.tsx
+++ b/src/components/ReportActionItem/LocalPDFReceiptPreview/index.tsx
@@ -1,0 +1,112 @@
+import LoadingIndicator from '@components/LoadingIndicator';
+import {Document, Thumbnail} from '@components/PDFThumbnail';
+import type {PDFDocumentProxy} from '@components/PDFThumbnail';
+import PDFThumbnailError from '@components/PDFThumbnail/PDFThumbnailError';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
+
+import React, {useState} from 'react';
+import {View} from 'react-native';
+
+import type LocalPDFReceiptPreviewProps from './types';
+
+// Must be a stable reference: react-pdf's <Document> reloads the PDF whenever this object changes identity,
+// so a new literal on every render would tear down and restart the load in a loop.
+const DOCUMENT_OPTIONS = {cMapUrl: '/cmaps/', cMapPacked: true};
+
+function LocalPDFReceiptPreview({sourceURL, shouldUseFullHeight, onLoadFailure, onLoadSuccess}: LocalPDFReceiptPreviewProps) {
+    const styles = useThemeStyles();
+    const [failedToLoad, setFailedToLoad] = useState(false);
+    const [containerSize, setContainerSize] = useState<{width: number; height: number} | undefined>(undefined);
+    const [pageAspectRatio, setPageAspectRatio] = useState<number | undefined>(undefined);
+
+    const handleDocumentLoadSuccess = (pdf: PDFDocumentProxy) => {
+        pdf.getPage(1)
+            .then((page) => {
+                const viewport = page.getViewport({scale: 1});
+                if (viewport.width > 0 && viewport.height > 0) {
+                    setPageAspectRatio(viewport.width / viewport.height);
+                }
+                onLoadSuccess?.();
+            })
+            .catch(() => onLoadSuccess?.());
+    };
+
+    const handleDocumentLoadError = () => {
+        setFailedToLoad(true);
+        onLoadFailure?.();
+    };
+
+    // Render at zoom-scale × display size, CSS-scale back to 1× so the canvas is already at zoom
+    // resolution and stays sharp when ReceiptHoverZoom applies its scale.
+    const oversampleStyle = (() => {
+        if (!containerSize || pageAspectRatio === undefined) {
+            return undefined;
+        }
+        const displayWidth = containerSize.width;
+        const tw = displayWidth * CONST.RECEIPT.HOVER_ZOOM_SCALE;
+        const th = (displayWidth / pageAspectRatio) * CONST.RECEIPT.HOVER_ZOOM_SCALE;
+        return {
+            divStyle: {
+                position: 'absolute' as const,
+                top: 0,
+                left: 0,
+                width: tw,
+                height: th,
+                transform: `scale(${1 / CONST.RECEIPT.HOVER_ZOOM_SCALE})`,
+                transformOrigin: 'top left',
+            },
+            thumbnailWidth: tw,
+        };
+    })();
+
+    const isReady = containerSize !== undefined && oversampleStyle !== undefined;
+
+    // Before the PDF aspect ratio is known, fill the parent so the loading indicator / error placeholder is
+    // centred. In a full-height context the parent is auto-height (flexibleHeight), so h100 would collapse to its
+    // minHeight — fall back to a 1:1 box so the placeholder fills the panel instead. Once the ratio is known,
+    // switch to the PDF's natural aspect ratio so the WideRHP container can expand to the full page height, while
+    // fixed-height contexts (e.g. 16:9 expenseViewImage) simply clip the excess.
+    const fallbackHeightStyle = shouldUseFullHeight ? {aspectRatio: 1} : styles.h100;
+    const heightStyle = pageAspectRatio !== undefined ? {aspectRatio: pageAspectRatio} : fallbackHeightStyle;
+
+    return (
+        <View
+            style={[styles.w100, heightStyle, styles.overflowHidden]}
+            onLayout={(e) => {
+                const {width, height} = e.nativeEvent.layout;
+                setContainerSize((prev) => (prev?.width === width && prev?.height === height ? prev : {width, height}));
+            }}
+        >
+            {!isReady && !failedToLoad && <LoadingIndicator />}
+            {failedToLoad ? (
+                <PDFThumbnailError style={shouldUseFullHeight ? styles.pdfErrorPlaceholderFullWidth : undefined} />
+            ) : (
+                <Document
+                    loading={null}
+                    file={sourceURL}
+                    options={DOCUMENT_OPTIONS}
+                    externalLinkTarget="_blank"
+                    onLoadSuccess={handleDocumentLoadSuccess}
+                    onLoadError={handleDocumentLoadError}
+                    error={() => null}
+                >
+                    {isReady && (
+                        <div style={oversampleStyle.divStyle}>
+                            <View pointerEvents="none">
+                                <Thumbnail
+                                    pageIndex={0}
+                                    width={oversampleStyle.thumbnailWidth}
+                                />
+                            </View>
+                        </div>
+                    )}
+                </Document>
+            )}
+        </View>
+    );
+}
+
+export default LocalPDFReceiptPreview;

--- a/src/components/ReportActionItem/LocalPDFReceiptPreview/types.ts
+++ b/src/components/ReportActionItem/LocalPDFReceiptPreview/types.ts
@@ -1,0 +1,15 @@
+type LocalPDFReceiptPreviewProps = {
+    /** Local URL of the PDF file to preview */
+    sourceURL: string;
+
+    /** Whether the preview should fill the full available height of its container */
+    shouldUseFullHeight?: boolean;
+
+    /** Called when the PDF fails to load */
+    onLoadFailure?: () => void;
+
+    /** Called when the PDF loads successfully */
+    onLoadSuccess?: () => void;
+};
+
+export default LocalPDFReceiptPreviewProps;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4832,6 +4832,11 @@ const staticStyles = (theme: ThemeColors) =>
             backgroundColor: theme.highlightBG,
         },
 
+        pdfErrorPlaceholderFullWidth: {
+            width: '100%',
+            maxWidth: '100%',
+        },
+
         moneyRequestAttachReceipt: {
             backgroundColor: theme.highlightBG,
             borderColor: theme.border,


### PR DESCRIPTION
### Explanation of Change

Introduces `LocalPDFReceiptPreview`, a platform-split component for rendering local PDF receipts in `ReceiptImage`. The web implementation uses `react-pdf`/`pdfjs-dist` and pre-renders at zoom resolution (oversample technique) so the canvas stays sharp when `ReceiptHoverZoom` applies its scale. The native implementation delegates to `PDFThumbnail`. `ReceiptImage` now uses this component instead of calling `PDFThumbnail` directly.

https://github.com/user-attachments/assets/593e476a-d7ef-4970-b966-dfa4289e1341

### Fixed Issues

$ [https://github.com/Expensify/App/pull/93583#issuecomment-4729415380](<https://github.com/Expensify/App/pull/93583#issuecomment-4729415380>)<br>PROPOSAL:

### Tests

1. Create or find an expense with a locally-attached PDF receipt (before SmartScan completes so the thumbnail is rendered from the local file).
2. Open the expense detail screen on **Web (Chrome/Safari)**.
3. Verify that the PDF receipt thumbnail renders correctly (first page visible, no blank/broken state).
4. Hover over the PDF thumbnail and verify that the image stays sharp when the zoom effect is applied.

---

1. Create or find an expense with a locally-attached PDF receipt on **iOS or Android**.
2. Open the expense detail screen.
3. Verify that the PDF receipt thumbnail renders correctly via the native viewer.

---

1. Attach a password-protected or corrupted PDF as a receipt.
2. Open the expense detail screen.
3. Verify that the error/empty state is shown gracefully (no crash, no unhandled error in console).

- [X] Verify that no errors appear in the JS console

### Offline tests

N/A — receipt rendering is local file access and does not depend on network state.

### QA Steps

Same as tests.

- [X] Verify that no errors appear in the JS console

### PR Author Checklist

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
  - [X] I added steps for local testing in the `Tests` section
  - [X] I added steps for the expected offline behavior in the `Offline steps` section
  - [X] I added steps for Staging and/or Production testing in the `QA steps` section
  - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [X] I tested this PR with a [High Traffic account](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts>) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms>)
- [X] I ran the tests on **all platforms** & verified they passed on:
  - [X] Android: Native
  - [X] Android: mWeb Chrome
  - [X] iOS: Native
  - [X] iOS: mWeb Safari
  - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code>))
  - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [X] I verified that comments were added to code that is not self explanatory
  - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md>)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] If any new file was added I verified that:
  - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
  - [X] A similar style doesn't already exist
  - [X] The style can't be created with an existing [StyleUtils](<https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts>) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
  - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [X] I verified that all the inputs inside a form are aligned with each other.
  - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] I added [unit tests](<https://github.com/Expensify/App/blob/main/tests/README.md>) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details><summary>Android: Native</summary>

</details>

<details><summary>Android: mWeb Chrome</summary>

</details>

<details><summary>iOS: Native</summary>

</details>

<details><summary>iOS: mWeb Safari</summary>

</details>

<details><summary>MacOS: Chrome / Safari</summary>

</details>