### PR TITLE
[No QA] Reduce unsafe type assertions in TSCompilerUtils tests

### DIFF
--- a/tests/unit/TSCompilerUtilsTest.ts
+++ b/tests/unit/TSCompilerUtilsTest.ts
@@ -11,6 +11,60 @@ function printSourceFile(sourceFile: ts.SourceFile): string {
     return ts.createPrinter().printFile(sourceFile);
 }
 
+function expectNode<T extends ts.Node>(node: ts.Node | undefined, guard: (candidate: ts.Node) => candidate is T, expected: string): T {
+    if (!node || !guard(node)) {
+        throw new Error(`Expected ${expected}`);
+    }
+    return node;
+}
+
+function getStatement<T extends ts.Statement>(sourceFile: ts.SourceFile, index: number, guard: (candidate: ts.Node) => candidate is T, expected: string): T {
+    return expectNode(sourceFile.statements.at(index), guard, expected);
+}
+
+function getProperty<T extends ts.ObjectLiteralElementLike>(objectLiteral: ts.ObjectLiteralExpression, index: number, guard: (candidate: ts.Node) => candidate is T, expected: string): T {
+    return expectNode(objectLiteral.properties.at(index), guard, expected);
+}
+
+function getMember<T extends ts.ClassElement>(classDeclaration: ts.ClassDeclaration, index: number, guard: (candidate: ts.Node) => candidate is T, expected: string): T {
+    return expectNode(classDeclaration.members.at(index), guard, expected);
+}
+
+function getBlockStatement<T extends ts.Statement>(block: ts.Block | undefined, index: number, guard: (candidate: ts.Node) => candidate is T, expected: string): T {
+    if (!block) {
+        throw new Error('Expected block');
+    }
+    return expectNode(block.statements.at(index), guard, expected);
+}
+
+function getObjectLiteralInitializer(property: ts.PropertyAssignment): ts.ObjectLiteralExpression {
+    return expectNode(property.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+}
+
+function getSatisfiesObjectLiteralInitializer(property: ts.PropertyAssignment): ts.ObjectLiteralExpression {
+    const satisfiesExpression = expectNode(property.initializer, ts.isSatisfiesExpression, 'satisfies expression initializer');
+    return expectNode(satisfiesExpression.expression, ts.isObjectLiteralExpression, 'object literal in satisfies expression');
+}
+
+function findPropertyAssignment(objectLiteral: ts.ObjectLiteralExpression, propertyName: string): ts.PropertyAssignment {
+    const property = objectLiteral.properties.find((prop) => ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) && prop.name.text === propertyName);
+    return expectNode(property, ts.isPropertyAssignment, `property assignment "${propertyName}"`);
+}
+
+function expectIdentifierText(node: ts.PropertyName, expected: string): void {
+    if (!ts.isIdentifier(node)) {
+        throw new Error('Expected identifier');
+    }
+    expect(node.text).toBe(expected);
+}
+
+function expectStringLiteralText(node: ts.Expression, expected: string): void {
+    if (!ts.isStringLiteral(node)) {
+        throw new Error('Expected string literal');
+    }
+    expect(node.text).toBe(expected);
+}
+
 describe('TSCompilerUtils', () => {
     describe('addImport', () => {
         it('adds a default import after an existing import', () => {
@@ -227,7 +281,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from simple identifier', () => {
             const code = 'translations';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -235,7 +289,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from satisfies expression', () => {
             const code = 'translations satisfies TranslationDeepObject<typeof translations>;';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -243,7 +297,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from as expression', () => {
             const code = 'translations as SomeType;';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -251,7 +305,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from parenthesized expression', () => {
             const code = '(translations);';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -259,7 +313,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from nested parenthesized expression', () => {
             const code = '((translations));';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -267,7 +321,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from type assertion (angle bracket syntax)', () => {
             const code = '<SomeType>translations;';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             // Note: This might be 'translations' or null depending on how TypeScript parses angle bracket syntax in JSX-enabled contexts
             expect(result).toEqual(expect.any(String));
@@ -276,7 +330,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from complex nested expression', () => {
             const code = '(translations as SomeType);';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -284,7 +338,7 @@ describe('TSCompilerUtils', () => {
         it('extracts identifier from satisfies expression with nested parentheses', () => {
             const code = '(translations) satisfies TranslationDeepObject<typeof translations>;';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -292,7 +346,7 @@ describe('TSCompilerUtils', () => {
         it('returns null for non-identifier expressions', () => {
             const code = '"hello world";';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBeNull();
         });
@@ -300,7 +354,7 @@ describe('TSCompilerUtils', () => {
         it('returns null for complex expressions that do not contain identifiers', () => {
             const code = '42 + 24;';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBeNull();
         });
@@ -308,7 +362,7 @@ describe('TSCompilerUtils', () => {
         it('returns null for call expressions', () => {
             const code = 'someFunction();';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBeNull();
         });
@@ -316,7 +370,7 @@ describe('TSCompilerUtils', () => {
         it('returns null for member expressions', () => {
             const code = 'obj.property;';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBeNull();
         });
@@ -324,7 +378,7 @@ describe('TSCompilerUtils', () => {
         it('handles deeply nested expression types', () => {
             const code = '((translations as SomeType) satisfies AnotherType);';
             const ast = createSourceFile(code);
-            const expression = ast.statements[0] as ts.ExpressionStatement;
+            const expression = getStatement(ast, 0, ts.isExpressionStatement, 'expression statement');
             const result = TSCompilerUtils.extractIdentifierFromExpression(expression.expression);
             expect(result).toBe('translations');
         });
@@ -338,9 +392,9 @@ describe('TSCompilerUtils', () => {
                 };
             `);
             const ast = createSourceFile(code);
-            const varDecl = ast.statements[0] as ts.VariableStatement;
-            const objLiteral = varDecl.declarationList.declarations[0].initializer as ts.ObjectLiteralExpression;
-            const propertyAssignment = objLiteral.properties[0] as ts.PropertyAssignment;
+            const varDecl = getStatement(ast, 0, ts.isVariableStatement, 'variable statement');
+            const objLiteral = expectNode(varDecl.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+            const propertyAssignment = getProperty(objLiteral, 0, ts.isPropertyAssignment, 'property assignment');
 
             const result = TSCompilerUtils.extractKeyFromPropertyNode(propertyAssignment);
             expect(result).toBe('myKey');
@@ -353,9 +407,9 @@ describe('TSCompilerUtils', () => {
                 };
             `);
             const ast = createSourceFile(code);
-            const varDecl = ast.statements[0] as ts.VariableStatement;
-            const objLiteral = varDecl.declarationList.declarations[0].initializer as ts.ObjectLiteralExpression;
-            const propertyAssignment = objLiteral.properties[0] as ts.PropertyAssignment;
+            const varDecl = getStatement(ast, 0, ts.isVariableStatement, 'variable statement');
+            const objLiteral = expectNode(varDecl.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+            const propertyAssignment = getProperty(objLiteral, 0, ts.isPropertyAssignment, 'property assignment');
 
             const result = TSCompilerUtils.extractKeyFromPropertyNode(propertyAssignment);
             expect(result).toBe('myStringKey');
@@ -370,9 +424,9 @@ describe('TSCompilerUtils', () => {
                 };
             `);
             const ast = createSourceFile(code);
-            const varDecl = ast.statements[0] as ts.VariableStatement;
-            const objLiteral = varDecl.declarationList.declarations[0].initializer as ts.ObjectLiteralExpression;
-            const methodDeclaration = objLiteral.properties[0] as ts.MethodDeclaration;
+            const varDecl = getStatement(ast, 0, ts.isVariableStatement, 'variable statement');
+            const objLiteral = expectNode(varDecl.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+            const methodDeclaration = getProperty(objLiteral, 0, ts.isMethodDeclaration, 'method declaration');
 
             const result = TSCompilerUtils.extractKeyFromPropertyNode(methodDeclaration);
             expect(result).toBe('myMethod');
@@ -385,9 +439,9 @@ describe('TSCompilerUtils', () => {
                 };
             `);
             const ast = createSourceFile(code);
-            const varDecl = ast.statements[0] as ts.VariableStatement;
-            const objLiteral = varDecl.declarationList.declarations[0].initializer as ts.ObjectLiteralExpression;
-            const propertyAssignment = objLiteral.properties[0] as ts.PropertyAssignment;
+            const varDecl = getStatement(ast, 0, ts.isVariableStatement, 'variable statement');
+            const objLiteral = expectNode(varDecl.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+            const propertyAssignment = getProperty(objLiteral, 0, ts.isPropertyAssignment, 'property assignment');
 
             const result = TSCompilerUtils.extractKeyFromPropertyNode(propertyAssignment);
             expect(result).toBeUndefined();
@@ -400,9 +454,9 @@ describe('TSCompilerUtils', () => {
                 };
             `);
             const ast = createSourceFile(code);
-            const varDecl = ast.statements[0] as ts.VariableStatement;
-            const objLiteral = varDecl.declarationList.declarations[0].initializer as ts.ObjectLiteralExpression;
-            const propertyAssignment = objLiteral.properties[0] as ts.PropertyAssignment;
+            const varDecl = getStatement(ast, 0, ts.isVariableStatement, 'variable statement');
+            const objLiteral = expectNode(varDecl.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+            const propertyAssignment = getProperty(objLiteral, 0, ts.isPropertyAssignment, 'property assignment');
 
             const result = TSCompilerUtils.extractKeyFromPropertyNode(propertyAssignment);
             expect(result).toBeUndefined();
@@ -417,9 +471,9 @@ describe('TSCompilerUtils', () => {
                 };
             `);
             const ast = createSourceFile(code);
-            const varDecl = ast.statements[0] as ts.VariableStatement;
-            const objLiteral = varDecl.declarationList.declarations[0].initializer as ts.ObjectLiteralExpression;
-            const methodDeclaration = objLiteral.properties[0] as ts.MethodDeclaration;
+            const varDecl = getStatement(ast, 0, ts.isVariableStatement, 'variable statement');
+            const objLiteral = expectNode(varDecl.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+            const methodDeclaration = getProperty(objLiteral, 0, ts.isMethodDeclaration, 'method declaration');
 
             const result = TSCompilerUtils.extractKeyFromPropertyNode(methodDeclaration);
             expect(result).toBeUndefined();
@@ -432,9 +486,9 @@ describe('TSCompilerUtils', () => {
                 };
             `);
             const ast = createSourceFile(code);
-            const varDecl = ast.statements[0] as ts.VariableStatement;
-            const objLiteral = varDecl.declarationList.declarations[0].initializer as ts.ObjectLiteralExpression;
-            const propertyAssignment = objLiteral.properties[0] as ts.PropertyAssignment;
+            const varDecl = getStatement(ast, 0, ts.isVariableStatement, 'variable statement');
+            const objLiteral = expectNode(varDecl.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'object literal initializer');
+            const propertyAssignment = getProperty(objLiteral, 0, ts.isPropertyAssignment, 'property assignment');
 
             const result = TSCompilerUtils.extractKeyFromPropertyNode(propertyAssignment);
             expect(result).toBe('arrowFunc');
@@ -1059,18 +1113,15 @@ describe('TSCompilerUtils', () => {
 
             // Verify structure was created
             expect(updatedObject.properties).toHaveLength(1);
-            const testProp = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            expect(ts.isPropertyAssignment(testProp)).toBe(true);
-            expect((testProp.name as ts.Identifier).text).toBe('test');
+            const testProp = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(testProp.name, 'test');
 
-            const testValue = testProp.initializer as ts.ObjectLiteralExpression;
-            expect(ts.isObjectLiteralExpression(testValue)).toBe(true);
+            const testValue = getObjectLiteralInitializer(testProp);
             expect(testValue.properties).toHaveLength(1);
 
-            const nestedProp = testValue.properties[0] as ts.PropertyAssignment;
-            expect((nestedProp.name as ts.Identifier).text).toBe('nested');
-            expect(ts.isStringLiteral(nestedProp.initializer)).toBe(true);
-            expect((nestedProp.initializer as ts.StringLiteral).text).toBe('test value');
+            const nestedProp = getProperty(testValue, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(nestedProp.name, 'nested');
+            expectStringLiteralText(nestedProp.initializer, 'test value');
         });
 
         it('should throw error when trying to inject into non-object property', () => {
@@ -1099,25 +1150,19 @@ describe('TSCompilerUtils', () => {
 
             // Should preserve existing structure and add new value
             expect(updatedObject.properties).toHaveLength(1);
-            const updatedProperty = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            expect((updatedProperty.name as ts.Identifier).text).toBe('existing');
+            const updatedProperty = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(updatedProperty.name, 'existing');
 
-            const updatedNestedObj = updatedProperty.initializer as ts.ObjectLiteralExpression;
+            const updatedNestedObj = getObjectLiteralInitializer(updatedProperty);
             expect(updatedNestedObj.properties).toHaveLength(2);
 
             // Check existing property is preserved
-            const existingNestedProp = updatedNestedObj.properties.find(
-                (prop) => ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) && prop.name.text === 'existingNested',
-            ) as ts.PropertyAssignment;
-            expect(existingNestedProp).toBeDefined();
-            expect((existingNestedProp.initializer as ts.StringLiteral).text).toBe('existing value');
+            const existingNestedProp = findPropertyAssignment(updatedNestedObj, 'existingNested');
+            expectStringLiteralText(existingNestedProp.initializer, 'existing value');
 
             // Check new property was added
-            const newNestedProp = updatedNestedObj.properties.find(
-                (prop) => ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) && prop.name.text === 'newNested',
-            ) as ts.PropertyAssignment;
-            expect(newNestedProp).toBeDefined();
-            expect((newNestedProp.initializer as ts.StringLiteral).text).toBe('new value');
+            const newNestedProp = findPropertyAssignment(updatedNestedObj, 'newNested');
+            expectStringLiteralText(newNestedProp.initializer, 'new value');
         });
 
         it('should replace existing value when path points to existing property', () => {
@@ -1132,9 +1177,9 @@ describe('TSCompilerUtils', () => {
 
             // Should replace the existing value
             expect(updatedObject.properties).toHaveLength(1);
-            const updatedProperty = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            expect((updatedProperty.name as ts.Identifier).text).toBe('existing');
-            expect((updatedProperty.initializer as ts.StringLiteral).text).toBe('new value');
+            const updatedProperty = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(updatedProperty.name, 'existing');
+            expectStringLiteralText(updatedProperty.initializer, 'new value');
         });
 
         it('should handle single-level paths', () => {
@@ -1144,10 +1189,9 @@ describe('TSCompilerUtils', () => {
             const updatedObject = TSCompilerUtils.injectDeepObjectValue(objectLiteral, 'single', finalValue);
 
             expect(updatedObject.properties).toHaveLength(1);
-            const prop = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            expect((prop.name as ts.Identifier).text).toBe('single');
-            expect(ts.isStringLiteral(prop.initializer)).toBe(true);
-            expect((prop.initializer as ts.StringLiteral).text).toBe('single value');
+            const prop = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(prop.name, 'single');
+            expectStringLiteralText(prop.initializer, 'single value');
         });
 
         it('should handle deep nested paths', () => {
@@ -1159,23 +1203,22 @@ describe('TSCompilerUtils', () => {
             expect(updatedObject.properties).toHaveLength(1);
 
             // Navigate down the nested structure
-            const aProp = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            expect((aProp.name as ts.Identifier).text).toBe('a');
+            const aProp = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(aProp.name, 'a');
 
-            const bObj = aProp.initializer as ts.ObjectLiteralExpression;
-            const bProp = bObj.properties[0] as ts.PropertyAssignment;
-            expect((bProp.name as ts.Identifier).text).toBe('b');
+            const bObj = getObjectLiteralInitializer(aProp);
+            const bProp = getProperty(bObj, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(bProp.name, 'b');
 
-            const cObj = bProp.initializer as ts.ObjectLiteralExpression;
-            const cProp = cObj.properties[0] as ts.PropertyAssignment;
-            expect((cProp.name as ts.Identifier).text).toBe('c');
+            const cObj = getObjectLiteralInitializer(bProp);
+            const cProp = getProperty(cObj, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(cProp.name, 'c');
 
-            const dObj = cProp.initializer as ts.ObjectLiteralExpression;
-            const dProp = dObj.properties[0] as ts.PropertyAssignment;
-            expect((dProp.name as ts.Identifier).text).toBe('d');
+            const dObj = getObjectLiteralInitializer(cProp);
+            const dProp = getProperty(dObj, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(dProp.name, 'd');
 
-            expect(ts.isStringLiteral(dProp.initializer)).toBe(true);
-            expect((dProp.initializer as ts.StringLiteral).text).toBe('deep value');
+            expectStringLiteralText(dProp.initializer, 'deep value');
         });
 
         it('should preserve existing properties when adding new ones', () => {
@@ -1198,13 +1241,13 @@ describe('TSCompilerUtils', () => {
             expect(updatedObject.properties.at(1)).toBe(existingProps.at(1));
 
             // Check the new nested property
-            const newProp = updatedObject.properties.at(2) as ts.PropertyAssignment;
-            expect((newProp.name as ts.Identifier).text).toBe('newSection');
+            const newProp = getProperty(updatedObject, 2, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(newProp.name, 'newSection');
 
-            const nestedObj = newProp.initializer as ts.ObjectLiteralExpression;
-            const nestedProp = nestedObj.properties[0] as ts.PropertyAssignment;
-            expect((nestedProp.name as ts.Identifier).text).toBe('nested');
-            expect((nestedProp.initializer as ts.StringLiteral).text).toBe('new nested value');
+            const nestedObj = getObjectLiteralInitializer(newProp);
+            const nestedProp = getProperty(nestedObj, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(nestedProp.name, 'nested');
+            expectStringLiteralText(nestedProp.initializer, 'new nested value');
         });
 
         it('should handle complex expressions as final values', () => {
@@ -1218,9 +1261,9 @@ describe('TSCompilerUtils', () => {
             const updatedObject = TSCompilerUtils.injectDeepObjectValue(objectLiteral, 'test.greeting', finalValue);
 
             expect(updatedObject.properties).toHaveLength(1);
-            const testProp = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            const testObj = testProp.initializer as ts.ObjectLiteralExpression;
-            const greetingProp = testObj.properties[0] as ts.PropertyAssignment;
+            const testProp = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            const testObj = getObjectLiteralInitializer(testProp);
+            const greetingProp = getProperty(testObj, 0, ts.isPropertyAssignment, 'property assignment');
 
             expect(ts.isTemplateExpression(greetingProp.initializer)).toBe(true);
         });
@@ -1241,9 +1284,9 @@ describe('TSCompilerUtils', () => {
             const updatedObject = TSCompilerUtils.injectDeepObjectValue(objectLiteral, 'test.func', finalValue);
 
             expect(updatedObject.properties).toHaveLength(1);
-            const testProp = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            const testObj = testProp.initializer as ts.ObjectLiteralExpression;
-            const funcProp = testObj.properties[0] as ts.PropertyAssignment;
+            const testProp = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            const testObj = getObjectLiteralInitializer(testProp);
+            const funcProp = getProperty(testObj, 0, ts.isPropertyAssignment, 'property assignment');
 
             expect(ts.isArrowFunction(funcProp.initializer)).toBe(true);
         });
@@ -1285,13 +1328,13 @@ describe('TSCompilerUtils', () => {
             const updatedObject = TSCompilerUtils.injectDeepObjectValue(objectLiteral, '123.456', finalValue);
 
             expect(updatedObject.properties).toHaveLength(1);
-            const numericProp = updatedObject.properties.at(0) as ts.PropertyAssignment;
-            expect((numericProp.name as ts.Identifier).text).toBe('123');
+            const numericProp = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(numericProp.name, '123');
 
-            const nestedObj = numericProp.initializer as ts.ObjectLiteralExpression;
-            const nestedProp = nestedObj.properties[0] as ts.PropertyAssignment;
-            expect((nestedProp.name as ts.Identifier).text).toBe('456');
-            expect((nestedProp.initializer as ts.StringLiteral).text).toBe('numeric value');
+            const nestedObj = getObjectLiteralInitializer(numericProp);
+            const nestedProp = getProperty(nestedObj, 0, ts.isPropertyAssignment, 'property assignment');
+            expectIdentifierText(nestedProp.name, '456');
+            expectStringLiteralText(nestedProp.initializer, 'numeric value');
         });
 
         it('should handle satisfies expressions in nested objects', () => {
@@ -1310,11 +1353,11 @@ describe('TSCompilerUtils', () => {
             const updatedObject = TSCompilerUtils.injectDeepObjectValue(objectLiteral, 'tasks.newKey', newValue);
 
             // Verify satisfies expression is preserved
-            const tasksProp = updatedObject.properties[0] as ts.PropertyAssignment;
+            const tasksProp = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
             expect(ts.isSatisfiesExpression(tasksProp.initializer)).toBe(true);
 
             // Verify both existing and new properties exist
-            const tasksObj = (tasksProp.initializer as ts.SatisfiesExpression).expression as ts.ObjectLiteralExpression;
+            const tasksObj = getSatisfiesObjectLiteralInitializer(tasksProp);
             expect(tasksObj.properties).toHaveLength(2);
         });
 
@@ -1334,12 +1377,12 @@ describe('TSCompilerUtils', () => {
             const updatedObject = TSCompilerUtils.injectDeepObjectValue(objectLiteral, 'nested.existingKey', newValue);
 
             // Verify satisfies expression is preserved and value is replaced
-            const nestedProp = updatedObject.properties[0] as ts.PropertyAssignment;
+            const nestedProp = getProperty(updatedObject, 0, ts.isPropertyAssignment, 'property assignment');
             expect(ts.isSatisfiesExpression(nestedProp.initializer)).toBe(true);
 
-            const nestedObj = (nestedProp.initializer as ts.SatisfiesExpression).expression as ts.ObjectLiteralExpression;
-            const existingKeyProp = nestedObj.properties[0] as ts.PropertyAssignment;
-            expect((existingKeyProp.initializer as ts.StringLiteral).text).toBe('new value');
+            const nestedObj = getSatisfiesObjectLiteralInitializer(nestedProp);
+            const existingKeyProp = getProperty(nestedObj, 0, ts.isPropertyAssignment, 'property assignment');
+            expectStringLiteralText(existingKeyProp.initializer, 'new value');
         });
     });
 
@@ -1459,14 +1502,10 @@ describe('TSCompilerUtils', () => {
             );
 
             // Find the const declaration inside the function
-            const functionDecl = source.statements[0] as ts.FunctionDeclaration;
-            const functionBody = functionDecl.body;
-            const constStatement = functionBody?.statements[0];
+            const functionDecl = getStatement(source, 0, ts.isFunctionDeclaration, 'function declaration');
+            const constStatement = getBlockStatement(functionDecl.body, 0, ts.isVariableStatement, 'variable statement');
 
-            expect(constStatement).toBeDefined();
-            if (constStatement) {
-                expect(TSCompilerUtils.getIndentationOfNode(constStatement, source)).toBe(4);
-            }
+            expect(TSCompilerUtils.getIndentationOfNode(constStatement, source)).toBe(4);
         });
 
         it('should handle nested indentation', () => {
@@ -1483,10 +1522,11 @@ describe('TSCompilerUtils', () => {
             );
 
             // Navigate to the deeply nested const statement
-            const classDecl = source.statements[0] as ts.ClassDeclaration;
-            const methodDecl = classDecl.members[0] as ts.MethodDeclaration;
-            const ifStatement = methodDecl.body?.statements[0] as ts.IfStatement;
-            const constStatement = (ifStatement.thenStatement as ts.Block).statements[0];
+            const classDecl = getStatement(source, 0, ts.isClassDeclaration, 'class declaration');
+            const methodDecl = getMember(classDecl, 0, ts.isMethodDeclaration, 'method declaration');
+            const ifStatement = getBlockStatement(methodDecl.body, 0, ts.isIfStatement, 'if statement');
+            const thenBlock = expectNode(ifStatement.thenStatement, ts.isBlock, 'then block');
+            const constStatement = getBlockStatement(thenBlock, 0, ts.isVariableStatement, 'variable statement');
 
             expect(TSCompilerUtils.getIndentationOfNode(constStatement, source)).toBe(12);
         });


### PR DESCRIPTION
### Explanation of Change

Reduced `@typescript-eslint/no-unsafe-type-assertion` violations in
`tests/unit/TSCompilerUtilsTest.ts` as part of the cleanup for Expensify/App
issue #94739.

What changed:

- Replaced repeated TypeScript AST casts in the tests with local typed guard helpers.
- Used TypeScript compiler guards such as `ts.isExpressionStatement`,
  `ts.isPropertyAssignment`, and `ts.isObjectLiteralExpression`.
- Verified with writable lint that the generated target-rule row for this file is removed from the seatbelt TSV.
- The generated TSV diff is intentionally not included in this PR because Expensify/App post-merge OSBotify automation tightens the baseline on `main`.

Why this approach is safe:

- Test-only change; no product/runtime behavior changed.
- The new helpers fail explicitly if a fixture has a different AST shape.
- Existing fixture strings and assertions were preserved.

Reviewer focus:

1. Start with `tests/unit/TSCompilerUtilsTest.ts` and confirm the helper checks
   are real AST narrowing rather than hidden unsafe casts.
2. Check the count evidence below and confirm writable lint locally removed the
   `TSCompilerUtilsTest.ts` target-rule row.
3. Check the commands below; no manual QA is expected for this test-only cleanup.

Safety checks:

- No `SEATBELT_INCREASE`.
- No new `eslint-disable` for `@typescript-eslint/no-unsafe-type-assertion`.
- No broad `as unknown as` substitutions.
- No generic unsafe helper that hides casts.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL:

### Count change

Current baseline source:

- `config/eslint/eslint.seatbelt.tsv`

Before:

- `tests/unit/TSCompilerUtilsTest.ts`: 96 violations
- Current global target-rule baseline: 5,449 violations

After:

- `tests/unit/TSCompilerUtilsTest.ts`: 0 violations
- Current global target-rule baseline: 5,353 violations

Net reduction:

- 96 fewer `@typescript-eslint/no-unsafe-type-assertion` violations.

TSV evidence:

- Writable lint locally removed the `tests/unit/TSCompilerUtilsTest.ts` row from
  `config/eslint/eslint.seatbelt.tsv`.
- Generated with:
  `CI=true npm run lint -- --no-cache --show-warnings tests/unit/TSCompilerUtilsTest.ts`
- The generated `config/eslint/eslint.seatbelt.tsv` diff is intentionally not
  included in this PR because Expensify/App post-merge OSBotify automation
  tightens the baseline on `main`.

### Tests

1. Run:

   ```bash
   npm run lint -- --show-warnings tests/unit/TSCompilerUtilsTest.ts
   ```

   Verify lint passes with no target-rule warnings for the edited file.

2. Run:

   ```bash
   CI=true npm run lint -- --no-cache --show-warnings tests/unit/TSCompilerUtilsTest.ts
   ```

   Verify `config/eslint/eslint.seatbelt.tsv` locally contains the decrement described
   above, then restore it before committing:

   ```bash
   git restore config/eslint/eslint.seatbelt.tsv
   ```

3. Run:

   ```bash
   npm run test -- tests/unit/TSCompilerUtilsTest.ts
   ```

   Verify the targeted test suite passes.

4. Run:

   ```bash
   npm run typecheck
   ```

   Verify TypeScript checks pass.

### Offline tests

Not applicable. This is test-only cleanup and does not change network behavior.

### QA Steps

No QA required. This PR only changes tests. The ESLint seatbelt baseline is tightened by Expensify/App post-merge OSBotify automation.

### PR Author Checklist

For checklist items that are not applicable to this test-only cleanup, checked
means the item was considered and determined not applicable.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>iOS: Native</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not applicable. This is test-only cleanup.

</details>

cc @blimpich

