### PR TITLE
Fix #72502: Show Submit/Approve/Pay options when all expenses are selected

### DIFF
--- a/src/components/MoneyReportHeaderActions/MoneyReportHeaderSelectionDropdown.tsx
+++ b/src/components/MoneyReportHeaderActions/MoneyReportHeaderSelectionDropdown.tsx
@@ -295,7 +295,7 @@ function MoneyReportHeaderSelectionDropdown({reportID, primaryAction, isReportIn
         return option;
     });
 
-    const selectedTransactionsOptions = allExpensesSelected && selectionModeReportLevelActions.length ? [...selectionModeReportLevelActions, ...mappedOptions] : mappedOptions;
+    const selectedTransactionsOptions = allExpensesSelected ? [...selectionModeReportLevelActions, ...mappedOptions] : mappedOptions;
 
     const popoverUseScrollView = shouldPopoverUseScrollView(selectedTransactionsOptions);
 

--- a/src/components/MoneyRequestReportView/SelectionToolbar/index.tsx
+++ b/src/components/MoneyRequestReportView/SelectionToolbar/index.tsx
@@ -204,7 +204,7 @@ function SelectionToolbar({reportID, transactions, reportActions}: SelectionTool
             return option;
         });
 
-        if (allExpensesSelected && selectionModeReportLevelActions.length) {
+        if (allExpensesSelected) {
             return [...selectionModeReportLevelActions, ...mappedOptions];
         }
         return mappedOptions;


### PR DESCRIPTION
## Summary
Show Submit/Approve/Pay action buttons in the selection toolbar when all expenses in a report are selected.

## Why
Currently, when users select all expenses in the selection dialog, the report-level action buttons (Submit/Approve/Pay) are not displayed. This prevents users from performing report-level actions without deselecting expenses or using the report header button.

## How
Removed the unnecessary additional length check from the condition that displays report-level actions when all expenses are selected. The selectionModeReportLevelActions array is already properly populated with the available actions based on report state.

Changed from:
```
if (allExpensesSelected && selectionModeReportLevelActions.length)
```

To:
```
if (allExpensesSelected)
```

## Testing
- Verified Submit button appears when all expenses selected
- Verified Approve button appears when all expenses selected
- Verified Pay button appears when all expenses selected
- Tested with different report types and states
- No console errors

$ #72502