### PR TITLE
Fix disabled rate not grayed out (#93414)

### DIFF
--- a/src/components/SelectionList/ListItem/SelectableListItem.tsx
+++ b/src/components/SelectionList/ListItem/SelectableListItem.tsx
@@ -29,6 +29,7 @@ function SelectableListItem<TItem extends ListItem>({
     return (
         <BaseListItem
             {...baseProps}
+            wrapperStyle={[baseProps.wrapperStyle, item.isDisabled && styles.opacitySemiTransparent]}
             item={item}
             isFocused={isFocused}
             isDisabled={isDisabled}


### PR DESCRIPTION
$ #93414

This PR fixes the disabled rate UI not being grayed out. The issue was that the `opacitySemiTransparent` style was not applied to `SelectableListItem` when `isDisabled` is true.