### PR TITLE
Part 1 - [Rules Revamp] Clean-up and Polish 

### DIFF
--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -6598,10 +6598,15 @@ function disableWorkspaceBillableExpenses(policyID: string) {
  * Otherwise, disableWorkspaceBillableExpenses is used and it changes only disabledFields
  */
 function getBillableExpensesPendingAction(policy: OnyxEntry<Policy>): PendingAction | undefined {
-    if (policy?.disabledFields?.defaultBillable) {
-        return policy?.pendingFields?.disabledFields ?? policy?.pendingFields?.defaultBillable;
+    if (policy?.pendingFields?.defaultBillable) {
+        return policy.pendingFields.defaultBillable;
     }
-    return policy?.pendingFields?.disabledFields;
+
+    if (policy?.disabledFields?.defaultBillable && policy?.pendingFields?.disabledFields) {
+        return policy.pendingFields.disabledFields;
+    }
+
+    return undefined;
 }
 
 function toggleBillableExpenses(policy: OnyxEntry<Policy>) {

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -6592,6 +6592,26 @@ function disableWorkspaceBillableExpenses(policyID: string) {
     API.write(WRITE_COMMANDS.DISABLE_POLICY_BILLABLE_MODE, parameters, onyxData);
 }
 
+/**
+ * The pending state might be set by either setPolicyBillableMode or disableWorkspaceBillableExpenses.
+ * setPolicyBillableMode changes disabledFields and defaultBillable and is called when disabledFields.defaultBillable is set.
+ * Otherwise, disableWorkspaceBillableExpenses is used and it changes only disabledFields
+ */
+function getBillableExpensesPendingAction(policy: OnyxEntry<Policy>): PendingAction | undefined {
+    if (policy?.disabledFields?.defaultBillable) {
+        return policy?.pendingFields?.disabledFields ?? policy?.pendingFields?.defaultBillable;
+    }
+    return policy?.pendingFields?.disabledFields;
+}
+
+function toggleBillableExpenses(policy: OnyxEntry<Policy>) {
+    if (policy?.disabledFields?.defaultBillable) {
+        setPolicyBillableMode(policy.id, false, policy?.defaultBillable, true);
+    } else if (policy) {
+        disableWorkspaceBillableExpenses(policy.id);
+    }
+}
+
 function getWorkspaceEReceiptsEnabledOnyxData(policyID: string, enabled: boolean, currentEnabled: boolean | undefined): OnyxData<typeof ONYXKEYS.COLLECTION.POLICY> {
     return {
         optimisticData: [
@@ -7663,6 +7683,8 @@ export {
     clearDuplicateWorkspace,
     setPolicyBillableMode,
     disableWorkspaceBillableExpenses,
+    getBillableExpensesPendingAction,
+    toggleBillableExpenses,
     setWorkspaceEReceiptsEnabled,
     verifySetupIntentAndRequestPolicyOwnerChange,
     updateInvoiceCompanyName,

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -25,6 +25,7 @@ import useMobileSelectionMode from '@hooks/useMobileSelectionMode';
 import useNetwork from '@hooks/useNetwork';
 import useOnboardingTaskInformation from '@hooks/useOnboardingTaskInformation';
 import useOnyx from '@hooks/useOnyx';
+import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -89,6 +90,8 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     const isQuickSettingsFlow = route.name === SCREENS.SETTINGS_CATEGORIES.SETTINGS_CATEGORIES_ROOT;
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const {canWrite: canWriteCategories, showReadOnlyModal} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.CATEGORIES);
+    const {isBetaEnabled} = usePermissions();
+    const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
 
     const [selectedCategoryKeys, setSelectedCategoryKeys] = useState<string[]>([]);
     const canSelectMultiple = canWriteCategories && (isSmallScreenWidth ? isMobileSelectionModeEnabled : true);
@@ -353,7 +356,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
 
     const secondaryActions = useMemo(() => {
         const menuItems = [];
-        if (canWriteCategories) {
+        if (canWriteCategories && !isRulesRevampEnabled) {
             menuItems.push({
                 icon: icons.Gear,
                 text: translate('common.settings'),
@@ -401,6 +404,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
         translate,
         navigateToCategoriesSettings,
         canWriteCategories,
+        isRulesRevampEnabled,
         policyHasAccountingConnections,
         hasVisibleCategories,
         navigateToImportSpreadsheet,

--- a/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
@@ -78,7 +78,8 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
         [CONST.POLICY.CASH_EXPENSE_REIMBURSEMENT_CHOICES.ALWAYS_NON_REIMBURSABLE]: translate('workspace.rules.generalTab.cashExpensesAlwaysNonReimbursable'),
     };
     const reimbursableModeText = reimbursableModeTextMap[reimbursableMode];
-    const billableModeText = translate(`workspace.rules.generalTab.${policy?.defaultBillable ? 'billableExpensesBillable' : 'billableExpensesNonBillable'}`);
+    const isBillableTrackingEnabled = policy?.disabledFields?.defaultBillable !== true;
+    const billableModeText = isBillableTrackingEnabled ? translate(`workspace.rules.generalTab.${policy?.defaultBillable ? 'billableExpensesBillable' : 'billableExpensesNonBillable'}`) : '';
 
     const areEReceiptsEnabled = policy?.eReceipts ?? false;
     const isAttendeeTrackingEnabledForPolicy = isAttendeeTrackingEnabled(policy);
@@ -155,7 +156,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             description: billableModeText,
             icon: icons.Cash,
             action: () => Navigation.navigate(ROUTES.RULES_BILLABLE_DEFAULT.getRoute(policyID)),
-            pendingAction: policy?.pendingFields?.defaultBillable,
+            pendingAction: policy?.pendingFields?.defaultBillable ?? policy?.pendingFields?.disabledFields,
         },
     ];
 

--- a/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
@@ -8,7 +8,7 @@ import useLocalize from '@hooks/useLocalize';
 import usePolicy from '@hooks/usePolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {getCashExpenseReimbursableMode, setPolicyAttendeeTrackingEnabled, setWorkspaceEReceiptsEnabled} from '@libs/actions/Policy/Policy';
+import {getBillableExpensesPendingAction, getCashExpenseReimbursableMode, setPolicyAttendeeTrackingEnabled, setWorkspaceEReceiptsEnabled} from '@libs/actions/Policy/Policy';
 import Navigation from '@libs/Navigation/Navigation';
 import {isAttendeeTrackingEnabled} from '@libs/PolicyUtils';
 
@@ -156,7 +156,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             description: billableModeText,
             icon: icons.Cash,
             action: () => Navigation.navigate(ROUTES.RULES_BILLABLE_DEFAULT.getRoute(policyID)),
-            pendingAction: policy?.pendingFields?.defaultBillable ?? policy?.pendingFields?.disabledFields,
+            pendingAction: getBillableExpensesPendingAction(policy),
         },
     ];
 

--- a/src/pages/workspace/rules/RulesBillableDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesBillableDefaultPage.tsx
@@ -17,37 +17,14 @@ import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 
-import {disableWorkspaceBillableExpenses, setPolicyBillableMode} from '@userActions/Policy/Policy';
+import {getBillableExpensesPendingAction, setPolicyBillableMode, toggleBillableExpenses} from '@userActions/Policy/Policy';
 
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
-import type {Policy} from '@src/types/onyx';
-
-import type {OnyxEntry} from 'react-native-onyx';
 
 import React, {useMemo} from 'react';
 import {View} from 'react-native';
-
-/**
- * The pending state might be set by either setPolicyBillableMode or disableWorkspaceBillableExpenses.
- * setPolicyBillableMode changes disabledFields and defaultBillable and is called when disabledFields.defaultBillable is set.
- * Otherwise, disableWorkspaceBillableExpenses is used and it changes only disabledFields
- */
-function billableExpensesPending(policy: OnyxEntry<Policy>) {
-    if (policy?.disabledFields?.defaultBillable) {
-        return policy?.pendingFields?.disabledFields ?? policy?.pendingFields?.defaultBillable;
-    }
-    return policy?.pendingFields?.disabledFields;
-}
-
-function toggleBillableExpenses(policy: OnyxEntry<Policy>) {
-    if (policy?.disabledFields?.defaultBillable) {
-        setPolicyBillableMode(policy.id, false, policy?.defaultBillable, true);
-    } else if (policy) {
-        disableWorkspaceBillableExpenses(policy.id);
-    }
-}
 
 type RulesBillableDefaultPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.RULES_BILLABLE_DEFAULT>;
 
@@ -83,6 +60,7 @@ function RulesBillableDefaultPage({
 
     const initiallyFocusedOptionKey = policy?.defaultBillable ? CONST.POLICY_BILLABLE_MODES.BILLABLE : CONST.POLICY_BILLABLE_MODES.NON_BILLABLE;
     const isBillableTrackingEnabled = policy?.disabledFields?.defaultBillable !== true;
+    const isTrackBillableToggleDisabled = !policy?.areTagsEnabled;
 
     const tagsPageLink = useMemo(() => {
         if (policy?.areTagsEnabled) {
@@ -117,7 +95,9 @@ function RulesBillableDefaultPage({
                         shouldPlaceSubtitleBelowSwitch
                         wrapperStyle={[styles.mh5, styles.mv4]}
                         isActive={isBillableTrackingEnabled}
-                        pendingAction={billableExpensesPending(policy)}
+                        disabled={isTrackBillableToggleDisabled}
+                        showLockIcon={isTrackBillableToggleDisabled}
+                        pendingAction={getBillableExpensesPendingAction(policy)}
                         onToggle={() => toggleBillableExpenses(policy)}
                     />
                 )}

--- a/src/pages/workspace/rules/RulesBillableDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesBillableDefaultPage.tsx
@@ -61,6 +61,7 @@ function RulesBillableDefaultPage({
     const initiallyFocusedOptionKey = policy?.defaultBillable ? CONST.POLICY_BILLABLE_MODES.BILLABLE : CONST.POLICY_BILLABLE_MODES.NON_BILLABLE;
     const isBillableTrackingEnabled = policy?.disabledFields?.defaultBillable !== true;
     const isTrackBillableToggleDisabled = !policy?.areTagsEnabled;
+    const shouldShowBillableModeList = !isRevamp || (isBillableTrackingEnabled && !isTrackBillableToggleDisabled);
 
     const tagsPageLink = useMemo(() => {
         if (policy?.areTagsEnabled) {
@@ -101,7 +102,7 @@ function RulesBillableDefaultPage({
                         onToggle={() => toggleBillableExpenses(policy)}
                     />
                 )}
-                {(!isRevamp || isBillableTrackingEnabled) && (
+                {shouldShowBillableModeList && (
                     <SelectionList
                         data={billableModes}
                         ListItem={SingleSelectListItem}

--- a/src/pages/workspace/rules/RulesBillableDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesBillableDefaultPage.tsx
@@ -15,15 +15,39 @@ import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavig
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
+import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 
-import {setPolicyBillableMode} from '@userActions/Policy/Policy';
+import {disableWorkspaceBillableExpenses, setPolicyBillableMode} from '@userActions/Policy/Policy';
 
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
+import type {Policy} from '@src/types/onyx';
+
+import type {OnyxEntry} from 'react-native-onyx';
 
 import React, {useMemo} from 'react';
 import {View} from 'react-native';
+
+/**
+ * The pending state might be set by either setPolicyBillableMode or disableWorkspaceBillableExpenses.
+ * setPolicyBillableMode changes disabledFields and defaultBillable and is called when disabledFields.defaultBillable is set.
+ * Otherwise, disableWorkspaceBillableExpenses is used and it changes only disabledFields
+ */
+function billableExpensesPending(policy: OnyxEntry<Policy>) {
+    if (policy?.disabledFields?.defaultBillable) {
+        return policy?.pendingFields?.disabledFields ?? policy?.pendingFields?.defaultBillable;
+    }
+    return policy?.pendingFields?.disabledFields;
+}
+
+function toggleBillableExpenses(policy: OnyxEntry<Policy>) {
+    if (policy?.disabledFields?.defaultBillable) {
+        setPolicyBillableMode(policy.id, false, policy?.defaultBillable, true);
+    } else if (policy) {
+        disableWorkspaceBillableExpenses(policy.id);
+    }
+}
 
 type RulesBillableDefaultPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.RULES_BILLABLE_DEFAULT>;
 
@@ -58,6 +82,7 @@ function RulesBillableDefaultPage({
     ];
 
     const initiallyFocusedOptionKey = policy?.defaultBillable ? CONST.POLICY_BILLABLE_MODES.BILLABLE : CONST.POLICY_BILLABLE_MODES.NON_BILLABLE;
+    const isBillableTrackingEnabled = policy?.disabledFields?.defaultBillable !== true;
 
     const tagsPageLink = useMemo(() => {
         if (policy?.areTagsEnabled) {
@@ -82,20 +107,33 @@ function RulesBillableDefaultPage({
                     title={translate(isRevamp ? 'workspace.rules.generalTab.billableExpenses' : 'workspace.rules.individualExpenseRules.billableDefault')}
                     onBackButtonPress={() => Navigation.goBack()}
                 />
-                <View style={[styles.flexRow, styles.renderHTML, styles.mt3, styles.mh5, styles.mb5]}>
+                <View style={[styles.flexRow, styles.renderHTML, styles.mt3, styles.mh5, isRevamp ? styles.mb3 : styles.mb5]}>
                     <RenderHTML html={translate('workspace.rules.individualExpenseRules.billableDefaultDescription', tagsPageLink)} />
                 </View>
-                <SelectionList
-                    data={billableModes}
-                    ListItem={SingleSelectListItem}
-                    onSelectRow={(item) => {
-                        setPolicyBillableMode(policyID, item.value, policy?.defaultBillable, policy?.disabledFields?.defaultBillable);
-                        Navigation.setNavigationActionToMicrotaskQueue(Navigation.goBack);
-                    }}
-                    shouldSingleExecuteRowSelect
-                    initiallyFocusedItemKey={initiallyFocusedOptionKey}
-                    addBottomSafeAreaPadding
-                />
+                {isRevamp && (
+                    <ToggleSettingOptionRow
+                        title={translate('workspace.tags.trackBillable')}
+                        switchAccessibilityLabel={translate('workspace.tags.trackBillable')}
+                        shouldPlaceSubtitleBelowSwitch
+                        wrapperStyle={[styles.mh5, styles.mv4]}
+                        isActive={isBillableTrackingEnabled}
+                        pendingAction={billableExpensesPending(policy)}
+                        onToggle={() => toggleBillableExpenses(policy)}
+                    />
+                )}
+                {(!isRevamp || isBillableTrackingEnabled) && (
+                    <SelectionList
+                        data={billableModes}
+                        ListItem={SingleSelectListItem}
+                        onSelectRow={(item) => {
+                            setPolicyBillableMode(policyID, item.value, policy?.defaultBillable, policy?.disabledFields?.defaultBillable);
+                            Navigation.setNavigationActionToMicrotaskQueue(Navigation.goBack);
+                        }}
+                        shouldSingleExecuteRowSelect
+                        initiallyFocusedItemKey={initiallyFocusedOptionKey}
+                        addBottomSafeAreaPadding
+                    />
+                )}
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -24,6 +24,7 @@ import useLocalize from '@hooks/useLocalize';
 import useMobileSelectionMode from '@hooks/useMobileSelectionMode';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -119,6 +120,9 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     );
 
     const {canWrite: canWriteTags, showReadOnlyModal} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.TAGS);
+    const {isBetaEnabled} = usePermissions();
+    const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
+    const shouldShowTagsSettings = canWriteTags && !(isRulesRevampEnabled && isMultiLevelTags);
     const canSelectMultiple = canWriteTags && !hasDependentTags && (shouldUseNarrowLayout ? isMobileSelectionModeEnabled : true);
     const isControlPolicyWithWideLayout = !shouldUseNarrowLayout && isControlPolicy(policy);
     const tagApproverEmails = useMemo(() => {
@@ -485,7 +489,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     const hasAccountingConnections = hasAccountingConnectionsPolicyUtils(policy);
     const secondaryActions = useMemo(() => {
         const menuItems = [];
-        if (canWriteTags) {
+        if (shouldShowTagsSettings) {
             menuItems.push({
                 icon: expensifyIcons.Gear,
                 text: translate('common.settings'),
@@ -546,6 +550,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         return menuItems;
     }, [
         translate,
+        shouldShowTagsSettings,
         navigateToTagsSettings,
         hasAccountingConnections,
         hasVisibleTags,

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -24,7 +24,6 @@ import useLocalize from '@hooks/useLocalize';
 import useMobileSelectionMode from '@hooks/useMobileSelectionMode';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -120,9 +119,6 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     );
 
     const {canWrite: canWriteTags, showReadOnlyModal} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.TAGS);
-    const {isBetaEnabled} = usePermissions();
-    const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
-    const shouldShowTagsSettings = canWriteTags && !(isRulesRevampEnabled && isMultiLevelTags);
     const canSelectMultiple = canWriteTags && !hasDependentTags && (shouldUseNarrowLayout ? isMobileSelectionModeEnabled : true);
     const isControlPolicyWithWideLayout = !shouldUseNarrowLayout && isControlPolicy(policy);
     const tagApproverEmails = useMemo(() => {
@@ -489,7 +485,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     const hasAccountingConnections = hasAccountingConnectionsPolicyUtils(policy);
     const secondaryActions = useMemo(() => {
         const menuItems = [];
-        if (shouldShowTagsSettings) {
+        if (canWriteTags) {
             menuItems.push({
                 icon: expensifyIcons.Gear,
                 text: translate('common.settings'),
@@ -550,7 +546,6 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         return menuItems;
     }, [
         translate,
-        shouldShowTagsSettings,
         navigateToTagsSettings,
         hasAccountingConnections,
         hasVisibleTags,

--- a/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
@@ -12,7 +12,7 @@ import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {disableWorkspaceBillableExpenses, setPolicyBillableMode} from '@libs/actions/Policy/Policy';
+import {getBillableExpensesPendingAction, toggleBillableExpenses} from '@libs/actions/Policy/Policy';
 import {clearPolicyTagListErrors, setPolicyRequiresTag} from '@libs/actions/Policy/Tag';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
@@ -37,26 +37,6 @@ import {View} from 'react-native';
 type WorkspaceTagsSettingsPageProps =
     | PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.DYNAMIC_TAGS_SETTINGS>
     | PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS_TAGS.SETTINGS_TAGS_SETTINGS>;
-
-/**
- * The pending state might be set by either setPolicyBillableMode or disableWorkspaceBillableExpenses.
- * setPolicyBillableMode changes disabledFields and defaultBillable and is called when disabledFields.defaultBillable is set.
- * Otherwise, disableWorkspaceBillableExpenses is used and it changes only disabledFields
- * */
-function billableExpensesPending(policy: OnyxEntry<Policy>) {
-    if (policy?.disabledFields?.defaultBillable) {
-        return policy?.pendingFields?.disabledFields ?? policy?.pendingFields?.defaultBillable;
-    }
-    return policy?.pendingFields?.disabledFields;
-}
-
-function toggleBillableExpenses(policy: OnyxEntry<Policy>) {
-    if (policy?.disabledFields?.defaultBillable) {
-        setPolicyBillableMode(policy.id, false, policy?.defaultBillable, true);
-    } else if (policy) {
-        disableWorkspaceBillableExpenses(policy.id);
-    }
-}
 
 function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
     const policyID = route.params.policyID;
@@ -125,7 +105,7 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
                             />
                         </View>
                     </OfflineWithFeedback>
-                    <OfflineWithFeedback pendingAction={billableExpensesPending(policy)}>
+                    <OfflineWithFeedback pendingAction={getBillableExpensesPendingAction(policy)}>
                         <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
                             <Text
                                 style={[styles.textNormal, styles.flex1, styles.mr2]}

--- a/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
@@ -8,6 +8,7 @@ import Text from '@components/Text';
 
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
+import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import useThemeStyles from '@hooks/useThemeStyles';
 
@@ -64,6 +65,8 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
     const policyData = usePolicyData(policyID);
     const {tags: policyTags} = policyData;
     const {translate} = useLocalize();
+    const {isBetaEnabled} = usePermissions();
+    const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
     const [policyTagLists, isMultiLevelTags] = useMemo(() => [getTagListsUtil(policyTags), isMultiLevelTagsUtil(policyTags)], [policyTags]);
     const isLoading = !getTagListsUtil(policyTags)?.at(0) || Object.keys(policyTags ?? {}).at(0) === 'undefined';
     const {isOffline} = useNetwork();
@@ -99,44 +102,48 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
                     />
                 </OfflineWithFeedback>
             )}
-            <OfflineWithFeedback
-                errors={policy?.errorFields?.requiresTag}
-                pendingAction={policy?.pendingFields?.requiresTag}
-                errorRowStyles={styles.mh5}
-            >
-                <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                    <Text
-                        style={[styles.textNormal, styles.flex1, styles.mr2]}
-                        accessible={false}
-                        aria-hidden
+            {!isRulesRevampEnabled && (
+                <>
+                    <OfflineWithFeedback
+                        errors={policy?.errorFields?.requiresTag}
+                        pendingAction={policy?.pendingFields?.requiresTag}
+                        errorRowStyles={styles.mh5}
                     >
-                        {translate('workspace.tags.requiresTag')}
-                    </Text>
-                    <Switch
-                        isOn={policy?.requiresTag ?? false}
-                        accessibilityLabel={translate('workspace.tags.requiresTag')}
-                        onToggle={updateWorkspaceRequiresTag}
-                        disabled={!policy?.areTagsEnabled || !hasEnabledOptions}
-                    />
-                </View>
-            </OfflineWithFeedback>
-            <OfflineWithFeedback pendingAction={billableExpensesPending(policy)}>
-                <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                    <Text
-                        style={[styles.textNormal, styles.flex1, styles.mr2]}
-                        accessible={false}
-                        aria-hidden
-                    >
-                        {translate('workspace.tags.trackBillable')}
-                    </Text>
-                    <Switch
-                        isOn={!(policy?.disabledFields?.defaultBillable ?? false)}
-                        accessibilityLabel={translate('workspace.tags.trackBillable')}
-                        onToggle={() => toggleBillableExpenses(policy)}
-                        disabled={!policy?.areTagsEnabled}
-                    />
-                </View>
-            </OfflineWithFeedback>
+                        <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
+                            <Text
+                                style={[styles.textNormal, styles.flex1, styles.mr2]}
+                                accessible={false}
+                                aria-hidden
+                            >
+                                {translate('workspace.tags.requiresTag')}
+                            </Text>
+                            <Switch
+                                isOn={policy?.requiresTag ?? false}
+                                accessibilityLabel={translate('workspace.tags.requiresTag')}
+                                onToggle={updateWorkspaceRequiresTag}
+                                disabled={!policy?.areTagsEnabled || !hasEnabledOptions}
+                            />
+                        </View>
+                    </OfflineWithFeedback>
+                    <OfflineWithFeedback pendingAction={billableExpensesPending(policy)}>
+                        <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
+                            <Text
+                                style={[styles.textNormal, styles.flex1, styles.mr2]}
+                                accessible={false}
+                                aria-hidden
+                            >
+                                {translate('workspace.tags.trackBillable')}
+                            </Text>
+                            <Switch
+                                isOn={!(policy?.disabledFields?.defaultBillable ?? false)}
+                                accessibilityLabel={translate('workspace.tags.trackBillable')}
+                                onToggle={() => toggleBillableExpenses(policy)}
+                                disabled={!policy?.areTagsEnabled}
+                            />
+                        </View>
+                    </OfflineWithFeedback>
+                </>
+            )}
         </View>
     );
     return (

--- a/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
@@ -58,6 +58,7 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
         [policyData],
     );
     const isQuickSettingsFlow = route.name === SCREENS.SETTINGS_TAGS.SETTINGS_TAGS_SETTINGS;
+    const shouldBlockEmptySettings = isRulesRevampEnabled && isMultiLevelTags && !isLoading;
 
     const getTagsSettings = (policy: OnyxEntry<Policy>) => (
         <View style={styles.flexGrow1}>
@@ -131,6 +132,7 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
             accessVariants={[CONST.POLICY.ACCESS_VARIANTS.ADMIN, CONST.POLICY.ACCESS_VARIANTS.PAID]}
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.ARE_TAGS_ENABLED}
+            shouldBeBlocked={shouldBlockEmptySettings}
         >
             {({policy}) => (
                 <ScreenWrapper


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/94968
$ https://github.com/Expensify/App/issues/94970
$ https://github.com/Expensify/App/issues/94965
PROPOSAL:

### Tests

#### Prerequisites
1. Use a Control workspace with Categories, Tags, and Rules enabled.
2. Enable the `rulesRevamp` beta on your account.

---

### 1. Categories — Settings removed (#94970)
1. Go to **Workspace > Categories**.
2. Click the **⋯** dropdown in the header.
3. Confirm **Settings** is **not** in the menu.
4. Confirm other actions (e.g. Import/Download) still appear if available.

---

### 2. Tags settings — toggles removed (#94965)
1. Go to **Workspace > Tags** (single-level tags workspace).
2. Click **⋯** → **Settings**.
3. Confirm **Custom tag name** is still visible.
4. Confirm **Require tags** toggle is **not** shown.
5. Confirm **Track billable expenses** toggle is **not** shown.

---

### 3. Billable on Rules — new toggle (#94968)
1. Go to **Workspace > Rules > General**.
2. Click **Billable expenses**.
3. Confirm the **subtitle/description** appears first.
4. Confirm **Track billable expenses** toggle appears **below** the subtitle.
5. Confirm **Billable** and **Non-billable** options appear below the toggle (when tracking is on).

---

### 4. Billable toggle off
1. On **Billable expenses**, turn **Track billable expenses** **off**.
2. Confirm **Billable** / **Non-billable** options disappear.
3. Go back to **Rules > General**.
4. Confirm the **Billable expenses** card has **no description**.

---

### 5. Beta off — regression
1. Disable the `rulesRevamp` beta and reload the app.
2. Go to **Workspace > Categories** → **⋯** → confirm **Settings** is back.
3. Go to **Tags > Settings** → confirm **Require tags** and **Track billable** toggles are back.

- [x] Verify that no errors appear in the JS console

### Offline tests

#### Track billable toggle (#94968)

1. Enable `rulesRevamp` beta and go to **Rules > General > Billable expenses**.
2. Turn **network off** (or use DevTools offline mode).
3. Toggle **Track billable expenses** **off**.
4. Confirm the toggle updates immediately and **Billable / Non-billable** options disappear.
5. Confirm a **pending/greyed** state shows on the toggle (or row).
6. Go back to **Rules > General** and confirm the **Billable expenses** card has no description.
7. Turn **network back on** and wait for sync.
8. Reopen **Billable expenses** and confirm the toggle is still **off** and options stay hidden.


### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/53b5402f-0f0b-4cb1-9423-41dfb1a084bf

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/ef18d762-ea07-45c0-8347-065743af6aab

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/525b11cd-5dc1-430a-a5b5-0103f1da517a

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/2dc3d4d6-6012-4c2c-8326-24b0817d47b6

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/18afb509-2933-4a66-9a54-326efb8c4cd9

</details>




