### PR TITLE
fix: cap tab navigation span duration to drop idle-inflated telemetry

### DIFF
--- a/src/libs/telemetry/middlewares/maxDurationFilter.ts
+++ b/src/libs/telemetry/middlewares/maxDurationFilter.ts
@@ -1,25 +1,38 @@
+import {TAB_NAVIGATION_SPAN_IDS} from '@libs/telemetry/cancelTabNavigationSpans';
+
 import CONST from '@src/CONST';
 
 import type {TelemetryBeforeSend} from './index';
 
 const MAX_SPAN_DURATION_MS = 60_000;
 
+// Ops whose spans measure a user-visible flow that completes within seconds (tab-navigation p99 is ~1.5s).
+// Span duration is wall-clock, so a machine sleep, frozen browser tab, or suspended mobile app between the
+// span start and the end signal inflates it to minutes or hours. Such durations measure the idle gap rather
+// than the flow, so drop them instead of skewing the metric's tail.
+const MAX_DURATION_OPS: ReadonlySet<string> = new Set([CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE, ...TAB_NAVIGATION_SPAN_IDS]);
+
+function isOverMaxDuration(startTimestamp: number | undefined, endTimestamp: number | undefined): boolean {
+    if (!startTimestamp || !endTimestamp) {
+        return false;
+    }
+    return (endTimestamp - startTimestamp) * 1000 > MAX_SPAN_DURATION_MS;
+}
+
 const maxDurationFilter: TelemetryBeforeSend = (event) => {
     const op = event.contexts?.trace?.op;
-    if (op !== CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE) {
-        return event;
-    }
-
-    if (!event.timestamp || !event.start_timestamp) {
-        return event;
-    }
-
-    const durationMs = (event.timestamp - event.start_timestamp) * 1000;
-    if (durationMs > MAX_SPAN_DURATION_MS) {
+    if (op && MAX_DURATION_OPS.has(op) && isOverMaxDuration(event.start_timestamp, event.timestamp)) {
         return null;
     }
 
-    return event;
+    // These spans are usually root transactions, but without forceTransaction they can be adopted
+    // as child spans of an active transaction, so filter those the same way (mirrors minDurationFilter).
+    if (!event.spans) {
+        return event;
+    }
+    const spans = event.spans.filter((span) => !(span.op && MAX_DURATION_OPS.has(span.op) && isOverMaxDuration(span.start_timestamp, span.timestamp)));
+
+    return {...event, spans};
 };
 
 export default maxDurationFilter;

--- a/tests/unit/maxDurationFilterTest.ts
+++ b/tests/unit/maxDurationFilterTest.ts
@@ -1,0 +1,76 @@
+import maxDurationFilter from '@libs/telemetry/middlewares/maxDurationFilter';
+
+import CONST from '@src/CONST';
+
+import type {TransactionEvent} from '@sentry/core';
+
+jest.mock('@libs/telemetry/activeSpans', () => ({
+    cancelSpan: jest.fn(),
+}));
+
+const INBOX_OP = CONST.TELEMETRY.SPAN_NAVIGATE_TO_INBOX_TAB;
+const REPORTS_OP = CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS;
+const SUBMIT_OP = CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE;
+
+const OVER_CAP_SECONDS = 61;
+const UNDER_CAP_SECONDS = 59;
+
+type ChildSpan = NonNullable<TransactionEvent['spans']>[number];
+
+function buildTransaction(op: string, durationSeconds: number, spans?: ChildSpan[]): TransactionEvent {
+    return {
+        type: 'transaction',
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- Sentry protocol field names
+        contexts: {trace: {span_id: 'a', trace_id: 'b', op}},
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- Sentry protocol field names
+        start_timestamp: 1000,
+        timestamp: 1000 + durationSeconds,
+        spans,
+    };
+}
+
+function buildChildSpan(op: string, durationSeconds: number): ChildSpan {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Sentry protocol field names
+    return {span_id: 'c', trace_id: 'b', start_timestamp: 1000, timestamp: 1000 + durationSeconds, data: {}, op};
+}
+
+describe('maxDurationFilter', () => {
+    it('drops an inbox tab navigation transaction over the duration cap', async () => {
+        expect(await maxDurationFilter(buildTransaction(INBOX_OP, OVER_CAP_SECONDS), {})).toBeNull();
+    });
+
+    it('drops a reports tab navigation transaction over the duration cap', async () => {
+        expect(await maxDurationFilter(buildTransaction(REPORTS_OP, OVER_CAP_SECONDS), {})).toBeNull();
+    });
+
+    it('drops a submit expense transaction over the duration cap', async () => {
+        expect(await maxDurationFilter(buildTransaction(SUBMIT_OP, OVER_CAP_SECONDS), {})).toBeNull();
+    });
+
+    it('keeps a tab navigation transaction under the duration cap', async () => {
+        const event = buildTransaction(INBOX_OP, UNDER_CAP_SECONDS);
+        expect(await maxDurationFilter(event, {})).toBe(event);
+    });
+
+    it('keeps a transaction with an unrelated op over the duration cap', async () => {
+        const event = buildTransaction('ManualAppStartup', OVER_CAP_SECONDS);
+        const result = await maxDurationFilter(event, {});
+        expect(result).not.toBeNull();
+    });
+
+    it('keeps a transaction without timestamps', async () => {
+        const event: TransactionEvent = {
+            type: 'transaction',
+            // eslint-disable-next-line @typescript-eslint/naming-convention -- Sentry protocol field names
+            contexts: {trace: {span_id: 'a', trace_id: 'b', op: INBOX_OP}},
+        };
+        expect(await maxDurationFilter(event, {})).toBe(event);
+    });
+
+    it('strips over-cap tab navigation child spans but keeps the rest', async () => {
+        const event = buildTransaction('pageload', UNDER_CAP_SECONDS, [buildChildSpan(INBOX_OP, OVER_CAP_SECONDS), buildChildSpan('http.client', OVER_CAP_SECONDS)]);
+        const result = await maxDurationFilter(event, {});
+        expect(result?.spans).toHaveLength(1);
+        expect(result?.spans?.at(0)?.op).toBe('http.client');
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The five slowest `ManualNavigateToInboxTab` spans in production over the last 14 days are 2.0h, 50.7min, 45.1min, 32.6min and 18.1min (releases 9.4.21-9 through 9.4.28-2, across Windows, macOS and iOS). None of them measure a navigation: their traces show zero JS, network or interaction activity for the entire span window, and each span ends at the moment the client resumes. The clearest example is an 18-minute span whose end shares a timestamp with an 89ms `ManualOpenReport` span, so the client and API were fast the moment the user actually interacted. In the last 14 days, 188 production `ManualNavigateToInboxTab` spans exceeded 60s while the real p99 is ~1.5s.

Span durations are wall-clock. A machine sleep, frozen browser tab, or suspended mobile app between the tab click (span start in `InboxTabButton`) and the end signal (`useInboxTabSpanLifecycle` onLayout/focus, or a cancel) inflates the duration to the length of the idle gap. #95480 already drops the spans that exit through `cancelSpan` (`canceled: true`), but a stale span that ends through the regular `endSpan` path after the app wakes up (sidebar layout or focus firing on resume) is not canceled and still ships with the idle gap as its duration.

The fix extends `maxDurationFilter`, which previously only applied to `SubmitToDestinationVisible` with a 60s cap, to also cover the tab-navigation ops (`TAB_NAVIGATION_SPAN_IDS`). It now filters both root transactions and adopted child spans, mirroring the structure of `canceledTabNavigationFilter`. The 60s cap is 40x the tab-navigation p99, so no legitimate navigation measurement is dropped. This is a telemetry send-time filter only, with no change to app behavior.

Note for metric consumers: `ManualNavigateToInboxTab` and `ManualNavigateToReports*` max/p99.9 will drop definitionally once this deploys, because multi-minute idle artifacts stop shipping.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ 
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Run `npx jest tests/unit/maxDurationFilterTest.ts` and verify all tests pass. The over-cap paths (root transaction and child span) can only be produced synthetically, so they are covered there.
2. Open the web app with the DevTools console and Network tab open.
3. Navigate to the Reports tab, then click the Inbox tab. Verify a console line `[Sentry][ManualNavigateToInboxTab] Ending span` appears and the `ManualNavigateToInboxTab` transaction is still present in the Sentry envelope requests (normal sub-cap spans are unaffected).
4. Click the Reports tab and verify the `ManualNavigateToReports*` spans are likewise still sent.
5. Verify Inbox and Reports tab navigation still works normally on narrow and wide layouts.

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
