### PR TITLE
[No QA] Enable copy AgentZero request ID in concierge chats

### DIFF
--- a/src/pages/inbox/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/inbox/report/ContextMenu/ContextMenuActions.tsx
@@ -1452,9 +1452,9 @@ const ContextMenuActions: ContextMenuAction[] = [
         icon: 'Copy',
         successTextTranslateKey: 'reportActionContextMenu.copied',
         successIcon: 'Checkmark',
-        shouldShow: ({type, reportAction, isProduction}) =>
+        shouldShow: ({type, reportAction, isProduction, isDebugModeEnabled}) =>
             type === CONST.CONTEXT_MENU_TYPES.REPORT_ACTION &&
-            !isProduction &&
+            (!isProduction || !!isDebugModeEnabled) &&
             !!(isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT) && getOriginalMessage(reportAction)?.agentZeroRequestID),
         onPress: (closePopover, {reportAction}) => {
             const agentZeroRequestID = isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT) ? getOriginalMessage(reportAction)?.agentZeroRequestID : undefined;


### PR DESCRIPTION
### Explanation of Change

This updates the report-action context menu so `copyAgentZeroRequestID` is available in production when debug mode is enabled. It keeps the existing non-production behavior and makes the copy action usable in real internal Concierge chat triage.

### Fixed Issues

$
PROPOSAL:

### Tests

1. Enable debug mode in the App.
2. Open a Concierge chat that has a report action with `agentZeroRequestID` in `originalMessage`.
3. Long-press/right-click the action to open context menu.
4. Verify `Copy agent zero request ID` appears (including on production).
5. Select it and verify clipboard contains the expected request ID.
6. Verify the action remains hidden when debug mode is disabled on production.

- [x] Verify that no errors appear in the JS console

### Offline tests

Not applicable (clipboard/context-menu visibility change only).

### QA Steps

No QA (internal debug-only flow).

- [x] Verify that no errors appear in the JS console

Made with [Cursor](https://cursor.com)