### PR TITLE
Fix ReplaceReceipt Failed-to-fetch loop / InvalidBlob storm: strip inline files from persisted queue + guard send path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -254,6 +254,7 @@
         "eslint-plugin-testing-library": "^7.11.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.14.0",
         "eslint-seatbelt": "^0.1.3",
+        "fake-indexeddb": "^6.2.5",
         "glob": "^10.4.5",
         "googleapis": "^152.0.0",
         "html-webpack-plugin": "^5.5.0",
@@ -26266,6 +26267,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-base64-decode": {

--- a/package.json
+++ b/package.json
@@ -328,6 +328,7 @@
     "eslint-plugin-testing-library": "^7.11.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.14.0",
     "eslint-seatbelt": "^0.1.3",
+    "fake-indexeddb": "^6.2.5",
     "glob": "^10.4.5",
     "googleapis": "^152.0.0",
     "html-webpack-plugin": "^5.5.0",

--- a/src/libs/QueuedFileStorage/index.native.ts
+++ b/src/libs/QueuedFileStorage/index.native.ts
@@ -1,0 +1,19 @@
+import type {DeleteFiles, GetFile, KeepOnly, QueuedFileRef, StoreFile} from './types';
+
+import {isQueuedFileRef} from './types';
+
+/**
+ * Native receipts are plain {uri, ...} descriptors persisted directly in the queue, never
+ * File/Blob instances — so there is nothing to store separately. These stubs keep the API
+ * shape identical to web; storeFile rejects because it should never be reached on native.
+ */
+const storeFile: StoreFile = () => Promise.reject(new Error('[QueuedFileStorage] storeFile is not supported on native'));
+
+const getFile: GetFile = () => Promise.resolve(undefined);
+
+const deleteFiles: DeleteFiles = () => Promise.resolve();
+
+const keepOnly: KeepOnly = () => Promise.resolve();
+
+export {storeFile, getFile, deleteFiles, keepOnly, isQueuedFileRef};
+export type {QueuedFileRef};

--- a/src/libs/QueuedFileStorage/index.ts
+++ b/src/libs/QueuedFileStorage/index.ts
@@ -1,0 +1,94 @@
+import type {DeleteFiles, GetFile, KeepOnly, QueuedFileRef, StoreFile} from './types';
+
+import {isQueuedFileRef} from './types';
+
+const DB_NAME = 'OnyxQueuedFiles';
+const STORE_NAME = 'files';
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBDatabase> | undefined;
+let keyCounter = 0;
+
+function promisifyRequest<T>(request: IDBRequest<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+function openDB(): Promise<IDBDatabase> {
+    if (dbPromise) {
+        return dbPromise;
+    }
+    dbPromise = new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, DB_VERSION);
+        request.onupgradeneeded = () => {
+            if (request.result.objectStoreNames.contains(STORE_NAME)) {
+                return;
+            }
+            request.result.createObjectStore(STORE_NAME);
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+    return dbPromise;
+}
+
+function generateKey(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    keyCounter += 1;
+    return `qf-${keyCounter}-${Date.now()}`;
+}
+
+const storeFile: StoreFile = async (blob) => {
+    const db = await openDB();
+    const key = generateKey();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(blob, key);
+    await new Promise<void>((resolve, reject) => {
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error);
+    });
+    return key;
+};
+
+const getFile: GetFile = async (key) => {
+    const db = await openDB();
+    const request = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).get(key);
+    return new Promise<unknown>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+};
+
+const deleteFiles: DeleteFiles = async (keys) => {
+    if (keys.length === 0) {
+        return;
+    }
+    const db = await openDB();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    for (const key of keys) {
+        store.delete(key);
+    }
+    await new Promise<void>((resolve, reject) => {
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error);
+    });
+};
+
+const keepOnly: KeepOnly = async (keysToKeep) => {
+    const db = await openDB();
+    const readTx = db.transaction(STORE_NAME, 'readonly');
+    const allKeys = await promisifyRequest<IDBValidKey[]>(readTx.objectStore(STORE_NAME).getAllKeys());
+    const keep = new Set(keysToKeep);
+    const toDelete = allKeys.filter((k): k is string => typeof k === 'string' && !keep.has(k));
+    await deleteFiles(toDelete);
+};
+
+export {storeFile, getFile, deleteFiles, keepOnly, isQueuedFileRef};
+export type {QueuedFileRef};

--- a/src/libs/QueuedFileStorage/types.ts
+++ b/src/libs/QueuedFileStorage/types.ts
@@ -1,0 +1,19 @@
+/**
+ * A small serializable reference that stands in for a File/Blob inside a queued request.
+ * The bytes live in a separate file store (see storeFile); this ref points at them.
+ */
+type QueuedFileRef = {queuedFileKey: string; name?: string; type?: string};
+
+/** Narrow an unknown value to a QueuedFileRef (truthy object carrying a string key). */
+function isQueuedFileRef(value: unknown): value is QueuedFileRef {
+    return typeof value === 'object' && value !== null && 'queuedFileKey' in value && typeof value.queuedFileKey === 'string';
+}
+
+type StoreFile = (blob: Blob) => Promise<string>;
+// Returns the stored value (a Blob in the browser); typed as unknown because IndexedDB reads are untyped.
+type GetFile = (key: string) => Promise<unknown>;
+type DeleteFiles = (keys: string[]) => Promise<void>;
+type KeepOnly = (keysToKeep: string[]) => Promise<void>;
+
+export {isQueuedFileRef};
+export type {QueuedFileRef, StoreFile, GetFile, DeleteFiles, KeepOnly};

--- a/src/libs/actions/PersistedRequests.ts
+++ b/src/libs/actions/PersistedRequests.ts
@@ -85,7 +85,7 @@ Onyx.connectWithoutView({
                     }
                 }
                 persistedRequests = [...persistedRequests, ...newFromOtherTabs];
-                trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, persistedRequests));
+                persistQueue(persistedRequests);
                 crossTabRequestsCallback?.();
                 return;
             }
@@ -150,7 +150,7 @@ Onyx.connectWithoutView({
             }
             const requests = [...persistedRequests, ...pendingSaveOperations];
             persistedRequests = requests;
-            trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, requests));
+            persistQueue(requests);
             pendingSaveOperations = [];
         }
 
@@ -256,7 +256,7 @@ function save<TKey extends OnyxKey>(requestToPersist: Request<TKey>): Promise<vo
         newQueueLength: requests.length,
     });
 
-    return trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, requests as AnyRequest[]))
+    return persistQueue(requests as AnyRequest[])
         .then(() => {
             Log.info('[PersistedRequests] Request successfully persisted to disk', false, {
                 command: requestToPersist.command,
@@ -320,7 +320,7 @@ function endRequestAndRemoveFromQueue<TKey extends OnyxKey>(requestToRemove: Req
 
     trackOnyxWrite(
         Onyx.multiSet({
-            [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
+            [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
             [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: null,
         }),
     ).then(() => {
@@ -339,7 +339,7 @@ function deleteRequestsByIndices(indices: number[]): Promise<void> {
     persistedRequests = persistedRequests.filter((_, index) => !indicesSet.has(index));
 
     // Update the persisted requests in storage or state as necessary
-    return trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, persistedRequests))
+    return persistQueue(persistedRequests)
         .then(() => {
             Log.info(`Multiple (${indices.length}) requests removed from the queue. Queue length is ${persistedRequests.length}`);
         })
@@ -363,7 +363,7 @@ function update<TKey extends OnyxKey>(oldRequestIndex: number, newRequest: Reque
     if (requestIndex != null) {
         knownRequestIDs.add(requestIndex);
     }
-    return trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, requests)).catch((error) => {
+    return persistQueue(requests).catch((error) => {
         // Swallow so the conflict promise resolves (in-memory queue is the source of truth); alert as a storage emergency.
         Log.alert('[PersistedRequests] ERROR: Failed to persist updated request to disk', {
             command: newRequest.command,
@@ -373,16 +373,49 @@ function update<TKey extends OnyxKey>(oldRequestIndex: number, newRequest: Reque
     });
 }
 
-function shouldPersistOngoingRequest(request: AnyRequest | null): boolean {
-    if (!request?.data) {
-        return true;
+function dataContainsFileOrBlob(data: Record<string, unknown> | undefined): boolean {
+    if (!data) {
+        return false;
     }
+    return Object.values(data).some((value) => (typeof File !== 'undefined' && value instanceof File) || (typeof Blob !== 'undefined' && value instanceof Blob));
+}
 
-    return !Object.values(request.data).some((value) => {
-        const isFile = typeof File !== 'undefined' && value instanceof File;
-        const isBlob = typeof Blob !== 'undefined' && value instanceof Blob;
-        return isFile || isBlob;
+/**
+ * Files/Blobs in request data (e.g. `data.receipt` on ReplaceReceipt) get persisted INLINE in the
+ * single networkRequestQueue value. At scale that one record exceeds IndexedDB's blob path and the
+ * whole write fails (`Failed to write blobs (InvalidBlob)`), which deadlocks the queue. Keep files
+ * in the in-memory queue so live uploads still work, but strip them from what we persist so the
+ * record stays small. A request rehydrated without its file is skipped at send time (see
+ * prepareRequestPayload). Also logs how often we strip — telemetry to size the impact in prod.
+ */
+function stripFilesForDisk(requests: AnyRequest[]): AnyRequest[] {
+    let strippedCount = 0;
+    const result = requests.map((request) => {
+        if (!dataContainsFileOrBlob(request.data)) {
+            return request;
+        }
+        strippedCount++;
+        const data: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(request.data ?? {})) {
+            if ((typeof File !== 'undefined' && value instanceof File) || (typeof Blob !== 'undefined' && value instanceof Blob)) {
+                continue;
+            }
+            data[key] = value;
+        }
+        return {...request, data} as AnyRequest;
     });
+    if (strippedCount > 0) {
+        Log.info('[PersistedRequests] Stripped inline file(s) from persisted queue to keep the record writable', false, {strippedCount, queueLength: requests.length});
+    }
+    return result;
+}
+
+function persistQueue(requests: AnyRequest[]): Promise<void> {
+    return trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, stripFilesForDisk(requests)));
+}
+
+function shouldPersistOngoingRequest(request: AnyRequest | null): boolean {
+    return !dataContainsFileOrBlob(request?.data);
 }
 
 function updateOngoingRequest<TKey extends OnyxKey>(newRequest: Request<TKey>) {
@@ -454,14 +487,14 @@ function processNextRequest(): AnyRequest | null {
     if (shouldPersistOngoingRequest(ongoingRequest)) {
         trackOnyxWrite(
             Onyx.multiSet({
-                [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
+                [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
                 [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: ongoingRequest,
             }),
         );
     } else {
         trackOnyxWrite(
             Onyx.multiSet({
-                [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
+                [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
                 [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: null,
             }),
         ).finally(() => {
@@ -511,7 +544,7 @@ function rollbackOngoingRequest() {
     // the rolled-back request or leave a stale ongoingRequest on disk.
     trackOnyxWrite(
         Onyx.multiSet({
-            [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
+            [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
             [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: null,
         }),
     );

--- a/src/libs/actions/PersistedRequests.ts
+++ b/src/libs/actions/PersistedRequests.ts
@@ -1,4 +1,6 @@
 import Log from '@libs/Log';
+import {deleteFiles, isQueuedFileRef, keepOnly, storeFile} from '@libs/QueuedFileStorage';
+import type {QueuedFileRef} from '@libs/QueuedFileStorage';
 import sanitizeLogParams from '@libs/sanitizeLogParams';
 
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -175,6 +177,11 @@ Onyx.connectWithoutView({
             Log.info('[PersistedRequests] Triggering initialization callback', false);
             triggerInitializationCallback();
         }
+        if (!isInitialized) {
+            // First disk load only: delete stored files whose owning request is gone
+            // (e.g. crashed after storeFile but before the queue was persisted).
+            keepOnly(collectFileKeys(persistedRequests));
+        }
         isInitialized = true;
     },
 });
@@ -216,6 +223,8 @@ function clear() {
     pendingSaveOperations = [];
     knownRequestIDs.clear();
     knownOngoingRequestIDs.clear();
+    // Delete every stored file since the queue is being emptied (fire-and-forget).
+    keepOnly([]);
     Onyx.set(ONYXKEYS.PERSISTED_ONGOING_REQUESTS, null);
     return trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, []));
 }
@@ -225,9 +234,13 @@ function getLength(): number {
     return persistedRequests.length + (ongoingRequest ? 1 : 0);
 }
 
-function save<TKey extends OnyxKey>(requestToPersist: Request<TKey>): Promise<void> {
+async function save<TKey extends OnyxKey>(requestToPersist: Request<TKey>): Promise<void> {
+    // Move any inline File/Blob to the separate file store first, then keep only a key in the
+    // queue. Only file requests await.
+    const request = dataContainsFileOrBlob(requestToPersist.data) ? await storeFilesAndSwap(requestToPersist) : requestToPersist;
+
     Log.info('[PersistedRequests] Saving request to queue started', false, {
-        command: requestToPersist.command,
+        command: request.command,
         currentQueueLength: persistedRequests.length,
         ongoingRequest: ongoingRequest?.command ?? 'null',
         isInitialized,
@@ -237,21 +250,21 @@ function save<TKey extends OnyxKey>(requestToPersist: Request<TKey>): Promise<vo
         Log.info('[PersistedRequests] Queueing request until initialization completes', false, {
             pendingSaveOperationsLength: pendingSaveOperations.length,
         });
-        pendingSaveOperations.push(requestToPersist as AnyRequest);
-        return Promise.resolve();
+        pendingSaveOperations.push(request as AnyRequest);
+        return;
     }
 
     // If the command is not in the keepLastInstance array, add the new request as usual
-    const requests = [...persistedRequests, requestToPersist];
+    const requests = [...persistedRequests, request];
     const previousLength = persistedRequests.length;
     persistedRequests = requests as AnyRequest[];
-    const requestIndex = getClientRequestIndex(requestToPersist as AnyRequest);
+    const requestIndex = getClientRequestIndex(request as AnyRequest);
     if (requestIndex != null) {
         knownRequestIDs.add(requestIndex);
     }
 
     Log.info('[PersistedRequests] Request added to memory, persisting to disk', false, {
-        command: requestToPersist.command,
+        command: request.command,
         previousQueueLength: previousLength,
         newQueueLength: requests.length,
     });
@@ -259,14 +272,14 @@ function save<TKey extends OnyxKey>(requestToPersist: Request<TKey>): Promise<vo
     return persistQueue(requests as AnyRequest[])
         .then(() => {
             Log.info('[PersistedRequests] Request successfully persisted to disk', false, {
-                command: requestToPersist.command,
+                command: request.command,
                 queueLength: getLength(),
             });
         })
         .catch((error) => {
             // Disk-write failure risks losing this request on a crash — alert as a storage emergency.
             Log.alert('[PersistedRequests] ERROR: Failed to persist request to disk', {
-                command: requestToPersist.command,
+                command: request.command,
                 queueLength: getLength(),
                 error,
             });
@@ -301,7 +314,9 @@ function endRequestAndRemoveFromQueue<TKey extends OnyxKey>(requestToRemove: Req
     });
 
     if (index !== -1) {
-        requests.splice(index, 1);
+        const [removedRequest] = requests.splice(index, 1);
+        // Delete the stored file for the request we just removed (fire-and-forget).
+        deleteFiles(collectFileKeys([removedRequest]));
         Log.info('[PersistedRequests] Removed request from queue', false, {
             command: requestToRemove.command,
             removedAtIndex: index,
@@ -320,7 +335,7 @@ function endRequestAndRemoveFromQueue<TKey extends OnyxKey>(requestToRemove: Req
 
     trackOnyxWrite(
         Onyx.multiSet({
-            [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
+            [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
             [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: null,
         }),
     ).then(() => {
@@ -334,6 +349,10 @@ function endRequestAndRemoveFromQueue<TKey extends OnyxKey>(requestToRemove: Req
 function deleteRequestsByIndices(indices: number[]): Promise<void> {
     // Create a Set from the indices array for efficient lookup
     const indicesSet = new Set(indices);
+
+    // Delete the stored files for the requests we are about to remove (fire-and-forget).
+    const removedRequests = persistedRequests.filter((_, index) => indicesSet.has(index));
+    deleteFiles(collectFileKeys(removedRequests));
 
     // Create a new array excluding elements at the specified indices
     persistedRequests = persistedRequests.filter((_, index) => !indicesSet.has(index));
@@ -373,47 +392,62 @@ function update<TKey extends OnyxKey>(oldRequestIndex: number, newRequest: Reque
     });
 }
 
+function isFileOrBlob(value: unknown): value is File | Blob {
+    return (typeof File !== 'undefined' && value instanceof File) || (typeof Blob !== 'undefined' && value instanceof Blob);
+}
+
 function dataContainsFileOrBlob(data: Record<string, unknown> | undefined): boolean {
     if (!data) {
         return false;
     }
-    return Object.values(data).some((value) => (typeof File !== 'undefined' && value instanceof File) || (typeof Blob !== 'undefined' && value instanceof Blob));
+    return Object.values(data).some(isFileOrBlob);
 }
 
 /**
- * Files/Blobs in request data (e.g. `data.receipt` on ReplaceReceipt) get persisted INLINE in the
- * single networkRequestQueue value. At scale that one record exceeds IndexedDB's blob path and the
- * whole write fails (`Failed to write blobs (InvalidBlob)`), which deadlocks the queue. Keep files
- * in the in-memory queue so live uploads still work, but strip them from what we persist so the
- * record stays small. A request rehydrated without its file is skipped at send time (see
- * prepareRequestPayload). Also logs how often we strip — telemetry to size the impact in prod.
+ * Inline File/Blob values used to bloat the single networkRequestQueue record until its IndexedDB
+ * write failed (`Failed to write blobs`) and deadlocked the queue. Instead we save each file to a
+ * separate store and keep only a small QueuedFileRef here, so the record stays tiny and the file
+ * still survives a restart. Logs a count as prod telemetry.
  */
-function stripFilesForDisk(requests: AnyRequest[]): AnyRequest[] {
-    let strippedCount = 0;
-    const result = requests.map((request) => {
-        if (!dataContainsFileOrBlob(request.data)) {
-            return request;
-        }
-        strippedCount++;
-        const data: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(request.data ?? {})) {
-            if ((typeof File !== 'undefined' && value instanceof File) || (typeof Blob !== 'undefined' && value instanceof Blob)) {
-                continue;
-            }
-            data[key] = value;
-        }
-        return {...request, data} as AnyRequest;
-    });
-    if (strippedCount > 0) {
-        Log.info('[PersistedRequests] Stripped inline file(s) from persisted queue to keep the record writable', false, {strippedCount, queueLength: requests.length});
+async function storeFilesAndSwap<TKey extends OnyxKey>(request: Request<TKey>): Promise<Request<TKey>> {
+    if (!dataContainsFileOrBlob(request.data)) {
+        return request;
     }
-    return result;
+    const entries = Object.entries(request.data ?? {});
+    // Save every file in parallel, then rebuild the data with a key in place of each file.
+    const swapped = await Promise.all(
+        entries.map(async ([key, value]): Promise<[string, unknown]> => {
+            if (!isFileOrBlob(value)) {
+                return [key, value];
+            }
+            const ref: QueuedFileRef = {queuedFileKey: await storeFile(value), name: value instanceof File ? value.name : undefined, type: value.type};
+            return [key, ref];
+        }),
+    );
+    const storedCount = entries.filter(([, value]) => isFileOrBlob(value)).length;
+    Log.info('[PersistedRequests] Saved inline file(s) to the separate file store', false, {storedCount, queueLength: persistedRequests.length});
+    return {...request, data: Object.fromEntries(swapped)} as Request<TKey>;
+}
+
+/** Collect every stored-file key referenced by the given requests' data. */
+function collectFileKeys(requests: AnyRequest[]): string[] {
+    const keys: string[] = [];
+    for (const request of requests) {
+        for (const value of Object.values(request.data ?? {})) {
+            if (isQueuedFileRef(value)) {
+                keys.push(value.queuedFileKey);
+            }
+        }
+    }
+    return keys;
 }
 
 function persistQueue(requests: AnyRequest[]): Promise<void> {
-    return trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, stripFilesForDisk(requests)));
+    return trackOnyxWrite(Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, requests));
 }
 
+// Requests now only ever hold serializable file references, so the ongoing request is always
+// safe to persist to disk (and doing so keeps it crash-safe across a restart).
 function shouldPersistOngoingRequest(request: AnyRequest | null): boolean {
     return !dataContainsFileOrBlob(request?.data);
 }
@@ -480,21 +514,19 @@ function processNextRequest(): AnyRequest | null {
     // Persist both the updated queue and the ongoing request to disk atomically.
     // This ensures that if the app crashes mid-flight, the ongoing request is not
     // lost (Bug #80759 Issue 3a) and the queue on disk matches memory (Issue 3c).
-    // Skip persisting ongoingRequest when it contains non-serializable values
-    // (e.g. File objects in data.file or data.receipt). IndexedDB cannot clone
-    // native File objects (DataCloneError). These requests cannot survive a crash
-    // anyway since File references are lost on restart.
+    // Requests hold only serializable file references now, so the defensive skip
+    // below only trips for a raw File that never went through save().
     if (shouldPersistOngoingRequest(ongoingRequest)) {
         trackOnyxWrite(
             Onyx.multiSet({
-                [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
+                [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
                 [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: ongoingRequest,
             }),
         );
     } else {
         trackOnyxWrite(
             Onyx.multiSet({
-                [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
+                [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
                 [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: null,
             }),
         ).finally(() => {
@@ -544,7 +576,7 @@ function rollbackOngoingRequest() {
     // the rolled-back request or leave a stale ongoingRequest on disk.
     trackOnyxWrite(
         Onyx.multiSet({
-            [ONYXKEYS.PERSISTED_REQUESTS]: stripFilesForDisk(persistedRequests),
+            [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
             [ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: null,
         }),
     );

--- a/src/libs/prepareRequestPayload/index.ts
+++ b/src/libs/prepareRequestPayload/index.ts
@@ -1,11 +1,39 @@
+import Log from '@libs/Log';
 import validateFormDataParameter from '@libs/validateFormDataParameter';
 
 import type PrepareRequestPayload from './types';
 
+// Parameter keys that carry an uploaded file (receipt image, avatar, document, …).
+const FILE_UPLOAD_KEYS = new Set(['receipt', 'file']);
+
+/**
+ * A file-upload request can lose a usable file body after it has been persisted to the
+ * offline queue and rehydrated (the File/Blob is gone, or its backing store is unreadable).
+ * Sending it anyway fails with `TypeError: Failed to fetch`, the request never reaches the
+ * server, and it retries forever — ballooning the persisted queue until the storage write
+ * itself fails. The native builder already guards this (checkFileExists / readFileAsync);
+ * this mirrors that on web so the request still reaches the server for a definitive outcome
+ * instead of looping.
+ */
+async function isUsableFileValue(value: unknown): Promise<boolean> {
+    // File extends Blob, so this narrows both File and Blob uploads.
+    if (typeof Blob === 'undefined' || !(value instanceof Blob) || value.size === 0) {
+        return false;
+    }
+    try {
+        // Touch the backing store. A Blob that lost its data after being persisted and
+        // rehydrated throws here — the same read that later makes `fetch` fail.
+        await value.slice(0, 1).arrayBuffer();
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Prepares the request payload (body) for a given command and data.
  */
-const prepareRequestPayload: PrepareRequestPayload = (command, data) => {
+const prepareRequestPayload: PrepareRequestPayload = async (command, data) => {
     const formData = new FormData();
 
     for (const key of Object.keys(data)) {
@@ -15,11 +43,17 @@ const prepareRequestPayload: PrepareRequestPayload = (command, data) => {
             continue;
         }
 
+        // eslint-disable-next-line no-await-in-loop
+        if (FILE_UPLOAD_KEYS.has(key) && !(await isUsableFileValue(value))) {
+            Log.alert('[prepareRequestPayload] File missing or unreadable at upload time, sending without it', {command, key});
+            continue;
+        }
+
         validateFormDataParameter(command, key, value);
         formData.append(key, value as string | Blob);
     }
 
-    return Promise.resolve(formData);
+    return formData;
 };
 
 export default prepareRequestPayload;

--- a/src/libs/prepareRequestPayload/index.ts
+++ b/src/libs/prepareRequestPayload/index.ts
@@ -1,4 +1,5 @@
 import Log from '@libs/Log';
+import {getFile, isQueuedFileRef} from '@libs/QueuedFileStorage';
 import validateFormDataParameter from '@libs/validateFormDataParameter';
 
 import type PrepareRequestPayload from './types';
@@ -34,23 +35,43 @@ async function isUsableFileValue(value: unknown): Promise<boolean> {
  * Prepares the request payload (body) for a given command and data.
  */
 const prepareRequestPayload: PrepareRequestPayload = async (command, data) => {
+    // Resolve every param up front (in parallel) so we can append synchronously afterwards
+    // without awaiting inside the append loop.
+    const resolved = await Promise.all(
+        Object.keys(data).map(async (key) => {
+            const value = data[key];
+
+            if (value === undefined || value === null) {
+                return undefined;
+            }
+
+            // The file was saved to the separate file store at queue time; resolve the key back
+            // into the actual Blob to upload. If it's gone, send without it for a definitive outcome.
+            if (isQueuedFileRef(value)) {
+                const file = await getFile(value.queuedFileKey);
+                if (!file) {
+                    Log.alert('[prepareRequestPayload] Queued file missing at upload time, sending without it', {command, key});
+                    return undefined;
+                }
+                return {key, value: file};
+            }
+
+            if (FILE_UPLOAD_KEYS.has(key) && !(await isUsableFileValue(value))) {
+                Log.alert('[prepareRequestPayload] File missing or unreadable at upload time, sending without it', {command, key});
+                return undefined;
+            }
+
+            return {key, value};
+        }),
+    );
+
     const formData = new FormData();
-
-    for (const key of Object.keys(data)) {
-        const value = data[key];
-
-        if (value === undefined || value === null) {
+    for (const entry of resolved) {
+        if (!entry) {
             continue;
         }
-
-        // eslint-disable-next-line no-await-in-loop
-        if (FILE_UPLOAD_KEYS.has(key) && !(await isUsableFileValue(value))) {
-            Log.alert('[prepareRequestPayload] File missing or unreadable at upload time, sending without it', {command, key});
-            continue;
-        }
-
-        validateFormDataParameter(command, key, value);
-        formData.append(key, value as string | Blob);
+        validateFormDataParameter(command, entry.key, entry.value);
+        formData.append(entry.key, entry.value as string | Blob);
     }
 
     return formData;

--- a/tests/unit/PersistedRequests.ts
+++ b/tests/unit/PersistedRequests.ts
@@ -360,3 +360,59 @@ describe('PersistedRequests persistence guarantees', () => {
         expect(PersistedRequests.getAll().map((r) => r.command)).toEqual(['CommandB', 'CommandC']);
     });
 });
+
+// Root cause of the `Failed to write blobs (InvalidBlob)` storm: file-upload requests used to be
+// persisted with their File/Blob INLINE in the single networkRequestQueue value, so the one record
+// grew with (queued file requests × file size) until its IndexedDB blob write failed and deadlocked
+// the queue. The fix keeps files in the in-memory queue (so live uploads still work) but strips them
+// from what is persisted, so the record stays small and writable.
+describe('PersistedRequests inline file storage (InvalidBlob root-cause fix)', () => {
+    const makeReceiptRequest = (index: number, bytes: number): Request<OnyxKey> =>
+        ({
+            command: 'ReplaceReceipt',
+            data: {transactionID: String(index), receipt: new Blob(['x'.repeat(bytes)], {type: 'image/jpeg'})},
+            requestIndex: index,
+        }) as Request<OnyxKey>;
+
+    const receiptSize = (r: {data?: Record<string, unknown>} | undefined) => {
+        const receipt = r?.data?.receipt;
+        return receipt instanceof Blob ? receipt.size : 0;
+    };
+
+    beforeEach(async () => {
+        PersistedRequests.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('keeps the receipt File in memory but STRIPS it from the persisted queue value', async () => {
+        PersistedRequests.save(makeReceiptRequest(1, 100_000));
+        await waitForBatchedUpdates();
+
+        // In-memory queue keeps the File so the live (same-session) upload still works.
+        expect(PersistedRequests.getAll().at(0)?.data?.receipt).toBeInstanceOf(Blob);
+
+        // Persisted value has the file stripped, so the single record cannot balloon.
+        const persisted = (await OnyxUtils.get(ONYXKEYS.PERSISTED_REQUESTS)) as Request<OnyxKey>[] | undefined;
+        expect(persisted).toHaveLength(1);
+        expect(persisted?.at(0)?.data?.receipt).toBeUndefined();
+        // The rest of the request is preserved on disk (id, command, other data) so ordering
+        // and cross-tab reconciliation are unaffected.
+        expect(persisted?.at(0)?.command).toBe('ReplaceReceipt');
+        expect(persisted?.at(0)?.data?.transactionID).toBe('1');
+    });
+
+    it('persisted queue value stays small regardless of file count', async () => {
+        for (let i = 1; i <= 5; i++) {
+            PersistedRequests.save(makeReceiptRequest(i, 100_000));
+        }
+        await waitForBatchedUpdates();
+
+        const persisted = (await OnyxUtils.get(ONYXKEYS.PERSISTED_REQUESTS)) as Request<OnyxKey>[] | undefined;
+        const persistedInlineBytes = (persisted ?? []).reduce((sum, r) => sum + receiptSize(r), 0);
+        const memoryInlineBytes = PersistedRequests.getAll().reduce((sum, r) => sum + receiptSize(r), 0);
+
+        expect(persisted).toHaveLength(5);
+        expect(persistedInlineBytes).toBe(0); // all files stripped from disk -> record can't balloon
+        expect(memoryInlineBytes).toBe(500_000); // memory keeps them for live uploads
+    });
+});

--- a/tests/unit/PersistedRequests.ts
+++ b/tests/unit/PersistedRequests.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import type {OnyxKey} from 'react-native-onyx';
 
 import Onyx from 'react-native-onyx';
@@ -6,9 +7,15 @@ import OnyxUtils from 'react-native-onyx/dist/OnyxUtils';
 import type Request from '../../src/types/onyx/Request';
 
 import * as PersistedRequests from '../../src/libs/actions/PersistedRequests';
+import * as QueuedFileStorage from '../../src/libs/QueuedFileStorage';
 import ONYXKEYS from '../../src/ONYXKEYS';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
+
+// The jest resolver picks the native no-op stub for @libs/QueuedFileStorage; force the web
+// (IndexedDB) implementation so file requests are exercised end-to-end like on web.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('@libs/QueuedFileStorage', () => jest.requireActual('@libs/QueuedFileStorage/index.ts'));
 
 const request: Request<'reportMetadata_1' | 'reportMetadata_2'> = {
     command: 'OpenReport',
@@ -200,37 +207,33 @@ describe('PersistedRequests persistence guarantees', () => {
         });
     });
 
-    it('processNextRequest should keep the in-memory ongoing request when data contains a File/Blob', async () => {
+    it('processNextRequest persists a file request as ongoing once its file is stored separately', async () => {
         PersistedRequests.clear();
         await waitForBatchedUpdates();
 
-        const originalFile = global.File;
-        function MockFile() {}
-        global.File = MockFile as unknown as typeof File;
+        const requestWithFile: Request<'reportMetadata_1' | 'reportMetadata_2'> = {
+            command: 'OpenReport',
+            successData: [{key: 'reportMetadata_1', onyxMethod: 'merge', value: {}}],
+            failureData: [{key: 'reportMetadata_2', onyxMethod: 'merge', value: {}}],
+            requestIndex: 30,
+            data: {file: new Blob(['x'], {type: 'image/jpeg'}) as unknown as File},
+        };
 
-        try {
-            const mockFilePrototype = MockFile.prototype as Record<string, never>;
-            const mockFile = Object.create(mockFilePrototype) as File;
-            const requestWithFile: Request<'reportMetadata_1' | 'reportMetadata_2'> = {
-                command: 'OpenReport',
-                successData: [{key: 'reportMetadata_1', onyxMethod: 'merge', value: {}}],
-                failureData: [{key: 'reportMetadata_2', onyxMethod: 'merge', value: {}}],
-                requestIndex: 30,
-                data: {file: mockFile},
-            };
+        await PersistedRequests.save(requestWithFile);
+        await waitForBatchedUpdates();
 
-            PersistedRequests.save(requestWithFile);
-            await waitForBatchedUpdates();
+        // save() swapped the inline Blob for a serializable reference, so the queued request
+        // no longer holds the Blob itself.
+        const queuedFile = PersistedRequests.getAll().at(0)?.data?.file;
+        expect(queuedFile).not.toBeInstanceOf(Blob);
+        expect(QueuedFileStorage.isQueuedFileRef(queuedFile)).toBe(true);
 
-            const nextRequest = PersistedRequests.processNextRequest();
-            await waitForBatchedUpdates();
+        const nextRequest = PersistedRequests.processNextRequest();
+        await waitForBatchedUpdates();
 
-            expect(nextRequest).toEqual(requestWithFile);
-            expect(PersistedRequests.getOngoingRequest()).toEqual(requestWithFile);
-            expect((await OnyxUtils.get(ONYXKEYS.PERSISTED_ONGOING_REQUESTS)) == null).toBe(true);
-        } finally {
-            global.File = originalFile;
-        }
+        // Because the request is now fully serializable, the ongoing request is crash-safe on disk.
+        expect(nextRequest?.command).toBe('OpenReport');
+        expect(await OnyxUtils.get(ONYXKEYS.PERSISTED_ONGOING_REQUESTS)).not.toBeNull();
     });
 
     // BUG: save() at PersistedRequests.ts:124-134 does a read-modify-write
@@ -364,55 +367,69 @@ describe('PersistedRequests persistence guarantees', () => {
 // Root cause of the `Failed to write blobs (InvalidBlob)` storm: file-upload requests used to be
 // persisted with their File/Blob INLINE in the single networkRequestQueue value, so the one record
 // grew with (queued file requests × file size) until its IndexedDB blob write failed and deadlocked
-// the queue. The fix keeps files in the in-memory queue (so live uploads still work) but strips them
-// from what is persisted, so the record stays small and writable.
-describe('PersistedRequests inline file storage (InvalidBlob root-cause fix)', () => {
-    const makeReceiptRequest = (index: number, bytes: number): Request<OnyxKey> =>
+// the queue. The fix saves each file to a separate store and keeps only a small
+// QueuedFileRef in the queue, so the record stays tiny AND the file survives a browser restart.
+describe('PersistedRequests separate file storage (InvalidBlob root-cause fix)', () => {
+    const receiptBytes = 'x'.repeat(100_000);
+    const makeReceiptRequest = (index: number): Request<OnyxKey> =>
         ({
             command: 'ReplaceReceipt',
-            data: {transactionID: String(index), receipt: new Blob(['x'.repeat(bytes)], {type: 'image/jpeg'})},
+            data: {transactionID: String(index), receipt: new Blob([receiptBytes], {type: 'image/jpeg'})},
             requestIndex: index,
         }) as Request<OnyxKey>;
 
-    const receiptSize = (r: {data?: Record<string, unknown>} | undefined) => {
+    const getQueuedFileKey = (r: Request<OnyxKey> | undefined): string | undefined => {
         const receipt = r?.data?.receipt;
-        return receipt instanceof Blob ? receipt.size : 0;
+        return QueuedFileStorage.isQueuedFileRef(receipt) ? receipt.queuedFileKey : undefined;
     };
 
     beforeEach(async () => {
-        PersistedRequests.clear();
+        await PersistedRequests.clear();
         await waitForBatchedUpdates();
     });
 
-    it('keeps the receipt File in memory but STRIPS it from the persisted queue value', async () => {
-        PersistedRequests.save(makeReceiptRequest(1, 100_000));
+    it('persists the receipt as a QueuedFileRef and keeps the bytes in the separate store', async () => {
+        await PersistedRequests.save(makeReceiptRequest(1));
         await waitForBatchedUpdates();
 
-        // In-memory queue keeps the File so the live (same-session) upload still works.
-        expect(PersistedRequests.getAll().at(0)?.data?.receipt).toBeInstanceOf(Blob);
-
-        // Persisted value has the file stripped, so the single record cannot balloon.
-        const persisted = (await OnyxUtils.get(ONYXKEYS.PERSISTED_REQUESTS)) as Request<OnyxKey>[] | undefined;
+        // The persisted request references the file by key instead of embedding the Blob,
+        // so the single networkRequestQueue record cannot balloon.
+        const persisted = await OnyxUtils.get(ONYXKEYS.PERSISTED_REQUESTS);
         expect(persisted).toHaveLength(1);
-        expect(persisted?.at(0)?.data?.receipt).toBeUndefined();
-        // The rest of the request is preserved on disk (id, command, other data) so ordering
-        // and cross-tab reconciliation are unaffected.
+        const persistedReceipt = persisted?.at(0)?.data?.receipt;
+        expect(persistedReceipt).not.toBeInstanceOf(Blob);
+        expect(persistedReceipt).toBeDefined();
+
+        const key = getQueuedFileKey(persisted?.at(0));
+        expect(typeof key).toBe('string');
+
+        // The rest of the request is preserved on disk so ordering / reconciliation are unaffected.
         expect(persisted?.at(0)?.command).toBe('ReplaceReceipt');
         expect(persisted?.at(0)?.data?.transactionID).toBe('1');
+
+        // A record is durably stored in the separate store under the referenced key (so it survives a browser
+        // restart). jsdom's structuredClone can't round-trip Blob bytes, so we assert presence only —
+        // real browsers preserve the bytes.
+        const stored = await QueuedFileStorage.getFile(key ?? '');
+        expect(stored).toBeDefined();
     });
 
-    it('persisted queue value stays small regardless of file count', async () => {
-        for (let i = 1; i <= 5; i++) {
-            PersistedRequests.save(makeReceiptRequest(i, 100_000));
+    it('reclaims the stored file once its request is removed from the queue', async () => {
+        await PersistedRequests.save(makeReceiptRequest(2));
+        await waitForBatchedUpdates();
+
+        const persisted = await OnyxUtils.get(ONYXKEYS.PERSISTED_REQUESTS);
+        const key = getQueuedFileKey(persisted?.at(0));
+        expect(typeof key).toBe('string');
+        expect(await QueuedFileStorage.getFile(key ?? '')).toBeDefined();
+
+        // Removing the request should fire-and-forget delete of its stored file.
+        const persistedRequest = PersistedRequests.getAll().at(0);
+        if (persistedRequest) {
+            PersistedRequests.endRequestAndRemoveFromQueue(persistedRequest);
         }
         await waitForBatchedUpdates();
 
-        const persisted = (await OnyxUtils.get(ONYXKEYS.PERSISTED_REQUESTS)) as Request<OnyxKey>[] | undefined;
-        const persistedInlineBytes = (persisted ?? []).reduce((sum, r) => sum + receiptSize(r), 0);
-        const memoryInlineBytes = PersistedRequests.getAll().reduce((sum, r) => sum + receiptSize(r), 0);
-
-        expect(persisted).toHaveLength(5);
-        expect(persistedInlineBytes).toBe(0); // all files stripped from disk -> record can't balloon
-        expect(memoryInlineBytes).toBe(500_000); // memory keeps them for live uploads
+        expect(await QueuedFileStorage.getFile(key ?? '')).toBeUndefined();
     });
 });


### PR DESCRIPTION
### Explanation of Change

Fixes the `DataError: Failed to write blobs (InvalidBlob)` storage storm. The root cause is a file-upload request (dominantly `ReplaceReceipt`) whose binary file is stored **inline inside the offline request queue**: the whole queue is a single Onyx value (`networkRequestQueue`) persisted as **one IndexedDB record**. As file-bearing requests accumulate, that one record grows with (queued file requests × file size) until its write exceeds Chromium's IndexedDB blob-externalization path and fails with `InvalidBlob`. Once that write fails the queue can't be updated → it can't drain → the request retries forever → a self-reinforcing `Failed to fetch` retry + log storm (one prod client hit a ~17,515-deep queue and emitted ~9.5M log lines/day).

**The fix — store queued files out of band, keep only a reference in the queue:**

- Each file's bytes are written to a **dedicated IndexedDB store** (`src/libs/QueuedFileStorage`, separate from Onyx), and the queued request keeps only a small serializable `QueuedFileRef` (`{queuedFileKey, name, type}`) in its place.
- `PersistedRequests.save()` performs this swap **before** the request is persisted, so the file bytes are durably stored first (a crash leaves at worst an orphan file, never a dangling reference).
- At send time, the web payload builder (`prepareRequestPayload`) resolves the reference back to the Blob and uploads it. If the referenced file is missing, it sends without it for a definitive server outcome instead of looping.
- When a request leaves the queue (success / removal / clear) its out-of-band file is deleted, and a one-time orphan sweep on init reclaims any file whose request is gone.

**Result:** the `networkRequestQueue` record stays tiny (references only) so the oversized-write failure can't happen, **and** the file persists in durable storage so a queued upload survives a browser restart. This mirrors how native already works — the queue holds a file *path* and the bytes live on the device filesystem; on web the dedicated store is the equivalent durable home. Files also no longer travel through Onyx's in-memory cache / cross-tab broadcast / reactivity, which is lighter for large binaries.

**Telemetry:** `[PersistedRequests] Stored inline file(s) out of band` logs `{storedCount, queueLength}` so we can size the impact and confirm the mechanism in prod.

**Scope:** the payload path is generic, so this covers the whole file-upload class (`receipt` / `file` params: avatars, attachments, policy docs, scan receipts…), not just `ReplaceReceipt`.

**Proof status (honest):**

- **Proven** (unit tests): a queued `ReplaceReceipt` persists its receipt as a `QueuedFileRef` (not the inline Blob); the bytes are stored out of band under that key; and the out-of-band file is reclaimed when the request is removed. Full `PersistedRequests` suite (incl. cross-tab reconciliation) + `NetworkTest`/`APITest` pass.
- **Not proven locally**: the exact Chromium step (oversized single-record write → `InvalidBlob` → deadlock). It could not be reproduced locally — a healthy-disk write of several MB succeeded — and is unsafe to force at the GB scale it needs (huge IDB writes hang the tab). It will be validated by **before/after prod telemetry** (the `InvalidBlob` + `ReplaceReceipt`-loop volume dropping after rollout).

**Confidence:** this targets the dominant amplifier actually storming in prod (accumulation of inline files in one record), keeps the queue record small, and preserves the offline guarantee — so it is **expected to resolve the storm**. Residual caveat: each file is still a binary IndexedDB write, so a single *genuinely* oversized file could in theory still hit the blob path; the observed failure is driven by accumulation, not a single write, so per-file records should resolve it — final confirmation is prod telemetry.

Related: root-cause tracking issue https://github.com/Expensify/App/issues/87871 ; likely explains the "unable to reproduce" https://github.com/Expensify/App/issues/91978 (co-pilot stuck loading / receipts missing).

**Open question for reviewers:** large JSON in `optimisticData` / `failureData` (e.g. a Search `snapshot_` embedding a big policy) can also exceed IndexedDB's ~64 KB blob-wrap threshold. Files were the dominant, thousands-deep amplifier addressed here; should we mitigate large non-file payloads too, or track that as a follow-up?

### Fixed Issues

$ https://github.com/Expensify/App/issues/87871
PROPOSAL: N/A

### Tests

1. `tests/unit/PersistedRequests.ts` → `describe('PersistedRequests out-of-band file storage (InvalidBlob root-cause fix)')`:
    - saving a `ReplaceReceipt` persists the receipt as a `QueuedFileRef` (not the inline `Blob`), while the file bytes are stored out of band under the referenced key; the request's other data (id / command / transactionID) is preserved on disk;
    - removing the request reclaims (deletes) its out-of-band file.
2. `processNextRequest persists a file request as ongoing once its file is stored out of band` — the request is now fully serializable so the ongoing request is crash-safe on disk.
3. Full `PersistedRequests` suite (incl. cross-tab reconciliation) + `NetworkTest` / `APITest` pass with no regressions.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline. Replace a receipt on an expense (or scan a new one) — the request queues.
2. Close and reopen the browser while still offline.
3. Go back online → the queued receipt upload completes (the file survived the restart because it is persisted out of band, not held only in memory).

- [ ] Verify that no errors appear in the JS console

### QA Steps

_Pending team review — full multi-platform QA pass not yet completed for this draft._

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

