### PR TITLE
fix: truncate (not strip) decimals when currency change lowers precision

### DIFF
--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -356,8 +356,12 @@ function NumberWithSymbolForm({
             return;
         }
 
-        // If the number doesn't support decimals, we can strip the decimals
-        setNewNumber(stripDecimalsFromAmount(currentNumber));
+        // If the new decimal count can't fit the current number, truncate to the new decimal
+        // precision instead of dropping the fractional part entirely (avoids silent data loss,
+        // e.g. 125.567 becoming 125.56 rather than 125 when decimals goes from 3 to 2).
+        const decimalIndex = currentNumber.indexOf('.');
+        const truncatedNumber = decimals > 0 && decimalIndex !== -1 ? currentNumber.slice(0, decimalIndex + 1 + decimals) : stripDecimalsFromAmount(currentNumber);
+        setNewNumber(truncatedNumber);
 
         // we want to update only when decimals change.
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/tests/ui/NumberWithSymbolFormTest.tsx
+++ b/tests/ui/NumberWithSymbolFormTest.tsx
@@ -1,0 +1,46 @@
+import {NavigationContainer} from '@react-navigation/native';
+import {render, screen} from '@testing-library/react-native';
+import React from 'react';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import NumberWithSymbolForm from '@components/NumberWithSymbolForm';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+describe('NumberWithSymbolForm', () => {
+    const buildTree = (value: string, decimals: number) => (
+        <NavigationContainer>
+            <LocaleContextProvider>
+                <NumberWithSymbolForm
+                    value={value}
+                    decimals={decimals}
+                    symbol="$"
+                />
+            </LocaleContextProvider>
+        </NavigationContainer>
+    );
+
+    it('truncates to the new decimal precision instead of deleting all decimals when decimals shrinks', async () => {
+        const {rerender} = render(buildTree('125.567', 3));
+
+        await waitForBatchedUpdatesWithAct();
+
+        // Currency changes to one that supports only 2 decimals: the amount should be truncated to 2
+        // decimal digits (125.56), not have its entire fractional part wiped out (125).
+        rerender(buildTree('125.567', 2));
+
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByDisplayValue('125.56')).toBeDefined();
+    });
+
+    it('drops the decimal point entirely when the new currency supports zero decimals', async () => {
+        const {rerender} = render(buildTree('125.50', 2));
+
+        await waitForBatchedUpdatesWithAct();
+
+        rerender(buildTree('125.50', 0));
+
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByDisplayValue('125')).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary

`NumberWithSymbolForm` silently dropped the entire fractional part of an entered amount whenever the currency changed to one supporting fewer decimal digits. Example: entering `125.567` for a 3-decimal currency, then switching to a 2-decimal currency, resulted in `125` instead of `125.56` — the component called `stripDecimalsFromAmount()` (which removes *all* decimals) on any validation failure, rather than truncating to the new precision.

## Fix

Truncate to the new decimal count when the current value doesn't fit, instead of dropping every decimal digit.

## Related context (not a fix for this issue)

This was found while investigating #95007 (XAF decimal entry). That issue's literal reported behavior — decimal points being rejected outright for zero-decimal currencies — checks out as intentional, tested behavior elsewhere in the codebase (`validateAmount`'s explicit `decimals === 0` rejection, confirmed by existing unit tests). So this PR does **not** $ #95007; it fixes a separate, adjacent silent-data-loss bug in the same component that surfaced during that investigation.

## Tests

Added `tests/ui/NumberWithSymbolFormTest.tsx` covering both the truncation case and the existing zero-decimal-drop case. `tsc --noEmit` is clean and both new tests pass.
