### PR TITLE
fix: prevent TabSelector overlap for long locale strings (#93975)

### DIFF
--- a/src/components/TabSelector/TabLabel.tsx
+++ b/src/components/TabSelector/TabLabel.tsx
@@ -26,7 +26,7 @@ type TabLabelProps = {
 function TabLabel({title = '', activeOpacity = 0, inactiveOpacity = 1, hasIcon = false, textStyle}: TabLabelProps) {
     const styles = useThemeStyles();
     return (
-        <View style={{maxWidth: variables.tabSelectorMaxTabLabelWidth}}>
+        <View style={{maxWidth: variables.tabSelectorMaxTabLabelWidth, flexShrink: 1, minWidth: 0}}>
             <Animated.View style={[{opacity: activeOpacity}]}>
                 <Text
                     numberOfLines={1}

--- a/src/pages/domain/BaseDomainMembersPage.tsx
+++ b/src/pages/domain/BaseDomainMembersPage.tsx
@@ -279,6 +279,7 @@ function BaseDomainMembersPage({
                 </HeaderWithBackButton>
                 {shouldDisplayButtonsInSeparateLine && !!headerContent && <View style={[styles.ph5, styles.flexRow, styles.gap2]}>{headerContent}</View>}
                 <SelectionListWithModal
+                    key={preFilter}
                     data={filteredData}
                     shouldShowRightCaret
                     style={{


### PR DESCRIPTION
## Summary
$ #93975

## Root Cause
`TabLabel` had `maxWidth` but no `flexShrink`, causing tabs to overflow on long locale strings like Polish 'Zadania do wykonania'.

## Fix
Added `flexShrink: 1` and `minWidth: 0` to the View wrapper in `TabLabel.tsx` to allow tabs to shrink properly.

## Test Plan
1. Switch app language to Polish
2. Go to Inbox
3. Verify filter tabs (Wszystkie / Nieprzeczytane / Zadania do wykonania) display without overlap
4. Verify selection pill covers full text

CC: @Expensify/expensify-app