### PR TITLE
Crash diagnostics: stop reporting hidden/backgrounded tabs as crashes

### DIFF
--- a/src/libs/telemetry/crashDiagnostics/index.ts
+++ b/src/libs/telemetry/crashDiagnostics/index.ts
@@ -43,6 +43,9 @@ const LIVENESS_FRESHNESS_MS = 2 * 60 * 1000;
 
 const LIVENESS_CHANNEL_NAME = 'crashDiagnosticsLiveness';
 
+// Number of most-recent samples inspected to decide whether the session was in the foreground near the end.
+const RECENT_SAMPLE_WINDOW = 4;
+
 /** A point-in-time snapshot of memory/DOM/route state, captured on every heartbeat to reconstruct what was growing before a crash. */
 type HeapSample = {
     /** When the sample was taken, as epoch ms. */
@@ -81,8 +84,14 @@ type SessionRecord = {
     /** Epoch ms of the most recent heartbeat or exit-state write; staleness of this is the primary crash signal. */
     lastHeartbeat: number;
 
-    /** True while the page is in a state where missing heartbeats are expected (pagehide/freeze) */
+    /** True while missing heartbeats are expected: a real/clean exit (pagehide/freeze) or a backgrounded (hidden) tab. */
     cleanExit: boolean;
+
+    /** Highest `usedJSHeapSizeMB` seen this session; survives ring-buffer eviction. Null on non-Chromium browsers. */
+    peakUsedJSHeapSizeMB: number | null;
+
+    /** Highest DOM-node count seen this session; survives ring-buffer eviction. */
+    peakDomNodes: number;
 
     /** Ring buffer of recent samples, capped at `MAX_SAMPLES` (oldest dropped first). */
     samples: HeapSample[];
@@ -111,8 +120,17 @@ function markCleanExit() {
     markExitState(true);
 }
 
-function markActive() {
-    markExitState(false);
+/**
+ * Sync the exit state to current page visibility. While the tab is `hidden`, throttled or absent heartbeats are
+ * expected: Chrome throttles/suspends background-tab timers, laptop sleep stops them with no `freeze` event, and
+ * `freeze` never fires at all in Safari/Firefox — so a hidden tab is marked clean and will not be misreported as
+ * a crash. A renderer crash the user actually experiences happens while the tab is `visible`.
+ */
+function syncExitStateWithVisibility() {
+    if (typeof document === 'undefined') {
+        return;
+    }
+    markExitState(document.visibilityState === 'hidden');
 }
 
 function isStorageAvailable(): boolean {
@@ -243,8 +261,16 @@ function heartbeat() {
             if (sessionRecord.samples.length > MAX_SAMPLES) {
                 sessionRecord.samples.splice(0, sessionRecord.samples.length - MAX_SAMPLES);
             }
+            if (sample.usedJSHeapSizeMB !== null && sample.usedJSHeapSizeMB > (sessionRecord.peakUsedJSHeapSizeMB ?? 0)) {
+                sessionRecord.peakUsedJSHeapSizeMB = sample.usedJSHeapSizeMB;
+            }
+            if (sample.domNodes > sessionRecord.peakDomNodes) {
+                sessionRecord.peakDomNodes = sample.domNodes;
+            }
             sessionRecord.lastHeartbeat = Date.now();
-            sessionRecord.cleanExit = false;
+            // While hidden, missing/throttled heartbeats are expected, so keep the session marked clean; only a
+            // tab that goes silent while visible is a crash candidate.
+            sessionRecord.cleanExit = sample.visibility === 'hidden';
             persistSessionRecord();
             announceLiveness();
             reapDeadSessions();
@@ -254,24 +280,72 @@ function heartbeat() {
         });
 }
 
+/**
+ * Buckets peak heap usage as a fraction of the hard limit, for indexed Sentry tagging. Returns `unknown` on
+ * non-Chromium browsers (no `performance.memory`) so those events stay visible rather than being filtered out.
+ * Reported from the session peak, not the last sample, because an OOM spike can occur between heartbeats.
+ */
+function getHeapPressureBucket(record: SessionRecord): string {
+    const limitMB = record.samples.at(-1)?.jsHeapSizeLimitMB ?? null;
+    if (record.peakUsedJSHeapSizeMB == null || limitMB == null || limitMB <= 0) {
+        return 'unknown';
+    }
+    const pct = (record.peakUsedJSHeapSizeMB / limitMB) * 100;
+    if (pct >= 80) {
+        return 'high';
+    }
+    if (pct >= 50) {
+        return 'mid';
+    }
+    return 'low';
+}
+
+/** Buckets session duration (minutes) for indexed Sentry tagging. */
+function getSessionDurationBucket(minutes: number): string {
+    if (minutes <= 5) {
+        return '0-5';
+    }
+    if (minutes <= 30) {
+        return '6-30';
+    }
+    if (minutes <= 120) {
+        return '31-120';
+    }
+    if (minutes <= 480) {
+        return '121-480';
+    }
+    return '480+';
+}
+
 function reportAbnormalExit(record: SessionRecord) {
     const lastSample = record.samples.at(-1);
+    const durationMinutes = Math.round((record.lastHeartbeat - record.startedAt) / MS_PER_MINUTE);
+    // A real renderer crash happens in the foreground; treat any visible sample in the recent window as
+    // "was in use" so background-only sessions can be filtered out in Sentry.
+    const wasForeground = record.samples.slice(-RECENT_SAMPLE_WINDOW).some((sample) => sample.visibility === 'visible');
     Sentry.captureEvent({
         message: 'Crash diagnostics: previous browser session ended abnormally (possible tab crash)',
         level: 'warning',
         tags: {
             crashDiagnostics: 'abnormal_exit',
             lastRoute: lastSample?.route ?? 'unknown',
+            lastVisibility: lastSample?.visibility ?? 'unknown',
+            wasForeground: String(wasForeground),
+            heapPressure: getHeapPressureBucket(record),
+            sessionDurationBucket: getSessionDurationBucket(durationMinutes),
+            browserEngine: lastSample?.jsHeapSizeLimitMB ? 'chromium' : 'other',
         },
         extra: {
             sessionID: record.id,
             sessionStartedAt: new Date(record.startedAt).toISOString(),
             lastHeartbeatAt: new Date(record.lastHeartbeat).toISOString(),
-            sessionDurationMinutes: Math.round((record.lastHeartbeat - record.startedAt) / MS_PER_MINUTE),
+            sessionDurationMinutes: durationMinutes,
             lastUsedJSHeapSizeMB: lastSample?.usedJSHeapSizeMB,
             lastTotalJSHeapSizeMB: lastSample?.totalJSHeapSizeMB,
             jsHeapSizeLimitMB: lastSample?.jsHeapSizeLimitMB,
             lastDOMNodes: lastSample?.domNodes,
+            peakUsedJSHeapSizeMB: record.peakUsedJSHeapSizeMB ?? null,
+            peakDOMNodes: record.peakDomNodes ?? null,
             samples: record.samples,
         },
     });
@@ -295,13 +369,22 @@ function reapDeadSessions() {
             continue;
         }
         const record = readSessionRecord(storageKey);
-        if (!record || record.cleanExit) {
+        if (!record) {
             window.localStorage.removeItem(storageKey);
+            continue;
+        }
+        const isStale = Date.now() - record.lastHeartbeat > STALE_HEARTBEAT_MS;
+        // A clean session (cleanly exited, or a currently-hidden background tab) is only safe to drop once it
+        // has also gone stale. Removing a fresh clean record would delete a live, backgrounded tab's diagnostics.
+        if (record.cleanExit) {
+            if (isStale) {
+                window.localStorage.removeItem(storageKey);
+            }
             continue;
         }
         // Heartbeat is stale, but that alone cannot tell a crash apart from a suspended-but-alive tab.
         // Confirm the session is really gone before reporting it as a crash.
-        if (Date.now() - record.lastHeartbeat > STALE_HEARTBEAT_MS) {
+        if (isStale) {
             confirmDeadThenReport(storageKey, record.id);
         }
     }
@@ -334,6 +417,13 @@ function confirmDeadThenReport(storageKey: string, sessionID: string) {
         if (isSessionRecentlyAlive(sessionID) || Date.now() - record.lastHeartbeat <= STALE_HEARTBEAT_MS) {
             return;
         }
+        // Defense in depth: a session that was hidden at its last heartbeat is a backgrounded/suspended tab,
+        // not a foreground crash. heartbeat() already keeps such sessions marked clean, but guard here too in
+        // case an older record (written before visibility-aware exit state) slipped through.
+        if (record.samples.at(-1)?.visibility === 'hidden') {
+            window.localStorage.removeItem(storageKey);
+            return;
+        }
         reportAbnormalExit(record);
         window.localStorage.removeItem(storageKey);
     }, LIVENESS_GRACE_MS);
@@ -364,6 +454,8 @@ function initializeCrashDiagnostics() {
         startedAt: Date.now(),
         lastHeartbeat: Date.now(),
         cleanExit: false,
+        peakUsedJSHeapSizeMB: null,
+        peakDomNodes: 0,
         samples: [],
     };
 
@@ -384,13 +476,15 @@ function initializeCrashDiagnostics() {
     });
 
     // pagehide fires on navigation away, refresh, and tab close — all clean exits. It does NOT fire on a
-    // renderer crash, which is exactly the signal we rely on. pageshow restores the session after a
-    // back/forward-cache restore. freeze/resume cover background tabs whose timers are fully suspended,
-    // so a frozen tab isn't misreported as crashed.
+    // renderer crash, which is exactly the signal we rely on. pageshow/resume restore the session after a
+    // back/forward-cache restore or freeze. visibilitychange is the broad, cross-browser signal that the tab
+    // was backgrounded: freeze only fires for the subset of background tabs Chrome actually suspends (and never
+    // in Safari/Firefox), so relying on it alone misreported hidden-but-not-frozen tabs as crashes.
     window.addEventListener('pagehide', markCleanExit);
-    window.addEventListener('pageshow', markActive);
+    window.addEventListener('pageshow', syncExitStateWithVisibility);
     document.addEventListener('freeze', markCleanExit);
-    document.addEventListener('resume', markActive);
+    document.addEventListener('resume', syncExitStateWithVisibility);
+    document.addEventListener('visibilitychange', syncExitStateWithVisibility);
 
     // Report any previous session that ended abnormally now that our own record and liveness channel exist
     reapDeadSessions();
@@ -420,9 +514,10 @@ function cleanupCrashDiagnostics() {
     }
     if (typeof window !== 'undefined') {
         window.removeEventListener('pagehide', markCleanExit);
-        window.removeEventListener('pageshow', markActive);
+        window.removeEventListener('pageshow', syncExitStateWithVisibility);
         document.removeEventListener('freeze', markCleanExit);
-        document.removeEventListener('resume', markActive);
+        document.removeEventListener('resume', syncExitStateWithVisibility);
+        document.removeEventListener('visibilitychange', syncExitStateWithVisibility);
     }
     markCleanExit();
     sessionRecord = undefined;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The web crash diagnostic (`crashDiagnostics`) reports a session to Sentry as a "possible tab crash" when its heartbeat goes stale without a clean-exit marker (Sentry issue **APP-F6C**: _"previous browser session ended abnormally"_, ~2.2k events / ~1.3k users).

Investigation of production events + Fullstory replays showed the large majority are **false positives** — healthy tabs, not crashes:

- The clean-exit signal was keyed off the `freeze` event, which only fires for the subset of background tabs Chrome actually suspends, and never in Safari/Firefox. A tab that is merely `hidden` (freeze-ineligible due to an open Pusher WebSocket / Onyx IndexedDB / Web Lock, or suspended by laptop sleep) keeps a stale heartbeat with no clean-exit marker and gets misreported.
- Examples: a tab `hidden` for 15.5 h with a flat heap at ~3% of the limit; abandoned `/transition` tabs `hidden` for 38 h. Both reported as "crashes." Several kept heartbeating _after_ being reported, proving they never died.

This PR keys the clean-exit state off **page visibility** instead of `freeze`, so a backgrounded tab is treated as expected-silence rather than a crash, and adds **indexed Sentry tags** so the genuine foreground crashes can be isolated.

What changed (`src/libs/telemetry/crashDiagnostics/index.ts`):

- `cleanExit` now follows `document.visibilityState` (via a new `visibilitychange` listener and per-heartbeat update); `hidden` ⇒ clean. `freeze`/`pagehide` still mark clean; `pageshow`/`resume` re-sync to visibility.
- Defense-in-depth: a record that was `hidden` at its last heartbeat is dropped, never reported.
- `reapDeadSessions` only removes a clean record once it is also **stale**, so a live backgrounded tab's diagnostics aren't deleted.
- New indexed tags on the report: `lastVisibility`, `wasForeground`, `heapPressure` (from session **peak**, not last sample, since an OOM spike can occur between heartbeats), `sessionDurationBucket`, `browserEngine`. Peak heap/DOM added to `extra`.

After this lands, real-crash candidates are simply: `issue:APP-F6C lastVisibility:visible heapPressure:[high,unknown]`.

This is the source-side half (Tier 1 + Tier 2) of the investigation. Ground-truth detection via the Chrome Crash Reporting API (`reason:"oom"`) is a planned follow-up.

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://expensify.sentry.io/issues/APP-F6C
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

This is web-only, non-UI telemetry. Verify via the browser DevTools and Sentry:

1. Open the app on web (Chrome) and confirm no errors appear in the JS console.
2. In DevTools → Application → Local Storage, observe a `crashDiagnostics_session_<id>` entry being written/updated.
3. With the tab **focused**, confirm the stored record has `cleanExit: false`.
4. Switch to another tab/window (background the app) for a few seconds, then re-inspect the record: `cleanExit` is now `true` (last sample's `visibility` is `hidden`).
5. Return to the tab: `cleanExit` flips back to `false`.
6. Real abnormal exit: with the tab **focused**, kill the renderer via `chrome://crash` (no clean-exit marker is written). Reopen the app and confirm exactly one Sentry event `crashDiagnostics: abnormal_exit` is captured, tagged `lastVisibility: visible`.
7. Confirm that backgrounding/closing a tab normally (or leaving it hidden) does **not** produce an `abnormal_exit` event on next launch.

- [x] Verify that no errors appear in the JS console

### Offline tests

<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests — the diagnostic uses `localStorage` only and is unaffected by network state.

### QA Steps

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests (web only).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android: Native
  - [ ] Android: mWeb Chrome
  - [ ] iOS: Native
  - [ ] iOS: mWeb Safari
  - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If any new file was added I verified that:
  - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
  - [ ] A similar style doesn't already exist
  - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
  - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [ ] I verified that all the inputs inside a form are aligned with each other.
  - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<!-- Web-only telemetry change, no UI. No visual output on any platform. -->
<details>
<summary>Android: Native</summary>

N/A — web-only telemetry, no UI.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — web-only telemetry, no UI.

</details>

<details>
<summary>iOS: Native</summary>

N/A — web-only telemetry, no UI.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — web-only telemetry, no UI.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — web-only telemetry, no UI.

</details>
