### PR TITLE
fix: clear domain member selection when group filter changes

### DIFF
--- a/src/pages/domain/BaseDomainMembersPage.tsx
+++ b/src/pages/domain/BaseDomainMembersPage.tsx
@@ -279,6 +279,7 @@ function BaseDomainMembersPage({
                 </HeaderWithBackButton>
                 {shouldDisplayButtonsInSeparateLine && !!headerContent && <View style={[styles.ph5, styles.flexRow, styles.gap2]}>{headerContent}</View>}
                 <SelectionListWithModal
+                    key={preFilter}
                     data={filteredData}
                     shouldShowRightCaret
                     style={{


### PR DESCRIPTION
## Summary
$ #93972 — Selection mode from previous group filter persists after applying new group filter.

## Root Cause
When switching between groups on the domain members page, the `SelectionListWithModal` component retains its internal selection state because React reuses the same component instance.

## Fix
Added `key={preFilter}` to `SelectionListWithModal` to force React to unmount and remount the component when the group filter changes, effectively clearing any previous selection state.

## Test Plan
1. Go to Workspaces > Domain > Groups
2. Select a group that has members (e.g. Group 9)
3. Select any member
4. Switch to a different group (e.g. Group 18)
5. Verify that the selection mode is cleared and no members are selected

## Screenshots
<details>
<summary>Before (bug)</summary>
Selection persists after group change
</details>
<details>
<summary>After (fixed)</summary>
Selection clears when group changes
</details>