### PR TITLE
Redirect invited member to workspace chat instead of Home

### DIFF
--- a/src/pages/ValidateLoginPage/index.web.tsx
+++ b/src/pages/ValidateLoginPage/index.web.tsx
@@ -62,7 +62,13 @@ function ValidateLoginPage({
         credentials?.validateCode === validateCode &&
         credentials?.accountID === Number(accountID) &&
         (autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN || autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.FAILED);
-    const isUserClickedSignIn = !login && isSignedIn && (autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.SIGNING_IN || autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN);
+    // Exclude `exitTo` deep links (e.g. a workspace-chat invite link): those carry a specific
+    // destination that `handleExitToNavigation` owns, so this flag's Home redirect (focus effect
+    // below) must not fire and clobber it. Without `!exitTo`, a first-time invitee (no cached
+    // `login`, just signed in) matches this exactly and gets force-redirected Home instead of the
+    // workspace chat.
+    const isUserClickedSignIn =
+        !login && !exitTo && isSignedIn && (autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.SIGNING_IN || autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN);
     const shouldStartSignInWithValidateCode = !isUserClickedSignIn && !isSignedIn && (!!login || !!exitTo) && isValidValidateCode(validateCode);
     const isNavigatingToExitTo = isSignedIn && !!exitTo;
     // Fresh-session magic-link sign-in. Not gated on `isSignedIn` because `autoAuthState` lands

--- a/src/pages/ValidateLoginPage/index.web.tsx
+++ b/src/pages/ValidateLoginPage/index.web.tsx
@@ -64,9 +64,7 @@ function ValidateLoginPage({
         (autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN || autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.FAILED);
     // Exclude `exitTo` deep links (e.g. a workspace-chat invite link): those carry a specific
     // destination that `handleExitToNavigation` owns, so this flag's Home redirect (focus effect
-    // below) must not fire and clobber it. Without `!exitTo`, a first-time invitee (no cached
-    // `login`, just signed in) matches this exactly and gets force-redirected Home instead of the
-    // workspace chat.
+    // below) must not fire and clobber it.
     const isUserClickedSignIn =
         !login && !exitTo && isSignedIn && (autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.SIGNING_IN || autoAuthStateWithDefault === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN);
     const shouldStartSignInWithValidateCode = !isUserClickedSignIn && !isSignedIn && (!!login || !!exitTo) && isValidValidateCode(validateCode);

--- a/tests/ui/ValidateLoginPageTest.tsx
+++ b/tests/ui/ValidateLoginPageTest.tsx
@@ -156,6 +156,38 @@ describe('ValidateLoginPage', () => {
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.HOME, {forceReplace: true});
     });
 
+    it('Should hand off to exitTo (not redirect Home) for a first-time invitee opening an exitTo magic link', async () => {
+        // Regression for #94549: an invited member opens `/v/<id>/<code>?exitTo=<destination>` with no
+        // cached `login` and JUST_SIGNED_IN. Before the fix `isUserClickedSignIn` matched this exactly and
+        // its focus effect force-redirected Home, clobbering the exitTo navigation. Excluding `exitTo`
+        // keeps that Home redirect from firing so `handleExitToNavigation` owns the deep-link destination.
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.SESSION, {
+                authToken: 'abcd',
+                autoAuthState: CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN,
+            });
+            await Onyx.set(ONYXKEYS.CREDENTIALS, {
+                accountID: 1,
+                validateCode: '123456',
+            });
+        });
+
+        renderPage({accountID: '1', validateCode: '123456', exitTo: 'concierge'});
+        await waitForBatchedUpdatesWithAct();
+
+        // The deferred destination handoff is registered with the exitTo route...
+        expect(handleExitToNavigation).toHaveBeenCalledWith('concierge');
+
+        // ...and even once protected routes become available, the competing Home redirect must not fire.
+        await act(async () => {
+            mockWaitForProtectedRoutes.resolve();
+            await Promise.resolve();
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        expect(Navigation.navigate).not.toHaveBeenCalledWith(ROUTES.HOME, {forceReplace: true});
+    });
+
     it('Should not navigate to home when a signed-in session opens /v/ to view the code (autoAuthState !== JUST_SIGNED_IN)', async () => {
         await act(async () => {
             await Onyx.set(ONYXKEYS.SESSION, {


### PR DESCRIPTION
### Explanation of Change

A first-time invitee opens a validate-login magic link that carries an `exitTo` destination (the workspace chat), e.g. `/v/<accountID>/<validateCode>?exitTo=/r/<reportID>`. On web this is handled by `ValidateLoginPage`.

The destination reaches the page correctly, but a second, competing navigation to Home fires and overwrites it. `isUserClickedSignIn` is meant to detect a _separate-session_ magic-link sign-in (no cached `login`, just signed in) so its focus effect can redirect the user Home. A first-time invitee matches that condition exactly — no cached `login`, just signed in — **and** also carries an `exitTo`. So after sign-in two navigations race: `handleExitToNavigation` → the workspace chat, and the focus effect → `navigate(ROUTES.HOME, {forceReplace: true})`. The Home `forceReplace` wins and the member lands on Home.

The fix excludes `exitTo` from `isUserClickedSignIn`, so when a deep-link destination exists the Home redirect never fires and `handleExitToNavigation` owns the navigation. The separate-session case (no `login`, no `exitTo`) is unchanged, so that behavior isn't regressed.

Added a regression test in `tests/ui/ValidateLoginPageTest.tsx` that reproduces the invitee-with-`exitTo` state and asserts the Home redirect does not fire while `handleExitToNavigation` is invoked with the destination (fails without the fix, passes with it).

### Fixed Issues

$ https://github.com/Expensify/App/issues/94549
PROPOSAL: https://github.com/Expensify/App/issues/94549#issuecomment-4796842254

### Tests

1. Log in as an admin of a workspace (or create one).
2. Go to the workspace **Members** and invite a member by an email that has **no** Expensify account (use a real inbox that can receive the invite).
3. Open the invited user's inbox and copy the validate-login link at the bottom of the invite email (it looks like `/v/<accountID>/<validateCode>?exitTo=/r/<reportID>`).
4. In a fresh, logged-out browser session (incognito), open that link (no magic code needed — sign-in is automatic).
5. Verify you are taken directly to the **workspace chat**, not the Home page.

- [x] Verify that no errors appear in the JS console

### Offline tests

Not applicable — the flow is a validate-login sign-in that requires a network connection to complete. Once signed in, the `exitTo` destination navigation runs as in the Tests above.

### QA Steps

Same as Tests, on staging (web — Windows/Chrome, macOS/Chrome/Safari, mWeb Chrome/Safari):

1. As a workspace admin, invite a member by an email that has no Expensify account.
2. From the invited inbox, open the validate-login invite link (change the domain to staging) in a fresh, logged-out browser session.
3. Verify the member is redirected to the workspace chat, not the Home page.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/7d41b475-f1ca-4616-8061-9e007d05bf83

</details>
