### PR TITLE
Hide the Agent rules enforced-by row when RuleBot is removed

### DIFF
--- a/src/pages/workspace/rules/AgentRulesSection.tsx
+++ b/src/pages/workspace/rules/AgentRulesSection.tsx
@@ -15,6 +15,7 @@ import usePolicy from '@hooks/usePolicy';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
+import {isPolicyMemberWithoutPendingDelete} from '@libs/PolicyUtils';
 import {clearPolicyAgentRuleErrors} from '@userActions/Policy/Rules';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
@@ -41,6 +42,9 @@ function AgentRulesSection({policyID, canWriteRules, showReadOnlyModal}: AgentRu
     const ruleBotAccountID = policy?.ruleBotAccountID;
     const ruleBot = ruleBotAccountID ? personalDetailsList?.[ruleBotAccountID] : undefined;
     const ruleBotDisplayName = ruleBot?.displayName ?? ruleBot?.login ?? translate('workspace.rules.agentRules.ruleBotName');
+
+    // ruleBotAccountID stays set on the policy after RuleBot is removed from the workspace, so also require it to still be an active member before showing the "enforced by" line.
+    const isRuleBotActiveMember = isPolicyMemberWithoutPendingDelete(ruleBot?.login, policy);
 
     const sortedRules = Object.entries(agentRules ?? {})
         .filter(([, rule]) => !!rule)
@@ -70,7 +74,7 @@ function AgentRulesSection({policyID, canWriteRules, showReadOnlyModal}: AgentRu
     const renderSubtitle = () => (
         <View style={[styles.mt2, styles.gap2]}>
             <Text style={[styles.textNormal, styles.colorMuted]}>{translate('workspace.rules.agentRules.subtitle')}</Text>
-            {!!ruleBotAccountID && (
+            {!!ruleBotAccountID && isRuleBotActiveMember && (
                 <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1Half]}>
                     <Text style={[styles.textNormal, styles.colorMuted]}>{translate('workspace.rules.agentRules.enforcedBy')}</Text>
                     <UserPill

--- a/tests/ui/AgentRulesSectionTest.tsx
+++ b/tests/ui/AgentRulesSectionTest.tsx
@@ -72,8 +72,8 @@ const mockedNavigate = jest.mocked(Navigation.navigate);
 
 const POLICY_ID = 'POLICY_ID_1';
 
-function setPolicyAgentRules(agentRules: Record<string, unknown> | undefined, ruleBotAccountID?: number) {
-    (mockedUsePolicy as jest.Mock).mockReturnValue({rules: {agentRules}, ruleBotAccountID});
+function setPolicyAgentRules(agentRules: Record<string, unknown> | undefined, ruleBotAccountID?: number, employeeList?: Record<string, unknown>) {
+    (mockedUsePolicy as jest.Mock).mockReturnValue({id: POLICY_ID, rules: {agentRules}, ruleBotAccountID, employeeList});
 }
 
 function getRuleTitles(): string[] {
@@ -303,12 +303,17 @@ describe('AgentRulesSection', () => {
     describe('RuleBot enforcement row', () => {
         const rule = {r1: {ruleID: 'r1', prompt: 'p', title: 'T', created: '2026-01-01 00:00:00'}};
         const RULE_BOT_ACCOUNT_ID = 777;
+        const RULE_BOT_LOGIN = 'agent_777@expensify.ai';
 
-        it('renders the RuleBot pill with the agent stored on the policy', () => {
+        function setRuleBotPersonalDetails() {
             mockPersonalDetails = {
-                [RULE_BOT_ACCOUNT_ID]: {accountID: RULE_BOT_ACCOUNT_ID, displayName: 'RuleBot', login: 'agent_777@expensify.ai', avatar: 'https://example.com/rulebot.png'},
+                [RULE_BOT_ACCOUNT_ID]: {accountID: RULE_BOT_ACCOUNT_ID, displayName: 'RuleBot', login: RULE_BOT_LOGIN, avatar: 'https://example.com/rulebot.png'},
             };
-            setPolicyAgentRules(rule, RULE_BOT_ACCOUNT_ID);
+        }
+
+        it('renders the RuleBot pill when RuleBot is an active policy member', () => {
+            setRuleBotPersonalDetails();
+            setPolicyAgentRules(rule, RULE_BOT_ACCOUNT_ID, {[RULE_BOT_LOGIN]: {}});
 
             render(
                 <AgentRulesSection
@@ -320,13 +325,13 @@ describe('AgentRulesSection', () => {
 
             expect(mockedUserPill).toHaveBeenCalledTimes(1);
             expect(mockedUserPill.mock.calls.at(0)?.at(0)).toEqual(
-                expect.objectContaining({accountID: RULE_BOT_ACCOUNT_ID, displayName: 'RuleBot', email: 'agent_777@expensify.ai', avatar: 'https://example.com/rulebot.png'}),
+                expect.objectContaining({accountID: RULE_BOT_ACCOUNT_ID, displayName: 'RuleBot', email: RULE_BOT_LOGIN, avatar: 'https://example.com/rulebot.png'}),
             );
         });
 
-        it('falls back to the localized RuleBot name when personal details are missing', () => {
-            mockPersonalDetails = {};
-            setPolicyAgentRules(rule, RULE_BOT_ACCOUNT_ID);
+        it('hides the RuleBot pill after RuleBot is removed from the workspace', () => {
+            setRuleBotPersonalDetails();
+            setPolicyAgentRules(rule, RULE_BOT_ACCOUNT_ID, {[RULE_BOT_LOGIN]: {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}});
 
             render(
                 <AgentRulesSection
@@ -336,8 +341,22 @@ describe('AgentRulesSection', () => {
                 />,
             );
 
-            expect(mockedUserPill).toHaveBeenCalledTimes(1);
-            expect(mockedUserPill.mock.calls.at(0)?.at(0)?.displayName).toBe('workspace.rules.agentRules.ruleBotName');
+            expect(mockedUserPill).not.toHaveBeenCalled();
+        });
+
+        it('hides the RuleBot pill when RuleBot is no longer a policy member', () => {
+            setRuleBotPersonalDetails();
+            setPolicyAgentRules(rule, RULE_BOT_ACCOUNT_ID, {});
+
+            render(
+                <AgentRulesSection
+                    policyID={POLICY_ID}
+                    canWriteRules
+                    showReadOnlyModal={jest.fn()}
+                />,
+            );
+
+            expect(mockedUserPill).not.toHaveBeenCalled();
         });
 
         it('does not render the RuleBot pill when no RuleBot is provisioned', () => {


### PR DESCRIPTION
### Explanation of Change

Follow-up to https://github.com/Expensify/App/pull/94131.

The "Agent rules are enforced by [RuleBot]" line was gated only on `policy.ruleBotAccountID`. That value is provisioned when the first agent rule is created but is **not** cleared when RuleBot is removed from the workspace — removing a member only marks the employee pending-delete in `employeeList`. So the line persisted after RuleBot was removed.

This adds a membership check: the line now also requires RuleBot to still be an active member of the policy via `isPolicyMemberWithoutPendingDelete(ruleBot.login, policy)`. The helper returns false when the member is absent or pending-delete, so the line disappears immediately (optimistically, and offline) when RuleBot is removed and stays hidden afterward.

### Fixed Issues
$ https://github.com/Expensify/App/issues/94642

### Tests
1. As an admin with the `customAgent` beta, enable **Rules** on a workspace.
2. Go to **Workspace > Rules > Add agent rule**, enter anything, save, and dismiss the modal.
3. Confirm **"Agent rules are enforced by [RuleBot]"** shows under the Agent rules section.
4. Go to **Members**, wait for RuleBot to appear, and remove it.
5. Go back to **Rules** → confirm the "Agent rules are enforced by" line is now gone.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. With RuleBot present and the app loaded, go offline.
2. Remove RuleBot from **Members** → confirm the "Agent rules are enforced by" line disappears immediately (optimistic pending-delete state).

### QA Steps

Same as Tests (requires the `customAgent` beta on the account).

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios
    - [x] I turned off my network connection and tested it while offline
    - [ ] I tested this PR with a High Traffic account
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be affected by my changes
- [x] I verified that all the inputs are working as expected
- [x] I verified that all the output of the function/component is working as expected
- [x] I followed proper code style
- [x] I verified that this PR follows the guidelines in the [Accessibility Checklist](https://github.com/Expensify/App/blob/main/contributingGuides/ACCESSIBILITY.md)
