### PR TITLE
fix(search): sync missingCategory violation live when workspace category rule changes

### DIFF
--- a/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
@@ -22,6 +22,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import type {TransactionPreviewData} from '@libs/actions/Search';
 import {handleActionButtonPress as handleActionButtonPressUtil} from '@libs/actions/Search';
 import {syncMissingAttendeesViolation} from '@libs/AttendeeUtils';
+import {syncMissingCategoryViolation} from '@libs/CategoryUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {isAttendeeTrackingEnabled} from '@libs/PolicyUtils';
 import {isInvoiceReport} from '@libs/ReportUtils';
@@ -157,7 +158,14 @@ function TransactionListItem<TItem extends ListItem>({
         isInvoice,
     );
 
-    const transactionViolations = mergeProhibitedViolations(attendeeOnyxViolations);
+    // Sync missingCategory violation with current policy requiresCategory setting (can be removed later when BE handles this)
+    const categoryOnyxViolations = syncMissingCategoryViolation(
+        attendeeOnyxViolations,
+        transaction?.category ?? transactionItem.category,
+        policyForViolations?.requiresCategory,
+    );
+
+    const transactionViolations = mergeProhibitedViolations(categoryOnyxViolations);
 
     const {isDelegateAccessRestricted} = useDelegateNoAccessState();
     const {showDelegateNoAccessModal} = useDelegateNoAccessActions();

--- a/src/libs/CategoryUtils.ts
+++ b/src/libs/CategoryUtils.ts
@@ -204,6 +204,20 @@ function getDecodedLeafCategoryName(categoryName: string): string {
     return Str.htmlDecode(leaf.trim());
 }
 
+function syncMissingCategoryViolation<T extends {name: string}>(violations: T[], category: string | undefined, requiresCategory: boolean | undefined): T[] {
+    const hasMissingCategoryViolation = violations.some((v) => v.name === CONST.VIOLATIONS.MISSING_CATEGORY);
+    // isCategoryMissing handles undefined, CATEGORY_EMPTY_VALUE, and "Uncategorized" sentinel
+    const shouldShowMissingCategory = !!requiresCategory && isCategoryMissing(category);
+
+    if (!hasMissingCategoryViolation && shouldShowMissingCategory) {
+        return [...violations, {name: CONST.VIOLATIONS.MISSING_CATEGORY, type: CONST.VIOLATION_TYPES.VIOLATION, showInReview: true} as unknown as T];
+    }
+    if (hasMissingCategoryViolation && !shouldShowMissingCategory) {
+        return violations.filter((v) => v.name !== CONST.VIOLATIONS.MISSING_CATEGORY);
+    }
+    return violations;
+}
+
 function getAvailableNonPersonalPolicyCategories(policyCategories: OnyxCollection<PolicyCategories>, personalPolicyID: string | undefined) {
     return Object.fromEntries(
         Object.entries(policyCategories ?? {}).filter(([key, categories]) => {
@@ -232,4 +246,5 @@ export {
     getDecodedLeafCategoryName,
     processCategoryNameSegments,
     getAvailableNonPersonalPolicyCategories,
+    syncMissingCategoryViolation,
 };


### PR DESCRIPTION
## Problem

$ #93770

When a workspace admin toggles "Members must categorize all expenses" on or off, the violation indicator on Spend rows does not update live. The user must open the expense to trigger the update.

## Root Cause

`TransactionListItem` already syncs the `missingAttendees` violation at render time via `syncMissingAttendeesViolation` (line 149-158), but had no equivalent for `missingCategory`. So when `policyForViolations.requiresCategory` changes, the row never re-derives the violation.

A secondary cause: the optimistic recompute triggered by `setWorkspaceRequiresCategory` → `pushTransactionViolationsOnyxData` checks `!categoryKey`, which is `false` for the Search sentinel value `"Uncategorized"` (`CONST.SEARCH.CATEGORY_DEFAULT_VALUE`) — a truthy string — so the violation is never written for expenses using that sentinel.

## Fix

**`src/libs/CategoryUtils.ts`** — add `syncMissingCategoryViolation` mirroring the `syncMissingAttendeesViolation` pattern:

- Uses `isCategoryMissing()` which correctly handles `undefined`, `CATEGORY_EMPTY_VALUE`, and the `"Uncategorized"` sentinel
- Adds `missingCategory` when `requiresCategory && isCategoryMissing(category)`
- Removes stale `missingCategory` when rule is toggled off

**`src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx`** — call `syncMissingCategoryViolation` after `syncMissingAttendeesViolation`, passing live transaction category and live policy `requiresCategory`.

## Testing

- In Spend view, have an uncategorized expense visible
- Toggle workspace "Members must categorize all expenses" on → violation indicator appears on the row immediately
- Toggle it off → indicator disappears immediately
- Verify attendees sync is unaffected