### PR TITLE
Fix translation bot flattening plural keys in incremental path

### DIFF
--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -1077,6 +1077,9 @@ class TranslationGenerator {
                 }
             }
 
+            TSCompilerUtils.removeDescendantPaths(this.pathsToModify);
+            TSCompilerUtils.removeDescendantPaths(this.pathsToAdd);
+
             if (this.verbose) {
                 console.log(`🔄 Paths to modify: ${Array.from(this.pathsToModify).join(', ')}`);
                 console.log(`➕ Paths to add: ${Array.from(this.pathsToAdd).join(', ')}`);

--- a/scripts/utils/TSCompilerUtils.ts
+++ b/scripts/utils/TSCompilerUtils.ts
@@ -535,6 +535,20 @@ function isStringConcatenationChain(node: ts.BinaryExpression): boolean {
     return false;
 }
 
+/**
+ * Remove paths that are strict descendants of another path in the same set.
+ * Prevents incremental translation from injecting leaf plural forms separately.
+ */
+function removeDescendantPaths(paths: Set<string>): void {
+    for (const path of [...paths]) {
+        for (const otherPath of paths) {
+            if (path !== otherPath && path.startsWith(`${otherPath}.`)) {
+                paths.delete(path);
+            }
+        }
+    }
+}
+
 export default {
     findAncestor,
     getIndentationOfNode,
@@ -550,6 +564,7 @@ export default {
     objectHas,
     injectDeepObjectValue,
     isStringConcatenationChain,
+    removeDescendantPaths,
 };
 export {TransformerAction};
 export type {ExpressionWithType, TransformerResult};

--- a/scripts/utils/TSCompilerUtils.ts
+++ b/scripts/utils/TSCompilerUtils.ts
@@ -255,6 +255,13 @@ function extractKeyFromPropertyNode(node: ts.PropertyAssignment | ts.MethodDecla
 }
 
 /**
+ * Returns true when a property assignment's value is an arrow or function expression.
+ */
+function isFunctionInitializer(initializer: ts.Expression | undefined): initializer is ts.ArrowFunction | ts.FunctionExpression {
+    return !!initializer && (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer));
+}
+
+/**
  * Build a dot-notation path from a node by traversing up the AST to find property assignments.
  * Useful for building paths like "common.save" from a string literal node.
  */
@@ -268,7 +275,13 @@ function buildDotNotationPath(node: ts.Node, rootNode?: ts.Node): string | null 
         if (ts.isPropertyAssignment(current)) {
             const key = extractKeyFromPropertyNode(current);
             if (key) {
-                pathParts.unshift(key);
+                if (isFunctionInitializer(current.initializer)) {
+                    // Collapse to the outermost function-valued property so plural keys stay a single translatable unit
+                    pathParts.length = 0;
+                    pathParts.unshift(key);
+                } else {
+                    pathParts.unshift(key);
+                }
             }
         }
         current = current.parent;

--- a/tests/unit/scripts/TSCompilerUtils.test.ts
+++ b/tests/unit/scripts/TSCompilerUtils.test.ts
@@ -1,0 +1,146 @@
+import ts from "typescript";
+import TSCompilerUtils from "../../../scripts/utils/TSCompilerUtils";
+
+const PLURAL_KEY_SOURCE = `
+const translations = {
+    policyCopyChangeLog: {
+        codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({
+            one: \`copied 1 merchant rule from \${sourcePolicyName}\`,
+            other: (count: number) => \`copied \${count} merchant rules from \${sourcePolicyName}\`,
+        }),
+    },
+};
+`;
+
+function createSourceFile(source = PLURAL_KEY_SOURCE) {
+  return ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+}
+
+function findFirstNode(
+  sourceFile: ts.SourceFile,
+  predicate: (node: ts.Node) => boolean,
+): ts.Node | undefined {
+  let found: ts.Node | undefined;
+  const visit = (node: ts.Node) => {
+    if (found) {
+      return;
+    }
+    if (predicate(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+function getTemplateStaticText(node: ts.TemplateExpression) {
+  let staticText = node.head.text;
+  for (const span of node.templateSpans) {
+    staticText += span.literal.text;
+  }
+  return staticText;
+}
+
+function findTemplateInPluralOther(sourceFile: ts.SourceFile) {
+  return findFirstNode(sourceFile, (node) => {
+    if (
+      !ts.isTemplateExpression(node) ||
+      !getTemplateStaticText(node).includes("merchant rules")
+    ) {
+      return false;
+    }
+
+    const otherProperty = TSCompilerUtils.findAncestor(
+      node,
+      (ancestor): ancestor is ts.PropertyAssignment => {
+        return (
+          ts.isPropertyAssignment(ancestor) &&
+          ts.isIdentifier(ancestor.name) &&
+          ancestor.name.text === "other"
+        );
+      },
+    );
+
+    return !!otherProperty;
+  });
+}
+
+function findTemplateInPluralOne(sourceFile: ts.SourceFile) {
+  return findFirstNode(sourceFile, (node) => {
+    if (!ts.isTemplateExpression(node)) {
+      return false;
+    }
+
+    const staticText = getTemplateStaticText(node);
+    if (
+      !staticText.includes("merchant rule from") ||
+      staticText.includes("merchant rules")
+    ) {
+      return false;
+    }
+
+    const oneProperty = TSCompilerUtils.findAncestor(
+      node,
+      (ancestor): ancestor is ts.PropertyAssignment => {
+        return (
+          ts.isPropertyAssignment(ancestor) &&
+          ts.isIdentifier(ancestor.name) &&
+          ancestor.name.text === "one"
+        );
+      },
+    );
+
+    return !!oneProperty;
+  });
+}
+
+describe("buildDotNotationPath", () => {
+  it("collapses to the function-valued property when a plural form string changes inside other", () => {
+    const sourceFile = createSourceFile();
+    const templateNode = findTemplateInPluralOther(sourceFile);
+
+    expect(templateNode).toBeDefined();
+
+    const dotPath = TSCompilerUtils.buildDotNotationPath(
+      templateNode as ts.Node,
+    );
+
+    expect(dotPath).toBe("policyCopyChangeLog.codingRules");
+    expect(dotPath).not.toBe("policyCopyChangeLog.codingRules.other");
+  });
+
+  it("collapses to the function-valued property when a plural form string changes inside one", () => {
+    const sourceFile = createSourceFile();
+    const stringNode = findTemplateInPluralOne(sourceFile);
+
+    expect(stringNode).toBeDefined();
+
+    const dotPath = TSCompilerUtils.buildDotNotationPath(stringNode as ts.Node);
+
+    expect(dotPath).toBe("policyCopyChangeLog.codingRules");
+    expect(dotPath).not.toBe("policyCopyChangeLog.codingRules.one");
+  });
+
+  it("still builds nested paths for ordinary object properties", () => {
+    const source = `
+const translations = {
+    common: {
+        save: 'Save',
+    },
+};
+`;
+    const sourceFile = createSourceFile(source);
+    const saveNode = findFirstNode(
+      sourceFile,
+      (node) => ts.isStringLiteral(node) && node.text === "Save",
+    );
+
+    expect(saveNode).toBeDefined();
+
+    const dotPath = TSCompilerUtils.buildDotNotationPath(saveNode as ts.Node);
+
+    expect(dotPath).toBe("common.save");
+  });
+});

--- a/tests/unit/scripts/TSCompilerUtils.test.ts
+++ b/tests/unit/scripts/TSCompilerUtils.test.ts
@@ -244,3 +244,20 @@ describe("incremental plural key injection", () => {
     expect(injectedText).not.toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
   });
 });
+
+describe("removeDescendantPaths", () => {
+  it("removes leaf plural paths when the parent function path is also present", () => {
+    const paths = new Set([
+      "policyCopyChangeLog.codingRules",
+      "policyCopyChangeLog.codingRules.one",
+      "policyCopyChangeLog.codingRules.other",
+      "common.save",
+    ]);
+
+    TSCompilerUtils.removeDescendantPaths(paths);
+
+    expect(paths).toEqual(
+      new Set(["policyCopyChangeLog.codingRules", "common.save"]),
+    );
+  });
+});

--- a/tests/unit/scripts/TSCompilerUtils.test.ts
+++ b/tests/unit/scripts/TSCompilerUtils.test.ts
@@ -1,5 +1,5 @@
-import ts from "typescript";
-import TSCompilerUtils from "../../../scripts/utils/TSCompilerUtils";
+import ts from 'typescript';
+import TSCompilerUtils from '../../../scripts/utils/TSCompilerUtils';
 
 const PLURAL_KEY_SOURCE = `
 const translations = {
@@ -13,251 +13,184 @@ const translations = {
 `;
 
 function createSourceFile(source = PLURAL_KEY_SOURCE) {
-  return ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+    return ts.createSourceFile('test.ts', source, ts.ScriptTarget.Latest, true);
 }
 
-function findFirstNode(
-  sourceFile: ts.SourceFile,
-  predicate: (node: ts.Node) => boolean,
-): ts.Node | undefined {
-  let found: ts.Node | undefined;
-  const visit = (node: ts.Node) => {
-    if (found) {
-      return;
-    }
-    if (predicate(node)) {
-      found = node;
-      return;
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  return found;
+function findFirstNode<T extends ts.Node>(sourceFile: ts.SourceFile, predicate: (node: ts.Node) => node is T): T | undefined;
+function findFirstNode(sourceFile: ts.SourceFile, predicate: (node: ts.Node) => boolean): ts.Node | undefined;
+function findFirstNode(sourceFile: ts.SourceFile, predicate: (node: ts.Node) => boolean): ts.Node | undefined {
+    let found: ts.Node | undefined;
+    const visit = (node: ts.Node) => {
+        if (found) {
+            return;
+        }
+        if (predicate(node)) {
+            found = node;
+            return;
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return found;
 }
 
 function getTemplateStaticText(node: ts.TemplateExpression) {
-  let staticText = node.head.text;
-  for (const span of node.templateSpans) {
-    staticText += span.literal.text;
-  }
-  return staticText;
+    let staticText = node.head.text;
+    for (const span of node.templateSpans) {
+        staticText += span.literal.text;
+    }
+    return staticText;
 }
 
 function findTemplateInPluralOther(sourceFile: ts.SourceFile) {
-  return findFirstNode(sourceFile, (node) => {
-    if (
-      !ts.isTemplateExpression(node) ||
-      !getTemplateStaticText(node).includes("merchant rules")
-    ) {
-      return false;
-    }
+    return findFirstNode(sourceFile, (node) => {
+        if (!ts.isTemplateExpression(node) || !getTemplateStaticText(node).includes('merchant rules')) {
+            return false;
+        }
 
-    const otherProperty = TSCompilerUtils.findAncestor(
-      node,
-      (ancestor): ancestor is ts.PropertyAssignment => {
-        return (
-          ts.isPropertyAssignment(ancestor) &&
-          ts.isIdentifier(ancestor.name) &&
-          ancestor.name.text === "other"
-        );
-      },
-    );
+        const otherProperty = TSCompilerUtils.findAncestor(node, (ancestor): ancestor is ts.PropertyAssignment => {
+            return ts.isPropertyAssignment(ancestor) && ts.isIdentifier(ancestor.name) && ancestor.name.text === 'other';
+        });
 
-    return !!otherProperty;
-  });
+        return !!otherProperty;
+    });
 }
 
 function findTemplateInPluralOne(sourceFile: ts.SourceFile) {
-  return findFirstNode(sourceFile, (node) => {
-    if (!ts.isTemplateExpression(node)) {
-      return false;
-    }
+    return findFirstNode(sourceFile, (node) => {
+        if (!ts.isTemplateExpression(node)) {
+            return false;
+        }
 
-    const staticText = getTemplateStaticText(node);
-    if (
-      !staticText.includes("merchant rule from") ||
-      staticText.includes("merchant rules")
-    ) {
-      return false;
-    }
+        const staticText = getTemplateStaticText(node);
+        if (!staticText.includes('merchant rule from') || staticText.includes('merchant rules')) {
+            return false;
+        }
 
-    const oneProperty = TSCompilerUtils.findAncestor(
-      node,
-      (ancestor): ancestor is ts.PropertyAssignment => {
-        return (
-          ts.isPropertyAssignment(ancestor) &&
-          ts.isIdentifier(ancestor.name) &&
-          ancestor.name.text === "one"
-        );
-      },
-    );
+        const oneProperty = TSCompilerUtils.findAncestor(node, (ancestor): ancestor is ts.PropertyAssignment => {
+            return ts.isPropertyAssignment(ancestor) && ts.isIdentifier(ancestor.name) && ancestor.name.text === 'one';
+        });
 
-    return !!oneProperty;
-  });
+        return !!oneProperty;
+    });
 }
 
-describe("buildDotNotationPath", () => {
-  it("collapses to the function-valued property when a plural form string changes inside other", () => {
-    const sourceFile = createSourceFile();
-    const templateNode = findTemplateInPluralOther(sourceFile);
+describe('buildDotNotationPath', () => {
+    it('collapses to the function-valued property when a plural form string changes inside other', () => {
+        const sourceFile = createSourceFile();
+        const templateNode = findTemplateInPluralOther(sourceFile);
 
-    expect(templateNode).toBeDefined();
+        expect(templateNode).toBeDefined();
 
-    const dotPath = TSCompilerUtils.buildDotNotationPath(
-      templateNode as ts.Node,
-    );
+        const dotPath = TSCompilerUtils.buildDotNotationPath(templateNode as ts.Node);
 
-    expect(dotPath).toBe("policyCopyChangeLog.codingRules");
-    expect(dotPath).not.toBe("policyCopyChangeLog.codingRules.other");
-  });
+        expect(dotPath).toBe('policyCopyChangeLog.codingRules');
+        expect(dotPath).not.toBe('policyCopyChangeLog.codingRules.other');
+    });
 
-  it("collapses to the function-valued property when a plural form string changes inside one", () => {
-    const sourceFile = createSourceFile();
-    const stringNode = findTemplateInPluralOne(sourceFile);
+    it('collapses to the function-valued property when a plural form string changes inside one', () => {
+        const sourceFile = createSourceFile();
+        const stringNode = findTemplateInPluralOne(sourceFile);
 
-    expect(stringNode).toBeDefined();
+        expect(stringNode).toBeDefined();
 
-    const dotPath = TSCompilerUtils.buildDotNotationPath(stringNode as ts.Node);
+        const dotPath = TSCompilerUtils.buildDotNotationPath(stringNode as ts.Node);
 
-    expect(dotPath).toBe("policyCopyChangeLog.codingRules");
-    expect(dotPath).not.toBe("policyCopyChangeLog.codingRules.one");
-  });
+        expect(dotPath).toBe('policyCopyChangeLog.codingRules');
+        expect(dotPath).not.toBe('policyCopyChangeLog.codingRules.one');
+    });
 
-  it("still builds nested paths for ordinary object properties", () => {
-    const source = `
+    it('still builds nested paths for ordinary object properties', () => {
+        const source = `
 const translations = {
     common: {
         save: 'Save',
     },
 };
 `;
-    const sourceFile = createSourceFile(source);
-    const saveNode = findFirstNode(
-      sourceFile,
-      (node) => ts.isStringLiteral(node) && node.text === "Save",
-    );
+        const sourceFile = createSourceFile(source);
+        const saveNode = findFirstNode(sourceFile, (node) => ts.isStringLiteral(node) && node.text === 'Save');
 
-    expect(saveNode).toBeDefined();
+        expect(saveNode).toBeDefined();
 
-    const dotPath = TSCompilerUtils.buildDotNotationPath(saveNode as ts.Node);
+        const dotPath = TSCompilerUtils.buildDotNotationPath(saveNode as ts.Node);
 
-    expect(dotPath).toBe("common.save");
-  });
+        expect(dotPath).toBe('common.save');
+    });
 });
 
-describe("incremental plural key injection", () => {
-  const tsPrinter = ts.createPrinter({ removeComments: true });
+describe('incremental plural key injection', () => {
+    const tsPrinter = ts.createPrinter({removeComments: true});
 
-  it("preserves the arrow function wrapper when injecting at the collapsed parent path", () => {
-    const sourceFile = createSourceFile();
-    const templateNode = findTemplateInPluralOther(sourceFile);
+    it('preserves the arrow function wrapper when injecting at the collapsed parent path', () => {
+        const sourceFile = createSourceFile();
+        const templateNode = findTemplateInPluralOther(sourceFile);
 
-    expect(templateNode).toBeDefined();
+        expect(templateNode).toBeDefined();
 
-    const dotPath = TSCompilerUtils.buildDotNotationPath(
-      templateNode as ts.Node,
-    );
-    expect(dotPath).toBe("policyCopyChangeLog.codingRules");
+        const dotPath = TSCompilerUtils.buildDotNotationPath(templateNode as ts.Node);
+        expect(dotPath).toBe('policyCopyChangeLog.codingRules');
 
-    const codingRulesProperty = findFirstNode(
-      sourceFile,
-      (node): node is ts.PropertyAssignment =>
-        ts.isPropertyAssignment(node) &&
-        ts.isIdentifier(node.name) &&
-        node.name.text === "codingRules",
-    );
+        const codingRulesProperty = findFirstNode(
+            sourceFile,
+            (node): node is ts.PropertyAssignment => ts.isPropertyAssignment(node) && ts.isIdentifier(node.name) && node.name.text === 'codingRules',
+        );
 
-    expect(codingRulesProperty).toBeDefined();
+        expect(codingRulesProperty).toBeDefined();
+        if (!codingRulesProperty) {
+            throw new Error('Expected codingRules property');
+        }
 
-    const translatedInitializer = TSCompilerUtils.parseCodeStringToAST(
-      tsPrinter
-        .printNode(
-          ts.EmitHint.Expression,
-          codingRulesProperty.initializer,
-          sourceFile,
-        )
-        .replace("merchant rules", "reglas de comercio"),
-    );
+        const translatedInitializer = TSCompilerUtils.parseCodeStringToAST(
+            tsPrinter.printNode(ts.EmitHint.Expression, codingRulesProperty.initializer, sourceFile).replace('merchant rules', 'translated merchant rules'),
+        );
 
-    const targetObject = ts.factory.createObjectLiteralExpression([
-      ts.factory.createPropertyAssignment(
-        "policyCopyChangeLog",
-        ts.factory.createObjectLiteralExpression([
-          ts.factory.createPropertyAssignment(
-            "codingRules",
-            ts.factory.createIdentifier("undefined as never"),
-          ),
-        ]),
-      ),
-    ]);
+        const targetObject = ts.factory.createObjectLiteralExpression([
+            ts.factory.createPropertyAssignment(
+                'policyCopyChangeLog',
+                ts.factory.createObjectLiteralExpression([ts.factory.createPropertyAssignment('codingRules', ts.factory.createIdentifier('undefined as never'))]),
+            ),
+        ]);
 
-    const injected = TSCompilerUtils.injectDeepObjectValue(
-      targetObject,
-      dotPath as string,
-      translatedInitializer,
-    );
-    const injectedText = tsPrinter.printNode(
-      ts.EmitHint.Unspecified,
-      injected,
-      sourceFile,
-    );
+        const injected = TSCompilerUtils.injectDeepObjectValue(targetObject, dotPath as string, translatedInitializer);
+        const injectedText = tsPrinter.printNode(ts.EmitHint.Unspecified, injected, sourceFile);
 
-    expect(injectedText).toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
-    expect(injectedText).toMatch(/=>\s*\(\{/);
-    expect(injectedText).not.toMatch(/codingRules:\s*\{one:/);
-  });
+        expect(injectedText).toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
+        expect(injectedText).toMatch(/=>\s*\(\{/);
+        expect(injectedText).not.toMatch(/codingRules:\s*\{one:/);
+    });
 
-  it("flattens plural keys when leaf paths are injected separately", () => {
-    const sourceFile = createSourceFile();
-    const oneValue = TSCompilerUtils.parseCodeStringToAST(
-      "`copiou 1 regra de comerciante de ${sourcePolicyName}`",
-    );
-    const otherValue = TSCompilerUtils.parseCodeStringToAST(
-      "(count: number) => `copiou ${count} regras de comerciante de ${sourcePolicyName}`",
-    );
+    it('flattens plural keys when leaf paths are injected separately', () => {
+        const sourceFile = createSourceFile();
+        const oneValue = TSCompilerUtils.parseCodeStringToAST('`copied 1 translated merchant rule from ${sourcePolicyName}`');
+        const otherValue = TSCompilerUtils.parseCodeStringToAST('(count: number) => `copied ${count} translated merchant rules from ${sourcePolicyName}`');
 
-    let targetObject = ts.factory.createObjectLiteralExpression([
-      ts.factory.createPropertyAssignment(
-        "policyCopyChangeLog",
-        ts.factory.createObjectLiteralExpression([]),
-      ),
-    ]);
+        let targetObject = ts.factory.createObjectLiteralExpression([ts.factory.createPropertyAssignment('policyCopyChangeLog', ts.factory.createObjectLiteralExpression([]))]);
 
-    targetObject = TSCompilerUtils.injectDeepObjectValue(
-      targetObject,
-      "policyCopyChangeLog.codingRules.one",
-      oneValue,
-    );
-    targetObject = TSCompilerUtils.injectDeepObjectValue(
-      targetObject,
-      "policyCopyChangeLog.codingRules.other",
-      otherValue,
-    );
+        targetObject = TSCompilerUtils.injectDeepObjectValue(targetObject, 'policyCopyChangeLog.codingRules.one', oneValue);
+        targetObject = TSCompilerUtils.injectDeepObjectValue(targetObject, 'policyCopyChangeLog.codingRules.other', otherValue);
 
-    const injectedText = tsPrinter.printNode(
-      ts.EmitHint.Unspecified,
-      targetObject,
-      sourceFile,
-    );
+        const injectedText = tsPrinter.printNode(ts.EmitHint.Unspecified, targetObject, sourceFile);
 
-    expect(injectedText).toMatch(/codingRules:\s*\{\s*one:/);
-    expect(injectedText).not.toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
-  });
+        expect(injectedText).toMatch(/codingRules:\s*\{\s*one:/);
+        expect(injectedText).not.toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
+    });
 });
 
-describe("removeDescendantPaths", () => {
-  it("removes leaf plural paths when the parent function path is also present", () => {
-    const paths = new Set([
-      "policyCopyChangeLog.codingRules",
-      "policyCopyChangeLog.codingRules.one",
-      "policyCopyChangeLog.codingRules.other",
-      "common.save",
-    ]);
+describe('removeDescendantPaths', () => {
+    it('removes leaf plural paths when the parent function path is also present', () => {
+        const paths = new Set(['policyCopyChangeLog.codingRules', 'policyCopyChangeLog.codingRules.one', 'policyCopyChangeLog.codingRules.other', 'common.save']);
 
-    TSCompilerUtils.removeDescendantPaths(paths);
+        TSCompilerUtils.removeDescendantPaths(paths);
 
-    expect(paths).toEqual(
-      new Set(["policyCopyChangeLog.codingRules", "common.save"]),
-    );
-  });
+        expect(paths).toEqual(new Set(['policyCopyChangeLog.codingRules', 'common.save']));
+    });
+
+    it('does not remove paths that only share a prefix with another path', () => {
+        const paths = new Set(['policyCopyChangeLog.codingRules', 'policyCopyChangeLog.codingRulesExtra', 'common.save']);
+
+        TSCompilerUtils.removeDescendantPaths(paths);
+
+        expect(paths).toEqual(new Set(['policyCopyChangeLog.codingRules', 'policyCopyChangeLog.codingRulesExtra', 'common.save']));
+    });
 });

--- a/tests/unit/scripts/TSCompilerUtils.test.ts
+++ b/tests/unit/scripts/TSCompilerUtils.test.ts
@@ -144,3 +144,103 @@ const translations = {
     expect(dotPath).toBe("common.save");
   });
 });
+
+describe("incremental plural key injection", () => {
+  const tsPrinter = ts.createPrinter({ removeComments: true });
+
+  it("preserves the arrow function wrapper when injecting at the collapsed parent path", () => {
+    const sourceFile = createSourceFile();
+    const templateNode = findTemplateInPluralOther(sourceFile);
+
+    expect(templateNode).toBeDefined();
+
+    const dotPath = TSCompilerUtils.buildDotNotationPath(
+      templateNode as ts.Node,
+    );
+    expect(dotPath).toBe("policyCopyChangeLog.codingRules");
+
+    const codingRulesProperty = findFirstNode(
+      sourceFile,
+      (node): node is ts.PropertyAssignment =>
+        ts.isPropertyAssignment(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === "codingRules",
+    );
+
+    expect(codingRulesProperty).toBeDefined();
+
+    const translatedInitializer = TSCompilerUtils.parseCodeStringToAST(
+      tsPrinter
+        .printNode(
+          ts.EmitHint.Expression,
+          codingRulesProperty.initializer,
+          sourceFile,
+        )
+        .replace("merchant rules", "reglas de comercio"),
+    );
+
+    const targetObject = ts.factory.createObjectLiteralExpression([
+      ts.factory.createPropertyAssignment(
+        "policyCopyChangeLog",
+        ts.factory.createObjectLiteralExpression([
+          ts.factory.createPropertyAssignment(
+            "codingRules",
+            ts.factory.createIdentifier("undefined as never"),
+          ),
+        ]),
+      ),
+    ]);
+
+    const injected = TSCompilerUtils.injectDeepObjectValue(
+      targetObject,
+      dotPath as string,
+      translatedInitializer,
+    );
+    const injectedText = tsPrinter.printNode(
+      ts.EmitHint.Unspecified,
+      injected,
+      sourceFile,
+    );
+
+    expect(injectedText).toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
+    expect(injectedText).toMatch(/=>\s*\(\{/);
+    expect(injectedText).not.toMatch(/codingRules:\s*\{one:/);
+  });
+
+  it("flattens plural keys when leaf paths are injected separately", () => {
+    const sourceFile = createSourceFile();
+    const oneValue = TSCompilerUtils.parseCodeStringToAST(
+      "`copiou 1 regra de comerciante de ${sourcePolicyName}`",
+    );
+    const otherValue = TSCompilerUtils.parseCodeStringToAST(
+      "(count: number) => `copiou ${count} regras de comerciante de ${sourcePolicyName}`",
+    );
+
+    let targetObject = ts.factory.createObjectLiteralExpression([
+      ts.factory.createPropertyAssignment(
+        "policyCopyChangeLog",
+        ts.factory.createObjectLiteralExpression([]),
+      ),
+    ]);
+
+    targetObject = TSCompilerUtils.injectDeepObjectValue(
+      targetObject,
+      "policyCopyChangeLog.codingRules.one",
+      oneValue,
+    );
+    targetObject = TSCompilerUtils.injectDeepObjectValue(
+      targetObject,
+      "policyCopyChangeLog.codingRules.other",
+      otherValue,
+    );
+
+    const injectedText = tsPrinter.printNode(
+      ts.EmitHint.Unspecified,
+      targetObject,
+      sourceFile,
+    );
+
+    expect(injectedText).toMatch(/codingRules:\s*\{\s*one:/);
+    expect(injectedText).not.toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
+  });
+});

--- a/tests/unit/scripts/TSCompilerUtils.test.ts
+++ b/tests/unit/scripts/TSCompilerUtils.test.ts
@@ -34,6 +34,14 @@ function findFirstNode(sourceFile: ts.SourceFile, predicate: (node: ts.Node) => 
     return found;
 }
 
+function assertDefined<T>(value: T | undefined | null, message: string): asserts value is T {
+    if (value !== undefined && value !== null) {
+        return;
+    }
+
+    throw new Error(message);
+}
+
 function getTemplateStaticText(node: ts.TemplateExpression) {
     let staticText = node.head.text;
     for (const span of node.templateSpans) {
@@ -81,8 +89,9 @@ describe('buildDotNotationPath', () => {
         const templateNode = findTemplateInPluralOther(sourceFile);
 
         expect(templateNode).toBeDefined();
+        assertDefined(templateNode, 'Expected template node in plural other');
 
-        const dotPath = TSCompilerUtils.buildDotNotationPath(templateNode as ts.Node);
+        const dotPath = TSCompilerUtils.buildDotNotationPath(templateNode);
 
         expect(dotPath).toBe('policyCopyChangeLog.codingRules');
         expect(dotPath).not.toBe('policyCopyChangeLog.codingRules.other');
@@ -93,8 +102,9 @@ describe('buildDotNotationPath', () => {
         const stringNode = findTemplateInPluralOne(sourceFile);
 
         expect(stringNode).toBeDefined();
+        assertDefined(stringNode, 'Expected template node in plural one');
 
-        const dotPath = TSCompilerUtils.buildDotNotationPath(stringNode as ts.Node);
+        const dotPath = TSCompilerUtils.buildDotNotationPath(stringNode);
 
         expect(dotPath).toBe('policyCopyChangeLog.codingRules');
         expect(dotPath).not.toBe('policyCopyChangeLog.codingRules.one');
@@ -112,8 +122,9 @@ const translations = {
         const saveNode = findFirstNode(sourceFile, (node) => ts.isStringLiteral(node) && node.text === 'Save');
 
         expect(saveNode).toBeDefined();
+        assertDefined(saveNode, 'Expected save node');
 
-        const dotPath = TSCompilerUtils.buildDotNotationPath(saveNode as ts.Node);
+        const dotPath = TSCompilerUtils.buildDotNotationPath(saveNode);
 
         expect(dotPath).toBe('common.save');
     });
@@ -127,9 +138,11 @@ describe('incremental plural key injection', () => {
         const templateNode = findTemplateInPluralOther(sourceFile);
 
         expect(templateNode).toBeDefined();
+        assertDefined(templateNode, 'Expected template node in plural other');
 
-        const dotPath = TSCompilerUtils.buildDotNotationPath(templateNode as ts.Node);
+        const dotPath = TSCompilerUtils.buildDotNotationPath(templateNode);
         expect(dotPath).toBe('policyCopyChangeLog.codingRules');
+        assertDefined(dotPath, 'Expected collapsed codingRules path');
 
         const codingRulesProperty = findFirstNode(
             sourceFile,
@@ -137,9 +150,7 @@ describe('incremental plural key injection', () => {
         );
 
         expect(codingRulesProperty).toBeDefined();
-        if (!codingRulesProperty) {
-            throw new Error('Expected codingRules property');
-        }
+        assertDefined(codingRulesProperty, 'Expected codingRules property');
 
         const translatedInitializer = TSCompilerUtils.parseCodeStringToAST(
             tsPrinter.printNode(ts.EmitHint.Expression, codingRulesProperty.initializer, sourceFile).replace('merchant rules', 'translated merchant rules'),
@@ -152,7 +163,7 @@ describe('incremental plural key injection', () => {
             ),
         ]);
 
-        const injected = TSCompilerUtils.injectDeepObjectValue(targetObject, dotPath as string, translatedInitializer);
+        const injected = TSCompilerUtils.injectDeepObjectValue(targetObject, dotPath, translatedInitializer);
         const injectedText = tsPrinter.printNode(ts.EmitHint.Unspecified, injected, sourceFile);
 
         expect(injectedText).toMatch(/\(\s*\{\s*sourcePolicyName\s*\}/);
@@ -162,8 +173,8 @@ describe('incremental plural key injection', () => {
 
     it('flattens plural keys when leaf paths are injected separately', () => {
         const sourceFile = createSourceFile();
-        const oneValue = TSCompilerUtils.parseCodeStringToAST('`copied 1 translated merchant rule from ${sourcePolicyName}`');
-        const otherValue = TSCompilerUtils.parseCodeStringToAST('(count: number) => `copied ${count} translated merchant rules from ${sourcePolicyName}`');
+        const oneValue = TSCompilerUtils.parseCodeStringToAST(`\`copied 1 translated merchant rule from \${sourcePolicyName}\``);
+        const otherValue = TSCompilerUtils.parseCodeStringToAST(`(count: number) => \`copied \${count} translated merchant rules from \${sourcePolicyName}\``);
 
         let targetObject = ts.factory.createObjectLiteralExpression([ts.factory.createPropertyAssignment('policyCopyChangeLog', ts.factory.createObjectLiteralExpression([]))]);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The incremental translation path was registering plural keys at leaf paths like `codingRules.other` instead of the parent function-valued key `codingRules`. That caused `injectDeepObjectValue` to rebuild a plain `{one, other}` object and drop the `(params) => (...)` wrapper.

This PR collapses dot-notation paths at function-valued properties in `buildDotNotationPath`, and removes descendant paths after diff classification so only the parent plural key is injected.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94343
PROPOSAL: https://github.com/Expensify/App/issues/94343#issuecomment-4782114421

### Tests

1. Run `npm test -- tests/unit/scripts/TSCompilerUtils.test.ts` and confirm all 6 tests pass.
2. Verify `buildDotNotationPath` returns `policyCopyChangeLog.codingRules` (not `codingRules.other`) for strings inside plural forms.
3. Verify collapsed-path injection preserves the arrow-function wrapper and param references.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A – translation script unit tests only.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android: Native
  - [ ] Android: mWeb Chrome
  - [ ] iOS: Native
  - [ ] iOS: mWeb Safari
  - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If any new file was added I verified that:
  - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
  - [ ] A similar style doesn't already exist
  - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
  - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [ ] I verified that all the inputs inside a form are aligned with each other.
  - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A – translation script change only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A – translation script change only.

</details>

<details>
<summary>iOS: Native</summary>

N/A – translation script change only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A – translation script change only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A – translation script change only.

</details>
