### PR TITLE
[No QA] Add Sentry logging when lastUpdateID advances but applying updates fails

### DIFF
--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -168,7 +168,7 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
     const logApplyFailureIfNeeded = <T>(promise: Promise<T>): Promise<T> =>
         promise.catch((error) => {
             if (didAdvanceLastUpdateID) {
-                Log.alert('[OnyxUpdateManager] lastUpdateID was advanced but applying the updates failed, the updates may be lost', {
+                Log.alert('[OnyxUpdateManagerError] lastUpdateID was advanced but applying the updates failed, the updates may be lost', {
                     type,
                     command: request?.command,
                     lastUpdateID,

--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -157,17 +157,36 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
 
         return Promise.resolve(response);
     }
-    if (lastUpdateID && (lastUpdateIDAppliedToClient === undefined || Number(lastUpdateID) > lastUpdateIDAppliedToClient)) {
+    const previousLastUpdateIDAppliedToClient = lastUpdateIDAppliedToClient;
+    const didAdvanceLastUpdateID = !!lastUpdateID && (lastUpdateIDAppliedToClient === undefined || Number(lastUpdateID) > lastUpdateIDAppliedToClient);
+    if (didAdvanceLastUpdateID) {
         Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, Number(lastUpdateID));
     }
+
+    // The watermark is advanced before the updates are applied, so if applying fails the updates are silently lost
+    // and the client goes stale. Surface that case in Sentry.
+    const logApplyFailureIfNeeded = <T>(promise: Promise<T>): Promise<T> =>
+        promise.catch((error) => {
+            if (didAdvanceLastUpdateID) {
+                Log.alert('[OnyxUpdateManager] lastUpdateID was advanced but applying the updates failed, the updates may be lost', {
+                    type,
+                    command: request?.command,
+                    lastUpdateID,
+                    previousLastUpdateIDAppliedToClient,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+            throw error;
+        });
+
     if (type === CONST.ONYX_UPDATE_TYPES.HTTPS && request && response) {
-        return applyHTTPSOnyxUpdates(request, response, Number(lastUpdateID));
+        return logApplyFailureIfNeeded(applyHTTPSOnyxUpdates(request, response, Number(lastUpdateID)));
     }
     if (type === CONST.ONYX_UPDATE_TYPES.PUSHER && updates) {
-        return applyPusherOnyxUpdates(updates, Number(lastUpdateID));
+        return logApplyFailureIfNeeded(applyPusherOnyxUpdates(updates, Number(lastUpdateID)));
     }
     if (type === CONST.ONYX_UPDATE_TYPES.AIRSHIP && updates) {
-        return applyAirshipOnyxUpdates(updates, Number(lastUpdateID));
+        return logApplyFailureIfNeeded(applyAirshipOnyxUpdates(updates, Number(lastUpdateID)));
     }
 }
 

--- a/src/libs/telemetry/forwardLogsToSentry.ts
+++ b/src/libs/telemetry/forwardLogsToSentry.ts
@@ -7,12 +7,21 @@ type SentryLogLevel = 'debug' | 'info' | 'warn' | 'error';
  * Exact strings match the key literally, regexes match against the flattened dot-notation key.
  * Example: /^mfa\./ matches all keys under the `mfa` namespace (mfa.scenario, mfa.isOffline, etc.).
  */
-const PARAMETERS_WHITELIST: ReadonlyArray<string | RegExp> = ['timestamp', 'error', 'command', 'isSupportAuthTokenUsed', /^mfa\./];
+const PARAMETERS_WHITELIST: ReadonlyArray<string | RegExp> = [
+    'timestamp',
+    'error',
+    'command',
+    'isSupportAuthTokenUsed',
+    'type',
+    'lastUpdateID',
+    'previousLastUpdateIDAppliedToClient',
+    /^mfa\./,
+];
 
 /**
  * Only log lines whose message contains one of these prefixes are forwarded to Sentry.
  */
-const FORWARDED_LOG_PREFIXES = ['[Reauthenticate]', '[MFA]'] as const;
+const FORWARDED_LOG_PREFIXES = ['[Reauthenticate]', '[MFA]', '[OnyxUpdateManager]'] as const;
 
 /**
  * Method deciding whether a log packet should be forwarded to Sentry.

--- a/src/libs/telemetry/forwardLogsToSentry.ts
+++ b/src/libs/telemetry/forwardLogsToSentry.ts
@@ -21,7 +21,7 @@ const PARAMETERS_WHITELIST: ReadonlyArray<string | RegExp> = [
 /**
  * Only log lines whose message contains one of these prefixes are forwarded to Sentry.
  */
-const FORWARDED_LOG_PREFIXES = ['[Reauthenticate]', '[MFA]', '[OnyxUpdateManager]'] as const;
+const FORWARDED_LOG_PREFIXES = ['[Reauthenticate]', '[MFA]', '[OnyxUpdateManager] lastUpdateID was advanced but applying the updates failed'] as const;
 
 /**
  * Method deciding whether a log packet should be forwarded to Sentry.

--- a/src/libs/telemetry/forwardLogsToSentry.ts
+++ b/src/libs/telemetry/forwardLogsToSentry.ts
@@ -21,7 +21,7 @@ const PARAMETERS_WHITELIST: ReadonlyArray<string | RegExp> = [
 /**
  * Only log lines whose message contains one of these prefixes are forwarded to Sentry.
  */
-const FORWARDED_LOG_PREFIXES = ['[Reauthenticate]', '[MFA]', '[OnyxUpdateManager] lastUpdateID was advanced but applying the updates failed'] as const;
+const FORWARDED_LOG_PREFIXES = ['[Reauthenticate]', '[MFA]', '[OnyxUpdateManagerError]'] as const;
 
 /**
  * Method deciding whether a log packet should be forwarded to Sentry.


### PR DESCRIPTION
### Explanation of Change

Ecard transactions intermittently appear as duplicates in NewDot — the pending and the posted transaction both show, even though the pending one should have been cleared. Backend logs confirm the server *is* sending the Onyx updates, so this is client-side.

The suspected root cause is in `OnyxUpdates.apply()`: the `lastUpdateID` watermark (`ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT`) is advanced **before** the updates are actually applied. If applying then fails, the updates are silently lost and the client is left stale — gap detection won't refetch (the watermark already claims we're caught up) and `OpenReport` won't recover it (`isUpdateOld` drops the onyxData).

This PR is **logging only** (no behavioural change) to confirm the hypothesis in production before fixing the root cause:

- `src/libs/actions/OnyxUpdates.ts` — emits `Log.alert('[OnyxUpdateManager] lastUpdateID was advanced but applying the updates failed, the updates may be lost', ...)` when the watermark was advanced but the subsequent apply (HTTPS / Pusher / Airship) rejects. The error is re-thrown so existing retry/recovery behaviour is unchanged. This single spot covers both the live response path and the deferred / `reconnectApp` path, since both funnel through `apply()`.
- `src/libs/telemetry/forwardLogsToSentry.ts` — adds the `[OnyxUpdateManager]` prefix to `FORWARDED_LOG_PREFIXES` and `type` / `lastUpdateID` / `previousLastUpdateIDAppliedToClient` to `PARAMETERS_WHITELIST` so the log and its (non-sensitive) context reach Sentry.

Follow-up (separate PR): only advance the watermark after updates apply successfully.

### Fixed Issues
$ https://github.com/Expensify/App/issues/94877
PROPOSAL:

### Tests
1. This is a logging-only change that fires when an Onyx update fails to apply after the `lastUpdateID` watermark was advanced — a rare error path that can't be triggered through normal UI use.

- [x] Verify that no errors appear in the JS console

### Offline tests
Go offline, perform actions (e.g. create an expense), then come back online. Verify the app syncs as before and no unexpected errors appear — this change does not alter offline behaviour.

### QA Steps
Same as Tests. This is an internal logging change with no user-facing behaviour; QA only needs to confirm there are no regressions or new console errors during normal use.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
