### PR TITLE
Fix blank Xero setup WebView on Android by loading an authenticated setup URL

### DIFF
--- a/src/pages/workspace/accounting/AccountingSetupWebViewPage.tsx
+++ b/src/pages/workspace/accounting/AccountingSetupWebViewPage.tsx
@@ -4,16 +4,19 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import getUAForWebView from '@libs/getUAForWebView';
 import Navigation from '@libs/Navigation/Navigation';
 
+import {getShortLivedAuthTokenURL} from '@userActions/Link';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {WebView} from 'react-native-webview';
 
@@ -26,13 +29,37 @@ type AccountingSetupWebViewPageProps = {
 
     /** Context label reported by the loading indicator for telemetry */
     context: string;
+
+    /** Whether to append a short-lived auth token to the setup link before loading it, so the incognito WebView opens an authenticated URL instead of the raw command URL */
+    shouldAppendShortLivedAuthToken?: boolean;
 };
 
-function AccountingSetupWebViewPage({uri, testID, context}: AccountingSetupWebViewPageProps) {
+function AccountingSetupWebViewPage({uri, testID, context, shouldAppendShortLivedAuthToken = false}: AccountingSetupWebViewPageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const authToken = session?.authToken ?? null;
+    const [authenticatedUri, setAuthenticatedUri] = useState<string | null>(null);
+    const hasFetchedAuthenticatedUri = useRef(false);
+
+    const fetchAuthenticatedUri = () => {
+        if (!shouldAppendShortLivedAuthToken || hasFetchedAuthenticatedUri.current) {
+            return;
+        }
+        hasFetchedAuthenticatedUri.current = true;
+        getShortLivedAuthTokenURL(uri).then(setAuthenticatedUri);
+    };
+
+    // Skip the token request while offline and retry it on reconnect, so an offline-opened page still ends up with an authenticated URL.
+    const {isOffline} = useNetwork({onReconnect: fetchAuthenticatedUri});
+
+    useEffect(() => {
+        if (isOffline) {
+            return;
+        }
+        fetchAuthenticatedUri();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- only fetch once on mount when online
+    }, []);
 
     const renderLoading = () => (
         <View style={[StyleSheet.absoluteFill, styles.fullScreenLoading]}>
@@ -42,6 +69,9 @@ function AccountingSetupWebViewPage({uri, testID, context}: AccountingSetupWebVi
             />
         </View>
     );
+
+    // Pages that don't opt into the short-lived auth token keep loading the raw uri immediately, exactly as before.
+    const webViewUri = shouldAppendShortLivedAuthToken ? authenticatedUri : uri;
 
     return (
         <ScreenWrapper
@@ -56,18 +86,22 @@ function AccountingSetupWebViewPage({uri, testID, context}: AccountingSetupWebVi
                 shouldDisplayHelpButton={false}
             />
             <FullPageOfflineBlockingView>
-                <WebView
-                    source={{
-                        uri,
-                        headers: {
-                            Cookie: `authToken=${authToken}`,
-                        },
-                    }}
-                    userAgent={getUAForWebView()}
-                    incognito // 'incognito' prop required for Android, issue here https://github.com/react-native-webview/react-native-webview/issues/1352
-                    startInLoadingState
-                    renderLoading={renderLoading}
-                />
+                {webViewUri ? (
+                    <WebView
+                        source={{
+                            uri: webViewUri,
+                            headers: {
+                                Cookie: `authToken=${authToken}`,
+                            },
+                        }}
+                        userAgent={getUAForWebView()}
+                        incognito // 'incognito' prop required for Android, issue here https://github.com/react-native-webview/react-native-webview/issues/1352
+                        startInLoadingState
+                        renderLoading={renderLoading}
+                    />
+                ) : (
+                    renderLoading()
+                )}
             </FullPageOfflineBlockingView>
         </ScreenWrapper>
     );

--- a/src/pages/workspace/accounting/AccountingSetupWebViewPage.tsx
+++ b/src/pages/workspace/accounting/AccountingSetupWebViewPage.tsx
@@ -41,13 +41,20 @@ function AccountingSetupWebViewPage({uri, testID, context, shouldAppendShortLive
     const authToken = session?.authToken ?? null;
     const [authenticatedUri, setAuthenticatedUri] = useState<string | null>(null);
     const hasFetchedAuthenticatedUri = useRef(false);
+    const isMounted = useRef(true);
 
     const fetchAuthenticatedUri = () => {
         if (!shouldAppendShortLivedAuthToken || hasFetchedAuthenticatedUri.current) {
             return;
         }
         hasFetchedAuthenticatedUri.current = true;
-        getShortLivedAuthTokenURL(uri).then(setAuthenticatedUri);
+        getShortLivedAuthTokenURL(uri).then((url) => {
+            // Discard the response if the user navigated away before the token request resolved.
+            if (!isMounted.current) {
+                return;
+            }
+            setAuthenticatedUri(url);
+        });
     };
 
     // Skip the token request while offline and retry it on reconnect, so an offline-opened page still ends up with an authenticated URL.
@@ -60,6 +67,13 @@ function AccountingSetupWebViewPage({uri, testID, context, shouldAppendShortLive
         fetchAuthenticatedUri();
         // eslint-disable-next-line react-hooks/exhaustive-deps -- only fetch once on mount when online
     }, []);
+
+    useEffect(
+        () => () => {
+            isMounted.current = false;
+        },
+        [],
+    );
 
     const renderLoading = () => (
         <View style={[StyleSheet.absoluteFill, styles.fullScreenLoading]}>

--- a/src/pages/workspace/accounting/xero/XeroSetupPage/index.native.tsx
+++ b/src/pages/workspace/accounting/xero/XeroSetupPage/index.native.tsx
@@ -18,6 +18,7 @@ function XeroSetupPage({route}: XeroSetupPageProps) {
             uri={getXeroSetupLink(policyID)}
             testID="XeroSetupPage"
             context="XeroSetupPage"
+            shouldAppendShortLivedAuthToken
         />
     );
 }

--- a/tests/unit/components/QuickbooksOnlineSetupPageTest.tsx
+++ b/tests/unit/components/QuickbooksOnlineSetupPageTest.tsx
@@ -5,6 +5,7 @@ import {getQuickbooksOnlineSetupLink} from '@libs/actions/connections/Quickbooks
 // This test exercises the native (in-app WebView) variant; jest resolves the `.native` entry point by default.
 import QuickbooksOnlineSetupPage from '@pages/workspace/accounting/qbo/QuickbooksOnlineSetupPage/index.native';
 
+import {getShortLivedAuthTokenURL} from '@userActions/Link';
 import {enablePolicyTaxes} from '@userActions/Policy/Policy';
 
 import React from 'react';
@@ -36,6 +37,10 @@ jest.mock('@libs/actions/connections/QuickbooksOnline', () => ({
 jest.mock('@userActions/Policy/Policy', () => ({
     enablePolicyTaxes: jest.fn(),
 }));
+jest.mock('@userActions/Link', () => ({
+    getShortLivedAuthTokenURL: jest.fn((setupLink: string) => Promise.resolve(`${setupLink}?authToken=short-lived-auth-token`)),
+}));
+jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
 jest.mock('@libs/Navigation/Navigation', () => ({
     navigate: jest.fn(),
     goBack: jest.fn(),
@@ -69,6 +74,7 @@ const mockRoute = {
 
 const mockedGetQuickbooksOnlineSetupLink = jest.mocked(getQuickbooksOnlineSetupLink);
 const mockedEnablePolicyTaxes = jest.mocked(enablePolicyTaxes);
+const mockedGetShortLivedAuthTokenURL = jest.mocked(getShortLivedAuthTokenURL);
 
 const renderQuickbooksOnlineSetupPage = () =>
     render(
@@ -94,6 +100,8 @@ describe('QuickbooksOnlineSetupPage', () => {
         renderQuickbooksOnlineSetupPage();
 
         expect(mockedGetQuickbooksOnlineSetupLink).toHaveBeenCalledWith(POLICY_ID);
+        // QBO does not opt into the short-lived auth token, so the WebView must mount immediately with the raw setup link.
+        expect(mockedGetShortLivedAuthTokenURL).not.toHaveBeenCalled();
         expect(screen.getByTestId('qbo-webview')).toBeOnTheScreen();
         expect(mockWebViewProps.current?.source?.uri).toBe(`https://qbo-setup.example/${POLICY_ID}`);
     });

--- a/tests/unit/components/XeroSetupPageTest.tsx
+++ b/tests/unit/components/XeroSetupPageTest.tsx
@@ -1,4 +1,4 @@
-import {act, render, screen, waitFor} from '@testing-library/react-native';
+import {act, render, screen} from '@testing-library/react-native';
 
 import {getXeroSetupLink} from '@libs/actions/connections/Xero';
 
@@ -108,7 +108,7 @@ describe('XeroSetupPage', () => {
         expect(screen.queryByTestId('xero-webview')).not.toBeOnTheScreen();
         expect(screen.getByTestId('setup-loading-indicator')).toBeOnTheScreen();
 
-        await waitFor(() => expect(screen.getByTestId('xero-webview')).toBeOnTheScreen());
+        expect(await screen.findByTestId('xero-webview')).toBeOnTheScreen();
 
         // The WebView must load the authenticated URL, not the raw getXeroSetupLink() command URL.
         expect(mockWebViewProps.current?.source?.uri).toBe(`https://xero-setup.example/${POLICY_ID}?authToken=${SHORT_LIVED_AUTH_TOKEN}`);
@@ -117,7 +117,7 @@ describe('XeroSetupPage', () => {
     it('passes the session auth token to the WebView as a cookie', async () => {
         renderXeroSetupPage();
 
-        await waitFor(() => expect(screen.getByTestId('xero-webview')).toBeOnTheScreen());
+        expect(await screen.findByTestId('xero-webview')).toBeOnTheScreen();
 
         expect(mockWebViewProps.current?.source?.headers?.Cookie).toBe(`authToken=${AUTH_TOKEN}`);
     });
@@ -136,7 +136,7 @@ describe('XeroSetupPage', () => {
         act(() => mockOnReconnect.current?.());
 
         expect(mockedGetShortLivedAuthTokenURL).toHaveBeenCalledWith(`https://xero-setup.example/${POLICY_ID}`);
-        await waitFor(() => expect(screen.getByTestId('xero-webview')).toBeOnTheScreen());
+        expect(await screen.findByTestId('xero-webview')).toBeOnTheScreen();
         expect(mockWebViewProps.current?.source?.uri).toBe(`https://xero-setup.example/${POLICY_ID}?authToken=${SHORT_LIVED_AUTH_TOKEN}`);
     });
 });

--- a/tests/unit/components/XeroSetupPageTest.tsx
+++ b/tests/unit/components/XeroSetupPageTest.tsx
@@ -1,15 +1,18 @@
-import {render, screen} from '@testing-library/react-native';
+import {act, render, screen, waitFor} from '@testing-library/react-native';
 
 import {getXeroSetupLink} from '@libs/actions/connections/Xero';
 
 // This test exercises the native (in-app WebView) variant; jest resolves the `.native` entry point by default.
 import XeroSetupPage from '@pages/workspace/accounting/xero/XeroSetupPage/index.native';
 
+import {getShortLivedAuthTokenURL} from '@userActions/Link';
+
 import React from 'react';
 import {View} from 'react-native';
 
 const AUTH_TOKEN = 'test-auth-token';
 const POLICY_ID = '123';
+const SHORT_LIVED_AUTH_TOKEN = 'short-lived-auth-token';
 
 type WebViewProps = {
     source?: {uri?: string; headers?: Record<string, string>};
@@ -23,6 +26,10 @@ const mockWebViewProps: {current: WebViewProps | undefined} = {
 // `Mock`-prefixed bindings are allowed inside jest.mock factories, unlike regular imports.
 const MockView = View;
 
+// Controls the network state the mocked useNetwork hook reports, and captures its onReconnect callback so tests can simulate a reconnect.
+const mockNetworkState = {isOffline: false};
+const mockOnReconnect: {current: (() => void) | undefined} = {current: undefined};
+
 jest.mock('@hooks/useLocalize', () => () => ({
     translate: (key: string) => key,
 }));
@@ -31,6 +38,15 @@ jest.mock('@hooks/useOnyx', () => jest.fn(() => [{authToken: 'test-auth-token'}]
 jest.mock('@libs/actions/connections/Xero', () => ({
     getXeroSetupLink: jest.fn((policyID: string) => `https://xero-setup.example/${policyID}`),
 }));
+jest.mock('@userActions/Link', () => ({
+    getShortLivedAuthTokenURL: jest.fn((setupLink: string) => Promise.resolve(`${setupLink}?authToken=short-lived-auth-token`)),
+}));
+jest.mock('@hooks/useNetwork', () =>
+    jest.fn(({onReconnect}: {onReconnect?: () => void} = {}) => {
+        mockOnReconnect.current = onReconnect;
+        return {isOffline: mockNetworkState.isOffline};
+    }),
+);
 jest.mock('@libs/Navigation/Navigation', () => ({
     navigate: jest.fn(),
     goBack: jest.fn(),
@@ -41,6 +57,7 @@ jest.mock('@components/ScreenWrapper', () => {
     return MockScreenWrapper;
 });
 jest.mock('@components/HeaderWithBackButton', () => () => null);
+jest.mock('@components/ActivityIndicator', () => () => <MockView testID="setup-loading-indicator" />);
 jest.mock(
     '@components/BlockingViews/FullPageOfflineBlockingView',
     () =>
@@ -63,6 +80,7 @@ const mockRoute = {
 };
 
 const mockedGetXeroSetupLink = jest.mocked(getXeroSetupLink);
+const mockedGetShortLivedAuthTokenURL = jest.mocked(getShortLivedAuthTokenURL);
 
 const renderXeroSetupPage = () =>
     render(
@@ -76,19 +94,49 @@ describe('XeroSetupPage', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockWebViewProps.current = undefined;
+        mockNetworkState.isOffline = false;
+        mockOnReconnect.current = undefined;
     });
 
-    it('opens a WebView pointing at the Xero setup link for the given policy', () => {
+    it('shows the loading indicator until the authenticated setup URL resolves, then opens a WebView pointing at it', async () => {
         renderXeroSetupPage();
 
         expect(mockedGetXeroSetupLink).toHaveBeenCalledWith(POLICY_ID);
-        expect(screen.getByTestId('xero-webview')).toBeOnTheScreen();
-        expect(mockWebViewProps.current?.source?.uri).toBe(`https://xero-setup.example/${POLICY_ID}`);
+        expect(mockedGetShortLivedAuthTokenURL).toHaveBeenCalledWith(`https://xero-setup.example/${POLICY_ID}`);
+
+        // Until the short-lived auth token resolves, only the loading indicator should be visible.
+        expect(screen.queryByTestId('xero-webview')).not.toBeOnTheScreen();
+        expect(screen.getByTestId('setup-loading-indicator')).toBeOnTheScreen();
+
+        await waitFor(() => expect(screen.getByTestId('xero-webview')).toBeOnTheScreen());
+
+        // The WebView must load the authenticated URL, not the raw getXeroSetupLink() command URL.
+        expect(mockWebViewProps.current?.source?.uri).toBe(`https://xero-setup.example/${POLICY_ID}?authToken=${SHORT_LIVED_AUTH_TOKEN}`);
     });
 
-    it('passes the session auth token to the WebView as a cookie', () => {
+    it('passes the session auth token to the WebView as a cookie', async () => {
         renderXeroSetupPage();
 
+        await waitFor(() => expect(screen.getByTestId('xero-webview')).toBeOnTheScreen());
+
         expect(mockWebViewProps.current?.source?.headers?.Cookie).toBe(`authToken=${AUTH_TOKEN}`);
+    });
+
+    it('skips the token request while offline and fetches the authenticated URL on reconnect', async () => {
+        mockNetworkState.isOffline = true;
+        renderXeroSetupPage();
+
+        // No token request should fire while offline, so the WebView must not mount with an unauthenticated URL.
+        expect(mockedGetShortLivedAuthTokenURL).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('xero-webview')).not.toBeOnTheScreen();
+        expect(screen.getByTestId('setup-loading-indicator')).toBeOnTheScreen();
+
+        // Simulate the network coming back: useNetwork fires its onReconnect callback.
+        mockNetworkState.isOffline = false;
+        act(() => mockOnReconnect.current?.());
+
+        expect(mockedGetShortLivedAuthTokenURL).toHaveBeenCalledWith(`https://xero-setup.example/${POLICY_ID}`);
+        await waitFor(() => expect(screen.getByTestId('xero-webview')).toBeOnTheScreen());
+        expect(mockWebViewProps.current?.source?.uri).toBe(`https://xero-setup.example/${POLICY_ID}?authToken=${SHORT_LIVED_AUTH_TOKEN}`);
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

On Android, connecting a workspace to Xero opened a blank page (with a small "Pretty-print" toolbar) instead of the Xero authorization UI. The native Xero setup screen passed the raw `getXeroSetupLink(policyID)` value — the OldDot `ConnectPolicyToXero` command URL — straight into the `AccountingSetupWebViewPage` incognito WebView, which only supplied auth as a first-request `Cookie` header, so the WebView rendered the raw command response instead of an authenticated setup flow.

This PR makes the native Xero setup WebView load an authenticated URL, the same way other native OldDot handoffs (e.g. `ConnectToHRFlow`) do:

- `AccountingSetupWebViewPage` gains an opt-in `shouldAppendShortLivedAuthToken` prop. When set, the page resolves `getShortLivedAuthTokenURL(uri)` before mounting the WebView and shows the existing loading indicator while the token request is in flight. If the token request fails while online, the helper falls back to the original link so the page does not hang in the loading state (the WebView then behaves as it did before this fix).
- Like `ConnectToHRFlow`, the page skips the token request while offline and fetches it on reconnect (`useNetwork({onReconnect})` with a fetch-once ref), so opening the page offline and then reconnecting still ends up on the authenticated URL.
- The native `XeroSetupPage` passes `shouldAppendShortLivedAuthToken`, so its WebView now loads `getXeroSetupLink(policyID)` with a short-lived `authToken` appended and the Xero authorization UI renders.
- QuickBooks Online also uses `AccountingSetupWebViewPage` but does not pass the new prop, so its setup WebView keeps mounting immediately with the unmodified `uri` — behavior there is unchanged by construction.
- Unit tests, per the proposal: the native Xero setup test now mocks `getShortLivedAuthTokenURL()` and verifies the WebView receives the authenticated URL (not the raw `getXeroSetupLink()` value), that the loading indicator shows until it resolves, and that an offline mount defers the token request until reconnect. The QBO setup test now verifies the token helper is not called and the WebView mounts immediately with the raw setup link.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95199
PROPOSAL: https://github.com/Expensify/App/issues/95199#issuecomment-4866046632

### Tests

1. On Android native (and repeat once on iOS native, which shares this code path), sign in and open a workspace where you are an admin.
2. Go to Workspace settings > More features and enable Accounting.
3. Go to Accounting and tap Connect next to Xero.
4. If prompted, complete the two-factor authentication setup flow and continue.
5. Verify the in-app setup screen shows a loading spinner briefly and then loads the Xero sign-in/authorization page, instead of a blank page with a "Pretty-print" toolbar.
6. Go back to Accounting and tap Connect next to QuickBooks Online. Verify the QuickBooks Online setup WebView still opens and loads as before (no regression from the shared component change).

- [x] Verify that no errors appear in the JS console

### Offline tests

Connecting an accounting integration requires being online; the setup WebView is wrapped in `FullPageOfflineBlockingView`, which is unchanged. The short-lived token request is skipped while offline and retried on reconnect.

1. Go offline, then open Workspace settings > Accounting and tap Connect next to Xero.
2. Verify the full-page offline blocking view is shown instead of the setup WebView.
3. While staying on the page, go back online. Verify the loading indicator appears and then the Xero sign-in/authorization page loads (the token request is made on reconnect).

### QA Steps

1. On Android native (staging), sign in and open a workspace where you are an admin.
2. Go to Workspace settings > More features and enable Accounting.
3. Go to Accounting and tap Connect next to Xero.
4. If prompted, complete the two-factor authentication setup flow and continue.
5. Verify the in-app setup screen loads the Xero sign-in/authorization page, instead of a blank page with a "Pretty-print" toolbar.
6. Go back to Accounting and tap Connect next to QuickBooks Online. Verify the QuickBooks Online setup WebView still opens and loads as before.
7. Repeat steps 3-5 once on iOS native, which shares this code path.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
