### PR TITLE
Skip reimbursable step in duplicate resolver for managed card transactions

### DIFF
--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -2619,6 +2619,16 @@ function compareDuplicateTransactionFields(
                         keep[fieldName] = firstTransaction?.[keys[0]] ?? firstTransaction?.[keys[1]];
                     }
                 }
+            } else if (fieldName === 'reimbursable') {
+                // Managed card transactions are always non-reimbursable, so we should never surface the reimbursable
+                // review step when any of the duplicates is a managed card transaction.
+                if (transactions.some(isManagedCardTransaction)) {
+                    keep[fieldName] = false;
+                } else if (areAllFieldsEqualForKey) {
+                    keep[fieldName] = firstTransaction?.[keys[0]] ?? firstTransaction?.[keys[1]];
+                } else {
+                    processChanges(fieldName, transactions, keys);
+                }
             } else if (areAllFieldsEqualForKey) {
                 keep[fieldName] = firstTransaction?.[keys[0]] ?? firstTransaction?.[keys[1]];
             } else {

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -2620,9 +2620,12 @@ function compareDuplicateTransactionFields(
                     }
                 }
             } else if (fieldName === 'reimbursable') {
-                // Managed card transactions are always non-reimbursable, so we should never surface the reimbursable
-                // review step when any of the duplicates is a managed card transaction.
-                if (transactions.some(isManagedCardTransaction)) {
+                // Managed card transactions are always non-reimbursable. Only suppress the reimbursable
+                // review step and force false when the transaction being kept is itself a managed card —
+                // if the user keeps the cash duplicate, the managed card is discarded and the cash
+                // transaction's reimbursable value should be left intact.
+                const selectedTransaction = transactions.find((t) => t?.transactionID === selectedTransactionID) ?? firstTransaction;
+                if (isManagedCardTransaction(selectedTransaction)) {
                     keep[fieldName] = false;
                 } else if (areAllFieldsEqualForKey) {
                     keep[fieldName] = firstTransaction?.[keys[0]] ?? firstTransaction?.[keys[1]];

--- a/tests/unit/TransactionUtilsTest.ts
+++ b/tests/unit/TransactionUtilsTest.ts
@@ -2979,23 +2979,61 @@ describe('TransactionUtils', () => {
                 expect(result.change.reimbursable).toEqual(expect.arrayContaining([true, false]));
             });
 
-            it('should force reimbursable to false and not show the step when one duplicate is a managed card transaction', () => {
+            it('should force reimbursable to false and suppress the step when the selected transaction is a managed card', () => {
                 const cashTransaction = generateTransaction({
                     reimbursable: true,
                     managedCard: false,
                 });
 
-                const duplicates = [
-                    generateTransaction({
-                        reimbursable: false,
-                        managedCard: true,
-                    }),
-                ];
+                const managedCardTransaction = generateTransaction({
+                    reimbursable: false,
+                    managedCard: true,
+                });
 
-                const result = TransactionUtils.compareDuplicateTransactionFields({}, cashTransaction, duplicates, mockReport, undefined, mockPolicy, undefined);
+                const duplicates = [managedCardTransaction];
 
-                expect(result.keep.reimbursable).toBe(false);
-                expect(result.change.reimbursable).toBeUndefined();
+                // When the user keeps the managed card transaction, reimbursable must be forced to false.
+                const resultKeepingCard = TransactionUtils.compareDuplicateTransactionFields(
+                    {},
+                    cashTransaction,
+                    duplicates,
+                    mockReport,
+                    managedCardTransaction.transactionID,
+                    mockPolicy,
+                    undefined,
+                );
+
+                expect(resultKeepingCard.keep.reimbursable).toBe(false);
+                expect(resultKeepingCard.change.reimbursable).toBeUndefined();
+            });
+
+            it('should show the reimbursable step when the user keeps the cash duplicate and the managed card is discarded', () => {
+                const cashTransaction = generateTransaction({
+                    reimbursable: true,
+                    managedCard: false,
+                });
+
+                const managedCardTransaction = generateTransaction({
+                    reimbursable: false,
+                    managedCard: true,
+                });
+
+                const duplicates = [managedCardTransaction];
+
+                // When the user keeps the cash expense (discarding the managed card), the cash
+                // transaction's reimbursable value should not be silently overridden.
+                const resultKeepingCash = TransactionUtils.compareDuplicateTransactionFields(
+                    {},
+                    cashTransaction,
+                    duplicates,
+                    mockReport,
+                    cashTransaction.transactionID,
+                    mockPolicy,
+                    undefined,
+                );
+
+                expect(resultKeepingCash.keep.reimbursable).toBeUndefined();
+                expect(resultKeepingCash.change.reimbursable).toEqual(expect.arrayContaining([true, false]));
             });
         });
 

--- a/tests/unit/TransactionUtilsTest.ts
+++ b/tests/unit/TransactionUtilsTest.ts
@@ -2978,6 +2978,25 @@ describe('TransactionUtils', () => {
                 expect(result.keep.reimbursable).toBeUndefined();
                 expect(result.change.reimbursable).toEqual(expect.arrayContaining([true, false]));
             });
+
+            it('should force reimbursable to false and not show the step when one duplicate is a managed card transaction', () => {
+                const cashTransaction = generateTransaction({
+                    reimbursable: true,
+                    managedCard: false,
+                });
+
+                const duplicates = [
+                    generateTransaction({
+                        reimbursable: false,
+                        managedCard: true,
+                    }),
+                ];
+
+                const result = TransactionUtils.compareDuplicateTransactionFields({}, cashTransaction, duplicates, mockReport, undefined, mockPolicy, undefined);
+
+                expect(result.keep.reimbursable).toBe(false);
+                expect(result.change.reimbursable).toBeUndefined();
+            });
         });
 
         describe('selectedTransactionID parameter', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The duplicate resolver decides which review steps to show and what values to merge from `compareDuplicateTransactionFields` in `src/libs/TransactionUtils/index.ts`. `reimbursable` was treated as a generic comparable field: when a manually-added cash expense (`reimbursable: true`) was a duplicate of a managed company-card transaction (`reimbursable: false`), the values differed, so `reimbursable` was added to the `change` map — surfacing the "Choose if transaction is reimbursable" step. The user could pick *reimbursable*, and the merge persisted `reimbursable: true` onto a managed card transaction, an invalid state with no in-product way to correct it.

This change adds a dedicated `reimbursable` branch in the field-comparison loop that gates on the **selected transaction** (the one the user chose to keep), not on any transaction in the duplicate set:

- If the **selected transaction is a managed card** (`isManagedCardTransaction(selectedTransaction)`), `reimbursable` is forced into `keep` as `false` and never added to `change`. Because every `Review*` page derives its step list from `Object.keys(change)`, dropping `reimbursable` from `change` removes the step, and seeding `keep.reimbursable = false` flows through `setReviewDuplicatesKey` so `buildMergeDuplicatesParams` merges the transaction as non-reimbursable.
- If the **selected transaction is the cash expense** (the managed card duplicate is being discarded), the cash expense's reimbursable value is left intact and the field is handled by the normal equal/differ logic. Silently overriding a valid reimbursable cash expense was the concern raised during review of the original approach (`transactions.some(isManagedCardTransaction)`).
- When no managed card is involved at all, the existing equal/differ behavior is fully preserved.

`isManagedCardTransaction` (`!!transaction?.managedCard`) is used deliberately rather than a broader card-import check, so personal/CSV card imports that can legitimately be reimbursable are unaffected — only centrally managed cards are constrained to non-reimbursable.

Supersedes #94777.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94679
PROPOSAL: https://github.com/Expensify/App/issues/94679#issuecomment-4808767996

### Tests

1. Create a workspace and connect a company card feed; import some transactions.
2. Add a cash expense matching one of the imported managed card transactions so they are flagged as duplicates.
3. Open one of the duplicates and tap **Review duplicates**.
4. Select the **managed card transaction** to keep and proceed.
5. Verify the "Choose if transaction is reimbursable" step is **not** shown.
6. Complete the merge and verify the resulting transaction is non-reimbursable.
7. Repeat steps 3–4 but this time select the **cash expense** to keep.
8. Verify the "Choose if transaction is reimbursable" step **is** shown and the cash expense retains its reimbursable value after merging.
9. Regression: resolve duplicates between two cash expenses with differing reimbursable values and verify the reimbursable step **is** still shown.
10. Verify that no errors appear in the JS console.

Automated coverage added in `tests/unit/TransactionUtilsTest.ts` (`compareDuplicateTransactionFields` → `reimbursable field comparison`):
- Keeping the managed card duplicate → `keep.reimbursable === false`, no `change.reimbursable`.
- Keeping the cash duplicate → reimbursable step shown with both values, cash value preserved.
- Existing cash-vs-cash behavior unchanged.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests.

### QA Steps

1. Create a workspace and connect a company card feed; import some transactions.
2. Add a cash expense matching one of the imported managed card transactions so they are flagged as duplicates.
3. Open the duplicate warning and tap **Review duplicates**.
4. Select the **managed card transaction** to keep — verify the "Choose if transaction is reimbursable" step is **not** shown and the merged result is non-reimbursable.
5. Repeat, this time selecting the **cash expense** to keep — verify the reimbursable step **is** shown and the merged result respects the chosen value.
6. Regression: verify the reimbursable step still appears when resolving duplicates between two non-managed-card (cash) expenses with differing reimbursable values.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>