### PR TITLE
Enhance odometer reading handling by introducing a baseline compariso…

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
@@ -296,6 +296,7 @@ function IOURequestStepDistanceOdometer({
         }
         return true;
     };
+    const readingsMatchBaseline = (nextStart: string, nextEnd: string) => nextStart === initialStartReadingRef.current && nextEnd === initialEndReadingRef.current;
 
     const handleStartReadingChange = (text: string) => {
         if (!isOdometerInputValid(text, startReading)) {
@@ -304,7 +305,7 @@ function IOURequestStepDistanceOdometer({
         const textForDisplay = DistanceRequestUtils.prepareTextForDisplay(text);
         setStartReading(textForDisplay);
         startReadingRef.current = textForDisplay;
-        userHasUnsavedTypingRef.current = true;
+        userHasUnsavedTypingRef.current = !readingsMatchBaseline(textForDisplay, endReadingRef.current);
         if (formError) {
             setFormError('');
         }
@@ -317,7 +318,7 @@ function IOURequestStepDistanceOdometer({
         const textForDisplay = DistanceRequestUtils.prepareTextForDisplay(text);
         setEndReading(textForDisplay);
         endReadingRef.current = textForDisplay;
-        userHasUnsavedTypingRef.current = true;
+        userHasUnsavedTypingRef.current = !readingsMatchBaseline(startReadingRef.current, textForDisplay);
         if (formError) {
             setFormError('');
         }

--- a/tests/unit/hooks/useOdometerReadingsState.test.ts
+++ b/tests/unit/hooks/useOdometerReadingsState.test.ts
@@ -248,6 +248,58 @@ describe('useOdometerReadingsState', () => {
         expect(result.current.inputKey).toBe(initialKey + 1);
     });
 
+    it('re-hydrates readings from the transaction when switching back onto the odometer tab (typing guard clear)', () => {
+        const typingRef = {current: false};
+        const emptyTransaction = buildOdometerTransaction({odometerStart: undefined, odometerEnd: undefined});
+        const {result, rerender} = renderHook((params: Params) => useOdometerReadingsState(params), {
+            initialProps: {...baseParams, userHasUnsavedTypingRef: typingRef},
+        });
+
+        expect(result.current.startReading).toBe('100');
+
+        // Switch away: local state is cleared and the transaction is rebuilt without odometer readings.
+        rerender({...baseParams, userHasUnsavedTypingRef: typingRef, selectedTab: CONST.TAB_REQUEST.DISTANCE, currentTransaction: emptyTransaction});
+        expect(result.current.startReading).toBe('');
+        expect(result.current.endReading).toBe('');
+
+        // Switch back: draft hydration restores the transaction readings, whose value change re-fires the resync effect.
+        rerender({...baseParams, userHasUnsavedTypingRef: typingRef, selectedTab: CONST.TAB_REQUEST.DISTANCE_ODOMETER});
+        expect(result.current.startReading).toBe('100');
+        expect(result.current.endReading).toBe('250');
+        expect(result.current.startReadingRef.current).toBe('100');
+        expect(result.current.endReadingRef.current).toBe('250');
+    });
+
+    // The stuck-typing-guard variant is the actual deploy-blocker repro: an edit-then-revert leaves userHasUnsavedTypingRef
+    // true, which blocks the resync branch above so the inputs stay empty on return. The fix (resetting the guard on revert,
+    // done in the screen) keeps it false, so the round-trip re-hydrates exactly as the no-edit case does.
+    it('does NOT re-hydrate on return while the typing guard is stuck true, but DOES once it is honest', () => {
+        const stuckTypingRef = {current: false};
+        const emptyTransaction = buildOdometerTransaction({odometerStart: undefined, odometerEnd: undefined});
+        const {result, rerender} = renderHook((params: Params) => useOdometerReadingsState(params), {
+            initialProps: {...baseParams, userHasUnsavedTypingRef: stuckTypingRef},
+        });
+
+        // Simulate the stuck flag an edit-then-revert would leave behind (pre-fix behavior).
+        act(() => {
+            stuckTypingRef.current = true;
+        });
+        rerender({...baseParams, userHasUnsavedTypingRef: stuckTypingRef, selectedTab: CONST.TAB_REQUEST.DISTANCE, currentTransaction: emptyTransaction});
+        rerender({...baseParams, userHasUnsavedTypingRef: stuckTypingRef, selectedTab: CONST.TAB_REQUEST.DISTANCE_ODOMETER});
+
+        // Stuck guard blocks the resync -> inputs stay empty (the bug).
+        expect(result.current.startReading).toBe('');
+
+        // With the guard reset (what the fix does on revert), the same return path re-hydrates.
+        act(() => {
+            stuckTypingRef.current = false;
+        });
+        rerender({...baseParams, userHasUnsavedTypingRef: stuckTypingRef, selectedTab: CONST.TAB_REQUEST.DISTANCE, currentTransaction: emptyTransaction});
+        rerender({...baseParams, userHasUnsavedTypingRef: stuckTypingRef, selectedTab: CONST.TAB_REQUEST.DISTANCE_ODOMETER});
+        expect(result.current.startReading).toBe('100');
+        expect(result.current.endReading).toBe('250');
+    });
+
     it('does not run the tab-reset effect while the selected-tab Onyx key is still loading', () => {
         const initialProps: Params = {...baseParams, isLoadingSelectedTab: true, selectedTab: undefined};
         const {result, rerender} = renderHook((params: Params) => useOdometerReadingsState(params), {initialProps});


### PR DESCRIPTION



<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/94961
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."


1. Open FAB > Track distance > Odometer.
2. Enter start and end reading > Save for later.
3. Open FAB > Track distance > Odometer.
4. Edit start reading then change back to the previous value.
5. Go to Map tab.
6. Go to Odometer tab.
7. Go to Map tab.
8. Start and end reading will not be cleared.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/2372e7a1-1194-429c-9620-9dee480415a3



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/95ac2aa8-768a-4fc2-81bc-5988bad5a7f0



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/57fed67b-0a0f-417c-ba47-554c3c2915ad



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/47738bce-b9fb-4d66-891f-c68d4283ecbb


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/7e2fbe0a-81b8-4b21-8987-460acfcf85e1


<!-- add screenshots or videos here -->

</details>
