### PR TITLE
[No QA] Reduce unsafe type assertions in checkFileExists, qbo/utils, parseAndCollectJSONs, and useLastWorkspaceNumber tests

### DIFF
--- a/tests/unit/checkFileExistsTest.ts
+++ b/tests/unit/checkFileExistsTest.ts
@@ -8,6 +8,18 @@ jest.mock('react-native-fs', () => ({
     stat: (...args: [string]) => mockStat(...args),
 }));
 
+const buildStatResult = (isFile: boolean): RNFS.StatResult => ({
+    name: undefined,
+    path: '',
+    size: 0,
+    mode: 0,
+    ctime: 0,
+    mtime: 0,
+    originalFilepath: '',
+    isFile: () => isFile,
+    isDirectory: () => !isFile,
+});
+
 describe('checkFileExists', () => {
     beforeEach(() => {
         mockStat.mockReset();
@@ -26,21 +38,21 @@ describe('checkFileExists', () => {
     });
 
     it('should call RNFS.stat with a plain POSIX path', async () => {
-        mockStat.mockResolvedValue({isFile: () => true} as RNFS.StatResult);
+        mockStat.mockResolvedValue(buildStatResult(true));
         const result = await checkFileExists('/var/mobile/Containers/shared_image.png');
         expect(result).toBe(true);
         expect(mockStat).toHaveBeenCalledWith('/var/mobile/Containers/shared_image.png');
     });
 
     it('should strip file:// prefix before calling RNFS.stat', async () => {
-        mockStat.mockResolvedValue({isFile: () => true} as RNFS.StatResult);
+        mockStat.mockResolvedValue(buildStatResult(true));
         const result = await checkFileExists('file:///var/mobile/Containers/shared_image.png');
         expect(result).toBe(true);
         expect(mockStat).toHaveBeenCalledWith('/var/mobile/Containers/shared_image.png');
     });
 
     it('should decode URI-encoded paths', async () => {
-        mockStat.mockResolvedValue({isFile: () => true} as RNFS.StatResult);
+        mockStat.mockResolvedValue(buildStatResult(true));
         const result = await checkFileExists('file:///var/mobile/Containers/my%20receipt.png');
         expect(result).toBe(true);
         expect(mockStat).toHaveBeenCalledWith('/var/mobile/Containers/my receipt.png');
@@ -53,7 +65,7 @@ describe('checkFileExists', () => {
     });
 
     it('should return false when path is a directory', async () => {
-        mockStat.mockResolvedValue({isFile: () => false} as RNFS.StatResult);
+        mockStat.mockResolvedValue(buildStatResult(false));
         const result = await checkFileExists('/var/mobile/Containers/');
         expect(result).toBe(false);
     });

--- a/tests/unit/pages/workspace/accounting/qbo/utilsTest.ts
+++ b/tests/unit/pages/workspace/accounting/qbo/utilsTest.ts
@@ -3,10 +3,35 @@ import {canUseVendorBillForCompanyCardExport} from '@pages/workspace/accounting/
 import CONST from '@src/CONST';
 import type {QBOConnectionConfig} from '@src/types/onyx/Policy';
 
-const buildQBOConfig = (syncLocations?: QBOConnectionConfig['syncLocations']): QBOConnectionConfig =>
-    ({
-        syncLocations,
-    }) as QBOConnectionConfig;
+const buildQBOConfig = (syncLocations: QBOConnectionConfig['syncLocations']): QBOConnectionConfig => ({
+    realmId: '123',
+    companyName: 'QuickBooks Company',
+    autoSync: {
+        jobID: '456',
+        enabled: false,
+    },
+    syncPeople: false,
+    syncItems: false,
+    markChecksToBePrinted: false,
+    reimbursableExpensesExportDestination: CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.VENDOR_BILL,
+    nonReimbursableExpensesExportDestination: CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD,
+    nonReimbursableBillDefaultVendor: '',
+    autoCreateVendor: false,
+    hasChosenAutoSyncOption: false,
+    syncClasses: CONST.INTEGRATION_ENTITY_MAP_TYPES.NONE,
+    syncCustomers: CONST.INTEGRATION_ENTITY_MAP_TYPES.NONE,
+    syncLocations,
+    lastConfigurationTime: 0,
+    syncTax: false,
+    enableNewCategories: false,
+    exportDate: CONST.QUICKBOOKS_EXPORT_DATE.LAST_EXPENSE,
+    export: {},
+    credentials: {
+        companyID: '123',
+        companyName: 'QuickBooks Company',
+        scope: '',
+    },
+});
 
 describe('canUseVendorBillForCompanyCardExport', () => {
     it('allows vendor bill when QBO config is missing', () => {

--- a/tests/unit/parseAndCollectJSONsTest.ts
+++ b/tests/unit/parseAndCollectJSONsTest.ts
@@ -10,7 +10,11 @@ function runScript(input: string): unknown[] {
     const result = execSync(`ruby ${SCRIPT_PATH} '${input}'`, {
         encoding: 'utf-8',
     });
-    return JSON.parse(result) as unknown[];
+    const parsed: unknown = JSON.parse(result);
+    if (!Array.isArray(parsed)) {
+        throw new Error('Expected parseAndCollectJSONs.rb to return a JSON array');
+    }
+    return parsed;
 }
 
 describe('Test if parseAndCollectJSONs works correctly', () => {

--- a/tests/unit/useLastWorkspaceNumberTest.ts
+++ b/tests/unit/useLastWorkspaceNumberTest.ts
@@ -15,6 +15,7 @@ describe('useLastWorkspaceNumber', () => {
     const email = 'jdoe@expensify.com';
     const displayName = 'Expensify';
     const workspaceName = `${displayName} Workspace`;
+    const buildPolicyWithName = (name: Policy['name']): Pick<Policy, 'name'> => ({name});
 
     beforeAll(() => {
         Onyx.init({keys: ONYXKEYS});
@@ -28,7 +29,7 @@ describe('useLastWorkspaceNumber', () => {
 
     it('should return the correct last workspace number from Onyx', async () => {
         await Onyx.merge(ONYXKEYS.SESSION, {email});
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}1`, {name: `${workspaceName} 3`} as Policy);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}1`, buildPolicyWithName(`${workspaceName} 3`));
         await waitForBatchedUpdates();
 
         const {result} = renderHook(() => useLastWorkspaceNumber());
@@ -38,13 +39,13 @@ describe('useLastWorkspaceNumber', () => {
 
     it('should update when Onyx data changes', async () => {
         await Onyx.merge(ONYXKEYS.SESSION, {email});
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}1`, {name: `${workspaceName} 3`} as Policy);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}1`, buildPolicyWithName(`${workspaceName} 3`));
         await waitForBatchedUpdates();
 
         const {result} = renderHook(() => useLastWorkspaceNumber());
         expect(result.current).toBe(3);
 
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}2`, {name: `${workspaceName} 5`} as Policy);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}2`, buildPolicyWithName(`${workspaceName} 5`));
         await waitForBatchedUpdates();
 
         expect(result.current).toBe(5);
@@ -52,7 +53,7 @@ describe('useLastWorkspaceNumber', () => {
 
     it('should return undefined if no matching workspaces exist', async () => {
         await Onyx.merge(ONYXKEYS.SESSION, {email});
-        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}1`, {name: 'Other Workspace'} as Policy);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}1`, buildPolicyWithName('Other Workspace'));
         await waitForBatchedUpdates();
 
         const {result} = renderHook(() => useLastWorkspaceNumber());


### PR DESCRIPTION
### Explanation of Change

Reduced `@typescript-eslint/no-unsafe-type-assertion` violations in `checkFileExistsTest.ts`, `utilsTest.ts`, `parseAndCollectJSONsTest.ts`, and `useLastWorkspaceNumberTest.ts` as part of the cleanup for Expensify/App issue #94739.

What changed:
* Replaced casted RNFS stat fixtures with a typed stat result builder.
* Replaced the casted QBO config fixture with a typed QBO connection config builder.
* Parsed JSON into `unknown` and added an `Array.isArray` guard before returning script output.
* Replaced casted workspace policy merge payloads with a typed policy-name helper.
* Verified with writable lint that the generated target-rule rows for these files are removed from the seatbelt TSV.
* The generated TSV diff is intentionally not included in this PR because Expensify/App post-merge OSBotify automation tightens the baseline on `main`.

Why this approach is safe:
* Test-only change; no product/runtime behavior changed.
* Existing scenarios and assertions were preserved.
* Mock fixtures are typed against the real imported types instead of hidden unsafe casts.

Reviewer focus:
1. Start with the four edited test files and confirm the helpers are honest typed fixtures rather than hidden unsafe casts.
2. Check the count evidence below and confirm writable lint locally removed the target-rule rows.
3. Check the commands below; no manual QA is expected for this test-only cleanup.

Safety checks:
* No `SEATBELT_INCREASE`.
* No new `eslint-disable` for `@typescript-eslint/no-unsafe-type-assertion`.
* No broad `as unknown as` substitutions.
* No generic unsafe helper that hides casts.

### Fixed Issues

$ #94739
PROPOSAL:

### Count change

Current baseline source:

* `config/eslint/eslint.seatbelt.tsv`

Before:

* `tests/unit/checkFileExistsTest.ts`: 4 violations
* `tests/unit/pages/workspace/accounting/qbo/utilsTest.ts`: 1 violation
* `tests/unit/parseAndCollectJSONsTest.ts`: 1 violation
* `tests/unit/useLastWorkspaceNumberTest.ts`: 4 violations
* Current global target-rule baseline: 5,329 violations

After:

* Target files: 0 violations
* Current global target-rule baseline: 5,319 violations

Net reduction:

* 10 fewer `@typescript-eslint/no-unsafe-type-assertion` violations.

TSV evidence:
* Writable lint locally removed all four target-file rows from `config/eslint/eslint.seatbelt.tsv`.
* Generated with:
`CI=true npm run lint -- --no-cache --show-warnings tests/unit/pages/workspace/accounting/qbo/utilsTest.ts tests/unit/parseAndCollectJSONsTest.ts tests/unit/checkFileExistsTest.ts tests/unit/useLastWorkspaceNumberTest.ts`
* The generated `config/eslint/eslint.seatbelt.tsv` diff is intentionally not included in this PR because Expensify/App post-merge OSBotify automation tightens the baseline on `main`.

### Tests

1. Run:

        CI=true npm run lint -- --no-cache --show-warnings tests/unit/pages/workspace/accounting/qbo/utilsTest.ts tests/unit/parseAndCollectJSONsTest.ts tests/unit/checkFileExistsTest.ts tests/unit/useLastWorkspaceNumberTest.ts

Verify lint passes with no target-rule warnings for the edited files.

2. Verify `config/eslint/eslint.seatbelt.tsv` locally contains the decrement described above, then restore it before committing:

        git restore config/eslint/eslint.seatbelt.tsv

3. Run:

        npm test -- --runTestsByPath tests/unit/pages/workspace/accounting/qbo/utilsTest.ts tests/unit/parseAndCollectJSONsTest.ts tests/unit/checkFileExistsTest.ts tests/unit/useLastWorkspaceNumberTest.ts

Verify the targeted test suites pass.

4. Run:

        npm run typecheck

Verify TypeScript checks pass.

### Offline tests

Not applicable. This is test-only cleanup and does not change network behavior.

### QA Steps

No QA required. This PR only changes tests. The ESLint seatbelt baseline is tightened by Expensify/App post-merge OSBotify automation.

### PR Author Checklist

For checklist items that are not applicable to this test-only cleanup, checked means the item was considered and determined not applicable.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on all platforms & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see Reviewing the code)
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing `StyleUtils` function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added Design label and/or tagged @Expensify/design so the design team can review the changes.
- [x] I added unit tests for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the main branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the Test steps.

### Screenshots/Videos

Android: Native

Not applicable. This is test-only cleanup.

Android: mWeb Chrome

Not applicable. This is test-only cleanup.

iOS: Native

Not applicable. This is test-only cleanup.

iOS: mWeb Safari

Not applicable. This is test-only cleanup.

MacOS: Chrome / Safari

Not applicable. This is test-only cleanup.


cc @blimpich
