### PR TITLE
[No QA] [Test] Pin react-native-onyx to #806 — Failed to write blobs classification + instrumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "react-native-localize": "^3.5.4",
         "react-native-nitro-modules": "0.35.0",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.88",
+        "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#9b9aba708a408af226563deff6add1e6035e9ea0",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -36672,9 +36672,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.88",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.88.tgz",
-      "integrity": "sha512-wCNHe+Kc6DX3yYVZxrITZdunu74P2x0XE7t8FGkpjEQdCRnlJhCTxn4NvxWZkURFxn5IRvIlVCGU8OdZhFNoOg==",
+      "version": "3.0.90",
+      "resolved": "git+ssh://git@github.com/callstack-internal/react-native-onyx.git#9b9aba708a408af226563deff6add1e6035e9ea0",
+      "integrity": "sha512-AsZW4f2+ch+8ZfWBR69AgTsPv3oI6fiy1S+Hz1uWS9Qwxw5hGuuZXZjY18tZTZCRoPgn3GwhK4k0yI44q07cWA==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "react-native-localize": "^3.5.4",
     "react-native-nitro-modules": "0.35.0",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.88",
+    "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#9b9aba708a408af226563deff6add1e6035e9ea0",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",


### PR DESCRIPTION
### Explanation of Change

Companion / verification PR for **react-native-onyx PR https://github.com/Expensify/react-native-onyx/pull/806**. It pins `react-native-onyx` to that PR's HEAD via `git+https` so E/App CI and manual testing exercise the change before the Onyx PR is merged and published.

The Onyx change addresses `DataError: Failed to write blobs`, which has grown from 1.9% to ~93% of all Onyx web storage errors (Expensify/App#87871). Chromium externalizes any IndexedDB value >64 KB into a blob file; when that write fails the error was unclassified, so Onyx retried it 5× (prod shows ~99.7% futile) and logged ~6× per failure before silently dropping the write. The Onyx PR classifies it as a new `UNRECOVERABLE` class (skip quietly — no retry/throw/eviction) and adds a log-only diagnostic that reports the failing key(s) + approximate serialized size, so we can confirm the >64 KB trigger and identify the culprit keys.

Pin: `"react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#9b9aba708a408af226563deff6add1e6035e9ea0"`.

⚠️ Not for merge as-is: once Onyx PR #806 merges and publishes, repin to the released version (e.g. `"react-native-onyx": "3.0.xx"`) — at which point this becomes the bump PR.

### Fixed Issues

$ https://github.com/Expensify/App/issues/87871
PROPOSAL:

### Tests

This is a library-only bump with no user-facing UI change; the goal is to confirm no regressions in normal Onyx read/write behavior and that the new classification behaves correctly. The underlying Chromium blob-write failure can't be reproduced on demand, so:

1. Launch the web app, log in, and use the app normally (open chats/reports, create an expense, switch workspaces). Verify everything loads and persists across reloads as before.
2. Verify no new JS console errors appear during normal use.
3. (Behavior check) In a local build, temporarily make an IndexedDB write reject with `new DOMException('Failed to write blobs (IOError)', 'DataError')` and confirm:
    - the operation is **not** retried 5× (previously it was),
    - a single `Storage operation skipped retry; unrecoverable errors cannot be recovered by retrying …` log line appears, followed by the `pairs: … over64KB: … largest: […]` payload summary,
    - no `Attempted to set invalid data …` throw, no eviction, and no `IDB heal …` reopen logs for this error,
    - normal (small, successful) writes are unaffected.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, perform actions that write to Onyx (e.g. draft a message, create an expense). Verify optimistic data is stored and the UI updates as expected.
2. Go back online and verify the queued changes sync normally. No change from current behavior is expected — the Onyx change only affects how an unrecoverable IndexedDB blob-write failure is handled.

### QA Steps

Same as tests. No user-facing behavior changes; this is an Onyx library bump. (Title should include "[No QA]" if QA is not required.)

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
