### PR TITLE
[NoQA] chore: log Search skeleton conditions when it stays past 10s

### DIFF
--- a/src/components/Search/SearchLoadingSkeleton.tsx
+++ b/src/components/Search/SearchLoadingSkeleton.tsx
@@ -7,6 +7,7 @@ import {endSpanWithAttributes} from '@libs/telemetry/activeSpans';
 import {endNavigateToReportsFirstPaint} from '@libs/telemetry/navigateToReportsSpans';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import CONST from '@src/CONST';
+import useStuckSkeletonLog from './hooks/useStuckSkeletonLog';
 
 type SearchLoadingSkeletonProps = {
     containerStyle?: StyleProp<ViewStyle>;
@@ -16,6 +17,8 @@ type SearchLoadingSkeletonProps = {
 function SearchLoadingSkeleton({containerStyle, reasonAttributes}: SearchLoadingSkeletonProps) {
     const styles = useThemeStyles();
     const skeletonReasonAttributes = reasonAttributes ?? {context: 'SearchLoadingSkeleton'};
+
+    useStuckSkeletonLog(skeletonReasonAttributes);
 
     return (
         <Animated.View

--- a/src/components/Search/hooks/useStuckSkeletonLog.ts
+++ b/src/components/Search/hooks/useStuckSkeletonLog.ts
@@ -1,36 +1,33 @@
 import {useEffect, useRef} from 'react';
 import Log from '@libs/Log';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 
-/** How long the Search skeleton may stay visible before we treat it as stuck and worth logging. */
+/** A Search loading skeleton visible longer than this is treated as stuck and worth a diagnostic log. */
 const STUCK_SKELETON_THRESHOLD_MS = 5000;
 
 /**
  * Diagnostic only, does not affect rendering.
  *
- * The Search skeleton is gated by many interdependent conditions (data loaded, search loading,
- * errors, card feeds, the heavy-work defer, and so on). The existing "[Search] Showing skeleton"
- * log fires the instant the skeleton appears, so it never tells us which condition is still
- * holding the skeleton on a slow load. This logs a single snapshot of all of those conditions
- * once the skeleton has stayed visible past STUCK_SKELETON_THRESHOLD_MS, so a slow-load repro
- * shows exactly which condition is stuck for that user instead of guessing.
+ * Call from SearchLoadingSkeleton, whose mount lifetime equals how long the Search loading skeleton is
+ * visible. If the skeleton stays up past STUCK_SKELETON_THRESHOLD_MS, this logs a one-off snapshot of its
+ * reason conditions (isDataLoaded, isSearchLoading, hasErrors, hasPendingResponse, and so on) so a
+ * slow-load repro shows which condition is holding the skeleton, which the immediate skeleton span does
+ * not surface on its own.
  */
-function useStuckSkeletonLog(isShowingSkeleton: boolean, conditions: Record<string, unknown>) {
-    // Mirror the latest conditions into a ref so the timeout reports the state at the moment it fires
-    // (which condition is still holding the skeleton), without re-arming the timer on every render.
-    const conditionsRef = useRef(conditions);
+function useStuckSkeletonLog(reasonAttributes: SkeletonSpanReasonAttributes) {
+    // Read the conditions at the moment the timeout fires (which condition is still holding the skeleton),
+    // not when it first appeared, without re-arming the timer when the conditions change.
+    const reasonAttributesRef = useRef(reasonAttributes);
     useEffect(() => {
-        conditionsRef.current = conditions;
+        reasonAttributesRef.current = reasonAttributes;
     });
 
     useEffect(() => {
-        if (!isShowingSkeleton) {
-            return;
-        }
         const timeoutID = setTimeout(() => {
-            Log.info(`[Search] Skeleton still visible after ${STUCK_SKELETON_THRESHOLD_MS}ms`, false, conditionsRef.current);
+            Log.info(`[Search] Loading skeleton still visible after ${STUCK_SKELETON_THRESHOLD_MS}ms`, false, reasonAttributesRef.current);
         }, STUCK_SKELETON_THRESHOLD_MS);
         return () => clearTimeout(timeoutID);
-    }, [isShowingSkeleton]);
+    }, []);
 }
 
 export default useStuckSkeletonLog;

--- a/src/components/Search/hooks/useStuckSkeletonLog.ts
+++ b/src/components/Search/hooks/useStuckSkeletonLog.ts
@@ -3,7 +3,7 @@ import Log from '@libs/Log';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 
 /** A Search loading skeleton visible longer than this is treated as stuck and worth a diagnostic log. */
-const STUCK_SKELETON_THRESHOLD_MS = 5000;
+const STUCK_SKELETON_THRESHOLD_MS = 10000;
 
 /**
  * Diagnostic only, does not affect rendering.

--- a/src/components/Search/hooks/useStuckSkeletonLog.ts
+++ b/src/components/Search/hooks/useStuckSkeletonLog.ts
@@ -1,0 +1,36 @@
+import {useEffect, useRef} from 'react';
+import Log from '@libs/Log';
+
+/** How long the Search skeleton may stay visible before we treat it as stuck and worth logging. */
+const STUCK_SKELETON_THRESHOLD_MS = 5000;
+
+/**
+ * Diagnostic only, does not affect rendering.
+ *
+ * The Search skeleton is gated by many interdependent conditions (data loaded, search loading,
+ * errors, card feeds, the heavy-work defer, and so on). The existing "[Search] Showing skeleton"
+ * log fires the instant the skeleton appears, so it never tells us which condition is still
+ * holding the skeleton on a slow load. This logs a single snapshot of all of those conditions
+ * once the skeleton has stayed visible past STUCK_SKELETON_THRESHOLD_MS, so a slow-load repro
+ * shows exactly which condition is stuck for that user instead of guessing.
+ */
+function useStuckSkeletonLog(isShowingSkeleton: boolean, conditions: Record<string, unknown>) {
+    // Mirror the latest conditions into a ref so the timeout reports the state at the moment it fires
+    // (which condition is still holding the skeleton), without re-arming the timer on every render.
+    const conditionsRef = useRef(conditions);
+    useEffect(() => {
+        conditionsRef.current = conditions;
+    });
+
+    useEffect(() => {
+        if (!isShowingSkeleton) {
+            return;
+        }
+        const timeoutID = setTimeout(() => {
+            Log.info(`[Search] Skeleton still visible after ${STUCK_SKELETON_THRESHOLD_MS}ms`, false, conditionsRef.current);
+        }, STUCK_SKELETON_THRESHOLD_MS);
+        return () => clearTimeout(timeoutID);
+    }, [isShowingSkeleton]);
+}
+
+export default useStuckSkeletonLog;

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -80,7 +80,6 @@ import type SearchResults from '@src/types/onyx/SearchResults';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
 import ExpenseFlatSearchView from './ExpenseFlatSearchView';
 import useSearchSnapshot from './hooks/useSearchSnapshot';
-import useStuckSkeletonLog from './hooks/useStuckSkeletonLog';
 import SearchChartView from './SearchChartView';
 import SearchChartWrapper from './SearchChartWrapper';
 import {useSearchQueryActions, useSearchQueryContext, useSearchResultsActions, useSearchResultsContext, useSearchSelectionActions} from './SearchContext';
@@ -345,25 +344,6 @@ function Search({
 
         Log.info('[Search] Showing skeleton', false, {isOffline, isDataLoaded, isCardFeedsLoading, isSearchLoading: !!searchResults?.search?.isLoading, hasErrors, shouldUseLiveData});
     }, [hasErrors, isCardFeedsLoading, isDataLoaded, isOffline, searchResults?.search?.isLoading, shouldShowLoadingState, shouldUseLiveData]);
-
-    useStuckSkeletonLog(shouldShowLoadingState, {
-        hash,
-        type,
-        status,
-        isOffline,
-        shouldUseLiveData,
-        isDataLoaded,
-        isWaitingForInitialData,
-        isSearchLoadingWithNoResults,
-        isCardFeedsLoading,
-        hasErrors,
-        hasUnresolvedErrors,
-        isDeferringHeavyWork,
-        shouldDeferHeavySearchWork,
-        searchIsLoading: !!searchResults?.search?.isLoading,
-        searchOffset: searchResults?.search?.offset,
-        searchRequestResponseStatusCode,
-    });
 
     useEffect(() => {
         /** We only want to display the skeleton for the status filters the first time we load them for a specific data type */

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -80,6 +80,7 @@ import type SearchResults from '@src/types/onyx/SearchResults';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
 import ExpenseFlatSearchView from './ExpenseFlatSearchView';
 import useSearchSnapshot from './hooks/useSearchSnapshot';
+import useStuckSkeletonLog from './hooks/useStuckSkeletonLog';
 import SearchChartView from './SearchChartView';
 import SearchChartWrapper from './SearchChartWrapper';
 import {useSearchQueryActions, useSearchQueryContext, useSearchResultsActions, useSearchResultsContext, useSearchSelectionActions} from './SearchContext';
@@ -344,6 +345,25 @@ function Search({
 
         Log.info('[Search] Showing skeleton', false, {isOffline, isDataLoaded, isCardFeedsLoading, isSearchLoading: !!searchResults?.search?.isLoading, hasErrors, shouldUseLiveData});
     }, [hasErrors, isCardFeedsLoading, isDataLoaded, isOffline, searchResults?.search?.isLoading, shouldShowLoadingState, shouldUseLiveData]);
+
+    useStuckSkeletonLog(shouldShowLoadingState, {
+        hash,
+        type,
+        status,
+        isOffline,
+        shouldUseLiveData,
+        isDataLoaded,
+        isWaitingForInitialData,
+        isSearchLoadingWithNoResults,
+        isCardFeedsLoading,
+        hasErrors,
+        hasUnresolvedErrors,
+        isDeferringHeavyWork,
+        shouldDeferHeavySearchWork,
+        searchIsLoading: !!searchResults?.search?.isLoading,
+        searchOffset: searchResults?.search?.offset,
+        searchRequestResponseStatusCode,
+    });
 
     useEffect(() => {
         /** We only want to display the skeleton for the status filters the first time we load them for a specific data type */


### PR DESCRIPTION


### Explanation of Change
When a user reports a long Search/Reports loading skeleton, our existing `[Search] Showing skeleton` log fires the moment the skeleton appears and does not capture which of the many interdependent conditions is still holding it (data not loaded, search still loading, errors, card feeds loading, and so on). This adds a small diagnostic hook, `useStuckSkeletonLog`, mounted in `SearchLoadingSkeleton` (whose mount lifetime is exactly how long the loading skeleton is visible), that logs a one-off snapshot of those conditions if the skeleton stays visible past 10 seconds. It is diagnostic only and changes no rendering or behavior, so the next slow-load repro shows exactly which condition is stuck for that user instead of guessing.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94801
PROPOSAL:




### Tests


1. Open Search (Reports/Expenses). On a fast load (skeleton under 10s) confirm NO new log appears.
2. Force a slow load (an account with a slow `/api/Search`, or throttle the network so the response takes over 10s).
3. After ~10s on the skeleton, confirm a single `[Search] Loading skeleton still visible after 10000ms` log with the condition snapshot.
4. Confirm there is no visible UI or behavior change in either case.

- [x] Verify that no errors appear in the JS console

### Offline tests


N/A

### QA Steps


Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari


<img width="1656" height="916" alt="image" src="https://github.com/user-attachments/assets/e9c72eba-328a-4194-bbdb-4fe4c0bd8d15"/>


