### PR TITLE
Open hyperlinked reports and expenses in the RHP

### DIFF
--- a/src/libs/Navigation/reportLinkRouteParams.ts
+++ b/src/libs/Navigation/reportLinkRouteParams.ts
@@ -1,0 +1,5 @@
+const REPORT_LINK_ROUTE_PARAMS = {
+    SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP: 'shouldReplaceWithExpenseReportRHP',
+} as const;
+
+export default REPORT_LINK_ROUTE_PARAMS;

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -1,14 +1,14 @@
-import type {CommonActions, NavigationContainerRefWithCurrent, NavigationState, NavigatorScreenParams, ParamListBase, PartialRoute, PartialState, Route} from '@react-navigation/native';
-import type {TupleToUnion, ValueOf} from 'type-fest';
-import type {UpperCaseCharacters} from 'type-fest/source/internal';
 import type {MultifactorAuthenticationPromptType} from '@components/MultifactorAuthentication/config/types';
 import type {SearchQueryString} from '@components/Search/types';
+
 import type {ReplacementReason} from '@libs/actions/Card';
 import type {SaveSearchParams} from '@libs/API/parameters';
 import type {ReimbursementAccountStepToOpen} from '@libs/ReimbursementAccountUtils';
 import type {AvatarSource} from '@libs/UserAvatarUtils';
+
 import type {AttachmentModalContainerModalProps} from '@pages/media/AttachmentModalScreen/types';
 import type RECONCILIATION_ACCOUNT_SETTINGS_TYPE from '@pages/workspace/accounting/reconciliation/constants';
+
 import type {Country, EnablePaymentsPageType, EnablePaymentsSubPageType, IOUAction, IOURequestType, IOUType, OdometerImageType} from '@src/CONST';
 import type CONST from '@src/CONST';
 import type NAVIGATORS from '@src/NAVIGATORS';
@@ -19,6 +19,11 @@ import type {CompanyCardFeedWithDomainID} from '@src/types/onyx';
 import type {ConnectionName, PolicyReportFieldType, SageIntacctMappingName} from '@src/types/onyx/Policy';
 import type {CustomFieldType} from '@src/types/onyx/PolicyEmployee';
 import type {FileObject} from '@src/types/utils/Attachment';
+
+import type {CommonActions, NavigationContainerRefWithCurrent, NavigationState, NavigatorScreenParams, ParamListBase, PartialRoute, PartialState, Route} from '@react-navigation/native';
+import type {TupleToUnion, ValueOf} from 'type-fest';
+import type {UpperCaseCharacters} from 'type-fest/source/internal';
+
 import type {SIDEBAR_TO_SPLIT} from './linkingConfig/RELATIONS';
 
 type NavigationRef = NavigationContainerRefWithCurrent<RootNavigatorParamList>;

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -2683,6 +2683,7 @@ type RightModalNavigatorParamList = {
     [SCREENS.RIGHT_MODAL.SEARCH_REPORT]: {
         reportID: string;
         reportActionID?: string;
+        shouldReplaceWithExpenseReportRHP?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo?: Routes;
     };

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -17,6 +17,7 @@ import swapBackgroundTabForRHPTarget from '@libs/Navigation/helpers/swapBackgrou
 import willRouteNavigateToRHP from '@libs/Navigation/helpers/willRouteNavigateToRHP';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
+import REPORT_LINK_ROUTE_PARAMS from '@libs/Navigation/reportLinkRouteParams';
 import {getIsOffline} from '@libs/NetworkState';
 import {findLastAccessedReport, getReportIDFromLink, getReportOrDraftReport, getRouteFromLink, isMoneyRequestReport} from '@libs/ReportUtils';
 import shouldSkipDeepLinkNavigation from '@libs/shouldSkipDeepLinkNavigation';
@@ -178,12 +179,19 @@ type ReportLinkRouteParams = {
 };
 
 type NavigationRouteWithState = {
+    key?: string;
     name?: string;
     params?: unknown;
     state?: {
+        key?: string;
         index?: number;
         routes?: NavigationRouteWithState[];
     };
+};
+
+type FocusedSearchReportActionRoute = {
+    routeKey: string;
+    navigatorKey: string;
 };
 
 function isReportRoute(route: string): route is Route {
@@ -244,6 +252,19 @@ function getReportRouteParamsFromRoute(route: string): ReportLinkRouteParams | u
     }
 }
 
+function getReportLinkRouteParams(href: string, internalNewExpensifyPath: string, hasSameOrigin: boolean, hasExpensifyOrigin: boolean): ReportLinkRouteParams | undefined {
+    const legacyNewDotReportID = getLegacyNewDotReportID(href, hasExpensifyOrigin);
+    const legacyNewDotReportRouteParams: ReportLinkRouteParams | undefined = legacyNewDotReportID
+        ? {
+              reportID: legacyNewDotReportID,
+              route: ROUTES.REPORT_WITH_ID.getRoute(legacyNewDotReportID),
+          }
+        : undefined;
+    const internalNewExpensifyReportRouteParams = internalNewExpensifyPath && hasSameOrigin ? getReportRouteParamsFromRoute(internalNewExpensifyPath) : undefined;
+
+    return legacyNewDotReportRouteParams ?? internalNewExpensifyReportRouteParams;
+}
+
 function getFocusedRoute(route: NavigationRouteWithState | undefined): NavigationRouteWithState | undefined {
     let focusedRoute = route;
     while (focusedRoute?.state?.routes?.length) {
@@ -286,25 +307,42 @@ function isFocusedCentralReport(reportID: string, currentState: ReturnType<typeo
     return getReportRouteParamValues(focusedRoute.params)?.reportID === reportID;
 }
 
+function getFocusedSearchReportActionRoute(
+    reportRouteParams: ReportLinkRouteParams | undefined,
+    currentState: ReturnType<typeof navigationRef.getRootState>,
+): FocusedSearchReportActionRoute | undefined {
+    if (!reportRouteParams?.reportActionID) {
+        return;
+    }
+
+    const focusedRootRoute = currentState?.routes?.at(currentState.index ?? (currentState.routes.length ? currentState.routes.length - 1 : -1)) as NavigationRouteWithState | undefined;
+    if (focusedRootRoute?.name !== NAVIGATORS.RIGHT_MODAL_NAVIGATOR) {
+        return;
+    }
+
+    const rhpState = focusedRootRoute.state;
+    const focusedRHPRoute = rhpState?.routes?.at(rhpState.index ?? (rhpState.routes.length ? rhpState.routes.length - 1 : -1));
+    if (focusedRHPRoute?.name !== SCREENS.RIGHT_MODAL.SEARCH_REPORT || !focusedRHPRoute.key || !rhpState?.key) {
+        return;
+    }
+
+    const focusedRHPReportParams = getReportRouteParamValues(focusedRHPRoute.params);
+    if (focusedRHPReportParams?.reportID !== reportRouteParams.reportID) {
+        return;
+    }
+
+    return {
+        routeKey: focusedRHPRoute.key,
+        navigatorKey: rhpState.key,
+    };
+}
+
 function getReportLinkRoute(
-    href: string,
-    internalNewExpensifyPath: string,
-    hasSameOrigin: boolean,
-    hasExpensifyOrigin: boolean,
+    reportRouteParams: ReportLinkRouteParams | undefined,
     isNarrowLayout: boolean,
     currentState: ReturnType<typeof navigationRef.getRootState>,
     shouldKeepReportRoute = false,
 ): Route | undefined {
-    const legacyNewDotReportID = getLegacyNewDotReportID(href, hasExpensifyOrigin);
-    const legacyNewDotReportRouteParams: ReportLinkRouteParams | undefined = legacyNewDotReportID
-        ? {
-              reportID: legacyNewDotReportID,
-              route: ROUTES.REPORT_WITH_ID.getRoute(legacyNewDotReportID),
-          }
-        : undefined;
-    const internalNewExpensifyReportRouteParams = internalNewExpensifyPath && hasSameOrigin ? getReportRouteParamsFromRoute(internalNewExpensifyPath) : undefined;
-    const reportRouteParams = legacyNewDotReportRouteParams ?? internalNewExpensifyReportRouteParams;
-
     if (!reportRouteParams) {
         return;
     }
@@ -314,24 +352,22 @@ function getReportLinkRoute(
     }
 
     const backTo = Navigation.getActiveRoute();
-    if (reportRouteParams.reportActionID) {
-        return ROUTES.SEARCH_REPORT.getRoute({
-            reportID: reportRouteParams.reportID,
-            reportActionID: reportRouteParams.reportActionID,
-            backTo,
-        });
-    }
-
     const report = getReportOrDraftReport(reportRouteParams.reportID);
-    if (isMoneyRequestReport(report)) {
+    if (!reportRouteParams.reportActionID && isMoneyRequestReport(report)) {
         return ROUTES.EXPENSE_REPORT_RHP.getRoute({reportID: reportRouteParams.reportID, backTo});
     }
 
-    return ROUTES.SEARCH_REPORT.getRoute({
+    const searchReportRoute = ROUTES.SEARCH_REPORT.getRoute({
         reportID: reportRouteParams.reportID,
         reportActionID: reportRouteParams.reportActionID,
         backTo,
     });
+
+    if (!report && !reportRouteParams.reportActionID) {
+        return Url.appendParam(searchReportRoute, REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP, 'true');
+    }
+
+    return searchReportRoute;
 }
 
 function openLink(href: string, environmentURL: string, isAttachment = false) {
@@ -342,11 +378,13 @@ function openLink(href: string, environmentURL: string, isAttachment = false) {
 
     const isNarrowLayout = getIsNarrowLayout();
     const currentState = navigationRef.getRootState();
-    const reportLinkRoute = getReportLinkRoute(href, internalNewExpensifyPath, hasSameOrigin, hasExpensifyOrigin, isNarrowLayout, currentState, isAnonymousUser());
+    const reportLinkRouteParams = getReportLinkRouteParams(href, internalNewExpensifyPath, hasSameOrigin, hasExpensifyOrigin);
+    const reportLinkRoute = getReportLinkRoute(reportLinkRouteParams, isNarrowLayout, currentState, isAnonymousUser());
+    const focusedSearchReportActionRoute = getFocusedSearchReportActionRoute(reportLinkRouteParams, currentState);
     const routeToNavigate = reportLinkRoute ?? internalNewExpensifyPath;
     const isRHPOpen = currentState?.routes?.at(-1)?.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR;
     let shouldCloseRHP = false;
-    if (!isNarrowLayout && isRHPOpen) {
+    if (!isNarrowLayout && isRHPOpen && !focusedSearchReportActionRoute) {
         const targetWillNavigateToRHP = willRouteNavigateToRHP(routeToNavigate as Route);
         if (!targetWillNavigateToRHP) {
             shouldCloseRHP = true;
@@ -361,6 +399,10 @@ function openLink(href: string, environmentURL: string, isAttachment = false) {
     if (reportLinkRoute) {
         if (internalNewExpensifyPath && hasSameOrigin && isAnonymousUser() && !canAnonymousUserAccessRoute(internalNewExpensifyPath)) {
             signOutAndRedirectToSignIn();
+            return;
+        }
+        if (focusedSearchReportActionRoute && reportLinkRouteParams?.reportActionID) {
+            Navigation.setParams({reportActionID: reportLinkRouteParams.reportActionID}, focusedSearchReportActionRoute.routeKey, focusedSearchReportActionRoute.navigatorKey);
             return;
         }
         if (shouldCloseRHP) {

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -9,6 +9,7 @@ import * as Environment from '@libs/Environment/Environment';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import isPublicScreenRoute from '@libs/isPublicScreenRoute';
 import Log from '@libs/Log';
+import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
 import {isOnboardingFlowName} from '@libs/Navigation/helpers/isNavigatorName';
 import normalizePath from '@libs/Navigation/helpers/normalizePath';
 import shouldOpenOnAdminRoom from '@libs/Navigation/helpers/shouldOpenOnAdminRoom';
@@ -17,7 +18,7 @@ import willRouteNavigateToRHP from '@libs/Navigation/helpers/willRouteNavigateTo
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
 import {getIsOffline} from '@libs/NetworkState';
-import {findLastAccessedReport, getReportIDFromLink, getRouteFromLink} from '@libs/ReportUtils';
+import {findLastAccessedReport, getReportIDFromLink, getReportOrDraftReport, getRouteFromLink, isMoneyRequestReport} from '@libs/ReportUtils';
 import shouldSkipDeepLinkNavigation from '@libs/shouldSkipDeepLinkNavigation';
 import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 import * as Url from '@libs/Url';
@@ -170,6 +171,169 @@ function getInternalExpensifyPath(href: string) {
     return attrPath;
 }
 
+type ReportLinkRouteParams = {
+    reportID: string;
+    reportActionID?: string;
+    route: Route;
+};
+
+type NavigationRouteWithState = {
+    name?: string;
+    params?: unknown;
+    state?: {
+        index?: number;
+        routes?: NavigationRouteWithState[];
+    };
+};
+
+function isReportRoute(route: string): route is Route {
+    return route.startsWith(addTrailingForwardSlash(ROUTES.REPORT));
+}
+
+function getReportRouteParamValues(params: unknown): {reportID: string; reportActionID?: string} | undefined {
+    if (!params || typeof params !== 'object' || !('reportID' in params) || typeof params.reportID !== 'string') {
+        return;
+    }
+
+    const reportActionID = 'reportActionID' in params && typeof params.reportActionID === 'string' ? params.reportActionID : undefined;
+    return {reportID: params.reportID, reportActionID};
+}
+
+function getLegacyNewDotReportID(href: string, hasExpensifyOrigin: boolean): string | undefined {
+    if (!hasExpensifyOrigin || !href.includes('newdotreport?reportID=')) {
+        return;
+    }
+
+    try {
+        return new URL(href).searchParams.get('reportID') ?? undefined;
+    } catch {
+        return href.split('newdotreport?reportID=').pop()?.split(/[&#]/).at(0);
+    }
+}
+
+function getReportRouteParamsFromRoute(route: string): ReportLinkRouteParams | undefined {
+    const normalizedRoute = route.startsWith('/') ? route.slice(1) : route;
+    if (!isReportRoute(normalizedRoute)) {
+        return;
+    }
+
+    const reportID = getReportIDFromLink(normalizedRoute);
+    if (!reportID) {
+        return;
+    }
+
+    try {
+        const state = getStateFromPath(normalizedRoute);
+        const focusedRoute = findFocusedRoute(state);
+        if (focusedRoute?.name !== SCREENS.REPORT) {
+            return;
+        }
+
+        const params = getReportRouteParamValues(focusedRoute.params);
+        if (!params) {
+            return;
+        }
+
+        return {
+            reportID: params.reportID,
+            reportActionID: params.reportActionID,
+            route: normalizedRoute,
+        };
+    } catch {
+        return undefined;
+    }
+}
+
+function getFocusedRoute(route: NavigationRouteWithState | undefined): NavigationRouteWithState | undefined {
+    let focusedRoute = route;
+    while (focusedRoute?.state?.routes?.length) {
+        const {routes, index} = focusedRoute.state;
+        focusedRoute = routes.at(index ?? routes.length - 1);
+    }
+
+    return focusedRoute;
+}
+
+function getFocusedCentralReportRoute(currentState: ReturnType<typeof navigationRef.getRootState>): NavigationRouteWithState | undefined {
+    const rootRoutes = currentState?.routes as NavigationRouteWithState[] | undefined;
+    const focusedRootIndex = currentState?.index ?? (rootRoutes?.length ?? 0) - 1;
+    const focusedRootRoute = focusedRootIndex >= 0 ? rootRoutes?.at(focusedRootIndex) : undefined;
+    const focusedRoute = getFocusedRoute(focusedRootRoute);
+    if (focusedRoute?.name === SCREENS.REPORT) {
+        return focusedRoute;
+    }
+
+    if (focusedRootRoute?.name !== NAVIGATORS.RIGHT_MODAL_NAVIGATOR) {
+        return;
+    }
+
+    const tabNavigatorRoute = rootRoutes?.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
+    const tabState = tabNavigatorRoute?.state;
+    const activeTabRoute = tabState?.routes?.at(tabState.index ?? 0);
+    if (activeTabRoute?.name !== NAVIGATORS.REPORTS_SPLIT_NAVIGATOR) {
+        return;
+    }
+
+    return getFocusedRoute(activeTabRoute);
+}
+
+function isFocusedCentralReport(reportID: string, currentState: ReturnType<typeof navigationRef.getRootState>): boolean {
+    const focusedRoute = getFocusedCentralReportRoute(currentState);
+    if (focusedRoute?.name !== SCREENS.REPORT) {
+        return false;
+    }
+
+    return getReportRouteParamValues(focusedRoute.params)?.reportID === reportID;
+}
+
+function getReportLinkRoute(
+    href: string,
+    internalNewExpensifyPath: string,
+    hasSameOrigin: boolean,
+    hasExpensifyOrigin: boolean,
+    isNarrowLayout: boolean,
+    currentState: ReturnType<typeof navigationRef.getRootState>,
+    shouldKeepReportRoute = false,
+): Route | undefined {
+    const legacyNewDotReportID = getLegacyNewDotReportID(href, hasExpensifyOrigin);
+    const legacyNewDotReportRouteParams: ReportLinkRouteParams | undefined = legacyNewDotReportID
+        ? {
+              reportID: legacyNewDotReportID,
+              route: ROUTES.REPORT_WITH_ID.getRoute(legacyNewDotReportID),
+          }
+        : undefined;
+    const internalNewExpensifyReportRouteParams = internalNewExpensifyPath && hasSameOrigin ? getReportRouteParamsFromRoute(internalNewExpensifyPath) : undefined;
+    const reportRouteParams = legacyNewDotReportRouteParams ?? internalNewExpensifyReportRouteParams;
+
+    if (!reportRouteParams) {
+        return;
+    }
+
+    if (shouldKeepReportRoute || isNarrowLayout || isFocusedCentralReport(reportRouteParams.reportID, currentState)) {
+        return reportRouteParams.route;
+    }
+
+    const backTo = Navigation.getActiveRoute();
+    if (reportRouteParams.reportActionID) {
+        return ROUTES.SEARCH_REPORT.getRoute({
+            reportID: reportRouteParams.reportID,
+            reportActionID: reportRouteParams.reportActionID,
+            backTo,
+        });
+    }
+
+    const report = getReportOrDraftReport(reportRouteParams.reportID);
+    if (isMoneyRequestReport(report)) {
+        return ROUTES.EXPENSE_REPORT_RHP.getRoute({reportID: reportRouteParams.reportID, backTo});
+    }
+
+    return ROUTES.SEARCH_REPORT.getRoute({
+        reportID: reportRouteParams.reportID,
+        reportActionID: reportRouteParams.reportActionID,
+        backTo,
+    });
+}
+
 function openLink(href: string, environmentURL: string, isAttachment = false) {
     const hasSameOrigin = Url.hasSameExpensifyOrigin(href, environmentURL);
     const hasExpensifyOrigin = Url.hasSameExpensifyOrigin(href, CONFIG.EXPENSIFY.EXPENSIFY_URL) || Url.hasSameExpensifyOrigin(href, CONFIG.EXPENSIFY.STAGING_API_ROOT);
@@ -178,32 +342,31 @@ function openLink(href: string, environmentURL: string, isAttachment = false) {
 
     const isNarrowLayout = getIsNarrowLayout();
     const currentState = navigationRef.getRootState();
+    const reportLinkRoute = getReportLinkRoute(href, internalNewExpensifyPath, hasSameOrigin, hasExpensifyOrigin, isNarrowLayout, currentState, isAnonymousUser());
+    const routeToNavigate = reportLinkRoute ?? internalNewExpensifyPath;
     const isRHPOpen = currentState?.routes?.at(-1)?.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR;
     let shouldCloseRHP = false;
     if (!isNarrowLayout && isRHPOpen) {
-        const targetWillNavigateToRHP = willRouteNavigateToRHP(internalNewExpensifyPath as Route);
+        const targetWillNavigateToRHP = willRouteNavigateToRHP(routeToNavigate as Route);
         if (!targetWillNavigateToRHP) {
             shouldCloseRHP = true;
         } else if (hasSameOrigin) {
             // Cross-tab RHP→RHP: swap the background tab in place so the RHP stays mounted and the
             // user sees only the RHP content update + the underlying tab animate, no close+reopen
             // flicker (issue: https://github.com/Expensify/App/issues/89710).
-            swapBackgroundTabForRHPTarget(currentState, internalNewExpensifyPath as Route);
+            swapBackgroundTabForRHPTarget(currentState, routeToNavigate as Route);
         }
     }
 
-    // There can be messages from Concierge with links to specific NewDot reports. Those URLs look like this:
-    // https://www.expensify.com.dev/newdotreport?reportID=3429600449838908 and they have a target="_blank" attribute. This is so that when a user is on OldDot,
-    // clicking on the link will open the chat in NewDot. However, when a user is in NewDot and clicks on the concierge link, the link needs to be handled differently.
-    // Normally, the link would be sent to Link.openOldDotLink() and opened in a new tab, and that's jarring to the user. Since the intention is to link to a specific NewDot chat,
-    // the reportID is extracted from the URL and then opened as an internal link, taking the user straight to the chat in the same tab.
-    if (hasExpensifyOrigin && href.indexOf('newdotreport?reportID=') > -1) {
-        const reportID = href.split('newdotreport?reportID=').pop();
-        const reportRoute = ROUTES.REPORT_WITH_ID.getRoute(reportID);
+    if (reportLinkRoute) {
+        if (internalNewExpensifyPath && hasSameOrigin && isAnonymousUser() && !canAnonymousUserAccessRoute(internalNewExpensifyPath)) {
+            signOutAndRedirectToSignIn();
+            return;
+        }
         if (shouldCloseRHP) {
             Navigation.closeRHPFlow();
         }
-        Navigation.navigate(reportRoute);
+        Navigation.navigate(reportLinkRoute);
         return;
     }
 

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -1,6 +1,3 @@
-import {findFocusedRoute} from '@react-navigation/native';
-import Onyx from 'react-native-onyx';
-import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import * as API from '@libs/API';
 import type {GenerateSpotnanaTokenParams} from '@libs/API/parameters';
 import {SIDE_EFFECT_REQUEST_COMMANDS} from '@libs/API/types';
@@ -24,6 +21,7 @@ import shouldSkipDeepLinkNavigation from '@libs/shouldSkipDeepLinkNavigation';
 import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 import * as Url from '@libs/Url';
 import addTrailingForwardSlash from '@libs/UrlUtils';
+
 import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
@@ -33,6 +31,12 @@ import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import {hasCompletedGuidedSetupFlowSelector} from '@src/selectors/Onboarding';
 import type {Beta, IntroSelected, Report} from '@src/types/onyx';
+
+import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
+
+import {findFocusedRoute} from '@react-navigation/native';
+import Onyx from 'react-native-onyx';
+
 import {doneCheckingPublicRoom, navigateToConciergeChat, openReport} from './Report';
 import {canAnonymousUserAccessRoute, isAnonymousUser, signOutAndRedirectToSignIn, waitForUserSignIn} from './Session';
 import {setOnboardingErrorMessage} from './Welcome';

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -180,6 +180,7 @@ type ReportLinkRouteParams = {
     reportID: string;
     reportActionID?: string;
     route: Route;
+    isLegacyNewDotReportLink?: boolean;
 };
 
 type NavigationRouteWithState = {
@@ -262,6 +263,7 @@ function getReportLinkRouteParams(href: string, internalNewExpensifyPath: string
         ? {
               reportID: legacyNewDotReportID,
               route: ROUTES.REPORT_WITH_ID.getRoute(legacyNewDotReportID),
+              isLegacyNewDotReportLink: true,
           }
         : undefined;
     const internalNewExpensifyReportRouteParams = internalNewExpensifyPath && hasSameOrigin ? getReportRouteParamsFromRoute(internalNewExpensifyPath) : undefined;
@@ -351,7 +353,16 @@ function getReportLinkRoute(
         return;
     }
 
-    if (shouldKeepReportRoute || isNarrowLayout || isFocusedCentralReport(reportRouteParams.reportID, currentState)) {
+    // On narrow layouts (e.g. mobile web) the RHP is full-screen, so preserving the background Inbox does not apply
+    // and report links are kept on the standard navigation as a safeguard. Regular internal report links return
+    // undefined so they fall through to the standard internal-link handling, exactly as before this feature. Legacy
+    // Concierge (`newdotreport`) links have no parseable internal path, so they keep the explicit report route to
+    // stay on the pre-existing internal navigation instead of falling back to OldDot link handling.
+    if (isNarrowLayout) {
+        return reportRouteParams.isLegacyNewDotReportLink ? reportRouteParams.route : undefined;
+    }
+
+    if (shouldKeepReportRoute || isFocusedCentralReport(reportRouteParams.reportID, currentState)) {
         return reportRouteParams.route;
     }
 

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -356,8 +356,8 @@ function getReportLinkRoute(
     // On narrow layouts (e.g. mobile web) the RHP is full-screen, so preserving the background Inbox does not apply
     // and report links are kept on the standard navigation as a safeguard. Regular internal report links return
     // undefined so they fall through to the standard internal-link handling, exactly as before this feature. Legacy
-    // Concierge (`newdotreport`) links have no parseable internal path, so they keep the explicit report route to
-    // stay on the pre-existing internal navigation instead of falling back to OldDot link handling.
+    // Concierge (`newdotreport`) links have no internal path that can be parsed, so they keep the explicit report
+    // route to stay on the pre-existing internal navigation instead of falling back to OldDot link handling.
     if (isNarrowLayout) {
         return reportRouteParams.isLegacyNewDotReportLink ? reportRouteParams.route : undefined;
     }

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -1,5 +1,3 @@
-import {useIsFocused, useNavigation, useRoute} from '@react-navigation/native';
-import {useEffect, useEffectEvent, useRef} from 'react';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useIsAnonymousUser from '@hooks/useIsAnonymousUser';
 import useIsInSidePanel from '@hooks/useIsInSidePanel';
@@ -11,6 +9,7 @@ import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
 import usePrevious from '@hooks/usePrevious';
 import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
+
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
 import Navigation from '@libs/Navigation/Navigation';
@@ -31,7 +30,9 @@ import {
     isThread,
     isValidReportIDFromPath,
 } from '@libs/ReportUtils';
+
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+
 import {
     clearStaleDMRecoveryTargetByTargetReportID,
     createTransactionThreadReport,
@@ -43,11 +44,15 @@ import {
     updateLastVisitTime,
     updateLoadingInitialReportAction,
 } from '@userActions/Report';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Transaction} from '@src/types/onyx';
+
+import {useIsFocused, useNavigation, useRoute} from '@react-navigation/native';
+import {useEffect, useEffectEvent, useRef} from 'react';
 
 type ReportScreenRoute =
     | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
@@ -76,8 +81,7 @@ function ReportFetchHandler() {
     const route = useRoute<ReportScreenRoute>();
     const reportIDFromRoute = getNonEmptyStringOnyxID(route.params?.reportID);
     const reportActionIDFromRoute = route?.params?.reportActionID;
-    const shouldReplaceWithExpenseReportRHP =
-        route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT && route.params?.[REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP] === 'true';
+    const shouldReplaceWithExpenseReportRHP = route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT && route.params?.[REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP] === 'true';
 
     const navigation = useNavigation();
     const isFocused = useIsFocused();

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -13,13 +13,16 @@ import useReportTransactionsCollection from '@hooks/useReportTransactionsCollect
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
+import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
+import REPORT_LINK_ROUTE_PARAMS from '@libs/Navigation/reportLinkRouteParams';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import type {CancelHandle} from '@libs/Navigation/TransitionTracker';
 import {getFilteredReportActionsForReportView, getIOUActionForReportID, getOneTransactionThreadReportID, isCreatedAction} from '@libs/ReportActionsUtils';
 import {
     isChatThread,
     isHiddenForCurrentUser,
+    isMoneyRequestReport,
     isOneTransactionThread,
     isPolicyExpenseChat,
     isPublicRoom,
@@ -42,6 +45,7 @@ import {
 } from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Transaction} from '@src/types/onyx';
 
@@ -72,6 +76,8 @@ function ReportFetchHandler() {
     const route = useRoute<ReportScreenRoute>();
     const reportIDFromRoute = getNonEmptyStringOnyxID(route.params?.reportID);
     const reportActionIDFromRoute = route?.params?.reportActionID;
+    const shouldReplaceWithExpenseReportRHP =
+        route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT && route.params?.[REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP] === 'true';
 
     const navigation = useNavigation();
     const isFocused = useIsFocused();
@@ -296,6 +302,19 @@ function ReportFetchHandler() {
         }
         updateLoadingInitialReportAction(reportIDFromRoute, true);
     }, [reportIDFromRoute, reportLoadingState.hasOnceLoadedReportActions]);
+
+    useEffect(() => {
+        if (!shouldReplaceWithExpenseReportRHP || !report || !reportIDFromRoute) {
+            return;
+        }
+
+        if (!isMoneyRequestReport(report)) {
+            Navigation.setParams({[REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP]: undefined});
+            return;
+        }
+
+        Navigation.navigate(ROUTES.EXPENSE_REPORT_RHP.getRoute({reportID: reportIDFromRoute, backTo: route.params?.backTo}), {forceReplace: true});
+    }, [report, reportIDFromRoute, route.params?.backTo, shouldReplaceWithExpenseReportRHP]);
 
     useEffect(() => {
         // This function is triggered when a user clicks on a link to navigate to a report.

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -308,20 +308,16 @@ function ReportFetchHandler() {
     }, [reportIDFromRoute, reportLoadingState.hasOnceLoadedReportActions]);
 
     useEffect(() => {
-        if (!shouldReplaceWithExpenseReportRHP || !report || !reportIDFromRoute) {
+        // Both `Navigation.setParams` and `forceReplace` below act on the currently focused route, but this effect
+        // can fire late (after a slow `OpenReport`) while this SearchReport RHP has been blurred but is still mounted.
+        // Bail while blurred so we never clear the flag on, or replace, whatever route the user has since navigated
+        // to; the effect re-runs if focus returns to this screen.
+        if (!shouldReplaceWithExpenseReportRHP || !report || !reportIDFromRoute || !isFocused) {
             return;
         }
 
         if (!isMoneyRequestReport(report)) {
             Navigation.setParams({[REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP]: undefined});
-            return;
-        }
-
-        // `forceReplace` replaces whatever route is currently focused. This effect can fire late (after a slow
-        // `OpenReport` resolves the report as a money request) while this SearchReport RHP has been blurred but is
-        // still mounted, which would replace the route the user has since navigated to. Only replace while focused;
-        // the effect re-runs if focus returns to this screen.
-        if (!isFocused) {
             return;
         }
 

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -317,8 +317,16 @@ function ReportFetchHandler() {
             return;
         }
 
+        // `forceReplace` replaces whatever route is currently focused. This effect can fire late (after a slow
+        // `OpenReport` resolves the report as a money request) while this SearchReport RHP has been blurred but is
+        // still mounted, which would replace the route the user has since navigated to. Only replace while focused;
+        // the effect re-runs if focus returns to this screen.
+        if (!isFocused) {
+            return;
+        }
+
         Navigation.navigate(ROUTES.EXPENSE_REPORT_RHP.getRoute({reportID: reportIDFromRoute, backTo: route.params?.backTo}), {forceReplace: true});
-    }, [report, reportIDFromRoute, route.params?.backTo, shouldReplaceWithExpenseReportRHP]);
+    }, [isFocused, report, reportIDFromRoute, route.params?.backTo, shouldReplaceWithExpenseReportRHP]);
 
     useEffect(() => {
         // This function is triggered when a user clicks on a link to navigate to a report.

--- a/tests/unit/LinkTest.ts
+++ b/tests/unit/LinkTest.ts
@@ -223,12 +223,35 @@ describe('Link.openLink', () => {
         );
     });
 
-    it('keeps report links as full-screen report routes on narrow layout', () => {
+    it('keeps report links on the standard full-screen navigation on narrow layout', () => {
         mockedGetIsNarrowLayout.mockReturnValue(true);
 
         openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/123456789`, environmentURL);
 
-        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('regular-report', '123456789'));
+        // On narrow layouts the report-link RHP handling does not apply; the link falls through to the standard
+        // internal-link handling and navigates exactly as it did before this feature.
+        expect(Navigation.navigate).toHaveBeenCalledWith('/r/regular-report/123456789');
+    });
+
+    it('keeps legacy Concierge report links navigating internally on narrow layout', () => {
+        mockedGetIsNarrowLayout.mockReturnValue(true);
+
+        openLink(`${CONFIG.EXPENSIFY.EXPENSIFY_URL}/newdotreport?reportID=legacy-report`, environmentURL);
+
+        // Legacy `newdotreport` links have no parseable internal path, so on narrow layouts they must keep the
+        // explicit report navigation instead of falling back to OldDot link handling.
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('legacy-report'));
+    });
+
+    it('does not update the focused RHP report action on narrow layout and keeps the standard navigation', () => {
+        mockedGetIsNarrowLayout.mockReturnValue(true);
+        mockedNavigationRef.getRootState.mockReturnValue(buildRootState({isRHPOpen: true, rhpReportID: 'regular-report', rhpReportActionID: '123456789'}));
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/987654321`, environmentURL);
+
+        expect(Navigation.setParams).not.toHaveBeenCalled();
+        expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalledWith('/r/regular-report/987654321');
     });
 
     it('keeps report links as full-screen report routes for anonymous users on wide layout', () => {

--- a/tests/unit/LinkTest.ts
+++ b/tests/unit/LinkTest.ts
@@ -1,0 +1,282 @@
+import type {NavigationState} from '@react-navigation/native';
+import {canAnonymousUserAccessRoute, isAnonymousUser} from '@libs/actions/Session';
+import getIsNarrowLayout from '@libs/getIsNarrowLayout';
+import Navigation from '@libs/Navigation/Navigation';
+import navigationRef from '@libs/Navigation/navigationRef';
+import CONFIG from '@src/CONFIG';
+import CONST from '@src/CONST';
+import {openLink} from '@src/libs/actions/Link';
+import NAVIGATORS from '@src/NAVIGATORS';
+import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
+
+const mockReports: Record<string, {isMoneyRequest?: boolean}> = {};
+type ReportUtilsMock = Record<string, unknown> & {
+    getReportOrDraftReport: (reportID: string) => {isMoneyRequest?: boolean} | undefined;
+    isMoneyRequestReport: (report: {isMoneyRequest?: boolean} | undefined) => boolean;
+};
+
+jest.mock('@libs/getIsNarrowLayout', () => jest.fn());
+jest.mock('@libs/Navigation/helpers/swapBackgroundTabForRHPTarget', () => jest.fn());
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    __esModule: true,
+    default: {
+        getRootState: jest.fn(),
+    },
+}));
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    default: {
+        closeRHPFlow: jest.fn(),
+        getActiveRoute: jest.fn(),
+        navigate: jest.fn(),
+    },
+}));
+jest.mock('@libs/actions/Session', () => ({
+    canAnonymousUserAccessRoute: jest.fn(() => true),
+    isAnonymousUser: jest.fn(() => false),
+    signOutAndRedirectToSignIn: jest.fn(),
+    waitForUserSignIn: jest.fn(),
+}));
+jest.mock('@libs/ReportUtils', () => {
+    const actual = jest.requireActual<ReportUtilsMock>('@libs/ReportUtils');
+
+    return {
+        ...actual,
+        getReportOrDraftReport: jest.fn((reportID: string) => mockReports[reportID]),
+        isMoneyRequestReport: jest.fn((report: {isMoneyRequest?: boolean} | undefined) => !!report?.isMoneyRequest),
+    };
+});
+
+const mockedGetIsNarrowLayout = jest.mocked(getIsNarrowLayout);
+const mockedNavigation = jest.mocked(Navigation);
+const mockedNavigationRef = jest.mocked(navigationRef);
+const mockedCanAnonymousUserAccessRoute = jest.mocked(canAnonymousUserAccessRoute);
+const mockedIsAnonymousUser = jest.mocked(isAnonymousUser);
+
+function buildNavigationState(key: string, routes: NavigationState['routes'], index = routes.length - 1): NavigationState {
+    return {
+        stale: false,
+        type: 'stack',
+        key,
+        index,
+        routeNames: routes.map((route) => route.name),
+        routes,
+    };
+}
+
+function buildRootState({
+    centralReportID = 'current-report',
+    activeTab = NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+    isRHPOpen = false,
+    focusedRootNavigator,
+}: {centralReportID?: string; activeTab?: string; isRHPOpen?: boolean; focusedRootNavigator?: string} = {}) {
+    const tabRoutes: NavigationState['routes'] = [
+        {
+            key: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+            name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+            state: buildNavigationState(`${NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}-state`, [
+                {
+                    key: `${SCREENS.REPORT}-${centralReportID}`,
+                    name: SCREENS.REPORT,
+                    params: {reportID: centralReportID},
+                },
+            ]),
+        },
+    ];
+    if (activeTab !== NAVIGATORS.REPORTS_SPLIT_NAVIGATOR) {
+        tabRoutes.push({
+            key: activeTab,
+            name: activeTab,
+            state: buildNavigationState(`${activeTab}-state`, [
+                {
+                    key: activeTab,
+                    name: activeTab,
+                },
+            ]),
+        });
+    }
+
+    const routes: NavigationState['routes'] = [
+        {
+            key: NAVIGATORS.TAB_NAVIGATOR,
+            name: NAVIGATORS.TAB_NAVIGATOR,
+            state: buildNavigationState(`${NAVIGATORS.TAB_NAVIGATOR}-state`, tabRoutes, activeTab === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR ? 0 : 1),
+        },
+    ];
+
+    if (isRHPOpen) {
+        routes.push({
+            key: NAVIGATORS.RIGHT_MODAL_NAVIGATOR,
+            name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR,
+            state: buildNavigationState(`${NAVIGATORS.RIGHT_MODAL_NAVIGATOR}-state`, [
+                {
+                    key: `${SCREENS.RIGHT_MODAL.SEARCH_REPORT}-rhp-report`,
+                    name: SCREENS.RIGHT_MODAL.SEARCH_REPORT,
+                    params: {reportID: 'rhp-report'},
+                },
+            ]),
+        });
+    }
+
+    if (focusedRootNavigator) {
+        routes.push({
+            key: focusedRootNavigator,
+            name: focusedRootNavigator,
+            state: buildNavigationState(`${focusedRootNavigator}-state`, [
+                {
+                    key: focusedRootNavigator,
+                    name: focusedRootNavigator,
+                },
+            ]),
+        });
+    }
+
+    return buildNavigationState('root', routes);
+}
+
+describe('Link.openLink', () => {
+    const environmentURL = CONST.NEW_EXPENSIFY_URL;
+    const activeRoute = ROUTES.REPORT_WITH_ID.getRoute('current-report');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        for (const reportID of Object.keys(mockReports)) {
+            delete mockReports[reportID];
+        }
+        mockedGetIsNarrowLayout.mockReturnValue(false);
+        mockedCanAnonymousUserAccessRoute.mockReturnValue(true);
+        mockedIsAnonymousUser.mockReturnValue(false);
+        mockedNavigation.getActiveRoute.mockReturnValue(activeRoute);
+        mockedNavigationRef.getRootState.mockReturnValue(buildRootState());
+    });
+
+    it('opens a regular report link in the RHP on wide layout and preserves the report action', () => {
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/123456789`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(
+            ROUTES.SEARCH_REPORT.getRoute({
+                reportID: 'regular-report',
+                reportActionID: '123456789',
+                backTo: activeRoute,
+            }),
+        );
+        expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
+    });
+
+    it('opens an expense report link in the expense RHP on wide layout', () => {
+        mockReports['expense-report'] = {isMoneyRequest: true};
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/expense-report`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.EXPENSE_REPORT_RHP.getRoute({reportID: 'expense-report', backTo: activeRoute}));
+    });
+
+    it('opens expense report action links in the report RHP so the linked action is preserved', () => {
+        mockReports['expense-report'] = {isMoneyRequest: true};
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/expense-report/123456789`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(
+            ROUTES.SEARCH_REPORT.getRoute({
+                reportID: 'expense-report',
+                reportActionID: '123456789',
+                backTo: activeRoute,
+            }),
+        );
+    });
+
+    it('opens legacy Concierge report links in the RHP on wide layout', () => {
+        openLink(`${CONFIG.EXPENSIFY.EXPENSIFY_URL}/newdotreport?reportID=legacy-report`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(
+            ROUTES.SEARCH_REPORT.getRoute({
+                reportID: 'legacy-report',
+                backTo: activeRoute,
+            }),
+        );
+    });
+
+    it('keeps report links as full-screen report routes on narrow layout', () => {
+        mockedGetIsNarrowLayout.mockReturnValue(true);
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/123456789`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('regular-report', '123456789'));
+    });
+
+    it('keeps report links as full-screen report routes for anonymous users on wide layout', () => {
+        mockedIsAnonymousUser.mockReturnValue(true);
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/123456789`, environmentURL);
+
+        expect(mockedCanAnonymousUserAccessRoute).toHaveBeenCalledWith('/r/regular-report/123456789');
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('regular-report', '123456789'));
+    });
+
+    it('keeps legacy Concierge report links as full-screen report routes for anonymous users on wide layout', () => {
+        mockedIsAnonymousUser.mockReturnValue(true);
+
+        openLink(`${CONFIG.EXPENSIFY.EXPENSIFY_URL}/newdotreport?reportID=legacy-report`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('legacy-report'));
+    });
+
+    it('closes an open RHP and navigates the central report when the linked report is already focused behind the RHP', () => {
+        mockedNavigationRef.getRootState.mockReturnValue(buildRootState({centralReportID: 'regular-report', isRHPOpen: true}));
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/123456789`, environmentURL);
+
+        expect(Navigation.closeRHPFlow).toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('regular-report', '123456789'));
+    });
+
+    it('opens an RHP when the target report exists in a stale inactive Reports tab', () => {
+        mockedNavigationRef.getRootState.mockReturnValue(buildRootState({centralReportID: 'regular-report', activeTab: SCREENS.HOME}));
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/123456789`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(
+            ROUTES.SEARCH_REPORT.getRoute({
+                reportID: 'regular-report',
+                reportActionID: '123456789',
+                backTo: activeRoute,
+            }),
+        );
+    });
+
+    it('opens an RHP when a non-RHP root route is focused over the target report', () => {
+        mockedNavigationRef.getRootState.mockReturnValue(buildRootState({centralReportID: 'regular-report', focusedRootNavigator: NAVIGATORS.ONBOARDING_MODAL_NAVIGATOR}));
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/123456789`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(
+            ROUTES.SEARCH_REPORT.getRoute({
+                reportID: 'regular-report',
+                reportActionID: '123456789',
+                backTo: activeRoute,
+            }),
+        );
+        expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
+    });
+
+    it('does not rewrite report subroutes', () => {
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/details`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith('/r/regular-report/details');
+    });
+
+    it('uses the resolved RHP route before deciding whether to close an existing RHP', () => {
+        mockedNavigationRef.getRootState.mockReturnValue(buildRootState({isRHPOpen: true}));
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report`, environmentURL);
+
+        expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalledWith(
+            ROUTES.SEARCH_REPORT.getRoute({
+                reportID: 'regular-report',
+                backTo: activeRoute,
+            }),
+        );
+    });
+});

--- a/tests/unit/LinkTest.ts
+++ b/tests/unit/LinkTest.ts
@@ -238,8 +238,8 @@ describe('Link.openLink', () => {
 
         openLink(`${CONFIG.EXPENSIFY.EXPENSIFY_URL}/newdotreport?reportID=legacy-report`, environmentURL);
 
-        // Legacy `newdotreport` links have no parseable internal path, so on narrow layouts they must keep the
-        // explicit report navigation instead of falling back to OldDot link handling.
+        // Legacy `newdotreport` links have no internal path that can be parsed, so on narrow layouts they must keep
+        // the explicit report navigation instead of falling back to OldDot link handling.
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('legacy-report'));
     });
 

--- a/tests/unit/LinkTest.ts
+++ b/tests/unit/LinkTest.ts
@@ -1,16 +1,18 @@
-import type {NavigationState} from '@react-navigation/native';
 import {canAnonymousUserAccessRoute, isAnonymousUser} from '@libs/actions/Session';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
 import REPORT_LINK_ROUTE_PARAMS from '@libs/Navigation/reportLinkRouteParams';
 import * as Url from '@libs/Url';
+
 import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
 import {openLink} from '@src/libs/actions/Link';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
+
+import type {NavigationState} from '@react-navigation/native';
 
 const mockReports: Record<string, {isMoneyRequest?: boolean}> = {};
 type ReportUtilsMock = Record<string, unknown> & {
@@ -267,11 +269,7 @@ describe('Link.openLink', () => {
 
         openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/987654321`, environmentURL);
 
-        expect(Navigation.setParams).toHaveBeenCalledWith(
-            {reportActionID: '987654321'},
-            `${SCREENS.RIGHT_MODAL.SEARCH_REPORT}-rhp-report`,
-            `${NAVIGATORS.RIGHT_MODAL_NAVIGATOR}-state`,
-        );
+        expect(Navigation.setParams).toHaveBeenCalledWith({reportActionID: '987654321'}, `${SCREENS.RIGHT_MODAL.SEARCH_REPORT}-rhp-report`, `${NAVIGATORS.RIGHT_MODAL_NAVIGATOR}-state`);
         expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
         expect(Navigation.navigate).not.toHaveBeenCalled();
     });

--- a/tests/unit/LinkTest.ts
+++ b/tests/unit/LinkTest.ts
@@ -3,6 +3,8 @@ import {canAnonymousUserAccessRoute, isAnonymousUser} from '@libs/actions/Sessio
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
+import REPORT_LINK_ROUTE_PARAMS from '@libs/Navigation/reportLinkRouteParams';
+import * as Url from '@libs/Url';
 import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
 import {openLink} from '@src/libs/actions/Link';
@@ -30,6 +32,7 @@ jest.mock('@libs/Navigation/Navigation', () => ({
         closeRHPFlow: jest.fn(),
         getActiveRoute: jest.fn(),
         navigate: jest.fn(),
+        setParams: jest.fn(),
     },
 }));
 jest.mock('@libs/actions/Session', () => ({
@@ -70,7 +73,9 @@ function buildRootState({
     activeTab = NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
     isRHPOpen = false,
     focusedRootNavigator,
-}: {centralReportID?: string; activeTab?: string; isRHPOpen?: boolean; focusedRootNavigator?: string} = {}) {
+    rhpReportID = 'rhp-report',
+    rhpReportActionID,
+}: {centralReportID?: string; activeTab?: string; isRHPOpen?: boolean; focusedRootNavigator?: string; rhpReportID?: string; rhpReportActionID?: string} = {}) {
     const tabRoutes: NavigationState['routes'] = [
         {
             key: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
@@ -113,7 +118,7 @@ function buildRootState({
                 {
                     key: `${SCREENS.RIGHT_MODAL.SEARCH_REPORT}-rhp-report`,
                     name: SCREENS.RIGHT_MODAL.SEARCH_REPORT,
-                    params: {reportID: 'rhp-report'},
+                    params: {reportID: rhpReportID, ...(rhpReportActionID ? {reportActionID: rhpReportActionID} : {})},
                 },
             ]),
         });
@@ -164,6 +169,21 @@ describe('Link.openLink', () => {
         expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
     });
 
+    it('marks uncached plain report links so loaded expenses can move to the expense RHP', () => {
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/uncached-report`, environmentURL);
+
+        expect(Navigation.navigate).toHaveBeenCalledWith(
+            Url.appendParam(
+                ROUTES.SEARCH_REPORT.getRoute({
+                    reportID: 'uncached-report',
+                    backTo: activeRoute,
+                }),
+                REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP,
+                'true',
+            ),
+        );
+    });
+
     it('opens an expense report link in the expense RHP on wide layout', () => {
         mockReports['expense-report'] = {isMoneyRequest: true};
 
@@ -190,10 +210,14 @@ describe('Link.openLink', () => {
         openLink(`${CONFIG.EXPENSIFY.EXPENSIFY_URL}/newdotreport?reportID=legacy-report`, environmentURL);
 
         expect(Navigation.navigate).toHaveBeenCalledWith(
-            ROUTES.SEARCH_REPORT.getRoute({
-                reportID: 'legacy-report',
-                backTo: activeRoute,
-            }),
+            Url.appendParam(
+                ROUTES.SEARCH_REPORT.getRoute({
+                    reportID: 'legacy-report',
+                    backTo: activeRoute,
+                }),
+                REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP,
+                'true',
+            ),
         );
     });
 
@@ -229,6 +253,27 @@ describe('Link.openLink', () => {
 
         expect(Navigation.closeRHPFlow).toHaveBeenCalled();
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('regular-report', '123456789'));
+    });
+
+    it('updates the focused RHP report action instead of stacking another RHP for the same report', () => {
+        mockedNavigationRef.getRootState.mockReturnValue(buildRootState({isRHPOpen: true, rhpReportID: 'regular-report', rhpReportActionID: '123456789'}));
+        mockedNavigation.getActiveRoute.mockReturnValue(
+            ROUTES.SEARCH_REPORT.getRoute({
+                reportID: 'regular-report',
+                reportActionID: '123456789',
+                backTo: activeRoute,
+            }),
+        );
+
+        openLink(`${CONST.NEW_EXPENSIFY_URL}/r/regular-report/987654321`, environmentURL);
+
+        expect(Navigation.setParams).toHaveBeenCalledWith(
+            {reportActionID: '987654321'},
+            `${SCREENS.RIGHT_MODAL.SEARCH_REPORT}-rhp-report`,
+            `${NAVIGATORS.RIGHT_MODAL_NAVIGATOR}-state`,
+        );
+        expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
+        expect(Navigation.navigate).not.toHaveBeenCalled();
     });
 
     it('opens an RHP when the target report exists in a stale inactive Reports tab', () => {
@@ -273,10 +318,14 @@ describe('Link.openLink', () => {
 
         expect(Navigation.closeRHPFlow).not.toHaveBeenCalled();
         expect(Navigation.navigate).toHaveBeenCalledWith(
-            ROUTES.SEARCH_REPORT.getRoute({
-                reportID: 'regular-report',
-                backTo: activeRoute,
-            }),
+            Url.appendParam(
+                ROUTES.SEARCH_REPORT.getRoute({
+                    reportID: 'regular-report',
+                    backTo: activeRoute,
+                }),
+                REPORT_LINK_ROUTE_PARAMS.SHOULD_REPLACE_WITH_EXPENSE_REPORT_RHP,
+                'true',
+            ),
         );
     });
 });


### PR DESCRIPTION
### Explanation of Change
This PR updates internal report hyperlink handling so top-level report links opened from chat preserve the current Inbox context on wide layouts. Report links are resolved before the existing RHP close/swap check, so regular reports open through the search report RHP, plain expense reports open through the expense RHP, action-bearing report links use the report RHP that can focus the linked action, and narrow layouts keep the existing full-screen report navigation.

It also keeps same-central-report links on the normal report route so linked report actions can scroll/highlight in the current report instead of opening another RHP, and leaves report subroutes such as report details/settings unchanged.

### Fixed Issues
$ https://github.com/Expensify/App/issues/92968
PROPOSAL: https://github.com/Expensify/App/issues/92968#issuecomment-4774961140

### Tests
1. Verify that no errors appear in the JS console.
2. On a wide layout, open any Inbox chat containing a hyperlink to another regular report URL like `/r/<reportID>`.
3. Click the report hyperlink and verify the linked report opens in the RHP while the original chat remains visible behind it.
4. On a wide layout, click a hyperlink to an expense or money request report without a report action ID and verify it opens in the expense RHP while the original chat remains visible behind it.
5. On a wide layout, click a hyperlink to `/r/<reportID>/<reportActionID>` and verify the linked report opens in the report RHP focused on the linked report action.
6. Open report A in the central pane, then click a hyperlink to a report action inside report A. Verify the app stays on the central report route and scrolls/highlights the linked action instead of opening report A again in the RHP.
7. Click a report subroute hyperlink such as `/r/<reportID>/details` and verify it keeps the existing destination instead of being rewritten to an RHP route.
8. While signed out or viewing as an anonymous user, open a public report hyperlink and verify it keeps the existing full-screen report navigation behavior.
9. Resize to a narrow layout, click a report hyperlink, and verify it keeps the existing full-screen report navigation behavior.

- [x] Verify that no errors appear in the JS console

### Offline tests
No dedicated offline behavior is changed. The link click is App-side navigation only and does not alter optimistic data, queued requests, or API behavior.

### QA Steps
1. Verify that no errors appear in the JS console.
2. On a wide layout, open an Inbox chat containing a hyperlink to another regular report or expense report.
3. Click the hyperlink and verify the linked report opens in the RHP while the original chat remains visible behind it.
4. Click a direct report-action hyperlink and verify the report RHP opens with the linked action focused.
5. On a narrow layout, click the same type of report hyperlink and verify it opens full-screen as before.
6. As an anonymous user, open a public report hyperlink and verify it remains on the full report route instead of opening an RHP.
7. Click a report subroute such as report details/settings and verify it is not rewritten to the RHP route.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving theming, moving elements, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/a248d9e5-f8da-49e1-b11c-2e754b82a4de



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/73766c49-2493-407b-b541-58e97103b6e1



</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/3e8e7fe6-3209-4443-8652-e05a19ff8056



</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/e4523caa-2297-43be-9cb9-26ab8a365132



</details>

<details>
<summary>MacOS: Chrome </summary>

https://github.com/user-attachments/assets/be942a87-2a6c-47a0-8348-7367483b2049



</details>

<details>
<summary>MacOS: Chrome (Edge case)</summary>

https://github.com/user-attachments/assets/839f0c07-2ac9-44a4-b4d3-11ca343681c3



</details>

