### PR TITLE
[No QA] Skip empty cherry-picks instead of opening a conflict PR

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -212,7 +212,8 @@ jobs:
             git commit --amend -m "$(git log -1 --pretty=%B)" -m "(cherry-picked to ${{ inputs.TARGET }} by ${{ github.actor }})"
           else
             UNMERGED_FILES="$(git diff --name-only --diff-filter=U)"
-            if [[ -z "$UNMERGED_FILES" ]] && git rev-parse --quiet --verify CHERRY_PICK_HEAD > /dev/null; then
+            # A failed -S signing leaves CHERRY_PICK_HEAD with the picked changes still staged, so only a fully clean index and worktree means the pick was truly empty
+            if [[ -z "$UNMERGED_FILES" ]] && git rev-parse --quiet --verify CHERRY_PICK_HEAD > /dev/null && git diff --cached --quiet && git diff --quiet; then
               echo "✅ Cherry-pick resulted in an empty commit, the change is already on ${{ inputs.TARGET }}. Skipping it and continuing with the version bump."
               git cherry-pick --skip
               echo "HAS_CONFLICTS=false" >> "$GITHUB_OUTPUT"
@@ -238,7 +239,11 @@ jobs:
 
               # Update and commit the submodule reference in E/App
               git add Mobile-Expensify
-              git commit -m "Update Mobile-Expensify submodule to include cherry-picked PR #${{ steps.getPRInfo.outputs.PR_NUMBER }}"
+              if git diff --cached --quiet; then
+                echo "Submodule pointer unchanged, nothing to commit"
+              else
+                git commit -m "Update Mobile-Expensify submodule to include cherry-picked PR #${{ steps.getPRInfo.outputs.PR_NUMBER }}"
+              fi
             fi
 
             # Push E/App changes

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -211,10 +211,17 @@ jobs:
             echo "HAS_CONFLICTS=false" >> "$GITHUB_OUTPUT"
             git commit --amend -m "$(git log -1 --pretty=%B)" -m "(cherry-picked to ${{ inputs.TARGET }} by ${{ github.actor }})"
           else
-            echo "😞 PR can't be automerged, there are merge conflicts in the following files:"
-            git --no-pager diff --name-only --diff-filter=U
-            git cherry-pick --abort
-            echo "HAS_CONFLICTS=true" >> "$GITHUB_OUTPUT"
+            UNMERGED_FILES="$(git diff --name-only --diff-filter=U)"
+            if [[ -z "$UNMERGED_FILES" ]] && git rev-parse --quiet --verify CHERRY_PICK_HEAD > /dev/null; then
+              echo "✅ Cherry-pick resulted in an empty commit, the change is already on ${{ inputs.TARGET }}. Skipping it and continuing with the version bump."
+              git cherry-pick --skip
+              echo "HAS_CONFLICTS=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "😞 PR can't be automerged, there are merge conflicts in the following files:"
+              echo "$UNMERGED_FILES"
+              git cherry-pick --abort
+              echo "HAS_CONFLICTS=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Push changes


### PR DESCRIPTION
### Explanation of Change

`git cherry-pick` exits non-zero when the pick results in an empty commit (the change is already on the target branch), and the CP workflow treated any non-zero exit as merge conflicts. This opened a bogus manual-conflict PR containing only version bumps, which then went stale as soon as the next CP claimed a newer version (see https://github.com/Expensify/App/pull/95499, where the conflict file list in the workflow logs was empty).

- Detect empty pick: no unmerged files, CHERRY_PICK_HEAD present
- Skip it and continue with the version bump
- Real conflicts still abort and open a conflict PR

### Fixed Issues

$ https://expensify.slack.com/archives/C07J32337/p1783433261570819
PROPOSAL:

### Tests

1. In a scratch repo, cherry-pick a commit whose change already exists on the target branch.
2. Run the updated step script against it.
3. Verify it prints the "already on target" message, runs `git cherry-pick --skip`, and sets `HAS_CONFLICTS=false`.
4. Cherry-pick a commit that genuinely conflicts with the target branch.
5. Verify the script lists the unmerged files, aborts the pick, and sets `HAS_CONFLICTS=true`.

- [x] Verify that no errors appear in the JS console

### Offline tests

None, CI workflow change only.

### QA Steps

None, CI workflow change only.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A, CI workflow change only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A, CI workflow change only.

</details>

<details>
<summary>iOS: Native</summary>

N/A, CI workflow change only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A, CI workflow change only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A, CI workflow change only.

</details>
