### PR TITLE
[NoQA] Add ATTRIBUTE_SEND_MESSAGE_SOURCE to ManualSendMessage

### DIFF
--- a/contributingGuides/OBSERVABILITY_METRICS.md
+++ b/contributingGuides/OBSERVABILITY_METRICS.md
@@ -154,10 +154,11 @@ This document lists all implemented telemetry metrics in the Expensify App.
 - User sees: Their message appears in chat
 - Technical: Message text rendered in report ([`src/pages/home/report/comment/TextCommentFragment.tsx`](https://github.com/Expensify/App/blob/8f123f449f1a4533830b18a1040c9a5f1949821d/src/pages/home/report/comment/TextCommentFragment.tsx#L70))
 **Span ID**: Based on reportID
-**Attributes**: `report_id`, `message_length`, `canceled_by_skeleton`
+**Attributes**: `report_id`, `message_length`, `canceled_by_skeleton`, `send_message_source`
 **Cancellation (report-actions skeleton)**: While a report-actions skeleton is on screen, we listen for `ManualSendMessage` spans started for that report and cancel them immediately, tagging `canceled: true` plus `canceled_by_skeleton` with the skeleton that caused it.
 - `canceled_by_skeleton` values (`CONST.TELEMETRY.CANCELED_BY_SKELETON`) based on skeleton condition
 **Cancellation (report unmount / navigate away)**: If the user leaves the report before their message renders, any pending `ManualSendMessage` span is cancelled via `cancelSpansByPrefix()` to avoid orphaned spans. Cancelled this way the span gets `canceled: true` but **no** `canceled_by_skeleton` (a blanket cancel by span-id prefix, not scoped to one `report_id`).
+**Notes**: `send_message_source` = `<tab>_<scenario>` (+ `_rhp` in the RHP, + `_from_report` when drilled in from a report) — slice the metric by send path.
 
 ## Failure Rates
 

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2277,19 +2277,16 @@ const CONST = {
             CONCIERGE_SIDE_PANEL: 'concierge_side_panel',
             // Side Panel hosting the workspace admins chat (admin onboarding), not Concierge.
             SIDE_PANEL: 'side_panel',
-            // Expense report, split single- vs multi-expense (only multi has a heavy transactions table).
-            // Central pane is bare; every RHP report route (e/:id, search/r/:id, search/view/:id) adds `_rhp`
-            // (e.g. `home_expense_report_multi_rhp`). e/:id and search/r/:id render the same component, so they
-            // share this base rather than one owning a separate `_search` value.
+            // Expense report, split single- vs multi-expense (only multi has a heavy transactions table). e/:id and
+            // search/r/:id render the same component, so they share this base rather than owning a `_search` value.
             EXPENSE_REPORT_SINGLE: 'expense_report_single',
             EXPENSE_REPORT_MULTI: 'expense_report_multi',
-            // Single-transaction expense thread (chat-type, expense parent). Central pane bare; RHP adds `_rhp`.
+            // Single-transaction expense thread (chat-type, expense parent).
             EXPENSE_TRANSACTION_THREAD: 'expense_transaction_thread',
             CONCIERGE: 'concierge',
             REPORT_THREAD: 'report_thread',
             INVOICE_ROOM: 'invoice_room',
             WORKSPACE_ROOM: 'workspace_room',
-            // policyExpenseChat isn't a "room", so it needs its own bucket.
             POLICY_EXPENSE_CHAT: 'policy_expense_chat',
             TASK_REPORT: 'task_report',
             GROUP_CHAT: 'group_chat',
@@ -2309,6 +2306,11 @@ const CONST = {
         // `inbox_report_thread_rhp`. Central pane has no suffix; the Side Panel lives in the base.
         SEND_MESSAGE_SOURCE_SURFACE: {
             RHP: 'rhp',
+        },
+        // Extra suffix (alongside `_rhp`) marking that the RHP screen was drilled into from its parent expense
+        // report vs opened directly from a list, e.g. `spend_expense_transaction_thread_rhp_from_report`.
+        SEND_MESSAGE_SOURCE_RHP_ORIGIN: {
+            FROM_REPORT: 'from_report',
         },
         // Start type stamped on the navigate-to-reports spans: cold, warm on the first render (warm_first),
         // or warm on a cached re-visit (warm_subsequent). UNKNOWN is a fallback that signals a bug.

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2191,6 +2191,7 @@ const CONST = {
         ATTRIBUTE_IOU_REQUEST_TYPE: 'iou_request_type',
         ATTRIBUTE_REPORT_ID: 'report_id',
         ATTRIBUTE_MESSAGE_LENGTH: 'message_length',
+        ATTRIBUTE_SEND_MESSAGE_SOURCE: 'send_message_source',
         ATTRIBUTE_CANCELED: 'canceled',
         ATTRIBUTE_CANCELED_BY_SKELETON: 'canceled_by_skeleton',
         ATTRIBUTE_ROUTE_FROM: 'route_from',
@@ -2271,6 +2272,43 @@ const CONST = {
             INVOICE: 'invoice',
             PER_DIEM: 'per_diem',
             SEND_MONEY: 'send_money',
+        },
+        SEND_MESSAGE_SOURCE: {
+            CONCIERGE_SIDE_PANEL: 'concierge_side_panel',
+            // Side Panel hosting the workspace admins chat (admin onboarding), not Concierge.
+            SIDE_PANEL: 'side_panel',
+            // Expense report, split single- vs multi-expense (only multi has a heavy transactions table).
+            // Central pane is bare; every RHP report route (e/:id, search/r/:id, search/view/:id) adds `_rhp`
+            // (e.g. `home_expense_report_multi_rhp`). e/:id and search/r/:id render the same component, so they
+            // share this base rather than one owning a separate `_search` value.
+            EXPENSE_REPORT_SINGLE: 'expense_report_single',
+            EXPENSE_REPORT_MULTI: 'expense_report_multi',
+            // Single-transaction expense thread (chat-type, expense parent). Central pane bare; RHP adds `_rhp`.
+            EXPENSE_TRANSACTION_THREAD: 'expense_transaction_thread',
+            CONCIERGE: 'concierge',
+            REPORT_THREAD: 'report_thread',
+            INVOICE_ROOM: 'invoice_room',
+            WORKSPACE_ROOM: 'workspace_room',
+            // policyExpenseChat isn't a "room", so it needs its own bucket.
+            POLICY_EXPENSE_CHAT: 'policy_expense_chat',
+            TASK_REPORT: 'task_report',
+            GROUP_CHAT: 'group_chat',
+            DIRECT_MESSAGE: 'direct_message',
+            SELF_DM: 'self_dm',
+            OTHER_CHAT: 'other_chat',
+        },
+        // Tab prefix on every send_message_source value. OTHER = a tab that doesn't host these surfaces
+        // (Workspaces/Settings) or an unresolved tab.
+        SEND_MESSAGE_SOURCE_TAB: {
+            HOME: 'home',
+            INBOX: 'inbox',
+            SPEND: 'spend',
+            OTHER: 'other',
+        },
+        // Surface suffix, added for the RHP report routes (e/:id, search/r/:id, search/view/:id), e.g.
+        // `inbox_report_thread_rhp`. Central pane has no suffix; the Side Panel lives in the base.
+        SEND_MESSAGE_SOURCE_SURFACE: {
+            RHP: 'rhp',
         },
         // Start type stamped on the navigate-to-reports spans: cold, warm on the first render (warm_first),
         // or warm on a cached re-visit (warm_subsequent). UNKNOWN is a fallback that signals a bug.

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2295,11 +2295,12 @@ const CONST = {
             OTHER_CHAT: 'other_chat',
         },
         // Tab prefix on every send_message_source value. OTHER = a tab that doesn't host these surfaces
-        // (Workspaces/Settings) or an unresolved tab.
+        // (Workspaces) or an unresolved tab.
         SEND_MESSAGE_SOURCE_TAB: {
             HOME: 'home',
             INBOX: 'inbox',
             SPEND: 'spend',
+            SETTINGS: 'settings',
             OTHER: 'other',
         },
         // Surface suffix, added for the RHP report routes (e/:id, search/r/:id, search/view/:id), e.g.

--- a/src/libs/Navigation/helpers/getCentralPaneReportID.ts
+++ b/src/libs/Navigation/helpers/getCentralPaneReportID.ts
@@ -1,13 +1,22 @@
 import navigationRef from '@libs/Navigation/navigationRef';
 
+import NAVIGATORS from '@src/NAVIGATORS';
+
+import getTopmostFullScreenRoute from './getTopmostFullScreenRoute';
 import getTopmostReportParams from './getTopmostReportParams';
 
 /**
  * The reportID of the report shown in the central pane, or undefined. getTopmostReportParams only descends into
  * the reports split navigator, so this returns the central-pane report even when an RHP overlay sits on top of
  * it (the RHP lives in a separate navigator) — i.e. the report "behind" the overlay.
+ *
+ * Gated on the reports split navigator being the *active* full-screen tab: getTopmostReportParams scans all tab
+ * routes, so a report left open on an inactive Inbox tab would otherwise leak through as a stale central report.
  */
 function getCentralPaneReportID(): string | undefined {
+    if (getTopmostFullScreenRoute()?.name !== NAVIGATORS.REPORTS_SPLIT_NAVIGATOR) {
+        return undefined;
+    }
     return getTopmostReportParams(navigationRef.getRootState())?.reportID;
 }
 

--- a/src/libs/Navigation/helpers/getCentralPaneReportID.ts
+++ b/src/libs/Navigation/helpers/getCentralPaneReportID.ts
@@ -1,0 +1,14 @@
+import navigationRef from '@libs/Navigation/navigationRef';
+
+import getTopmostReportParams from './getTopmostReportParams';
+
+/**
+ * The reportID of the report shown in the central pane, or undefined. getTopmostReportParams only descends into
+ * the reports split navigator, so this returns the central-pane report even when an RHP overlay sits on top of
+ * it (the RHP lives in a separate navigator) — i.e. the report "behind" the overlay.
+ */
+function getCentralPaneReportID(): string | undefined {
+    return getTopmostReportParams(navigationRef.getRootState())?.reportID;
+}
+
+export default getCentralPaneReportID;

--- a/src/libs/Navigation/helpers/getRouteBeneathTopmostRHP.ts
+++ b/src/libs/Navigation/helpers/getRouteBeneathTopmostRHP.ts
@@ -1,0 +1,21 @@
+import navigationRef from '@libs/Navigation/navigationRef';
+import type {NavigationRoute} from '@libs/Navigation/types';
+
+import NAVIGATORS from '@src/NAVIGATORS';
+
+/**
+ * Returns the route directly beneath the topmost one in the Right-Hand-Panel stack, or undefined when the RHP
+ * has a single route (or is absent). The RHP inner stack records the drill path, so this tells you what screen
+ * the current RHP screen was opened on top of (e.g. an expense report beneath a transaction thread).
+ */
+function getRouteBeneathTopmostRHP(): NavigationRoute | undefined {
+    const rootState = navigationRef.getRootState();
+    if (!rootState) {
+        return undefined;
+    }
+
+    const rhpState = rootState.routes.findLast((route) => route.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR)?.state;
+    return rhpState?.routes?.at(-2);
+}
+
+export default getRouteBeneathTopmostRHP;

--- a/src/libs/telemetry/getSendMessageSource.ts
+++ b/src/libs/telemetry/getSendMessageSource.ts
@@ -1,3 +1,5 @@
+import getCentralPaneReportID from '@libs/Navigation/helpers/getCentralPaneReportID';
+import getRouteBeneathTopmostRHP from '@libs/Navigation/helpers/getRouteBeneathTopmostRHP';
 import getTopmostFullScreenRoute from '@libs/Navigation/helpers/getTopmostFullScreenRoute';
 import {
     isChatRoom,
@@ -26,12 +28,16 @@ import type {ValueOf} from 'type-fest';
 type SendMessageSourceBase = ValueOf<typeof CONST.TELEMETRY.SEND_MESSAGE_SOURCE>;
 type SendMessageSourceTab = ValueOf<typeof CONST.TELEMETRY.SEND_MESSAGE_SOURCE_TAB>;
 type SendMessageSourceSurface = ValueOf<typeof CONST.TELEMETRY.SEND_MESSAGE_SOURCE_SURFACE>;
+type SendMessageSourceRhpOrigin = ValueOf<typeof CONST.TELEMETRY.SEND_MESSAGE_SOURCE_RHP_ORIGIN>;
 
 /**
- * A stamped value: the tab prefix + scenario base, plus an optional surface suffix for the generic RHP
- * (e.g. `inbox_direct_message`, `home_expense_report_rhp`, `spend_expense_transaction_thread_rhp`).
+ * The stamped value: `<tab>_<scenario>`, optionally `_rhp`, optionally `_from_report`. E.g.
+ * `inbox_direct_message`, `home_expense_report_rhp`, `spend_expense_transaction_thread_rhp_from_report`.
  */
-type SendMessageSource = `${SendMessageSourceTab}_${SendMessageSourceBase}` | `${SendMessageSourceTab}_${SendMessageSourceBase}_${SendMessageSourceSurface}`;
+type SendMessageSource =
+    | `${SendMessageSourceTab}_${SendMessageSourceBase}`
+    | `${SendMessageSourceTab}_${SendMessageSourceBase}_${SendMessageSourceSurface}`
+    | `${SendMessageSourceTab}_${SendMessageSourceBase}_${SendMessageSourceSurface}_${SendMessageSourceRhpOrigin}`;
 
 function getOriginTab(): SendMessageSourceTab {
     const {SEND_MESSAGE_SOURCE_TAB} = CONST.TELEMETRY;
@@ -67,21 +73,15 @@ function getSendMessageSourceBase({report, conciergeReportID, isInSidePanel}: Om
     if (isInSidePanel) {
         return isConciergeChatReport(report, conciergeReportID) ? SEND_MESSAGE_SOURCE.CONCIERGE_SIDE_PANEL : SEND_MESSAGE_SOURCE.SIDE_PANEL;
     }
-    // Split single- vs multi-expense reports (only multi has a heavy transactions table), via
-    // isOneTransactionReport (report.transactionCount === 1). Serves both the central pane and the RHP report
-    // routes — e/:id and search/r/:id render the same money-request-report component, so they fall through here
-    // and pick up `_rhp` in getSendMessageSource rather than owning a separate base.
     if (isMoneyRequestReport(report) || isInvoiceReport(report)) {
         return isOneTransactionReport(report) ? SEND_MESSAGE_SOURCE.EXPENSE_REPORT_SINGLE : SEND_MESSAGE_SOURCE.EXPENSE_REPORT_MULTI;
     }
-    // A single-transaction expense opens as a transaction thread (chat-type with an expense parent), so this
-    // must run before the generic chat-thread check below or it would be mislabeled report_thread. The `_rhp`
-    // surface suffix (added later) keeps the RHP variant distinct from this central-pane one.
+    // A transaction thread is a chat-type report, so it must run before the generic chat-thread check below or
+    // it would be mislabeled report_thread.
     if (isReportTransactionThread(report)) {
         return SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD;
     }
 
-    // Classify by report type — for both the central pane and the generic RHP routes (the latter get `_rhp`).
     if (isConciergeChatReport(report, conciergeReportID)) {
         return SEND_MESSAGE_SOURCE.CONCIERGE;
     }
@@ -118,16 +118,36 @@ function getSendMessageSourceBase({report, conciergeReportID, isInSidePanel}: Om
 // report routes here; a new RHP report route is covered automatically.
 const RHP_SCREEN_NAMES = new Set<string>(Object.values(SCREENS.RIGHT_MODAL));
 
+// The RHP screens that render an expense report (both use the money-request-report component).
+const RHP_EXPENSE_REPORT_SCREEN_NAMES = new Set<string>([SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT]);
+
+// A parent expense report behind an RHP screen means the user drilled in (vs opening directly, e.g. off a Search
+// list, where neither holds). It can sit in two places:
+//   1. stacked directly beneath the screen in the RHP, or
+//   2. shown in the central pane behind the overlay, matched via the thread's parentReportID.
+// Case 2 is gated on isReportTransactionThread so parentReportID is by definition the expense report.
+function isDrilledFromExpenseReport(report: OnyxEntry<Report>): boolean {
+    if (RHP_EXPENSE_REPORT_SCREEN_NAMES.has(getRouteBeneathTopmostRHP()?.name ?? '')) {
+        return true;
+    }
+    return isReportTransactionThread(report) && !!report?.parentReportID && getCentralPaneReportID() === report.parentReportID;
+}
+
 /**
- * The `send_message_source` span attribute: tab prefix + scenario base (+ `_rhp` when the report is in the RHP).
- * Tab and surface are uniform affixes, so Sentry can slice by tab, scenario, or surface across every send path.
+ * The `send_message_source` span attribute: tab prefix + scenario base (+ `_rhp` in the RHP, + `_from_report`
+ * when drilled in from a report behind it). The affixes are uniform, so Sentry can slice by tab, scenario,
+ * surface, or drill-down path across every send path.
  */
 function getSendMessageSource(params: GetSendMessageSourceParams): SendMessageSource {
-    const {SEND_MESSAGE_SOURCE_SURFACE} = CONST.TELEMETRY;
+    const {SEND_MESSAGE_SOURCE_SURFACE, SEND_MESSAGE_SOURCE_RHP_ORIGIN} = CONST.TELEMETRY;
     const value = `${getOriginTab()}_${getSendMessageSourceBase(params)}` as const;
     // The Side Panel owns its own bases and can't be on an RHP route, so never suffix it (defensive — a stray
     // RHP routeName in the panel would otherwise produce a nonsensical `..._side_panel_rhp`).
-    return RHP_SCREEN_NAMES.has(params.routeName) && !params.isInSidePanel ? `${value}_${SEND_MESSAGE_SOURCE_SURFACE.RHP}` : value;
+    if (!RHP_SCREEN_NAMES.has(params.routeName) || params.isInSidePanel) {
+        return value;
+    }
+    const rhpValue = `${value}_${SEND_MESSAGE_SOURCE_SURFACE.RHP}` as const;
+    return isDrilledFromExpenseReport(params.report) ? `${rhpValue}_${SEND_MESSAGE_SOURCE_RHP_ORIGIN.FROM_REPORT}` : rhpValue;
 }
 
 export default getSendMessageSource;

--- a/src/libs/telemetry/getSendMessageSource.ts
+++ b/src/libs/telemetry/getSendMessageSource.ts
@@ -1,0 +1,133 @@
+import getTopmostFullScreenRoute from '@libs/Navigation/helpers/getTopmostFullScreenRoute';
+import {
+    isChatRoom,
+    isChatThread,
+    isConciergeChatReport,
+    isDM,
+    isGroupChat,
+    isInvoiceReport,
+    isInvoiceRoom,
+    isMoneyRequestReport,
+    isOneTransactionReport,
+    isPolicyExpenseChat,
+    isReportTransactionThread,
+    isSelfDM,
+    isTaskReport,
+} from '@libs/ReportUtils';
+
+import CONST from '@src/CONST';
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+import type {Report} from '@src/types/onyx';
+
+import type {OnyxEntry} from 'react-native-onyx';
+import type {ValueOf} from 'type-fest';
+
+type SendMessageSourceBase = ValueOf<typeof CONST.TELEMETRY.SEND_MESSAGE_SOURCE>;
+type SendMessageSourceTab = ValueOf<typeof CONST.TELEMETRY.SEND_MESSAGE_SOURCE_TAB>;
+type SendMessageSourceSurface = ValueOf<typeof CONST.TELEMETRY.SEND_MESSAGE_SOURCE_SURFACE>;
+
+/**
+ * A stamped value: the tab prefix + scenario base, plus an optional surface suffix for the generic RHP
+ * (e.g. `inbox_direct_message`, `home_expense_report_rhp`, `spend_expense_transaction_thread_rhp`).
+ */
+type SendMessageSource = `${SendMessageSourceTab}_${SendMessageSourceBase}` | `${SendMessageSourceTab}_${SendMessageSourceBase}_${SendMessageSourceSurface}`;
+
+function getOriginTab(): SendMessageSourceTab {
+    const {SEND_MESSAGE_SOURCE_TAB} = CONST.TELEMETRY;
+    switch (getTopmostFullScreenRoute()?.name) {
+        case SCREENS.HOME:
+            return SEND_MESSAGE_SOURCE_TAB.HOME;
+        case NAVIGATORS.REPORTS_SPLIT_NAVIGATOR:
+            return SEND_MESSAGE_SOURCE_TAB.INBOX;
+        case NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR:
+            return SEND_MESSAGE_SOURCE_TAB.SPEND;
+        default:
+            return SEND_MESSAGE_SOURCE_TAB.OTHER;
+    }
+}
+
+type GetSendMessageSourceParams = {
+    report: OnyxEntry<Report>;
+    /** Used to identify the Concierge chat by identity (not type/chatType). */
+    conciergeReportID: string | undefined;
+    isInSidePanel: boolean;
+    routeName: string;
+};
+
+/**
+ * Resolve the tab-agnostic scenario base. Checks run in precedence order (first match wins) so a report
+ * matching several predicates is attributed to the most specific surface.
+ */
+function getSendMessageSourceBase({report, conciergeReportID, isInSidePanel}: Omit<GetSendMessageSourceParams, 'routeName'>): SendMessageSourceBase {
+    const {SEND_MESSAGE_SOURCE} = CONST.TELEMETRY;
+
+    // Surfaces first: they own a distinct render tree regardless of the report's own type.
+    // The Side Panel is usually Concierge, but hosts the workspace admins chat during admin onboarding.
+    if (isInSidePanel) {
+        return isConciergeChatReport(report, conciergeReportID) ? SEND_MESSAGE_SOURCE.CONCIERGE_SIDE_PANEL : SEND_MESSAGE_SOURCE.SIDE_PANEL;
+    }
+    // Split single- vs multi-expense reports (only multi has a heavy transactions table), via
+    // isOneTransactionReport (report.transactionCount === 1). Serves both the central pane and the RHP report
+    // routes — e/:id and search/r/:id render the same money-request-report component, so they fall through here
+    // and pick up `_rhp` in getSendMessageSource rather than owning a separate base.
+    if (isMoneyRequestReport(report) || isInvoiceReport(report)) {
+        return isOneTransactionReport(report) ? SEND_MESSAGE_SOURCE.EXPENSE_REPORT_SINGLE : SEND_MESSAGE_SOURCE.EXPENSE_REPORT_MULTI;
+    }
+    // A single-transaction expense opens as a transaction thread (chat-type with an expense parent), so this
+    // must run before the generic chat-thread check below or it would be mislabeled report_thread. The `_rhp`
+    // surface suffix (added later) keeps the RHP variant distinct from this central-pane one.
+    if (isReportTransactionThread(report)) {
+        return SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD;
+    }
+
+    // Classify by report type — for both the central pane and the generic RHP routes (the latter get `_rhp`).
+    if (isConciergeChatReport(report, conciergeReportID)) {
+        return SEND_MESSAGE_SOURCE.CONCIERGE;
+    }
+    if (isChatThread(report)) {
+        return SEND_MESSAGE_SOURCE.REPORT_THREAD;
+    }
+    if (isInvoiceRoom(report)) {
+        return SEND_MESSAGE_SOURCE.INVOICE_ROOM;
+    }
+    if (isChatRoom(report)) {
+        return SEND_MESSAGE_SOURCE.WORKSPACE_ROOM;
+    }
+    // policyExpenseChat is not a "room" (isChatRoom excludes it), so it needs its own branch.
+    if (isPolicyExpenseChat(report)) {
+        return SEND_MESSAGE_SOURCE.POLICY_EXPENSE_CHAT;
+    }
+    if (isTaskReport(report)) {
+        return SEND_MESSAGE_SOURCE.TASK_REPORT;
+    }
+    if (isGroupChat(report)) {
+        return SEND_MESSAGE_SOURCE.GROUP_CHAT;
+    }
+    if (isDM(report)) {
+        return SEND_MESSAGE_SOURCE.DIRECT_MESSAGE;
+    }
+    if (isSelfDM(report)) {
+        return SEND_MESSAGE_SOURCE.SELF_DM;
+    }
+    return SEND_MESSAGE_SOURCE.OTHER_CHAT;
+}
+
+// Every Right-Hand-Panel screen name. getSendMessageSource only runs where a composer is mounted (report
+// screens), so any RHP routeName it sees means the report is hosted in the RHP — no need to list the specific
+// report routes here; a new RHP report route is covered automatically.
+const RHP_SCREEN_NAMES = new Set<string>(Object.values(SCREENS.RIGHT_MODAL));
+
+/**
+ * The `send_message_source` span attribute: tab prefix + scenario base (+ `_rhp` when the report is in the RHP).
+ * Tab and surface are uniform affixes, so Sentry can slice by tab, scenario, or surface across every send path.
+ */
+function getSendMessageSource(params: GetSendMessageSourceParams): SendMessageSource {
+    const {SEND_MESSAGE_SOURCE_SURFACE} = CONST.TELEMETRY;
+    const value = `${getOriginTab()}_${getSendMessageSourceBase(params)}` as const;
+    // The Side Panel owns its own bases and can't be on an RHP route, so never suffix it (defensive — a stray
+    // RHP routeName in the panel would otherwise produce a nonsensical `..._side_panel_rhp`).
+    return RHP_SCREEN_NAMES.has(params.routeName) && !params.isInSidePanel ? `${value}_${SEND_MESSAGE_SOURCE_SURFACE.RHP}` : value;
+}
+
+export default getSendMessageSource;

--- a/src/libs/telemetry/getSendMessageSource.ts
+++ b/src/libs/telemetry/getSendMessageSource.ts
@@ -48,6 +48,8 @@ function getOriginTab(): SendMessageSourceTab {
             return SEND_MESSAGE_SOURCE_TAB.INBOX;
         case NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR:
             return SEND_MESSAGE_SOURCE_TAB.SPEND;
+        case NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR:
+            return SEND_MESSAGE_SOURCE_TAB.SETTINGS;
         default:
             return SEND_MESSAGE_SOURCE_TAB.OTHER;
     }

--- a/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
+++ b/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
@@ -41,7 +41,6 @@ function useComposerSubmit(reportID: string) {
     const isInSidePanel = useIsInSidePanel();
     const sidePanelContext = useSidePanelContext(reportID);
     const route = useRoute();
-    const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
     const [quickAction] = useOnyx(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE);
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
     const [isComposerFullSize = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${reportID}`);

--- a/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
+++ b/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
@@ -13,6 +13,7 @@ import {isEmailPublicDomain} from '@libs/LoginUtils';
 import {rand64} from '@libs/NumberUtils';
 import {addDomainToShortMention} from '@libs/ParsingUtils';
 import {startSpan} from '@libs/telemetry/activeSpans';
+import getSendMessageSource from '@libs/telemetry/getSendMessageSource';
 import {generateAccountID} from '@libs/UserUtils';
 
 import {useActionListContext} from '@pages/inbox/ActionListContext';
@@ -26,6 +27,7 @@ import type * as OnyxTypes from '@src/types/onyx';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
+import {useRoute} from '@react-navigation/native';
 import {Str} from 'expensify-common';
 
 import {useComposerActions, useComposerEditActions, useComposerEditState, useComposerMeta, useComposerSendState} from './ComposerContext';
@@ -38,6 +40,8 @@ function useComposerSubmit(reportID: string) {
     const {availableLoginsList} = useShortMentionsList();
     const isInSidePanel = useIsInSidePanel();
     const sidePanelContext = useSidePanelContext(reportID);
+    const route = useRoute();
+    const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
     const [quickAction] = useOnyx(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE);
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
     const [isComposerFullSize = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${reportID}`);
@@ -157,6 +161,7 @@ function useComposerSubmit(reportID: string) {
                 attributes: {
                     [CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID,
                     [CONST.TELEMETRY.ATTRIBUTE_MESSAGE_LENGTH]: draftMessageTrimmed.length,
+                    [CONST.TELEMETRY.ATTRIBUTE_SEND_MESSAGE_SOURCE]: getSendMessageSource({report, conciergeReportID, isInSidePanel, routeName: route.name}),
                 },
             });
         }

--- a/tests/unit/getCentralPaneReportIDTest.ts
+++ b/tests/unit/getCentralPaneReportIDTest.ts
@@ -1,0 +1,22 @@
+import getCentralPaneReportID from '@libs/Navigation/helpers/getCentralPaneReportID';
+import getTopmostReportParams from '@libs/Navigation/helpers/getTopmostReportParams';
+
+jest.mock('@libs/Navigation/navigationRef', () => ({getRootState: jest.fn(() => ({}))}));
+jest.mock('@libs/Navigation/helpers/getTopmostReportParams', () => jest.fn());
+
+const mockGetTopmostReportParams = jest.mocked(getTopmostReportParams);
+type ReportParams = ReturnType<typeof getTopmostReportParams>;
+
+beforeEach(() => mockGetTopmostReportParams.mockReset());
+
+describe('getCentralPaneReportID', () => {
+    it('returns the reportID of the report in the central pane', () => {
+        mockGetTopmostReportParams.mockReturnValue({reportID: '42'} as ReportParams);
+        expect(getCentralPaneReportID()).toBe('42');
+    });
+
+    it('returns undefined when no report is in the central pane', () => {
+        mockGetTopmostReportParams.mockReturnValue(undefined);
+        expect(getCentralPaneReportID()).toBeUndefined();
+    });
+});

--- a/tests/unit/getCentralPaneReportIDTest.ts
+++ b/tests/unit/getCentralPaneReportIDTest.ts
@@ -1,13 +1,25 @@
 import getCentralPaneReportID from '@libs/Navigation/helpers/getCentralPaneReportID';
+import getTopmostFullScreenRoute from '@libs/Navigation/helpers/getTopmostFullScreenRoute';
 import getTopmostReportParams from '@libs/Navigation/helpers/getTopmostReportParams';
+
+import NAVIGATORS from '@src/NAVIGATORS';
 
 jest.mock('@libs/Navigation/navigationRef', () => ({getRootState: jest.fn(() => ({}))}));
 jest.mock('@libs/Navigation/helpers/getTopmostReportParams', () => jest.fn());
+jest.mock('@libs/Navigation/helpers/getTopmostFullScreenRoute', () => jest.fn());
 
 const mockGetTopmostReportParams = jest.mocked(getTopmostReportParams);
+const mockGetTopmostFullScreenRoute = jest.mocked(getTopmostFullScreenRoute);
 type ReportParams = ReturnType<typeof getTopmostReportParams>;
+type FullScreenRoute = ReturnType<typeof getTopmostFullScreenRoute>;
 
-beforeEach(() => mockGetTopmostReportParams.mockReset());
+const inboxRoute = {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR} as FullScreenRoute;
+
+beforeEach(() => {
+    mockGetTopmostReportParams.mockReset();
+    // Default: Inbox is the active full-screen tab, so the central report is not gated out.
+    mockGetTopmostFullScreenRoute.mockReset().mockReturnValue(inboxRoute);
+});
 
 describe('getCentralPaneReportID', () => {
     it('returns the reportID of the report in the central pane', () => {
@@ -17,6 +29,12 @@ describe('getCentralPaneReportID', () => {
 
     it('returns undefined when no report is in the central pane', () => {
         mockGetTopmostReportParams.mockReturnValue(undefined);
+        expect(getCentralPaneReportID()).toBeUndefined();
+    });
+
+    it('returns undefined when the reports split navigator is not the active tab (stale report on an inactive Inbox)', () => {
+        mockGetTopmostFullScreenRoute.mockReturnValue({name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR} as FullScreenRoute);
+        mockGetTopmostReportParams.mockReturnValue({reportID: '42'} as ReportParams);
         expect(getCentralPaneReportID()).toBeUndefined();
     });
 });

--- a/tests/unit/getRouteBeneathTopmostRHPTest.ts
+++ b/tests/unit/getRouteBeneathTopmostRHPTest.ts
@@ -1,0 +1,56 @@
+import getRouteBeneathTopmostRHP from '@libs/Navigation/helpers/getRouteBeneathTopmostRHP';
+import navigationRef from '@libs/Navigation/navigationRef';
+
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+
+jest.mock('@libs/Navigation/navigationRef', () => ({getRootState: jest.fn()}));
+
+// eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock doesn't rely on `this` binding
+const mockGetRootState = jest.mocked(navigationRef.getRootState);
+
+type RootState = ReturnType<typeof navigationRef.getRootState>;
+type RootRoutes = RootState['routes'];
+
+// Wrap a routes array into a full navigation state (the fields getRootState is typed to return).
+const asRoot = (routes: RootRoutes): RootState => ({stale: false, type: 'stack', key: 'root', index: Math.max(0, routes.length - 1), routeNames: routes.map((route) => route.name), routes});
+
+// The RIGHT_MODAL_NAVIGATOR route with the given inner stack (bottom → top).
+const rhpNavigator = (innerRouteNames: string[]): RootRoutes[number] => ({
+    key: 'rhp-0',
+    name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR,
+    state: {
+        stale: false,
+        type: 'stack',
+        key: 'rhp-state',
+        index: Math.max(0, innerRouteNames.length - 1),
+        routeNames: innerRouteNames,
+        routes: innerRouteNames.map((name, index) => ({key: `k${index}`, name})),
+    },
+});
+
+const tabNavigator: RootRoutes[number] = {key: 'tab-0', name: NAVIGATORS.TAB_NAVIGATOR};
+
+beforeEach(() => mockGetRootState.mockReset());
+
+describe('getRouteBeneathTopmostRHP', () => {
+    it('returns undefined when there is no root state', () => {
+        // beforeEach reset leaves getRootState returning undefined.
+        expect(getRouteBeneathTopmostRHP()).toBeUndefined();
+    });
+
+    it('returns undefined when the root has no RHP navigator', () => {
+        mockGetRootState.mockReturnValue(asRoot([tabNavigator]));
+        expect(getRouteBeneathTopmostRHP()).toBeUndefined();
+    });
+
+    it('returns undefined when the RHP stack has a single route (opened directly)', () => {
+        mockGetRootState.mockReturnValue(asRoot([tabNavigator, rhpNavigator([SCREENS.RIGHT_MODAL.SEARCH_REPORT])]));
+        expect(getRouteBeneathTopmostRHP()).toBeUndefined();
+    });
+
+    it('returns the route directly beneath the top of the RHP stack (the drill-down parent)', () => {
+        mockGetRootState.mockReturnValue(asRoot([tabNavigator, rhpNavigator([SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT])]));
+        expect(getRouteBeneathTopmostRHP()?.name).toBe(SCREENS.RIGHT_MODAL.EXPENSE_REPORT);
+    });
+});

--- a/tests/unit/getSendMessageSourceTest.ts
+++ b/tests/unit/getSendMessageSourceTest.ts
@@ -20,28 +20,44 @@ import getSendMessageSource from '@libs/telemetry/getSendMessageSource';
 
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
+import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
 import type {Report} from '@src/types/onyx';
 
 import type {ValueOf} from 'type-fest';
 
-// Mock the ReportUtils predicates so we test getSendMessageSource's precedence logic in isolation,
-// not ReportUtils' report-shape rules. Every predicate defaults to false; each test flips the ones it needs.
-jest.mock('@libs/ReportUtils', () => ({
-    isChatRoom: jest.fn(() => false),
-    isChatThread: jest.fn(() => false),
-    isConciergeChatReport: jest.fn(() => false),
-    isDM: jest.fn(() => false),
-    isGroupChat: jest.fn(() => false),
-    isInvoiceReport: jest.fn(() => false),
-    isInvoiceRoom: jest.fn(() => false),
-    isMoneyRequestReport: jest.fn(() => false),
-    isOneTransactionReport: jest.fn(() => false),
-    isPolicyExpenseChat: jest.fn(() => false),
-    isReportTransactionThread: jest.fn(() => false),
-    isSelfDM: jest.fn(() => false),
-    isTaskReport: jest.fn(() => false),
-}));
+import Onyx from 'react-native-onyx';
+
+import createRandomReportAction from '../utils/collections/reportActions';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+// The ReportUtils namespace type, used only to type jest.requireActual below. A `* as` import is banned for this
+// module (it pulls restricted paid-policy members), so derive the type inline here instead.
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type ReportUtilsModuleType = typeof import('@libs/ReportUtils');
+
+// Wrap the ReportUtils predicates so the precedence suite can force each true/false in isolation, while every
+// other export (and the integration suite) keeps the real implementation. The file-level beforeEach resets the
+// wrapped predicates to false for the precedence tests; the integration suite restores their real behavior.
+jest.mock('@libs/ReportUtils', () => {
+    const actual = jest.requireActual<ReportUtilsModuleType>('@libs/ReportUtils');
+    return {
+        ...actual,
+        isChatRoom: jest.fn(actual.isChatRoom),
+        isChatThread: jest.fn(actual.isChatThread),
+        isConciergeChatReport: jest.fn(actual.isConciergeChatReport),
+        isDM: jest.fn(actual.isDM),
+        isGroupChat: jest.fn(actual.isGroupChat),
+        isInvoiceReport: jest.fn(actual.isInvoiceReport),
+        isInvoiceRoom: jest.fn(actual.isInvoiceRoom),
+        isMoneyRequestReport: jest.fn(actual.isMoneyRequestReport),
+        isOneTransactionReport: jest.fn(actual.isOneTransactionReport),
+        isPolicyExpenseChat: jest.fn(actual.isPolicyExpenseChat),
+        isReportTransactionThread: jest.fn(actual.isReportTransactionThread),
+        isSelfDM: jest.fn(actual.isSelfDM),
+        isTaskReport: jest.fn(actual.isTaskReport),
+    };
+});
 
 // Every value is prefixed with the tab the send is on; mock the topmost tab route so each test controls it.
 jest.mock('@libs/Navigation/helpers/getTopmostFullScreenRoute', () => jest.fn(() => undefined));
@@ -53,6 +69,9 @@ jest.mock('@libs/Navigation/helpers/getRouteBeneathTopmostRHP', () => jest.fn(()
 // The central-pane report id (behind the RHP overlay) is the other drill-down signal: it marks `_from_report`
 // when it matches a transaction thread's parent. Default to none; the central-pane test overrides it.
 jest.mock('@libs/Navigation/helpers/getCentralPaneReportID', () => jest.fn(() => undefined));
+
+// Real predicate implementations, used by the integration block below to classify genuine report shapes.
+const actualReportUtils = jest.requireActual<ReportUtilsModuleType>('@libs/ReportUtils');
 
 const PREDICATES = [
     isChatRoom,
@@ -344,5 +363,62 @@ describe('getSendMessageSource', () => {
         it('returns other_chat when nothing matches', () => {
             expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.OTHER_CHAT));
         });
+    });
+});
+
+// The suite above mocks the ReportUtils predicates to test precedence/composition in isolation. This block points
+// them at the REAL implementations (with Onyx-backed fixtures) so genuine report shapes drive classification —
+// guarding the one thing mocks can't: that a real report matches the predicate the ladder assumes (e.g. a
+// single-transaction expense is a money-request report, and a transaction thread — which also satisfies
+// isChatThread — wins the precedence guard).
+describe('getSendMessageSource — integration with real ReportUtils', () => {
+    // The transaction thread's parent: an EXPENSE report holding an IOU/create action, so the real
+    // isReportTransactionThread can resolve the parent and classify the thread as an expense request.
+    const PARENT_EXPENSE_REPORT_ID = '100';
+    const PARENT_IOU_ACTION_ID = '200';
+
+    beforeAll(async () => {
+        Onyx.init({keys: ONYXKEYS});
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${PARENT_EXPENSE_REPORT_ID}`, {reportID: PARENT_EXPENSE_REPORT_ID, type: CONST.REPORT.TYPE.EXPENSE});
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${PARENT_EXPENSE_REPORT_ID}`, {
+            [PARENT_IOU_ACTION_ID]: {
+                ...createRandomReportAction(1),
+                reportActionID: PARENT_IOU_ACTION_ID,
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE},
+            },
+        });
+        await waitForBatchedUpdates();
+    });
+
+    afterAll(() => Onyx.clear());
+
+    // The file-level beforeEach forces every predicate to false; restore the real implementations for the ones
+    // these fixtures exercise (the rest correctly stay false for these report shapes).
+    beforeEach(() => {
+        jest.mocked(isMoneyRequestReport).mockImplementation(actualReportUtils.isMoneyRequestReport);
+        jest.mocked(isOneTransactionReport).mockImplementation(actualReportUtils.isOneTransactionReport);
+        jest.mocked(isReportTransactionThread).mockImplementation(actualReportUtils.isReportTransactionThread);
+        jest.mocked(isChatThread).mockImplementation(actualReportUtils.isChatThread);
+    });
+
+    it('classifies a multi-transaction expense report as expense_report_multi', () => {
+        const multiExpenseReport = {reportID: '1', type: CONST.REPORT.TYPE.EXPENSE, transactionCount: 2} as Report;
+        expect(getSendMessageSource(params({report: multiExpenseReport}))).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_MULTI));
+    });
+
+    it('classifies a single-transaction expense report as expense_report_single (a money-request report, not a thread)', () => {
+        const singleExpenseReport = {reportID: '2', type: CONST.REPORT.TYPE.EXPENSE, transactionCount: 1} as Report;
+        expect(getSendMessageSource(params({report: singleExpenseReport}))).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_SINGLE));
+    });
+
+    it('classifies a transaction thread as expense_transaction_thread, beating the chat-thread check it also matches', () => {
+        const transactionThread = {reportID: '300', type: CONST.REPORT.TYPE.CHAT, parentReportID: PARENT_EXPENSE_REPORT_ID, parentReportActionID: PARENT_IOU_ACTION_ID} as Report;
+        expect(getSendMessageSource(params({report: transactionThread}))).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+    });
+
+    it('classifies a plain chat thread (no expense parent) as report_thread', () => {
+        const chatThread = {reportID: '301', type: CONST.REPORT.TYPE.CHAT, parentReportID: '999', parentReportActionID: '998'} as Report;
+        expect(getSendMessageSource(params({report: chatThread}))).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.REPORT_THREAD));
     });
 });

--- a/tests/unit/getSendMessageSourceTest.ts
+++ b/tests/unit/getSendMessageSourceTest.ts
@@ -1,3 +1,5 @@
+import getCentralPaneReportID from '@libs/Navigation/helpers/getCentralPaneReportID';
+import getRouteBeneathTopmostRHP from '@libs/Navigation/helpers/getRouteBeneathTopmostRHP';
 import getTopmostFullScreenRoute from '@libs/Navigation/helpers/getTopmostFullScreenRoute';
 import {
     isChatRoom,
@@ -44,6 +46,14 @@ jest.mock('@libs/ReportUtils', () => ({
 // Every value is prefixed with the tab the send is on; mock the topmost tab route so each test controls it.
 jest.mock('@libs/Navigation/helpers/getTopmostFullScreenRoute', () => jest.fn(() => undefined));
 
+// The route beneath the top RHP screen decides the `_from_report` drill-down suffix; default to none (opened
+// directly), each RHP-drill test overrides it.
+jest.mock('@libs/Navigation/helpers/getRouteBeneathTopmostRHP', () => jest.fn(() => undefined));
+
+// The central-pane report id (behind the RHP overlay) is the other drill-down signal: it marks `_from_report`
+// when it matches a transaction thread's parent. Default to none; the central-pane test overrides it.
+jest.mock('@libs/Navigation/helpers/getCentralPaneReportID', () => jest.fn(() => undefined));
+
 const PREDICATES = [
     isChatRoom,
     isChatThread,
@@ -60,14 +70,22 @@ const PREDICATES = [
     isTaskReport,
 ];
 
-const {SEND_MESSAGE_SOURCE, SEND_MESSAGE_SOURCE_TAB, SEND_MESSAGE_SOURCE_SURFACE} = CONST.TELEMETRY;
+const {SEND_MESSAGE_SOURCE, SEND_MESSAGE_SOURCE_TAB, SEND_MESSAGE_SOURCE_SURFACE, SEND_MESSAGE_SOURCE_RHP_ORIGIN} = CONST.TELEMETRY;
 const report = {reportID: '1'} as Report;
+const threadWithParent = {reportID: '2', parentReportID: 'parent-1'} as Report;
 
 /** Prefix a scenario base with a tab, mirroring how getSendMessageSource stamps a central-pane value. */
 const withTab = (tab: ValueOf<typeof SEND_MESSAGE_SOURCE_TAB>, base: ValueOf<typeof SEND_MESSAGE_SOURCE>) => `${tab}_${base}` as const;
 
 /** Same, plus the generic-RHP `_rhp` surface suffix. */
 const withRhp = (tab: ValueOf<typeof SEND_MESSAGE_SOURCE_TAB>, base: ValueOf<typeof SEND_MESSAGE_SOURCE>) => `${tab}_${base}_${SEND_MESSAGE_SOURCE_SURFACE.RHP}` as const;
+
+/** Same as withRhp, plus the `_from_report` suffix for a screen drilled into from a report behind it. */
+const withRhpFromReport = (tab: ValueOf<typeof SEND_MESSAGE_SOURCE_TAB>, base: ValueOf<typeof SEND_MESSAGE_SOURCE>) =>
+    `${withRhp(tab, base)}_${SEND_MESSAGE_SOURCE_RHP_ORIGIN.FROM_REPORT}` as const;
+
+/** Fake the route sitting beneath the top RHP screen (the drill-down parent). */
+const rhpRoute = (name: string) => ({key: 'k', name}) as ReturnType<typeof getRouteBeneathTopmostRHP>;
 
 /** Build the params with sane defaults; override per test. SCREENS.REPORT is a non-expense-report route. */
 function params(overrides: Partial<Parameters<typeof getSendMessageSource>[0]> = {}) {
@@ -85,6 +103,8 @@ beforeEach(() => {
         jest.mocked(predicate).mockReturnValue(false);
     }
     jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR));
+    jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(undefined);
+    jest.mocked(getCentralPaneReportID).mockReturnValue(undefined);
 });
 
 describe('getSendMessageSource', () => {
@@ -157,6 +177,70 @@ describe('getSendMessageSource', () => {
 
             jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
             expect(getSendMessageSource(rhpReport)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+        });
+
+        it('appends _from_report when an expense report sits beneath the RHP screen (drilled in, not opened directly)', () => {
+            jest.mocked(isReportTransactionThread).mockReturnValue(true);
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
+            const rhpThread = params({routeName: SCREENS.RIGHT_MODAL.SEARCH_REPORT});
+
+            // Drilled from an e/:id expense report beneath it.
+            jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(rhpRoute(SCREENS.RIGHT_MODAL.EXPENSE_REPORT));
+            expect(getSendMessageSource(rhpThread)).toBe(withRhpFromReport(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+
+            // Drilled from a search/r/:id expense report beneath it.
+            jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(rhpRoute(SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT));
+            expect(getSendMessageSource(rhpThread)).toBe(withRhpFromReport(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+        });
+
+        it('omits _from_report when the RHP screen was opened directly (nothing / a non-report screen beneath it)', () => {
+            jest.mocked(isReportTransactionThread).mockReturnValue(true);
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
+            const rhpThread = params({routeName: SCREENS.RIGHT_MODAL.SEARCH_REPORT});
+
+            // Bottom of the RHP stack — opened straight from a list.
+            jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(undefined);
+            expect(getSendMessageSource(rhpThread)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+
+            // A non-expense-report screen beneath it is not a drill-down from a report.
+            jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(rhpRoute(SCREENS.RIGHT_MODAL.REPORT_DETAILS));
+            expect(getSendMessageSource(rhpThread)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+        });
+
+        it('appends _from_report when the transaction thread parent report is shown in the central pane behind the RHP', () => {
+            jest.mocked(isReportTransactionThread).mockReturnValue(true);
+            // RHP stack has only the thread (nothing beneath), but its parent expense report is in the central pane.
+            jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(undefined);
+            jest.mocked(getCentralPaneReportID).mockReturnValue('parent-1');
+            expect(getSendMessageSource(params({report: threadWithParent, routeName: SCREENS.RIGHT_MODAL.SEARCH_REPORT}))).toBe(
+                withRhpFromReport(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD),
+            );
+        });
+
+        it('omits _from_report when the central-pane report is not the thread parent (opened directly)', () => {
+            jest.mocked(isReportTransactionThread).mockReturnValue(true);
+            jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(undefined);
+            // A different report sits in the central pane — the thread was not drilled from it.
+            jest.mocked(getCentralPaneReportID).mockReturnValue('some-other-report');
+            expect(getSendMessageSource(params({report: threadWithParent, routeName: SCREENS.RIGHT_MODAL.SEARCH_REPORT}))).toBe(
+                withRhp(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD),
+            );
+        });
+
+        it('does not use the central-pane parent match for a non-transaction-thread report (e.g. a chat thread)', () => {
+            jest.mocked(isChatThread).mockReturnValue(true);
+            // The central pane holds the parent chat, but a chat thread is not a drill-down from an expense report.
+            jest.mocked(getCentralPaneReportID).mockReturnValue('parent-1');
+            expect(getSendMessageSource(params({report: threadWithParent, routeName: SCREENS.RIGHT_MODAL.SEARCH_REPORT}))).toBe(
+                withRhp(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.REPORT_THREAD),
+            );
+        });
+
+        it('does not append _from_report to a central-pane value even if the RHP stack has a report beneath', () => {
+            jest.mocked(isReportTransactionThread).mockReturnValue(true);
+            jest.mocked(getRouteBeneathTopmostRHP).mockReturnValue(rhpRoute(SCREENS.RIGHT_MODAL.EXPENSE_REPORT));
+            // Central-pane route (not an RHP route) never gets the surface or origin suffix.
+            expect(getSendMessageSource(params({routeName: SCREENS.REPORT}))).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
         });
 
         it('derives a non-expense report type + _rhp on the RHP ReportScreen route (e.g. a DM)', () => {

--- a/tests/unit/getSendMessageSourceTest.ts
+++ b/tests/unit/getSendMessageSourceTest.ts
@@ -1,0 +1,264 @@
+import getTopmostFullScreenRoute from '@libs/Navigation/helpers/getTopmostFullScreenRoute';
+import {
+    isChatRoom,
+    isChatThread,
+    isConciergeChatReport,
+    isDM,
+    isGroupChat,
+    isInvoiceReport,
+    isInvoiceRoom,
+    isMoneyRequestReport,
+    isOneTransactionReport,
+    isPolicyExpenseChat,
+    isReportTransactionThread,
+    isSelfDM,
+    isTaskReport,
+} from '@libs/ReportUtils';
+import getSendMessageSource from '@libs/telemetry/getSendMessageSource';
+
+import CONST from '@src/CONST';
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+import type {Report} from '@src/types/onyx';
+
+import type {ValueOf} from 'type-fest';
+
+// Mock the ReportUtils predicates so we test getSendMessageSource's precedence logic in isolation,
+// not ReportUtils' report-shape rules. Every predicate defaults to false; each test flips the ones it needs.
+jest.mock('@libs/ReportUtils', () => ({
+    isChatRoom: jest.fn(() => false),
+    isChatThread: jest.fn(() => false),
+    isConciergeChatReport: jest.fn(() => false),
+    isDM: jest.fn(() => false),
+    isGroupChat: jest.fn(() => false),
+    isInvoiceReport: jest.fn(() => false),
+    isInvoiceRoom: jest.fn(() => false),
+    isMoneyRequestReport: jest.fn(() => false),
+    isOneTransactionReport: jest.fn(() => false),
+    isPolicyExpenseChat: jest.fn(() => false),
+    isReportTransactionThread: jest.fn(() => false),
+    isSelfDM: jest.fn(() => false),
+    isTaskReport: jest.fn(() => false),
+}));
+
+// Every value is prefixed with the tab the send is on; mock the topmost tab route so each test controls it.
+jest.mock('@libs/Navigation/helpers/getTopmostFullScreenRoute', () => jest.fn(() => undefined));
+
+const PREDICATES = [
+    isChatRoom,
+    isChatThread,
+    isConciergeChatReport,
+    isDM,
+    isGroupChat,
+    isInvoiceReport,
+    isInvoiceRoom,
+    isMoneyRequestReport,
+    isOneTransactionReport,
+    isPolicyExpenseChat,
+    isReportTransactionThread,
+    isSelfDM,
+    isTaskReport,
+];
+
+const {SEND_MESSAGE_SOURCE, SEND_MESSAGE_SOURCE_TAB, SEND_MESSAGE_SOURCE_SURFACE} = CONST.TELEMETRY;
+const report = {reportID: '1'} as Report;
+
+/** Prefix a scenario base with a tab, mirroring how getSendMessageSource stamps a central-pane value. */
+const withTab = (tab: ValueOf<typeof SEND_MESSAGE_SOURCE_TAB>, base: ValueOf<typeof SEND_MESSAGE_SOURCE>) => `${tab}_${base}` as const;
+
+/** Same, plus the generic-RHP `_rhp` surface suffix. */
+const withRhp = (tab: ValueOf<typeof SEND_MESSAGE_SOURCE_TAB>, base: ValueOf<typeof SEND_MESSAGE_SOURCE>) => `${tab}_${base}_${SEND_MESSAGE_SOURCE_SURFACE.RHP}` as const;
+
+/** Build the params with sane defaults; override per test. SCREENS.REPORT is a non-expense-report route. */
+function params(overrides: Partial<Parameters<typeof getSendMessageSource>[0]> = {}) {
+    return {report, conciergeReportID: undefined, isInSidePanel: false, routeName: SCREENS.REPORT, ...overrides};
+}
+
+/** Fake the topmost tab route so the tab prefix resolves to home / inbox / spend. */
+const tabRoute = (name: string) => ({key: 'k', name}) as ReturnType<typeof getTopmostFullScreenRoute>;
+
+// clearAllMocks keeps mockReturnValue implementations, so reset every mock before each test. The default tab
+// is the inbox (REPORTS_SPLIT_NAVIGATOR) — where a normal central-pane report lives — so report-type tests
+// read `inbox_*`; surface tests override the tab as needed.
+beforeEach(() => {
+    for (const predicate of PREDICATES) {
+        jest.mocked(predicate).mockReturnValue(false);
+    }
+    jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR));
+});
+
+describe('getSendMessageSource', () => {
+    describe('tab prefix', () => {
+        it('prefixes with the tab the send is on, falling back to other for an unresolved tab', () => {
+            jest.mocked(isDM).mockReturnValue(true);
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(SCREENS.HOME));
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.HOME, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR));
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(undefined);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.OTHER, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+        });
+    });
+
+    describe('surfaces (take precedence over report type)', () => {
+        it('resolves Concierge in the side panel, prefixed by the tab underneath', () => {
+            jest.mocked(isConciergeChatReport).mockReturnValue(true);
+            const sidePanel = params({isInSidePanel: true});
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(SCREENS.HOME));
+            expect(getSendMessageSource(sidePanel)).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.HOME, SEND_MESSAGE_SOURCE.CONCIERGE_SIDE_PANEL));
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
+            expect(getSendMessageSource(sidePanel)).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.CONCIERGE_SIDE_PANEL));
+        });
+
+        it('resolves a non-Concierge side panel (admins chat), prefixed by tab', () => {
+            const sidePanel = params({isInSidePanel: true});
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(SCREENS.HOME));
+            expect(getSendMessageSource(sidePanel)).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.HOME, SEND_MESSAGE_SOURCE.SIDE_PANEL));
+        });
+
+        it('treats the Search money-request-report route as an RHP report (expense_report + _rhp), split single/multi', () => {
+            jest.mocked(isMoneyRequestReport).mockReturnValue(true);
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
+            const searchReport = params({routeName: SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT});
+
+            expect(getSendMessageSource(searchReport)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_MULTI));
+
+            jest.mocked(isOneTransactionReport).mockReturnValue(true);
+            expect(getSendMessageSource(searchReport)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_SINGLE));
+        });
+
+        it('appends _rhp to the single/multi expense-report base on the RHP expense-report route, prefixed by tab', () => {
+            jest.mocked(isMoneyRequestReport).mockReturnValue(true);
+            const rhpExpense = params({routeName: SCREENS.RIGHT_MODAL.EXPENSE_REPORT});
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(SCREENS.HOME));
+            expect(getSendMessageSource(rhpExpense)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.HOME, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_MULTI));
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
+            jest.mocked(isOneTransactionReport).mockReturnValue(true);
+            expect(getSendMessageSource(rhpExpense)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_SINGLE));
+        });
+
+        it('derives the report type + _rhp on the RHP ReportScreen route (transaction thread), prefixed by tab', () => {
+            jest.mocked(isReportTransactionThread).mockReturnValue(true);
+            const rhpReport = params({routeName: SCREENS.RIGHT_MODAL.SEARCH_REPORT});
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(SCREENS.HOME));
+            expect(getSendMessageSource(rhpReport)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.HOME, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+
+            jest.mocked(getTopmostFullScreenRoute).mockReturnValue(tabRoute(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR));
+            expect(getSendMessageSource(rhpReport)).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.SPEND, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+        });
+
+        it('derives a non-expense report type + _rhp on the RHP ReportScreen route (e.g. a DM)', () => {
+            jest.mocked(isDM).mockReturnValue(true);
+            expect(getSendMessageSource(params({routeName: SCREENS.RIGHT_MODAL.SEARCH_REPORT}))).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+        });
+
+        it('adds _rhp for any Right-Hand-Panel route, not just the report ones (generic RHP detection)', () => {
+            jest.mocked(isDM).mockReturnValue(true);
+            // A non-report RHP screen name still yields `_rhp` — the check is "is this the RHP", not a fixed list.
+            expect(getSendMessageSource(params({routeName: SCREENS.RIGHT_MODAL.REPORT_DETAILS}))).toBe(withRhp(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+            // A central-pane (non-RHP) route stays bare.
+            expect(getSendMessageSource(params({routeName: SCREENS.REPORT}))).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+        });
+
+        it('side panel wins over an RHP report route and does NOT get a _rhp suffix', () => {
+            jest.mocked(isConciergeChatReport).mockReturnValue(true);
+            // Even with an RHP report routeName, the side panel keeps its own base and is never suffixed.
+            expect(getSendMessageSource(params({isInSidePanel: true, routeName: SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT}))).toBe(
+                withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.CONCIERGE_SIDE_PANEL),
+            );
+        });
+
+        it('returns expense_report_multi for a multi-expense money-request report in the central pane', () => {
+            jest.mocked(isMoneyRequestReport).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_MULTI));
+        });
+
+        it('returns expense_report_single for a one-expense money-request report in the central pane', () => {
+            jest.mocked(isMoneyRequestReport).mockReturnValue(true);
+            jest.mocked(isOneTransactionReport).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_SINGLE));
+        });
+
+        it('returns an expense_report base for an invoice report in the central pane', () => {
+            jest.mocked(isInvoiceReport).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_REPORT_MULTI));
+        });
+    });
+
+    describe('report types (central-pane chat surface, default inbox tab)', () => {
+        it('returns expense_transaction_thread for a transaction thread (before the chat-thread check)', () => {
+            jest.mocked(isReportTransactionThread).mockReturnValue(true);
+            jest.mocked(isChatThread).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.EXPENSE_TRANSACTION_THREAD));
+        });
+
+        it('returns concierge for the Concierge chat', () => {
+            jest.mocked(isConciergeChatReport).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.CONCIERGE));
+        });
+
+        it('concierge beats thread/room checks', () => {
+            jest.mocked(isConciergeChatReport).mockReturnValue(true);
+            jest.mocked(isChatThread).mockReturnValue(true);
+            jest.mocked(isChatRoom).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.CONCIERGE));
+        });
+
+        it('returns report_thread for a chat thread', () => {
+            jest.mocked(isChatThread).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.REPORT_THREAD));
+        });
+
+        it('returns invoice_room for an invoice room (before the generic room check)', () => {
+            jest.mocked(isInvoiceRoom).mockReturnValue(true);
+            jest.mocked(isChatRoom).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.INVOICE_ROOM));
+        });
+
+        it('returns workspace_room for a chat room', () => {
+            jest.mocked(isChatRoom).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.WORKSPACE_ROOM));
+        });
+
+        it('returns policy_expense_chat for a workspace expense chat', () => {
+            jest.mocked(isPolicyExpenseChat).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.POLICY_EXPENSE_CHAT));
+        });
+
+        it('returns task_report for a task report', () => {
+            jest.mocked(isTaskReport).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.TASK_REPORT));
+        });
+
+        it('returns group_chat for a group chat', () => {
+            jest.mocked(isGroupChat).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.GROUP_CHAT));
+        });
+
+        it('returns direct_message for a DM', () => {
+            jest.mocked(isDM).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.DIRECT_MESSAGE));
+        });
+
+        it('returns self_dm for a self-DM', () => {
+            jest.mocked(isSelfDM).mockReturnValue(true);
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.SELF_DM));
+        });
+
+        it('returns other_chat when nothing matches', () => {
+            expect(getSendMessageSource(params())).toBe(withTab(SEND_MESSAGE_SOURCE_TAB.INBOX, SEND_MESSAGE_SOURCE.OTHER_CHAT));
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Tag every `ManualSendMessage` span with **where the message was sent from**, so we can slice the metric by
scenario in Sentry and answer: *which send path is the slowest the most, and where should we
focus optimization?*. New attribute: `send_message_source`

There is updated dashboard showing % distribution based on these values: https://expensify.sentry.io/dashboard/166325/?statsPeriod=7d


How the value is built

`<tab>_<scenario>` + optional `_rhp` + optional `_from_report`. Example: `inbox_expense_transaction_thread_rhp_from_report`.

- **`tab_`** — the tab behind the screen: `home_` / `inbox_` / `spend_` / `settings_` / `other_` (Workspaces, Settings, or unresolved).
- **`_single` / `_multi`** — expense report with one transaction vs many (only on `expense_report_*`).
- **`_rhp`** — the report is open in the Right-Hand Panel (overlay), not the central pane (still fullscreen on mobile/narrow).
- **`_from_report`** — an RHP screen was drilled into from its parent expense report (stacked in the RHP, or in the central pane behind the overlay). Absent when opened directly from a list/chat without going through report with listed transactions.

| How to open | Example result |
|---|---|
| 1:1 DM from the LHN | `inbox_direct_message` |
| Your own self-DM (notes) | `inbox_self_dm` |
| Group chat (or FAB → Start chat → 2+ people) | `inbox_group_chat` |
| Concierge from the LHN | `inbox_concierge` |
| `#admins` / `#announce` / policy room | `inbox_workspace_room` |
| Workspace chat (submit-expense chat) | `inbox_policy_expense_chat` |
| Invoice room | `inbox_invoice_room` |
| FAB → Assign task, comment in its chat | `inbox_task_report` |
| Plain message → Reply in thread, send in thread | `inbox_report_thread` |
| Single-transaction expense in central pane (`/r/:id`) | `inbox_expense_transaction_thread` |
| Multi-expense report in central pane | `inbox_expense_report_multi` |
| One-expense report in central pane | `inbox_expense_report_single` |
| Expense report in RHP (`e/:id`) — multi | `home_expense_report_multi_rhp` |
| Expense report in RHP (`e/:id`) — single | `home_expense_report_single_rhp` |
| On Spend, open a report (RHP, `search/r/:id`) | `spend_expense_report_multi_rhp` |
| RHP expense report → tap a specific expense (report stacked in RHP) | `spend_expense_transaction_thread_rhp_from_report` |
| Spend, open a transaction thread directly from a list (no report behind it) | `spend_expense_transaction_thread_rhp` |
| Concierge Side Panel (top right icon) | `inbox_concierge_side_panel` |
| Fallback — should never appear | `other_chat` NOT seen |


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95709
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Send a short message from different places in the app.
2. Check the Sentry span in DevTools by filtering for ManualSendMessage_, then verify that the send_message_source attribute matches the table above.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>

<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/33a80316-f740-471b-8bbc-ce11c9f030ee


</details>

<img width="1403" height="735" alt="image" src="https://github.com/user-attachments/assets/54ad2bfc-44da-4a96-9914-829f714ecb5d" />


