### PR TITLE
[No QA] Fix flaky SessionTest timeout on CI job 8

### DIFF
--- a/tests/ui/SessionTest.tsx
+++ b/tests/ui/SessionTest.tsx
@@ -34,6 +34,10 @@ const TEST_AUTH_TOKEN_2 = 'zxcvbnm';
 
 // We need a large timeout here as we are lazy loading React Navigation screens and this test is running against the entire mounted App
 jest.setTimeout(120000);
+
+// Full-App integration tests below render <App /> and drain the entire React/Onyx work queue via act().
+// With coverage enabled and other tests in the same CI shard competing for CPU, they can exceed 4 minutes.
+const FULL_APP_UI_TEST_TIMEOUT_MS = 6 * 60 * 1000;
 TestHelper.setupApp();
 TestHelper.setupGlobalFetchMock();
 
@@ -146,7 +150,7 @@ describe('Deep linking', () => {
     });
 
     // This test renders the full App and processes a deep-link sign-in flow, so it runs
-    // significantly longer than the suite default on loaded CI runners.
+    // significantly longer than the suite default on loaded CI runners (see FULL_APP_UI_TEST_TIMEOUT_MS).
     it(
         'should not remember the report path of the last deep link login after signing out and in again',
         async () => {
@@ -181,11 +185,11 @@ describe('Deep linking', () => {
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },
-        4 * 60 * 1000,
+        FULL_APP_UI_TEST_TIMEOUT_MS,
     );
 
     // This test renders the full App three times, so it runs significantly longer than
-    // the suite default on loaded CI runners.
+    // the suite default on loaded CI runners (see FULL_APP_UI_TEST_TIMEOUT_MS).
     it(
         'should not reuse the last deep link and log in again when signing out',
         async () => {
@@ -234,7 +238,7 @@ describe('Deep linking', () => {
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },
-        4 * 60 * 1000,
+        FULL_APP_UI_TEST_TIMEOUT_MS,
     );
 });
 
@@ -269,7 +273,7 @@ describe('Support auth token login', () => {
         setLastShortAuthToken(null);
     });
 
-    // Renders the full App and processes a supportal transition, so it runs longer than the suite default.
+    // Renders the full App and processes a supportal transition, so it runs longer than the suite default (see FULL_APP_UI_TEST_TIMEOUT_MS).
     it(
         'does not fire the support sign-in again when LogOutPreviousUserPage re-processes an already-handled token',
         async () => {
@@ -303,6 +307,6 @@ describe('Support auth token login', () => {
             await waitForBatchedUpdatesWithAct();
             await waitForNetworkPromises();
         },
-        4 * 60 * 1000,
+        FULL_APP_UI_TEST_TIMEOUT_MS,
     );
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Fixes flaky `tests/ui/SessionTest.tsx` failures on CI job 8/8 where full `<App />` deep-link integration tests exceeded the 4-minute per-test timeout on loaded runners.

Introduces a shared `FULL_APP_UI_TEST_TIMEOUT_MS` constant (6 minutes) for all three heavy SessionTest cases, replacing the previous inline `4 * 60 * 1000` values. Locally, the failing test takes ~203s with `--coverage`; under CI load it was hitting the 240s ceiling and failing (e.g. [workflow run 28575574530 job 8](https://github.com/Expensify/App/actions/runs/28575574530/job/84728107276)).

### Fixed Issues

$

PROPOSAL:

### Tests

1. Run `npx jest tests/ui/SessionTest.tsx --silent` and confirm all 3 tests pass.
2. Run `npx jest tests/ui/SessionTest.tsx --silent --no-cache --coverage --testNamePattern="should not remember the report path"` to confirm the previously failing test completes under CI-like conditions.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — test infrastructure only.

### QA Steps

N/A — [No QA]. Test-only change; no production code or user-visible behavior changed.

- [x] Verify that no errors appear in the JS console
