### PR TITLE
Cancel ManualSendMessage spans when report is loading

### DIFF
--- a/contributingGuides/OBSERVABILITY_METRICS.md
+++ b/contributingGuides/OBSERVABILITY_METRICS.md
@@ -154,7 +154,10 @@ This document lists all implemented telemetry metrics in the Expensify App.
 - User sees: Their message appears in chat
 - Technical: Message text rendered in report ([`src/pages/home/report/comment/TextCommentFragment.tsx`](https://github.com/Expensify/App/blob/8f123f449f1a4533830b18a1040c9a5f1949821d/src/pages/home/report/comment/TextCommentFragment.tsx#L70))
 **Span ID**: Based on reportID
-**Attributes**: `report_id`, `message_length`
+**Attributes**: `report_id`, `message_length`, `canceled_by_skeleton`
+**Cancellation (report-actions skeleton)**: While a report-actions skeleton is on screen, we listen for `ManualSendMessage` spans started for that report and cancel them immediately, tagging `canceled: true` plus `canceled_by_skeleton` with the skeleton that caused it.
+- `canceled_by_skeleton` values (`CONST.TELEMETRY.CANCELED_BY_SKELETON`) based on skeleton condition
+**Cancellation (report unmount / navigate away)**: If the user leaves the report before their message renders, any pending `ManualSendMessage` span is cancelled via `cancelSpansByPrefix()` to avoid orphaned spans. Cancelled this way the span gets `canceled: true` but **no** `canceled_by_skeleton` (a blanket cancel by span-id prefix, not scoped to one `report_id`).
 
 ## Failure Rates
 

--- a/server/stubs/telemetry-activeSpans.ts
+++ b/server/stubs/telemetry-activeSpans.ts
@@ -19,8 +19,10 @@ function getSpan() {
 
 function cancelSpan() {}
 
+function cancelSpanByInstance() {}
+
 function cancelAllSpans() {}
 
 function cancelSpansByPrefix() {}
 
-export {startSpan, endSpan, endSpanWithAttributes, getSpan, cancelSpan, cancelAllSpans, cancelSpansByPrefix};
+export {startSpan, endSpan, endSpanWithAttributes, getSpan, cancelSpan, cancelSpanByInstance, cancelAllSpans, cancelSpansByPrefix};

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2192,6 +2192,7 @@ const CONST = {
         ATTRIBUTE_REPORT_ID: 'report_id',
         ATTRIBUTE_MESSAGE_LENGTH: 'message_length',
         ATTRIBUTE_CANCELED: 'canceled',
+        ATTRIBUTE_CANCELED_BY_SKELETON: 'canceled_by_skeleton',
         ATTRIBUTE_ROUTE_FROM: 'route_from',
         ATTRIBUTE_ROUTE_TO: 'route_to',
         ATTRIBUTE_MIN_DURATION: 'min_duration',
@@ -2221,6 +2222,13 @@ const CONST = {
         ATTRIBUTE_SOURCE: 'source',
         ATTRIBUTE_ODOMETER_IMAGE_TYPE: 'odometer_image_type',
         ATTRIBUTE_DURATION_SINCE_NATIVE_APP_STARTUP_MS: 'duration_since_native_app_startup_ms',
+        /** Which report-actions skeleton cancelled a send-message span (value of the canceled_by_skeleton attribute). */
+        CANCELED_BY_SKELETON: {
+            REPORT_ACTIONS_REPORT_DATA_LOADING: 'report_actions_report_data_loading',
+            REPORT_ACTIONS_APP_LOAD: 'report_actions_app_load',
+            SKELETON_GUARD_LOADING: 'skeleton_guard_loading',
+            SKELETON_GUARD_DERIVED_TIMING: 'skeleton_guard_derived_timing',
+        },
         /** Follow-up action after expense submit (action-based; used as submit_follow_up_action in span). */
         SUBMIT_FOLLOW_UP_ACTION: {
             DISMISS_MODAL_AND_OPEN_REPORT: 'dismiss_modal_and_open_report',

--- a/src/hooks/useCancelSendMessageSpanOnSkeleton.ts
+++ b/src/hooks/useCancelSendMessageSpanOnSkeleton.ts
@@ -1,0 +1,41 @@
+import {cancelSpanByInstance} from '@libs/telemetry/activeSpans';
+
+import CONST from '@src/CONST';
+
+import type {ValueOf} from 'type-fest';
+
+import * as Sentry from '@sentry/react-native';
+import {useEffect} from 'react';
+
+/** Identifies which report-actions skeleton cancelled a send-message span (stamped as canceled_by_skeleton). */
+type SkeletonName = ValueOf<typeof CONST.TELEMETRY.CANCELED_BY_SKELETON>;
+
+/**
+ * Call from a component that is mounted exactly while a report-actions skeleton is on screen. A message sent
+ * while the skeleton shows can't render, so its send-message span would never end. This cancels any such span
+ * for `reportID` (matched by `report_id`, since the span id uses a random report-action id) and tags it with
+ * `skeletonName` so Sentry shows which skeleton caused it.
+ */
+function useCancelSendMessageSpanOnSkeleton(reportID: string | undefined, skeletonName: SkeletonName) {
+    useEffect(() => {
+        if (!reportID) {
+            return;
+        }
+        const client = Sentry.getClient();
+        if (!client) {
+            return;
+        }
+        // `client.on` returns an unsubscribe function, used as the effect cleanup.
+        return client.on('spanStart', (span) => {
+            const {op, data} = Sentry.spanToJSON(span);
+            if (op !== CONST.TELEMETRY.SPAN_SEND_MESSAGE || data[CONST.TELEMETRY.ATTRIBUTE_REPORT_ID] !== reportID) {
+                return;
+            }
+            // Defer so activeSpans has registered the span (set right after the `startInactiveSpan` that emits this).
+            queueMicrotask(() => cancelSpanByInstance(span, {[CONST.TELEMETRY.ATTRIBUTE_CANCELED_BY_SKELETON]: skeletonName}));
+        });
+    }, [reportID, skeletonName]);
+}
+
+export default useCancelSendMessageSpanOnSkeleton;
+export type {SkeletonName};

--- a/src/libs/telemetry/activeSpans.ts
+++ b/src/libs/telemetry/activeSpans.ts
@@ -1,6 +1,6 @@
 import CONST from '@src/CONST';
 
-import type {SpanAttributeValue, StartSpanOptions} from '@sentry/core';
+import type {Span, SpanAttributeValue, StartSpanOptions} from '@sentry/core';
 
 import {SPAN_STATUS_OK} from '@sentry/core';
 import * as Sentry from '@sentry/react-native';
@@ -94,6 +94,22 @@ function cancelSpansByPrefix(prefix: string) {
     }
 }
 
+/**
+ * Cancel a tracked span by its Sentry span instance rather than its id (e.g. from a lifecycle listener that
+ * only has the raw span). Optionally stamps attributes first. No-op if the span isn't tracked.
+ */
+function cancelSpanByInstance(target: Span, attributes?: Record<string, SpanAttributeValue>) {
+    for (const [spanID, entry] of activeSpans.entries()) {
+        if (entry.span === target) {
+            if (attributes) {
+                entry.span.setAttributes(attributes);
+            }
+            cancelSpan(spanID);
+            return;
+        }
+    }
+}
+
 function getSpan(spanId: string) {
     return activeSpans.get(spanId)?.span;
 }
@@ -104,4 +120,4 @@ function endSpanWithAttributes(spanId: string, attributes: Record<string, SpanAt
     endSpan(spanId);
 }
 
-export {startSpan, endSpan, endSpanWithAttributes, getSpan, cancelSpan, cancelAllSpans, cancelSpansByPrefix};
+export {startSpan, endSpan, endSpanWithAttributes, getSpan, cancelSpan, cancelSpanByInstance, cancelAllSpans, cancelSpansByPrefix};

--- a/src/pages/inbox/ReportActions.tsx
+++ b/src/pages/inbox/ReportActions.tsx
@@ -1,5 +1,4 @@
 import MoneyRequestReportActionsList from '@components/MoneyRequestReportView/MoneyRequestReportActionsList';
-import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
 import useMarkOpenReportEndOnSkeleton from '@hooks/useMarkOpenReportEndOnSkeleton';
 import useNetwork from '@hooks/useNetwork';
@@ -11,6 +10,7 @@ import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getAllNonDeletedTransactions, shouldDisplayReportTableView, shouldWaitForTransactions as shouldWaitForTransactionsUtil} from '@libs/MoneyRequestReportUtils';
 import {isConciergeChatReport, isInvoiceReport, isMoneyRequestReport} from '@libs/ReportUtils';
 
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 import {useRoute} from '@react-navigation/native';
@@ -19,6 +19,7 @@ import React from 'react';
 import type ReportScreenNavigationProps from './types';
 
 import ReportActionsList from './report/ReportActionsList';
+import ReportActionsLoadingSkeleton from './report/ReportActionsLoadingSkeleton';
 import UserTypingEventListener from './report/UserTypingEventListener';
 
 const defaultReportLoadingState = {
@@ -69,7 +70,12 @@ function ReportActions() {
     useMarkOpenReportEndOnSkeleton(report, shouldShowAppLoadSkeleton);
 
     if (!report || shouldWaitForTransactions) {
-        return <ReportActionsSkeletonView />;
+        return (
+            <ReportActionsLoadingSkeleton
+                reportID={reportIDFromRoute}
+                skeletonName={CONST.TELEMETRY.CANCELED_BY_SKELETON.REPORT_ACTIONS_REPORT_DATA_LOADING}
+            />
+        );
     }
 
     if (shouldDisplayMoneyRequestActionsList) {
@@ -77,7 +83,12 @@ function ReportActions() {
     }
 
     if (shouldShowAppLoadSkeleton) {
-        return <ReportActionsSkeletonView />;
+        return (
+            <ReportActionsLoadingSkeleton
+                reportID={reportIDFromRoute}
+                skeletonName={CONST.TELEMETRY.CANCELED_BY_SKELETON.REPORT_ACTIONS_APP_LOAD}
+            />
+        );
     }
 
     return (

--- a/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
+++ b/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
@@ -1,0 +1,30 @@
+import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
+
+import useCancelSendMessageSpanOnSkeleton from '@hooks/useCancelSendMessageSpanOnSkeleton';
+import type {SkeletonName} from '@hooks/useCancelSendMessageSpanOnSkeleton';
+
+import React from 'react';
+
+type ReportActionsLoadingSkeletonProps = {
+    /** The report whose actions list is loading */
+    reportID: string | undefined;
+
+    /** Which skeleton this is, stamped on any send-message span it cancels */
+    skeletonName: SkeletonName;
+
+    /** Whether the skeleton rows animate */
+    shouldAnimate?: boolean;
+};
+
+/**
+ * Report-actions loading skeleton. Mounted only while the skeleton shows, so it hosts the hook that cancels
+ * the otherwise never-ending send-message span (tagged with `skeletonName`).
+ */
+function ReportActionsLoadingSkeleton({reportID, skeletonName, shouldAnimate = true}: ReportActionsLoadingSkeletonProps) {
+    useCancelSendMessageSpanOnSkeleton(reportID, skeletonName);
+    return <ReportActionsSkeletonView shouldAnimate={shouldAnimate} />;
+}
+
+ReportActionsLoadingSkeleton.displayName = 'ReportActionsLoadingSkeleton';
+
+export default ReportActionsLoadingSkeleton;

--- a/src/pages/inbox/report/ReportActionsSkeletonGuard.tsx
+++ b/src/pages/inbox/report/ReportActionsSkeletonGuard.tsx
@@ -1,16 +1,17 @@
-import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
-
 import useCopySelectionHelper from '@hooks/useCopySelectionHelper';
 import useMarkOpenReportEndOnSkeleton from '@hooks/useMarkOpenReportEndOnSkeleton';
 import usePendingConciergeResponse from '@hooks/usePendingConciergeResponse';
 import useReportActionsListModel from '@hooks/useReportActionsListModel';
 import useStartConciergeSession from '@hooks/useStartConciergeSession';
 
+import CONST from '@src/CONST';
+
 import type {ReactNode} from 'react';
 
 import React from 'react';
 
 import {computeReportActionsSkeletonState, ReportActionsListActionsContext, ReportActionsListStateContext} from './ReportActionsListContext';
+import ReportActionsLoadingSkeleton from './ReportActionsLoadingSkeleton';
 
 type ReportActionsSkeletonGuardProps = {
     /** The ID of the report to display actions for */
@@ -49,11 +50,22 @@ function ReportActionsSkeletonGuard({reportID, children}: ReportActionsSkeletonG
     useMarkOpenReportEndOnSkeleton(report, shouldShowInitialSkeleton);
 
     if (shouldShowLoadingSkeleton) {
-        return <ReportActionsSkeletonView />;
+        return (
+            <ReportActionsLoadingSkeleton
+                reportID={reportID}
+                skeletonName={CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_LOADING}
+            />
+        );
     }
 
     if (shouldShowDerivedTimingSkeleton) {
-        return <ReportActionsSkeletonView shouldAnimate={false} />;
+        return (
+            <ReportActionsLoadingSkeleton
+                reportID={reportID}
+                skeletonName={CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_DERIVED_TIMING}
+                shouldAnimate={false}
+            />
+        );
     }
 
     return (

--- a/tests/unit/useCancelSendMessageSpanOnSkeletonTest.ts
+++ b/tests/unit/useCancelSendMessageSpanOnSkeletonTest.ts
@@ -1,0 +1,139 @@
+import {renderHook} from '@testing-library/react-native';
+
+import useCancelSendMessageSpanOnSkeleton from '@hooks/useCancelSendMessageSpanOnSkeleton';
+
+import {cancelAllSpans, getSpan, startSpan} from '@libs/telemetry/activeSpans';
+
+import CONST from '@src/CONST';
+
+import * as Sentry from '@sentry/react-native';
+
+type SpanStartListener = (span: unknown) => void;
+
+jest.mock('@sentry/react-native', () => {
+    const spanStartListeners = new Set<SpanStartListener>();
+    const client = {
+        on: (hook: string, callback: SpanStartListener) => {
+            if (hook !== 'spanStart') {
+                return () => {};
+            }
+            spanStartListeners.add(callback);
+            return () => spanStartListeners.delete(callback);
+        },
+    };
+    return {
+        getClient: () => client,
+        startInactiveSpan: (options: {op?: string; attributes?: Record<string, unknown>}) => {
+            const span = {
+                op: options?.op,
+                attributes: {...(options?.attributes ?? {})} as Record<string, unknown>,
+                setAttribute(key: string, value: unknown) {
+                    this.attributes[key] = value;
+                },
+                setAttributes(attrs: Record<string, unknown>) {
+                    Object.assign(this.attributes, attrs);
+                },
+                setStatus() {},
+                end() {},
+            };
+            // The real SDK emits spanStart synchronously during span creation, before startInactiveSpan returns.
+            for (const listener of spanStartListeners) {
+                listener(span);
+            }
+            return span;
+        },
+        spanToJSON: (span: {op?: string; attributes: Record<string, unknown>}) => ({op: span.op, data: span.attributes}),
+    };
+});
+
+/** Start a send-message span the way the composer does, for a given report. Returns the (typed-as-Sentry) span. */
+function sendMessageWhileLoading(reportID: string) {
+    const spanID = `${CONST.TELEMETRY.SPAN_SEND_MESSAGE}_${Math.random()}`;
+    const span = startSpan(spanID, {
+        name: 'send-message',
+        op: CONST.TELEMETRY.SPAN_SEND_MESSAGE,
+        attributes: {[CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID},
+    });
+    return {spanID, span};
+}
+
+/** Flush the queueMicrotask the hook schedules before cancelling. */
+function flushMicrotasks() {
+    return Promise.resolve();
+}
+
+afterEach(() => {
+    cancelAllSpans();
+});
+
+describe('useCancelSendMessageSpanOnSkeleton', () => {
+    it('cancels a send-message span sent while the skeleton for that report is showing', async () => {
+        renderHook(() => useCancelSendMessageSpanOnSkeleton('reportA', CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_LOADING));
+
+        const {spanID, span} = sendMessageWhileLoading('reportA');
+        if (!span) {
+            throw new Error('Expected a span to be started');
+        }
+        await flushMicrotasks();
+
+        const {data} = Sentry.spanToJSON(span);
+        expect(data[CONST.TELEMETRY.ATTRIBUTE_CANCELED]).toBe(true);
+        expect(data[CONST.TELEMETRY.ATTRIBUTE_CANCELED_BY_SKELETON]).toBe(CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_LOADING);
+        // Truly cancelled: ended and removed from the tracking map.
+        expect(getSpan(spanID)).toBeUndefined();
+    });
+
+    it('does NOT cancel a send-message span for a different report (two reports open, one loading)', async () => {
+        renderHook(() => useCancelSendMessageSpanOnSkeleton('loadingReport', CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_LOADING));
+
+        const {spanID, span} = sendMessageWhileLoading('otherReport');
+        if (!span) {
+            throw new Error('Expected a span to be started');
+        }
+        await flushMicrotasks();
+
+        expect(Sentry.spanToJSON(span).data[CONST.TELEMETRY.ATTRIBUTE_CANCELED]).toBeUndefined();
+        expect(getSpan(spanID)).toBeDefined();
+    });
+
+    it('does NOT cancel spans of a different op', async () => {
+        renderHook(() => useCancelSendMessageSpanOnSkeleton('reportOp', CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_LOADING));
+
+        const spanID = `not-send-message_${Math.random()}`;
+        const span = startSpan(spanID, {name: 'other', op: 'ManualOpenReport', attributes: {[CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: 'reportOp'}});
+        if (!span) {
+            throw new Error('Expected a span to be started');
+        }
+        await flushMicrotasks();
+
+        expect(Sentry.spanToJSON(span).data[CONST.TELEMETRY.ATTRIBUTE_CANCELED]).toBeUndefined();
+        expect(getSpan(spanID)).toBeDefined();
+    });
+
+    it('does NOT cancel spans started after the skeleton unmounts', async () => {
+        const {unmount} = renderHook(() => useCancelSendMessageSpanOnSkeleton('reportUnmount', CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_LOADING));
+        unmount();
+
+        const {spanID, span} = sendMessageWhileLoading('reportUnmount');
+        if (!span) {
+            throw new Error('Expected a span to be started');
+        }
+        await flushMicrotasks();
+
+        expect(Sentry.spanToJSON(span).data[CONST.TELEMETRY.ATTRIBUTE_CANCELED]).toBeUndefined();
+        expect(getSpan(spanID)).toBeDefined();
+    });
+
+    it('does nothing without a reportID', async () => {
+        renderHook(() => useCancelSendMessageSpanOnSkeleton(undefined, CONST.TELEMETRY.CANCELED_BY_SKELETON.SKELETON_GUARD_LOADING));
+
+        const {spanID, span} = sendMessageWhileLoading('reportNoId');
+        if (!span) {
+            throw new Error('Expected a span to be started');
+        }
+        await flushMicrotasks();
+
+        expect(Sentry.spanToJSON(span).data[CONST.TELEMETRY.ATTRIBUTE_CANCELED]).toBeUndefined();
+        expect(getSpan(spanID)).toBeDefined();
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The `ManualSendMessage` span measures time from pressing **Send** until the sent message renders
(`TextCommentFragment` mounts). If a message is sent while the report-actions list is still showing a skeleton, the message can't render yet, so the span is blocked by other loading conditions.

Fix: while a report-actions skeleton is on screen, we now listen for `ManualSendMessage` spans started for
that report and cancel them immediately.

- `useCancelSendMessageSpanOnSkeleton` — subscribes to Sentry's `spanStart` while mounted; cancels spans
  matching the report's `report_id`, tagging them with `canceled_by_skeleton` attribute.
- `ReportActionsLoadingSkeleton` — thin wrapper rendered wherever a report-actions skeleton shows (in
  `ReportActions` and `ReportActionsSkeletonGuard`); hosts the hook and passes the `skeletonName`.
- `activeSpans.cancelSpanByInstance` — cancels a span by its Sentry instance (the listener only has the raw
  span, not the id).
- Composer is unchanged: it always starts the span, we don't block spans here based on skeleton conditions as these are not trivial and requires many onyx subscriptions or state lift up

Cancelled spans get: `canceled: true`, `canceled_by_skeleton: <name>` (`report_actions_report_data_loading`,
`report_actions_app_load`, `skeleton_guard_loading`, or `skeleton_guard_derived_timing`). Normal sends are
untouched and end with `finished_manually: true`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95583
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

The app logs each span to the console. In DevTools **Console**, filter by `ManualSendMessage`. Each span
prints a **Starting span** line and an **Ending span** line; expand the attributes object on the ending line
to read `canceled`, `canceled_by_skeleton`, `report_id`

### Test 1 — sending while loading (span is cancelled)

1. DevTools → Network → set throttling to Slow 3G or custom slower.
2. App settings Troubleshoot → clear Onyx cache to force to allow reports to be fetched again when open
3. Open a chat so the report shows a loading skeleton.
4. Fast, While the skeleton is still visible, type a message and press Send (send 2–3 quickly).
5. In the Console (filtered `ManualSendMessage`), verify each span's **Ending span** attributes have:
   - `canceled: true`
   - `canceled_by_skeleton` set to a skeleton name (e.g. `skeleton_guard_loading` for Concierge)
   - `report_id` = the open report's ID
6. Duration is short (cancelled promptly), not seconds. No leaked/open `ManualSendMessage` span remains.

### Test 2 — sending with no loading (works as before)

1. Turn off network throttling; make sure the chat is fully loaded (no skeleton, messages visible).
2. Type a message and press Send
3. In the Console, verify the `ManualSendMessage` span's **Ending span** attributes have:
   - no `canceled` and no `canceled_by_skeleton`
   - `report_id` present
4. Duration reflects the real send-to-render time

### Test 3 — loaded Concierge + freshly opened chat, only the loading one is affected

1. With normal network, open Concierge (right upper side icon that opens right panel on wide layout) and let it fully load (messages visible, no skeleton). Keep it open.
2. Set Network throttling to Slow 3G
3. Open a normal report/chat you haven't visited this session so it shows a loading skeleton
4. In the still-loading chat, type a message and press Send → its `ManualSendMessage` span is `canceled`
   with `canceled_by_skeleton` and `report_id` = that chat.
5. Switch to the already-loaded Concierge sand send a message → its span ends normally:
    no `canceled` / `canceled_by_skeleton`, 


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b849f33d-82d6-4dd7-8897-88d209f7b60c


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/4189c83f-0b53-46c8-84fd-a50b57d8f603


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/52410c83-5c06-4c65-bd1c-bfd58b8b9935


</details>
