### PR TITLE
perf(search): replace useTransition with TransitionTracker for autocomplete list render

### DIFF
--- a/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
+++ b/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
@@ -33,9 +33,9 @@ function DeferredAutocompleteList(props: SearchAutocompleteListProps) {
         setHasLayout(true);
     };
 
-    // Wait for the slide-in animation to finish before rendering the list. Using startTransition would put the render
-    // on React's low-priority lane, causing Onyx storms during open to restart it 2-3x and recompute heavy memos.
-    // runAfterTransitions queues a single blocking render after the navigation animation completes.
+    // Wait for the slide-in animation to finish before rendering the list. startTransition made the (expensive) first
+    // mount render preemptible: a competing update interrupted and discarded it before it could commit, forcing React
+    // to redo that same render a second time. runAfterTransitions fires a plain, non-preemptible update instead, so the first render always completes in a single pass.
     useEffect(() => {
         if (!hasLayout) {
             return;

--- a/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
+++ b/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
@@ -32,9 +32,9 @@ function DeferredAutocompleteList(props: SearchAutocompleteListProps) {
         setHasLayout(true);
     };
 
-    // Wait for the slide-in animation to finish before rendering the list. startTransition made the (expensive) first
-    // mount render preemptible: a competing update interrupted and discarded it before it could commit, forcing React
-    // to redo that same render a second time. useRunAfterTransitions fires a plain, non-preemptible update instead, so the first render always completes in a single pass.
+    // Wait for the slide-in animation to finish before rendering the list. With startTransition, a competing update
+    // interrupted and discarded the (expensive) first mount render before it could commit, forcing React to redo
+    // that same render a second time. useRunAfterTransitions fires a plain, synchronous update instead, so the first render always completes in a single pass.
     const shouldRender = useRunAfterTransitions(hasLayout);
 
     if (!shouldRender || !isFocusedUntilTransitionEnd) {

--- a/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
+++ b/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
@@ -3,14 +3,14 @@ import type {SearchAutocompleteListProps} from '@components/Search/SearchAutocom
 import SearchAutocompleteList from '@components/Search/SearchAutocompleteList';
 
 import useIsFocusedUntilTransitionEnd from '@hooks/useIsFocusedUntilTransitionEnd';
+import useRunAfterTransitions from '@hooks/useRunAfterTransitions';
 
-import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import {endSpan} from '@libs/telemetry/activeSpans';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 
 import CONST from '@src/CONST';
 
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useRef, useState} from 'react';
 
 /**
  * This component acts as a wrapper for a SearchAutocompleteList, waiting for the navigation to be ready and deferring it,
@@ -21,11 +21,10 @@ function DeferredAutocompleteList(props: SearchAutocompleteListProps) {
     // On native it stays mounted behind when a chat is opened from it.
     // Unmount the heavy list once this screen loses focus (kept mounted through the closing transition so it doesn't blank mid-navigation).
     const isFocusedUntilTransitionEnd = useIsFocusedUntilTransitionEnd();
-    const [shouldRender, setShouldRender] = useState(false);
     const [hasLayout, setHasLayout] = useState(false);
     const hasEndedPageVisibleSpan = useRef(false);
 
-    const handleLayout = () => {
+    const markLayoutComplete = () => {
         if (!hasEndedPageVisibleSpan.current) {
             hasEndedPageVisibleSpan.current = true;
             endSpan(CONST.TELEMETRY.SPAN_SEARCH_PAGE_VISIBLE);
@@ -35,25 +34,21 @@ function DeferredAutocompleteList(props: SearchAutocompleteListProps) {
 
     // Wait for the slide-in animation to finish before rendering the list. startTransition made the (expensive) first
     // mount render preemptible: a competing update interrupted and discarded it before it could commit, forcing React
-    // to redo that same render a second time. runAfterTransitions fires a plain, non-preemptible update instead, so the first render always completes in a single pass.
-    useEffect(() => {
-        if (!hasLayout) {
-            return;
-        }
-        const handle = TransitionTracker.runAfterTransitions({
-            callback: () => setShouldRender(true),
-        });
-        return () => handle.cancel();
-    }, [hasLayout]);
+    // to redo that same render a second time. useRunAfterTransitions fires a plain, non-preemptible update instead, so the first render always completes in a single pass.
+    const shouldRender = useRunAfterTransitions(hasLayout);
 
     if (!shouldRender || !isFocusedUntilTransitionEnd) {
         return (
             <OptionsListSkeletonView
                 fixedNumItems={4}
                 shouldStyleAsTable
-                onLayout={handleLayout}
+                onLayout={markLayoutComplete}
                 speed={CONST.TIMING.SKELETON_ANIMATION_SPEED}
-                reasonAttributes={{context: 'DeferredSearchAutocompleteList'} satisfies SkeletonSpanReasonAttributes}
+                reasonAttributes={
+                    {
+                        context: 'DeferredSearchAutocompleteList',
+                    } satisfies SkeletonSpanReasonAttributes
+                }
             />
         );
     }

--- a/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
+++ b/src/components/Search/DeferredSearchAutocompleteList/index.native.tsx
@@ -4,12 +4,13 @@ import SearchAutocompleteList from '@components/Search/SearchAutocompleteList';
 
 import useIsFocusedUntilTransitionEnd from '@hooks/useIsFocusedUntilTransitionEnd';
 
+import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import {endSpan} from '@libs/telemetry/activeSpans';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 
 import CONST from '@src/CONST';
 
-import React, {useRef, useState, useTransition} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 /**
  * This component acts as a wrapper for a SearchAutocompleteList, waiting for the navigation to be ready and deferring it,
@@ -21,24 +22,36 @@ function DeferredAutocompleteList(props: SearchAutocompleteListProps) {
     // Unmount the heavy list once this screen loses focus (kept mounted through the closing transition so it doesn't blank mid-navigation).
     const isFocusedUntilTransitionEnd = useIsFocusedUntilTransitionEnd();
     const [shouldRender, setShouldRender] = useState(false);
-    const [, startTransition] = useTransition();
+    const [hasLayout, setHasLayout] = useState(false);
     const hasEndedPageVisibleSpan = useRef(false);
 
-    // Run the transition after the skeleton is mounted; end the "page visible" span once
-    const renderComponent = () => {
+    const handleLayout = () => {
         if (!hasEndedPageVisibleSpan.current) {
             hasEndedPageVisibleSpan.current = true;
             endSpan(CONST.TELEMETRY.SPAN_SEARCH_PAGE_VISIBLE);
         }
-        startTransition(() => setShouldRender(true));
+        setHasLayout(true);
     };
+
+    // Wait for the slide-in animation to finish before rendering the list. Using startTransition would put the render
+    // on React's low-priority lane, causing Onyx storms during open to restart it 2-3x and recompute heavy memos.
+    // runAfterTransitions queues a single blocking render after the navigation animation completes.
+    useEffect(() => {
+        if (!hasLayout) {
+            return;
+        }
+        const handle = TransitionTracker.runAfterTransitions({
+            callback: () => setShouldRender(true),
+        });
+        return () => handle.cancel();
+    }, [hasLayout]);
 
     if (!shouldRender || !isFocusedUntilTransitionEnd) {
         return (
             <OptionsListSkeletonView
                 fixedNumItems={4}
                 shouldStyleAsTable
-                onLayout={renderComponent}
+                onLayout={handleLayout}
                 speed={CONST.TIMING.SKELETON_ANIMATION_SPEED}
                 reasonAttributes={{context: 'DeferredSearchAutocompleteList'} satisfies SkeletonSpanReasonAttributes}
             />

--- a/src/hooks/useRunAfterTransitions.ts
+++ b/src/hooks/useRunAfterTransitions.ts
@@ -1,5 +1,6 @@
-import {useEffect, useState} from 'react';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
+
+import {useEffect, useState} from 'react';
 
 /**
  * Defers `active` from `false` to `true` until after navigation transitions finish, once `ready` becomes true.

--- a/src/hooks/useRunAfterTransitions.ts
+++ b/src/hooks/useRunAfterTransitions.ts
@@ -1,0 +1,25 @@
+import {useEffect, useState} from 'react';
+import TransitionTracker from '@libs/Navigation/TransitionTracker';
+
+/**
+ * Defers `active` from `false` to `true` until after navigation transitions finish, once `ready` becomes true.
+ * Unlike `startTransition`/`useDeferredValue`, the update runs as a plain, non-preemptible render, so it can't be
+ * interrupted and redone by a competing update.
+ */
+function useRunAfterTransitions(ready: boolean): boolean {
+    const [active, setActive] = useState(false);
+
+    useEffect(() => {
+        if (!ready) {
+            return;
+        }
+        const handle = TransitionTracker.runAfterTransitions({
+            callback: () => setActive(true),
+        });
+        return () => handle.cancel();
+    }, [ready]);
+
+    return active;
+}
+
+export default useRunAfterTransitions;

--- a/src/hooks/useRunAfterTransitions.ts
+++ b/src/hooks/useRunAfterTransitions.ts
@@ -3,7 +3,7 @@ import TransitionTracker from '@libs/Navigation/TransitionTracker';
 
 /**
  * Defers `active` from `false` to `true` until after navigation transitions finish, once `ready` becomes true.
- * Unlike `startTransition`/`useDeferredValue`, the update runs as a plain, non-preemptible render, so it can't be
+ * Unlike `startTransition`/`useDeferredValue`, the update runs as a plain, synchronous render that can't be
  * interrupted and redone by a competing update.
  */
 function useRunAfterTransitions(ready: boolean): boolean {

--- a/tests/unit/hooks/useRunAfterTransitions.test.ts
+++ b/tests/unit/hooks/useRunAfterTransitions.test.ts
@@ -1,5 +1,7 @@
 import {act, renderHook} from '@testing-library/react-native';
+
 import useRunAfterTransitions from '@hooks/useRunAfterTransitions';
+
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 
 jest.mock('@libs/Navigation/TransitionTracker', () => ({

--- a/tests/unit/hooks/useRunAfterTransitions.test.ts
+++ b/tests/unit/hooks/useRunAfterTransitions.test.ts
@@ -1,0 +1,92 @@
+import {act, renderHook} from '@testing-library/react-native';
+import useRunAfterTransitions from '@hooks/useRunAfterTransitions';
+import TransitionTracker from '@libs/Navigation/TransitionTracker';
+
+jest.mock('@libs/Navigation/TransitionTracker', () => ({
+    runAfterTransitions: jest.fn(),
+}));
+
+const mockedRunAfterTransitions = jest.mocked(TransitionTracker.runAfterTransitions);
+
+// Captures the callbacks handed to `runAfterTransitions` so tests can fire them on demand, and stubs a cancel handle.
+let pendingCallbacks: Array<() => void | Promise<void>> = [];
+const cancel = jest.fn();
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    pendingCallbacks = [];
+    mockedRunAfterTransitions.mockImplementation(({callback}) => {
+        pendingCallbacks.push(callback);
+        return {cancel};
+    });
+});
+
+describe('useRunAfterTransitions', () => {
+    it('returns false while not ready', () => {
+        const {result} = renderHook(() => useRunAfterTransitions(false));
+
+        expect(result.current).toBe(false);
+        expect(mockedRunAfterTransitions).not.toHaveBeenCalled();
+    });
+
+    it('schedules a callback via runAfterTransitions once ready', () => {
+        const {result} = renderHook(() => useRunAfterTransitions(true));
+
+        expect(mockedRunAfterTransitions).toHaveBeenCalledTimes(1);
+        // Stays false until the scheduled callback actually fires.
+        expect(result.current).toBe(false);
+    });
+
+    it('turns true once the scheduled callback fires', () => {
+        const {result} = renderHook(() => useRunAfterTransitions(true));
+
+        act(() => {
+            for (const callback of pendingCallbacks) {
+                callback();
+            }
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('does not schedule anything while toggling not-ready -> ready -> not-ready', () => {
+        const {result, rerender} = renderHook(({ready}) => useRunAfterTransitions(ready), {initialProps: {ready: false}});
+
+        rerender({ready: false});
+
+        expect(mockedRunAfterTransitions).not.toHaveBeenCalled();
+        expect(result.current).toBe(false);
+    });
+
+    it('cancels the pending handle when ready flips back to false before the callback fires', () => {
+        const {rerender} = renderHook(({ready}) => useRunAfterTransitions(ready), {initialProps: {ready: true}});
+        expect(mockedRunAfterTransitions).toHaveBeenCalledTimes(1);
+
+        rerender({ready: false});
+
+        expect(cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not flip back to false once active, even if ready later flips back to false', () => {
+        const {result, rerender} = renderHook(({ready}) => useRunAfterTransitions(ready), {initialProps: {ready: true}});
+        act(() => {
+            for (const callback of pendingCallbacks) {
+                callback();
+            }
+        });
+        expect(result.current).toBe(true);
+
+        rerender({ready: false});
+
+        expect(result.current).toBe(true);
+    });
+
+    it('cancels the handle on unmount', () => {
+        const {unmount} = renderHook(() => useRunAfterTransitions(true));
+        expect(mockedRunAfterTransitions).toHaveBeenCalledTimes(1);
+
+        unmount();
+
+        expect(cancel).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Replaces `useTransition`/`startTransition` with `TransitionTracker.runAfterTransitions` in `DeferredSearchAutocompleteList` (native) to defer rendering the heavy `SearchAutocompleteList` until after the slide-in navigation animation. `startTransition` made the expensive first mount render preemptible: a competing update interrupted and discarded it before it could commit, forcing React to redo it (measured ~150-250ms wasted per open, 5/5 sampled opens). `runAfterTransitions` fires a plain, non-preemptible update instead, so the first render always completes in a single pass.

1st test:
To verify this, both versions were instrumented with two logs: one at the top of `SearchAutocompleteList`'s render function counting every render _attempt_ (including ones React discards before they commit), and one in a dependency-less `useEffect` logging every _commit_, tagged with the matching attempt number. An attempt whose render log has no later matching commit log was thrown away by React before reaching the screen. Both versions were A/B tested on-device with 5 real opens/closes of the search router each, capturing Metro logs.

<details>
<summary>Before: `startTransition` — 20/27 attempts committed, 7 discarded</summary>

```
startTransition firing at 257048
startTransition firing at 257295          ← fired twice (see caveat below)
  render attempt #1  at 257355             ❌ discarded — no "COMMITTED #1" anywhere in the log
  render attempt #2  at 257938             ❌ discarded — no "COMMITTED #2" anywhere in the log
  render attempt #3  at 258226
  COMMITTED #3       at 258472   ✅
  render attempt #4  at 258490
  COMMITTED #4       at 258559   ✅
  render attempt #5  at 258807
  COMMITTED #5       at 258821   ✅
  render attempt #6  at 259522
  COMMITTED #6       at 259558   ✅
startTransition firing at 263996
  render attempt #7  at 264035             ❌ discarded — no "COMMITTED #7" anywhere in the log
  render attempt #8  at 264219
  COMMITTED #8       at 264404   ✅
  render attempt #9  at 264411
  COMMITTED #9       at 264437   ✅
  render attempt #10 at 264667
  COMMITTED #10      at 264704   ✅
  render attempt #11 at 265432
  COMMITTED #11      at 265461   ✅
  render attempt #12 at 265465             ❌ discarded — no "COMMITTED #12" anywhere in the log
startTransition firing at 269857
  render attempt #13 at 269884             ❌ discarded — no "COMMITTED #13" anywhere in the log
  render attempt #14 at 270059
  COMMITTED #14      at 270224   ✅
  render attempt #15 at 270228
  COMMITTED #15      at 270240   ✅
  render attempt #16 at 270340
  COMMITTED #16      at 270357   ✅
  render attempt #17 at 271250
  COMMITTED #17      at 271289   ✅
startTransition firing at 276288
  render attempt #18 at 276314             ❌ discarded — no "COMMITTED #18" anywhere in the log
  render attempt #19 at 276495
  COMMITTED #19      at 276659   ✅
  render attempt #20 at 276663
  COMMITTED #20      at 276672   ✅
  render attempt #21 at 276777
  COMMITTED #21      at 276794   ✅
  render attempt #22 at 277682
  COMMITTED #22      at 277713   ✅
startTransition firing at 284784
  render attempt #23 at 284809             ❌ discarded — no "COMMITTED #23" anywhere in the log
  render attempt #24 at 284990
  COMMITTED #24      at 285157   ✅
  render attempt #25 at 285161
  COMMITTED #25      at 285174   ✅
  render attempt #26 at 285277
  COMMITTED #26      at 285294   ✅
  render attempt #27 at 286184
  COMMITTED #27      at 286226   ✅
```

7 of 27 attempts (attempts 1, 2, 7, 12, 13, 18, and 23) never got a `COMMITTED` line anywhere in the captured log. Two distinct failure modes:

- **Mid-open supersession** (attempts 1, 2, 7, 13, 18, and 23): the discarded attempt is immediately followed by a second attempt that redoes the same work and successfully commits, all within the same open — in every one of the 5 sampled opens.
- **Abandoned-on-unmount** (attempt 12, open 2 only): this is the last attempt of its open and never gets a commit before the next open's `startTransition firing` line appears 4.4 seconds later — the user closed the router before this pending low-priority render ever flushed.

</details>

<details>
<summary>After: `runAfterTransitions` — 21/21 attempts committed, 0 discarded</summary>

```
runAfterTransitions firing at 096677
  render attempt #1  at 096883
  COMMITTED #1       at 097457   ✅
  render attempt #2  at 097471
  COMMITTED #2       at 097519   ✅
  render attempt #3  at 097690
  COMMITTED #3       at 097706   ✅
  render attempt #4  at 097726
  COMMITTED #4       at 097741   ✅
  render attempt #5  at 098630
  COMMITTED #5       at 098679   ✅
runAfterTransitions firing at 102872
  render attempt #6  at 102876
  COMMITTED #6       at 103061   ✅
  ... (identical pattern through attempt #21 — every attempt commits immediately, across all 5 sampled opens)
```

Every one of the 21 attempts across 5 opens has its own `COMMITTED` line immediately following it, before the next `render attempt` line appears. Attempt #1 of each open (the expensive mount render) took 185-580ms render→commit; follow-up attempts (as Onyx data continues to arrive) took 14-70ms.

</details>

2nd test:
**Methodology:** The table below reports the `ManualOpenSearchRouter` Sentry span (`CONST.TELEMETRY.SPAN_OPEN_SEARCH_ROUTER`), which covers user gesture → search list fully laid out on screen. Navigated from the Home page to the SearchRouter 20 times (warm open) per configuration and averaged the span duration. The cold open was excluded from the count and from the averages below.

| Platform | Without fix (avg ms) | With fix (avg ms) | Improvement |
| -------- | --------------------- | ------------------ | ----------- |
| Android  | 851.70                | 499.05              | -41.4%      |
| iOS      | 539.10                | 436.05              | -19.1%      |

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/79353
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. On iOS or Android, tap the search icon from the Home page to open the autocomplete screen.
2. Verify that the skeleton loader appears immediately and the autocomplete list renders smoothly after the navigation animation finishes — no blank flash, no double-render jank.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this change only affects when the list renders relative to the navigation animation; it does not involve network calls or Onyx writes.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
