### PR TITLE
Show card name on narrow Expensify Card table rows

### DIFF
--- a/src/components/Tables/WorkspaceExpensifyCardsTable/WorkspaceExpensifyCardsTableRow.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/WorkspaceExpensifyCardsTableRow.tsx
@@ -37,6 +37,7 @@ export default function WorkspaceExpensifyCardsTableRow({item, rowIndex, shouldU
     const session = useSession();
 
     const cardholderName = getDisplayNameOrDefault(item.cardholder);
+    const narrowLayoutSubtitle = [item.lastFourPAN, item.name].filter(Boolean).join(` ${CONST.DOT_SEPARATOR} `);
     const cardType = item.isVirtual ? translate('workspace.expensifyCard.virtual') : translate('workspace.expensifyCard.physical');
     const limitTypeLabel = translate(getTranslationKeyForLimitType(item.limitType));
     const formattedLimit = convertToShortDisplayString(item.limit, item.currency);
@@ -105,7 +106,7 @@ export default function WorkspaceExpensifyCardsTableRow({item, rowIndex, shouldU
                                 <TextWithTooltip
                                     shouldShowTooltip
                                     numberOfLines={1}
-                                    text={item.lastFourPAN}
+                                    text={narrowLayoutSubtitle}
                                     style={[styles.textLabelSupporting, styles.lh16, styles.pre, styles.mr3]}
                                 />
                             ) : (


### PR DESCRIPTION
### Explanation of Change
Show the card name after the last four digits on narrow Expensify Card table rows (`1234 • Card Name`).

### Fixed Issues
$ https://github.com/Expensify/App/issues/95003

### Tests
1. Open a workspace **Expensify Card** page with issued cards on a narrow screen (Android app or resized browser)
2. Confirm each row shows last four digits and card name under the cardholder name
3. Confirm wide layout is unchanged

- [x] Verify that no errors appear in the JS console
<img width="361" height="743" alt="Screenshot 2026-06-30 at 1 54 55 PM" src="https://github.com/user-attachments/assets/48f51d6b-659a-47f6-af5d-5c6104cf7646" />


### Offline tests
N/A

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console