### PR TITLE
Always fallback to sorting by name

### DIFF
--- a/src/components/Tables/WorkspaceMembersTable/index.tsx
+++ b/src/components/Tables/WorkspaceMembersTable/index.tsx
@@ -130,7 +130,7 @@ export default function WorkspaceMembersTable({
                 return -1;
             }
 
-            const roleComparison = localeCompare(item1.role, item2.role);
+            const roleComparison = localeCompare(translate('workspace.common.roleName', item1.role), translate('workspace.common.roleName', item2.role));
 
             if (roleComparison !== 0) {
                 return roleComparison * orderMultiplier;
@@ -144,7 +144,7 @@ export default function WorkspaceMembersTable({
             const item2CustomField1Value = item2.employeeUserID;
 
             if (!item1CustomField1Value && !item2CustomField1Value) {
-                return localeCompare(item1.name, item2.name) * orderMultiplier;
+                return memberNameComparison;
             }
 
             if (!item1CustomField1Value) {

--- a/src/components/Tables/WorkspaceMembersTable/index.tsx
+++ b/src/components/Tables/WorkspaceMembersTable/index.tsx
@@ -117,37 +117,75 @@ export default function WorkspaceMembersTable({
         }
 
         if (activeSorting.columnKey === 'role') {
+            if (!item1.role && !item2.role) {
+                return localeCompare(item1.name, item2.name) * orderMultiplier;
+            }
+
             if (!item1.role) {
                 return 1;
             }
+
             if (!item2.role) {
                 return -1;
             }
-            return localeCompare(item1.role, item2.role) * orderMultiplier;
+
+            const roleComparison = localeCompare(item1.role, item2.role);
+
+            if (roleComparison !== 0) {
+                return roleComparison * orderMultiplier;
+            }
+
+            return localeCompare(item1.name, item2.name) * orderMultiplier;
         }
 
         if (activeSorting.columnKey === 'customField1') {
             const item1CustomField1Value = item1.employeeUserID;
             const item2CustomField1Value = item2.employeeUserID;
+
+            if (!item1CustomField1Value && !item2CustomField1Value) {
+                return localeCompare(item1.name, item2.name) * orderMultiplier;
+            }
+
             if (!item1CustomField1Value) {
                 return 1;
             }
+
             if (!item2CustomField1Value) {
                 return -1;
             }
-            return localeCompare(item1CustomField1Value, item2CustomField1Value) * orderMultiplier;
+
+            const employeeIdComparison = localeCompare(item1CustomField1Value, item2CustomField1Value);
+
+            if (employeeIdComparison !== 0) {
+                return employeeIdComparison * orderMultiplier;
+            }
+
+            return localeCompare(item1.name, item2.name) * orderMultiplier;
         }
 
         if (activeSorting.columnKey === 'customField2') {
             const item1CustomField2Value = item1.employeePayrollID;
             const item2CustomField2Value = item2.employeePayrollID;
+
+            if (!item1CustomField2Value && !item2CustomField2Value) {
+                return localeCompare(item1.name, item2.name) * orderMultiplier;
+            }
+
             if (!item1CustomField2Value) {
                 return 1;
             }
+
             if (!item2CustomField2Value) {
                 return -1;
             }
-            return localeCompare(item1CustomField2Value, item2CustomField2Value) * orderMultiplier;
+
+            const payrollIdComparison = localeCompare(item1CustomField2Value, item2CustomField2Value);
+
+            if (payrollIdComparison !== 0) {
+                return payrollIdComparison * orderMultiplier;
+            }
+
+            return localeCompare(item1.name, item2.name) * orderMultiplier;
         }
 
         return 1;

--- a/src/components/Tables/WorkspaceMembersTable/index.tsx
+++ b/src/components/Tables/WorkspaceMembersTable/index.tsx
@@ -111,14 +111,15 @@ export default function WorkspaceMembersTable({
 
     const compareTableItems: CompareItemsCallback<WorkspaceMemberRowData, WorkspaceMembersTableColumnKey> = (item1, item2, activeSorting) => {
         const orderMultiplier = activeSorting.order === 'asc' ? 1 : -1;
+        const memberNameComparison = localeCompare(item1.name, item2.name) * orderMultiplier;
 
         if (activeSorting.columnKey === 'member') {
-            return localeCompare(item1.name, item2.name) * orderMultiplier;
+            return memberNameComparison;
         }
 
         if (activeSorting.columnKey === 'role') {
             if (!item1.role && !item2.role) {
-                return localeCompare(item1.name, item2.name) * orderMultiplier;
+                return memberNameComparison;
             }
 
             if (!item1.role) {
@@ -135,7 +136,7 @@ export default function WorkspaceMembersTable({
                 return roleComparison * orderMultiplier;
             }
 
-            return localeCompare(item1.name, item2.name) * orderMultiplier;
+            return memberNameComparison;
         }
 
         if (activeSorting.columnKey === 'customField1') {
@@ -160,7 +161,7 @@ export default function WorkspaceMembersTable({
                 return employeeIdComparison * orderMultiplier;
             }
 
-            return localeCompare(item1.name, item2.name) * orderMultiplier;
+            return memberNameComparison;
         }
 
         if (activeSorting.columnKey === 'customField2') {
@@ -168,7 +169,7 @@ export default function WorkspaceMembersTable({
             const item2CustomField2Value = item2.employeePayrollID;
 
             if (!item1CustomField2Value && !item2CustomField2Value) {
-                return localeCompare(item1.name, item2.name) * orderMultiplier;
+                return memberNameComparison;
             }
 
             if (!item1CustomField2Value) {
@@ -185,7 +186,7 @@ export default function WorkspaceMembersTable({
                 return payrollIdComparison * orderMultiplier;
             }
 
-            return localeCompare(item1.name, item2.name) * orderMultiplier;
+            return memberNameComparison;
         }
 
         return 1;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Fallback to user name sorting when other fields are the same in the sort order

### Fixed Issues
$ https://github.com/Expensify/App/issues/94645

### Tests
Precondition:

Workspace has members of all types of roles (card admin, auditor, etc).
Go to staging.new.expensify.com
Go to workspace settings > Members.
Click Role on the table header.
Ensure that the users are sorted by role, and then in the corresponding alphabetical order based on the role

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I verified that similar component doesn't exist in the codebase
- [x] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [x] I verified that each file is named correctly
- [x] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [x] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [x] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [x] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [x] I verified that all JSX used for rendering exists in the render method
- [x] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
