### PR TITLE
[No QA] fix: checkout Mobile-Expensify PR before calling `Setup Node` action

### DIFF
--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -4,10 +4,14 @@ name: Remote Build Android
 on:
   workflow_dispatch:
     inputs:
-      mobile_expensify_pr:
-        description: 'Mobile-Expensify PR number to use for hybrid build'
+      app_pull_request_url:
+        description: 'The Expensify/App pull request URL. Its description is scanned for a MOBILE-EXPENSIFY entry.'
         required: false
-        type: string
+        default: ''
+      mobile_expensify_pull_request_url:
+        description: 'The Expensify/Mobile-Expensify pull request URL to check out the submodule. Overrides MOBILE-EXPENSIFY set in the App PR description.'
+        required: false
+        default: ''
   push:
     branches-ignore: [staging, production, cherry-pick-*]
     paths-ignore: ['docs/**', 'contributingGuides/**', 'help/**', '.github/**', 'scripts/**', 'tests/**']
@@ -17,7 +21,17 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  getMobileExpensifyRef:
+    name: Resolve Mobile-Expensify ref
+    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+    with:
+      APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
+      MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.mobile_expensify_pull_request_url }}
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
   build:
+    needs: [getMobileExpensifyRef]
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-16vcpu-ubuntu-2404' || 'blacksmith-2vcpu-ubuntu-2404' }}
     strategy:
       fail-fast: false
@@ -35,18 +49,18 @@ jobs:
           submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
+      - name: Checkout Mobile-Expensify to specified branch or commit
+        if: ${{ matrix.is_hybrid_build && needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF != '' }}
+        run: |
+          cd Mobile-Expensify
+          git fetch origin ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
+          git checkout ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
+          echo "Checked out Mobile-Expensify PR #${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_PR }} (${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }})"
+
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
         with:
           IS_HYBRID_BUILD: ${{ matrix.is_hybrid_build && 'true' || 'false' }}
-
-      - name: Checkout specific Mobile-Expensify PR
-        if: ${{ matrix.is_hybrid_build && github.event.inputs.mobile_expensify_pr }}
-        run: |
-          cd Mobile-Expensify
-          git fetch origin pull/${{ github.event.inputs.mobile_expensify_pr }}/head:pr-${{ github.event.inputs.mobile_expensify_pr }}
-          git checkout pr-${{ github.event.inputs.mobile_expensify_pr }}
-          echo "Checked out Mobile-Expensify PR #${{ github.event.inputs.mobile_expensify_pr }}"
 
       - name: Configure AWS Credentials
         # v6

--- a/.github/workflows/remote-build-ios.yml
+++ b/.github/workflows/remote-build-ios.yml
@@ -4,10 +4,14 @@ name: Remote Build iOS
 on:
   workflow_dispatch:
     inputs:
-      mobile_expensify_pr:
-        description: 'Mobile-Expensify PR number to use for hybrid build'
+      app_pull_request_url:
+        description: 'The Expensify/App pull request URL. Its description is scanned for a MOBILE-EXPENSIFY entry.'
         required: false
-        type: string
+        default: ''
+      mobile_expensify_pull_request_url:
+        description: 'The Expensify/Mobile-Expensify pull request URL to check out the submodule. Overrides MOBILE-EXPENSIFY set in the App PR description.'
+        required: false
+        default: ''
   push:
     branches-ignore: [staging, production, cherry-pick-*]
     paths-ignore: ['docs/**', 'contributingGuides/**', 'help/**', '.github/**', 'scripts/**', 'tests/**']
@@ -17,7 +21,17 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  getMobileExpensifyRef:
+    name: Resolve Mobile-Expensify ref
+    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+    with:
+      APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
+      MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.mobile_expensify_pull_request_url }}
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
   build:
+    needs: [getMobileExpensifyRef]
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-12vcpu-macos-latest' || 'macos-latest' }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
@@ -39,6 +53,14 @@ jobs:
           submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
+      - name: Checkout Mobile-Expensify to specified branch or commit
+        if: ${{ matrix.is_hybrid_build && needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF != '' }}
+        run: |
+          cd Mobile-Expensify
+          git fetch origin ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
+          git checkout ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
+          echo "Checked out Mobile-Expensify PR #${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_PR }} (${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }})"
+
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
         with:
@@ -49,14 +71,6 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
         with:
           bundler-cache: true
-
-      - name: Checkout specific Mobile-Expensify PR
-        if: ${{ matrix.is_hybrid_build && github.event.inputs.mobile_expensify_pr }}
-        run: |
-          cd Mobile-Expensify
-          git fetch origin pull/${{ github.event.inputs.mobile_expensify_pr }}/head:pr-${{ github.event.inputs.mobile_expensify_pr }}
-          git checkout pr-${{ github.event.inputs.mobile_expensify_pr }}
-          echo "Checked out Mobile-Expensify PR #${{ github.event.inputs.mobile_expensify_pr }}"
 
       - name: Configure AWS Credentials
         # v6


### PR DESCRIPTION
### Explanation of Change

This PR fixes and reworks how the `Remote Build iOS` and `Remote Build Android` workflows resolve and check out a specific `Mobile-Expensify` submodule ref for hybrid ad-hoc builds.

**The fix (primary change)**

Previously the "Checkout specific Mobile-Expensify PR" step ran *after* the `Setup Node` composite action. `Setup Node` relies on the `Mobile-Expensify` submodule contents (dotenv merging, dependency install, etc.), so checking out the target PR afterwards meant Node was set up against the wrong ref. This PR moves the `Mobile-Expensify` checkout so it runs **before** `Setup Node`.

This aligns the ad-hoc build workflows with the URL-based resolution used elsewhere and makes it possible to trigger a hybrid build directly from an App PR link.

### Fixed Issues
$ https://github.com/Expensify/App/issues/95387
PROPOSAL:

### Tests

1. Trigger the `Remote Build iOS` (and `Remote Build Android`) workflow via `workflow_dispatch` with an `app_pull_request_url` pointing at an App PR whose description contains a `MOBILE-EXPENSIFY:` link.
2. Verify the `Resolve Mobile-Expensify ref` job runs first and resolves the expected `MOBILE_EXPENSIFY_REF` / PR number.
3. Verify the hybrid `build` job checks out the resolved `Mobile-Expensify` ref **before** the `Setup Node` step runs (check the "Checkout Mobile-Expensify to specified branch or commit" log line appears before "Setup Node").
4. Re-run providing `mobile_expensify_pull_request_url` directly and verify it overrides the ref resolved from the App PR description.
5. Trigger a push/normal run with no inputs and verify the hybrid checkout step is skipped (empty ref) and the build proceeds against the submodule default.

### Offline tests

N/A — CI workflow change only.

### QA Steps

[No QA]

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>iOS: Native</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — CI workflow change only.

</details>
