### PR TITLE
[No QA] Reduce unsafe type assertions in navigation tests

### DIFF
--- a/tests/navigation/isDynamicRouteScreenTests.ts
+++ b/tests/navigation/isDynamicRouteScreenTests.ts
@@ -1,6 +1,6 @@
 import isDynamicRouteScreen from '@libs/Navigation/helpers/dynamicRoutesUtils/isDynamicRouteScreen';
+import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
 
-import type {Screen} from '@src/SCREENS';
 import SCREENS from '@src/SCREENS';
 
 describe('isDynamicRouteScreen', () => {
@@ -37,6 +37,15 @@ describe('isDynamicRouteScreen', () => {
     });
 
     it('should return false for a screen name not present in normalizedConfigs', () => {
-        expect(isDynamicRouteScreen('NonExistentScreen_12345' as Screen)).toBe(false);
+        const screen = SCREENS.VALIDATE_LOGIN;
+        const config = normalizedConfigs[screen];
+
+        Reflect.deleteProperty(normalizedConfigs, screen);
+
+        try {
+            expect(isDynamicRouteScreen(screen)).toBe(false);
+        } finally {
+            normalizedConfigs[screen] = config;
+        }
     });
 });

--- a/tests/unit/Navigation/getCreateReportRouteTest.ts
+++ b/tests/unit/Navigation/getCreateReportRouteTest.ts
@@ -16,10 +16,10 @@ jest.mock('@libs/Navigation/Navigation', () => ({
 jest.mock('@src/libs/Navigation/helpers/isSearchTopmostFullScreenRoute', () => jest.fn());
 
 describe('getCreateReportRoute', () => {
-    const mockNavigate = Navigation.navigate as jest.MockedFunction<typeof Navigation.navigate>;
-    const mockGetActiveRoute = Navigation.getActiveRoute as jest.MockedFunction<typeof Navigation.getActiveRoute>;
-    const mockSetNavigationActionToMicrotaskQueue = Navigation.setNavigationActionToMicrotaskQueue as jest.MockedFunction<typeof Navigation.setNavigationActionToMicrotaskQueue>;
-    const mockIsSearchTopmostFullScreenRoute = isSearchTopmostFullScreenRoute as jest.MockedFunction<typeof isSearchTopmostFullScreenRoute>;
+    const mockNavigate = jest.mocked(Navigation.navigate);
+    const mockGetActiveRoute = jest.mocked(Navigation.getActiveRoute);
+    const mockSetNavigationActionToMicrotaskQueue = jest.mocked(Navigation.setNavigationActionToMicrotaskQueue);
+    const mockIsSearchTopmostFullScreenRoute = jest.mocked(isSearchTopmostFullScreenRoute);
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/tests/unit/getOnboardingRouteFromScreenTest.ts
+++ b/tests/unit/getOnboardingRouteFromScreenTest.ts
@@ -1,4 +1,5 @@
 import getOnboardingRouteFromScreen from '@libs/Navigation/helpers/getOnboardingRouteFromScreen';
+import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
 
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
@@ -9,7 +10,16 @@ describe('getOnboardingRouteFromScreen', () => {
     });
 
     it('returns undefined for screens without a linking config path', () => {
-        expect(getOnboardingRouteFromScreen('not-a-screen' as typeof SCREENS.ONBOARDING.EMPLOYEES)).toBeUndefined();
+        const screen = SCREENS.ONBOARDING.EMPLOYEES;
+        const config = normalizedConfigs[screen];
+
+        Reflect.deleteProperty(normalizedConfigs, screen);
+
+        try {
+            expect(getOnboardingRouteFromScreen(screen)).toBeUndefined();
+        } finally {
+            normalizedConfigs[screen] = config;
+        }
     });
 
     it('matches ROUTES.getRoute when backTo is provided', () => {


### PR DESCRIPTION
### Explanation of Change

Reduced `@typescript-eslint/no-unsafe-type-assertion` violations in
`tests/unit/getOnboardingRouteFromScreenTest.ts`,
`tests/navigation/isDynamicRouteScreenTests.ts`, and
`tests/unit/Navigation/getCreateReportRouteTest.ts` as part of the cleanup for
Expensify/App issue #94739.

What changed:

- Replaced invalid screen casts with typed screen values and temporary
  `normalizedConfigs` removal/restoration to test missing-config behavior.
- Replaced Jest mock function casts with `jest.mocked(...)`.
- Verified with writable lint that the generated target-rule rows for these files
  are removed from the seatbelt TSV.
- The generated TSV diff is intentionally not included in this PR because
  Expensify/App post-merge OSBotify automation tightens the baseline on `main`.

Why this approach is safe:

- Test-only change; no product/runtime behavior changed.
- Missing-config tests use valid screen values and restore `normalizedConfigs` in
  `finally`.
- Existing route expectations and assertions were preserved.

Reviewer focus:

1. Start with the three edited test files and confirm the cleanup does not hide
   unsafe casts behind another helper.
2. Check the count evidence below and confirm writable lint locally removed the
   target-rule rows for the edited files.
3. Check the commands below; no manual QA is expected for this test-only cleanup.

Safety checks:

- No `SEATBELT_INCREASE`.
- No new `eslint-disable` for `@typescript-eslint/no-unsafe-type-assertion`.
- No broad `as unknown as` substitutions.
- No `@ts-expect-error` comments.
- No generic unsafe helper that hides casts.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL:

### Count change

Current baseline source:

- `config/eslint/eslint.seatbelt.tsv`

Before:

- `tests/unit/getOnboardingRouteFromScreenTest.ts`: 1 violation
- `tests/navigation/isDynamicRouteScreenTests.ts`: 1 violation
- `tests/unit/Navigation/getCreateReportRouteTest.ts`: 4 violations
- Current global target-rule baseline: 5,329 violations

After:

- `tests/unit/getOnboardingRouteFromScreenTest.ts`: 0 violations
- `tests/navigation/isDynamicRouteScreenTests.ts`: 0 violations
- `tests/unit/Navigation/getCreateReportRouteTest.ts`: 0 violations
- Current global target-rule baseline: 5,323 violations

Net reduction:

- 6 fewer `@typescript-eslint/no-unsafe-type-assertion` violations.

TSV evidence:

- Writable lint locally removed the target-rule rows for all three edited files
  from `config/eslint/eslint.seatbelt.tsv`.
- Generated with:
  `CI=true npm run lint -- --no-cache --show-warnings tests/unit/getOnboardingRouteFromScreenTest.ts tests/navigation/isDynamicRouteScreenTests.ts tests/unit/Navigation/getCreateReportRouteTest.ts`
- The generated `config/eslint/eslint.seatbelt.tsv` diff is intentionally not
  included in this PR because Expensify/App post-merge OSBotify automation
  tightens the baseline on `main`.

### Tests

1. Run:

   ```bash
   CI=true npm run lint -- --no-cache --show-warnings tests/unit/getOnboardingRouteFromScreenTest.ts tests/navigation/isDynamicRouteScreenTests.ts tests/unit/Navigation/getCreateReportRouteTest.ts
   ```

   Verify lint passes and the generated target-rule rows for the edited files are
   removed from `config/eslint/eslint.seatbelt.tsv`, then restore it before
   committing:

   ```bash
   git restore config/eslint/eslint.seatbelt.tsv
   ```

2. Run:

   ```bash
   npm test -- --runTestsByPath tests/unit/getOnboardingRouteFromScreenTest.ts tests/navigation/isDynamicRouteScreenTests.ts tests/unit/Navigation/getCreateReportRouteTest.ts
   ```

   Verify the targeted test suites pass.

3. Run:

   ```bash
   npm run typecheck
   ```

   Verify TypeScript checks pass.

### Offline tests

Not applicable. This is test-only cleanup and does not change network behavior.

### QA Steps

No QA required. This PR only changes tests. The ESLint seatbelt baseline is tightened by Expensify/App post-merge OSBotify automation.

### PR Author Checklist

For checklist items that are not applicable to this test-only cleanup, checked
means the item was considered and determined not applicable.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>iOS: Native</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not applicable. This is test-only cleanup.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not applicable. This is test-only cleanup.

</details>

cc @blimpich
