### PR TITLE
Fix iOS multi-select OOM on high-traffic accounts: strip large policy collections from retryParams

### DIFF
--- a/src/libs/actions/IOU/TrackExpense.ts
+++ b/src/libs/actions/IOU/TrackExpense.ts
@@ -1701,6 +1701,15 @@ function requestMoney(requestMoneyInformation: RequestMoneyInformation): {iouRep
             ...requestMoneyInformation.participantParams,
             participant: (({icons, ...rest}) => rest)(requestMoneyInformation.participantParams.participant),
         },
+        // Strip the large policy collections from retryParams to keep the serialized error JSON small.
+        // These scale with workspace size and are stringified into every failed transaction's error, causing OOM on high-traffic accounts.
+        policyParams: {
+            ...requestMoneyInformation.policyParams,
+            policyCategories: undefined,
+            policyTagList: undefined,
+            policyRecentlyUsedTags: undefined,
+            policyRecentlyUsedCategories: undefined,
+        },
         transactionParams: {
             ...requestMoneyInformation.transactionParams,
             receipt: undefined,


### PR DESCRIPTION
### Explanation of Change

This is a follow-up to #94976, which fixed the receipt image **decode/conversion** memory spike during iOS multi-select. That fix resolved the crash for low-traffic accounts, but on [high-traffic accounts](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) the app still OOMs right after tapping **Create expenses**.

The remaining spike comes from `retryParams`. When a receipt upload fails, `requestMoney` builds a `retryParams` object from nearly the whole request payload and `getReceiptError` serializes it with `JSON.stringify` into **every** failed transaction's error (`failureData`). The heavy part is `policyParams`, which carries `policyCategories` and `policyTagList` — these scale with workspace size. On a large workspace, multi-selecting many receipts means the same large policy collections are stringified once per receipt, producing many big JSON strings at once and exhausting memory.

Notably, `retryParams` is **written** into the error but is never **read** back on the NewDot side — the receipt-error row in `DotIndicatorMessage` only offers "Save receipt" (`fileDownload(source, filename)`) and "Delete", with no retry path that consumes `retryParams`. So the large policy collections add memory cost without being used.

This PR strips the large policy collections (`policyCategories`, `policyTagList`, `policyRecentlyUsedTags`, `policyRecentlyUsedCategories`) from the `requestMoney` `retryParams`, mirroring the existing pattern in `trackExpense` where `reportActionsList` is stripped "to keep the serialized error JSON small". It's kept as a separate PR so it can be reverted independently of the decode fix if needed.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93846
PROPOSAL:

### Tests

1. Sign in with a **high-traffic account** that has a large workspace (many categories and tags).
2. On iOS, open an expense chat and start a scan/manual request, then multi-select a large batch of receipts (e.g. 20–30).
3. Tap **Create expenses**.
4. Verify the app creates the expenses without crashing / running out of memory.
5. Force a receipt upload failure (e.g. go offline mid-upload) so a receipt error is shown, and verify:
    - The "Save receipt" and "Delete" actions on the failed expense still work.
    - No errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Multi-select receipts and tap **Create expenses**.
3. Verify the expenses are created optimistically and, on a forced upload failure, the receipt-error row still shows "Save receipt" / "Delete" and behaves as before.

### QA Steps

1. Sign in with a [high-traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) with a large workspace on iOS.
2. Multi-select a large batch of receipts and tap **Create expenses**.
3. Verify the app does not crash and the expenses are created.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [ ] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>



https://github.com/user-attachments/assets/d53d03aa-a504-424c-b1ab-39badfa25f3d



</details>

<details>
<summary>Android: mWeb Chrome</summary>



https://github.com/user-attachments/assets/a21b73f6-75bd-481c-ac6f-93cfb2289d27



</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/5ae6c65e-a943-4837-a04a-327e86f4b1c9



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/6a821ee8-4083-4fb3-8250-90f2b471c2ff




https://github.com/user-attachments/assets/d1243799-2664-438f-9c44-355ab6c2126e



<details>
