### PR TITLE
refactor: add dedicated ExpenseGroupedSearchView

### DIFF
--- a/src/components/Search/ExpenseGroupedSearchView.tsx
+++ b/src/components/Search/ExpenseGroupedSearchView.tsx
@@ -24,7 +24,7 @@ import TransactionGroupListItem from './SearchList/ListItem/TransactionGroupList
 import {isGroupChildrenContainerItem, isGroupHeaderItem} from './SearchList/ListItem/types';
 import type {SearchListItem} from './SearchList/ListItem/types';
 import SearchListViewLayout from './SearchListViewLayout';
-import type {SearchColumnType, SearchQueryJSON} from './types';
+import type {SearchColumnType, SearchQueryJSON, SelectedTransactions} from './types';
 
 /** Imperative handle the router uses for highlight-driven scrolling (mirrors SearchList's handle). */
 type SearchListHandle = {
@@ -97,7 +97,7 @@ const keyExtractor = (item: SearchListItem, index: number) => item.keyForList ??
 
 const isRowDeleted = (item: SearchListItem) => item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
 
-const isRowSelected = (key: string | undefined, selectedTransactions: Record<string, {isSelected?: boolean}>) => !!(key && selectedTransactions[key]?.isSelected);
+const isRowSelected = (key: string | undefined, selectedTransactions: SelectedTransactions) => !!(key && selectedTransactions[key]?.isSelected);
 
 /**
  * On wide web layouts each group is split into a sticky header row plus a children-container row, so the

--- a/src/components/Search/ExpenseGroupedSearchView.tsx
+++ b/src/components/Search/ExpenseGroupedSearchView.tsx
@@ -1,0 +1,423 @@
+import React, {useImperativeHandle, useMemo, useState} from 'react';
+import type {ForwardedRef} from 'react';
+import type {NativeScrollEvent, NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
+import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
+import useOnyx from '@hooks/useOnyx';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import type {TransactionPreviewData} from '@libs/actions/Search';
+import getPlatform from '@libs/getPlatform';
+import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
+import {isTransactionGroupListItemType, splitGroupsIntoPairs} from '@libs/SearchUIUtils';
+import variables from '@styles/variables';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import {columnsSelector} from '@src/selectors/AdvancedSearchFiltersForm';
+import type {CardList, Transaction} from '@src/types/onyx';
+import useSearchListViewState from './hooks/useSearchListViewState';
+import AnimatedExitRow from './primitives/AnimatedExitRow';
+import SelectionTopBar from './primitives/SelectionTopBar';
+import {isTransactionMatchWithGroupItem} from './SearchList';
+import BaseSearchList from './SearchList/BaseSearchList';
+import GroupChildrenContainer from './SearchList/ListItem/GroupChildrenContainer';
+import GroupHeader from './SearchList/ListItem/GroupHeader';
+import TransactionGroupListItem from './SearchList/ListItem/TransactionGroupListItem';
+import {isGroupChildrenContainerItem, isGroupHeaderItem} from './SearchList/ListItem/types';
+import type {SearchListItem} from './SearchList/ListItem/types';
+import SearchListViewLayout from './SearchListViewLayout';
+import type {SearchColumnType, SearchQueryJSON} from './types';
+
+/** Imperative handle the router uses for highlight-driven scrolling (mirrors SearchList's handle). */
+type SearchListHandle = {
+    scrollToIndex: (index: number, animated?: boolean) => void;
+};
+
+type ExpenseGroupedSearchViewProps = {
+    /** The grouped-expense search query (a valid groupBy is set). */
+    queryJSON: SearchQueryJSON;
+
+    /** The sorted group rows to render (from the router's useSearchSnapshot). */
+    data: SearchListItem[];
+
+    /** The columns to render in the list. */
+    columns: SearchColumnType[];
+
+    /** Whether the list supports multi-select. */
+    canSelectMultiple: boolean;
+
+    /** Whether the action column uses its wider variant. */
+    isActionColumnWide: boolean;
+
+    /** Precomputed attendee-tracking boolean (derived from policy-for-moving-expenses). */
+    isAttendeesEnabledForMovingPolicy?: boolean;
+
+    /** Non-personal and workspace cards for row rendering (subscribed once by the router). */
+    nonPersonalAndWorkspaceCards?: CardList;
+
+    /** Whether mobile selection mode is on. */
+    isMobileSelectionModeEnabled: boolean;
+
+    /** The column header element (undefined on narrow layouts). */
+    SearchTableHeader?: React.JSX.Element;
+
+    /** Whether a table header bar is shown above the list. */
+    tableHeaderVisible: boolean;
+
+    /** Whether everything has been loaded (gates the fully-checked select-all state). */
+    hasLoadedAllTransactions?: boolean;
+
+    /** Transactions flagged for the post-create highlight animation. */
+    newTransactions: Transaction[];
+
+    /** The navigation handler for a row tap (owned by the router). */
+    onSelectRow: (item: SearchListItem, transactionPreviewData?: TransactionPreviewData, event?: ModifiedMouseEvent) => void;
+
+    /** The list footer (pagination / pending skeleton). */
+    ListFooterComponent?: React.JSX.Element;
+
+    /** Fires when the list scrolls near its end (router's fetchMoreResults). */
+    onEndReached: () => void;
+
+    /** Fires on the list's first layout and on layout changes. */
+    onLayout: () => void;
+
+    /** Scroll handler forwarded to the list. */
+    onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+
+    /** Content container style for the list. */
+    contentContainerStyle: StyleProp<ViewStyle>;
+
+    /** Outer container style for the list wrapper. */
+    containerStyle: StyleProp<ViewStyle>;
+
+    /** Imperative handle for highlight-driven scrolling, set by the router. */
+    ref?: ForwardedRef<SearchListHandle>;
+};
+
+const keyExtractor = (item: SearchListItem, index: number) => item.keyForList ?? `${index}`;
+
+const isRowDeleted = (item: SearchListItem) => item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
+
+const isRowSelected = (key: string | undefined, selectedTransactions: Record<string, {isSelected?: boolean}>) => !!(key && selectedTransactions[key]?.isSelected);
+
+/**
+ * On wide web layouts each group is split into a sticky header row plus a children-container row, so the
+ * rendered list differs from the source data. Returns the rendered list plus the sticky-header and
+ * children-container indices FlashList needs. On narrow/native layouts the group rows render as-is.
+ */
+function buildSplitGroupData(data: SearchListItem[], shouldSplitGroups: boolean) {
+    if (!shouldSplitGroups) {
+        return {listData: data, stickyHeaderIndices: undefined, childrenContainerIndices: CONST.EMPTY_ARRAY as readonly number[]};
+    }
+
+    const {splitData, stickyHeaderIndices} = splitGroupsIntoPairs(data);
+    const childrenContainerIndices: number[] = [];
+    for (let i = 0; i < splitData.length; i++) {
+        const item = splitData.at(i);
+        if (item && isGroupChildrenContainerItem(item)) {
+            childrenContainerIndices.push(i);
+        }
+    }
+
+    return {
+        listData: splitData,
+        stickyHeaderIndices: stickyHeaderIndices.length > 0 ? stickyHeaderIndices : undefined,
+        childrenContainerIndices,
+    };
+}
+
+/** Maps each group's `keyForList` to the id of a just-created transaction inside it, for the highlight animation. */
+function buildNewTransactionIDMap(data: SearchListItem[], newTransactions: Transaction[], groupBy: SearchQueryJSON['groupBy']) {
+    const map = new Map<string, string>();
+    if (newTransactions.length === 0) {
+        return map;
+    }
+    for (const item of data) {
+        const matchedTransactionID = newTransactions.find((transaction) => isTransactionMatchWithGroupItem(transaction, item, groupBy))?.transactionID;
+        if (matchedTransactionID && item.keyForList) {
+            map.set(item.keyForList, matchedTransactionID);
+        }
+    }
+    return map;
+}
+
+/**
+ * The grouped-expense Search list (expense search with a valid group-by).
+ *
+ * Rendered by `<Search>` as a child of the selection providers. Shared list state and interactions come from
+ * `useSearchListViewState`, and the surrounding chrome from `SearchListViewLayout`. This view owns the group
+ * machinery: on wide web it splits each group into a sticky `GroupHeader` plus an expandable
+ * `GroupChildrenContainer` (`shouldSplitGroups`); otherwise each group renders through `TransactionGroupListItem`.
+ * Selection counts are report-aware (flattened over child transactions plus empty groups), and the scroll
+ * handle remaps the router's data index to the split-list index.
+ */
+function ExpenseGroupedSearchView({
+    queryJSON,
+    data,
+    columns,
+    canSelectMultiple,
+    isActionColumnWide,
+    isAttendeesEnabledForMovingPolicy,
+    nonPersonalAndWorkspaceCards,
+    isMobileSelectionModeEnabled,
+    SearchTableHeader: searchTableHeader,
+    tableHeaderVisible,
+    hasLoadedAllTransactions,
+    newTransactions,
+    onSelectRow,
+    ListFooterComponent,
+    onEndReached,
+    onLayout,
+    onScroll,
+    contentContainerStyle,
+    containerStyle,
+    ref,
+}: ExpenseGroupedSearchViewProps) {
+    const {type, groupBy} = queryJSON;
+    const {isLargeScreenWidth} = useResponsiveLayout();
+
+    // Wide web layouts split each group into a sticky header row plus an expandable children-container row.
+    // Computed here (not from the shared hook) because the split list feeds back into the hook as `listData`.
+    const shouldSplit = !!groupBy && isLargeScreenWidth && getPlatform() === CONST.PLATFORM.WEB;
+    const {listData, stickyHeaderIndices, childrenContainerIndices} = useMemo(() => buildSplitGroupData(data, shouldSplit), [data, shouldSplit]);
+
+    const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
+    const onToggleGroup = (key: string) =>
+        setExpandedGroups((prev) => {
+            const next = new Set(prev);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            return next;
+        });
+
+    const [visibleColumns] = useOnyx(ONYXKEYS.FORMS.SEARCH_ADVANCED_FILTERS_FORM, {selector: columnsSelector});
+    const [bankAccountList] = useOnyx(ONYXKEYS.BANK_ACCOUNT_LIST);
+    const [cardFeeds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER);
+    const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
+
+    const {
+        isOffline,
+        isKeyboardShown,
+        safeAreaPaddingBottomStyle,
+        toggle,
+        toggleAll,
+        selectedTransactions,
+        listRef,
+        hasItemsBeingRemoved,
+        lastPaymentMethod,
+        personalPolicyID,
+        userBillingGracePeriodEnds,
+        ownerBillingGracePeriodEnd,
+        handleUndelete,
+        onLongPressRow,
+        modal,
+        handleSelectRow,
+        scrollToListIndex,
+    } = useSearchListViewState({data, listData, isMobileSelectionModeEnabled, onSelectRow});
+
+    const newTransactionIDByItemKey = useMemo(() => buildNewTransactionIDMap(data, newTransactions, groupBy), [data, newTransactions, groupBy]);
+
+    // Selection is tracked per child transaction (plus empty groups), so flatten each group's transactions.
+    const groupItems = data.filter(isTransactionGroupListItemType);
+    const flattenedTransactions = groupItems.flatMap((item) => item.transactions);
+    const emptyReports = groupItems.filter((item) => item.transactions.length === 0 && !!item.keyForList);
+    const selectedItemsLength =
+        flattenedTransactions.reduce((acc, item) => acc + (isRowSelected(item.keyForList, selectedTransactions) ? 1 : 0), 0) +
+        emptyReports.reduce((acc, item) => acc + (isRowSelected(item.keyForList, selectedTransactions) ? 1 : 0), 0);
+    const totalItems = flattenedTransactions.filter((item) => !isRowDeleted(item)).length + emptyReports.filter((item) => !isRowDeleted(item)).length;
+
+    // Visibility is computed over the rendered (possibly split) list.
+    const isItemVisible = (item: SearchListItem) => !isRowDeleted(item) || isOffline;
+    const firstVisibleIndex = listData.findIndex(isItemVisible);
+    const lastVisibleIndex = listData.findLastIndex(isItemVisible);
+
+    // The router highlights by source-data index; remap it to the split-list index before scrolling.
+    useImperativeHandle(
+        ref,
+        () => ({
+            scrollToIndex: (index: number, animated = true) => {
+                if (!shouldSplit) {
+                    scrollToListIndex(index, animated);
+                    return;
+                }
+                const item = data.at(index);
+                const splitIndex = item?.keyForList ? listData.findIndex((listItem) => listItem.keyForList === `header_${item.keyForList}`) : -1;
+                scrollToListIndex(splitIndex !== -1 ? splitIndex : index, animated);
+            },
+        }),
+        [data, listData, shouldSplit, scrollToListIndex],
+    );
+
+    const getItemType = (item: SearchListItem) => {
+        if (!shouldSplit) {
+            return undefined;
+        }
+        if (isGroupHeaderItem(item) || isGroupChildrenContainerItem(item)) {
+            return item.listItemType;
+        }
+        return 'default';
+    };
+
+    const overrideItemLayout = (layout: {size?: number; span?: number}, item: SearchListItem) => {
+        if (!isGroupHeaderItem(item)) {
+            return;
+        }
+        // FlashList requires mutating the layout object passed to overrideItemLayout.
+        // eslint-disable-next-line no-param-reassign -- FlashList overrideItemLayout API
+        layout.size = variables.tableRowHeight;
+    };
+
+    const stickyHeaderConfig = shouldSplit ? {hideRelatedCell: true, useNativeDriver: true, zIndex: 2} : undefined;
+
+    const renderItem = (item: SearchListItem, index: number, isItemFocused: boolean, onFocus?: (event: NativeSyntheticEvent<ExtendedTargetedEvent>) => void) => {
+        if (isGroupHeaderItem(item)) {
+            const originalKey = (item.keyForList ?? '').replace('header_', '');
+            return (
+                <GroupHeader
+                    item={item}
+                    groupBy={groupBy}
+                    searchType={type}
+                    columns={columns}
+                    canSelectMultiple={canSelectMultiple}
+                    isExpanded={expandedGroups.has(originalKey)}
+                    onToggle={() => onToggleGroup(originalKey)}
+                    onSelectRow={handleSelectRow}
+                    onCheckboxPress={toggle}
+                    onLongPressRow={onLongPressRow}
+                    onFocus={onFocus}
+                    isFocused={isItemFocused}
+                    isFirstItem={index === firstVisibleIndex}
+                    isLastItem={false}
+                    originalKey={originalKey}
+                    lastPaymentMethod={lastPaymentMethod}
+                    personalPolicyID={personalPolicyID}
+                    userBillingGracePeriodEnds={userBillingGracePeriodEnds}
+                    ownerBillingGracePeriodEnd={ownerBillingGracePeriodEnd}
+                    visibleColumns={visibleColumns}
+                />
+            );
+        }
+
+        if (isGroupChildrenContainerItem(item)) {
+            const originalKey = (item.keyForList ?? '').replace('children_', '');
+            const containerNewTransactionID = item.keyForList ? newTransactionIDByItemKey.get(originalKey) : undefined;
+            return (
+                <GroupChildrenContainer
+                    item={item}
+                    isExpanded={expandedGroups.has(originalKey)}
+                    groupBy={groupBy}
+                    searchType={type}
+                    columns={columns}
+                    canSelectMultiple={canSelectMultiple}
+                    onSelectRow={handleSelectRow}
+                    onCheckboxPress={toggle}
+                    onLongPressRow={onLongPressRow}
+                    nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                    onUndelete={handleUndelete}
+                    isLastItem={index === lastVisibleIndex && !ListFooterComponent}
+                    newTransactionID={containerNewTransactionID}
+                    bankAccountList={bankAccountList}
+                    cardFeeds={cardFeeds}
+                    conciergeReportID={conciergeReportID}
+                />
+            );
+        }
+
+        // Non-split group rows: TransactionGroupListItem renders the whole group (header + children).
+        const newTransactionID = item.keyForList ? newTransactionIDByItemKey.get(item.keyForList) : undefined;
+        return (
+            <AnimatedExitRow
+                shouldApplyAnimation={index < listData.length - 1}
+                hasItemsBeingRemoved={hasItemsBeingRemoved}
+            >
+                <TransactionGroupListItem
+                    showTooltip
+                    isFocused={isItemFocused}
+                    onSelectRow={handleSelectRow}
+                    onLongPressRow={onLongPressRow}
+                    onSelectionButtonPress={toggle}
+                    canSelectMultiple={canSelectMultiple}
+                    item={item}
+                    columns={columns}
+                    isDisabled={isRowDeleted(item)}
+                    groupBy={groupBy}
+                    searchType={type}
+                    lastPaymentMethod={lastPaymentMethod}
+                    personalPolicyID={personalPolicyID}
+                    userBillingGracePeriodEnds={userBillingGracePeriodEnds}
+                    ownerBillingGracePeriodEnd={ownerBillingGracePeriodEnd}
+                    nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                    onFocus={onFocus}
+                    newTransactionID={newTransactionID}
+                    onUndelete={handleUndelete}
+                    keyForList={item.keyForList}
+                    isFirstItem={index === firstVisibleIndex}
+                    isLastItem={index === lastVisibleIndex && !ListFooterComponent}
+                />
+            </AnimatedExitRow>
+        );
+    };
+
+    const isSelectAllChecked = selectedItemsLength > 0 && selectedItemsLength === totalItems && hasLoadedAllTransactions;
+    const selectAllButtonVisible = canSelectMultiple && !searchTableHeader;
+
+    return (
+        <SearchListViewLayout
+            columns={columns}
+            type={type}
+            isActionColumnWide={isActionColumnWide}
+            isHeaderVisible={!!searchTableHeader}
+            dataKey={data}
+            isKeyboardShown={isKeyboardShown}
+            safeAreaPaddingBottomStyle={safeAreaPaddingBottomStyle}
+            containerStyle={containerStyle}
+        >
+            {tableHeaderVisible && (
+                <SelectionTopBar
+                    isLargeScreenWidth={isLargeScreenWidth}
+                    shouldSplitGroups={shouldSplit}
+                    canSelectMultiple={canSelectMultiple}
+                    isSelectAllChecked={isSelectAllChecked}
+                    selectedItemsLength={selectedItemsLength}
+                    totalItems={totalItems}
+                    hasLoadedAllTransactions={hasLoadedAllTransactions}
+                    selectAllButtonVisible={selectAllButtonVisible}
+                    onAllCheckboxPress={toggleAll}
+                    SearchTableHeader={searchTableHeader}
+                />
+            )}
+            <BaseSearchList
+                data={listData}
+                renderItem={renderItem}
+                onSelectRow={handleSelectRow}
+                keyExtractor={keyExtractor}
+                onScroll={onScroll}
+                showsVerticalScrollIndicator={false}
+                ref={listRef}
+                columns={columns}
+                scrollToIndex={scrollToListIndex}
+                flattenedItemsLength={listData.length}
+                onEndReached={onEndReached}
+                onEndReachedThreshold={0.75}
+                ListFooterComponent={ListFooterComponent}
+                onLayout={onLayout}
+                contentContainerStyle={contentContainerStyle}
+                newTransactions={newTransactions}
+                isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
+                nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                stickyHeaderIndices={stickyHeaderIndices}
+                getItemType={getItemType}
+                stickyHeaderConfig={stickyHeaderConfig}
+                disabledIndexes={shouldSplit ? childrenContainerIndices : undefined}
+                overrideItemLayout={shouldSplit ? overrideItemLayout : undefined}
+            />
+            {modal}
+        </SearchListViewLayout>
+    );
+}
+
+ExpenseGroupedSearchView.displayName = 'ExpenseGroupedSearchView';
+
+export default ExpenseGroupedSearchView;

--- a/src/components/Search/ExpenseGroupedSearchView.tsx
+++ b/src/components/Search/ExpenseGroupedSearchView.tsx
@@ -1,4 +1,4 @@
-import React, {useImperativeHandle, useMemo, useState} from 'react';
+import React, {useImperativeHandle, useState} from 'react';
 import type {ForwardedRef} from 'react';
 import type {NativeScrollEvent, NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
@@ -178,7 +178,7 @@ function ExpenseGroupedSearchView({
     // Wide web layouts split each group into a sticky header row plus an expandable children-container row.
     // Computed here (not from the shared hook) because the split list feeds back into the hook as `listData`.
     const shouldSplit = !!groupBy && isLargeScreenWidth && getPlatform() === CONST.PLATFORM.WEB;
-    const {listData, stickyHeaderIndices, childrenContainerIndices} = useMemo(() => buildSplitGroupData(data, shouldSplit), [data, shouldSplit]);
+    const {listData, stickyHeaderIndices, childrenContainerIndices} = buildSplitGroupData(data, shouldSplit);
 
     const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
     const onToggleGroup = (key: string) =>
@@ -217,7 +217,7 @@ function ExpenseGroupedSearchView({
         scrollToListIndex,
     } = useSearchListViewState({data, listData, isMobileSelectionModeEnabled, onSelectRow});
 
-    const newTransactionIDByItemKey = useMemo(() => buildNewTransactionIDMap(data, newTransactions, groupBy), [data, newTransactions, groupBy]);
+    const newTransactionIDByItemKey = buildNewTransactionIDMap(data, newTransactions, groupBy);
 
     // Selection is tracked per child transaction (plus empty groups), so flatten each group's transactions.
     const groupItems = data.filter(isTransactionGroupListItemType);

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -655,3 +655,4 @@ function SearchList({
 }
 
 export default SearchList;
+export {isTransactionMatchWithGroupItem};

--- a/src/components/Search/hooks/useSearchListViewState.ts
+++ b/src/components/Search/hooks/useSearchListViewState.ts
@@ -20,8 +20,12 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {Transaction} from '@src/types/onyx';
 
 type UseSearchListViewStateParams = {
-    /** The rows the view renders. Drives exit-animation tracking and scroll-to-index. */
+    /** The source rows the view renders. Drives exit-animation tracking. */
     data: SearchListItem[];
+
+    /** The rows actually rendered by the list, if they differ from `data` (e.g. grouped views split each group
+     *  into a header + children-container pair). `scrollToListIndex` indexes over this. Defaults to `data`. */
+    listData?: SearchListItem[];
 
     /** Whether mobile selection mode is on (a row tap toggles selection instead of navigating). */
     isMobileSelectionModeEnabled: boolean;
@@ -42,7 +46,7 @@ type UseSearchListViewStateParams = {
  * Must be used inside SearchWriteActionsProvider so `toggle`/`toggleAll` resolve to the real actions rather
  * than the no-op defaults.
  */
-function useSearchListViewState({data, isMobileSelectionModeEnabled, onSelectRow, shouldPreventLongPressRow = false}: UseSearchListViewStateParams) {
+function useSearchListViewState({data, listData = data, isMobileSelectionModeEnabled, onSelectRow, shouldPreventLongPressRow = false}: UseSearchListViewStateParams) {
     const {toggle, toggleAll} = useSearchRowSelectionActions();
     const {selectedTransactions} = useSearchSelectionContext();
 
@@ -84,7 +88,7 @@ function useSearchListViewState({data, isMobileSelectionModeEnabled, onSelectRow
     };
 
     const scrollToListIndex = (index: number, animated = true) => {
-        const item = data.at(index);
+        const item = listData.at(index);
         if (!listRef.current || !item || index === -1) {
             return;
         }

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -82,6 +82,7 @@ import type SearchResults from '@src/types/onyx/SearchResults';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
 import ExpenseFlatSearchView from './ExpenseFlatSearchView';
+import ExpenseGroupedSearchView from './ExpenseGroupedSearchView';
 import useSearchSnapshot from './hooks/useSearchSnapshot';
 import SearchChartView from './SearchChartView';
 import SearchChartWrapper from './SearchChartWrapper';
@@ -1040,11 +1041,93 @@ function Search({
             />
         ) : undefined;
 
-    // Flat-expense (a plain transaction list) renders through the dedicated ExpenseFlatSearchView, which
-    // composes the reusable Search list primitives directly over BaseSearchList. Every other variant
-    // (chat, task, report, grouped) keeps the legacy SearchList shell. The snapshot, lifecycle and
-    // selection providers stay here so the data layer runs once.
     const isFlatExpenseView = type === CONST.SEARCH.DATA_TYPES.EXPENSE && !validGroupBy;
+    const isExpenseGroupedView = type === CONST.SEARCH.DATA_TYPES.EXPENSE && !!validGroupBy;
+
+    // Flat-expense and grouped-expense each render through a dedicated view composed over BaseSearchList; the
+    // remaining types keep the legacy SearchList shell. The snapshot, lifecycle and selection providers stay
+    // here so the data layer runs once.
+    let searchListContent: React.JSX.Element;
+    if (isFlatExpenseView) {
+        searchListContent = (
+            <ExpenseFlatSearchView
+                ref={searchListRef}
+                queryJSON={queryJSON}
+                data={stableSortedData}
+                columns={columnsToShow}
+                onSelectRow={onSelectRow}
+                canSelectMultiple={canSelectMultiple}
+                SearchTableHeader={searchTableHeader}
+                tableHeaderVisible={tableHeaderVisible}
+                contentContainerStyle={[styles.pb3, contentContainerStyle]}
+                containerStyle={[styles.pv0]}
+                onScroll={onSearchListScroll}
+                onEndReached={fetchMoreResults}
+                ListFooterComponent={listFooterComponent}
+                onLayout={onLayout}
+                isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                newTransactions={newTransactions}
+                hasLoadedAllTransactions={hasLoadedAllTransactions}
+                isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
+                nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                isActionColumnWide={isTask || hasDeletedTransaction}
+            />
+        );
+    } else if (isExpenseGroupedView) {
+        searchListContent = (
+            <ExpenseGroupedSearchView
+                ref={searchListRef}
+                queryJSON={queryJSON}
+                data={stableSortedData}
+                columns={columnsToShow}
+                onSelectRow={onSelectRow}
+                canSelectMultiple={canSelectMultiple}
+                SearchTableHeader={searchTableHeader}
+                tableHeaderVisible={tableHeaderVisible}
+                contentContainerStyle={[styles.pb3, contentContainerStyle]}
+                containerStyle={[styles.pv0]}
+                onScroll={onSearchListScroll}
+                onEndReached={fetchMoreResults}
+                ListFooterComponent={listFooterComponent}
+                onLayout={onLayout}
+                isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                newTransactions={newTransactions}
+                hasLoadedAllTransactions={hasLoadedAllTransactions}
+                isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
+                nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                isActionColumnWide={isTask || hasDeletedTransaction}
+            />
+        );
+    } else {
+        searchListContent = (
+            <SearchList
+                ref={searchListRef}
+                data={stableSortedData}
+                ListItem={ListItem}
+                onSelectRow={onSelectRow}
+                canSelectMultiple={canSelectMultiple}
+                shouldPreventLongPressRow={isChat || isTask}
+                SearchTableHeader={searchTableHeader}
+                contentContainerStyle={[styles.pb3, contentContainerStyle]}
+                containerStyle={[styles.pv0]}
+                onScroll={onSearchListScroll}
+                onEndReachedThreshold={0.75}
+                onEndReached={fetchMoreResults}
+                ListFooterComponent={listFooterComponent}
+                queryJSON={queryJSON}
+                columns={columnsToShow}
+                onLayout={onLayout}
+                isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                shouldAnimate={type === CONST.SEARCH.DATA_TYPES.EXPENSE}
+                newTransactions={newTransactions}
+                hasLoadedAllTransactions={hasLoadedAllTransactions}
+                isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
+                nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
+                policyTags={policyTags}
+                isActionColumnWide={isTask || hasDeletedTransaction}
+            />
+        );
+    }
 
     return (
         <SearchScopeProvider>
@@ -1059,59 +1142,7 @@ function Search({
                 isExpenseReportType={isExpenseReportType}
                 isSearchResultsEmpty={isSearchResultsEmpty}
             >
-                <Animated.View style={[styles.flex1, animatedStyle]}>
-                    {isFlatExpenseView ? (
-                        <ExpenseFlatSearchView
-                            ref={searchListRef}
-                            queryJSON={queryJSON}
-                            data={stableSortedData}
-                            columns={columnsToShow}
-                            onSelectRow={onSelectRow}
-                            canSelectMultiple={canSelectMultiple}
-                            SearchTableHeader={searchTableHeader}
-                            tableHeaderVisible={tableHeaderVisible}
-                            contentContainerStyle={[styles.pb3, contentContainerStyle]}
-                            containerStyle={[styles.pv0]}
-                            onScroll={onSearchListScroll}
-                            onEndReached={fetchMoreResults}
-                            ListFooterComponent={listFooterComponent}
-                            onLayout={onLayout}
-                            isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                            newTransactions={newTransactions}
-                            hasLoadedAllTransactions={hasLoadedAllTransactions}
-                            isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
-                            nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
-                            isActionColumnWide={isTask || hasDeletedTransaction}
-                        />
-                    ) : (
-                        <SearchList
-                            ref={searchListRef}
-                            data={stableSortedData}
-                            ListItem={ListItem}
-                            onSelectRow={onSelectRow}
-                            canSelectMultiple={canSelectMultiple}
-                            shouldPreventLongPressRow={isChat || isTask}
-                            SearchTableHeader={searchTableHeader}
-                            contentContainerStyle={[styles.pb3, contentContainerStyle]}
-                            containerStyle={[styles.pv0]}
-                            onScroll={onSearchListScroll}
-                            onEndReachedThreshold={0.75}
-                            onEndReached={fetchMoreResults}
-                            ListFooterComponent={listFooterComponent}
-                            queryJSON={queryJSON}
-                            columns={columnsToShow}
-                            onLayout={onLayout}
-                            isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                            shouldAnimate={type === CONST.SEARCH.DATA_TYPES.EXPENSE}
-                            newTransactions={newTransactions}
-                            hasLoadedAllTransactions={hasLoadedAllTransactions}
-                            isAttendeesEnabledForMovingPolicy={isAttendeesEnabledForMovingPolicy}
-                            nonPersonalAndWorkspaceCards={nonPersonalAndWorkspaceCards}
-                            policyTags={policyTags}
-                            isActionColumnWide={isTask || hasDeletedTransaction}
-                        />
-                    )}
-                </Animated.View>
+                <Animated.View style={[styles.flex1, animatedStyle]}>{searchListContent}</Animated.View>
             </SearchWriteActionsProvider>
         </SearchScopeProvider>
     );

--- a/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
+++ b/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
@@ -143,17 +143,17 @@ const STABLE_QUERY_JSON: SearchQueryJSON = {
 
 const STABLE_COLUMNS: SearchColumnType[] = [CONST.SEARCH.TABLE_COLUMNS.DATE, CONST.SEARCH.TABLE_COLUMNS.MERCHANT, CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT, CONST.SEARCH.TABLE_COLUMNS.ACTION];
 
-/** Builds group rows, each carrying child transactions; `deletedTxns` marks transaction indices as pending-delete. */
-function createMockGroupData(groups: Array<{txns: number; deletedTxns?: Set<number>}>): SearchListItem[] {
+/** Builds group rows, each carrying child transactions; `deletedTransactions` marks transaction indices as pending-delete. */
+function createMockGroupData(groups: Array<{transactionCount: number; deletedTransactions?: Set<number>}>): SearchListItem[] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test fixtures are intentionally partial group rows
     return groups.map((group, i) => ({
         keyForList: `group-${i}`,
         cardID: i,
         action: CONST.SEARCH.ACTION_TYPES.VIEW,
-        transactions: Array.from({length: group.txns}, (_, j) => ({
+        transactions: Array.from({length: group.transactionCount}, (_, j) => ({
             keyForList: `txn-${i}-${j}`,
             transactionID: `${i}-${j}`,
-            pendingAction: group.deletedTxns?.has(j) ? CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE : undefined,
+            pendingAction: group.deletedTransactions?.has(j) ? CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE : undefined,
         })),
     })) as unknown as SearchListItem[];
 }
@@ -177,7 +177,7 @@ type RenderOverrides = {
 };
 
 function renderView(overrides: RenderOverrides = {}) {
-    const data = overrides.data ?? createMockGroupData([{txns: 1}, {txns: 1}, {txns: 1}]);
+    const data = overrides.data ?? createMockGroupData([{transactionCount: 1}, {transactionCount: 1}, {transactionCount: 1}]);
 
     function Wrapper() {
         const onSelectRow = useCallback((item: SearchListItem) => overrides.onSelectRow?.(item), []);
@@ -249,13 +249,13 @@ afterEach(() => Onyx.clear());
 describe('ExpenseGroupedSearchView', () => {
     it('does not exceed the max render count on initial mount with stable props', async () => {
         let renderCount = 0;
-        renderView({data: createMockGroupData(Array.from({length: 100}, () => ({txns: 1}))), onRenderCount: () => (renderCount += 1)});
+        renderView({data: createMockGroupData(Array.from({length: 100}, () => ({transactionCount: 1}))), onRenderCount: () => (renderCount += 1)});
         await waitForBatchedUpdates();
         expect(renderCount).toBeLessThanOrEqual(MAX_INITIAL_RENDER_COUNT);
     });
 
     it('renders one row per group item', async () => {
-        renderView({data: createMockGroupData([{txns: 2}, {txns: 1}, {txns: 3}])});
+        renderView({data: createMockGroupData([{transactionCount: 2}, {transactionCount: 1}, {transactionCount: 3}])});
         await waitForBatchedUpdates();
         expect(screen.queryAllByTestId(/^row-group-/)).toHaveLength(3);
     });
@@ -265,7 +265,7 @@ describe('ExpenseGroupedSearchView', () => {
         // One transaction selected -> not all-checked.
         mockSelectedTransactions.current = selectKeys('txn-0-0');
         renderView({
-            data: createMockGroupData([{txns: 2}, {txns: 1, deletedTxns: new Set([0])}]),
+            data: createMockGroupData([{transactionCount: 2}, {transactionCount: 1, deletedTransactions: new Set([0])}]),
             canSelectMultiple: true,
             tableHeaderVisible: true,
             hasLoadedAllTransactions: true,
@@ -280,7 +280,7 @@ describe('ExpenseGroupedSearchView', () => {
     it('marks select-all checked when every selectable transaction is selected', async () => {
         mockSelectedTransactions.current = selectKeys('txn-0-0', 'txn-0-1');
         renderView({
-            data: createMockGroupData([{txns: 2}, {txns: 1, deletedTxns: new Set([0])}]),
+            data: createMockGroupData([{transactionCount: 2}, {transactionCount: 1, deletedTransactions: new Set([0])}]),
             canSelectMultiple: true,
             tableHeaderVisible: true,
             hasLoadedAllTransactions: true,
@@ -294,7 +294,7 @@ describe('ExpenseGroupedSearchView', () => {
 
     it('toggles selection on row tap while in mobile selection mode, instead of navigating', async () => {
         const onSelectRow = jest.fn();
-        renderView({data: createMockGroupData([{txns: 1}, {txns: 1}]), isMobileSelectionModeEnabled: true, onSelectRow});
+        renderView({data: createMockGroupData([{transactionCount: 1}, {transactionCount: 1}]), isMobileSelectionModeEnabled: true, onSelectRow});
         await waitForBatchedUpdates();
 
         act(() => mockRowSelect['group-0']?.());
@@ -305,7 +305,7 @@ describe('ExpenseGroupedSearchView', () => {
 
     it('navigates on row tap when not in mobile selection mode', async () => {
         const onSelectRow = jest.fn();
-        renderView({data: createMockGroupData([{txns: 1}, {txns: 1}]), isMobileSelectionModeEnabled: false, onSelectRow});
+        renderView({data: createMockGroupData([{transactionCount: 1}, {transactionCount: 1}]), isMobileSelectionModeEnabled: false, onSelectRow});
         await waitForBatchedUpdates();
 
         act(() => mockRowSelect['group-0']?.());

--- a/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
+++ b/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
@@ -1,0 +1,316 @@
+import {act, render, screen} from '@testing-library/react-native';
+import React, {Profiler, useCallback, useMemo} from 'react';
+import Onyx from 'react-native-onyx';
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import ScrollOffsetContextProvider from '@components/ScrollOffsetContextProvider';
+import ExpenseGroupedSearchView from '@components/Search/ExpenseGroupedSearchView';
+import type {SearchListItem} from '@components/Search/SearchList/ListItem/types';
+import type {SearchColumnType, SearchQueryJSON} from '@components/Search/types';
+import ThemeProvider from '@components/ThemeProvider';
+import ThemeStylesProvider from '@components/ThemeStylesContextProvider';
+import {setHasRadio} from '@libs/NetworkState';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import * as TestHelper from '../../utils/TestHelper';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+import wrapOnyxWithWaitForBatchedUpdates from '../../utils/wrapOnyxWithWaitForBatchedUpdates';
+
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: jest.fn((key: string) => key),
+        numberFormat: jest.fn(),
+    })),
+);
+
+jest.mock('@hooks/useNetwork', () =>
+    jest.fn(() => ({
+        isOffline: false,
+    })),
+);
+
+jest.mock('@hooks/useKeyboardState', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({isKeyboardShown: false, keyboardHeight: 0})),
+}));
+
+jest.mock('@hooks/useResponsiveLayout', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({isSmallScreenWidth: false, isLargeScreenWidth: true, shouldUseNarrowLayout: false})),
+}));
+
+jest.mock('@hooks/useSafeAreaPaddings', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({safeAreaPaddingBottomStyle: {}})),
+}));
+
+jest.mock('@hooks/useWindowDimensions', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({windowWidth: 1200, windowHeight: 800})),
+}));
+
+// Force the non-split (native/narrow) rendering path so groups render through TransactionGroupListItem.
+jest.mock('@libs/getPlatform', () => ({
+    __esModule: true,
+    default: jest.fn(() => 'ios'),
+}));
+
+// The grouped view imports isTransactionMatchWithGroupItem from the heavy SearchList module; stub it out.
+jest.mock('@components/Search/SearchList', () => ({
+    __esModule: true,
+    default: () => null,
+    isTransactionMatchWithGroupItem: jest.fn(() => false),
+}));
+
+// Group header/children only render on the split path; stub them so importing the view stays lightweight.
+jest.mock('@components/Search/SearchList/ListItem/GroupHeader', () => ({__esModule: true, default: () => null}));
+jest.mock('@components/Search/SearchList/ListItem/GroupChildrenContainer', () => ({__esModule: true, default: () => null}));
+
+jest.mock('@react-navigation/native', () => ({
+    useFocusEffect: jest.fn((callback: () => void) => {
+        queueMicrotask(() => callback());
+        return () => {};
+    }),
+    useRoute: jest.fn(() => ({key: 'search-test-route'})),
+    useIsFocused: () => true,
+    createNavigationContainerRef: jest.fn(() => ({
+        getCurrentRoute: jest.fn(),
+        addListener: jest.fn(() => jest.fn()),
+        removeListener: jest.fn(),
+        isReady: jest.fn(() => true),
+        getState: jest.fn(),
+    })),
+}));
+
+jest.mock('@src/components/ConfirmedRoute.tsx');
+
+// Capture each group row's tap handler so the mobile-selection-mode toggle can be exercised without the heavy real TransactionGroupListItem.
+const mockRowSelect: Record<string, () => void> = {};
+jest.mock('@components/Search/SearchList/ListItem/TransactionGroupListItem', () => {
+    const ReactLocal = jest.requireActual<typeof React>('react');
+    const {View: RNView} = jest.requireActual<{View: React.ComponentType<{testID?: string}>}>('react-native');
+    return {
+        __esModule: true,
+        default: (props: {item: SearchListItem; onSelectRow: (item: SearchListItem) => void}) => {
+            mockRowSelect[props.item?.keyForList ?? ''] = () => props.onSelectRow?.(props.item);
+            return ReactLocal.createElement(RNView, {testID: `row-${props.item?.keyForList ?? 'unknown'}`});
+        },
+    };
+});
+
+// Capture SelectionTopBar props so the selection-count math can be asserted directly.
+type CapturedTopBarProps = {selectedItemsLength: number; totalItems: number; isSelectAllChecked: boolean | undefined};
+const mockTopBar: {current: CapturedTopBarProps | null} = {current: null};
+jest.mock('@components/Search/primitives/SelectionTopBar', () => ({
+    __esModule: true,
+    default: (props: CapturedTopBarProps) => {
+        mockTopBar.current = {selectedItemsLength: props.selectedItemsLength, totalItems: props.totalItems, isSelectAllChecked: props.isSelectAllChecked};
+        return null;
+    },
+}));
+
+const mockToggle = jest.fn();
+const mockToggleAll = jest.fn();
+const mockSelectedTransactions: {current: Record<string, {isSelected: boolean}>} = {current: {}};
+jest.mock('@components/Search/SearchContext', () => ({
+    useSearchRowSelectionActions: () => ({toggle: mockToggle, toggleAll: mockToggleAll}),
+    useSearchSelectionContext: () => ({selectedTransactions: mockSelectedTransactions.current}),
+}));
+
+function selectKeys(...keys: string[]): Record<string, {isSelected: boolean}> {
+    return Object.fromEntries(keys.map((key) => [key, {isSelected: true}]));
+}
+
+const STABLE_QUERY_JSON: SearchQueryJSON = {
+    hash: 0,
+    recentSearchHash: 0,
+    similarSearchHash: 0,
+    groupBy: CONST.SEARCH.GROUP_BY.CARD,
+    type: CONST.SEARCH.DATA_TYPES.EXPENSE,
+    status: CONST.SEARCH.STATUS.EXPENSE.ALL,
+    sortBy: CONST.SEARCH.TABLE_COLUMNS.DATE,
+    sortOrder: 'desc',
+    view: CONST.SEARCH.VIEW.TABLE,
+    flatFilters: [],
+    inputQuery: '',
+    filters: {operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, left: CONST.SEARCH.SYNTAX_FILTER_KEYS.STATUS, right: ''},
+    policyID: undefined,
+    columns: undefined,
+    limit: undefined,
+    rawFilterList: undefined,
+};
+
+const STABLE_COLUMNS: SearchColumnType[] = [CONST.SEARCH.TABLE_COLUMNS.DATE, CONST.SEARCH.TABLE_COLUMNS.MERCHANT, CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT, CONST.SEARCH.TABLE_COLUMNS.ACTION];
+
+/** Builds group rows, each carrying child transactions; `deletedTxns` marks transaction indices as pending-delete. */
+function createMockGroupData(groups: Array<{txns: number; deletedTxns?: Set<number>}>): SearchListItem[] {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test fixtures are intentionally partial group rows
+    return groups.map((group, i) => ({
+        keyForList: `group-${i}`,
+        cardID: i,
+        action: CONST.SEARCH.ACTION_TYPES.VIEW,
+        transactions: Array.from({length: group.txns}, (_, j) => ({
+            keyForList: `txn-${i}-${j}`,
+            transactionID: `${i}-${j}`,
+            pendingAction: group.deletedTxns?.has(j) ? CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE : undefined,
+        })),
+    })) as unknown as SearchListItem[];
+}
+
+/** Max render count for the view subtree on initial mount with stable props. Also guards against re-render regressions. */
+const MAX_INITIAL_RENDER_COUNT = 15;
+
+function ThemeProviderWithLight({children}: {children: React.ReactNode}) {
+    return <ThemeProvider theme="light">{children}</ThemeProvider>;
+}
+ThemeProviderWithLight.displayName = 'ThemeProviderWithLight';
+
+type RenderOverrides = {
+    data?: SearchListItem[];
+    canSelectMultiple?: boolean;
+    tableHeaderVisible?: boolean;
+    isMobileSelectionModeEnabled?: boolean;
+    hasLoadedAllTransactions?: boolean;
+    onSelectRow?: (item: SearchListItem) => void;
+    onRenderCount?: () => void;
+};
+
+function renderView(overrides: RenderOverrides = {}) {
+    const data = overrides.data ?? createMockGroupData([{txns: 1}, {txns: 1}, {txns: 1}]);
+
+    function Wrapper() {
+        const onSelectRow = useCallback((item: SearchListItem) => overrides.onSelectRow?.(item), []);
+        const onEndReached = useCallback(() => {}, []);
+        const onLayout = useCallback(() => {}, []);
+        const queryJSON = useMemo(() => STABLE_QUERY_JSON, []);
+        const columns = useMemo(() => STABLE_COLUMNS, []);
+        const contentContainerStyle = useMemo(() => ({}), []);
+        const containerStyle = useMemo(() => ({}), []);
+
+        const view = (
+            <ExpenseGroupedSearchView
+                queryJSON={queryJSON}
+                data={data}
+                columns={columns}
+                canSelectMultiple={overrides.canSelectMultiple ?? false}
+                isActionColumnWide={false}
+                isMobileSelectionModeEnabled={overrides.isMobileSelectionModeEnabled ?? false}
+                tableHeaderVisible={overrides.tableHeaderVisible ?? false}
+                hasLoadedAllTransactions={overrides.hasLoadedAllTransactions ?? true}
+                newTransactions={[]}
+                onSelectRow={onSelectRow}
+                onEndReached={onEndReached}
+                onLayout={onLayout}
+                contentContainerStyle={contentContainerStyle}
+                containerStyle={containerStyle}
+            />
+        );
+
+        if (!overrides.onRenderCount) {
+            return view;
+        }
+        return (
+            <Profiler
+                id="expense-grouped-search-view"
+                onRender={overrides.onRenderCount}
+            >
+                {view}
+            </Profiler>
+        );
+    }
+
+    return render(
+        <ComposeProviders components={[ThemeProviderWithLight, ThemeStylesProvider, OnyxListItemProvider, LocaleContextProvider, ScrollOffsetContextProvider]}>
+            <Wrapper />
+        </ComposeProviders>,
+    );
+}
+
+beforeAll(() => Onyx.init({keys: ONYXKEYS, evictableKeys: [ONYXKEYS.COLLECTION.REPORT]}));
+
+beforeEach(() => {
+    global.fetch = TestHelper.getGlobalFetchMock();
+    wrapOnyxWithWaitForBatchedUpdates(Onyx);
+    setHasRadio(true);
+    mockToggle.mockClear();
+    mockToggleAll.mockClear();
+    mockSelectedTransactions.current = {};
+    mockTopBar.current = null;
+    for (const key of Object.keys(mockRowSelect)) {
+        delete mockRowSelect[key];
+    }
+    Onyx.merge(ONYXKEYS.COLLECTION.REPORT, {});
+    Onyx.merge(ONYXKEYS.COLLECTION.POLICY, {});
+});
+
+afterEach(() => Onyx.clear());
+
+describe('ExpenseGroupedSearchView', () => {
+    it('does not exceed the max render count on initial mount with stable props', async () => {
+        let renderCount = 0;
+        renderView({data: createMockGroupData(Array.from({length: 100}, () => ({txns: 1}))), onRenderCount: () => (renderCount += 1)});
+        await waitForBatchedUpdates();
+        expect(renderCount).toBeLessThanOrEqual(MAX_INITIAL_RENDER_COUNT);
+    });
+
+    it('renders one row per group item', async () => {
+        renderView({data: createMockGroupData([{txns: 2}, {txns: 1}, {txns: 3}])});
+        await waitForBatchedUpdates();
+        expect(screen.queryAllByTestId(/^row-group-/)).toHaveLength(3);
+    });
+
+    it('computes selection counts over child transactions, excluding deleted ones', async () => {
+        // 2 groups: group-0 has txn-0-0, txn-0-1; group-1 has txn-1-0 (deleted) -> 2 selectable transactions.
+        // One transaction selected -> not all-checked.
+        mockSelectedTransactions.current = selectKeys('txn-0-0');
+        renderView({
+            data: createMockGroupData([{txns: 2}, {txns: 1, deletedTxns: new Set([0])}]),
+            canSelectMultiple: true,
+            tableHeaderVisible: true,
+            hasLoadedAllTransactions: true,
+        });
+        await waitForBatchedUpdates();
+
+        expect(mockTopBar.current?.selectedItemsLength).toBe(1);
+        expect(mockTopBar.current?.totalItems).toBe(2);
+        expect(mockTopBar.current?.isSelectAllChecked).toBe(false);
+    });
+
+    it('marks select-all checked when every selectable transaction is selected', async () => {
+        mockSelectedTransactions.current = selectKeys('txn-0-0', 'txn-0-1');
+        renderView({
+            data: createMockGroupData([{txns: 2}, {txns: 1, deletedTxns: new Set([0])}]),
+            canSelectMultiple: true,
+            tableHeaderVisible: true,
+            hasLoadedAllTransactions: true,
+        });
+        await waitForBatchedUpdates();
+
+        expect(mockTopBar.current?.selectedItemsLength).toBe(2);
+        expect(mockTopBar.current?.totalItems).toBe(2);
+        expect(mockTopBar.current?.isSelectAllChecked).toBe(true);
+    });
+
+    it('toggles selection on row tap while in mobile selection mode, instead of navigating', async () => {
+        const onSelectRow = jest.fn();
+        renderView({data: createMockGroupData([{txns: 1}, {txns: 1}]), isMobileSelectionModeEnabled: true, onSelectRow});
+        await waitForBatchedUpdates();
+
+        act(() => mockRowSelect['group-0']?.());
+
+        expect(mockToggle).toHaveBeenCalledTimes(1);
+        expect(onSelectRow).not.toHaveBeenCalled();
+    });
+
+    it('navigates on row tap when not in mobile selection mode', async () => {
+        const onSelectRow = jest.fn();
+        renderView({data: createMockGroupData([{txns: 1}, {txns: 1}]), isMobileSelectionModeEnabled: false, onSelectRow});
+        await waitForBatchedUpdates();
+
+        act(() => mockRowSelect['group-0']?.());
+
+        expect(onSelectRow).toHaveBeenCalledTimes(1);
+        expect(mockToggle).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

This adds a dedicated `ExpenseGroupedSearchView` for grouped-expense search (an expense search with a valid group-by), composing the shared `useSearchListViewState` hook and `SearchListViewLayout` chrome over `BaseSearchList` (the same pattern as the other dedicated views). The router now dispatches grouped expenses to it instead of the legacy `SearchList` shell.

This is the most involved of the views, so it owns the full group machinery:
- On wide web it splits each group into a sticky `GroupHeader` plus an expandable `GroupChildrenContainer`; otherwise each group renders through `TransactionGroupListItem`.
- Selection counts are report-aware (flattened over child transactions plus empty groups).
- The scroll handle remaps the router's source-data index to the split-list index.

Supporting changes:
- `useSearchListViewState` gains an optional `listData` param so `scrollToListIndex` can index the rendered (split) list. It defaults to `data`, so the other views are unchanged.
- `isTransactionMatchWithGroupItem` is now exported from `SearchList` so the grouped view can reuse it for the post-create highlight mapping (it moves to a shared util when `SearchList` is removed).

### Fixed Issues
$ https://github.com/Expensify/App/issues/95032

### Tests
1. Open the Search tab and run an expense search, then group it (for example Group by Card, Category, or Merchant).
2. Verify the grouped rows render the same as before.
3. On a wide screen, verify the group headers stick while scrolling and that expanding/collapsing a group works.
4. Select transactions across different groups and verify the selected count and select-all state are correct (the count reflects transactions, not group rows).
5. Click a row and verify it opens as before, and that the post-create highlight still plays after adding an expense.
6. Switch group-by options and between other search types (chats, reports) and back, and verify each list still renders correctly.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go offline.
2. Open a grouped expense search and verify the list still renders, groups expand/collapse, and rows remain tappable.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ba2a5b83-4d11-4132-9463-1d0dc141e880


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a105cbd3-5159-4519-8172-1d6d94ddaae9


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/89f39f08-8cc2-45b7-b3f0-546dcc13bf81


</details>




