### PR TITLE
[No QA] Reduce unsafe type assertions in search, hook, and mention tests

### DIFF
--- a/tests/unit/MentionUtilsTest.ts
+++ b/tests/unit/MentionUtilsTest.ts
@@ -1,25 +1,59 @@
 import {getReportMentionDetails} from '@libs/MentionUtils';
 
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
 
-import type {TText} from 'react-native-render-html';
+import type {OnyxCollection} from 'react-native-onyx';
+import type {TNode, TText} from 'react-native-render-html';
+
+import {TRenderEngine} from 'react-native-render-html';
+
+type ReportFixture = Report & {reportID: string};
+
+const renderEngine = new TRenderEngine();
+
+const getFirstTextNode = (nodes: readonly TNode[]): TText | undefined => {
+    for (const node of nodes) {
+        if (node.type === 'text') {
+            return node;
+        }
+
+        const textNode = getFirstTextNode(node.children);
+        if (textNode) {
+            return textNode;
+        }
+    }
+
+    return undefined;
+};
+
+const makeTextNode = (data: string): TText => {
+    const textNode = getFirstTextNode(renderEngine.buildTTree(`<span>${data}</span>`).children);
+    if (!textNode) {
+        throw new Error(`Unable to build mention text node for ${data}`);
+    }
+
+    return textNode;
+};
+
+const makeReportCollection = (...reports: ReportFixture[]): OnyxCollection<Report> =>
+    Object.fromEntries(reports.map((report) => [`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report]));
 
 describe('MentionUtils', () => {
     describe('getReportMentionDetails', () => {
         it('should return the room report ID', () => {
             const reportID = '1';
-            const mentionDetails = getReportMentionDetails(
-                '',
-                {policyID: '1'} as Report,
-                {[reportID]: {reportID, reportName: '#hello', policyID: '1', chatType: CONST.REPORT.CHAT_TYPE.POLICY_ROOM}},
-                {data: '#hello'} as TText,
-            );
+            const currentReport: Report = {reportID: 'currentReport', policyID: '1'};
+            const reports = makeReportCollection({reportID, reportName: '#hello', policyID: '1', chatType: CONST.REPORT.CHAT_TYPE.POLICY_ROOM});
+            const mentionDetails = getReportMentionDetails('', currentReport, reports, makeTextNode('#hello'));
             expect(mentionDetails?.reportID).toBe(reportID);
         });
         it('should return undefined report ID when the report is not a room', () => {
             const reportID = '1';
-            const mentionDetails = getReportMentionDetails('', {policyID: '1'} as Report, {[reportID]: {reportID, reportName: '#hello', policyID: '1'}}, {data: '#hello'} as TText);
+            const currentReport: Report = {reportID: 'currentReport', policyID: '1'};
+            const reports = makeReportCollection({reportID, reportName: '#hello', policyID: '1'});
+            const mentionDetails = getReportMentionDetails('', currentReport, reports, makeTextNode('#hello'));
             expect(mentionDetails?.reportID).toBeUndefined();
         });
     });

--- a/tests/unit/Search/getSpendOverTimeStateTest.ts
+++ b/tests/unit/Search/getSpendOverTimeStateTest.ts
@@ -6,22 +6,45 @@ import CONST from '@src/CONST';
 import type SearchResults from '@src/types/onyx/SearchResults';
 
 const queryJSON: SearchQueryJSON = {
+    inputQuery: '',
+    hash: 0,
+    recentSearchHash: 0,
+    similarSearchHash: 0,
     type: CONST.SEARCH.DATA_TYPES.EXPENSE,
     status: CONST.SEARCH.STATUS.EXPENSE.ALL,
     groupBy: CONST.SEARCH.GROUP_BY.MONTH,
     view: CONST.SEARCH.VIEW.LINE,
     sortBy: CONST.SEARCH.TABLE_COLUMNS.GROUP_MONTH,
     sortOrder: CONST.SEARCH.SORT_ORDER.ASC,
-} as SearchQueryJSON;
+    flatFilters: [],
+    filters: {operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, left: CONST.SEARCH.SYNTAX_FILTER_KEYS.TYPE, right: CONST.SEARCH.DATA_TYPES.EXPENSE},
+};
 
-const makeSearchResults = (overrides: Partial<SearchResults> = {}): SearchResults =>
-    ({
-        search: {offset: 0, type: queryJSON.type, status: queryJSON.status, hasMoreResults: false, hasResults: true, isLoading: false},
-        data: {},
-        ...overrides,
-    }) as SearchResults;
+const defaultSearchResults: SearchResults = {
+    search: {offset: 0, type: queryJSON.type, status: queryJSON.status, hasMoreResults: false, hasResults: true, isLoading: false},
+    data: {},
+};
 
-const makeData = (count: number): GroupedItem[] => Array.from({length: count}, (_, i) => ({keyForList: String(i)})) as unknown as GroupedItem[];
+const makeSearchResults = (overrides: Partial<SearchResults> = {}): SearchResults => ({
+    ...defaultSearchResults,
+    ...overrides,
+    search: overrides.search ?? defaultSearchResults.search,
+    data: overrides.data ?? defaultSearchResults.data,
+});
+
+const makeData = (count: number): GroupedItem[] =>
+    Array.from({length: count}, (_, i) => ({
+        keyForList: String(i),
+        transactions: [],
+        groupedBy: CONST.SEARCH.GROUP_BY.MONTH,
+        year: 2026,
+        month: i + 1,
+        count: 1,
+        total: 0,
+        currency: CONST.CURRENCY.USD,
+        formattedMonth: `Month ${i + 1}`,
+        sortKey: i,
+    }));
 
 describe('getSpendOverTimeState', () => {
     it('returns OFFLINE when offline with no data', () => {

--- a/tests/unit/hooks/useSaveSortedReportIDs.test.ts
+++ b/tests/unit/hooks/useSaveSortedReportIDs.test.ts
@@ -1,12 +1,13 @@
 import {renderHook} from '@testing-library/react-native';
 
-import type {TransactionListItemType} from '@components/Search/SearchList/ListItem/types';
-
 import useSaveSortedReportIDs from '@hooks/useSaveSortedReportIDs';
 
 import CONST from '@src/CONST';
 
 const mockSetSortedReportIDs = jest.fn();
+type SearchResultItem = Parameters<typeof useSaveSortedReportIDs>[1][number];
+
+const makeSearchItems = (...reportIDs: string[]): SearchResultItem[] => reportIDs.map((reportID) => ({reportID}));
 
 jest.mock('@components/Search/SearchContext', () => ({
     useSearchResultsActions: () => ({setSortedReportIDs: mockSetSortedReportIDs}),
@@ -25,19 +26,19 @@ describe('useSaveSortedReportIDs', () => {
         });
 
         it('stores only the provided report IDs in context', () => {
-            renderHook(() => useSaveSortedReportIDs(CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT, [{reportID: '1'}, {reportID: '3'}] as TransactionListItemType[]));
+            renderHook(() => useSaveSortedReportIDs(CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT, makeSearchItems('1', '3')));
 
             expect(mockSetSortedReportIDs).toHaveBeenCalledWith(['1', '3']);
         });
 
         it('stores all IDs in context', () => {
-            renderHook(() => useSaveSortedReportIDs(CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT, [{reportID: '1'}, {reportID: '2'}, {reportID: '3'}] as TransactionListItemType[]));
+            renderHook(() => useSaveSortedReportIDs(CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT, makeSearchItems('1', '2', '3')));
 
             expect(mockSetSortedReportIDs).toHaveBeenCalledWith(['1', '2', '3']);
         });
 
         it('clears context when type is not expense-report', () => {
-            renderHook(() => useSaveSortedReportIDs(CONST.SEARCH.DATA_TYPES.EXPENSE, [{reportID: '1'}, {reportID: '2'}] as TransactionListItemType[]));
+            renderHook(() => useSaveSortedReportIDs(CONST.SEARCH.DATA_TYPES.EXPENSE, makeSearchItems('1', '2')));
 
             expect(mockSetSortedReportIDs).toHaveBeenCalledWith([]);
         });


### PR DESCRIPTION
### Explanation of Change

Reduced `@typescript-eslint/no-unsafe-type-assertion` violations in `tests/unit/Search/getSpendOverTimeStateTest.ts`, `tests/unit/hooks/useSaveSortedReportIDs.test.ts`, and `tests/unit/MentionUtilsTest.ts` as part of the cleanup for Expensify/App issue #94739.

What changed:

- Replaced unsafe test fixture assertions in `tests/unit/Search/getSpendOverTimeStateTest.ts` with structurally typed `SearchQueryJSON`, `SearchResults`, and month-group fixtures.
- Replaced broad `TransactionListItemType[]` casts in `tests/unit/hooks/useSaveSortedReportIDs.test.ts` with fixture items derived from the hook parameter type.
- Replaced partial `Report` and `TText` assertions in `tests/unit/MentionUtilsTest.ts` with typed report collection helpers and real render-html text nodes.
- Verified with writable lint that the generated target-rule rows for these files are removed from the seatbelt TSV.
- The generated TSV diff is intentionally not included in this PR because Expensify/App post-merge OSBotify automation tightens the baseline on `main`.

Why this approach is safe:

- Test-only change; no product/runtime behavior changed.
- Existing test scenarios and assertions were preserved.
- The new fixtures are typed against the code under test instead of hiding mismatches behind unsafe assertions.

Reviewer focus:

1. Start with the three edited test files and confirm the fixture helpers are real typing/narrowing rather than hidden unsafe casts.
2. Check the count evidence below and confirm writable lint locally removed the target-rule rows for the edited files.
3. Check the commands below; no manual QA is expected for this test-only cleanup.

Safety checks:

- No `SEATBELT_INCREASE`.
- No new `eslint-disable` for `@typescript-eslint/no-unsafe-type-assertion`.
- No broad `as unknown as` substitutions.
- No generic unsafe helper that hides casts.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL:

### Count change

Current baseline source:

- `config/eslint/eslint.seatbelt.tsv`

Before:

- `tests/unit/MentionUtilsTest.ts`: 4 violations
- `tests/unit/Search/getSpendOverTimeStateTest.ts`: 2 violations
- `tests/unit/hooks/useSaveSortedReportIDs.test.ts`: 3 violations
- Current global target-rule baseline: 5,329 violations

After:

- `tests/unit/MentionUtilsTest.ts`: 0 violations
- `tests/unit/Search/getSpendOverTimeStateTest.ts`: 0 violations
- `tests/unit/hooks/useSaveSortedReportIDs.test.ts`: 0 violations
- Current global target-rule baseline: 5,320 violations

Net reduction:

- 9 fewer `@typescript-eslint/no-unsafe-type-assertion` violations.

TSV evidence:

- Writable lint locally removed the target-rule rows for all three edited files from
  `config/eslint/eslint.seatbelt.tsv`.
- Generated with:
  `CI=true npm run lint -- --no-cache --show-warnings tests/unit/Search/getSpendOverTimeStateTest.ts tests/unit/hooks/useSaveSortedReportIDs.test.ts tests/unit/MentionUtilsTest.ts`
- The generated `config/eslint/eslint.seatbelt.tsv` diff is intentionally not
  included in this PR because Expensify/App post-merge OSBotify automation
  tightens the baseline on `main`.

### Tests

1. Run:

   ```bash
   CI=true npm run lint -- --no-cache --show-warnings tests/unit/Search/getSpendOverTimeStateTest.ts tests/unit/hooks/useSaveSortedReportIDs.test.ts tests/unit/MentionUtilsTest.ts
   ```

   Verify lint passes with no target-rule warnings for the edited files.

2. Verify `config/eslint/eslint.seatbelt.tsv` locally contains the decrement described
   above, then restore it before committing:

   ```bash
   git diff -- config/eslint/eslint.seatbelt.tsv
   git restore config/eslint/eslint.seatbelt.tsv
   git diff --exit-code -- config/eslint/eslint.seatbelt.tsv
   ```

3. Run:

   ```bash
   npm test -- --runTestsByPath tests/unit/Search/getSpendOverTimeStateTest.ts tests/unit/hooks/useSaveSortedReportIDs.test.ts tests/unit/MentionUtilsTest.ts
   ```

   Verify the targeted test suites pass.

4. Run:

   ```bash
   npm run typecheck
   ```

   Verify TypeScript checks pass.

### Offline tests

Not applicable. This is test-only cleanup and does not change network behavior.

### QA Steps

No QA required. This PR only changes tests. The ESLint seatbelt baseline is tightened by Expensify/App post-merge OSBotify automation.

### PR Author Checklist

For checklist items that are not applicable to this test-only cleanup, checked
means the item was considered and determined not applicable.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>iOS: Native</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not applicable. This is test-only cleanup.

</details>

cc @blimpich


