### PR TITLE
[No QA] Align remote build workflows with testBuild ref resolution

### DIFF
--- a/.github/workflows/publishReactNativeAndroidArtifacts.yml
+++ b/.github/workflows/publishReactNativeAndroidArtifacts.yml
@@ -19,6 +19,11 @@ on:
         description: 'The Expensify/Mobile-Expensify pull request URL to check out the submodule.'
         required: false
         default: ''
+      reviewed_code:
+        description: I reviewed this pull request and verified that it does not contain any malicious code.
+        type: boolean
+        required: true
+        default: false
   push:
     branches:
       - main
@@ -128,8 +133,17 @@ jobs:
             echo "BUILD_TARGETS=[\"true\"]" >> "$GITHUB_OUTPUT"
           fi
 
+  # Validates the actor and that they reviewed the PR before any token is used or untrusted App PR code is checked out.
+  prep:
+    uses: ./.github/workflows/validateBuildRequest.yml
+    with:
+      REVIEWED_CODE: ${{ inputs.reviewed_code || false }}
+    secrets:
+      OS_BOTIFY_COMMIT_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
+
   resolveRefs:
     name: Resolve build refs
+    needs: [prep]
     uses: ./.github/workflows/resolveBuildRefs.yml
     with:
       APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
@@ -140,7 +154,7 @@ jobs:
   buildAndPublishReactNativeArtifacts:
     name: Build and Publish React Native Artifacts
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-16vcpu-ubuntu-2404' || 'blacksmith-2vcpu-ubuntu-2404' }}
-    needs: [verifyPatches, resolveRefs]
+    needs: [verifyPatches, prep, resolveRefs]
     if: needs.verifyPatches.outputs.build_targets != ''
     strategy:
       # Disable fail-fast to prevent cancelling both jobs when only one needs to be stopped due to concurrency limits

--- a/.github/workflows/publishReactNativeAndroidArtifacts.yml
+++ b/.github/workflows/publishReactNativeAndroidArtifacts.yml
@@ -128,9 +128,9 @@ jobs:
             echo "BUILD_TARGETS=[\"true\"]" >> "$GITHUB_OUTPUT"
           fi
 
-  getMobileExpensifyRef:
-    name: Resolve Mobile-Expensify ref
-    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+  resolveRefs:
+    name: Resolve build refs
+    uses: ./.github/workflows/resolveBuildRefs.yml
     with:
       APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
       MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.mobile_expensify_pull_request_url }}
@@ -140,7 +140,7 @@ jobs:
   buildAndPublishReactNativeArtifacts:
     name: Build and Publish React Native Artifacts
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-16vcpu-ubuntu-2404' || 'blacksmith-2vcpu-ubuntu-2404' }}
-    needs: [verifyPatches, getMobileExpensifyRef]
+    needs: [verifyPatches, resolveRefs]
     if: needs.verifyPatches.outputs.build_targets != ''
     strategy:
       # Disable fail-fast to prevent cancelling both jobs when only one needs to be stopped due to concurrency limits
@@ -155,15 +155,16 @@ jobs:
       - name: Checkout Code
         uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
         with:
+          ref: ${{ needs.resolveRefs.outputs.APP_REF }}
           submodules: ${{ matrix.is_hybrid }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Checkout Mobile-Expensify to specified branch or commit
-        if: ${{ matrix.is_hybrid == 'true' && needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF != '' }}
+        if: ${{ matrix.is_hybrid == 'true' && needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF != '' }}
         run: |
           cd Mobile-Expensify
-          git fetch origin ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
-          git checkout ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
+          git fetch origin ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }}
+          git checkout ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }}
 
       # Recompute the patches hash from the actually checked-out tree (which may include a custom Mobile-Expensify
       # ref) so the published artifact is tagged with a hash that consumers will match against.

--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -12,6 +12,11 @@ on:
         description: 'The Expensify/Mobile-Expensify pull request URL to check out the submodule. Overrides MOBILE-EXPENSIFY set in the App PR description.'
         required: false
         default: ''
+      reviewed_code:
+        description: I reviewed this pull request and verified that it does not contain any malicious code.
+        type: boolean
+        required: true
+        default: false
   push:
     branches-ignore: [staging, production, cherry-pick-*]
     paths-ignore: ['docs/**', 'contributingGuides/**', 'help/**', '.github/**', 'scripts/**', 'tests/**']
@@ -21,7 +26,16 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Validates the actor and that they reviewed the PR before any token is used or untrusted App PR code is checked out.
+  prep:
+    uses: ./.github/workflows/validateBuildRequest.yml
+    with:
+      REVIEWED_CODE: ${{ inputs.reviewed_code || false }}
+    secrets:
+      OS_BOTIFY_COMMIT_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
+
   resolveRefs:
+    needs: [prep]
     uses: ./.github/workflows/resolveBuildRefs.yml
     with:
       APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
@@ -30,7 +44,7 @@ jobs:
       OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   build:
-    needs: [resolveRefs]
+    needs: [prep, resolveRefs]
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-16vcpu-ubuntu-2404' || 'blacksmith-2vcpu-ubuntu-2404' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -21,9 +21,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  getMobileExpensifyRef:
-    name: Resolve Mobile-Expensify ref
-    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+  resolveRefs:
+    uses: ./.github/workflows/resolveBuildRefs.yml
     with:
       APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
       MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.mobile_expensify_pull_request_url }}
@@ -31,7 +30,7 @@ jobs:
       OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   build:
-    needs: [getMobileExpensifyRef]
+    needs: [resolveRefs]
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-16vcpu-ubuntu-2404' || 'blacksmith-2vcpu-ubuntu-2404' }}
     strategy:
       fail-fast: false
@@ -46,16 +45,17 @@ jobs:
       - name: Checkout
         uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
         with:
+          ref: ${{ needs.resolveRefs.outputs.APP_REF }}
           submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Checkout Mobile-Expensify to specified branch or commit
-        if: ${{ matrix.is_hybrid_build && needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF != '' }}
+        if: ${{ matrix.is_hybrid_build && needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF != '' }}
         run: |
           cd Mobile-Expensify
-          git fetch origin ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
-          git checkout ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
-          echo "Checked out Mobile-Expensify PR #${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_PR }} (${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }})"
+          git fetch origin ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }}
+          git checkout ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }}
+          echo "Checked out Mobile-Expensify PR #${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_PR }} (${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }})"
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/remote-build-ios.yml
+++ b/.github/workflows/remote-build-ios.yml
@@ -12,6 +12,11 @@ on:
         description: 'The Expensify/Mobile-Expensify pull request URL to check out the submodule. Overrides MOBILE-EXPENSIFY set in the App PR description.'
         required: false
         default: ''
+      reviewed_code:
+        description: I reviewed this pull request and verified that it does not contain any malicious code.
+        type: boolean
+        required: true
+        default: false
   push:
     branches-ignore: [staging, production, cherry-pick-*]
     paths-ignore: ['docs/**', 'contributingGuides/**', 'help/**', '.github/**', 'scripts/**', 'tests/**']
@@ -21,7 +26,16 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Validates the actor and that they reviewed the PR before any token is used or untrusted App PR code is checked out.
+  prep:
+    uses: ./.github/workflows/validateBuildRequest.yml
+    with:
+      REVIEWED_CODE: ${{ inputs.reviewed_code || false }}
+    secrets:
+      OS_BOTIFY_COMMIT_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
+
   resolveRefs:
+    needs: [prep]
     uses: ./.github/workflows/resolveBuildRefs.yml
     with:
       APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
@@ -30,7 +44,7 @@ jobs:
       OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   build:
-    needs: [resolveRefs]
+    needs: [prep, resolveRefs]
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-12vcpu-macos-latest' || 'macos-latest' }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer

--- a/.github/workflows/remote-build-ios.yml
+++ b/.github/workflows/remote-build-ios.yml
@@ -21,9 +21,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  getMobileExpensifyRef:
-    name: Resolve Mobile-Expensify ref
-    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+  resolveRefs:
+    uses: ./.github/workflows/resolveBuildRefs.yml
     with:
       APP_PULL_REQUEST_URL: ${{ inputs.app_pull_request_url }}
       MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.mobile_expensify_pull_request_url }}
@@ -31,7 +30,7 @@ jobs:
       OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   build:
-    needs: [getMobileExpensifyRef]
+    needs: [resolveRefs]
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-12vcpu-macos-latest' || 'macos-latest' }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
@@ -50,16 +49,17 @@ jobs:
       - name: Checkout
         uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
         with:
+          ref: ${{ needs.resolveRefs.outputs.APP_REF }}
           submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Checkout Mobile-Expensify to specified branch or commit
-        if: ${{ matrix.is_hybrid_build && needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF != '' }}
+        if: ${{ matrix.is_hybrid_build && needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF != '' }}
         run: |
           cd Mobile-Expensify
-          git fetch origin ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
-          git checkout ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }}
-          echo "Checked out Mobile-Expensify PR #${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_PR }} (${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF }})"
+          git fetch origin ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }}
+          git checkout ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }}
+          echo "Checked out Mobile-Expensify PR #${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_PR }} (${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF }})"
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/resolveBuildRefs.yml
+++ b/.github/workflows/resolveBuildRefs.yml
@@ -1,7 +1,12 @@
-name: Resolve Mobile-Expensify ref
+name: Resolve build refs
 
-# Reusable workflow that resolves which Expensify/Mobile-Expensify commit a build should check out.
-# Resolution order:
+# Reusable workflow that resolves which Expensify/App and Expensify/Mobile-Expensify commits a build should check out.
+#
+# App head ref (APP_REF):
+#   - The head SHA of the App PR (APP_PULL_REQUEST_URL), if provided.
+#   - Otherwise, empty — callers fall back to the triggering ref (push commit / dispatch branch).
+#
+# Mobile-Expensify head ref (MOBILE_EXPENSIFY_REF), resolution order:
 #   1. An explicit Mobile-Expensify PR URL (MOBILE_EXPENSIFY_PULL_REQUEST_URL), if provided.
 #   2. Otherwise, a `MOBILE-EXPENSIFY: <pr-url>` entry in the body of the App PR (APP_PULL_REQUEST_URL).
 #   3. Otherwise, empty — callers fall back to the pinned submodule commit.
@@ -22,6 +27,9 @@ on:
       APP_PR_NUMBER:
         description: PR number extracted from the App PR URL (empty if none).
         value: ${{ jobs.resolve.outputs.APP_PR_NUMBER }}
+      APP_REF:
+        description: Resolved Expensify/App head SHA (empty to use the triggering ref).
+        value: ${{ jobs.resolve.outputs.APP_REF }}
       MOBILE_EXPENSIFY_PR:
         description: Resolved Mobile-Expensify PR number (empty if none).
         value: ${{ jobs.resolve.outputs.MOBILE_EXPENSIFY_PR }}
@@ -35,10 +43,11 @@ on:
 
 jobs:
   resolve:
-    name: Resolve Mobile-Expensify ref
+    name: Resolve build refs
     runs-on: 'blacksmith-4vcpu-ubuntu-2404'
     outputs:
       APP_PR_NUMBER: ${{ steps.extractAppPRNumber.outputs.PR_NUMBER }}
+      APP_REF: ${{ steps.getAppHeadRef.outputs.REF }}
       MOBILE_EXPENSIFY_PR: ${{ steps.mobileExpensifyPR.outputs.result }}
       MOBILE_EXPENSIFY_REF: ${{ steps.getHeadRef.outputs.REF }}
     steps:
@@ -52,6 +61,15 @@ jobs:
             exit 1
           fi
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve App head ref from PR number
+        id: getAppHeadRef
+        if: ${{ steps.extractAppPRNumber.outputs.PR_NUMBER != '' }}
+        run: |
+          set -e
+          echo "REF=$(gh pr view ${{ steps.extractAppPRNumber.outputs.PR_NUMBER }} -R Expensify/App --json headRefOid --jq '.headRefOid')" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Extract Mobile-Expensify PR number from URL
         id: extractMobilePRNumber

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -36,23 +36,13 @@ on:
         default: false
 
 jobs:
+  # Validates the actor and that they reviewed the PR before any token is used or untrusted code is checked out.
   prep:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Checkout
-        uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
-
-      - name: Validate that user is an Expensify employee
-        uses: ./.github/actions/composite/validateActor
-        with:
-          REQUIRE_APP_DEPLOYER: false
-          OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
-
-      - name: Validate that the user reviewed the pull request before running a test build
-        if: ${{ !inputs.REVIEWED_CODE }}
-        run: |
-          echo "::error::🕵️‍♀️ Please carefully review the pull request before running a test build to ensure it does not contain any malicious code"
-          exit 1
+    uses: ./.github/workflows/validateBuildRequest.yml
+    with:
+      REVIEWED_CODE: ${{ inputs.REVIEWED_CODE }}
+    secrets:
+      OS_BOTIFY_COMMIT_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
 
   # Resolves the App head ref and the Mobile-Expensify ref from the provided PR URLs (or the App PR's MOBILE-EXPENSIFY entry).
   # `needs: [prep]` gates this behind prep's actor validation before any token is used.

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -38,9 +38,6 @@ on:
 jobs:
   prep:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    outputs:
-      APP_REF: ${{ steps.getHeadRef.outputs.REF || 'main' }}
-      APP_PR_NUMBER: ${{ steps.extractAppPRNumber.outputs.PR_NUMBER }}
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
@@ -57,34 +54,11 @@ jobs:
           echo "::error::🕵️‍♀️ Please carefully review the pull request before running a test build to ensure it does not contain any malicious code"
           exit 1
 
-      - name: Extract App PR number from URL
-        id: extractAppPRNumber
-        if: ${{ inputs.APP_PULL_REQUEST_URL != '' }}
-        run: |
-          PR_NUMBER=$(echo '${{ inputs.APP_PULL_REQUEST_URL }}' | sed -E 's|.*/pull/([0-9]+).*|\1|')
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::error::❌ Could not extract PR number from URL. Please provide a valid GitHub PR URL (e.g., https://github.com/Expensify/App/pull/12345)"
-            exit 1
-          fi
-          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
-      - name: Check if App pull request number is correct
-        id: getHeadRef
-        run: |
-          set -e
-          if [ -z "${{ steps.extractAppPRNumber.outputs.PR_NUMBER }}" ]; then
-            echo "REF=" >> "$GITHUB_OUTPUT"
-          else
-            echo "REF=$(gh pr view ${{ steps.extractAppPRNumber.outputs.PR_NUMBER }} --json headRefOid --jq '.headRefOid')" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-  # Resolves the Mobile-Expensify ref from the explicit ME PR URL or the App PR's MOBILE-EXPENSIFY entry.
+  # Resolves the App head ref and the Mobile-Expensify ref from the provided PR URLs (or the App PR's MOBILE-EXPENSIFY entry).
   # `needs: [prep]` gates this behind prep's actor validation before any token is used.
-  getMobileExpensifyRef:
+  resolveRefs:
     needs: [prep]
-    uses: ./.github/workflows/resolveMobileExpensifyRef.yml
+    uses: ./.github/workflows/resolveBuildRefs.yml
     with:
       APP_PULL_REQUEST_URL: ${{ inputs.APP_PULL_REQUEST_URL }}
       MOBILE_EXPENSIFY_PULL_REQUEST_URL: ${{ inputs.MOBILE_EXPENSIFY_PULL_REQUEST_URL }}
@@ -92,14 +66,15 @@ jobs:
       OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   buildApps:
-    needs: [prep, getMobileExpensifyRef]
+    needs: [prep, resolveRefs]
     uses: ./.github/workflows/buildAdHoc.yml
     with:
-      APP_REF: ${{ needs.prep.outputs.APP_REF }}
-      APP_PR_NUMBER: ${{ needs.prep.outputs.APP_PR_NUMBER }}
+      # Fall back to App main when nothing is resolved (test builds default to the latest NewDot).
+      APP_REF: ${{ needs.resolveRefs.outputs.APP_REF || 'main' }}
+      APP_PR_NUMBER: ${{ needs.resolveRefs.outputs.APP_PR_NUMBER }}
       # Fall back to Mobile-Expensify main when nothing is resolved (test builds track the latest OldDot).
-      MOBILE_EXPENSIFY_REF: ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_REF || 'main' }}
-      MOBILE_EXPENSIFY_PR: ${{ needs.getMobileExpensifyRef.outputs.MOBILE_EXPENSIFY_PR }}
+      MOBILE_EXPENSIFY_REF: ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_REF || 'main' }}
+      MOBILE_EXPENSIFY_PR: ${{ needs.resolveRefs.outputs.MOBILE_EXPENSIFY_PR }}
       BUILD_WEB: ${{ inputs.WEB && 'true' || 'false' }}
       BUILD_IOS: ${{ inputs.IOS && 'true' || 'false' }}
       BUILD_ANDROID: ${{ inputs.ANDROID && 'true' || 'false' }}

--- a/.github/workflows/validateBuildRequest.yml
+++ b/.github/workflows/validateBuildRequest.yml
@@ -1,0 +1,43 @@
+name: Validate build request
+
+# Reusable workflow that gates a build before any untrusted App PR code is checked out or build secrets are exposed.
+# It mirrors the safeguards testBuild.yml historically ran inline in its `prep` job:
+#   1. The dispatching actor must be an Expensify employee with write access.
+#   2. The actor must confirm they reviewed the pull request for malicious code (REVIEWED_CODE).
+#
+# The checks only run for `workflow_dispatch`. On `push` the checked-out code is the pushed commit (already trusted,
+# and authored by someone with write access), so the gate is a no-op and downstream jobs proceed.
+
+on:
+  workflow_call:
+    inputs:
+      REVIEWED_CODE:
+        description: Whether the dispatcher confirmed they reviewed the pull request for malicious code.
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      OS_BOTIFY_COMMIT_TOKEN:
+        description: OSBotify token used to check the actor's repository permissions.
+        required: true
+
+jobs:
+  validate:
+    name: Validate build request
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@c9796daa2a4bdebdab5bd16be2c09a70cd4e1121 # v1
+
+      - name: Validate that user is an Expensify employee
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: ./.github/actions/composite/validateActor
+        with:
+          REQUIRE_APP_DEPLOYER: false
+          OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
+
+      - name: Validate that the user reviewed the pull request before running a build
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.REVIEWED_CODE }}
+        run: |
+          echo "::error::🕵️‍♀️ Please carefully review the pull request before running a build to ensure it does not contain any malicious code"
+          exit 1


### PR DESCRIPTION
### Explanation of Change

The three remote build workflows (`remote-build-android.yml`, `remote-build-ios.yml`, and `publishReactNativeAndroidArtifacts.yml`) previously only resolved the **Mobile-Expensify** ref and always checked out the triggering ref for **Expensify/App**. This meant they could not build a specific App PR head the way `testBuild.yml` already did, so the two paths were inconsistent.

This PR aligns them by teaching the shared reusable workflow to resolve the App ref as well:

- **Renamed `resolveMobileExpensifyRef.yml` → `resolveBuildRefs.yml`** and extended it to resolve **both** refs a build should check out:
  - `APP_REF`: the head SHA of the App PR (from `APP_PULL_REQUEST_URL`), or empty to fall back to the triggering ref.
  - `MOBILE_EXPENSIFY_REF`: unchanged resolution order (explicit ME PR URL → `MOBILE-EXPENSIFY:` entry in the App PR body → pinned submodule commit).
- **Updated the three remote build workflows** to consume `resolveBuildRefs.yml`, renaming the job `getMobileExpensifyRef` → `resolveRefs` and passing the resolved `APP_REF` to the `Checkout` step so they build the correct App PR head.
- **Simplified `testBuild.yml`** by removing the inline App PR number/head-ref resolution from the `prep` job and delegating it to the shared `resolveBuildRefs.yml` workflow (with a `|| 'main'` fallback so test builds still default to the latest NewDot).

The net result is a single reusable workflow that resolves both the App and Mobile-Expensify refs, used consistently across `testBuild` and all remote build workflows.

### Fixed Issues
$ https://github.com/Expensify/App/issues/95038
$ https://github.com/Expensify/App/issues/95387
PROPOSAL:

### Tests

This is a CI/GitHub Actions-only change with no runtime app impact.

1. Trigger a test build (`testBuild.yml`) with an App PR URL and verify the `resolveRefs` job resolves `APP_REF` to the PR head SHA and the build checks out that commit.
2. Trigger a test build without an App PR URL and verify the App ref falls back to `main`.
3. Trigger a remote iOS/Android build with an App PR URL and verify the `Checkout` step uses the resolved `APP_REF`.
4. Provide a `MOBILE-EXPENSIFY:` entry in the App PR body (or an explicit ME PR URL) and verify `MOBILE_EXPENSIFY_REF` still resolves and the Mobile-Expensify submodule is checked out to that ref.

### Offline tests

N/A — CI workflow change only.

### QA Steps

N/A — this PR only modifies GitHub Actions workflows and has no user-facing or runtime impact

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
</content>
</invoke>
