### PR TITLE
[No QA] Fix broken OptionsListUtils test and repo-wide ESLint resolution error

### DIFF
--- a/scripts/checkOnyxConnectBypass.ts
+++ b/scripts/checkOnyxConnectBypass.ts
@@ -35,7 +35,8 @@ function isRuleModule(value: unknown): value is Rule.RuleModule {
 /** Dynamically import the shipped `no-onyx-connect` rule, which is ESM with relative imports. */
 async function loadNoOnyxConnectRule(): Promise<Rule.RuleModule> {
     const require = createRequire(__filename);
-    const expensifyConfigDirectory = path.dirname(require.resolve('eslint-config-expensify/package.json'));
+    // Resolve the package entry rather than its package.json, since eslint-config-expensify's `exports` map doesn't expose ./package.json.
+    const expensifyConfigDirectory = path.dirname(require.resolve('eslint-config-expensify'));
     const ruleFile = path.join(expensifyConfigDirectory, 'eslint-plugin-expensify', 'no-onyx-connect.js');
     const imported: unknown = await import(ruleFile);
     if (isRuleModule(imported)) {

--- a/tests/unit/OptionsListUtilsTest.tsx
+++ b/tests/unit/OptionsListUtilsTest.tsx
@@ -818,16 +818,17 @@ describe('OptionsListUtils', () => {
                     policyName: POLICY.name,
                 },
             };
-            const optionsWithMemberWorkspaceChat = createOptionList(
+            const optionsWithMemberWorkspaceChat = createFilteredOptionList(
                 PERSONAL_DETAILS,
-                EMPTY_PRIVATE_IS_ARCHIVED_MAP,
                 memberWorkspaceChat,
-                undefined,
                 createMockReportAttributesDerived(memberWorkspaceChat, PERSONAL_DETAILS, CURRENT_USER_ACCOUNT_ID),
+                EMPTY_PRIVATE_IS_ARCHIVED_MAP,
+                allPolicies,
+                {isSearching: true},
             );
 
             // When we call getSearchOptions
-            const results = getSearchOptions({
+            const {options: results} = getSearchOptions({
                 options: optionsWithMemberWorkspaceChat,
                 reportAttributesDerived: createMockReportAttributesDerived(memberWorkspaceChat, PERSONAL_DETAILS, CURRENT_USER_ACCOUNT_ID),
                 draftComments: {},


### PR DESCRIPTION
### Explanation of Change

Updates the `tests/unit/OptionsListUtilsTest.tsx` test to the current `OptionsListUtils` API (`createFilteredOptionList` and destructuring `{options}` from `getSearchOptions`), fixing the typecheck/lint/test failures the PR #92226 merge introduced on `main`. Also fixes a separate repo-wide ESLint failure by resolving `eslint-config-expensify`'s package entry instead of its `package.json`, which its `exports` map doesn't expose.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95242
$ https://github.com/Expensify/App/issues/95241
$ https://github.com/Expensify/App/issues/95243
$ https://github.com/Expensify/App/issues/95252
PROPOSAL:

### Tests

1. Check out this branch.
2. Run `npm run typecheck` and verify it passes.
3. Run `npm run lint` and verify it passes.
4. Run `npx jest tests/unit/OptionsListUtilsTest.tsx` and verify all tests pass, including "should include a policy expense chat when the current user notification preference is hidden".

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — test-only change.

### QA Steps

N/A — test-only change, covered by CI. See title `[No QA]`.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
