### PR TITLE
[DO NOT MERGE] TEST — Onyx.connectWithoutView reviewer workflow

### DIFF
--- a/src/libs/ConnectWithoutViewWorkflowProbe.ts
+++ b/src/libs/ConnectWithoutViewWorkflowProbe.ts
@@ -13,3 +13,5 @@ Onyx.connectWithoutView({
 export default function getProbeEmail(): string | undefined {
     return email;
 }
+
+// touch: trigger synchronize event for workflow test

--- a/src/libs/ConnectWithoutViewWorkflowProbe.ts
+++ b/src/libs/ConnectWithoutViewWorkflowProbe.ts
@@ -15,3 +15,4 @@ export default function getProbeEmail(): string | undefined {
 }
 
 // touch: trigger synchronize event for workflow test
+// touch 2: synchronize test on reopened PR

--- a/src/libs/ConnectWithoutViewWorkflowProbe.ts
+++ b/src/libs/ConnectWithoutViewWorkflowProbe.ts
@@ -1,0 +1,15 @@
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+// Temporary file to exercise the Onyx.connectWithoutView reviewer workflow. Not for merge.
+let email: string | undefined;
+Onyx.connectWithoutView({
+    key: ONYXKEYS.SESSION,
+    callback: (session) => {
+        email = session?.email;
+    },
+});
+
+export default function getProbeEmail(): string | undefined {
+    return email;
+}


### PR DESCRIPTION
Throwaway PR to verify the workflow added in https://github.com/Expensify/App/pull/94846 (issue https://github.com/Expensify/App/issues/93693). It adds a single new `Onyx.connectWithoutView` call, so opening it should make the workflow **request reviews from @tgolen, @mountiny, @luacmartins** and **post a comment** asking for the Slack approval link.

Expected checks:
1. On open → the three reviewers are requested + the comment appears.
2. Push a no-op commit → no duplicate request.
3. Will be closed without merging once verified.

Not for merge.
