### PR TITLE
Fix offline tax rate deletion bug not showing in default picker

### DIFF
--- a/src/libs/TaxOptionsListUtils.ts
+++ b/src/libs/TaxOptionsListUtils.ts
@@ -70,15 +70,16 @@ function getTaxRatesSection({
 
     const sortedTaxRates = sortTaxRates(taxes, localeCompare);
     const selectedOptionNames = new Set(selectedOptions.map((selectedOption) => selectedOption.modifiedName));
-    const enabledTaxRates = sortedTaxRates.filter((taxRate) => !taxRate.isDisabled);
+    const enabledTaxRates = sortedTaxRates.filter((taxRate) => !taxRate.isDisabled || taxRate.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
     const enabledTaxRatesNames = new Set(enabledTaxRates.map((tax) => tax.modifiedName));
     const enabledTaxRatesWithoutSelectedOptions = enabledTaxRates.filter((tax) => tax.modifiedName && !selectedOptionNames.has(tax.modifiedName));
     const selectedTaxRateWithDisabledState: Tax[] = [];
     const numberOfTaxRates = enabledTaxRates.length;
 
     for (const tax of selectedOptions) {
-        if (enabledTaxRatesNames.has(tax.modifiedName)) {
-            selectedTaxRateWithDisabledState.push({...tax, isDisabled: false, isSelected: true});
+        const realTax = enabledTaxRates.find((t) => t.modifiedName === tax.modifiedName);
+        if (realTax) {
+            selectedTaxRateWithDisabledState.push({...realTax, isDisabled: false, isSelected: true});
             continue;
         }
         selectedTaxRateWithDisabledState.push({...tax, isDisabled: true, isSelected: true});


### PR DESCRIPTION
### Details
$ #95231.

This PR addresses the issue where tax rates deleted offline completely disappear from the Workspace Default Settings picker, instead of appearing disabled with a strike-through.
- Updated \TaxOptionsListUtils.ts\ to not aggressive filter out offline-deleted tax rates (those with \pendingAction: DELETE\).
- Ensured \selectedOptions\ correctly forwards the \pendingAction\ state if it was deleted.

### Fixed Issues
$ #95231