### PR TITLE
[No QA] Add selector gating to OnyxDerived dependencies

### DIFF
--- a/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
@@ -44,6 +44,20 @@ const hasPolicyRelevantFieldChanged = (prev: Policy | null | undefined, next: Po
     );
 };
 
+/**
+ * Projects a policy to the fields that affect report attributes, so a policy write touching none of them
+ * (e.g. a `pendingAction`/`employeeList` change) produces no delta and the dispatcher gates the recompute.
+ * MUST stay in sync with `hasPolicyRelevantFieldChanged` above — same fields, compared with shallow equality.
+ */
+const policyReportAttributesSelector = (policy: OnyxEntry<Policy>) => ({
+    type: policy?.type,
+    approvalMode: policy?.approvalMode,
+    reimbursementChoice: policy?.reimbursementChoice,
+    autoReimbursementLimit: policy?.autoReimbursementLimit,
+    role: policy?.role,
+    autoReimbursementNestedLimit: policy?.autoReimbursement?.limit,
+});
+
 const checkDisplayNamesChanged = (personalDetails: OnyxEntry<PersonalDetailsList>) => {
     if (!personalDetails) {
         return false;
@@ -87,7 +101,7 @@ export default createOnyxDerivedValueConfig({
         ONYXKEYS.COLLECTION.TRANSACTION,
         ONYXKEYS.PERSONAL_DETAILS_LIST,
         ONYXKEYS.SESSION,
-        ONYXKEYS.COLLECTION.POLICY,
+        {key: ONYXKEYS.COLLECTION.POLICY, selector: policyReportAttributesSelector},
         ONYXKEYS.COLLECTION.POLICY_TAGS,
         ONYXKEYS.CONCIERGE_REPORT_ID,
         ONYXKEYS.COLLECTION.REPORT_METADATA,

--- a/src/libs/actions/OnyxDerived/configs/todos.ts
+++ b/src/libs/actions/OnyxDerived/configs/todos.ts
@@ -1,11 +1,64 @@
+import {deepEqual} from 'fast-equals';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import {getLoginByAccountID} from '@libs/PersonalDetailsUtils';
+import {getOriginalMessage} from '@libs/ReportActionsUtils';
 import {isApproveAction, isExportAction, isPrimaryPayAction, isSubmitAction} from '@libs/ReportPrimaryActionUtils';
 import {hasOnlyHeldExpenses, hasOnlyNonReimbursableTransactions} from '@libs/ReportUtils';
 import createOnyxDerivedValueConfig from '@userActions/OnyxDerived/createOnyxDerivedValueConfig';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {BankAccountList, PersonalDetailsList, Policy, Report, ReportActions, ReportMetadata, ReportNameValuePairs, Transaction} from '@src/types/onyx';
+
+// Last-activity fields `addComment` merges onto a report. None are read by the todo eligibility checks
+// (isSubmitAction/isApproveAction/isPrimaryPayAction/isExportAction), so a change confined to them is irrelevant.
+const REPORT_FIELDS_IRRELEVANT_TO_TODOS = ['lastVisibleActionCreated', 'lastMessageText', 'lastMessageHtml', 'lastActorAccountID', 'lastReadTime', 'lastActionType'] as const;
+
+/**
+ * Projects a report to the slice that can affect the todo lists, so chat activity (e.g. `addComment`)
+ * doesn't trigger an O(all-reports) recompute:
+ *  - todos only ever considers EXPENSE reports, so any other report collapses to just its `type` — a
+ *    change to a non-expense report (most chat traffic) can't alter the output and is gated. This is
+ *    safe because the compute never reads non-expense report objects.
+ *  - the last-activity fields `addComment` writes are stripped.
+ *  - `managerID` is normalized to `?? DEFAULT_NUMBER_ID`, matching how `isApproveAction` reads it, so the
+ *    common `undefined -> 0` placeholder write produces no delta.
+ */
+const reportTodoSelector = (report: OnyxEntry<Report>) => {
+    if (!report) {
+        return report;
+    }
+    if (report.type !== CONST.REPORT.TYPE.EXPENSE) {
+        return {type: report.type};
+    }
+    const projection: Partial<Report> = {...report};
+    for (const field of REPORT_FIELDS_IRRELEVANT_TO_TODOS) {
+        delete projection[field];
+    }
+    projection.managerID = report.managerID ?? CONST.DEFAULT_NUMBER_ID;
+    return projection;
+};
+
+/**
+ * Projects a report's actions to only what the todo eligibility reads (export-state detection in
+ * `isExportAction` → `isExported`/`hasExportError`, which read `actionName`, `created`, `originalMessage`).
+ * `ADD_COMMENT` actions are excluded entirely, and per-action chat metadata (`childVisibleActionCount`,
+ * `pendingAction`, `errors`, …) is dropped — so `addComment`'s optimistic comment, its success/failure
+ * patches, and ancestor `child*` bumps all project to an unchanged value and don't trigger a recompute.
+ * Compared with `deepEqual` since the projection allocates new objects each run.
+ */
+const reportActionsTodoSelector = (reportActions: OnyxEntry<ReportActions>) => {
+    if (!reportActions) {
+        return reportActions;
+    }
+    const projection: Array<{actionName: string; created: string; originalMessage: unknown}> = [];
+    for (const action of Object.values(reportActions)) {
+        if (!action || action.actionName === CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT) {
+            continue;
+        }
+        projection.push({actionName: action.actionName, created: action.created, originalMessage: getOriginalMessage(action)});
+    }
+    return projection;
+};
 
 type CreateTodosReportsAndTransactionsParams = {
     allReports: OnyxCollection<Report>;
@@ -107,11 +160,11 @@ const createTodosReportsAndTransactions = ({
 export default createOnyxDerivedValueConfig({
     key: ONYXKEYS.DERIVED.TODOS,
     dependencies: [
-        ONYXKEYS.COLLECTION.REPORT,
+        {key: ONYXKEYS.COLLECTION.REPORT, selector: reportTodoSelector},
         ONYXKEYS.COLLECTION.POLICY,
         ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS,
         ONYXKEYS.COLLECTION.TRANSACTION,
-        ONYXKEYS.COLLECTION.REPORT_ACTIONS,
+        {key: ONYXKEYS.COLLECTION.REPORT_ACTIONS, selector: reportActionsTodoSelector, isEqual: deepEqual},
         ONYXKEYS.COLLECTION.REPORT_METADATA,
         ONYXKEYS.BANK_ACCOUNT_LIST,
         ONYXKEYS.SESSION,

--- a/src/libs/actions/OnyxDerived/createOnyxDerivedValueConfig.ts
+++ b/src/libs/actions/OnyxDerived/createOnyxDerivedValueConfig.ts
@@ -1,7 +1,7 @@
 import type {NonEmptyTuple, ValueOf} from 'type-fest';
 import type {OnyxKey} from '@src/ONYXKEYS';
 import type ONYXKEYS from '@src/ONYXKEYS';
-import type {OnyxDerivedValueConfig} from './types';
+import type {OnyxDerivedDependency, OnyxDerivedValueConfig} from './types';
 
 /**
  * Helper function to create a derived value config. This function is just here to help TypeScript infer Deps, so instead of writing this:
@@ -17,7 +17,7 @@ import type {OnyxDerivedValueConfig} from './types';
  *     dependencies: [ONYXKEYS.COLLECTION.REPORT, ONYXKEYS.CONCIERGE_REPORT_ID]
  * })
  */
-export default function createOnyxDerivedValueConfig<Key extends ValueOf<typeof ONYXKEYS.DERIVED>, Deps extends NonEmptyTuple<Exclude<OnyxKey, Key>>>(
+export default function createOnyxDerivedValueConfig<Key extends ValueOf<typeof ONYXKEYS.DERIVED>, Deps extends NonEmptyTuple<OnyxDerivedDependency<Exclude<OnyxKey, Key>>>>(
     config: OnyxDerivedValueConfig<Key, Deps>,
 ): OnyxDerivedValueConfig<Key, Deps> {
     return config;

--- a/src/libs/actions/OnyxDerived/index.ts
+++ b/src/libs/actions/OnyxDerived/index.ts
@@ -5,7 +5,9 @@
  *
  * The primary purpose is to optimize performance by reducing redundant computations. More info can be found in the README.
  */
+import {shallowEqual} from 'fast-equals';
 import Onyx from 'react-native-onyx';
+import type {OnyxCollection} from 'react-native-onyx';
 import OnyxKeys from 'react-native-onyx/dist/OnyxKeys';
 import OnyxUtils from 'react-native-onyx/dist/OnyxUtils';
 import Log from '@libs/Log';
@@ -13,10 +15,45 @@ import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {OnyxKey} from '@src/ONYXKEYS';
 import ObjectUtils from '@src/types/utils/ObjectUtils';
 import ONYX_DERIVED_VALUES from './ONYX_DERIVED_VALUES';
 import type {DerivedValueContext} from './types';
 import {setDerivedValue} from './utils';
+
+/**
+ * A widened view of a dependency for the dispatcher to read its optional selector/isEqual without
+ * caring about each config's precise per-key types. `selector` is a method (bivariant) so the precise
+ * declared dependency is assignable to this — keeping `rawDependency as RawDependency` a safe upcast.
+ */
+type RawDependency = OnyxKey | {key: OnyxKey; selector?(member: unknown): unknown; isEqual?: (a: unknown, b: unknown) => boolean};
+
+/**
+ * For a dependency declared with a selector, narrows Onyx's native `sourceValue` (the changed collection
+ * members) to only those whose selected slice actually changed, comparing each against the previous snapshot.
+ * Returns the filtered partial collection, or `undefined` when no relevant member changed — so the caller can
+ * skip the recompute. Members absent from the previous snapshot (added) are always kept.
+ */
+function selectRelevantSourceValue(
+    sourceValue: Record<string, unknown>,
+    currentCollection: OnyxCollection<unknown>,
+    previousCollection: OnyxCollection<unknown>,
+    selector: (member: unknown) => unknown,
+    isEqual: (a: unknown, b: unknown) => boolean,
+): Record<string, unknown> | undefined {
+    const filtered: Record<string, unknown> = {};
+    let hasRelevantChange = false;
+    for (const memberKey of Object.keys(sourceValue)) {
+        const previousMember = previousCollection?.[memberKey];
+        // Reference-changed member whose projected slice is unchanged → irrelevant, drop it.
+        if (previousMember !== undefined && isEqual(selector(currentCollection?.[memberKey]), selector(previousMember))) {
+            continue;
+        }
+        filtered[memberKey] = sourceValue[memberKey];
+        hasRelevantChange = true;
+    }
+    return hasRelevantChange ? filtered : undefined;
+}
 
 /**
  * Initialize all Onyx derived values, store them in Onyx, and setup listeners to update them when dependencies change.
@@ -61,8 +98,9 @@ function init() {
                 sourceValues: undefined,
             };
 
-            const recomputeDerivedValue = (sourceKey?: string, sourceValue?: unknown, triggeredByIndex?: number) => {
-                // If this recompute was triggered by a connection callback, check if it initializes the connection
+            const recomputeDerivedValue = (sourceKey?: string, sourceValue?: unknown, triggeredByIndex?: number, isGatedBySelector = false) => {
+                // If this recompute was triggered by a connection callback, check if it initializes the connection.
+                // This must run even when gated, otherwise areAllConnectionsSet would never flip.
                 if (!areAllConnectionsSet && triggeredByIndex !== undefined) {
                     checkAndMarkConnectionInitialized(triggeredByIndex);
                 }
@@ -73,6 +111,14 @@ function init() {
                 // We still update dependencyValues via setDependencyValue so data accumulates correctly.
                 if (!areAllConnectionsSet) {
                     Log.info(`[OnyxDerived] not all connections set for ${key}, deferring Onyx write`);
+                    return;
+                }
+
+                // A selector dependency whose changed members all projected to an unchanged slice carries no
+                // relevant change — skip the recompute entirely. This is distinct from a plain `undefined`
+                // sourceValue, which means "no incremental info" and still triggers a full recompute (e.g. initial load).
+                if (isGatedBySelector) {
+                    Log.info(`[OnyxDerived] no relevant change for dependency ${sourceKey} on ${key}, skipping recompute`);
                     return;
                 }
 
@@ -100,16 +146,39 @@ function init() {
 
             for (let i = 0; i < dependencies.length; i++) {
                 const dependencyIndex = i;
-                const dependencyOnyxKey = dependencies[dependencyIndex];
+                // A dependency is either a bare Onyx key or the object form `{key, selector, isEqual?}`.
+                // Read the key from the precise declared type (avoids widening it to all OnyxKeys), but read the
+                // optional selector/isEqual through the widened RawDependency view.
+                const rawDependency = dependencies[dependencyIndex];
+                const dependencyOnyxKey = typeof rawDependency === 'object' ? rawDependency.key : rawDependency;
+                const dependencyDescriptor = rawDependency as RawDependency;
+                // `selector` is a method (bivariant, for type-variance reasons in ./types), so reading it as a value
+                // trips `unbound-method` — safe to ignore: derived-value selectors are pure standalone functions.
+                // eslint-disable-next-line @typescript-eslint/unbound-method
+                const dependencySelector = typeof dependencyDescriptor === 'object' ? dependencyDescriptor.selector : undefined;
+                const dependencyIsEqual = typeof dependencyDescriptor === 'object' ? dependencyDescriptor.isEqual : undefined;
 
                 if (OnyxKeys.isCollectionKey(dependencyOnyxKey)) {
+                    // Track the previous snapshot per dependency so a selector can compare each changed member's
+                    // projection against its prior value. Structural sharing keeps unchanged members reference-equal.
+                    let previousCollectionValue: OnyxCollection<unknown>;
                     Onyx.connectWithoutView({
                         key: dependencyOnyxKey,
                         waitForCollectionCallback: true,
                         callback: (value, collectionKey, sourceValue) => {
                             Log.info(`[OnyxDerived] dependency ${collectionKey} for derived key ${key} changed, recomputing`);
                             setDependencyValue(dependencyIndex, value as Parameters<typeof compute>[0][typeof dependencyIndex]);
-                            recomputeDerivedValue(dependencyOnyxKey, sourceValue, dependencyIndex);
+
+                            let effectiveSourceValue = sourceValue as Record<string, unknown> | undefined;
+                            let isGatedBySelector = false;
+                            // Only filter when a selector is declared AND Onyx gave us an incremental delta.
+                            // A missing sourceValue (initial load) must still trigger a full recompute, so it is never gated.
+                            if (dependencySelector && effectiveSourceValue) {
+                                effectiveSourceValue = selectRelevantSourceValue(effectiveSourceValue, value, previousCollectionValue, dependencySelector, dependencyIsEqual ?? shallowEqual);
+                                isGatedBySelector = effectiveSourceValue === undefined;
+                            }
+                            previousCollectionValue = value;
+                            recomputeDerivedValue(dependencyOnyxKey, effectiveSourceValue, dependencyIndex, isGatedBySelector);
                         },
                     });
                 } else if (dependencyOnyxKey === ONYXKEYS.NVP_PREFERRED_LOCALE) {

--- a/src/libs/actions/OnyxDerived/types.ts
+++ b/src/libs/actions/OnyxDerived/types.ts
@@ -3,37 +3,60 @@ import type {NonEmptyTuple, ValueOf} from 'type-fest';
 import type {OnyxCollectionKey, OnyxCollectionValuesMapping, OnyxDerivedValuesMapping, OnyxKey} from '@src/ONYXKEYS';
 import type ONYXKEYS from '@src/ONYXKEYS';
 
+/**
+ * A dependency declared with a selector that gates its changed-member delta by relevance.
+ * Only meaningful for collection keys: the selector receives a single collection member, and a
+ * reference-changed member only triggers a recompute when its projection differs. For a non-collection
+ * key the selector argument resolves to `never`, so selectors are collection-only by construction.
+ */
+type OnyxDerivedDependencyWithSelector<K extends OnyxKey = OnyxKey> = {
+    key: K;
+    // Declared as a method (not an arrow property) so the `member` parameter is bivariant — this lets a
+    // dependency typed for a specific key satisfy the general `OnyxDerivedDependency<OnyxKey>` constraint.
+    selector(member: K extends keyof OnyxCollectionValuesMapping ? OnyxCollectionValuesMapping[K] | undefined : never): unknown;
+    isEqual?: (a: unknown, b: unknown) => boolean;
+};
+
+/** A single declared dependency: a bare Onyx key, or the object form carrying a selector. */
+type OnyxDerivedDependency<K extends OnyxKey = OnyxKey> = K | OnyxDerivedDependencyWithSelector<K>;
+
+/** Extract the underlying Onyx key from either dependency form. */
+type DepKey<D> = D extends OnyxDerivedDependencyWithSelector<infer K> ? K : D extends OnyxKey ? D : never;
+
 type OnyxCollectionSourceValue<K extends OnyxKey> = K extends OnyxCollectionKey
     ? K extends keyof OnyxCollectionValuesMapping
         ? OnyxCollection<OnyxCollectionValuesMapping[K]>
         : never
     : never;
 
-type DerivedSourceValues<Deps extends readonly OnyxKey[]> = Partial<{
-    [K in Deps[number]]: OnyxCollectionSourceValue<K>;
+type DerivedSourceValues<Deps extends readonly OnyxDerivedDependency[]> = Partial<{
+    [K in DepKey<Deps[number]>]: OnyxCollectionSourceValue<K>;
 }>;
 
-type DerivedValueContext<Key extends OnyxKey, Deps extends NonEmptyTuple<Exclude<OnyxKey, Key>>> = {
+type DerivedValueContext<Key extends OnyxKey, Deps extends NonEmptyTuple<OnyxDerivedDependency>> = {
     currentValue?: OnyxValue<Key>;
     sourceValues?: DerivedSourceValues<Deps>;
 };
 
 /**
  * A derived value configuration describes:
- *  - a tuple of Onyx keys to subscribe to (dependencies),
+ *  - a tuple of Onyx keys to subscribe to (dependencies). A dependency may be a bare key, or the object
+ *    form `{key, selector, isEqual?}` that gates the collection delta by relevance (see OnyxDerivedDependency).
  *  - a compute function that derives a value from the dependent Onyx values.
- *    The compute function receives a single argument that's a tuple of the onyx values for the declared dependencies.
- *    For example, if your dependencies are `['report_', 'account'], then compute will receive a [OnyxCollection<Report>, OnyxEntry<Account>]
+ *    The compute function receives a single argument that's a tuple of the onyx values for the declared
+ *    dependencies. Selectors never change the compute arguments — compute always receives the FULL
+ *    `OnyxValue` for each dependency's key. For example, if your dependencies are `['report_', 'account']`,
+ *    then compute receives a `[OnyxCollection<Report>, OnyxEntry<Account>]`.
  */
-type OnyxDerivedValueConfig<Key extends ValueOf<typeof ONYXKEYS.DERIVED>, Deps extends NonEmptyTuple<Exclude<OnyxKey, Key>>> = {
+type OnyxDerivedValueConfig<Key extends ValueOf<typeof ONYXKEYS.DERIVED>, Deps extends NonEmptyTuple<OnyxDerivedDependency<Exclude<OnyxKey, Key>>>> = {
     key: Key;
     dependencies: Deps;
     compute: (
         args: {
-            [Index in keyof Deps]: OnyxValue<Deps[Index]>;
+            [Index in keyof Deps]: OnyxValue<DepKey<Deps[Index]>>;
         },
         context: DerivedValueContext<Key, Deps>,
     ) => OnyxDerivedValuesMapping[Key];
 };
 
-export type {OnyxDerivedValueConfig, DerivedValueContext};
+export type {OnyxDerivedValueConfig, DerivedValueContext, OnyxDerivedDependency, OnyxDerivedDependencyWithSelector, DepKey};

--- a/src/libs/actions/OnyxDerived/utils.ts
+++ b/src/libs/actions/OnyxDerived/utils.ts
@@ -2,12 +2,15 @@ import Onyx from 'react-native-onyx';
 import type {OnyxInput} from 'react-native-onyx';
 import type {NonEmptyTuple} from 'type-fest';
 import type {OnyxDerivedKey, OnyxKey} from '@src/ONYXKEYS';
-import type {DerivedValueContext} from './types';
+import type {DerivedValueContext, OnyxDerivedDependency} from './types';
 
 /**
  * Check if a specific key exists in sourceValue from OnyxDerived
  */
-const hasKeyTriggeredCompute = <TKey extends OnyxKey, Deps extends NonEmptyTuple<Exclude<OnyxKey, TKey>>>(key: TKey, sourceValues: DerivedValueContext<TKey, Deps>['sourceValues']) => {
+const hasKeyTriggeredCompute = <TKey extends OnyxKey, Deps extends NonEmptyTuple<OnyxDerivedDependency<Exclude<OnyxKey, TKey>>>>(
+    key: TKey,
+    sourceValues: DerivedValueContext<TKey, Deps>['sourceValues'],
+) => {
     if (!sourceValues) {
         return false;
     }

--- a/tests/unit/OnyxDerivedTest.tsx
+++ b/tests/unit/OnyxDerivedTest.tsx
@@ -660,6 +660,86 @@ describe('OnyxDerived', () => {
             });
         });
 
+        describe('selector gating on addComment', () => {
+            const GATING_REPORT_ID = 'gating_report_1';
+            const GATING_TXN_ID = 'gating_txn_1';
+
+            beforeEach(async () => {
+                const report = createMockReport(GATING_REPORT_ID, {ownerAccountID: CURRENT_USER_ACCOUNT_ID});
+                // Seed an existing non-comment action so adding a comment is a member UPDATE the selector can gate.
+                // The policy is intentionally omitted — these tests assert reference equality of the derived value
+                // (gated vs. recomputed), not its contents, so todo eligibility is irrelevant here.
+                const reportActions: ReportActions = {
+                    created_action: {reportActionID: 'created_action', reportID: GATING_REPORT_ID, actionName: CONST.REPORT.ACTIONS.TYPE.CREATED, created: '2024-01-01 00:00:00.000'},
+                };
+                await Onyx.set(ONYXKEYS.SESSION, {email: CURRENT_USER_EMAIL, accountID: CURRENT_USER_ACCOUNT_ID});
+                await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${GATING_REPORT_ID}`, report);
+                await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${GATING_TXN_ID}`, createMockTransaction(GATING_TXN_ID, GATING_REPORT_ID));
+                await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${GATING_REPORT_ID}`, reportActions);
+                await waitForBatchedUpdates();
+            });
+
+            it('does not recompute when an addComment-style write lands (gated)', async () => {
+                const before = await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS);
+
+                // Mimic addComment: bump the report's last-activity fields and append an ADD_COMMENT action.
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${GATING_REPORT_ID}`, {
+                    lastVisibleActionCreated: '2024-06-01 12:00:00.000',
+                    lastMessageText: 'hello',
+                    lastMessageHtml: 'hello',
+                    lastActorAccountID: CURRENT_USER_ACCOUNT_ID,
+                    lastReadTime: '2024-06-01 12:00:00.000',
+                    lastActionType: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                });
+                const commentAction: ReportActions = {
+                    comment_action: {reportActionID: 'comment_action', reportID: GATING_REPORT_ID, actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT, created: '2024-06-01 12:00:00.000'},
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${GATING_REPORT_ID}`, commentAction);
+                await waitForBatchedUpdates();
+
+                // Gated: compute never ran, so Onyx still holds the exact same derived object reference.
+                expect(await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS)).toBe(before);
+            });
+
+            it('still recomputes when a todo-relevant field changes (control)', async () => {
+                const before = await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS);
+
+                // stateNum is read by the eligibility checks → not stripped by the selector → must recompute.
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${GATING_REPORT_ID}`, {
+                    stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
+                    statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+                });
+                await waitForBatchedUpdates();
+
+                expect(await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS)).not.toBe(before);
+            });
+
+            it('does not recompute when a non-expense (chat) report changes', async () => {
+                const CHAT_REPORT_ID = 'gating_chat_1';
+                await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${CHAT_REPORT_ID}`, createMockReport(CHAT_REPORT_ID, {type: CONST.REPORT.TYPE.CHAT}));
+                await waitForBatchedUpdates();
+
+                const before = await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS);
+                // Fields that WOULD be relevant on an expense report — but todos ignores non-expense reports.
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${CHAT_REPORT_ID}`, {managerID: CURRENT_USER_ACCOUNT_ID, stateNum: CONST.REPORT.STATE_NUM.SUBMITTED});
+                await waitForBatchedUpdates();
+
+                expect(await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS)).toBe(before);
+            });
+
+            it('does not recompute when managerID changes undefined -> DEFAULT_NUMBER_ID (normalized)', async () => {
+                // Seed (via set) a report with no managerID, let todos settle, then write the 0 placeholder.
+                await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${GATING_REPORT_ID}`, createMockReport(GATING_REPORT_ID, {managerID: undefined}));
+                await waitForBatchedUpdates();
+
+                const before = await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${GATING_REPORT_ID}`, {managerID: CONST.DEFAULT_NUMBER_ID});
+                await waitForBatchedUpdates();
+
+                expect(await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS)).toBe(before);
+            });
+        });
+
         describe('excludes reports with all expenses on hold', () => {
             const HELD_SUBMIT_REPORT_ID = 'held_submit_1';
             const HELD_APPROVE_REPORT_ID = 'held_approve_1';

--- a/tests/unit/OnyxDerivedTest.tsx
+++ b/tests/unit/OnyxDerivedTest.tsx
@@ -218,6 +218,37 @@ describe('OnyxDerived', () => {
             expect(derivedReportAttributesAfterDisplayNameChange).not.toBe(initialDerivedReportAttributes);
         });
 
+        describe('selector gating on policy changes', () => {
+            beforeEach(async () => {
+                await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${mockReport.reportID}`, mockReport);
+                // Seed the policy this report references so a later merge is a member UPDATE the selector can gate.
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${mockReport.policyID}`, {
+                    id: mockReport.policyID,
+                    name: 'Initial name',
+                    type: CONST.POLICY.TYPE.TEAM,
+                    approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
+                    role: CONST.POLICY.ROLE.USER,
+                });
+                await waitForBatchedUpdates();
+            });
+
+            it('does not recompute when an irrelevant policy field changes', async () => {
+                const before = await OnyxUtils.get(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES);
+                // `name` is not in the policy selector (nor in hasPolicyRelevantFieldChanged) → gated.
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${mockReport.policyID}`, {name: 'Changed name'});
+                await waitForBatchedUpdates();
+                expect(await OnyxUtils.get(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES)).toBe(before);
+            });
+
+            it('recomputes when a relevant policy field changes', async () => {
+                const before = await OnyxUtils.get(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES);
+                // approvalMode is in the selector → must recompute.
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${mockReport.policyID}`, {approvalMode: CONST.POLICY.APPROVAL_MODE.ADVANCED});
+                await waitForBatchedUpdates();
+                expect(await OnyxUtils.get(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES)).not.toBe(before);
+            });
+        });
+
         describe('reportErrors', () => {
             it('returns empty errors when no errors exist', async () => {
                 const report = createRandomReport(1, undefined);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Adds optional **selectors** on OnyxDerived dependency definitions (mirroring `useOnyx`'s `selector`), so each dependency can declare which slice of a collection member it cares about. The dispatcher projects each incoming `sourceValue` through the selector, compares the result against its previous snapshot, and **gates** (skips) the recompute entirely when no relevant member changed.

**New config API** (`types.ts`, `createOnyxDerivedValueConfig.ts`, `utils.ts`): a dependency can now be either a plain `key` string or a `{key, selector, isEqual?}` object. The `selector` receives the raw collection value for each changed key and returns only the slice the derived computation needs. `isEqual` is optional and defaults to strict equality.

**Dispatcher changes** (`index.ts`): `selectRelevantSourceValue` filters the native Onyx `sourceValue` map through each dependency's selector. A per-dependency previous-snapshot is kept and compared on every update; if nothing changed the recompute is skipped via an explicit gate flag. A missing `sourceValue` (e.g. initial load) always triggers a full recompute so correctness is preserved.

**First adoption — `todos.ts`**: gates the O(all-reports) todos recompute on `addComment`-style writes. The REPORT selector collapses non-EXPENSE reports to `{type}`, strips the 6 last-activity fields `addComment` writes, and normalizes `managerID`; the REPORT_ACTIONS selector projects only export-relevant (non-comment) actions. This avoids a full todos recompute on every chat message.

This is independent of Onyx PR #801 / `getCollectionDelta` and is not related to the coalescing PR #94574.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>