### PR TITLE
perf: shrink SearchRouter's initial recent-reports build, paginate on scroll

### DIFF
--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -107,8 +107,12 @@ const EMPTY_RANK_MAP: ReadonlyMap<string, number> = new Map();
 // excludes hidden/muted chats, so the visible list can come out shorter than this number. 100 leaves
 // enough buffer that a few hidden chats near the top of a user's recency ordering won't visibly thin
 // the initial list, while still cutting the default 500 by 5x.
+// createFilteredOptionList rebuilds the whole top-N slice from scratch on every call rather than
+// appending incrementally, so a small batch size means repeated full rebuilds of already-processed
+// reports as the user keeps scrolling. Using the original 500-report batch size keeps pagination to a
+// single extra rebuild for the (rare) user who scrolls past the initial screenful.
 const INITIAL_MAX_RECENT_REPORTS = 100;
-const RECENT_REPORTS_BATCH_SIZE = 100;
+const RECENT_REPORTS_BATCH_SIZE = 500;
 
 // A DM's keyForList changes from the accountID to the reportID once its report loads from search, which would move the
 // row between sections. To keep it stable, key DMs and personal details by accountID instead. We can't do this for every
@@ -622,6 +626,19 @@ function SearchAutocompleteList({
     ]);
 
     const trimmedAutocompleteQueryValue = autocompleteQueryValue.trim();
+
+    // Guard for the INITIAL_MAX_RECENT_REPORTS cap above: if every report within that raw cap gets excluded by
+    // getSearchOptions (e.g. all hidden/muted chats) and no other section has rows, "sections" is empty and
+    // SelectionListWithSections renders its empty state instead of a FlashList — onEndReached never mounts there,
+    // so loadMoreRecentReports would otherwise never run and the user would be stuck looking at an empty
+    // "Recent chats" list. Escalate the cap ourselves until either a row surfaces or we've truly run out of reports.
+    useEffect(() => {
+        if (trimmedAutocompleteQueryValue !== '' || isLoadingOptions || suggestionsCount > 0 || !hasMoreRecentReports) {
+            return;
+        }
+        loadMoreRecentReports();
+    }, [trimmedAutocompleteQueryValue, isLoadingOptions, suggestionsCount, hasMoreRecentReports, loadMoreRecentReports]);
+
     const isLoading = !isRecentSearchesDataLoaded;
     const suggestionsAnnouncement = suggestionsCount > 0 ? translate('search.suggestionsAvailable', {count: suggestionsCount}, trimmedAutocompleteQueryValue) : '';
     useDebouncedAccessibilityAnnouncement(suggestionsAnnouncement, !!suggestionsAnnouncement, autocompleteQueryValue);

--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -99,6 +99,17 @@ const defaultListOptions = {
 
 const EMPTY_RANK_MAP: ReadonlyMap<string, number> = new Map();
 
+// The empty-query "Recent chats" section rarely gets scrolled past the first screenful, so building
+// options (icons, subtitles, translated text) for the full 500-report default on every open is mostly
+// wasted work. Start smaller and grow via onEndReached; typing a query bypasses this cap entirely
+// (isSearching drops the limit in createFilteredOptionList), so search results are never truncated by it.
+// Note: createFilteredOptionList slices to this count by raw recency *before* shouldReportBeInOptionList
+// excludes hidden/muted chats, so the visible list can come out shorter than this number. 100 leaves
+// enough buffer that a few hidden chats near the top of a user's recency ordering won't visibly thin
+// the initial list, while still cutting the default 500 by 5x.
+const INITIAL_MAX_RECENT_REPORTS = 100;
+const RECENT_REPORTS_BATCH_SIZE = 100;
+
 // A DM's keyForList changes from the accountID to the reportID once its report loads from search, which would move the
 // row between sections. To keep it stable, key DMs and personal details by accountID instead. We can't do this for every
 // account-backed option though: task/expense reports also carry an accountID, and keying them by it would let them
@@ -200,7 +211,18 @@ function SearchAutocompleteList({
     const taxRates = useMemo(() => getAllTaxRates(policies), [policies]);
     const [isTrackIntentUser] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED, {selector: isTrackIntentUserSelector});
 
-    const {options: listOptions, isLoading: isLoadingOptions} = useFilteredOptions({enabled: true, isSearching: !!autocompleteQueryValue.trim(), betas: betas ?? []});
+    const {
+        options: listOptions,
+        isLoading: isLoadingOptions,
+        loadMore: loadMoreRecentReports,
+        hasMore: hasMoreRecentReports,
+    } = useFilteredOptions({
+        enabled: true,
+        isSearching: !!autocompleteQueryValue.trim(),
+        betas: betas ?? [],
+        maxRecentReports: INITIAL_MAX_RECENT_REPORTS,
+        batchSize: RECENT_REPORTS_BATCH_SIZE,
+    });
 
     const isRecentSearchesDataLoaded = !isLoadingOnyxValue(recentSearchesMetadata);
 
@@ -687,6 +709,8 @@ function SearchAutocompleteList({
                 sectionTitleStyles: styles.mhn2,
             }}
             shouldSingleExecuteRowSelect
+            onEndReached={hasMoreRecentReports ? loadMoreRecentReports : undefined}
+            onEndReachedThreshold={0.75}
             ref={setListRef}
             initialScrollIndex={0}
             initiallyFocusedItemKey={!shouldUseNarrowLayout ? firstRecentReportKey : undefined}

--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -99,18 +99,12 @@ const defaultListOptions = {
 
 const EMPTY_RANK_MAP: ReadonlyMap<string, number> = new Map();
 
-// The empty-query "Recent chats" section rarely gets scrolled past the first screenful, so building
-// options (icons, subtitles, translated text) for the full 500-report default on every open is mostly
-// wasted work. Start smaller and grow via onEndReached; typing a query bypasses this cap entirely
-// (isSearching drops the limit in createFilteredOptionList), so search results are never truncated by it.
-// Note: createFilteredOptionList slices to this count by raw recency *before* shouldReportBeInOptionList
-// excludes hidden/muted chats, so the visible list can come out shorter than this number. 100 leaves
-// enough buffer that a few hidden chats near the top of a user's recency ordering won't visibly thin
-// the initial list, while still cutting the default 500 by 5x.
-// createFilteredOptionList rebuilds the whole top-N slice from scratch on every call rather than
-// appending incrementally, so a small batch size means repeated full rebuilds of already-processed
-// reports as the user keeps scrolling. Using the original 500-report batch size keeps pagination to a
-// single extra rebuild for the (rare) user who scrolls past the initial screenful.
+// Most opens never scroll past the initial rows, so building full option data for the default
+// 500-report list every time is unnecessary. Start smaller and grow via onEndReached; typing a
+// query bypasses this cap entirely (isSearching drops the limit in createFilteredOptionList).
+// 100 leaves buffer for hidden/muted chats getting filtered out after the raw-recency slice.
+// The batch size stays at 500 (not smaller) because createFilteredOptionList rebuilds its whole
+// top-N slice from scratch each call, so a small batch would mean repeated rebuilds on scroll.
 const INITIAL_MAX_RECENT_REPORTS = 100;
 const RECENT_REPORTS_BATCH_SIZE = 500;
 
@@ -627,17 +621,20 @@ function SearchAutocompleteList({
 
     const trimmedAutocompleteQueryValue = autocompleteQueryValue.trim();
 
-    // Guard for the INITIAL_MAX_RECENT_REPORTS cap above: if every report within that raw cap gets excluded by
-    // getSearchOptions (e.g. all hidden/muted chats) and no other section has rows, "sections" is empty and
-    // SelectionListWithSections renders its empty state instead of a FlashList — onEndReached never mounts there,
-    // so loadMoreRecentReports would otherwise never run and the user would be stuck looking at an empty
-    // "Recent chats" list. Escalate the cap ourselves until either a row surfaces or we've truly run out of reports.
+    // If every report within the raw cap gets excluded (e.g. all hidden/muted), sections is empty and
+    // SelectionListWithSections shows its empty state instead of a FlashList, so onEndReached never
+    // mounts and loadMoreRecentReports would never run. Escalate the cap ourselves until a row surfaces.
     useEffect(() => {
         if (trimmedAutocompleteQueryValue !== '' || isLoadingOptions || suggestionsCount > 0 || !hasMoreRecentReports) {
             return;
         }
         loadMoreRecentReports();
     }, [trimmedAutocompleteQueryValue, isLoadingOptions, suggestionsCount, hasMoreRecentReports, loadMoreRecentReports]);
+
+    // hasMoreRecentReports only tracks raw reports, not the visible MAX_AMOUNT_OF_SUGGESTIONS cap. Once the
+    // visible cap is full, remaining raw reports are all less recent and can never surface, so loading more
+    // would just rebuild larger batches for no UI change. Stop wiring onEndReached in that case.
+    const canLoadMoreRecentReports = hasMoreRecentReports && recentReportsOptions.length < CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_SUGGESTIONS;
 
     const isLoading = !isRecentSearchesDataLoaded;
     const suggestionsAnnouncement = suggestionsCount > 0 ? translate('search.suggestionsAvailable', {count: suggestionsCount}, trimmedAutocompleteQueryValue) : '';
@@ -726,7 +723,7 @@ function SearchAutocompleteList({
                 sectionTitleStyles: styles.mhn2,
             }}
             shouldSingleExecuteRowSelect
-            onEndReached={hasMoreRecentReports ? loadMoreRecentReports : undefined}
+            onEndReached={canLoadMoreRecentReports ? loadMoreRecentReports : undefined}
             onEndReachedThreshold={0.75}
             ref={setListRef}
             initialScrollIndex={0}

--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -213,6 +213,7 @@ function SearchAutocompleteList({
         options: listOptions,
         isLoading: isLoadingOptions,
         loadMore: loadMoreRecentReports,
+        loadAll: loadAllRecentReports,
         hasMore: hasMoreRecentReports,
     } = useFilteredOptions({
         enabled: true,
@@ -622,14 +623,15 @@ function SearchAutocompleteList({
     const trimmedAutocompleteQueryValue = autocompleteQueryValue.trim();
 
     // If every report within the raw cap gets excluded (e.g. all hidden/muted), sections is empty and
-    // SelectionListWithSections shows its empty state instead of a FlashList, so onEndReached never
-    // mounts and loadMoreRecentReports would never run. Escalate the cap ourselves until a row surfaces.
+    // SelectionListWithSections shows its empty state instead of a FlashList, so onEndReached never mounts
+    // and loadMoreRecentReports would never run. Expand to the full report set in one step so any surviving
+    // row surfaces. This fires at most once: afterwards either a row appears or hasMoreRecentReports is false.
     useEffect(() => {
         if (trimmedAutocompleteQueryValue !== '' || isLoadingOptions || suggestionsCount > 0 || !hasMoreRecentReports) {
             return;
         }
-        loadMoreRecentReports();
-    }, [trimmedAutocompleteQueryValue, isLoadingOptions, suggestionsCount, hasMoreRecentReports, loadMoreRecentReports]);
+        loadAllRecentReports();
+    }, [trimmedAutocompleteQueryValue, isLoadingOptions, suggestionsCount, hasMoreRecentReports, loadAllRecentReports]);
 
     // hasMoreRecentReports only tracks raw reports, not the visible MAX_AMOUNT_OF_SUGGESTIONS cap. Once the
     // visible cap is full, remaining raw reports are all less recent and can never surface, so loading more

--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -99,12 +99,13 @@ const defaultListOptions = {
 
 const EMPTY_RANK_MAP: ReadonlyMap<string, number> = new Map();
 
-// Most opens never scroll past the initial rows, so building full option data for the default
-// 500-report list every time is unnecessary. Start smaller and grow via onEndReached; typing a
+// The list shows at most MAX_AMOUNT_OF_SUGGESTIONS recent reports, so building full option data for the
+// default 500-report list every time is unnecessary. Start from a smaller raw cap and only expand to the
+// full set if that batch filters down below the visible cap (see the loadAll effect below); typing a
 // query bypasses this cap entirely (isSearching drops the limit in createFilteredOptionList).
 // 100 leaves buffer for hidden/muted chats getting filtered out after the raw-recency slice.
 // The batch size stays at 500 (not smaller) because createFilteredOptionList rebuilds its whole
-// top-N slice from scratch each call, so a small batch would mean repeated rebuilds on scroll.
+// top-N slice from scratch each call, so a small batch would mean repeated rebuilds.
 const INITIAL_MAX_RECENT_REPORTS = 100;
 const RECENT_REPORTS_BATCH_SIZE = 500;
 
@@ -212,7 +213,6 @@ function SearchAutocompleteList({
     const {
         options: listOptions,
         isLoading: isLoadingOptions,
-        loadMore: loadMoreRecentReports,
         loadAll: loadAllRecentReports,
         hasMore: hasMoreRecentReports,
     } = useFilteredOptions({
@@ -622,21 +622,17 @@ function SearchAutocompleteList({
 
     const trimmedAutocompleteQueryValue = autocompleteQueryValue.trim();
 
-    // If every report within the raw cap gets excluded (e.g. all hidden/muted), sections is empty and
-    // SelectionListWithSections shows its empty state instead of a FlashList, so onEndReached never mounts
-    // and loadMoreRecentReports would never run. Expand to the full report set in one step so any surviving
-    // row surfaces. This fires at most once: afterwards either a row appears or hasMoreRecentReports is false.
+    // The list shows at most MAX_AMOUNT_OF_SUGGESTIONS recent reports. If the initial raw cap filters down
+    // below that (e.g. many hidden/muted chats), expand to the full report set in one step so the remaining
+    // slots fill from less-recent reports. This replaces scroll-driven loading: the list never paginates past
+    // the visible cap, so there is nothing to load on scroll. Fires at most once: afterwards either the visible
+    // cap is reached or hasMoreRecentReports is false.
     useEffect(() => {
-        if (trimmedAutocompleteQueryValue !== '' || isLoadingOptions || suggestionsCount > 0 || !hasMoreRecentReports) {
+        if (trimmedAutocompleteQueryValue !== '' || isLoadingOptions || recentReportsOptions.length >= CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_SUGGESTIONS || !hasMoreRecentReports) {
             return;
         }
         loadAllRecentReports();
-    }, [trimmedAutocompleteQueryValue, isLoadingOptions, suggestionsCount, hasMoreRecentReports, loadAllRecentReports]);
-
-    // hasMoreRecentReports only tracks raw reports, not the visible MAX_AMOUNT_OF_SUGGESTIONS cap. Once the
-    // visible cap is full, remaining raw reports are all less recent and can never surface, so loading more
-    // would just rebuild larger batches for no UI change. Stop wiring onEndReached in that case.
-    const canLoadMoreRecentReports = hasMoreRecentReports && recentReportsOptions.length < CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_SUGGESTIONS;
+    }, [trimmedAutocompleteQueryValue, isLoadingOptions, recentReportsOptions.length, hasMoreRecentReports, loadAllRecentReports]);
 
     const isLoading = !isRecentSearchesDataLoaded;
     const suggestionsAnnouncement = suggestionsCount > 0 ? translate('search.suggestionsAvailable', {count: suggestionsCount}, trimmedAutocompleteQueryValue) : '';
@@ -725,7 +721,6 @@ function SearchAutocompleteList({
                 sectionTitleStyles: styles.mhn2,
             }}
             shouldSingleExecuteRowSelect
-            onEndReached={canLoadMoreRecentReports ? loadMoreRecentReports : undefined}
             ref={setListRef}
             initialScrollIndex={0}
             initiallyFocusedItemKey={!shouldUseNarrowLayout ? firstRecentReportKey : undefined}

--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -726,7 +726,6 @@ function SearchAutocompleteList({
             }}
             shouldSingleExecuteRowSelect
             onEndReached={canLoadMoreRecentReports ? loadMoreRecentReports : undefined}
-            onEndReachedThreshold={0.75}
             ref={setListRef}
             initialScrollIndex={0}
             initiallyFocusedItemKey={!shouldUseNarrowLayout ? firstRecentReportKey : undefined}

--- a/src/hooks/useFilteredOptions.ts
+++ b/src/hooks/useFilteredOptions.ts
@@ -7,7 +7,7 @@ import type Beta from '@src/types/onyx/Beta';
 import type {OnyxEntry} from 'react-native-onyx';
 
 import {isTrackIntentUserSelector} from '@selectors/Onboarding';
-import {useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import useOnyx from './useOnyx';
 import usePrivateIsArchivedMap from './usePrivateIsArchivedMap';
@@ -37,6 +37,8 @@ type UseFilteredOptionsResult = {
     isLoading: boolean;
     /** Function to load the next batch of reports */
     loadMore: () => void;
+    /** Function to expand the window to every available report in a single step */
+    loadAll: () => void;
     /** Whether there are more reports available to load */
     hasMore: boolean;
     /** Whether currently loading the next batch */
@@ -119,10 +121,17 @@ function useFilteredOptions(config: UseFilteredOptionsConfig = {}): UseFilteredO
         setReportsLimit((prev) => prev + batchSize);
     };
 
+    // Expand the window to cover every report in a single step. Used when the visible list is empty so the
+    // option list is rebuilt once to surface any surviving row, instead of paginating batch-by-batch.
+    const loadAll = useCallback(() => {
+        setReportsLimit((prev) => (prev < totalReports ? totalReports : prev));
+    }, [totalReports]);
+
     return {
         options,
         isLoading: !options,
         loadMore,
+        loadAll,
         hasMore,
         // Options are derived synchronously from reportsLimit, so there is no
         // intermediate "loading" state between calling loadMore and the recomputed options.

--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -1559,12 +1559,14 @@ function processReport(
 }
 
 /**
- * Sort Report objects by archived status and last visible action
- * Similar to recentReportComparator, but works with raw Report objects instead of SearchOptionData
+ * Sort Report objects by self-DM status, archived status, and last visible action.
+ * Mirrors recentReportComparator's isSelfDM priority so the raw top-N cap in createFilteredOptionList
+ * can't exclude the self-DM report before recentReportComparator gets a chance to keep it.
  */
 const reportSortComparator = (report: Report, privateIsArchivedMap: PrivateIsArchivedMap): string => {
     const isArchived = privateIsArchivedMap[`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${report.reportID}`];
-    return `${isArchived ? 0 : 1}_${report.lastVisibleActionCreated ?? ''}`;
+    const isSelfDM = report.chatType === CONST.REPORT.CHAT_TYPE.SELF_DM;
+    return `${isSelfDM ? 1 : 0}_${isArchived ? 0 : 1}_${report.lastVisibleActionCreated ?? ''}`;
 };
 
 /**

--- a/tests/ui/components/SearchAutocompleteListTest.tsx
+++ b/tests/ui/components/SearchAutocompleteListTest.tsx
@@ -51,6 +51,7 @@ jest.mock('@hooks/useFilteredOptions', () => ({
         },
         isLoading: false,
         loadMore: jest.fn(),
+        loadAll: jest.fn(),
         hasMore: false,
         isLoadingMore: false,
     })),
@@ -97,6 +98,7 @@ describe('SearchAutocompleteList', () => {
             options: {reports: [], personalDetails: []},
             isLoading: false,
             loadMore: jest.fn(),
+            loadAll: jest.fn(),
             hasMore: false,
             isLoadingMore: false,
         });
@@ -227,6 +229,7 @@ describe('SearchAutocompleteList', () => {
             options: {reports: [], personalDetails: []},
             isLoading: false,
             loadMore: jest.fn(),
+            loadAll: jest.fn(),
             hasMore: false,
             isLoadingMore: false,
         });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->




### Explanation of Change

SearchRouter built full option data for the default ~500-report recent-reports list on every open, even though the recent-reports view only ever shows up to 20 rows (`CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_SUGGESTIONS`). This PR makes that build lazy without changing anything the user sees:

- `useFilteredOptions` now starts with a 100-report cap (`INITIAL_MAX_RECENT_REPORTS`) instead of building option data for all ~500 raw reports up front.
- If fewer than 20 rows survive filtering (e.g. lots of hidden/muted chats), the window escalates to the full report set in a single step (`loadAll`) so the remaining slots fill from less-recent reports. This runs at most once per open and only in that under-fill case; when the initial 100-report window already fills the 20 visible slots, nothing extra is built. There is no scroll-driven pagination, since the view is capped at 20 rows and can never show more.
- Typing a query bypasses the cap entirely (`isSearching` drops the limit in `createFilteredOptionList`), so search suggestions are unaffected.
- Fixed a regression where the raw top-N cap could drop the self-DM report before `recentReportComparator` had a chance to keep it, by mirroring the self-DM priority in `reportSortComparator`.

**This is a pure performance optimization. The recent-reports view is still capped at 20 rows exactly as before** — the `loadAll` escalation is an internal mechanism to top up those 20 slots when the initial 100-report window has too many filtered-out reports, not user-facing infinite scroll.

Measured over 19 warm opens of SearchRouter:

Android native:
| Metric | main     | with fix |
|--------|----------|----------|
| Avg    | 935.6 ms | 846.1 ms |
| Median | 883 ms   | 779 ms   |

Web:
| Metric | web with fix v2 | web     |
|--------|------------------|---------|
| Avg    | 207.1 ms         | 222.7 ms |
| Median | 205.5 ms         | 218 ms   |

### Fixed Issues
$ https://github.com/Expensify/App/issues/79353#issuecomment-4929857502
PROPOSAL:


<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Open the app and click the search bar (or press the keyboard shortcut) to open SearchRouter without typing a query.
2. Verify the recent reports list appears immediately, with the same rows and ordering as before this change (the view shows up to 20 recent reports — this cap is unchanged).
3. Verify that the self-DM report (chat with yourself) is still visible in the recent reports list and not dropped, even in an account with many reports.
4. Type a search query into SearchRouter.
5. Verify that suggestions still appear correctly and are not limited by the 100-report initial cap (the cap only applies to the unfiltered recent reports view).
6. Log into an account where most/all recent reports are hidden or muted (or simulate this state) and open SearchRouter without a query.
7. Verify that the list still surfaces visible rows instead of showing an empty state (the window escalates automatically until rows appear or no reports remain).

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open SearchRouter and verify the recent reports list still loads from cached Onyx data, showing the same rows as when online.
3. Verify the self-DM report is still present in the list while offline.

### QA Steps

1. Open the app and click the search bar to open SearchRouter without typing a query.
2. Verify the recent reports list appears immediately and matches the rows shown before this change (up to 20 recent reports).
3. Verify that the self-DM report (chat with yourself) is still visible in the recent reports list.
4. Type a search query into SearchRouter and verify suggestions still appear correctly.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/5ec3aee7-80b8-4ced-9d59-7f8db0131276
</details>
