### PR TITLE
Fix Track workspace admins room visibility in LHN

### DIFF
--- a/src/hooks/useAutoCreateTrackWorkspace.ts
+++ b/src/hooks/useAutoCreateTrackWorkspace.ts
@@ -95,6 +95,7 @@ function useAutoCreateTrackWorkspace() {
                       isSelfTourViewed,
                       hasActiveAdminPolicies,
                       personalTrackGoal: onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.TRACK_PERSONAL && !!personalTrackGoal ? personalTrackGoal : undefined,
+                      shouldShowTrackAdminRoomInLHN: onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE,
                   })
                 : {adminsChatReportID: onboardingAdminsChatReportID, policyID: onboardingPolicyID};
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -626,7 +626,6 @@ type OptimisticChatReport = Pick<
     | 'iouReportID'
     | 'isOwnPolicyExpenseChat'
     | 'isPinned'
-    | 'isTrackOnboardingAdminRoom'
     | 'lastActorAccountID'
     | 'lastMessageHtml'
     | 'lastMessageText'
@@ -8631,7 +8630,6 @@ function buildOptimisticWorkspaceChats(
     currentUserAccountID: number | undefined,
     currentUserEmail: string | undefined,
     expenseReportId?: string,
-    shouldShowTrackAdminRoomInLHN = false,
 ): OptimisticWorkspaceChats {
     const pendingChatMembers = getPendingChatMembers(currentUserAccountID ? [currentUserAccountID] : [], [], CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
     const adminsChatData = {
@@ -8645,7 +8643,6 @@ function buildOptimisticWorkspaceChats(
             isPinned: shouldPinAdminRoomByDefault(),
             currentUserAccountID,
         }),
-        ...(shouldShowTrackAdminRoomInLHN && {isTrackOnboardingAdminRoom: true}),
     };
     const adminsChatReportID = adminsChatData.reportID;
     const adminsCreatedAction = buildOptimisticCreatedReportAction({emailCreatingAction: CONST.POLICY.OWNER_EMAIL_FAKE});
@@ -9703,7 +9700,7 @@ function reasonForReportToBeInOptionList({
         !isConciergeChatReport(report, conciergeReportID) &&
         !isSystemChatReport &&
         !isSelfDMWithVisiblePreference &&
-        !(report.isTrackOnboardingAdminRoom && isAdminRoom(report) && !isReportArchived) &&
+        !(getReportMetadata(report.reportID)?.isTrackOnboardingAdminRoom && isAdminRoom(report) && !isReportArchived) &&
         canHideReport
     ) {
         return null;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -626,6 +626,7 @@ type OptimisticChatReport = Pick<
     | 'iouReportID'
     | 'isOwnPolicyExpenseChat'
     | 'isPinned'
+    | 'isTrackOnboardingAdminRoom'
     | 'lastActorAccountID'
     | 'lastMessageHtml'
     | 'lastMessageText'
@@ -8630,6 +8631,7 @@ function buildOptimisticWorkspaceChats(
     currentUserAccountID: number | undefined,
     currentUserEmail: string | undefined,
     expenseReportId?: string,
+    shouldShowTrackAdminRoomInLHN = false,
 ): OptimisticWorkspaceChats {
     const pendingChatMembers = getPendingChatMembers(currentUserAccountID ? [currentUserAccountID] : [], [], CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
     const adminsChatData = {
@@ -8643,6 +8645,7 @@ function buildOptimisticWorkspaceChats(
             isPinned: shouldPinAdminRoomByDefault(),
             currentUserAccountID,
         }),
+        ...(shouldShowTrackAdminRoomInLHN && {isTrackOnboardingAdminRoom: true}),
     };
     const adminsChatReportID = adminsChatData.reportID;
     const adminsCreatedAction = buildOptimisticCreatedReportAction({emailCreatingAction: CONST.POLICY.OWNER_EMAIL_FAKE});
@@ -9700,6 +9703,7 @@ function reasonForReportToBeInOptionList({
         !isConciergeChatReport(report, conciergeReportID) &&
         !isSystemChatReport &&
         !isSelfDMWithVisiblePreference &&
+        !(report.isTrackOnboardingAdminRoom && isAdminRoom(report) && !isReportArchived) &&
         canHideReport
     ) {
         return null;

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -327,7 +327,7 @@ function shouldDisplayReportInLHN({
     const parentReport = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID}`];
     const hasErrorsOtherThanFailedReceipt = hasReportErrorsOtherThanFailedReceipt(report, chatReport, doesReportHaveViolations, transactionViolations, transactions, reportAttributes);
     const isReportInAccessible = report?.errorFields?.notFound;
-    const isTrackOnboardingAdminRoom = report.isTrackOnboardingAdminRoom && isAdminRoom(report);
+    const isTrackOnboardingAdminRoom = getReportMetadata(report.reportID)?.isTrackOnboardingAdminRoom && isAdminRoom(report);
 
     if (isTrackOnboardingAdminRoom && isReportArchived) {
         return {shouldDisplay: false};

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -327,6 +327,12 @@ function shouldDisplayReportInLHN({
     const parentReport = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID}`];
     const hasErrorsOtherThanFailedReceipt = hasReportErrorsOtherThanFailedReceipt(report, chatReport, doesReportHaveViolations, transactionViolations, transactions, reportAttributes);
     const isReportInAccessible = report?.errorFields?.notFound;
+    const isTrackOnboardingAdminRoom = report.isTrackOnboardingAdminRoom && isAdminRoom(report);
+
+    if (isTrackOnboardingAdminRoom && isReportArchived) {
+        return {shouldDisplay: false};
+    }
+
     if (isOneTransactionThread(report, parentReport, parentReportAction, isOffline)) {
         return {shouldDisplay: false};
     }
@@ -345,6 +351,7 @@ function shouldDisplayReportInLHN({
         isFocused ||
         isSystemChat ||
         !!report.isPinned ||
+        isTrackOnboardingAdminRoom ||
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         requiresAttention ||
         (report.isOwnPolicyExpenseChat && !isReportArchived);

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -351,6 +351,7 @@ function shouldDisplayReportInLHN({
         isFocused ||
         isSystemChat ||
         !!report.isPinned ||
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         isTrackOnboardingAdminRoom ||
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         requiresAttention ||

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -244,6 +244,7 @@ type BuildPolicyDataOptions = {
     hasActiveAdminPolicies: boolean | undefined;
     betas?: OnyxEntry<Beta[]>;
     personalTrackGoal?: string;
+    shouldShowTrackAdminRoomInLHN?: boolean;
 };
 
 // TODO: Remove this type once we complete refactoring the buildPolicyData function to use isSelfTourViewed. Refactor issue: https://github.com/Expensify/App/issues/66424
@@ -2612,6 +2613,7 @@ function buildPolicyData(options: BuildPolicyDataOptions): OnyxData<BuildPolicyD
         isSelfTourViewed,
         hasActiveAdminPolicies,
         personalTrackGoal,
+        shouldShowTrackAdminRoomInLHN,
     } = options;
 
     const {customUnits, customUnitID, customUnitRateID, outputCurrency} = buildOptimisticDistanceRateCustomUnits(currency);
@@ -2626,7 +2628,7 @@ function buildPolicyData(options: BuildPolicyDataOptions): OnyxData<BuildPolicyD
         expenseReportActionData,
         expenseCreatedReportActionID,
         pendingChatMembers,
-    } = ReportUtils.buildOptimisticWorkspaceChats(policyID, policyName, currentUserAccountIDParam, currentUserEmailParam, expenseReportId);
+    } = ReportUtils.buildOptimisticWorkspaceChats(policyID, policyName, currentUserAccountIDParam, currentUserEmailParam, expenseReportId, shouldShowTrackAdminRoomInLHN);
 
     // When creating a workspace for a different owner without keeping admin, the caller is not added to the workspace.
     // Skip writing the admins/expense chat reports into the caller's Onyx so they don't appear in the LHN.

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -2807,6 +2807,7 @@ function buildPolicyData(options: BuildPolicyDataOptions): OnyxData<BuildPolicyD
                         addWorkspaceRoom: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
                     },
                     ...adminsChatData,
+                    ...(shouldShowTrackAdminRoomInLHN && {isPinned: false}),
                 },
             },
             {

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -2628,7 +2628,7 @@ function buildPolicyData(options: BuildPolicyDataOptions): OnyxData<BuildPolicyD
         expenseReportActionData,
         expenseCreatedReportActionID,
         pendingChatMembers,
-    } = ReportUtils.buildOptimisticWorkspaceChats(policyID, policyName, currentUserAccountIDParam, currentUserEmailParam, expenseReportId, shouldShowTrackAdminRoomInLHN);
+    } = ReportUtils.buildOptimisticWorkspaceChats(policyID, policyName, currentUserAccountIDParam, currentUserEmailParam, expenseReportId);
 
     // When creating a workspace for a different owner without keeping admin, the caller is not added to the workspace.
     // Skip writing the admins/expense chat reports into the caller's Onyx so they don't appear in the LHN.
@@ -2814,6 +2814,7 @@ function buildPolicyData(options: BuildPolicyDataOptions): OnyxData<BuildPolicyD
                 key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${adminsChatReportID}`,
                 value: {
                     pendingChatMembers,
+                    ...(shouldShowTrackAdminRoomInLHN && {isTrackOnboardingAdminRoom: true}),
                 },
             },
             {

--- a/src/types/onyx/Report.ts
+++ b/src/types/onyx/Report.ts
@@ -124,6 +124,9 @@ type Report = OnyxCommon.OnyxValueWithOfflineFeedback<
         /** Indicates if the report is pinned to the LHN or not */
         isPinned?: boolean;
 
+        /** Whether this is the admins room created during Track workspace onboarding and should remain visible in the LHN while active */
+        isTrackOnboardingAdminRoom?: boolean;
+
         /** The text of the last message on the report */
         lastMessageText?: string;
 

--- a/src/types/onyx/Report.ts
+++ b/src/types/onyx/Report.ts
@@ -124,9 +124,6 @@ type Report = OnyxCommon.OnyxValueWithOfflineFeedback<
         /** Indicates if the report is pinned to the LHN or not */
         isPinned?: boolean;
 
-        /** Whether this is the admins room created during Track workspace onboarding and should remain visible in the LHN while active */
-        isTrackOnboardingAdminRoom?: boolean;
-
         /** The text of the last message on the report */
         lastMessageText?: string;
 

--- a/src/types/onyx/ReportMetadata.ts
+++ b/src/types/onyx/ReportMetadata.ts
@@ -23,6 +23,9 @@ type ReportMetadata = {
     /** Whether the current report is optimistic */
     isOptimisticReport?: boolean;
 
+    /** Whether this is the admins room created during Track workspace onboarding and should remain visible in the LHN while active */
+    isTrackOnboardingAdminRoom?: boolean;
+
     /** Pending members of the report */
     pendingChatMembers?: PendingChatMember[];
 

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -77,7 +77,7 @@ describe('actions/Policy', () => {
         });
 
         it('creates Track onboarding admins rooms unpinned without changing the regular workspace default', async () => {
-            (fetch as MockFetch)?.pause?.();
+            mockFetch.pause?.();
             await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
             await waitForBatchedUpdates();
 

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -76,6 +76,44 @@ describe('actions/Policy', () => {
             mockFetch?.resume?.();
         });
 
+        it('creates Track onboarding admins rooms unpinned without changing the regular workspace default', async () => {
+            (fetch as MockFetch)?.pause?.();
+            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await waitForBatchedUpdates();
+
+            const createWorkspaceOptions = {
+                policyOwnerEmail: ESH_EMAIL,
+                makeMeAdmin: true,
+                policyName: WORKSPACE_NAME,
+                engagementChoice: CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE,
+                introSelected: {choice: CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE},
+                currentUserAccountIDParam: ESH_ACCOUNT_ID,
+                currentUserEmailParam: ESH_EMAIL,
+                currency: CONST.CURRENCY.USD,
+                isSelfTourViewed: false,
+                hasActiveAdminPolicies: false,
+                activePolicy: undefined,
+            };
+
+            const trackWorkspaceParams = Policy.createWorkspace({
+                ...createWorkspaceOptions,
+                policyID: Policy.generatePolicyID(),
+                shouldShowTrackAdminRoomInLHN: true,
+            });
+            const regularWorkspaceParams = Policy.createWorkspace({
+                ...createWorkspaceOptions,
+                policyID: Policy.generatePolicyID(),
+                shouldShowTrackAdminRoomInLHN: false,
+            });
+            await waitForBatchedUpdates();
+
+            const trackAdminReport = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${trackWorkspaceParams.adminsChatReportID}`);
+            const regularAdminReport = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${regularWorkspaceParams.adminsChatReportID}`);
+
+            expect(trackAdminReport?.isPinned).toBe(false);
+            expect(regularAdminReport?.isPinned).toBe(true);
+        });
+
         it('creates a new workspace', async () => {
             (fetch as MockFetch)?.pause?.();
             await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -6689,12 +6689,13 @@ describe('ReportUtils', () => {
             ).toBeFalsy();
         });
 
-        it('should return true for an active empty Track onboarding admins room when empty chats are excluded', () => {
+        it('should return true for an active empty Track onboarding admins room when empty chats are excluded', async () => {
             const report: Report = {
                 ...createAdminRoom(1),
                 isPinned: false,
-                isTrackOnboardingAdminRoom: true,
             };
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report.reportID}`, {isTrackOnboardingAdminRoom: true});
+            await waitForBatchedUpdates();
 
             expect(
                 shouldReportBeInOptionList({
@@ -6711,12 +6712,13 @@ describe('ReportUtils', () => {
             ).toBeTruthy();
         });
 
-        it('should retain archived Track onboarding admins rooms in report option lists used by search', () => {
+        it('should retain archived Track onboarding admins rooms in report option lists used by search', async () => {
             const report: Report = {
                 ...createAdminRoom(1),
                 isPinned: false,
-                isTrackOnboardingAdminRoom: true,
             };
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report.reportID}`, {isTrackOnboardingAdminRoom: true});
+            await waitForBatchedUpdates();
 
             expect(
                 reasonForReportToBeInOptionList({
@@ -7495,20 +7497,6 @@ describe('ReportUtils', () => {
 
             expect(result.expenseChatReportID).toBe(providedExpenseReportID);
             expect(result.expenseChatData.reportID).toBe(providedExpenseReportID);
-        });
-
-        it('should mark only the Track onboarding admins room for LHN visibility', () => {
-            const result = buildOptimisticWorkspaceChats(policyID, policyName, 100, 'user@expensifail.com', undefined, true);
-
-            expect(result.adminsChatData.isTrackOnboardingAdminRoom).toBe(true);
-            expect(result.expenseChatData.isTrackOnboardingAdminRoom).toBeUndefined();
-        });
-
-        it('should not mark workspace chats by default', () => {
-            const result = buildOptimisticWorkspaceChats(policyID, policyName, 100, 'user@expensifail.com');
-
-            expect(result.adminsChatData.isTrackOnboardingAdminRoom).toBeUndefined();
-            expect(result.expenseChatData.isTrackOnboardingAdminRoom).toBeUndefined();
         });
     });
 

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -6689,6 +6689,50 @@ describe('ReportUtils', () => {
             ).toBeFalsy();
         });
 
+        it('should return true for an active empty Track onboarding admins room when empty chats are excluded', () => {
+            const report: Report = {
+                ...createAdminRoom(1),
+                isPinned: false,
+                isTrackOnboardingAdminRoom: true,
+            };
+
+            expect(
+                shouldReportBeInOptionList({
+                    report,
+                    chatReport: mockedChatReport,
+                    currentReportId: '',
+                    isInFocusMode: false,
+                    betas: [CONST.BETAS.DEFAULT_ROOMS],
+                    doesReportHaveViolations: false,
+                    excludeEmptyChats: true,
+                    draftComment: '',
+                    isReportArchived: false,
+                }),
+            ).toBeTruthy();
+        });
+
+        it('should retain archived Track onboarding admins rooms in report option lists used by search', () => {
+            const report: Report = {
+                ...createAdminRoom(1),
+                isPinned: false,
+                isTrackOnboardingAdminRoom: true,
+            };
+
+            expect(
+                reasonForReportToBeInOptionList({
+                    report,
+                    chatReport: mockedChatReport,
+                    currentReportId: '',
+                    isInFocusMode: false,
+                    betas: [CONST.BETAS.DEFAULT_ROOMS],
+                    doesReportHaveViolations: false,
+                    excludeEmptyChats: false,
+                    draftComment: '',
+                    isReportArchived: true,
+                }),
+            ).toBe(CONST.REPORT_IN_LHN_REASONS.IS_ARCHIVED);
+        });
+
         it('should return DEFAULT for an empty concierge chat when excludeEmptyChats is true', async () => {
             const conciergeReportID = 'concierge-report-123';
             const report: Report = {
@@ -7451,6 +7495,20 @@ describe('ReportUtils', () => {
 
             expect(result.expenseChatReportID).toBe(providedExpenseReportID);
             expect(result.expenseChatData.reportID).toBe(providedExpenseReportID);
+        });
+
+        it('should mark only the Track onboarding admins room for LHN visibility', () => {
+            const result = buildOptimisticWorkspaceChats(policyID, policyName, 100, 'user@expensifail.com', undefined, true);
+
+            expect(result.adminsChatData.isTrackOnboardingAdminRoom).toBe(true);
+            expect(result.expenseChatData.isTrackOnboardingAdminRoom).toBeUndefined();
+        });
+
+        it('should not mark workspace chats by default', () => {
+            const result = buildOptimisticWorkspaceChats(policyID, policyName, 100, 'user@expensifail.com');
+
+            expect(result.adminsChatData.isTrackOnboardingAdminRoom).toBeUndefined();
+            expect(result.expenseChatData.isTrackOnboardingAdminRoom).toBeUndefined();
         });
     });
 

--- a/tests/unit/SidebarUtilsTest.ts
+++ b/tests/unit/SidebarUtilsTest.ts
@@ -836,7 +836,7 @@ describe('SidebarUtils', () => {
     });
 
     describe('shouldDisplayReportInLHN', () => {
-        const getAdminRoomDisplayResult = (reportOverrides: Partial<Report>, isReportArchived = false, currentReportId?: string) => {
+        const getAdminRoomDisplayResult = async (reportOverrides: Partial<Report>, isReportArchived = false, currentReportId?: string, isTrackOnboardingAdminRoom = false) => {
             const report: Report = {
                 ...createAdminRoom(92431),
                 participants: {
@@ -848,6 +848,9 @@ describe('SidebarUtils', () => {
                 lastMessageText: '',
                 ...reportOverrides,
             };
+            await act(async () => {
+                await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report.reportID}`, {isTrackOnboardingAdminRoom});
+            });
 
             return SidebarUtils.shouldDisplayReportInLHN({
                 report,
@@ -865,8 +868,8 @@ describe('SidebarUtils', () => {
             });
         };
 
-        it('shows an active hidden and empty Track onboarding admins room without pinning it', () => {
-            const result = getAdminRoomDisplayResult({isTrackOnboardingAdminRoom: true});
+        it('shows an active hidden and empty Track onboarding admins room without pinning it', async () => {
+            const result = await getAdminRoomDisplayResult({}, false, undefined, true);
 
             expect(result).toStrictEqual({shouldDisplay: true});
         });
@@ -875,21 +878,21 @@ describe('SidebarUtils', () => {
             ['unpinned and empty', {isPinned: false}],
             ['pinned', {isPinned: true}],
             ['non-empty', {lastMessageText: 'Message'}],
-        ])('hides an archived Track onboarding admins room when it is %s', (_description, reportOverrides) => {
-            const result = getAdminRoomDisplayResult({isTrackOnboardingAdminRoom: true, ...reportOverrides}, true);
+        ])('hides an archived Track onboarding admins room when it is %s', async (_description, reportOverrides) => {
+            const result = await getAdminRoomDisplayResult(reportOverrides, true, undefined, true);
 
             expect(result).toStrictEqual({shouldDisplay: false});
         });
 
-        it('hides an archived Track onboarding admins room even when it is focused', () => {
+        it('hides an archived Track onboarding admins room even when it is focused', async () => {
             const report = createAdminRoom(92431);
-            const result = getAdminRoomDisplayResult({reportID: report.reportID, isTrackOnboardingAdminRoom: true}, true, report.reportID);
+            const result = await getAdminRoomDisplayResult({reportID: report.reportID}, true, report.reportID, true);
 
             expect(result).toStrictEqual({shouldDisplay: false});
         });
 
-        it('does not change visibility for an unmarked hidden and empty admins room', () => {
-            const result = getAdminRoomDisplayResult({});
+        it('does not change visibility for an unmarked hidden and empty admins room', async () => {
+            const result = await getAdminRoomDisplayResult({});
 
             expect(result).toStrictEqual({shouldDisplay: false});
         });

--- a/tests/unit/SidebarUtilsTest.ts
+++ b/tests/unit/SidebarUtilsTest.ts
@@ -29,7 +29,7 @@ import {actionR14932 as mockIOUAction} from '../../__mocks__/reportData/actions'
 import {chatReportR14932, iouReportR14932} from '../../__mocks__/reportData/reports';
 import createRandomPolicy from '../utils/collections/policies';
 import createRandomReportAction from '../utils/collections/reportActions';
-import {createRandomReport} from '../utils/collections/reports';
+import {createAdminRoom, createRandomReport} from '../utils/collections/reports';
 import {createSidebarReportsCollection, createSidebarTestData} from '../utils/collections/sidebarReports';
 import createRandomTransaction from '../utils/collections/transaction';
 import * as LHNTestUtils from '../utils/LHNTestUtils';
@@ -836,6 +836,64 @@ describe('SidebarUtils', () => {
     });
 
     describe('shouldDisplayReportInLHN', () => {
+        const getAdminRoomDisplayResult = (reportOverrides: Partial<Report>, isReportArchived = false, currentReportId?: string) => {
+            const report: Report = {
+                ...createAdminRoom(92431),
+                participants: {
+                    [CURRENT_USER_ACCOUNT_ID]: {
+                        notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                    },
+                },
+                isPinned: false,
+                lastMessageText: '',
+                ...reportOverrides,
+            };
+
+            return SidebarUtils.shouldDisplayReportInLHN({
+                report,
+                reports: {[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`]: report},
+                currentReportId,
+                isInFocusMode: false,
+                betas: [],
+                transactionViolations: {},
+                draftComment: undefined,
+                transactions: {},
+                isOffline: false,
+                isReportArchived,
+                currentUserLogin: CURRENT_USER_LOGIN,
+                currentUserAccountID: CURRENT_USER_ACCOUNT_ID,
+            });
+        };
+
+        it('shows an active hidden and empty Track onboarding admins room without pinning it', () => {
+            const result = getAdminRoomDisplayResult({isTrackOnboardingAdminRoom: true});
+
+            expect(result).toStrictEqual({shouldDisplay: true});
+        });
+
+        it.each([
+            ['unpinned and empty', {isPinned: false}],
+            ['pinned', {isPinned: true}],
+            ['non-empty', {lastMessageText: 'Message'}],
+        ])('hides an archived Track onboarding admins room when it is %s', (_description, reportOverrides) => {
+            const result = getAdminRoomDisplayResult({isTrackOnboardingAdminRoom: true, ...reportOverrides}, true);
+
+            expect(result).toStrictEqual({shouldDisplay: false});
+        });
+
+        it('hides an archived Track onboarding admins room even when it is focused', () => {
+            const report = createAdminRoom(92431);
+            const result = getAdminRoomDisplayResult({reportID: report.reportID, isTrackOnboardingAdminRoom: true}, true, report.reportID);
+
+            expect(result).toStrictEqual({shouldDisplay: false});
+        });
+
+        it('does not change visibility for an unmarked hidden and empty admins room', () => {
+            const result = getAdminRoomDisplayResult({});
+
+            expect(result).toStrictEqual({shouldDisplay: false});
+        });
+
         it('returns shouldDisplay as true if a one transaction thread expense report has receipt upload error', async () => {
             const MOCK_REPORT: Report = {
                 reportID: '1',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Marks the `#admins` room created during Track-business onboarding so it remains visible in the LHN while active, without pinning it or changing regular workspace rooms. Archived rooms are excluded from the LHN while remaining accessible through search.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/92431
PROPOSAL: https://github.com/Expensify/App/issues/92431#issuecomment-4608303840


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Create a new account.
2. Select **Track expenses for my business**.
3. Complete onboarding.
4. Open **Inbox**.
5. Verify the workspace `#admins` room is visible in the LHN.
6. Verify the room is not pinned.
7. Open another chat.
8. Verify `#admins` remains visible.


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Not applicable. Completing Track-business onboarding and creating the workspace requires an active network connection.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as Tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/f02f9379-5379-41f8-9ac8-7f2e60c79a2f

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/a2701eb9-41d3-4fd8-a320-047e1bdf6f44

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/c1f16199-d603-489a-bdc4-310ecd5ddff7

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/be79c28b-c6f8-4c7f-a1fe-9d62976790a6

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/89e9ac17-91cb-4344-9846-8f442e4d820f

</details>
