### PR TITLE
fix(scan): show empty amount and error when SmartScan fails

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -314,6 +314,7 @@ function MoneyRequestView({
     const isOdometerDistanceRequest = isOdometerDistanceRequestTransactionUtils(transaction);
     const isMapDistanceRequest = isMapDistanceRequestTransactionUtils(transaction) || isDistanceTypeRequest(transaction);
     const isTransactionScanning = isScanning(updatedTransaction ?? transaction);
+    const isTransactionScanFailed = (updatedTransaction ?? transaction)?.receipt?.state === CONST.IOU.RECEIPT_STATE.SCAN_FAILED;
     const hasRoute = hasRouteTransactionUtils(transactionBackup ?? transaction, isDistanceRequest);
 
     const rawActualAttendees = isFromMergeTransaction && updatedTransaction ? updatedTransaction.comment?.attendees : transactionAttendees;
@@ -556,6 +557,8 @@ function MoneyRequestView({
     if (isTransactionScanning) {
         merchantTitle = translate('iou.receiptStatusTitle');
         amountTitle = translate('iou.receiptStatusTitle');
+    } else if (isTransactionScanFailed) {
+        amountTitle = '';
     }
 
     const shouldNavigateToUpgradePath = !policyForMovingExpenses && !shouldSelectPolicy;
@@ -704,6 +707,10 @@ function MoneyRequestView({
             date: {
                 isError: transactionDate === '',
                 translationPath: canEditDate ? 'common.error.enterDate' : 'common.error.missingDate',
+            },
+            amount: {
+                isError: isTransactionScanFailed,
+                translationPath: 'iou.receiptScanningFailed',
             },
         };
 


### PR DESCRIPTION
## Problem

$ #94494

When a SmartScan fails (`receipt.state === SCANFAILED`), the expense detail Amount field renders `$0.00` and no error indicator is shown. It should show an empty field with a red-brick error.

## Root Cause

`MoneyRequestView.tsx` computes `amountTitle` by branching on `isTransactionScanning` (lines 556-559). `isTransactionScanning` is only `true` while `receipt.state` is `SCAN_READY` or `SCANNING`. When the receipt transitions to `SCAN_FAILED`, `isTransactionScanning` is `false`, so `amountTitle` falls back to `formattedTransactionAmount.toString()` — which formats the placeholder `transaction.amount = 0` as `"$0.00"`.

There was no branch for `SCAN_FAILED`, so:
1. The placeholder amount displayed as `$0.00` instead of empty.
2. `getErrorForField("amount")` had no check for this state, so no red-brick indicator was shown.

## Fix

**3 minimal changes in `MoneyRequestView.tsx`:**

1. Introduce `isTransactionScanFailed` from `receipt.state === CONST.IOU.RECEIPT_STATE.SCAN_FAILED`
2. Clear `amountTitle` in the scan-failed branch (placeholder 0 is not a real user amount)
3. Add `amount` to `fieldChecks` inside `getErrorForField` so the existing `iou.receiptScanningFailed` translation drives the red-brick indicator

## Testing

- Create a scan expense and trigger a SmartScan failure
- Verify Amount field is empty (not `$0.00`)
- Verify red error indicator appears on the amount row
- Verify scanning and completed states are unaffected