### PR TITLE
Fix stale fields leaking when merging odometer and map distance expenses

### DIFF
--- a/src/libs/MergeTransactionUtils.ts
+++ b/src/libs/MergeTransactionUtils.ts
@@ -690,6 +690,12 @@ function getMergeFieldUpdatedValues<K extends MergeFieldKey>({
             updatedValues.odometerEnd = transaction?.comment?.odometerEnd;
             updatedValues.odometerStartImage = transaction?.comment?.odometerStartImage;
             updatedValues.odometerEndImage = transaction?.comment?.odometerEndImage;
+        } else {
+            // A map/manual selection has no odometer readings, so null them to clear any carried over from a previous odometer selection
+            updatedValues.odometerStart = null;
+            updatedValues.odometerEnd = null;
+            updatedValues.odometerStartImage = null;
+            updatedValues.odometerEndImage = null;
         }
     }
 

--- a/src/pages/TransactionMerge/DetailsReviewPage.tsx
+++ b/src/pages/TransactionMerge/DetailsReviewPage.tsx
@@ -109,6 +109,13 @@ function DetailsReviewPage({route}: DetailsReviewPageProps) {
                 policy: transaction.transactionID === targetTransaction?.transactionID ? targetTransactionPolicy : sourceTransactionPolicy,
             });
 
+            // receipt and customUnit are objects, and setMergeTransactionKey uses Onyx.merge which deep-extends objects.
+            // Without an explicit clear, sub-keys from a previously selected expense survive (e.g. a combined receipt or
+            // a mixed customUnit). Nulling them first in the same synchronous batch forces the new value to fully replace the old.
+            if ('receipt' in updatedValues || 'customUnit' in updatedValues) {
+                setMergeTransactionKey(transactionID, {receipt: null, customUnit: null});
+            }
+
             setMergeTransactionKey(transactionID, {
                 ...updatedValues,
                 selectedTransactionByField: {

--- a/tests/actions/MergeTransactionTest.ts
+++ b/tests/actions/MergeTransactionTest.ts
@@ -1477,6 +1477,36 @@ describe('setMergeTransactionKey', () => {
             description: 'New Description', // Added
         });
     });
+
+    it('should fully replace receipt and customUnit when nulled in the same synchronous batch', async () => {
+        // Given a merge transaction holding a hybrid receipt and customUnit accumulated from a previous odometer selection
+        const transactionID = 'test-transaction-replace';
+        await Onyx.set(`${ONYXKEYS.COLLECTION.MERGE_TRANSACTION}${transactionID}`, {
+            targetTransactionID: transactionID,
+            receipt: {receiptID: 1, source: 'odometer.jpg', filename: 'odometer.jpg'},
+            customUnit: {name: CONST.CUSTOM_UNITS.NAME_DISTANCE, customUnitID: 'old', quantity: 25.5},
+            odometerStart: 1000,
+            odometerEnd: 1042,
+        });
+
+        // When a map expense is selected: null receipt/customUnit/odometer, then write the new values in the same tick
+        setMergeTransactionKey(transactionID, {receipt: null, customUnit: null});
+        setMergeTransactionKey(transactionID, {
+            receipt: {receiptID: 2},
+            customUnit: {name: CONST.CUSTOM_UNITS.NAME_DISTANCE, distanceUnit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
+            odometerStart: null,
+            odometerEnd: null,
+        });
+        await waitForBatchedUpdates();
+
+        // Then the new receipt/customUnit fully replace the old ones (no stale sub-keys) and odometer readings are gone
+        const mergeTransaction = await getOnyxValue(`${ONYXKEYS.COLLECTION.MERGE_TRANSACTION}${transactionID}`);
+        expect(mergeTransaction).toEqual({
+            targetTransactionID: transactionID,
+            receipt: {receiptID: 2},
+            customUnit: {name: CONST.CUSTOM_UNITS.NAME_DISTANCE, distanceUnit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES},
+        });
+    });
 });
 
 describe('areTransactionsEligibleForMerge', () => {

--- a/tests/unit/MergeTransactionUtilsTest.ts
+++ b/tests/unit/MergeTransactionUtilsTest.ts
@@ -1093,7 +1093,7 @@ describe('MergeTransactionUtils', () => {
             // When we get updated values for merchant field
             const result = getMergeFieldUpdatedValues({transaction, field: 'merchant', fieldValue, getCurrencyDecimals: mockGetCurrencyDecimals});
 
-            // Then it should include merchant plus all distance-specific fields
+            // Then it should include merchant plus all distance-specific fields, with odometer readings nulled for a non-odometer request
             expect(result).toEqual({
                 merchant: 'New Distance Merchant',
                 amount: -2500,
@@ -1114,7 +1114,65 @@ describe('MergeTransactionUtils', () => {
                 taxValue: '5%',
                 taxName: '5%',
                 taxAmount: 125,
+                odometerStart: null,
+                odometerEnd: null,
+                odometerStartImage: null,
+                odometerEndImage: null,
             });
+        });
+
+        it('should copy odometer readings when an odometer distance expense is selected', () => {
+            // Given an odometer distance request transaction with odometer readings
+            const transaction = {
+                ...createRandomDistanceRequestTransaction(0),
+                iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_ODOMETER,
+                comment: {
+                    customUnit: {
+                        name: CONST.CUSTOM_UNITS.NAME_DISTANCE,
+                        customUnitID: 'unit123',
+                    },
+                    odometerStart: 1000,
+                    odometerEnd: 1042,
+                    odometerStartImage: 'start.jpg',
+                    odometerEndImage: 'end.jpg',
+                },
+            };
+            const fieldValue = 'Odometer Merchant';
+
+            // When we get updated values for merchant field
+            const result = getMergeFieldUpdatedValues({transaction, field: 'merchant', fieldValue, getCurrencyDecimals: mockGetCurrencyDecimals});
+
+            // Then the odometer readings should be carried over from the selected transaction
+            expect(result).toEqual(
+                expect.objectContaining({
+                    odometerStart: 1000,
+                    odometerEnd: 1042,
+                    odometerStartImage: 'start.jpg',
+                    odometerEndImage: 'end.jpg',
+                }),
+            );
+        });
+
+        it('should null odometer readings when a map distance expense is selected', () => {
+            // Given a map distance request transaction (no odometer readings)
+            const transaction = {
+                ...createRandomDistanceRequestTransaction(0, true),
+                iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE_MAP,
+            };
+            const fieldValue = 'Map Merchant';
+
+            // When we get updated values for merchant field
+            const result = getMergeFieldUpdatedValues({transaction, field: 'merchant', fieldValue, getCurrencyDecimals: mockGetCurrencyDecimals});
+
+            // Then the odometer readings should be explicitly nulled so none leak in from a previous odometer selection
+            expect(result).toEqual(
+                expect.objectContaining({
+                    odometerStart: null,
+                    odometerEnd: null,
+                    odometerStartImage: null,
+                    odometerEndImage: null,
+                }),
+            );
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Merging an odometer distance expense with a map distance expense produced a corrupted result — leaked odometer readings, the wrong route, and a combined receipt — because the front end accumulated both modalities' fields in the merge transaction instead of replacing them on each merchant selection.

Two distinct leaks, both fixed by making a merchant selection fully own the distance bundle:

- **Odometer readings** (`getMergeFieldUpdatedValues`, `MergeTransactionUtils.ts`): odometer fields were only set when the selected expense was itself an odometer request, so selecting a map merchant left the previous odometer readings untouched — `Onyx.merge` ignores omitted keys. They are now explicitly nulled for any non-odometer selection.
- **`receipt` and `customUnit`** (`handleSelect`, `DetailsReviewPage.tsx`): these are objects, and `setMergeTransactionKey` uses `Onyx.merge`, which deep-extends them and keeps stale sub-keys from the previously selected expense. They are now nulled first in the same synchronous batch so the new value fully replaces rather than merges.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/91794
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
---->

**Setup — produce two eligible distance expenses**

Both expenses must be **distance** requests and neither may be on an IOU report. They do **not** need a workspace — two unreported (personal) distance expenses are eligible.

1. Create a distance expense via the **Odometer** tab — enter start/end readings and attach a receipt. _(If the Odometer tab isn't available on a personal account, create both expenses on a workspace that has odometer distance enabled.)_
2. Create a distance expense via the **Map** tab — set a route with at least two waypoints and attach a receipt.

**Merge — finishing on the map expense**

3. Open the **odometer** expense, tap the header's **More** (⋯) menu, and select **Merge**.
   - The **map** expense should appear in the eligible list. If you see **"No eligible expenses found"** instead, the setup is wrong: confirm both expenses are distance requests, neither is on an IOU report, and neither is still scanning/pending.
4. Select the map expense to merge with.
5. On the **Details review** page, for the **Merchant** field, tap the odometer expense, then the map expense, then the odometer expense again (toggle back and forth), finishing on the **map** expense.
6. Tap **Continue** and confirm the merge.
7. Verify the merged expense is a **clean map distance expense**: it shows the map route/waypoints, shows **no** odometer readings, and the receipt is the map expense's receipt only (not a combined image).

**Merge — finishing on the odometer expense**

8. Repeat steps 3–6, but finish the **Merchant** toggle on the **odometer** expense.
9. Verify the merged expense shows the **odometer readings**, **no** map route/waypoints, and the odometer receipt only.

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

