### PR TITLE
Fix duplicate supportal sign-in that trips the support-token rate limit

### DIFF
--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -236,6 +236,11 @@ function getShortLivedLoginParams(isSupportAuthTokenUsed = false, isSAML = false
 function signInWithSupportAuthToken(authToken: string) {
     const {optimisticData, finallyData} = getShortLivedLoginParams(true);
     API.read(READ_COMMANDS.SIGN_IN_WITH_SUPPORT_AUTH_TOKEN, {authToken}, {optimisticData, finallyData});
+
+    // Record the token so the transition pages skip a duplicate sign-in for it. The Public/Auth navigator
+    // swap re-mounts the transition screen mid-login, and without this the re-mounted page fires this call
+    // again and trips the support-token rate limit. Matches signInWithShortLivedAuthToken.
+    NetworkStore.setLastShortAuthToken(authToken);
 }
 
 /**

--- a/src/pages/LogOutPreviousUserPage.tsx
+++ b/src/pages/LogOutPreviousUserPage.tsx
@@ -3,6 +3,7 @@ import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import {useInitialURLState} from '@components/InitialURLContextProvider';
 import useOnyx from '@hooks/useOnyx';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import {getLastShortAuthToken} from '@libs/Network/NetworkStore';
 import {isLoggingInAsDelegate as isLoggingInAsDelegateSessionUtils, isLoggingInAsNewUser as isLoggingInAsNewUserSessionUtils} from '@libs/SessionUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import Navigation from '@navigation/Navigation';
@@ -41,7 +42,12 @@ function LogOutPreviousUserPage({route}: LogOutPreviousUserPageProps) {
         }
 
         if (isSupportalLogin) {
-            signInWithSupportAuthToken(shortLivedAuthToken);
+            // The public transition page may already have started this exact sign-in before the Public/Auth
+            // navigator swap re-mounted us here. Firing it again trips the support-token rate limit, so skip
+            // the duplicate but still finish navigating home.
+            if (shortLivedAuthToken !== getLastShortAuthToken()) {
+                signInWithSupportAuthToken(shortLivedAuthToken);
+            }
             Navigation.isNavigationReady().then(() => {
                 // We must call goBack() to remove the /transition route from history
                 Navigation.goBack();

--- a/tests/ui/SessionTest.tsx
+++ b/tests/ui/SessionTest.tsx
@@ -50,6 +50,20 @@ function getInitialURL() {
     return deeplinkUrl;
 }
 
+// cspell:disable-next-line
+const TEST_SUPPORT_AUTH_TOKEN = 'supporttoken123';
+
+function getSupportAuthURL() {
+    const params = new URLSearchParams();
+
+    params.set('email', TEST_USER_LOGIN_1);
+    params.set('delegatorEmail', TEST_USER_LOGIN_2);
+    params.set('shortLivedAuthToken', TEST_SUPPORT_AUTH_TOKEN);
+    params.set('authTokenType', CONST.AUTH_TOKEN_TYPES.SUPPORT);
+
+    return `${CONST.DEEPLINK_BASE_URL}/transition?${params.toString()}`;
+}
+
 describe('Deep linking', () => {
     let lastVisitedPath: string | undefined;
     let lastVisitedPathConnectionID: ReturnType<typeof Onyx.connect> | undefined;
@@ -217,6 +231,75 @@ describe('Deep linking', () => {
             expect(hasAuthToken()).toBe(false);
 
             unmount3();
+            await waitForBatchedUpdatesWithAct();
+            await waitForNetworkPromises();
+        },
+        4 * 60 * 1000,
+    );
+});
+
+describe('Support auth token login', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        wrapOnyxWithWaitForBatchedUpdates(Onyx);
+
+        jest.spyOn(Session, 'signInWithSupportAuthToken').mockImplementation(() => {});
+
+        // Set the keys the app needs to finish loading rather than going through a full OpenApp round-trip.
+        jest.spyOn(AppActions, 'openApp').mockImplementation(() =>
+            Onyx.multiSet({
+                [ONYXKEYS.IS_LOADING_APP]: false,
+                [ONYXKEYS.IS_LOADING_REPORT_DATA]: false,
+                [ONYXKEYS.HAS_LOADED_APP]: true,
+                [ONYXKEYS.NVP_ONBOARDING]: {hasCompletedGuidedSetupFlow: true},
+            }),
+        );
+    });
+
+    afterEach(async () => {
+        cleanup();
+        await act(async () => {
+            await Onyx.clear();
+        });
+        await waitForBatchedUpdatesWithAct();
+        await waitForNetworkPromises();
+        PusherHelper.teardown();
+        jest.clearAllMocks();
+        Linking.setInitialURL('');
+        setLastShortAuthToken(null);
+    });
+
+    // Renders the full App and processes a supportal transition, so it runs longer than the suite default.
+    it(
+        'does not fire the support sign-in again when LogOutPreviousUserPage re-processes an already-handled token',
+        async () => {
+            expect(hasAuthToken()).toBe(false);
+
+            // Sign in so the app is on AuthScreens, where LogOutPreviousUserPage owns the /transition route.
+            const {unmount: unmount1} = render(<App />);
+            await TestHelper.signInWithTestUser(TEST_USER_ACCOUNT_ID_2, TEST_USER_LOGIN_2, undefined, TEST_AUTH_TOKEN_2);
+
+            await waitForBatchedUpdatesWithAct();
+
+            expect(hasAuthToken()).toBe(true);
+            unmount1();
+
+            await waitForBatchedUpdatesWithAct();
+            await waitForNetworkPromises();
+
+            // The public transition page (LogInWithShortLivedAuthTokenPage) records the support token when it
+            // fires the sign-in. Simulate that, then re-process the SAME support deep link, which lands on
+            // LogOutPreviousUserPage. It must skip the duplicate sign-in; before the fix it fired
+            // unconditionally and tripped the support-token rate limit.
+            setLastShortAuthToken(TEST_SUPPORT_AUTH_TOKEN);
+            Linking.setInitialURL(getSupportAuthURL());
+            const {unmount: unmount2} = render(<App />);
+
+            await waitForBatchedUpdatesWithAct();
+
+            expect(Session.signInWithSupportAuthToken).not.toHaveBeenCalled();
+
+            unmount2();
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },


### PR DESCRIPTION
### Explanation of Change

A supportal `/transition` link is handled by two different screens depending on auth state: `LogInWithShortLivedAuthTokenPage` on `PublicScreens` and `LogOutPreviousUserPage` on `AuthScreens`. When the support sign-in sets `session.authToken`, `AppNavigator` swaps `PublicScreens` → `AuthScreens`, which re-mounts the transition screen and fires `signInWithSupportAuthToken` a second time. Each mint hits the same throttled Auth `GetSupportAuthToken` command, and the intended supportal-to-NewDot flow already spends all 3 slots of the 3-in-30s `supportLogin` throttle, so the duplicate call comes back `405 throttled`. The backend returns that throttle as an empty `200`, so NewDot ends up with no session and shows the blank "session expired" screen.

The dedupe guard (`token === getLastShortAuthToken()`) only lived in `LogInWithShortLivedAuthTokenPage`, and `signInWithSupportAuthToken` never recorded the token, so neither firing site was actually deduped. This PR makes the guard symmetric across both transition owners:

- `signInWithSupportAuthToken` now records the handled token via `NetworkStore.setLastShortAuthToken`, matching `signInWithShortLivedAuthToken`.
- `LogOutPreviousUserPage` now checks that guard before firing the supportal sign-in, so the re-mount after the navigator swap does not fire a duplicate.

This supersedes #91200 (which added only the `setLastShortAuthToken` half). Thanks @dsilva for the handoff.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/647201
$ https://github.com/Expensify/Expensify/issues/383021
PROPOSAL: N/A (internal RCA from production logs)

### Tests
1. Sign in to NewDot as a support agent.
2. From OldDot supportal, open a customer via the "New Expensify" button.
3. Verify you land in the customer's account, not a blank page or a "session expired" screen.
4. In the Network tab, verify only one `SignInWithSupportAuthToken` request is sent for the transition (no duplicate that returns `405 throttled`).
5. Supportal into a second customer and verify the same result.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A. The supportal transition requires an active connection to establish the session.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
