### PR TITLE
Refactor: isolate allReportActions from doesReportHaveVisibleActions function

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1977,16 +1977,8 @@ function getOneTransactionThreadReportID(...args: Parameters<typeof getOneTransa
  * When we delete certain reports, we want to check whether there are any visible actions left to display.
  * If there are no visible actions left (including system messages), we can hide the report from view entirely
  */
-function doesReportHaveVisibleActions(
-    reportID: string,
-    canUserPerformWriteAction?: boolean,
-    actionsToMerge: ReportActions = {},
-    visibleReportActionsData?: VisibleReportActionsDerivedValue,
-): boolean {
-    const reportActions = Object.values(fastMerge(allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`] ?? {}, actionsToMerge, true));
-    const visibleReportActions = Object.values(reportActions ?? {}).filter((action) =>
-        isReportActionVisibleAsLastAction(action, canUserPerformWriteAction, visibleReportActionsData, reportID),
-    );
+function doesReportHaveVisibleActions(reportID: string, reportActionsParam: OnyxEntry<ReportActions>, canUserPerformWriteAction?: boolean): boolean {
+    const visibleReportActions = Object.values(reportActionsParam ?? {}).filter((action) => isReportActionVisibleAsLastAction(action, canUserPerformWriteAction, undefined, reportID));
 
     // Exclude the task system message and the created message
     const visibleReportActionsWithoutTaskSystemMessage = visibleReportActions.filter((action) => !isTaskAction(action) && !isCreatedAction(action));

--- a/src/libs/actions/Task.ts
+++ b/src/libs/actions/Task.ts
@@ -1166,12 +1166,12 @@ function getShareDestination(
  * @param report - The task report being deleted
  * @returns The URL to navigate to
  */
-function getNavigationUrlOnTaskDelete(report: OnyxEntry<OnyxTypes.Report>, conciergeReportID: string | undefined): string | undefined {
+function getNavigationUrlOnTaskDelete(report: OnyxEntry<OnyxTypes.Report>, conciergeReportID: string | undefined, reportActions: OnyxEntry<OnyxTypes.ReportActions>): string | undefined {
     if (!report) {
         return undefined;
     }
 
-    const shouldDeleteTaskReport = !ReportActionsUtils.doesReportHaveVisibleActions(report.reportID);
+    const shouldDeleteTaskReport = !ReportActionsUtils.doesReportHaveVisibleActions(report.reportID, reportActions);
     if (!shouldDeleteTaskReport) {
         return undefined;
     }
@@ -1201,6 +1201,7 @@ function deleteTask(
     parentReportAction: OnyxEntry<ReportAction>,
     conciergeReportID: string | undefined,
     delegateEmail: string | undefined,
+    reportActions: OnyxEntry<OnyxTypes.ReportActions>,
     ancestors: ReportUtils.Ancestor[] = [],
 ) {
     if (!report) {
@@ -1212,7 +1213,7 @@ function deleteTask(
     const canUserPerformWriteAction = ReportUtils.canUserPerformWriteAction(report, isReportArchived);
 
     // If the task report is the last visible action in the parent report, we should navigate back to the parent report
-    const shouldDeleteTaskReport = !ReportActionsUtils.doesReportHaveVisibleActions(report.reportID, canUserPerformWriteAction);
+    const shouldDeleteTaskReport = !ReportActionsUtils.doesReportHaveVisibleActions(report.reportID, reportActions, canUserPerformWriteAction);
     const optimisticReportAction: Partial<ReportUtils.OptimisticTaskReportAction> = {
         pendingAction: shouldDeleteTaskReport ? CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE : CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
         previousMessage: parentReportAction?.message,
@@ -1326,7 +1327,7 @@ function deleteTask(
     API.write(WRITE_COMMANDS.CANCEL_TASK, parameters, {optimisticData, successData, failureData});
     notifyNewAction(report.reportID, undefined, true);
 
-    const urlToNavigateBack = getNavigationUrlOnTaskDelete(report, conciergeReportID);
+    const urlToNavigateBack = getNavigationUrlOnTaskDelete(report, conciergeReportID, reportActions);
     if (urlToNavigateBack) {
         Navigation.goBack();
         return urlToNavigateBack;

--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -941,6 +941,7 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
                 parentReportAction,
                 conciergeReportID,
                 delegateEmail,
+                reportActionsForOriginalReportID,
                 ancestors,
             );
             return;
@@ -993,6 +994,7 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
         conciergeReportID,
         delegateEmail,
         ancestors,
+        reportActionsForOriginalReportID,
         moneyRequestReport,
         iouReport,
         chatIOUReport,

--- a/tests/actions/TaskTest.ts
+++ b/tests/actions/TaskTest.ts
@@ -25,7 +25,6 @@ import {
 import * as API from '@libs/API';
 import DateUtils from '@libs/DateUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import * as ReportActionsUtils from '@libs/ReportActionsUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import * as ReportUtils from '@libs/ReportUtils';
 
@@ -73,6 +72,18 @@ jest.spyOn(ReportUtils, 'formatReportLastMessageText').mockImplementation(mockFo
 
 // Spy on API.write but allow calls to go through
 const writeSpy = jest.spyOn(API, 'write');
+
+// A report actions map containing a single visible comment — used to exercise the real
+// doesReportHaveVisibleActions instead of mocking it.
+const REPORT_ACTIONS_WITH_VISIBLE_COMMENT: Record<string, ReportAction> = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '1': {
+        reportActionID: '1',
+        actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+        created: '2025-01-01 00:00:00.000',
+        message: [{type: 'COMMENT', html: 'hello', text: 'hello'}],
+    },
+};
 
 OnyxUpdateManager();
 describe('actions/Task', () => {
@@ -1155,46 +1166,40 @@ describe('actions/Task', () => {
     });
 
     describe('getNavigationUrlOnTaskDelete', () => {
-        let doesReportHaveVisibleActionsSpy: jest.SpyInstance;
         let getMostRecentReportIDSpy: jest.SpyInstance;
 
         beforeEach(() => {
-            doesReportHaveVisibleActionsSpy = jest.spyOn(ReportActionsUtils, 'doesReportHaveVisibleActions');
             getMostRecentReportIDSpy = jest.spyOn(ReportModule, 'getMostRecentReportID');
         });
 
         afterEach(() => {
-            doesReportHaveVisibleActionsSpy.mockRestore();
             getMostRecentReportIDSpy.mockRestore();
         });
 
         it('should return undefined when report is undefined', () => {
-            expect(getNavigationUrlOnTaskDelete(undefined, 'concierge_123')).toBeUndefined();
+            expect(getNavigationUrlOnTaskDelete(undefined, 'concierge_123', undefined)).toBeUndefined();
         });
 
         it('should return undefined when report has visible actions (should not delete)', () => {
             const taskReport = getFakeReport();
-            doesReportHaveVisibleActionsSpy.mockReturnValue(true);
 
-            expect(getNavigationUrlOnTaskDelete(taskReport, 'concierge_123')).toBeUndefined();
+            expect(getNavigationUrlOnTaskDelete(taskReport, 'concierge_123', REPORT_ACTIONS_WITH_VISIBLE_COMMENT)).toBeUndefined();
         });
 
         it('should return parent report route when report has parentReportID and no visible actions', () => {
             const parentReportID = 'parent_123';
             const taskReport = {...getFakeReport(), parentReportID};
-            doesReportHaveVisibleActionsSpy.mockReturnValue(false);
 
-            const result = getNavigationUrlOnTaskDelete(taskReport, 'concierge_123');
+            const result = getNavigationUrlOnTaskDelete(taskReport, 'concierge_123', undefined);
             expect(result).toBe(`r/${parentReportID}`);
         });
 
         it('should return most recent report route when no parentReportID and getMostRecentReportID returns a value', () => {
             const taskReport = {...getFakeReport(), parentReportID: undefined};
             const mostRecentReportID = 'recent_456';
-            doesReportHaveVisibleActionsSpy.mockReturnValue(false);
             getMostRecentReportIDSpy.mockReturnValue(mostRecentReportID);
 
-            const result = getNavigationUrlOnTaskDelete(taskReport, 'concierge_123');
+            const result = getNavigationUrlOnTaskDelete(taskReport, 'concierge_123', undefined);
             expect(result).toBe(`r/${mostRecentReportID}`);
             expect(getMostRecentReportIDSpy).toHaveBeenCalledWith(taskReport, 'concierge_123');
         });
@@ -1202,20 +1207,18 @@ describe('actions/Task', () => {
         it('should pass conciergeReportID to getMostRecentReportID as fallback', () => {
             const taskReport = {...getFakeReport(), parentReportID: undefined};
             const conciergeReportID = 'concierge_789';
-            doesReportHaveVisibleActionsSpy.mockReturnValue(false);
             getMostRecentReportIDSpy.mockReturnValue(conciergeReportID);
 
-            const result = getNavigationUrlOnTaskDelete(taskReport, conciergeReportID);
+            const result = getNavigationUrlOnTaskDelete(taskReport, conciergeReportID, undefined);
             expect(result).toBe(`r/${conciergeReportID}`);
             expect(getMostRecentReportIDSpy).toHaveBeenCalledWith(taskReport, conciergeReportID);
         });
 
         it('should return undefined when no parentReportID, no most recent report, and conciergeReportID is undefined', () => {
             const taskReport = {...getFakeReport(), parentReportID: undefined};
-            doesReportHaveVisibleActionsSpy.mockReturnValue(false);
             getMostRecentReportIDSpy.mockReturnValue(undefined);
 
-            expect(getNavigationUrlOnTaskDelete(taskReport, undefined)).toBeUndefined();
+            expect(getNavigationUrlOnTaskDelete(taskReport, undefined, undefined)).toBeUndefined();
         });
     });
 
@@ -1392,7 +1395,6 @@ describe('actions/Task', () => {
     });
 
     describe('deleteTask', () => {
-        let doesReportHaveVisibleActionsSpy: jest.SpyInstance;
         let getMostRecentReportIDSpy: jest.SpyInstance;
         const mockCurrentUserAccountID = 123;
         const DELEGATE_EMAIL = 'delegate@example.com';
@@ -1404,7 +1406,6 @@ describe('actions/Task', () => {
 
             global.fetch = getGlobalFetchMock();
 
-            doesReportHaveVisibleActionsSpy = jest.spyOn(ReportActionsUtils, 'doesReportHaveVisibleActions');
             getMostRecentReportIDSpy = jest.spyOn(ReportModule, 'getMostRecentReportID');
 
             await act(async () => {
@@ -1425,12 +1426,11 @@ describe('actions/Task', () => {
         });
 
         afterEach(() => {
-            doesReportHaveVisibleActionsSpy.mockRestore();
             getMostRecentReportIDSpy.mockRestore();
         });
 
         it('should return early when report is undefined', () => {
-            deleteTask(undefined, undefined, false, mockCurrentUserAccountID, false, undefined, 'concierge_123', undefined);
+            deleteTask(undefined, undefined, false, mockCurrentUserAccountID, false, undefined, 'concierge_123', undefined, undefined);
 
             // eslint-disable-next-line rulesdir/no-multiple-api-calls
             expect(API.write).not.toHaveBeenCalled();
@@ -1469,9 +1469,7 @@ describe('actions/Task', () => {
             });
             await waitForBatchedUpdatesWithAct();
 
-            doesReportHaveVisibleActionsSpy.mockReturnValue(true);
-
-            deleteTask(taskReport, parentReport, false, mockCurrentUserAccountID, false, parentReportAction, 'concierge_123', undefined);
+            deleteTask(taskReport, parentReport, false, mockCurrentUserAccountID, false, parentReportAction, 'concierge_123', undefined, REPORT_ACTIONS_WITH_VISIBLE_COMMENT);
 
             // eslint-disable-next-line rulesdir/no-multiple-api-calls
             expect(API.write).toHaveBeenCalledWith(
@@ -1513,9 +1511,8 @@ describe('actions/Task', () => {
             await waitForBatchedUpdatesWithAct();
 
             // No visible actions means the task report should be deleted
-            doesReportHaveVisibleActionsSpy.mockReturnValue(false);
 
-            const result = deleteTask(taskReport, parentReport, false, mockCurrentUserAccountID, false, undefined, 'concierge_123', undefined);
+            const result = deleteTask(taskReport, parentReport, false, mockCurrentUserAccountID, false, undefined, 'concierge_123', undefined, undefined);
 
             expect(result).toBe(`r/${parentReportID}`);
             expect(Navigation.goBack).toHaveBeenCalled();
@@ -1540,10 +1537,9 @@ describe('actions/Task', () => {
             });
             await waitForBatchedUpdatesWithAct();
 
-            doesReportHaveVisibleActionsSpy.mockReturnValue(false);
             getMostRecentReportIDSpy.mockReturnValue(conciergeReportID);
 
-            const result = deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, conciergeReportID, undefined);
+            const result = deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, conciergeReportID, undefined, undefined);
 
             expect(result).toBe(`r/${conciergeReportID}`);
             expect(getMostRecentReportIDSpy).toHaveBeenCalledWith(taskReport, conciergeReportID);
@@ -1576,9 +1572,8 @@ describe('actions/Task', () => {
             await waitForBatchedUpdatesWithAct();
 
             // Has visible actions, so should not navigate away
-            doesReportHaveVisibleActionsSpy.mockReturnValue(true);
 
-            const result = deleteTask(taskReport, parentReport, false, mockCurrentUserAccountID, false, undefined, 'concierge_123', undefined);
+            const result = deleteTask(taskReport, parentReport, false, mockCurrentUserAccountID, false, undefined, 'concierge_123', undefined, REPORT_ACTIONS_WITH_VISIBLE_COMMENT);
 
             expect(result).toBeUndefined();
             expect(Navigation.goBack).not.toHaveBeenCalled();
@@ -1602,10 +1597,9 @@ describe('actions/Task', () => {
             });
             await waitForBatchedUpdatesWithAct();
 
-            doesReportHaveVisibleActionsSpy.mockReturnValue(false);
             getMostRecentReportIDSpy.mockReturnValue(undefined);
 
-            const result = deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, undefined, undefined);
+            const result = deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, undefined, undefined, undefined);
 
             // API.write should still be called
             // eslint-disable-next-line rulesdir/no-multiple-api-calls
@@ -1632,7 +1626,7 @@ describe('actions/Task', () => {
             });
             await waitForBatchedUpdatesWithAct();
 
-            deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, undefined, DELEGATE_EMAIL);
+            deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, undefined, DELEGATE_EMAIL, undefined);
 
             // eslint-disable-next-line rulesdir/no-multiple-api-calls -- Inspecting mock call args to verify optimistic data structure
             const calls = (API.write as jest.Mock).mock.calls;
@@ -1663,7 +1657,7 @@ describe('actions/Task', () => {
             });
             await waitForBatchedUpdatesWithAct();
 
-            deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, undefined, undefined);
+            deleteTask(taskReport, undefined, false, mockCurrentUserAccountID, false, undefined, undefined, undefined, undefined);
 
             // eslint-disable-next-line rulesdir/no-multiple-api-calls -- Inspecting mock call args to verify optimistic data structure
             const calls = (API.write as jest.Mock).mock.calls;

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -2108,7 +2108,7 @@ describe('ReportActionsUtils', () => {
     });
 
     describe('doesReportHaveVisibleActions', () => {
-        const reportID = 'report_dhva_1';
+        const reportID = 'report_1';
         const visibleComment: ReportAction = {
             reportActionID: '1',
             actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -2107,6 +2107,58 @@ describe('ReportActionsUtils', () => {
         });
     });
 
+    describe('doesReportHaveVisibleActions', () => {
+        const reportID = 'report_dhva_1';
+        const visibleComment: ReportAction = {
+            reportActionID: '1',
+            actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+            created: '2025-01-01 00:00:00.000',
+            message: [{type: 'COMMENT', html: 'hello', text: 'hello'}],
+        };
+        const createdAction: ReportAction = {
+            reportActionID: '2',
+            actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
+            created: '2025-01-01 00:00:01.000',
+            message: [{type: 'COMMENT', html: '', text: ''}],
+        };
+        const taskCompletedAction: ReportAction = {
+            reportActionID: '3',
+            actionName: CONST.REPORT.ACTIONS.TYPE.TASK_COMPLETED,
+            created: '2025-01-01 00:00:02.000',
+            message: [{type: 'COMMENT', html: 'completed', text: 'completed'}],
+        };
+
+        it('returns false when reportActions is undefined', () => {
+            expect(ReportActionsUtils.doesReportHaveVisibleActions(reportID, undefined)).toBe(false);
+        });
+
+        it('returns false when reportActions is empty', () => {
+            expect(ReportActionsUtils.doesReportHaveVisibleActions(reportID, {})).toBe(false);
+        });
+
+        it('returns true when there is a visible comment action', () => {
+            expect(ReportActionsUtils.doesReportHaveVisibleActions(reportID, {[visibleComment.reportActionID]: visibleComment})).toBe(true);
+        });
+
+        it('returns false when the only action is the CREATED system message', () => {
+            expect(ReportActionsUtils.doesReportHaveVisibleActions(reportID, {[createdAction.reportActionID]: createdAction})).toBe(false);
+        });
+
+        it('returns false when the only action is a task system message', () => {
+            expect(ReportActionsUtils.doesReportHaveVisibleActions(reportID, {[taskCompletedAction.reportActionID]: taskCompletedAction})).toBe(false);
+        });
+
+        it('returns true when a visible comment coexists with system messages', () => {
+            expect(
+                ReportActionsUtils.doesReportHaveVisibleActions(reportID, {
+                    [createdAction.reportActionID]: createdAction,
+                    [taskCompletedAction.reportActionID]: taskCompletedAction,
+                    [visibleComment.reportActionID]: visibleComment,
+                }),
+            ).toBe(true);
+        });
+    });
+
     describe('shouldReportActionBeVisible', () => {
         it('should return false for moved transaction if the report destination is unavailable', () => {
             // Given a moved transaction action but the report destination is not available


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/66405

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open App
2. Go to any chat.
3. Create a task.
4. Add a comment
5. Delete the task
6. Verify that the task is being shown as deleted task.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
15. Upload an image via copy paste
16. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/2bfb7bf1-1234-4649-bc57-f2322476b9af

