### PR TITLE
[No QA][INP] Defer PrevNextButtons-NextButton work off the press frame

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
@@ -21,7 +21,7 @@ import type LastSearchParams from '@src/types/onyx/ReportNavigation';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
-import React, {useEffect, useState} from 'react';
+import React, {startTransition, useEffect, useState} from 'react';
 import {View} from 'react-native';
 
 type MoneyRequestReportNavigationProps = {
@@ -191,10 +191,14 @@ function MoneyRequestReportNavigationContent({reportID, shouldDisplayNarrowVersi
             name: 'ReportNavigation',
             op: CONST.TELEMETRY.SPAN_OPEN_REPORT,
         });
-        Navigation.setParams({
-            reportID: reportId,
-            reportActionID: undefined,
-            referrer: undefined,
+        // Commit the destination report swap as a non-urgent transition so the press frame paints
+        // before the heavy destination tree renders.
+        startTransition(() => {
+            Navigation.setParams({
+                reportID: reportId,
+                reportActionID: undefined,
+                referrer: undefined,
+            });
         });
     };
 
@@ -206,14 +210,19 @@ function MoneyRequestReportNavigationContent({reportID, shouldDisplayNarrowVersi
 
         if (currentIndex + 1 >= threshold && lastSearchQuery?.hasMoreResults) {
             const newOffset = (lastSearchQuery.offset ?? 0) + CONST.SEARCH.RESULTS_PAGE_SIZE;
-            search({
-                queryJSON: lastSearchQuery.queryJSON,
-                offset: newOffset,
-                prevReportsLength: effectiveAllReports.length,
-                shouldCalculateTotals: false,
-                searchKey: lastSearchQuery.searchKey,
-                isLoading: isSearchLoading,
-                shouldUpdateLastSearchParams: true,
+            const queryJSON = lastSearchQuery.queryJSON;
+            // Defer the pagination request off the press frame — it builds optimistic snapshot data
+            // synchronously and doesn't need to block the interaction's paint.
+            requestAnimationFrame(() => {
+                search({
+                    queryJSON,
+                    offset: newOffset,
+                    prevReportsLength: effectiveAllReports.length,
+                    shouldCalculateTotals: false,
+                    searchKey: lastSearchQuery.searchKey,
+                    isLoading: isSearchLoading,
+                    shouldUpdateLastSearchParams: true,
+                });
             });
         }
 

--- a/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
@@ -191,8 +191,6 @@ function MoneyRequestReportNavigationContent({reportID, shouldDisplayNarrowVersi
             name: 'ReportNavigation',
             op: CONST.TELEMETRY.SPAN_OPEN_REPORT,
         });
-        // Commit the destination report swap as a non-urgent transition so the press frame paints
-        // before the heavy destination tree renders.
         startTransition(() => {
             Navigation.setParams({
                 reportID: reportId,
@@ -211,8 +209,6 @@ function MoneyRequestReportNavigationContent({reportID, shouldDisplayNarrowVersi
         if (currentIndex + 1 >= threshold && lastSearchQuery?.hasMoreResults) {
             const newOffset = (lastSearchQuery.offset ?? 0) + CONST.SEARCH.RESULTS_PAGE_SIZE;
             const queryJSON = lastSearchQuery.queryJSON;
-            // Defer the pagination request off the press frame — it builds optimistic snapshot data
-            // synchronously and doesn't need to block the interaction's paint.
             requestAnimationFrame(() => {
                 search({
                     queryJSON,

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
@@ -22,7 +22,7 @@ import type {GestureResponderEvent} from 'react-native';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 
 import {findFocusedRoute} from '@react-navigation/native';
-import React, {useCallback, useEffect, useMemo} from 'react';
+import React, {startTransition, useCallback, useEffect, useMemo} from 'react';
 
 type MoneyRequestReportRHPNavigationButtonsProps = {
     currentTransactionID: string;
@@ -140,37 +140,46 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         // hydrate it on arrival.
         const nextDescriptor = nextTransactionID ? siblingDescriptorsByTransactionID?.[nextTransactionID] : undefined;
         if (nextDescriptor) {
-            const nextReportID = getReportIDToOpenForExpense(nextDescriptor, {introSelected, betas, currentUserEmail, currentUserAccountID});
-            markReportIDAsExpense(nextReportID);
-            requestAnimationFrame(() => Navigation.setParams({reportID: nextReportID, reportActionID: undefined, backTo}));
+            // Defer the thread resolution off the press frame so the button paints its pressed state first,
+            // then commit the destination swap as a non-urgent transition one frame later.
+            requestAnimationFrame(() => {
+                const nextReportID = getReportIDToOpenForExpense(nextDescriptor, {introSelected, betas, currentUserEmail, currentUserAccountID});
+                markReportIDAsExpense(nextReportID);
+                requestAnimationFrame(() => startTransition(() => Navigation.setParams({reportID: nextReportID, reportActionID: undefined, backTo})));
+            });
             return;
         }
 
         const nextThreadReportID = nextParentReportAction?.childReportID;
         const navigationParams = {reportID: nextThreadReportID, reportActionID: undefined, backTo};
 
-        if (nextThreadReportID) {
-            markReportIDAsExpense(nextThreadReportID);
-        }
-        // We know that the next thread report exists, it just wasn't fetched to Onyx yet, so we set it optimistically.
-        if (!nextThreadReport && nextThreadReportID) {
-            setOptimisticTransactionThread(nextThreadReportID, nextParentReport?.reportID, nextParentReportAction?.reportActionID, nextParentReport?.policyID);
-        }
-        // The transaction thread doesn't exist yet, so we should create it
-        if (!nextThreadReportID) {
-            const transactionThreadReport = createTransactionThreadReport({
-                introSelected,
-                currentUserLogin: currentUserEmail ?? '',
-                currentUserAccountID,
-                betas,
-                iouReport: nextParentReport,
-                iouReportAction: nextParentReportAction,
-                transaction: nextTransaction,
-            });
-            navigationParams.reportID = transactionThreadReport?.reportID;
-        }
-        // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating
-        requestAnimationFrame(() => Navigation.setParams(navigationParams));
+        // Defer the optimistic-thread prep off the press frame so the button paints its pressed state
+        // before the createTransactionThreadReport/openReport work runs.
+        requestAnimationFrame(() => {
+            if (nextThreadReportID) {
+                markReportIDAsExpense(nextThreadReportID);
+            }
+            // We know that the next thread report exists, it just wasn't fetched to Onyx yet, so we set it optimistically.
+            if (!nextThreadReport && nextThreadReportID) {
+                setOptimisticTransactionThread(nextThreadReportID, nextParentReport?.reportID, nextParentReportAction?.reportActionID, nextParentReport?.policyID);
+            }
+            // The transaction thread doesn't exist yet, so we should create it
+            if (!nextThreadReportID) {
+                const transactionThreadReport = createTransactionThreadReport({
+                    introSelected,
+                    currentUserLogin: currentUserEmail ?? '',
+                    currentUserAccountID,
+                    betas,
+                    iouReport: nextParentReport,
+                    iouReportAction: nextParentReportAction,
+                    transaction: nextTransaction,
+                });
+                navigationParams.reportID = transactionThreadReport?.reportID;
+            }
+            // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating,
+            // and mark the destination render as a transition so the heavy destination tree commits off the interaction's paint.
+            requestAnimationFrame(() => startTransition(() => Navigation.setParams(navigationParams)));
+        });
     };
 
     const onPrevious = (e: GestureResponderEvent | KeyboardEvent | undefined) => {
@@ -186,37 +195,46 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         // See onNext: resolve the target sibling lazily from its descriptor when present.
         const prevDescriptor = prevTransactionID ? siblingDescriptorsByTransactionID?.[prevTransactionID] : undefined;
         if (prevDescriptor) {
-            const prevReportID = getReportIDToOpenForExpense(prevDescriptor, {introSelected, betas, currentUserEmail, currentUserAccountID});
-            markReportIDAsExpense(prevReportID);
-            requestAnimationFrame(() => Navigation.setParams({reportID: prevReportID, reportActionID: undefined, backTo}));
+            // Defer the thread resolution off the press frame so the button paints its pressed state first,
+            // then commit the destination swap as a non-urgent transition one frame later.
+            requestAnimationFrame(() => {
+                const prevReportID = getReportIDToOpenForExpense(prevDescriptor, {introSelected, betas, currentUserEmail, currentUserAccountID});
+                markReportIDAsExpense(prevReportID);
+                requestAnimationFrame(() => startTransition(() => Navigation.setParams({reportID: prevReportID, reportActionID: undefined, backTo})));
+            });
             return;
         }
 
         const prevThreadReportID = prevParentReportAction?.childReportID;
         const navigationParams = {reportID: prevThreadReportID, reportActionID: undefined, backTo};
 
-        if (prevThreadReportID) {
-            markReportIDAsExpense(prevThreadReportID);
-        }
-        // We know that the previous thread report exists, it just wasn't fetched to Onyx yet, so we set it optimistically.
-        if (!prevThreadReport && prevThreadReportID) {
-            setOptimisticTransactionThread(prevThreadReportID, prevParentReport?.reportID, prevParentReportAction?.reportActionID, prevParentReport?.policyID);
-        }
-        // The transaction thread doesn't exist yet, so we should create it
-        if (!prevThreadReportID) {
-            const transactionThreadReport = createTransactionThreadReport({
-                introSelected,
-                currentUserLogin: currentUserEmail ?? '',
-                currentUserAccountID,
-                betas,
-                iouReport: prevParentReport,
-                iouReportAction: prevParentReportAction,
-                transaction: prevTransaction,
-            });
-            navigationParams.reportID = transactionThreadReport?.reportID;
-        }
-        // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating
-        requestAnimationFrame(() => Navigation.setParams(navigationParams));
+        // Defer the optimistic-thread prep off the press frame so the button paints its pressed state
+        // before the createTransactionThreadReport/openReport work runs.
+        requestAnimationFrame(() => {
+            if (prevThreadReportID) {
+                markReportIDAsExpense(prevThreadReportID);
+            }
+            // We know that the previous thread report exists, it just wasn't fetched to Onyx yet, so we set it optimistically.
+            if (!prevThreadReport && prevThreadReportID) {
+                setOptimisticTransactionThread(prevThreadReportID, prevParentReport?.reportID, prevParentReportAction?.reportActionID, prevParentReport?.policyID);
+            }
+            // The transaction thread doesn't exist yet, so we should create it
+            if (!prevThreadReportID) {
+                const transactionThreadReport = createTransactionThreadReport({
+                    introSelected,
+                    currentUserLogin: currentUserEmail ?? '',
+                    currentUserAccountID,
+                    betas,
+                    iouReport: prevParentReport,
+                    iouReportAction: prevParentReportAction,
+                    transaction: prevTransaction,
+                });
+                navigationParams.reportID = transactionThreadReport?.reportID;
+            }
+            // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating,
+            // and mark the destination render as a transition so the heavy destination tree commits off the interaction's paint.
+            requestAnimationFrame(() => startTransition(() => Navigation.setParams(navigationParams)));
+        });
     };
 
     return (

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
@@ -140,8 +140,6 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         // hydrate it on arrival.
         const nextDescriptor = nextTransactionID ? siblingDescriptorsByTransactionID?.[nextTransactionID] : undefined;
         if (nextDescriptor) {
-            // Defer the thread resolution off the press frame so the button paints its pressed state first,
-            // then commit the destination swap as a non-urgent transition one frame later.
             requestAnimationFrame(() => {
                 const nextReportID = getReportIDToOpenForExpense(nextDescriptor, {introSelected, betas, currentUserEmail, currentUserAccountID});
                 markReportIDAsExpense(nextReportID);
@@ -153,8 +151,6 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         const nextThreadReportID = nextParentReportAction?.childReportID;
         const navigationParams = {reportID: nextThreadReportID, reportActionID: undefined, backTo};
 
-        // Defer the optimistic-thread prep off the press frame so the button paints its pressed state
-        // before the createTransactionThreadReport/openReport work runs.
         requestAnimationFrame(() => {
             if (nextThreadReportID) {
                 markReportIDAsExpense(nextThreadReportID);
@@ -176,8 +172,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
                 });
                 navigationParams.reportID = transactionThreadReport?.reportID;
             }
-            // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating,
-            // and mark the destination render as a transition so the heavy destination tree commits off the interaction's paint.
+            // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating
             requestAnimationFrame(() => startTransition(() => Navigation.setParams(navigationParams)));
         });
     };
@@ -195,8 +190,6 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         // See onNext: resolve the target sibling lazily from its descriptor when present.
         const prevDescriptor = prevTransactionID ? siblingDescriptorsByTransactionID?.[prevTransactionID] : undefined;
         if (prevDescriptor) {
-            // Defer the thread resolution off the press frame so the button paints its pressed state first,
-            // then commit the destination swap as a non-urgent transition one frame later.
             requestAnimationFrame(() => {
                 const prevReportID = getReportIDToOpenForExpense(prevDescriptor, {introSelected, betas, currentUserEmail, currentUserAccountID});
                 markReportIDAsExpense(prevReportID);
@@ -208,8 +201,6 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         const prevThreadReportID = prevParentReportAction?.childReportID;
         const navigationParams = {reportID: prevThreadReportID, reportActionID: undefined, backTo};
 
-        // Defer the optimistic-thread prep off the press frame so the button paints its pressed state
-        // before the createTransactionThreadReport/openReport work runs.
         requestAnimationFrame(() => {
             if (prevThreadReportID) {
                 markReportIDAsExpense(prevThreadReportID);
@@ -231,8 +222,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
                 });
                 navigationParams.reportID = transactionThreadReport?.reportID;
             }
-            // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating,
-            // and mark the destination render as a transition so the heavy destination tree commits off the interaction's paint.
+            // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating
             requestAnimationFrame(() => startTransition(() => Navigation.setParams(navigationParams)));
         });
     };

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -774,16 +774,14 @@ function IOURequestStepConfirmation({
     const showNextTransaction = () => {
         const nextTransaction = transactions.at(currentTransactionIndex + 1);
         if (nextTransaction) {
-            // Swap the displayed transaction as a non-urgent transition so the press frame paints
-            // before the whole confirmation list re-renders for the next transaction.
-            startTransition(() => setCurrentTransactionID(nextTransaction.transactionID));
+            setCurrentTransactionID(nextTransaction.transactionID);
         }
     };
 
     const showPreviousTransaction = () => {
         const previousTransaction = transactions.at(currentTransactionIndex - 1);
         if (previousTransaction) {
-            startTransition(() => setCurrentTransactionID(previousTransaction.transactionID));
+            setCurrentTransactionID(previousTransaction.transactionID);
         }
     };
 
@@ -892,8 +890,8 @@ function IOURequestStepConfirmation({
                                 <PrevNextButtons
                                     isPrevButtonDisabled={currentTransactionIndex === 0}
                                     isNextButtonDisabled={currentTransactionIndex === transactions.length - 1}
-                                    onNext={showNextTransaction}
-                                    onPrevious={showPreviousTransaction}
+                                    onNext={() => startTransition(showNextTransaction)}
+                                    onPrevious={() => startTransition(showPreviousTransaction)}
                                 />
                             ) : null}
                         </HeaderWithBackButton>

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -86,7 +86,7 @@ import type {FileObject} from '@src/types/utils/Attachment';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
 import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {startTransition, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 
 import type {WithFullTransactionOrNotFoundProps} from './withFullTransactionOrNotFound';
@@ -774,14 +774,16 @@ function IOURequestStepConfirmation({
     const showNextTransaction = () => {
         const nextTransaction = transactions.at(currentTransactionIndex + 1);
         if (nextTransaction) {
-            setCurrentTransactionID(nextTransaction.transactionID);
+            // Swap the displayed transaction as a non-urgent transition so the press frame paints
+            // before the whole confirmation list re-renders for the next transaction.
+            startTransition(() => setCurrentTransactionID(nextTransaction.transactionID));
         }
     };
 
     const showPreviousTransaction = () => {
         const previousTransaction = transactions.at(currentTransactionIndex - 1);
         if (previousTransaction) {
-            setCurrentTransactionID(previousTransaction.transactionID);
+            startTransition(() => setCurrentTransactionID(previousTransaction.transactionID));
         }
     };
 

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -1401,4 +1401,74 @@ describe('IOURequestStepConfirmationPageTest', () => {
             expect(params?.personalDetails).toBeDefined();
         });
     });
+
+    describe('Transaction navigation (prev/next)', () => {
+        beforeEach(async () => {
+            await signInWithTestUser(ACCOUNT_ID, ACCOUNT_LOGIN);
+        });
+
+        it('switches the displayed transaction when pressing the Next and Previous buttons', async () => {
+            // Given two scanned draft transactions, so the confirmation renders in its multi-transaction mode
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}1`, {
+                    ...DEFAULT_SPLIT_TRANSACTION,
+                    transactionID: '1',
+                    iouRequestType: 'scan',
+                    receipt: {filename: 'receipt1.jpg', source: 'path/to/receipt1.jpg', type: ''},
+                });
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}2`, {
+                    ...DEFAULT_SPLIT_TRANSACTION,
+                    transactionID: '2',
+                    iouRequestType: 'scan',
+                    receipt: {filename: 'receipt2.jpg', source: 'path/to/receipt2.jpg', type: ''},
+                });
+            });
+
+            render(
+                <OnyxListItemProvider>
+                    <HTMLProviderWrapper>
+                        <CurrentUserPersonalDetailsProvider>
+                            <LocaleContextProvider>
+                                <IOURequestStepConfirmationWithWritableReportOrNotFound
+                                    route={{
+                                        key: 'Money_Request_Step_Confirmation--30aPPAdjWan56sE5OpcG',
+                                        name: 'Money_Request_Step_Confirmation',
+                                        params: {
+                                            action: 'create',
+                                            iouType: 'split',
+                                            transactionID: TRANSACTION_ID,
+                                            reportID: REPORT_ID,
+                                        },
+                                    }}
+                                    // @ts-expect-error we don't need navigation param here.
+                                    navigation={undefined}
+                                />
+                            </LocaleContextProvider>
+                        </CurrentUserPersonalDetailsProvider>
+                    </HTMLProviderWrapper>
+                </OnyxListItemProvider>,
+            );
+
+            await waitForBatchedUpdatesWithAct();
+
+            const of = translateLocal('common.of');
+
+            // The confirmation starts on the first of the two transactions
+            expect(await screen.findByText(`1 ${of} 2`)).toBeOnTheScreen();
+
+            // When pressing the Next button (the second of the two prev/next nav buttons)
+            const navButtons = screen.getAllByRole(CONST.ROLE.BUTTON, {name: CONST.ROLE.BUTTON});
+            expect(navButtons).toHaveLength(2);
+            const [, nextButton] = navButtons;
+            fireEvent.press(nextButton);
+
+            // Then the second transaction is displayed (setCurrentTransactionID committed inside startTransition)
+            expect(await screen.findByText(`2 ${of} 2`)).toBeOnTheScreen();
+
+            // And pressing the Previous button returns to the first transaction
+            const [prevButton] = screen.getAllByRole(CONST.ROLE.BUTTON, {name: CONST.ROLE.BUTTON});
+            fireEvent.press(prevButton);
+            expect(await screen.findByText(`1 ${of} 2`)).toBeOnTheScreen();
+        });
+    });
 });


### PR DESCRIPTION
### Explanation of Change

Improves the INP of the `PrevNextButtons-NextButton` interaction by taking two costs off the press frame at all three call sites that feed this Sentry label:

**1. Transaction-thread carousel (`MoneyRequestReportTransactionsNavigation`)** — the main contributor. Previously, `onNext`/`onPrevious` ran the optimistic-thread prep (`markReportIDAsExpense`, `setOptimisticTransactionThread`, `createTransactionThreadReport` → `openReport`) synchronously on the press frame, and the existing `requestAnimationFrame` around `Navigation.setParams` fired _before_ the next paint, so both the prep long task and the urgent destination re-render still landed inside the interaction's measurement window. Now:

- The prep is deferred to the frame after the press, so the button paints its pressed state immediately.
- `Navigation.setParams` runs one frame later (preserving the documented Onyx-flush ordering guard) wrapped in `startTransition`, so React paints first and commits the heavy destination tree (header, expense details, report-actions list) as a non-urgent transition.
- The snapshot-descriptor fast paths get the same treatment.

**2. Search-report carousel (`MoneyRequestReportNavigation`)** — the report swap in `goToReportId` is now committed inside `startTransition`, and the pagination `search()` call (which builds optimistic snapshot data synchronously) is deferred off the press frame.

**3. IOU confirmation transaction switcher (`IOURequestStepConfirmation`)** — `setCurrentTransactionID` is wrapped in `startTransition` so the whole confirmation list re-render no longer blocks the interaction's paint.

No behavior changes: the same work runs in the same order, only its scheduling relative to the interaction's paint changes.

### Metrics improvement

Interaction: `PrevNextButtons-NextButton` (`data-sentry-label`).

Captured on a **production (staging) web build** with the React Profiler — 11 samples before and 11 after, cold forward navigation through a 12-expense report (the `Next` button):

|                 | Average total duration |
| --------------- | ---------------------- |
| Before (main)   | **36.50 ms**           |
| After (this PR) | **5.32 ms**            |
| Diff            | **-31.18 ms (-85.4%)** |

At the commit level, the interaction drops from ~7 commits to 1 per navigation. In the baseline the heaviest commits re-render the full destination tree (~1,700 fibers each); after the change only ~174 fibers commit inside the interaction window.

The optimistic-thread prep and the destination re-render are moved off the press frame (`requestAnimationFrame` + `startTransition`), so the heavy destination commit no longer lands inside the interaction's paint window. Navigation still completes a frame later with the current expense kept on screen, so there is no visual regression, and First Paint on first open is unaffected since only the navigation work is deferred.

<img width="1347" height="756" alt="React Profiler comparator" src="https://github.com/user-attachments/assets/2711839b-5a31-4225-b4df-3e014d866c9f" />
<img width="1902" height="347" alt="React Profiler comparator summary" src="https://github.com/user-attachments/assets/a98c7b6d-ffbc-49f5-ae39-0f9515ea9f18" />

### Fixed Issues

$ https://github.com/Expensify/App/issues/94721
PROPOSAL: https://github.com/Expensify/App/issues/94721#issuecomment-4811826025

### Tests

**Transaction-thread carousel:**

1. Create a workspace and submit 3+ expenses to the same report.
2. Open the expense report and click one expense to open its transaction thread in the RHP.
3. Click the Next (>) arrow in the RHP header — verify the button shows pressed feedback immediately and the next expense's details load correctly (header, amount, description, report actions).
4. Keep clicking Next through all siblings, then Previous (<) back — verify every sibling renders correctly and no thread is skipped or duplicated.
5. Repeat from Home > "Recently added" expense (snapshot-backed flow) — verify next/previous still resolve and open the correct sibling threads.

**Search-report carousel:** 6. Go to Reports > Expense reports (with more than one report), open a report. 7. Use the next/previous arrows in the header — verify navigation between reports works and the `x of y` counter stays correct. 8. With more results than one page, navigate near the end of the loaded list — verify the next page is fetched and navigation continues.

**IOU confirmation:** 9. Start a scan expense and upload multiple receipts to reach the multi-transaction confirmation step. 10. Use the next/previous arrows — verify the displayed transaction swaps correctly (receipt, amount, fields).

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open an expense report with 3+ expenses, open one expense's thread, and click Next through siblings whose threads don't exist yet — verify the optimistic transaction thread is created and displayed correctly.
3. Verify next/previous navigation still works across all three flows above while offline.

### QA Steps

[No QA] — performance-only change with no user-facing behavior change. The interaction produces the same result in the same order; only the scheduling relative to paint changes, verified by the before/after React Profiler metrics above and the Tests section.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f238fbca-0d88-462b-863f-a82c564fb5ff

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/515847f3-f1b5-46ae-a972-54f6d6897a8d

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/7f7f2595-6678-4fe9-a6a8-84c0a3434e18

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/2e863398-9478-45b9-853b-fde55d870cad

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/e7e1851f-b643-4432-be0c-f6329be2a913

https://github.com/user-attachments/assets/dce02779-51eb-4ab1-b644-3f13a9ed8118

</details>
