### PR TITLE
fix: dismiss modal before createTransaction on narrow layout for global-create DEFAULT path

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1546,6 +1546,7 @@ const translations = {
             noParticipantSelected: 'Please select a participant',
             other: 'Unexpected error. Please try again later.',
             genericCreateFailureMessage: 'Unexpected error submitting this expense. Please try again later.',
+            genericApproveFailureMessage: 'Unexpected error approving this report. Please try again later.',
             genericCreateInvoiceFailureMessage: 'Unexpected error sending this invoice. Please try again later.',
             genericHoldExpenseFailureMessage: 'Unexpected error holding this expense. Please try again later.',
             genericUnholdExpenseFailureMessage: 'Unexpected error taking this expense off hold. Please try again later.',

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -2348,7 +2348,7 @@ function getDynamicExternalWorkflowApproveFailedActionMessage(translate: Localiz
     }
     const originalMessage = getOriginalMessage(action);
     const wasAutoApproveAction = originalMessage?.automaticAction ?? false;
-    const message = originalMessage?.message ?? translate('iou.error.genericCreateFailureMessage');
+    const message = originalMessage?.message ?? translate('iou.error.genericApproveFailureMessage');
     const failedApproveReason = wasAutoApproveAction ? translate('iou.failedToAutoApproveViaDEW', message) : translate('iou.failedToApproveViaDEW', message);
     return failedApproveReason;
 }

--- a/src/libs/actions/IOU/ReportWorkflow.ts
+++ b/src/libs/actions/IOU/ReportWorkflow.ts
@@ -657,7 +657,7 @@ function approveMoneyRequest(params: ApproveMoneyRequestFunctionParams) {
                 key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${expenseReport.reportID}`,
                 value: {
                     [optimisticApprovedReportAction.reportActionID]: {
-                        errors: getMicroSecondOnyxErrorWithTranslationKey('iou.error.other'),
+                        errors: getMicroSecondOnyxErrorWithTranslationKey('iou.error.genericApproveFailureMessage'),
                     },
                 },
             });

--- a/src/pages/iou/request/step/confirmation/SubmitExpenseOrchestrator.tsx
+++ b/src/pages/iou/request/step/confirmation/SubmitExpenseOrchestrator.tsx
@@ -362,6 +362,21 @@ function SubmitExpenseOrchestrator({
 
     const handleDefaultSubmit = (locationPermissionGranted = false) => {
         setFastPath(CONST.TELEMETRY.FAST_PATH_HANDLER.DEFAULT);
+
+        // On narrow layout, a global-create flow that falls through to DEFAULT (e.g. distance expense to a
+        // new domain user whose optimistic report is not yet in Onyx) must dismiss the modal before running
+        // createTransaction. Without the dismiss, the SEARCH deferred-write channel is reserved while the
+        // RHP stack is still open, and the Search screen's onLayout never fires to flush the channel —
+        // leaving the API write permanently deferred and the UI frozen.
+        if (isFromGlobalCreateForNavigation && !isReportTopmostSplitNavigator() && getIsNarrowLayout()) {
+            reserveDeferredWriteChannel(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);
+            dismissOnly(() => {
+                createTransaction(locationPermissionGranted, false);
+                setIsConfirming(false);
+            });
+            return;
+        }
+
         reserveSearchChannelIfGlobalCreate();
         requestAnimationFrame(() => {
             createTransaction(locationPermissionGranted);


### PR DESCRIPTION
## What Problem This Solves

On iOS (narrow layout), creating a **distance expense via the global FAB to a brand-new domain user** (no existing chat) causes the app to freeze. The expense is never created and the UI gets stuck.

## Root Cause

The `DEFAULT` submit handler in `SubmitExpenseOrchestrator` was introduced by a prior refactor that added `reserveSearchChannelIfGlobalCreate`. For the new-user distance case, `getSubmitHandler` falls through to `DEFAULT` because:
- `isDestinationReportLoaded = false` (the optimistic report UUID doesn't exist in Onyx yet)
- `navigatesToDestinationReport = false` (iouType is `SUBMIT`, not `SPLIT`/`TRACK`)

`handleDefaultSubmit` then:
1. Reserves the `SEARCH` deferred-write channel
2. Calls `createTransaction(true)` (with `shouldHandleNavigation=true`) — while the RHP is still on the navigation stack
3. `createDistanceRequest` defers the `CREATE_DISTANCE_REQUEST` write to the SEARCH channel
4. `navigateAfterExpenseCreate` → `navigateToSearch()` calls `Navigation.navigate(SEARCH_ROOT, {forceReplace: true})` — but the RHP modal is still open, blocking the Search screen from mounting
5. The Search screen's `onLayout` **never fires** → the deferred-write channel is **never flushed** → the API write is permanently stuck → the UI freezes

Every other handler that reserves the SEARCH channel (`handleSearchDismiss`, `handleSearchPreInsert`, `handleDismissModalFastPath`) dismisses the modal **first**, then calls `createTransaction(false)`. Only `handleDefaultSubmit` on narrow global-create skipped this pattern.

## Why This Change Was Made

On narrow layout with `isFromGlobalCreate` and not on the inbox, the fix mirrors every other dismiss-first handler: call `dismissOnly()` to slide the RHP out first, then call `createTransaction(false)` in the `afterTransition` callback. `shouldHandleNavigation=false` prevents double navigation since `dismissOnly` already gets us to Search.

The non-narrow path (wide layout) is unchanged — on wide layout, Search is in a separate panel and there's no race between RHP dismissal and Search mounting.

## User Impact

Users can now create distance expenses to new domain users from the global FAB on iOS without the app freezing.

## Evidence

Reproduced by following the steps in the issue:
1. Open iOS app → Global FAB → Track distance → Map tab → set Start/Stop → Next
2. Enter a brand-new domain user email → Create expense
3. Before fix: app freezes. After fix: modal dismisses and expense is created.

$ #95468