### PR TITLE
fix: make View button size consistent across Spend reports and expenses

### DIFF
--- a/src/components/ReportSubmitToPopoverAnchor.tsx
+++ b/src/components/ReportSubmitToPopoverAnchor.tsx
@@ -84,6 +84,11 @@ type ReportSubmitToPopoverHostProps = {
     anchorAlignment?: AnchorAlignment;
 };
 
+type ReportSubmitToPopoverMeasurableAnchorProps = {
+    children: React.ReactNode;
+    style?: StyleProp<ViewStyle>;
+};
+
 /**
  * Renders a single submit-to popover for Search. List rows register their button anchors here so we do not mount
  * a Modal inside each FlashList cell (iOS only showed the backdrop when the modal lived in a recycled row).
@@ -280,7 +285,7 @@ function ReportSubmitToPopoverRootWithLocalPopover({reportID, onSubmitSuccess, a
 }
 
 /** Binds submit-to measurements to children only — use under {@link ReportSubmitToPopoverRoot}. */
-function ReportSubmitToPopoverMeasurableAnchor({children, wrapperStyle}: {children: React.ReactNode; wrapperStyle?: StyleProp<ViewStyle>}) {
+function ReportSubmitToPopoverMeasurableAnchor({children, style}: ReportSubmitToPopoverMeasurableAnchorProps) {
     const anchorRef = useContext(ReportSubmitToPopoverAnchorRefContext);
 
     if (!anchorRef) {
@@ -291,7 +296,7 @@ function ReportSubmitToPopoverMeasurableAnchor({children, wrapperStyle}: {childr
         <View
             ref={anchorRef}
             collapsable={false}
-            style={wrapperStyle}
+            style={style}
         >
             {children}
         </View>
@@ -306,7 +311,7 @@ function ReportSubmitToPopoverAnchor({reportID, onSubmitSuccess, anchorAlignment
             onSubmitSuccess={onSubmitSuccess}
             anchorAlignment={anchorAlignment}
         >
-            <ReportSubmitToPopoverMeasurableAnchor wrapperStyle={wrapperStyle}>{children}</ReportSubmitToPopoverMeasurableAnchor>
+            <ReportSubmitToPopoverMeasurableAnchor style={wrapperStyle}>{children}</ReportSubmitToPopoverMeasurableAnchor>
         </ReportSubmitToPopoverRoot>
     );
 }

--- a/src/components/Search/SearchList/ListItem/ExpenseReportListItemRow/ExpenseReportListItemRowWide.tsx
+++ b/src/components/Search/SearchList/ListItem/ExpenseReportListItemRow/ExpenseReportListItemRowWide.tsx
@@ -212,7 +212,7 @@ function ExpenseReportListItemRowWide({
         ),
         [CONST.SEARCH.TABLE_COLUMNS.ACTION]: (
             <View style={[StyleUtils.getReportTableColumnStyles(CONST.SEARCH.TABLE_COLUMNS.ACTION)]}>
-                <ReportSubmitToPopoverMeasurableAnchor>
+                <ReportSubmitToPopoverMeasurableAnchor style={styles.w100}>
                     <DeferredActionCell
                         action={item.action}
                         onButtonPress={onButtonPress}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Updated `ReportSubmitToPopoverMeasurableAnchor` to accept an optional style prop and apply it to its wrapper `View`.

Passed `styles.w100` to the measurable anchor used around the Reports wide-row action cell, so the `View` button fills the fixed action column width just like it does on the Expenses table. This keeps the layout change scoped to the Reports action cell and avoids stretching unrelated submit-to-popover anchors.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/94347
PROPOSAL: https://github.com/Expensify/App/issues/94347#issuecomment-4782257960

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the app on web.
2. Go to a workspace chat.
3. Create two expenses.
4. Create an empty report.
5. Go to Spend > Reports.
6. Verify the `View` button in the Reports table action column is not smaller than the `View` button in Expenses.
7. Go to Spend > Expenses.
8. Click Display > Edit columns.
9. Select Action and save.
10. Verify the `View` button size matches the Reports tab `View` button size.


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A. This is a layout-only change for the Spend table action cell and does not change offline behavior.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as Tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
>
N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
>

N/A

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
>
N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
>
N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
>

https://github.com/user-attachments/assets/ccf19ac5-8426-4985-9ead-931b0899f518


</details>
