### PR TITLE
[NoQA] feat: add ME PR support to Publish React Native Android Artifacts workflow

### DIFF
--- a/.github/workflows/publishReactNativeAndroidArtifacts.yml
+++ b/.github/workflows/publishReactNativeAndroidArtifacts.yml
@@ -11,6 +11,14 @@ on:
         description: 'Build HybridApp artifacts'
         required: false
         type: boolean
+      app_pull_request_url:
+        description: 'The Expensify/App pull request URL.'
+        required: false
+        default: ''
+      mobile_expensify_pull_request_url:
+        description: 'The Expensify/Mobile-Expensify pull request URL to check out the submodule.'
+        required: false
+        default: ''
   push:
     branches:
       - main
@@ -28,8 +36,6 @@ jobs:
     runs-on: 'blacksmith-4vcpu-ubuntu-2404'
     outputs:
       build_targets: ${{ steps.getArtifactBuildTargets.outputs.BUILD_TARGETS }}
-      hybrid_app_patches_hash: ${{ steps.getNewPatchesHash.outputs.HYBRID_APP_HASH }}
-      standalone_patches_hash: ${{ steps.getNewPatchesHash.outputs.STANDALONE_APP_HASH }}
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
@@ -42,8 +48,8 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: getOldPatchesHash
         run: |
-            echo "HYBRID_APP_HASH=$(./scripts/compute-patches-hash.sh patches Mobile-Expensify/patches)" >> "$GITHUB_OUTPUT"
-            echo "STANDALONE_APP_HASH=$(./scripts/compute-patches-hash.sh patches)" >> "$GITHUB_OUTPUT"
+          echo "HYBRID_APP_HASH=$(./scripts/compute-patches-hash.sh patches Mobile-Expensify/patches)" >> "$GITHUB_OUTPUT"
+          echo "STANDALONE_APP_HASH=$(./scripts/compute-patches-hash.sh patches)" >> "$GITHUB_OUTPUT"
 
       - name: Get previous react-native version
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -60,8 +66,8 @@ jobs:
       - name: Get new patches hash
         id: getNewPatchesHash
         run: |
-            echo "HYBRID_APP_HASH=$(./scripts/compute-patches-hash.sh patches Mobile-Expensify/patches)" >> "$GITHUB_OUTPUT"
-            echo "STANDALONE_APP_HASH=$(./scripts/compute-patches-hash.sh patches)" >> "$GITHUB_OUTPUT"
+          echo "HYBRID_APP_HASH=$(./scripts/compute-patches-hash.sh patches Mobile-Expensify/patches)" >> "$GITHUB_OUTPUT"
+          echo "STANDALONE_APP_HASH=$(./scripts/compute-patches-hash.sh patches)" >> "$GITHUB_OUTPUT"
 
       - name: Get new react-native version
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -122,10 +128,19 @@ jobs:
             echo "BUILD_TARGETS=[\"true\"]" >> "$GITHUB_OUTPUT"
           fi
 
+  getMobileExpensifyRef:
+    name: Resolve Mobile-Expensify ref
+    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+    with:
+      APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
+      MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.mobile_expensify_pull_request_url }}
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
   buildAndPublishReactNativeArtifacts:
     name: Build and Publish React Native Artifacts
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-16vcpu-ubuntu-2404' || 'blacksmith-2vcpu-ubuntu-2404' }}
-    needs: verifyPatches
+    needs: [verifyPatches, getMobileExpensifyRef]
     if: needs.verifyPatches.outputs.build_targets != ''
     strategy:
       # Disable fail-fast to prevent cancelling both jobs when only one needs to be stopped due to concurrency limits
@@ -142,6 +157,24 @@ jobs:
         with:
           submodules: ${{ matrix.is_hybrid }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Checkout Mobile-Expensify to specified branch or commit
+        if: ${{ matrix.is_hybrid == 'true' && needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF != '' }}
+        run: |
+          cd Mobile-Expensify
+          git fetch origin ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
+          git checkout ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
+
+      # Recompute the patches hash from the actually checked-out tree (which may include a custom Mobile-Expensify
+      # ref) so the published artifact is tagged with a hash that consumers will match against.
+      - name: Compute patches hash
+        id: computePatchesHash
+        run: |
+          if [[ '${{ matrix.is_hybrid }}' == 'true' ]]; then
+            echo "PATCHES_HASH=$(./scripts/compute-patches-hash.sh patches Mobile-Expensify/patches)" >> "$GITHUB_OUTPUT"
+          else
+            echo "PATCHES_HASH=$(./scripts/compute-patches-hash.sh patches)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
@@ -194,7 +227,7 @@ jobs:
           GH_PUBLISH_TOKEN: ${{ github.token }}
           IS_HYBRID_BUILD: ${{ matrix.is_hybrid }}
           PATCHED_VERSION: ${{ steps.getNewPatchedVersion.outputs.NEW_PATCHED_VERSION }}
-          PATCHES_HASH: ${{ matrix.is_hybrid == 'true' && needs.verifyPatches.outputs.hybrid_app_patches_hash || needs.verifyPatches.outputs.standalone_patches_hash }}
+          PATCHES_HASH: ${{ steps.computePatchesHash.outputs.PATCHES_HASH }}
           CMAKE_VERSION: 3.31.6
 
       - name: Announce failed workflow in Slack
@@ -203,3 +236,4 @@ jobs:
         with:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           CHANNEL: '#expensify-open-source'
+

--- a/.github/workflows/resolveMobileExpensifyRef.yml
+++ b/.github/workflows/resolveMobileExpensifyRef.yml
@@ -1,0 +1,103 @@
+name: Resolve Mobile-Expensify ref
+
+# Reusable workflow that resolves which Expensify/Mobile-Expensify commit a build should check out.
+# Resolution order:
+#   1. An explicit Mobile-Expensify PR URL (MOBILE_EXPENSIFY_PULL_REQUEST_URL), if provided.
+#   2. Otherwise, a `MOBILE-EXPENSIFY: <pr-url>` entry in the body of the App PR (APP_PULL_REQUEST_URL).
+#   3. Otherwise, empty — callers fall back to the pinned submodule commit.
+on:
+  workflow_call:
+    inputs:
+      APP_PULL_REQUEST_URL:
+        description: The Expensify/App pull request URL. Its description is scanned for a MOBILE-EXPENSIFY entry. Ignored if a Mobile-Expensify PR URL is provided.
+        required: false
+        type: string
+        default: ''
+      MOBILE_EXPENSIFY_PULL_REQUEST_URL:
+        description: The Expensify/Mobile-Expensify pull request URL. Overrides MOBILE-EXPENSIFY set in the App PR description.
+        required: false
+        type: string
+        default: ''
+    outputs:
+      APP_PR_NUMBER:
+        description: PR number extracted from the App PR URL (empty if none).
+        value: ${{ jobs.resolve.outputs.APP_PR_NUMBER }}
+      MOBILE_EXPENSIFY_PR:
+        description: Resolved Mobile-Expensify PR number (empty if none).
+        value: ${{ jobs.resolve.outputs.MOBILE_EXPENSIFY_PR }}
+      MOBILE_EXPENSIFY_REF:
+        description: Resolved Mobile-Expensify head SHA (empty to use the pinned submodule commit).
+        value: ${{ jobs.resolve.outputs.MOBILE_EXPENSIFY_REF }}
+    secrets:
+      OS_BOTIFY_TOKEN:
+        description: Token with read access to Expensify/Mobile-Expensify, used to resolve the PR head ref.
+        required: true
+
+jobs:
+  resolve:
+    name: Resolve Mobile-Expensify ref
+    runs-on: 'blacksmith-4vcpu-ubuntu-2404'
+    outputs:
+      APP_PR_NUMBER: ${{ steps.extractAppPRNumber.outputs.PR_NUMBER }}
+      MOBILE_EXPENSIFY_PR: ${{ steps.mobileExpensifyPR.outputs.result }}
+      MOBILE_EXPENSIFY_REF: ${{ steps.getHeadRef.outputs.REF }}
+    steps:
+      - name: Extract App PR number from URL
+        id: extractAppPRNumber
+        if: ${{ inputs.APP_PULL_REQUEST_URL != '' }}
+        run: |
+          PR_NUMBER=$(echo '${{ inputs.APP_PULL_REQUEST_URL }}' | sed -E 's|.*/pull/([0-9]+).*|\1|')
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::❌ Could not extract PR number from the App PR URL. Please provide a valid GitHub PR URL (e.g., https://github.com/Expensify/App/pull/12345)"
+            exit 1
+          fi
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Mobile-Expensify PR number from URL
+        id: extractMobilePRNumber
+        if: ${{ inputs.MOBILE_EXPENSIFY_PULL_REQUEST_URL != '' }}
+        run: |
+          PR_NUMBER=$(echo '${{ inputs.MOBILE_EXPENSIFY_PULL_REQUEST_URL }}' | sed -E 's|.*/pull/([0-9]+).*|\1|')
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::❌ Could not extract PR number from the Mobile-Expensify PR URL. Please provide a valid GitHub PR URL (e.g., https://github.com/Expensify/Mobile-Expensify/pull/12345)"
+            exit 1
+          fi
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve which Mobile-Expensify PR to use
+        id: mobileExpensifyPR
+        # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          github-token: ${{ github.token }}
+          result-encoding: string
+          script: |
+            // An explicit Mobile-Expensify PR URL takes precedence over the App PR description
+            if ('${{ steps.extractMobilePRNumber.outputs.PR_NUMBER }}') {
+              return '${{ steps.extractMobilePRNumber.outputs.PR_NUMBER }}';
+            }
+
+            if (!'${{ steps.extractAppPRNumber.outputs.PR_NUMBER }}') {
+              return '';
+            }
+
+            const pullRequest = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: '${{ steps.extractAppPRNumber.outputs.PR_NUMBER }}',
+            });
+
+            const body = pullRequest.data.body ?? '';
+            const regex = /MOBILE-EXPENSIFY:\s*https:\/\/github.com\/Expensify\/Mobile-Expensify\/pull\/(?<prNumber>\d+)/;
+            const found = body.match(regex)?.groups?.prNumber || "";
+
+            return found.trim();
+
+      - name: Resolve Mobile-Expensify head ref from PR number
+        id: getHeadRef
+        if: ${{ steps.mobileExpensifyPR.outputs.result != '' }}
+        run: |
+          set -e
+          echo "REF=$(gh pr view ${{ steps.mobileExpensifyPR.outputs.result }} -R Expensify/Mobile-Expensify --json headRefOid --jq '.headRefOid')" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -41,7 +41,6 @@ jobs:
     outputs:
       APP_REF: ${{ steps.getHeadRef.outputs.REF || 'main' }}
       APP_PR_NUMBER: ${{ steps.extractAppPRNumber.outputs.PR_NUMBER }}
-      MOBILE_PR_NUMBER: ${{ steps.extractMobilePRNumber.outputs.PR_NUMBER }}
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
@@ -69,17 +68,6 @@ jobs:
           fi
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-      - name: Extract Mobile-Expensify PR number from URL
-        id: extractMobilePRNumber
-        if: ${{ inputs.MOBILE_EXPENSIFY_PULL_REQUEST_URL != '' }}
-        run: |
-          PR_NUMBER=$(echo '${{ inputs.MOBILE_EXPENSIFY_PULL_REQUEST_URL }}' | sed -E 's|.*/pull/([0-9]+).*|\1|')
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::error::❌ Could not extract PR number from URL. Please provide a valid GitHub PR URL (e.g., https://github.com/Expensify/Mobile-Expensify/pull/12345)"
-            exit 1
-          fi
-          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
       - name: Check if App pull request number is correct
         id: getHeadRef
         run: |
@@ -92,70 +80,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-  getMobileExpensifyPR:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [prep]
-    outputs:
-      MOBILE_EXPENSIFY_PR: ${{ steps.mobileExpensifyPR.outputs.result }}
-    steps:
-      - name: Check if author specified Expensify/Mobile-Expensify PR
-        id: mobileExpensifyPR
-        # v8
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        with:
-          github-token: ${{ github.token }}
-          result-encoding: string
-          script: |
-            if ('${{ needs.prep.outputs.MOBILE_PR_NUMBER }}') {
-              return '${{ needs.prep.outputs.MOBILE_PR_NUMBER }}';
-            }
-
-            if (!'${{ needs.prep.outputs.APP_PR_NUMBER }}') {
-              return '';
-            }
-
-            const pullRequest = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: '${{ needs.prep.outputs.APP_PR_NUMBER }}',
-            });
-            
-            const body = pullRequest.data.body;
-            const regex = /MOBILE-EXPENSIFY:\s*https:\/\/github.com\/Expensify\/Mobile-Expensify\/pull\/(?<prNumber>\d+)/;
-            const found = body.match(regex)?.groups?.prNumber || "";
-
-            return found.trim();
-
+  # Resolves the Mobile-Expensify ref from the explicit ME PR URL or the App PR's MOBILE-EXPENSIFY entry.
+  # `needs: [prep]` gates this behind prep's actor validation before any token is used.
   getMobileExpensifyRef:
-      runs-on: blacksmith-4vcpu-ubuntu-2404
-      needs: [prep, getMobileExpensifyPR]
-      outputs:
-        MOBILE_EXPENSIFY_REF: ${{ steps.getHeadRef.outputs.REF || 'main' }}
-      steps:
-        - name: Checkout
-          uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
-
-        - name: Check if Expensify/Mobile-Expensify pull request number is correct
-          id: getHeadRef
-          run: |
-            set -e
-            if [[ -z "${{ needs.prep.outputs.MOBILE_PR_NUMBER }}" && -z "${{ needs.getMobileExpensifyPR.outputs.MOBILE_EXPENSIFY_PR }}" ]]; then
-              echo "REF=" >> "$GITHUB_OUTPUT"
-            else
-              echo "PR=${{ needs.prep.outputs.MOBILE_PR_NUMBER || needs.getMobileExpensifyPR.outputs.MOBILE_EXPENSIFY_PR }}" >> "$GITHUB_OUTPUT"
-              echo "REF=$(gh pr view ${{ needs.prep.outputs.MOBILE_PR_NUMBER || needs.getMobileExpensifyPR.outputs.MOBILE_EXPENSIFY_PR }} -R Expensify/Mobile-Expensify --json headRefOid --jq '.headRefOid')" >> "$GITHUB_OUTPUT"
-            fi
-          env:
-            GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+    needs: [prep]
+    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+    with:
+      APP_PULL_REQUEST_URL: ${{ inputs.APP_PULL_REQUEST_URL }}
+      MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.MOBILE_EXPENSIFY_PULL_REQUEST_URL }}
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   buildApps:
-    needs: [prep, getMobileExpensifyPR, getMobileExpensifyRef]
+    needs: [prep, getMobileExpensifyRef]
     uses: ./.github/workflows/buildAdHoc.yml
     with:
       APP_REF: ${{ needs.prep.outputs.APP_REF }}
       APP_PR_NUMBER: ${{ needs.prep.outputs.APP_PR_NUMBER }}
-      MOBILE_EXPENSIFY_REF: ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
-      MOBILE_EXPENSIFY_PR: ${{ needs.getMobileExpensifyPR.outputs.MOBILE_EXPENSIFY_PR }}
+      # Fall back to Mobile-Expensify main when nothing is resolved (test builds track the latest OldDot).
+      MOBILE_EXPENSIFY_REF: ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF || 'main' }}
+      MOBILE_EXPENSIFY_PR: ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_PR }}
       BUILD_WEB: ${{ inputs.WEB && 'true' || 'false' }}
       BUILD_IOS: ${{ inputs.IOS && 'true' || 'false' }}
       BUILD_ANDROID: ${{ inputs.ANDROID && 'true' || 'false' }}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

`Publish React Native Android Artifacts` did not support resolving a specific `Mobile-Expensify` PR/branch when building HybridApp artifacts - it always checked out the pinned submodule commit. `testBuild.yml` already had this logic (via inline `getMobileExpensifyPR`/`getMobileExpensifyRef` jobs), but it wasn't reusable elsewhere.

This PR:

- Extracts the Mobile-Expensify ref resolution logic out of `testBuild.yml` into a new reusable workflow, `.github/workflows/resolveMobileExpensifyRef.yml`. It resolves the commit to check out in this order:
  1. An explicit `mobile_expensify_pull_request_url` input.
  2. A `MOBILE-EXPENSIFY: <pr-url>` entry in the App PR body.
  3. Falls back to empty (caller uses the pinned submodule commit).
- Adds `app_pull_request_url` and `mobile_expensify_pull_request_url` inputs to `publishReactNativeAndroidArtifacts.yml` and wires in the new `getMobileExpensifyRef` reusable workflow, so ME PR artifacts can now be built/published from this workflow.
- Moves patches hash computation to run after checkout (from the actual tree), instead of upfront in `verifyPatches`, since the checked-out Mobile-Expensify ref can now differ from the pinned submodule commit. This keeps the published artifact tagged with a hash that matches what consumers will look for.
- Updates `testBuild.yml` to call the new reusable workflow instead of its own inline jobs, falling back to `main` for `MOBILE_EXPENSIFY_REF` when nothing is resolved.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95038
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

Precondition: workflows `publishReactNativeAndroidArtifacts.yml` and `testBuild.yml` can only be triggered by Expensify employees

Trigger `Publish React Native Android Artifacts` manually with `mobile_expensify_pull_request_url` set to an open `Expensify/Mobile-Expensify` PR.
   - Verify the `getMobileExpensifyRef` job resolves the PR's head SHA.
   - Verify the `buildAndPublishReactNativeArtifacts` job checks out that SHA in `Mobile-Expensify/` before building.
   - Verify the published artifact's patches hash reflects the patches from that checked-out ref.

This has already been verified here https://github.com/Expensify/App/actions/runs/28351312713 by @mountiny  - confirming the `Resolve Mobile-Expensify ref` job correctly picked up the intended Mobile-Expensify PR and the hybrid build completed successfully using that ref.

### Offline tests

N/A

### QA Steps

N/A

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability). - N/A, CI workflow change, no App/API interaction
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) - N/A, no UI change; see `Tests` section for the linked verification run instead
- [x] I ran the tests on **all platforms** & verified they passed on: - N/A, this only affects CI workflows, not the App itself
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) - N/A, no App components touched
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that: - N/A
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that: - N/A
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. - N/A
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) - N/A
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. - N/A
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account. - N/A
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles: - N/A
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow. - N/A, GitHub Actions YAML isn't covered by Jest; verified via the live run linked in `Tests` instead
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>
</details>

<details>
<summary>Android: mWeb Chrome</summary>
</details>

<details>
<summary>iOS: Native</summary>
</details>

<details>
<summary>iOS: mWeb Safari</summary>
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
</details>
