### PR TITLE
[Payment due @rojiphil] Show rules feature as on when areRulesEnabled is undefined but categories have active rules

### DIFF
--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -18,7 +18,7 @@ import DistanceRequestUtils from '@libs/DistanceRequestUtils';
 import {isMovingTransactionFromTrackExpense as isMovingTransactionFromTrackExpenseUtil} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
-import {isTaxTrackingEnabled} from '@libs/PolicyUtils';
+import {arePolicyRulesEnabled, isTaxTrackingEnabled} from '@libs/PolicyUtils';
 import type {OptionData} from '@libs/ReportUtils';
 import {
     getCategory,
@@ -358,7 +358,7 @@ function MoneyRequestConfirmationList({
 
     const isCategoryRequired = !!policy?.requiresCategory && !isTypeInvoice;
 
-    const isDescriptionRequired = isCategoryDescriptionRequired(policyCategories, iouCategory, policy?.areRulesEnabled);
+    const isDescriptionRequired = isCategoryDescriptionRequired(policyCategories, iouCategory, arePolicyRulesEnabled(policy, policyCategories));
 
     // If completing a split expense fails, set didConfirm to false to allow the user to edit the fields again
     if (isEditingSplitBill && didConfirm) {

--- a/src/libs/CategoryUtils.ts
+++ b/src/libs/CategoryUtils.ts
@@ -216,6 +216,25 @@ function getAvailableNonPersonalPolicyCategories(policyCategories: OnyxCollectio
     );
 }
 
+function hasAnyCategoryRules(categories: PolicyCategories | undefined): boolean {
+    return Object.values(categories ?? {}).some((category) => {
+        if (category.maxExpenseAmount !== undefined && category.maxExpenseAmount !== null && category.maxExpenseAmount !== CONST.DISABLED_MAX_EXPENSE_VALUE) {
+            return true;
+        }
+        // null means "use policy default" (inactive); 0 = always required, DISABLED_MAX_EXPENSE_VALUE = never required — both are explicit overrides
+        if (category.maxAmountNoReceipt !== undefined && category.maxAmountNoReceipt !== null) {
+            return true;
+        }
+        if (category.maxAmountNoItemizedReceipt !== undefined && category.maxAmountNoItemizedReceipt !== null) {
+            return true;
+        }
+        if (category.areCommentsRequired || category.areAttendeesRequired) {
+            return true;
+        }
+        return !!category.commentHint;
+    });
+}
+
 export {
     formatDefaultTaxRateText,
     formatRequireReceiptsOverText,
@@ -232,4 +251,5 @@ export {
     getDecodedLeafCategoryName,
     processCategoryNameSegments,
     getAvailableNonPersonalPolicyCategories,
+    hasAnyCategoryRules,
 };

--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -4,7 +4,7 @@ import type {Entries, ValueOf} from 'type-fest';
 import type {LocalizedTranslate} from '@components/LocaleContextProvider';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
-import type {Policy, PolicyTagLists, Report, ReportAction, ReportAttributesDerivedValue} from '@src/types/onyx';
+import type {Policy, PolicyCategories, PolicyTagLists, Report, ReportAction, ReportAttributesDerivedValue} from '@src/types/onyx';
 import type {PersonalRulesModifiedFields, PolicyRulesModifiedFields} from '@src/types/onyx/OriginalMessage';
 import ObjectUtils from '@src/types/utils/ObjectUtils';
 import {getDecodedCategoryName, isCategoryMissing} from './CategoryUtils';
@@ -262,6 +262,7 @@ function getForReportAction({
     movedFromReport,
     movedToReport,
     policyTags,
+    policyCategories,
     currentUserLogin,
     reportAttributes,
 }: {
@@ -274,6 +275,7 @@ function getForReportAction({
     // getReportName itself will be migrated away from Onyx.connect in a follow-up PR.
     // See https://github.com/Expensify/App/pull/75562
     policyTags?: OnyxEntry<PolicyTagLists>;
+    policyCategories?: OnyxEntry<PolicyCategories>;
     currentUserLogin: string;
     reportAttributes?: ReportAttributesDerivedValue['reports'];
 }): string {
@@ -526,7 +528,7 @@ function getForReportAction({
         const policyRulesModifiedFields = reportActionOriginalMessage.policyRulesModifiedFields;
 
         if (policyRulesModifiedFields && policy?.id) {
-            const hasPolicyRuleAccess = arePolicyRulesEnabled(policy) && isPolicyAdmin(policy, currentUserLogin);
+            const hasPolicyRuleAccess = arePolicyRulesEnabled(policy, policyCategories) && isPolicyAdmin(policy, currentUserLogin);
             return getRulesModifiedMessage(translate, policyRulesModifiedFields, false, policy?.id, hasPolicyRuleAccess);
         }
     }

--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -15,7 +15,7 @@ import {formatList} from './Localize';
 import Log from './Log';
 import Parser from './Parser';
 import {getPersonalDetailByEmail} from './PersonalDetailsUtils';
-import {findVendorByID, getCleanedTagName, getCommaSeparatedTagNameWithSanitizedColons, getSortedTagKeys, isPolicyAdmin} from './PolicyUtils';
+import {arePolicyRulesEnabled, findVendorByID, getCleanedTagName, getCommaSeparatedTagNameWithSanitizedColons, getSortedTagKeys, isPolicyAdmin} from './PolicyUtils';
 import {getOriginalMessage, isModifiedExpenseAction} from './ReportActionsUtils';
 // This cycle import is safe because ReportNameUtils was extracted from ReportUtils to separate report name computation logic.
 // The functions imported here are pure utility functions that don't create initialization-time dependencies.
@@ -526,7 +526,7 @@ function getForReportAction({
         const policyRulesModifiedFields = reportActionOriginalMessage.policyRulesModifiedFields;
 
         if (policyRulesModifiedFields && policy?.id) {
-            const hasPolicyRuleAccess = !!policy?.areRulesEnabled && isPolicyAdmin(policy, currentUserLogin);
+            const hasPolicyRuleAccess = arePolicyRulesEnabled(policy) && isPolicyAdmin(policy, currentUserLogin);
             return getRulesModifiedMessage(translate, policyRulesModifiedFields, false, policy?.id, hasPolicyRuleAccess);
         }
     }

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1421,7 +1421,7 @@ function arePolicyRulesEnabled(policy: OnyxEntry<Policy>, policyCategories?: Pol
     if (policy?.areRulesEnabled === false) {
         return false;
     }
-    // areRulesEnabled is undefined — derive from per-category rule fields set by OldDot Classic
+    // areRulesEnabled is undefined - this can happen in case of migrated old policies, in such case users might have set up category rules in Classic and we should show Rules as enabled
     return hasAnyCategoryRules(policyCategories ?? undefined);
 }
 

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -45,7 +45,7 @@ import {hasSynchronizationErrorMessage, isConnectionUnverified} from './actions/
 import {shouldShowQBOReimbursableExportDestinationAccountError} from './actions/connections/QuickbooksOnline';
 import addEncryptedAuthTokenToURL from './addEncryptedAuthTokenToURL';
 import {getApiRoot} from './ApiUtils';
-import {getCategoryApproverRule} from './CategoryUtils';
+import {getCategoryApproverRule, hasAnyCategoryRules} from './CategoryUtils';
 import {convertToBackendAmount} from './CurrencyUtils';
 import {isAnyHRConnected, isMergeHRCompleteSetupNeeded} from './HRUtils';
 import Navigation from './Navigation/Navigation';
@@ -1411,7 +1411,24 @@ function canEditTaxRate(policy: Policy, taxID: string): boolean {
     return policy.taxRates?.defaultExternalID !== taxID && policy.taxRates?.foreignTaxDefault !== taxID;
 }
 
-function isPolicyFeatureEnabled(policy: OnyxEntry<Policy>, featureName: PolicyFeatureName): boolean {
+function arePolicyRulesEnabled(policy: OnyxEntry<Policy>, policyCategories?: PolicyCategories | null): boolean {
+    if (!isControlPolicy(policy)) {
+        return false;
+    }
+    if (policy?.areRulesEnabled === true) {
+        return true;
+    }
+    if (policy?.areRulesEnabled === false) {
+        return false;
+    }
+    // areRulesEnabled is undefined — derive from per-category rule fields set by OldDot Classic
+    return hasAnyCategoryRules(policyCategories ?? undefined);
+}
+
+function isPolicyFeatureEnabled(policy: OnyxEntry<Policy>, featureName: PolicyFeatureName, policyCategories?: PolicyCategories | null): boolean {
+    if (featureName === CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED) {
+        return arePolicyRulesEnabled(policy, policyCategories);
+    }
     if (featureName === CONST.POLICY.MORE_FEATURES.ARE_TAXES_ENABLED) {
         return !!policy?.tax?.trackingEnabled;
     }
@@ -2629,6 +2646,7 @@ export {
     isPolicyAuditor,
     hasEligibleActiveAdminFromWorkspaces,
     isPolicyEmployee,
+    arePolicyRulesEnabled,
     isPolicyFeatureEnabled,
     isPolicyFieldListEmpty,
     getUberConnectionErrorDirectlyFromPolicy,

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -930,7 +930,7 @@ function hasCustomCategories(policyCategories: OnyxEntry<PolicyCategories>): boo
 /**
  * Checks if a policy has any rules configured (structured rules, individual expense limits, or prohibited expenses).
  */
-function hasConfiguredRules(policy: OnyxEntry<Policy>): boolean {
+function hasConfiguredRules(policy: OnyxEntry<Policy>, policyCategories?: PolicyCategories | null): boolean {
     if (!policy) {
         return false;
     }
@@ -985,13 +985,17 @@ function hasConfiguredRules(policy: OnyxEntry<Policy>): boolean {
     }
 
     const {prohibitedExpenses} = policy;
-    return (
+    if (
         !!prohibitedExpenses &&
         Object.entries(CONST.POLICY.DEFAULT_PROHIBITED_EXPENSES).some(([key, defaultValue]) => {
             const value = prohibitedExpenses[key as keyof typeof CONST.POLICY.DEFAULT_PROHIBITED_EXPENSES];
             return value !== undefined && value !== defaultValue;
         })
-    );
+    ) {
+        return true;
+    }
+
+    return hasAnyCategoryRules(policyCategories ?? undefined);
 }
 
 /**

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -15,6 +15,7 @@ import {getCurrentUserEmail} from '@libs/Network/NetworkStore';
 import Parser from '@libs/Parser';
 import Permissions from '@libs/Permissions';
 import {
+    arePolicyRulesEnabled,
     getDistanceRateCustomUnitRate,
     getMatchingVendorByID,
     getPerDiemRateCustomUnitRate,
@@ -585,7 +586,11 @@ const ViolationsUtils = {
         const shouldCategoryShowOverLimitViolation =
             canCalculateAmountViolations && !isInvoiceTransaction && typeof categoryOverLimit === 'number' && expenseAmount > categoryOverLimit && isControlPolicy;
         const shouldShowMissingComment =
-            !isInvoiceTransaction && policyCategories?.[categoryName ?? '']?.areCommentsRequired && !updatedTransaction.comment?.comment && isControlPolicy && policy?.areRulesEnabled;
+            !isInvoiceTransaction &&
+            policyCategories?.[categoryName ?? '']?.areCommentsRequired &&
+            !updatedTransaction.comment?.comment &&
+            isControlPolicy &&
+            arePolicyRulesEnabled(policy, policyCategories);
         const rawAttendees = updatedTransaction.modifiedAttendees ?? updatedTransaction.comment?.attendees;
         const attendees = convertAttendeesToArray(rawAttendees);
         const isAttendeeTrackingEnabled = isAttendeeTrackingEnabledForPolicy(policy);

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -7,6 +7,7 @@ import {enablePolicyCategories} from '@libs/actions/Policy/Category';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {
+    arePolicyRulesEnabled,
     getValidConnectedIntegration,
     hasAccountingFeatureConnection,
     hasConfiguredRules,
@@ -144,7 +145,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         enableFeature: () => enableCompanyCards(activePolicyID, true, false),
     });
 
-    if (policy.areRulesEnabled) {
+    if (arePolicyRulesEnabled(policy)) {
         items.push({
             key: 'setupRules',
             label: translate('homePage.gettingStartedSection.setupRules'),

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -145,11 +145,11 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         enableFeature: () => enableCompanyCards(activePolicyID, true, false),
     });
 
-    if (arePolicyRulesEnabled(policy)) {
+    if (arePolicyRulesEnabled(policy, policyCategories)) {
         items.push({
             key: 'setupRules',
             label: translate('homePage.gettingStartedSection.setupRules'),
-            isComplete: hasConfiguredRules(policy),
+            isComplete: hasConfiguredRules(policy, policyCategories),
             route: ROUTES.WORKSPACE_RULES.getRoute(activePolicyID),
         });
     }

--- a/src/pages/inbox/report/actionContents/ModifiedExpenseContent.tsx
+++ b/src/pages/inbox/report/actionContents/ModifiedExpenseContent.tsx
@@ -28,6 +28,7 @@ function ModifiedExpenseContent({action, policyID, originalReport}: ModifiedExpe
     // Fall back to policyForMovingExpensesID (actual destination workspace) for correct tag list.
     const policyIDForTags = policyID === CONST.POLICY.OWNER_EMAIL_FAKE && policyForMovingExpensesID ? policyForMovingExpensesID : policyID;
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyIDForTags}`);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyIDForTags}`);
     const [movedFromReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getMovedReportID(action, CONST.REPORT.MOVE_TYPE.FROM)}`);
     const [movedToReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getMovedReportID(action, CONST.REPORT.MOVE_TYPE.TO)}`);
 
@@ -38,6 +39,7 @@ function ModifiedExpenseContent({action, policyID, originalReport}: ModifiedExpe
         movedFromReport,
         movedToReport,
         policyTags: policyTags ?? CONST.POLICY.DEFAULT_TAG_LIST,
+        policyCategories,
         currentUserLogin: currentUserEmail ?? '',
     });
 

--- a/src/pages/iou/SplitExpenseEditPage.tsx
+++ b/src/pages/iou/SplitExpenseEditPage.tsx
@@ -35,7 +35,7 @@ import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavig
 import type {SplitExpenseParamList} from '@libs/Navigation/types';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
 import Parser from '@libs/Parser';
-import {getDistanceRateCustomUnitRate, getTagLists, hasAnyPaidPolicy, isGroupPolicyByType} from '@libs/PolicyUtils';
+import {arePolicyRulesEnabled, getDistanceRateCustomUnitRate, getTagLists, hasAnyPaidPolicy, isGroupPolicyByType} from '@libs/PolicyUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import {isSplitAction} from '@libs/ReportSecondaryActionUtils';
 import type {TransactionDetails} from '@libs/ReportUtils';
@@ -145,7 +145,7 @@ function SplitExpenseEditPage({route}: SplitExpensePageProps) {
     const isCategoryRequired = !!effectivePolicy?.requiresCategory && !isSelfDMSplit;
     const reportAttributes = useReportAttributes();
     const reportName = getReportName(currentReport, reportAttributes) || parentReport?.reportName;
-    const isDescriptionRequired = isCategoryDescriptionRequired(policyCategories, splitExpenseDraftTransactionDetails?.category, effectivePolicy?.areRulesEnabled);
+    const isDescriptionRequired = isCategoryDescriptionRequired(policyCategories, splitExpenseDraftTransactionDetails?.category, arePolicyRulesEnabled(effectivePolicy, policyCategories));
 
     // Mirror MoneyRequestView's `shouldShowTag`, plus always surface the row when the original
     // (parent) transaction carried a tag — same rationale as `shouldShowCategory` above: workspace

--- a/src/pages/workspace/AccessOrNotFoundWrapper.tsx
+++ b/src/pages/workspace/AccessOrNotFoundWrapper.tsx
@@ -167,6 +167,7 @@ function AccessOrNotFoundWrapper({
     const {login = ''} = useCurrentUserPersonalDetails();
     const {isRestrictedToPreferredPolicy} = usePreferredPolicy();
     const [betas] = useOnyx(ONYXKEYS.BETAS);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
     const isPolicyIDInRoute = !!policyID?.length;
     const isMoneyRequest = !!iouType && isValidMoneyRequestType(iouType);
     const isFromGlobalCreate = !!reportID && isEmptyObject(report?.reportID);
@@ -187,7 +188,8 @@ function AccessOrNotFoundWrapper({
     const isPolicyEmpty = !Object.entries(policy ?? {}).length || !policy?.id;
     const shouldShowFullScreenLoadingIndicator = !isMoneyRequest && (isLoadingReportData !== false || !!policy?.isLoading) && isPolicyEmpty;
 
-    const isFeatureEnabled = featureName ? isPolicyFeatureEnabledUtil(policy, featureName) : true;
+    // Pass categories so that migrated corporate policies with only Classic category rules (areRulesEnabled === undefined) are correctly treated as enabled
+    const isFeatureEnabled = featureName ? isPolicyFeatureEnabledUtil(policy, featureName, policyCategories) : true;
 
     const {isOffline} = useNetwork();
 

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -35,6 +35,7 @@ import goBackFromWorkspaceSettingPages from '@libs/Navigation/helpers/goBackFrom
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import {
+    arePolicyRulesEnabled,
     canMemberRead,
     canPolicyAccessFeature,
     shouldShowPolicy as checkIfShouldShowPolicy,
@@ -189,7 +190,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
         [CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED]: (policy?.isHREnabled === true || isAnyHRConnected(policy)) && canPolicyAccessFeature(policy, CONST.POLICY.MORE_FEATURES.IS_HR_ENABLED),
         [CONST.POLICY.MORE_FEATURES.ARE_EXPENSIFY_CARDS_ENABLED]: policy?.areExpensifyCardsEnabled,
         [CONST.POLICY.MORE_FEATURES.ARE_REPORT_FIELDS_ENABLED]: policy?.areReportFieldsEnabled,
-        [CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED]: policy?.areRulesEnabled,
+        [CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED]: arePolicyRulesEnabled(policy, policyCategories),
         [CONST.POLICY.MORE_FEATURES.ARE_INVOICES_ENABLED]: policy?.areInvoicesEnabled,
         [CONST.POLICY.MORE_FEATURES.ARE_PER_DIEM_RATES_ENABLED]: policy?.arePerDiemRatesEnabled && canPolicyAccessFeature(policy, CONST.POLICY.MORE_FEATURES.ARE_PER_DIEM_RATES_ENABLED),
         [CONST.POLICY.MORE_FEATURES.ARE_RECEIPT_PARTNERS_ENABLED]: policy?.receiptPartners?.enabled ?? false,

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -27,6 +27,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {WorkspaceSplitNavigatorParamList} from '@libs/Navigation/types';
 import {
+    arePolicyRulesEnabled,
     canPolicyAccessFeature,
     getDistanceRateCustomUnit,
     getPerDiemCustomUnit,
@@ -109,6 +110,7 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
     const isUberConnected = useIsPolicyConnectedToUberReceiptPartner({policyID});
     const [cardFeeds] = useCardFeeds(policyID);
     const policyData = usePolicyData(policyID);
+    const {categories: policyCategories} = policyData;
     const defaultFundID = useDefaultFundID(policyID);
 
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
@@ -462,7 +464,7 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
                             icon={illustrations.Rules}
                             title={translate('workspace.moreFeatures.rules.title')}
                             subtitle={translate('workspace.moreFeatures.rules.subtitle')}
-                            isActive={policy?.areRulesEnabled ?? false}
+                            isActive={arePolicyRulesEnabled(policy, policyCategories)}
                             pendingAction={policy?.pendingFields?.areRulesEnabled}
                             disabled={!canWriteMoreFeatures}
                             disabledAction={withReadOnlyFallback()}

--- a/src/pages/workspace/categories/CategorySettingsPage.tsx
+++ b/src/pages/workspace/categories/CategorySettingsPage.tsx
@@ -37,7 +37,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import {isDisablingOrDeletingLastEnabledCategory} from '@libs/OptionsListUtils';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
-import {getWorkflowApprovalsUnavailable, hasTags, isAttendeeTrackingEnabled, isControlPolicy} from '@libs/PolicyUtils';
+import {arePolicyRulesEnabled, getWorkflowApprovalsUnavailable, hasTags, isAttendeeTrackingEnabled, isControlPolicy} from '@libs/PolicyUtils';
 import type {SettingsNavigatorParamList} from '@navigation/types';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
@@ -377,7 +377,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
                         />
                     )}
 
-                    {!!policy?.areRulesEnabled && (
+                    {arePolicyRulesEnabled(policy, policyCategories) && (
                         <>
                             <View style={[styles.mh5, styles.pt3, styles.borderTop]}>
                                 <Text style={[styles.textNormal, styles.textStrong, styles.mv3]}>{translate('workspace.rules.categoryRules.title')}</Text>

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -43,7 +43,7 @@ import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavig
 import type {WorkspaceSplitNavigatorParamList} from '@libs/Navigation/types';
 import {isDisablingOrDeletingLastEnabledCategory} from '@libs/OptionsListUtils';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
-import {getConnectedIntegration, getCurrentConnectionName, hasAccountingConnections, hasTags, isControlPolicy, shouldShowSyncError} from '@libs/PolicyUtils';
+import {arePolicyRulesEnabled, getConnectedIntegration, getCurrentConnectionName, hasAccountingConnections, hasTags, isControlPolicy, shouldShowSyncError} from '@libs/PolicyUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import {close} from '@userActions/Modal';
@@ -257,7 +257,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     }, [categories, policy?.rules?.approvalRules]);
 
     const shouldShowGLCodeColumn = Object.values(policyCategories ?? {}).some((category) => !!category['GL Code']) && isControlPolicyWithWideLayout;
-    const shouldShowApproverColumn = isControlPolicyWithWideLayout && !!policy?.areRulesEnabled && Object.keys(categoryApproverEmails).length > 0;
+    const shouldShowApproverColumn = isControlPolicyWithWideLayout && arePolicyRulesEnabled(policy, policyCategories) && Object.keys(categoryApproverEmails).length > 0;
 
     const categoryRows = useMemo<WorkspaceCategoryTableRowData[]>(() => {
         return categories.reduce<WorkspaceCategoryTableRowData[]>((acc, value) => {

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardDetailsPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardDetailsPage.tsx
@@ -95,6 +95,7 @@ function WorkspaceExpensifyCardDetailsPage({route}: WorkspaceExpensifyCardDetail
     const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
     const [cardFromCardList] = useOnyx(ONYXKEYS.CARD_LIST, {selector: cardByIdSelector(cardID)});
     const [cardFeeds] = useCardFeeds(policyID);
     const expensifyCardSettings = useExpensifyCardFeeds(policyID);
@@ -114,7 +115,7 @@ function WorkspaceExpensifyCardDetailsPage({route}: WorkspaceExpensifyCardDetail
     const remainingLimitHintTranslationKey = getLimitHintTranslationKey(card?.nameValuePairs?.limitType);
     const remainingLimitHint = remainingLimitHintTranslationKey ? translate(remainingLimitHintTranslationKey, formattedAvailableSpendAmount) : undefined;
     const canWriteExpensifyCard = canMemberWrite(policy, currentUserLogin, CONST.POLICY.POLICY_FEATURE.EXPENSIFY_CARD);
-    const canEditSpendRules = canWriteExpensifyCard && arePolicyRulesEnabled(policy);
+    const canEditSpendRules = canWriteExpensifyCard && arePolicyRulesEnabled(policy, policyCategories);
     const isDeactivated = card?.state === CONST.EXPENSIFY_CARD.STATE.STATE_DEACTIVATED;
     const isCardOpen = card?.state === CONST.EXPENSIFY_CARD.STATE.OPEN;
 

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardDetailsPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardDetailsPage.tsx
@@ -38,7 +38,7 @@ import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/crea
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import {temporaryGetDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
-import {canMemberWrite} from '@libs/PolicyUtils';
+import {arePolicyRulesEnabled, canMemberWrite} from '@libs/PolicyUtils';
 import {getSpendRuleByCardID, getSpendRuleSummaryText} from '@libs/SpendRulesUtils';
 import Navigation from '@navigation/Navigation';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
@@ -114,7 +114,7 @@ function WorkspaceExpensifyCardDetailsPage({route}: WorkspaceExpensifyCardDetail
     const remainingLimitHintTranslationKey = getLimitHintTranslationKey(card?.nameValuePairs?.limitType);
     const remainingLimitHint = remainingLimitHintTranslationKey ? translate(remainingLimitHintTranslationKey, formattedAvailableSpendAmount) : undefined;
     const canWriteExpensifyCard = canMemberWrite(policy, currentUserLogin, CONST.POLICY.POLICY_FEATURE.EXPENSIFY_CARD);
-    const canEditSpendRules = canWriteExpensifyCard && !!policy?.areRulesEnabled;
+    const canEditSpendRules = canWriteExpensifyCard && arePolicyRulesEnabled(policy);
     const isDeactivated = card?.state === CONST.EXPENSIFY_CARD.STATE.STATE_DEACTIVATED;
     const isCardOpen = card?.state === CONST.EXPENSIFY_CARD.STATE.OPEN;
 

--- a/src/pages/workspace/expensifyCard/issueNew/CardNameStep.tsx
+++ b/src/pages/workspace/expensifyCard/issueNew/CardNameStep.tsx
@@ -39,12 +39,13 @@ function CardNameStep({policyID, stepNames, startStepIndex}: CardNameStepProps) 
     const isInLandscapeMode = useIsInLandscapeMode();
 
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
     const [issueNewCard] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_ISSUE_NEW_EXPENSIFY_CARD}${policyID}`);
 
     const isEditing = issueNewCard?.isEditing;
     const data = issueNewCard?.data;
     const isVirtualCard = data?.cardType === CONST.EXPENSIFY_CARD.CARD_TYPE.VIRTUAL;
-    const areSpendRulesAvailable = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED);
+    const areSpendRulesAvailable = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED, policyCategories);
 
     const userName = getUserNameByEmail(data?.assigneeEmail ?? '', 'firstName');
     const defaultCardTitle = !isVirtualCard ? getDefaultCardName(userName) : '';

--- a/src/pages/workspace/expensifyCard/issueNew/ConfirmationStep.tsx
+++ b/src/pages/workspace/expensifyCard/issueNew/ConfirmationStep.tsx
@@ -45,6 +45,7 @@ function ConfirmationStep({policyID, stepNames, startStepIndex}: ConfirmationSte
     const [account] = useOnyx(ONYXKEYS.ACCOUNT);
     const [issueNewCard] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_ISSUE_NEW_EXPENSIFY_CARD}${policyID}`);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
     const defaultFundID = useDefaultFundID(policyID);
     const {isBetaEnabled} = usePermissions();
     const {cardRules} = useExpensifyCardRules(policyID);
@@ -53,7 +54,7 @@ function ConfirmationStep({policyID, stepNames, startStepIndex}: ConfirmationSte
     const isSuccessful = issueNewCard?.isSuccessful;
     const hasApprovalError = !!policy?.errorFields?.approvalMode;
     const isSpendRuleApplied = !!issueNewCard?.data.spendRuleEnabled;
-    const areRulesEnabled = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED);
+    const areRulesEnabled = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED, policyCategories);
     const isAddApprovalEnabled = policy?.approvalMode !== CONST.POLICY.APPROVAL_MODE.OPTIONAL && !hasApprovalError;
     const shouldDisableSubmitButton = !isAddApprovalEnabled && data?.limitType === CONST.EXPENSIFY_CARD.LIMIT_TYPES.SMART;
     const personalDetails = usePersonalDetails();

--- a/src/pages/workspace/expensifyCard/issueNew/LimitTypeStep.tsx
+++ b/src/pages/workspace/expensifyCard/issueNew/LimitTypeStep.tsx
@@ -41,6 +41,7 @@ function LimitTypeStep({policy, stepNames, startStepIndex}: LimitTypeStepProps) 
     const policyID = policy?.id;
     const formRef = useRef<FormRef | null>(null);
     const [issueNewCard] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_ISSUE_NEW_EXPENSIFY_CARD}${policyID}`);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
 
     const areApprovalsConfigured = getApprovalWorkflow(policy) !== CONST.POLICY.APPROVAL_MODE.OPTIONAL;
     const defaultType = getDefaultExpensifyCardLimitType(policy);
@@ -48,7 +49,7 @@ function LimitTypeStep({policy, stepNames, startStepIndex}: LimitTypeStepProps) 
     const [typeSelected, setTypeSelected] = useState(issueNewCard?.data?.limitType ?? defaultType);
 
     const isEditing = issueNewCard?.isEditing;
-    const areSpendRulesAvailable = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED);
+    const areSpendRulesAvailable = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED, policyCategories);
 
     const nextStep = useMemo(() => {
         if (isEditing) {

--- a/src/pages/workspace/expensifyCard/issueNew/spendRules/SetSpendRulesStep.tsx
+++ b/src/pages/workspace/expensifyCard/issueNew/spendRules/SetSpendRulesStep.tsx
@@ -51,6 +51,7 @@ function SetSpendRulesStep({policyID, stepNames, startStepIndex}: SetSpendRulesS
     const domainAccountID = useDefaultFundID(policyID);
     const icons = useMemoizedLazyExpensifyIcons(['Copy', 'Pencil']);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
     const [issueNewCard] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_ISSUE_NEW_EXPENSIFY_CARD}${policyID}`);
     const [expensifyCardSettings] = useOnyx(`${ONYXKEYS.COLLECTION.PRIVATE_EXPENSIFY_CARD_SETTINGS}${domainAccountID}`);
 
@@ -65,7 +66,7 @@ function SetSpendRulesStep({policyID, stepNames, startStepIndex}: SetSpendRulesS
     const isEditing = issueNewCard?.isEditing;
     const currencyCode = issueNewCard?.data?.currency ?? CONST.CURRENCY.USD;
     const isVirtualCard = issueNewCard?.data?.cardType === CONST.EXPENSIFY_CARD.CARD_TYPE.VIRTUAL;
-    const isSpendRuleVisible = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED);
+    const isSpendRuleVisible = isPolicyFeatureEnabled(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED, policyCategories);
 
     const spendRuleID = issueNewCard?.data?.spendRuleID;
     const spendRuleForm = issueNewCard?.data.spendRuleValue ?? {};

--- a/src/pages/workspace/tags/TagSettingsPage.tsx
+++ b/src/pages/workspace/tags/TagSettingsPage.tsx
@@ -24,6 +24,7 @@ import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavig
 import {isDisablingOrDeletingLastEnabledTag} from '@libs/OptionsListUtils';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
 import {
+    arePolicyRulesEnabled,
     getCleanedTagName,
     getTagApproverRule,
     getTagListByOrderWeight,
@@ -203,7 +204,7 @@ function TagSettingsPage({route, navigation}: TagSettingsPageProps) {
                         </OfflineWithFeedback>
                     )}
 
-                    {!!policy?.areRulesEnabled && !isMultiLevelTags && (
+                    {arePolicyRulesEnabled(policy, policyData.categories) && !isMultiLevelTags && (
                         <>
                             <View style={[styles.mh5, styles.mv3, styles.pt3, styles.borderTop]}>
                                 <Text style={[styles.textNormal, styles.textStrong, styles.mv3]}>{translate('workspace.tags.tagRules')}</Text>

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -52,6 +52,7 @@ import type {WorkspaceSplitNavigatorParamList} from '@libs/Navigation/types';
 import {isDisablingOrDeletingLastEnabledTag, isMakingLastRequiredTagListOptional} from '@libs/OptionsListUtils';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
 import {
+    arePolicyRulesEnabled,
     getCleanedTagName,
     getConnectedIntegration,
     getCountOfEnabledTagsOfList,
@@ -95,6 +96,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     const isMobileSelectionModeEnabled = useMobileSelectionMode();
     const {environmentURL} = useEnvironment();
     const [connectionSyncProgress] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS}${policy?.id}`);
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policy?.id}`);
     const isSyncInProgress = isConnectionInProgress(connectionSyncProgress, policy);
     const syncingAccountingIntegration = CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES.find((connectionName) => connectionName === connectionSyncProgress?.connectionName);
     const hasSyncError = shouldShowSyncError(policy, isSyncInProgress, CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES);
@@ -130,7 +132,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         return approverEmails;
     }, [isMultiLevelTags, policy, policyTagLists]);
 
-    const shouldShowApproverColumn = isControlPolicyWithWideLayout && !isMultiLevelTags && !!policy?.areRulesEnabled && Object.keys(tagApproverEmails).length > 0;
+    const shouldShowApproverColumn = isControlPolicyWithWideLayout && !isMultiLevelTags && arePolicyRulesEnabled(policy, policyCategories) && Object.keys(tagApproverEmails).length > 0;
     const fetchTags = useCallback(() => {
         openPolicyTagsPage(policyID);
     }, [policyID]);

--- a/tests/unit/CategoryUtilsTest.ts
+++ b/tests/unit/CategoryUtilsTest.ts
@@ -4,6 +4,7 @@ import {
     getAvailableNonPersonalPolicyCategories,
     getCategoryGLCode,
     getDecodedLeafCategoryName,
+    hasAnyCategoryRules,
     isCategoryDescriptionRequired,
     isCategoryMissing,
     processCategoryNameSegments,
@@ -241,6 +242,131 @@ describe('getAvailableNonPersonalPolicyCategories', () => {
                 expect(getDecodedLeafCategoryName('A: B:')).toEqual('B:');
             });
         });
+    });
+});
+
+describe('hasAnyCategoryRules', () => {
+    const createCategory = (overrides: Partial<PolicyCategories[string]> = {}) => ({
+        enabled: true,
+        name: 'Test',
+        pendingAction: null,
+        ...overrides,
+    });
+
+    it('returns false when categories are undefined', () => {
+        expect(hasAnyCategoryRules(undefined)).toBe(false);
+    });
+
+    it('returns false when categories are empty', () => {
+        expect(hasAnyCategoryRules({})).toBe(false);
+    });
+
+    it('returns false when category has only metadata and no rule fields', () => {
+        const categories: PolicyCategories = {
+            Advertising: createCategory({name: 'Advertising', 'GL Code': '1234'}), // eslint-disable-line @typescript-eslint/naming-convention
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(false);
+    });
+
+    it('returns true when maxExpenseAmount is set to an active value', () => {
+        const categories: PolicyCategories = {
+            Advertising: createCategory({maxExpenseAmount: 50000}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns false when maxExpenseAmount is disabled or undefined', () => {
+        expect(hasAnyCategoryRules({Advertising: createCategory({maxExpenseAmount: CONST.DISABLED_MAX_EXPENSE_VALUE})})).toBe(false);
+        expect(hasAnyCategoryRules({Advertising: createCategory({maxExpenseAmount: undefined})})).toBe(false);
+    });
+
+    it('returns true when maxAmountNoReceipt is 0', () => {
+        const categories: PolicyCategories = {
+            Travel: createCategory({name: 'Travel', maxAmountNoReceipt: 0}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns true when maxAmountNoReceipt is a positive amount', () => {
+        const categories: PolicyCategories = {
+            Travel: createCategory({name: 'Travel', maxAmountNoReceipt: 2500}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns true when maxAmountNoReceipt is explicitly disabled', () => {
+        const categories: PolicyCategories = {
+            Travel: createCategory({name: 'Travel', maxAmountNoReceipt: CONST.DISABLED_MAX_EXPENSE_VALUE}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns false when maxAmountNoReceipt is null or undefined', () => {
+        expect(hasAnyCategoryRules({Travel: createCategory({name: 'Travel', maxAmountNoReceipt: null})})).toBe(false);
+        expect(hasAnyCategoryRules({Travel: createCategory({name: 'Travel', maxAmountNoReceipt: undefined})})).toBe(false);
+    });
+
+    it('returns true when maxAmountNoItemizedReceipt is 0', () => {
+        const categories: PolicyCategories = {
+            Travel: createCategory({name: 'Travel', maxAmountNoItemizedReceipt: 0}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns true when maxAmountNoItemizedReceipt is explicitly disabled', () => {
+        const categories: PolicyCategories = {
+            Travel: createCategory({name: 'Travel', maxAmountNoItemizedReceipt: CONST.DISABLED_MAX_EXPENSE_VALUE}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns false when maxAmountNoItemizedReceipt is null or undefined', () => {
+        expect(hasAnyCategoryRules({Travel: createCategory({name: 'Travel', maxAmountNoItemizedReceipt: null})})).toBe(false);
+        expect(hasAnyCategoryRules({Travel: createCategory({name: 'Travel', maxAmountNoItemizedReceipt: undefined})})).toBe(false);
+    });
+
+    it('returns true when areCommentsRequired is true', () => {
+        const categories: PolicyCategories = {
+            Meals: createCategory({name: 'Meals', areCommentsRequired: true}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns true when areAttendeesRequired is true', () => {
+        const categories: PolicyCategories = {
+            Meals: createCategory({name: 'Meals', areAttendeesRequired: true}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns true when commentHint is set', () => {
+        const categories: PolicyCategories = {
+            Car: createCategory({name: 'Car', commentHint: 'Enter purpose'}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns false when commentHint is empty', () => {
+        const categories: PolicyCategories = {
+            Car: createCategory({name: 'Car', commentHint: ''}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(false);
+    });
+
+    it('returns true when only the second category has a rule field', () => {
+        const categories: PolicyCategories = {
+            Advertising: createCategory({name: 'Advertising', 'GL Code': '1234'}), // eslint-disable-line @typescript-eslint/naming-convention
+            Travel: createCategory({name: 'Travel', maxAmountNoReceipt: 0}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(true);
+    });
+
+    it('returns false when multiple categories have no rule fields', () => {
+        const categories: PolicyCategories = {
+            Advertising: createCategory({name: 'Advertising', 'GL Code': '1234'}), // eslint-disable-line @typescript-eslint/naming-convention
+            Meals: createCategory({name: 'Meals', enabled: true}),
+        };
+        expect(hasAnyCategoryRules(categories)).toBe(false);
     });
 });
 

--- a/tests/unit/ModifiedExpenseMessageTest.ts
+++ b/tests/unit/ModifiedExpenseMessageTest.ts
@@ -1194,7 +1194,7 @@ describe('ModifiedExpenseMessage', () => {
                 environmentURL = await getEnvironmentURL();
             });
 
-            const policyRulesPolicy = {id: policyRulesPolicyId, areRulesEnabled: true} as Policy;
+            const policyRulesPolicy = {id: policyRulesPolicyId, areRulesEnabled: true, type: CONST.POLICY.TYPE.CORPORATE} as Policy;
 
             beforeEach(() => {
                 // Default: current user has policy rule access (admin + rules enabled), so link points to workspace rules

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -2896,6 +2896,16 @@ describe('PolicyUtils', () => {
                 expect(hasConfiguredRules(createMock<Policy>({prohibitedExpenses: {}}))).toBe(false);
             });
         });
+
+        it('returns true when only Classic category rules exist', () => {
+            const categories = {Travel: {name: 'Travel', enabled: true, maxAmountNoReceipt: 0}};
+            expect(hasConfiguredRules(createMock<Policy>({}), categories)).toBe(true);
+        });
+
+        it('returns false when categories have no active rule fields', () => {
+            const categories = {Advertising: {name: 'Advertising', enabled: true, 'GL Code': '1234'}};
+            expect(hasConfiguredRules(createMock<Policy>({}), categories)).toBe(false);
+        });
     });
 
     describe('getExpensifyTeamExclusions', () => {

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -5,8 +5,8 @@ import type {OnyxCollection, OnyxEntry, OnyxMultiSetInput} from 'react-native-on
 import useDefaultFundID from '@hooks/useDefaultFundID';
 import DateUtils from '@libs/DateUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {arePolicyRulesEnabled} from '@libs/PolicyUtils';
 import {
+    arePolicyRulesEnabled,
     canAccessSubmitWorkspaceFeatures,
     canMemberRead,
     canMemberWrite,
@@ -26,6 +26,7 @@ import {
     getManagerAccountID,
     getMatchingVendorByID,
     getMatchingVendors,
+    getPolicyBrickRoadIndicatorStatus,
     getPolicyEmployeeAccountIDs,
     getRateDisplayValue,
     getSubmitToAccountID,
@@ -54,7 +55,6 @@ import {
 } from '@libs/PolicyUtils';
 import {isWorkspaceEligibleForReportChange} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
-import {getPolicyBrickRoadIndicatorStatus} from '@src/libs/PolicyUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {PersonalDetailsList, Policy, PolicyEmployeeList, PolicyTagLists, Report, Transaction} from '@src/types/onyx';
@@ -3444,8 +3444,8 @@ describe('PolicyUtils', () => {
 });
 
 describe('arePolicyRulesEnabled', () => {
-    const corporateBase = {id: 'policy1', type: CONST.POLICY.TYPE.CORPORATE} as unknown as Policy;
-    const teamBase = {id: 'policy2', type: CONST.POLICY.TYPE.TEAM} as unknown as Policy;
+    const corporateBase = createMock<Policy>({id: 'policy1', type: CONST.POLICY.TYPE.CORPORATE});
+    const teamBase = createMock<Policy>({id: 'policy2', type: CONST.POLICY.TYPE.TEAM});
 
     it('returns true for a corporate policy with areRulesEnabled explicitly true', () => {
         expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: true})).toBe(true);

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -5,6 +5,7 @@ import type {OnyxCollection, OnyxEntry, OnyxMultiSetInput} from 'react-native-on
 import useDefaultFundID from '@hooks/useDefaultFundID';
 import DateUtils from '@libs/DateUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import {arePolicyRulesEnabled} from '@libs/PolicyUtils';
 import {
     canAccessSubmitWorkspaceFeatures,
     canMemberRead,
@@ -3429,5 +3430,55 @@ describe('PolicyUtils', () => {
             const policy = buildMergeHRPolicy(5, mergeHRBase);
             expect(isMergeHRCompleteSetupNeededSelector(policy)).toBe(true);
         });
+    });
+});
+
+describe('arePolicyRulesEnabled', () => {
+    const corporateBase = {id: 'policy1', type: CONST.POLICY.TYPE.CORPORATE} as unknown as Policy;
+    const teamBase = {id: 'policy2', type: CONST.POLICY.TYPE.TEAM} as unknown as Policy;
+
+    it('returns true for a corporate policy with areRulesEnabled explicitly true', () => {
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: true})).toBe(true);
+    });
+
+    it('returns false for a corporate policy with areRulesEnabled explicitly false', () => {
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: false})).toBe(false);
+    });
+
+    it('returns false for a corporate policy with areRulesEnabled undefined and no categories', () => {
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: undefined})).toBe(false);
+    });
+
+    it('returns false for a corporate policy with areRulesEnabled undefined and categories with no rule fields', () => {
+        const categories = {Advertising: {name: 'Advertising', enabled: true, 'GL Code': '1234'}};
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: undefined}, categories)).toBe(false);
+    });
+
+    it('returns true for a corporate policy with areRulesEnabled undefined and a category with maxExpenseAmount set', () => {
+        const categories = {Advertising: {name: 'Advertising', enabled: true, maxExpenseAmount: 50000}};
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: undefined}, categories)).toBe(true);
+    });
+
+    it('returns true for a corporate policy with areRulesEnabled undefined and a category with maxAmountNoReceipt = 0', () => {
+        const categories = {Travel: {name: 'Travel', enabled: true, maxAmountNoReceipt: 0}};
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: undefined}, categories)).toBe(true);
+    });
+
+    it('returns true for a corporate policy with areRulesEnabled undefined and a category with areCommentsRequired = true', () => {
+        const categories = {Meals: {name: 'Meals', enabled: true, areCommentsRequired: true}};
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: undefined}, categories)).toBe(true);
+    });
+
+    it('returns true for a corporate policy with areRulesEnabled undefined and a category with commentHint set', () => {
+        const categories = {Car: {name: 'Car', enabled: true, commentHint: 'Enter purpose'}};
+        expect(arePolicyRulesEnabled({...corporateBase, areRulesEnabled: undefined}, categories)).toBe(true);
+    });
+
+    it('returns false for a team policy with areRulesEnabled undefined', () => {
+        expect(arePolicyRulesEnabled({...teamBase, areRulesEnabled: undefined})).toBe(false);
+    });
+
+    it('returns false for a team policy even when areRulesEnabled is true', () => {
+        expect(arePolicyRulesEnabled({...teamBase, areRulesEnabled: true})).toBe(false);
     });
 });

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -625,7 +625,7 @@ describe('useGettingStartedItems', () => {
         it('should be shown when areRulesEnabled is true', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areRulesEnabled: true},
+                policy: {areRulesEnabled: true, type: CONST.POLICY.TYPE.CORPORATE},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -664,7 +664,7 @@ describe('useGettingStartedItems', () => {
         it('should navigate to workspace rules route', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areRulesEnabled: true},
+                policy: {areRulesEnabled: true, type: CONST.POLICY.TYPE.CORPORATE},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -677,7 +677,7 @@ describe('useGettingStartedItems', () => {
         it('should be not completed when workspace has default rules only', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areRulesEnabled: true, rules: undefined, customRules: undefined},
+                policy: {areRulesEnabled: true, rules: undefined, customRules: undefined, type: CONST.POLICY.TYPE.CORPORATE},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -692,6 +692,7 @@ describe('useGettingStartedItems', () => {
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
                     areRulesEnabled: true,
+                    type: CONST.POLICY.TYPE.CORPORATE,
                     rules: {
                         approvalRules: [
                             {
@@ -716,6 +717,7 @@ describe('useGettingStartedItems', () => {
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
                     areRulesEnabled: true,
+                    type: CONST.POLICY.TYPE.CORPORATE,
                     customRules: 'All expenses over $500 need manager approval',
                 },
             });
@@ -732,7 +734,7 @@ describe('useGettingStartedItems', () => {
         it('should return items in the correct order: createWorkspace, accounting/categories, companyCards, rules', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areConnectionsEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
+                policy: {areConnectionsEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true, type: CONST.POLICY.TYPE.CORPORATE},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -745,7 +747,7 @@ describe('useGettingStartedItems', () => {
         it('should return items in the correct order with categories instead of connect', async () => {
             await setupManageTeamScenario({
                 accounting: 'none',
-                policy: {areCategoriesEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
+                policy: {areCategoriesEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true, type: CONST.POLICY.TYPE.CORPORATE},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -306,7 +306,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('shows "Set up spend rules" row when rules feature is enabled', async () => {
-            await setManageTeamUserState({areRulesEnabled: true});
+            await setManageTeamUserState({areRulesEnabled: true, policyType: CONST.POLICY.TYPE.CORPORATE});
 
             renderGettingStartedSection();
             await waitForBatchedUpdates();
@@ -329,6 +329,7 @@ describe('GettingStartedSection', () => {
                 areAccountingEnabled: true,
                 areCompanyCardsEnabled: true,
                 areRulesEnabled: true,
+                policyType: CONST.POLICY.TYPE.CORPORATE,
             });
 
             renderGettingStartedSection();
@@ -445,7 +446,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('navigates to workspace rules when "Set up spend rules" row is pressed', async () => {
-            await setManageTeamUserState({areRulesEnabled: true});
+            await setManageTeamUserState({areRulesEnabled: true, policyType: CONST.POLICY.TYPE.CORPORATE});
 
             renderGettingStartedSection();
             await waitForBatchedUpdates();

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -1,10 +1,13 @@
-import {fireEvent, render, screen} from '@testing-library/react-native';
+import {fireEvent, render, renderHook, screen} from '@testing-library/react-native';
+import React from 'react';
 import Onyx from 'react-native-onyx';
+import type {ValueOf} from 'type-fest';
 import Navigation from '@libs/Navigation/Navigation';
 import OnyxListItemProvider from '@src/components/OnyxListItemProvider';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import GettingStartedSection from '@src/pages/home/GettingStartedSection';
+import useGettingStartedItems from '@src/pages/home/GettingStartedSection/hooks/useGettingStartedItems';
 import ROUTES from '@src/ROUTES';
 import waitForBatchedUpdates from '../../../../utils/waitForBatchedUpdates';
 
@@ -43,6 +46,8 @@ const renderGettingStartedSection = () =>
         </OnyxListItemProvider>,
     );
 
+const gettingStartedItemsWrapper = ({children}: {children: React.ReactNode}) => <OnyxListItemProvider>{children}</OnyxListItemProvider>;
+
 /**
  * Sets up Onyx state for a manage-team user with an active trial
  * so the section is visible by default.
@@ -58,6 +63,8 @@ async function setManageTeamUserState(overrides?: {
     hasCompanyCardConnection?: boolean;
     hasConfiguredRules?: boolean;
     trialStartDate?: string;
+    policyType?: ValueOf<typeof CONST.POLICY.TYPE>;
+    policyCategories?: Record<string, unknown>;
 }) {
     const trialStart = overrides?.trialStartDate ?? RECENT_TRIAL_START;
 
@@ -71,13 +78,18 @@ async function setManageTeamUserState(overrides?: {
     const policyData: Record<string, unknown> = {
         id: TEST_POLICY_ID,
         name: 'Test Workspace',
-        type: CONST.POLICY.TYPE.TEAM,
+        type: overrides?.policyType ?? CONST.POLICY.TYPE.TEAM,
         role: CONST.POLICY.ROLE.ADMIN,
         areCompanyCardsEnabled: overrides?.areCompanyCardsEnabled ?? true,
-        areRulesEnabled: overrides?.areRulesEnabled ?? true,
         areConnectionsEnabled: overrides?.areAccountingEnabled,
         areCategoriesEnabled: overrides?.areCategoriesEnabled,
     };
+
+    if (overrides && 'areRulesEnabled' in overrides) {
+        policyData.areRulesEnabled = overrides.areRulesEnabled;
+    } else {
+        policyData.areRulesEnabled = true;
+    }
 
     if (overrides?.hasAccountingConnection) {
         policyData.connections = {
@@ -89,6 +101,11 @@ async function setManageTeamUserState(overrides?: {
     }
 
     await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${TEST_POLICY_ID}` as never, policyData as never);
+
+    if (overrides?.policyCategories) {
+        await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${TEST_POLICY_ID}` as never, overrides.policyCategories as never);
+    }
+
     await waitForBatchedUpdates();
 }
 
@@ -353,6 +370,28 @@ describe('GettingStartedSection', () => {
             await waitForBatchedUpdates();
 
             expect(screen.getByText(/homePage\.gettingStartedSection\.connectAccounting/)).toBeTruthy();
+        });
+
+        it('shows and completes setup rules when Classic category rules exist on a migrated corporate policy', async () => {
+            await setManageTeamUserState({
+                integration: 'other',
+                policyType: CONST.POLICY.TYPE.CORPORATE,
+                areRulesEnabled: undefined,
+                policyCategories: {
+                    Travel: {
+                        name: 'Travel',
+                        enabled: true,
+                        maxAmountNoReceipt: 0,
+                    },
+                },
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems(), {wrapper: gettingStartedItemsWrapper});
+            await waitForBatchedUpdates();
+
+            const setupRulesItem = result.current.items.find((item) => item.key === 'setupRules');
+            expect(setupRulesItem).toBeDefined();
+            expect(setupRulesItem?.isComplete).toBe(true);
         });
     });
 

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -9,6 +9,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import GettingStartedSection from '@src/pages/home/GettingStartedSection';
 import useGettingStartedItems from '@src/pages/home/GettingStartedSection/hooks/useGettingStartedItems';
 import ROUTES from '@src/ROUTES';
+import type {PolicyCategories} from '@src/types/onyx';
 import waitForBatchedUpdates from '../../../../utils/waitForBatchedUpdates';
 
 const TEST_POLICY_ID = 'ABC123';
@@ -64,7 +65,7 @@ async function setManageTeamUserState(overrides?: {
     hasConfiguredRules?: boolean;
     trialStartDate?: string;
     policyType?: ValueOf<typeof CONST.POLICY.TYPE>;
-    policyCategories?: Record<string, unknown>;
+    policyCategories?: PolicyCategories;
 }) {
     const trialStart = overrides?.trialStartDate ?? RECENT_TRIAL_START;
 
@@ -103,7 +104,7 @@ async function setManageTeamUserState(overrides?: {
     await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${TEST_POLICY_ID}` as never, policyData as never);
 
     if (overrides?.policyCategories) {
-        await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${TEST_POLICY_ID}` as never, overrides.policyCategories as never);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${TEST_POLICY_ID}`, overrides.policyCategories);
     }
 
     await waitForBatchedUpdates();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Adds `arePolicyRulesEnabled(policy, policyCategories?)` to `PolicyUtils.ts` and `hasAnyCategoryRules(categories?)` to `CategoryUtils.ts` to implement consistent three-state logic for the Rules feature flag:

- `areRulesEnabled === true` → always show Rules UI
- `areRulesEnabled === false` → always hide Rules UI
- `areRulesEnabled === undefined` (corporate policy) → derive from active per-category rule fields set via OldDot Classic (`maxExpenseAmount`, receipt thresholds, required description/attendees, `commentHint`)

This covers the edge case where a workspace admin configured category rules in OldDot without the `areRulesEnabled` flag ever being set. NewDot was silently hiding all Rules UI for these users even though their rules were actively configured.

**Changes:**

- `CategoryUtils.ts` — new `hasAnyCategoryRules(categories?)` checks per-category rule fields
- `PolicyUtils.ts` — new `arePolicyRulesEnabled(policy, policyCategories?)` with three-state logic; team policies always return `false`; `isPolicyFeatureEnabled` delegates to it for `ARE_RULES_ENABLED`; `hasConfiguredRules` extended to treat Classic category rules as configured
- **16 call sites** updated to pass `policyCategories` where available (workspace pages, card issue wizard, `useGettingStartedItems`, `ModifiedExpenseMessage`)
- `AccessOrNotFoundWrapper.tsx` — reads `policyCategories` from Onyx and passes them to `isPolicyFeatureEnabledUtil`, so all ~20 Rules routes correctly gate access for migrated policies (without this, the sidebar could show Rules as enabled but navigating to `/rules` would bounce back to More Features)

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/652345

### Tests

1. Run `npm run test -- PolicyUtilsTest.ts` and verify all `arePolicyRulesEnabled` and `hasConfiguredRules` cases pass
2. Run `npm run test -- CategoryUtilsTest.ts` and verify all `hasAnyCategoryRules` cases pass
3. Run `npm run test -- useGettingStartedItems.test.ts GettingStartedSectionTest.tsx ModifiedExpenseMessageTest.ts` and verify setup rules row and policy rules message behavior pass
4. On a corporate workspace with `areRulesEnabled` undefined and at least one Classic category rule configured (e.g. max amount or required receipt), open Workspace → Categories → that category and verify the Category rules section is visible
5. On the same workspace, navigate directly to Workspace → Rules and verify the page loads (not redirected to More Features)
6. Open Workspace → More features and verify Rules appears enabled; toggle Rules off and verify all Rules UI hides and navigating to `/rules` now redirects to More Features
7. On a corporate workspace with `areRulesEnabled: false`, verify Rules UI stays hidden even when category rule fields are present
8. Issue a new Expensify Card on a corporate workspace with `areRulesEnabled` undefined and Classic category rules; verify spend rules steps appear in the card wizard
9. Verify the Getting Started section shows the Set up spend rules item as complete for a migrated policy that has Classic category rules

- [x] Verify that no errors appear in the JS console

### Offline tests

No offline-specific behavior changed. All rules visibility logic reads from Onyx policy and category data which is already available offline; no new network requests are made.

### QA Steps

1. Create or use a corporate workspace in OldDot (Expensify Classic) where `areRulesEnabled` was never explicitly set
2. In OldDot Policy Editor → Categories → Edit Category, set Receipts = Required on at least one category
3. Log in to NewDot → Workspace → Categories → open that category
4. Verify the Category rules section is visible and shows the configured rule
5. Verify Workspace → More features shows Rules as enabled for that workspace
6. Navigate directly to Workspace → Rules and verify the page loads correctly (not bounced back to More Features)
7. Verify Getting Started shows the Set up spend rules item as complete
8. In NewDot, disable Rules explicitly via More features → Rules toggle off
9. Verify category rules sections and all Rules-gated UI are hidden; navigating to `/rules` should now redirect to More Features
10. On a team workspace, verify Rules UI does not appear regardless of category data

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>