### PR TITLE
[Payment due @parasharrajat] Add None option to clear default custom unit category

### DIFF
--- a/src/components/CategoryPicker/index.tsx
+++ b/src/components/CategoryPicker/index.tsx
@@ -13,7 +13,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {getCategoryListSections} from '@libs/CategoryOptionListUtils';
 import type {Category} from '@libs/CategoryOptionListUtils';
 import {getEnabledCategoriesCount} from '@libs/CategoryUtils';
-import {getHeaderMessageForNonUserList} from '@libs/OptionsListUtils';
+import {getHeaderMessageForNonUserList, getNoneOption} from '@libs/OptionsListUtils';
 import type {OptionTree} from '@libs/OptionsListUtils/types';
 
 import CONST from '@src/CONST';
@@ -73,18 +73,17 @@ function CategoryPicker({selectedCategory, policyID, onSubmit, shouldShowNoneOpt
         translate,
     });
 
-    const shouldShowNoneOptionForSearch = shouldShowNoneOption && translate('common.none').toLowerCase().includes(debouncedSearchValue.toLowerCase());
-    const noneOption: OptionTree[] = shouldShowNoneOptionForSearch
-        ? [
-              {
-                  text: translate('common.none'),
-                  keyForList: CONST.SEARCH.NONE_OPTION_KEY,
+    const noneOption: OptionTree[] = shouldShowNoneOption
+        ? getNoneOption(debouncedSearchValue, !selectedCategory, translate).map(
+              (option): OptionTree => ({
+                  text: option.text,
+                  keyForList: option.keyForList,
                   searchText: '',
-                  tooltipText: translate('common.none'),
+                  tooltipText: option.text,
                   isDisabled: false,
-                  isSelected: !selectedCategory,
-              },
-          ]
+                  isSelected: option.isSelected,
+              }),
+          )
         : [];
     const noneOptionSection = {
         title: '',
@@ -92,9 +91,8 @@ function CategoryPicker({selectedCategory, policyID, onSubmit, shouldShowNoneOpt
         sectionIndex: -1,
     };
     const selectedCategorySectionIndex = sections.findIndex((section) => section.data.some((category) => category.searchText === selectedCategory));
-    const sectionsWithNoneOption = shouldShowNoneOptionForSearch
-        ? [...sections.slice(0, selectedCategorySectionIndex + 1), noneOptionSection, ...sections.slice(selectedCategorySectionIndex + 1)]
-        : sections;
+    const sectionsWithNoneOption =
+        noneOption.length > 0 ? [...sections.slice(0, selectedCategorySectionIndex + 1), noneOptionSection, ...sections.slice(selectedCategorySectionIndex + 1)] : sections;
 
     const categoryData = sectionsWithNoneOption.flatMap((section) => section.data);
     const categoriesCount = getEnabledCategoriesCount(categories);

--- a/src/components/CategoryPicker/index.tsx
+++ b/src/components/CategoryPicker/index.tsx
@@ -14,6 +14,7 @@ import {getCategoryListSections} from '@libs/CategoryOptionListUtils';
 import type {Category} from '@libs/CategoryOptionListUtils';
 import {getEnabledCategoriesCount} from '@libs/CategoryUtils';
 import {getHeaderMessageForNonUserList} from '@libs/OptionsListUtils';
+import type {OptionTree} from '@libs/OptionsListUtils/types';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -73,12 +74,14 @@ function CategoryPicker({selectedCategory, policyID, onSubmit, shouldShowNoneOpt
     });
 
     const shouldShowNoneOptionForSearch = shouldShowNoneOption && translate('common.none').toLowerCase().includes(debouncedSearchValue.toLowerCase());
-    const noneOption: ListItem[] = shouldShowNoneOptionForSearch
+    const noneOption: OptionTree[] = shouldShowNoneOptionForSearch
         ? [
               {
                   text: translate('common.none'),
                   keyForList: CONST.SEARCH.NONE_OPTION_KEY,
                   searchText: '',
+                  tooltipText: translate('common.none'),
+                  isDisabled: false,
                   isSelected: !selectedCategory,
               },
           ]

--- a/src/components/CategoryPicker/index.tsx
+++ b/src/components/CategoryPicker/index.tsx
@@ -25,6 +25,7 @@ type CategoryPickerProps = {
     policyID: string | undefined;
     selectedCategory?: string;
     onSubmit: (item: ListItem) => void;
+    shouldShowNoneOption?: boolean;
 
     /**
      * If enabled, the content will have a bottom padding equal to account for the safe bottom area inset.
@@ -46,7 +47,7 @@ const getSelectedOptions = (selectedCategory?: string): Category[] => {
     ];
 };
 
-function CategoryPicker({selectedCategory, policyID, onSubmit, addBottomSafeAreaPadding = false}: CategoryPickerProps) {
+function CategoryPicker({selectedCategory, policyID, onSubmit, shouldShowNoneOption = false, addBottomSafeAreaPadding = false}: CategoryPickerProps) {
     const styles = useThemeStyles();
     const {inputCallbackRef} = useAutoFocusInput();
     const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
@@ -71,7 +72,29 @@ function CategoryPicker({selectedCategory, policyID, onSubmit, addBottomSafeArea
         translate,
     });
 
-    const categoryData = sections?.at(0)?.data ?? [];
+    const shouldShowNoneOptionForSearch = shouldShowNoneOption && translate('common.none').toLowerCase().includes(debouncedSearchValue.toLowerCase());
+    const noneOption: ListItem[] = shouldShowNoneOptionForSearch
+        ? [
+              {
+                  text: translate('common.none'),
+                  keyForList: CONST.SEARCH.NONE_OPTION_KEY,
+                  searchText: '',
+                  isSelected: !selectedCategory,
+              },
+          ]
+        : [];
+    const sectionsWithNoneOption = shouldShowNoneOptionForSearch
+        ? [
+              {
+                  title: '',
+                  data: noneOption,
+                  sectionIndex: -1,
+              },
+              ...sections,
+          ]
+        : sections;
+
+    const categoryData = sectionsWithNoneOption.flatMap((section) => section.data);
     const categoriesCount = getEnabledCategoriesCount(categories);
     const selectedOptionKey = categoryData.find((category) => category.searchText === selectedCategory)?.keyForList;
 
@@ -87,7 +110,7 @@ function CategoryPicker({selectedCategory, policyID, onSubmit, addBottomSafeArea
 
     return (
         <SelectionListWithSections
-            sections={sections}
+            sections={sectionsWithNoneOption}
             onSelectRow={onSubmit}
             ListItem={SingleSelectListItem}
             shouldShowTextInput={categoriesCount >= CONST.STANDARD_LIST_ITEM_LIMIT}

--- a/src/components/CategoryPicker/index.tsx
+++ b/src/components/CategoryPicker/index.tsx
@@ -86,15 +86,14 @@ function CategoryPicker({selectedCategory, policyID, onSubmit, shouldShowNoneOpt
               },
           ]
         : [];
+    const noneOptionSection = {
+        title: '',
+        data: noneOption,
+        sectionIndex: -1,
+    };
+    const selectedCategorySectionIndex = sections.findIndex((section) => section.data.some((category) => category.searchText === selectedCategory));
     const sectionsWithNoneOption = shouldShowNoneOptionForSearch
-        ? [
-              {
-                  title: '',
-                  data: noneOption,
-                  sectionIndex: -1,
-              },
-              ...sections,
-          ]
+        ? [...sections.slice(0, selectedCategorySectionIndex + 1), noneOptionSection, ...sections.slice(selectedCategorySectionIndex + 1)]
         : sections;
 
     const categoryData = sectionsWithNoneOption.flatMap((section) => section.data);

--- a/src/components/CustomUnitDefaultCategorySelector/index.tsx
+++ b/src/components/CustomUnitDefaultCategorySelector/index.tsx
@@ -1,5 +1,6 @@
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 
+import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {getDecodedCategoryName} from '@libs/CategoryUtils';
@@ -35,8 +36,10 @@ type CustomUnitDefaultCategorySelectorProps = {
 
 function CustomUnitDefaultCategorySelector({defaultValue = '', wrapperStyle, label, focused, customUnitID, interactive = true}: CustomUnitDefaultCategorySelectorProps) {
     const styles = useThemeStyles();
+    const {translate} = useLocalize();
 
     const decodedCategoryName = getDecodedCategoryName(defaultValue);
+    const title = decodedCategoryName || translate('common.none');
     const descStyle = decodedCategoryName.length === 0 ? styles.textNormal : null;
 
     const onPress = () => {
@@ -46,7 +49,7 @@ function CustomUnitDefaultCategorySelector({defaultValue = '', wrapperStyle, lab
     return (
         <MenuItemWithTopDescription
             shouldShowRightIcon={interactive}
-            title={decodedCategoryName}
+            title={title}
             description={label}
             descriptionTextStyle={descStyle}
             onPress={onPress}

--- a/src/components/Search/SearchSingleSelectionPicker.tsx
+++ b/src/components/Search/SearchSingleSelectionPicker.tsx
@@ -5,10 +5,10 @@ import useDebouncedState from '@hooks/useDebouncedState';
 import useLocalize from '@hooks/useLocalize';
 
 import Navigation from '@libs/Navigation/Navigation';
+import {getNoneOption} from '@libs/OptionsListUtils';
 import type {OptionData} from '@libs/ReportUtils';
 import {sortOptionsWithEmptyValue} from '@libs/SearchQueryUtils';
 
-import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 
@@ -53,17 +53,7 @@ function SearchSingleSelectionPicker({
     }, [initiallySelectedItem]);
 
     const searchLower = debouncedSearchTerm?.toLowerCase();
-    const noneItem =
-        allowNoneOption && translate('common.none').toLowerCase().includes(searchLower)
-            ? [
-                  {
-                      text: translate('common.none'),
-                      keyForList: CONST.SEARCH.NONE_OPTION_KEY,
-                      isSelected: !selectedItem?.value,
-                      value: '',
-                  },
-              ]
-            : [];
+    const noneItem = allowNoneOption ? getNoneOption(debouncedSearchTerm, !selectedItem?.value, translate) : [];
 
     const initiallySelectedItemSection =
         initiallySelectedItem?.name.toLowerCase().includes(searchLower) || initiallySelectedItem?.searchableText?.toLowerCase().includes(searchLower)

--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -2979,6 +2979,22 @@ function getHeaderMessageForNonUserList(hasSelectableOptions: boolean, searchVal
     return '';
 }
 
+function getNoneOption(searchValue: string, isSelected: boolean, translate: LocalizedTranslate) {
+    const noneText = translate('common.none');
+    if (!noneText.toLowerCase().includes(searchValue.toLowerCase())) {
+        return [];
+    }
+
+    return [
+        {
+            text: noneText,
+            keyForList: CONST.SEARCH.NONE_OPTION_KEY,
+            isSelected,
+            value: '',
+        },
+    ];
+}
+
 /**
  * Helper method to check whether an option can show tooltip or not
  */
@@ -3397,6 +3413,7 @@ export {
     getLastActorDisplayName,
     getLastActorDisplayNameFromLastVisibleActions,
     getLastMessageTextForReport,
+    getNoneOption,
     getParticipantsOption,
     getPersonalDetailsForAccountIDs,
     getPolicyExpenseReportOption,

--- a/src/libs/actions/Policy/Category.ts
+++ b/src/libs/actions/Policy/Category.ts
@@ -31,7 +31,7 @@ import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import Log from '@libs/Log';
 import enhanceParameters from '@libs/Network/enhanceParameters';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
-import {goBackWhenEnableFeature} from '@libs/PolicyUtils';
+import {goBackWhenEnableFeature, removePendingFieldsFromCustomUnit} from '@libs/PolicyUtils';
 import {pushTransactionAutoSelectionsOnyxData, pushTransactionViolationsOnyxData} from '@libs/ReportUtils';
 
 import {getFinishOnboardingTaskOnyxData} from '@userActions/Task';
@@ -40,7 +40,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy, PolicyCategories, PolicyCategory, Report, ReportAction} from '@src/types/onyx';
 import type {ImportFinalModal} from '@src/types/onyx/ImportedSpreadsheet';
-import type {ApprovalRule, ExpenseRule, MccGroup} from '@src/types/onyx/Policy';
+import type {ApprovalRule, CustomUnit, ExpenseRule, MccGroup} from '@src/types/onyx/Policy';
 import type {PolicyCategoryExpenseLimitType} from '@src/types/onyx/PolicyCategory';
 import type {OnyxData} from '@src/types/onyx/Request';
 
@@ -1454,7 +1454,7 @@ function enablePolicyCategories(policyData: PolicyData, enabled: boolean, should
     }
 }
 
-function setPolicyCustomUnitDefaultCategory(policyID: string, customUnitID: string, oldCategory: string | undefined, category: string) {
+function setPolicyCustomUnitDefaultCategory(policyID: string, customUnitID: string, oldCategory: string | undefined, category: string, customUnit?: CustomUnit) {
     const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.POLICY>> = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
@@ -1503,6 +1503,20 @@ function setPolicyCustomUnitDefaultCategory(policyID: string, customUnitID: stri
             },
         },
     ];
+
+    if (category === '' && customUnit) {
+        const updatedCustomUnit = removePendingFieldsFromCustomUnit({
+            ...customUnit,
+            defaultCategory: category,
+        });
+        const params = {
+            policyID,
+            customUnit: JSON.stringify(updatedCustomUnit),
+        };
+
+        API.write(WRITE_COMMANDS.UPDATE_WORKSPACE_CUSTOM_UNIT, params, {optimisticData, successData, failureData});
+        return;
+    }
 
     const params = {
         policyID,

--- a/src/libs/actions/Policy/Category.ts
+++ b/src/libs/actions/Policy/Category.ts
@@ -1504,27 +1504,25 @@ function setPolicyCustomUnitDefaultCategory(policyID: string, customUnitID: stri
         },
     ];
 
-    if (category === '' && customUnit) {
-        const updatedCustomUnit = removePendingFieldsFromCustomUnit({
-            ...customUnit,
-            defaultCategory: category,
-        });
-        const params = {
-            policyID,
-            customUnit: JSON.stringify(updatedCustomUnit),
-        };
+    const shouldUpdateCustomUnit = category === '' && customUnit !== undefined;
+    const command = shouldUpdateCustomUnit ? WRITE_COMMANDS.UPDATE_WORKSPACE_CUSTOM_UNIT : WRITE_COMMANDS.SET_CUSTOM_UNIT_DEFAULT_CATEGORY;
+    const params = shouldUpdateCustomUnit
+        ? {
+              policyID,
+              customUnit: JSON.stringify(
+                  removePendingFieldsFromCustomUnit({
+                      ...customUnit,
+                      defaultCategory: category,
+                  }),
+              ),
+          }
+        : {
+              policyID,
+              customUnitID,
+              category,
+          };
 
-        API.write(WRITE_COMMANDS.UPDATE_WORKSPACE_CUSTOM_UNIT, params, {optimisticData, successData, failureData});
-        return;
-    }
-
-    const params = {
-        policyID,
-        customUnitID,
-        category,
-    };
-
-    API.write(WRITE_COMMANDS.SET_CUSTOM_UNIT_DEFAULT_CATEGORY, params, {
+    API.write(command, params, {
         optimisticData,
         successData,
         failureData,

--- a/src/pages/workspace/categories/DynamicDefaultCategorySelectorPage.tsx
+++ b/src/pages/workspace/categories/DynamicDefaultCategorySelectorPage.tsx
@@ -31,7 +31,8 @@ function DynamicDefaultCategorySelectorPage({route}: DynamicDefaultCategorySelec
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${getNonEmptyStringOnyxID(policyID)}`);
-    const currentCategory = policy?.customUnits?.[customUnitID]?.defaultCategory ?? '';
+    const customUnit = policy?.customUnits?.[customUnitID];
+    const currentCategory = customUnit?.defaultCategory ?? '';
     const backPath = useDynamicBackPath(DYNAMIC_ROUTES.DEFAULT_CATEGORY_SELECTOR.path);
 
     const onCategorySelected = (selectedCategory: ListItem) => {
@@ -44,7 +45,7 @@ function DynamicDefaultCategorySelectorPage({route}: DynamicDefaultCategorySelec
             Navigation.goBack(backPath);
             return;
         }
-        setPolicyCustomUnitDefaultCategory(policyID, customUnitID, currentCategory, newCategory);
+        setPolicyCustomUnitDefaultCategory(policyID, customUnitID, currentCategory, newCategory, customUnit);
         Navigation.goBack(backPath);
     };
 

--- a/src/pages/workspace/categories/DynamicDefaultCategorySelectorPage.tsx
+++ b/src/pages/workspace/categories/DynamicDefaultCategorySelectorPage.tsx
@@ -35,14 +35,16 @@ function DynamicDefaultCategorySelectorPage({route}: DynamicDefaultCategorySelec
     const backPath = useDynamicBackPath(DYNAMIC_ROUTES.DEFAULT_CATEGORY_SELECTOR.path);
 
     const onCategorySelected = (selectedCategory: ListItem) => {
-        if (!selectedCategory.searchText) {
+        const isNoneSelected = selectedCategory.keyForList === CONST.SEARCH.NONE_OPTION_KEY;
+        if (!isNoneSelected && !selectedCategory.searchText) {
             return;
         }
-        if (currentCategory === selectedCategory.searchText) {
+        const newCategory = isNoneSelected ? '' : (selectedCategory.searchText ?? '');
+        if (currentCategory === newCategory) {
             Navigation.goBack(backPath);
             return;
         }
-        setPolicyCustomUnitDefaultCategory(policyID, customUnitID, currentCategory, selectedCategory.searchText);
+        setPolicyCustomUnitDefaultCategory(policyID, customUnitID, currentCategory, newCategory);
         Navigation.goBack(backPath);
     };
 
@@ -67,6 +69,7 @@ function DynamicDefaultCategorySelectorPage({route}: DynamicDefaultCategorySelec
                     policyID={policyID}
                     selectedCategory={currentCategory}
                     onSubmit={onCategorySelected}
+                    shouldShowNoneOption
                     addBottomSafeAreaPadding
                 />
             </ScreenWrapper>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Adds a `None` option to the NewDot default custom unit category picker so a workspace admin can clear an already selected default category.

The category picker now supports an opt-in `None` row, the default category selector sends an empty category when that row is selected, and the settings row shows `None` when no default category is set.

Related OldDot PR: https://github.com/Expensify/Web-Expensify/pull/54116

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/Expensify/issues/653921
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open a workspace where categories and distance rates are enabled.
2. Go to workspace settings and open the distance rates settings page.
3. Set a default category and verify the settings row shows that category.
4. Reopen the default category selector and choose `None`.
5. Verify the settings row shows `None`.
6. Start a new distance expense and verify no default category is applied.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Open the default category selector from the distance rates settings page.
2. Go offline.
3. Choose `None`.
4. Verify the settings row shows `None` with the pending offline state.
5. Go back online and verify the pending state clears and the row still shows `None`.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/fd17911e-74ae-4376-817e-1b509eb99857



</details>
