### PR TITLE
Remove invalid skeletonReasonAttributes prop from PersonalExpenseRulesTableRow

### DIFF
--- a/src/components/Tables/PersonalExpenseRulesTable/PersonalExpenseRulesTableRow.tsx
+++ b/src/components/Tables/PersonalExpenseRulesTable/PersonalExpenseRulesTableRow.tsx
@@ -30,7 +30,6 @@ export default function PersonalExpenseRulesTableRow({item, rowIndex, shouldUseN
             rowIndex={rowIndex}
             disabled={item.disabled}
             accessibilityLabel={accessibilityLabel}
-            skeletonReasonAttributes={{context: 'personalExpenseRulesTableRow'}}
             sentryLabel={CONST.SENTRY_LABEL.EXPENSE_RULES.TABLE_ROW}
             onPress={item.action}
             offlineWithFeedback={{


### PR DESCRIPTION
### Explanation of Change
PR #94342 removed `skeletonReasonAttributes` from `TableRow`, but `PersonalExpenseRulesTableRow` was still passing the prop, causing a typecheck failure on main.

### Fixed Issues
$ https://github.com/Expensify/App/issues/94888

### Tests
1. Run `npm run typecheck` and confirm it passes
2. Open **Settings > Expenses > Rules** and confirm the personal expense rules table renders correctly
3. Tap a rule row and confirm navigation still works

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console