### PR TITLE
[No QA] Bump expensify-common to 2.0.191

### DIFF
--- a/.github/actions/javascript/isDeployChecklistLocked/index.js
+++ b/.github/actions/javascript/isDeployChecklistLocked/index.js
@@ -12132,7 +12132,116 @@ exports["default"] = new Logger_1.default({
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.MAX_LOG_LINE_BYTES = void 0;
+exports.truncateMessageToFitLine = truncateMessageToFitLine;
+exports.serializeLineWithinByteLimit = serializeLineWithinByteLimit;
+exports.utf8ByteLength = utf8ByteLength;
 const MAX_LOG_LINES_BEFORE_FLUSH = 50;
+// The server rejects any single serialized log line larger than 1,048,576 bytes (1 MiB).
+// We enforce a lower cap on the JSON-serialized line (message + parameters + metadata, with
+// escaping) so it stays comfortably under the server limit.
+const MAX_LOG_LINE_BYTES = 1000000;
+exports.MAX_LOG_LINE_BYTES = MAX_LOG_LINE_BYTES;
+/**
+ * Gets the UTF-8 byte length of a single unicode code point.
+ */
+function codePointByteSize(code) {
+    if (code >= 0x10000) {
+        return 4;
+    }
+    if (code >= 0x800) {
+        return 3;
+    }
+    if (code >= 0x80) {
+        return 2;
+    }
+    return 1;
+}
+/**
+ * Gets the total UTF-8 byte length of a string.
+ */
+function utf8ByteLength(input) {
+    return Array.from(input).reduce((sum, char) => { var _a; return sum + codePointByteSize((_a = char.codePointAt(0)) !== null && _a !== void 0 ? _a : 0); }, 0);
+}
+/**
+ * UTF-8 byte length of a single code point *after JSON string escaping*, matching the output of
+ * JSON.stringify: `"` `\` and the short control escapes are 2 bytes, other control characters
+ * and lone surrogates become `\uXXXX` (6 bytes), everything else is its plain UTF-8 size.
+ */
+function jsonEscapedByteSize(code) {
+    if (code === 0x22 || code === 0x5c || code === 0x08 || code === 0x09 || code === 0x0a || code === 0x0c || code === 0x0d) {
+        return 2;
+    }
+    if (code < 0x20 || (code >= 0xd800 && code <= 0xdfff)) {
+        return 6;
+    }
+    return codePointByteSize(code);
+}
+/**
+ * Truncates `message` so that the SERIALIZED `line` fits within maxSize bytes. The serialized
+ * line is `overhead(empty message) + JSON-escaped bytes of the message`, so we measure the
+ * message's escaped size directly (single pass) instead of repeatedly re-serializing the whole
+ * line. This is exact for JSON.stringify's escaping and avoids the cost of a binary search.
+ */
+function truncateMessageToFitLine(line, message, maxSize) {
+    var _a;
+    const overhead = utf8ByteLength(JSON.stringify(Object.assign(Object.assign({}, line), { message: '' })));
+    const totalRawBytes = utf8ByteLength(message);
+    // Marker "...[truncated N bytes]" is escape-free ASCII, so its serialized size equals its
+    // raw size = 21 + digits(N). Reserve for the max possible N so the final line never overflows.
+    const MARKER_STATIC_BYTES = 21;
+    const reservedMarkerBytes = MARKER_STATIC_BYTES + String(totalRawBytes).length;
+    const contentBudget = maxSize - overhead - reservedMarkerBytes;
+    if (contentBudget <= 0) {
+        return '';
+    }
+    // Keep whole code points until the escaped budget is exhausted (never splits a character).
+    let keptUnits = 0;
+    let keptEscapedBytes = 0;
+    let keptRawBytes = 0;
+    for (let i = 0; i < message.length;) {
+        const code = (_a = message.codePointAt(i)) !== null && _a !== void 0 ? _a : 0;
+        const escapedBytes = jsonEscapedByteSize(code);
+        if (keptEscapedBytes + escapedBytes > contentBudget) {
+            break;
+        }
+        keptEscapedBytes += escapedBytes;
+        keptRawBytes += codePointByteSize(code);
+        const units = code > 0xffff ? 2 : 1;
+        i += units;
+        keptUnits += units;
+    }
+    if (keptRawBytes >= totalRawBytes) {
+        return message;
+    }
+    const removed = totalRawBytes - keptRawBytes;
+    return `${message.slice(0, keptUnits)}...[truncated ${removed} bytes]`;
+}
+/**
+ * Serializes a log line while enforcing the per-line byte limit on the *serialized* line — what
+ * the server measures — covering the message, parameters and metadata plus JSON-escaping
+ * overhead. Returns the JSON string for the line (reused to build the packet, so each line is
+ * serialized only once). Oversized `parameters` (structured data we can't safely truncate
+ * mid-JSON) are replaced with a size marker; the message is then truncated to fit the remainder.
+ */
+function serializeLineWithinByteLimit(line, maxSize) {
+    var _a;
+    const serialized = JSON.stringify(line);
+    // Cheap fast path: at most 3 UTF-8 bytes per UTF-16 code unit, so if 3 * length fits the
+    // line is definitely under the limit and we avoid the exact byte count entirely.
+    if (serialized.length * 3 <= maxSize || utf8ByteLength(serialized) <= maxSize) {
+        return serialized;
+    }
+    const result = Object.assign({}, line);
+    // If the line is over the limit even with an empty message, the bulk is in `parameters` —
+    // replace it with a marker so the (human-readable) message is what we keep room for.
+    if (utf8ByteLength(JSON.stringify(Object.assign(Object.assign({}, result), { message: '' }))) > maxSize) {
+        const parametersByteSize = utf8ByteLength(JSON.stringify((_a = result.parameters) !== null && _a !== void 0 ? _a : ''));
+        result.parameters = { truncated: true, originalByteSize: parametersByteSize };
+    }
+    result.message = truncateMessageToFitLine(result, line.message, maxSize);
+    return JSON.stringify(result);
+}
 class Logger {
     constructor({ serverLoggingCallback, isDebug, clientLoggingCallback, maxLogLinesBeforeFlush, getContextEmail }) {
         // An array of log lines that limits itself to a certain number of entries (deleting the oldest)
@@ -12158,16 +12267,20 @@ class Logger {
         if (!this.logLines.length || ((_a = this.logLines) === null || _a === void 0 ? void 0 : _a.every((l) => l.onlyFlushWithOthers))) {
             return;
         }
-        // We don't care about log setting web cookies so let's define it as false
-        const linesToLog = (_b = this.logLines) === null || _b === void 0 ? void 0 : _b.map((l) => {
+        // We don't care about log setting web cookies so let's define it as false.
+        // Serialize each line while bounding it to the server's per-line size limit (covers
+        // message, parameters and JSON-escaping overhead). Building the packet by joining the
+        // per-line JSON keeps each line serialized only once — identical output to
+        // JSON.stringify(array) with no extra pass.
+        const serializedLines = (_b = this.logLines) === null || _b === void 0 ? void 0 : _b.map((l) => {
             // eslint-disable-next-line no-param-reassign
             delete l.onlyFlushWithOthers;
-            return l;
+            return serializeLineWithinByteLimit(l, MAX_LOG_LINE_BYTES);
         });
         this.logLines = [];
         const promise = this.serverLoggingCallback(this, {
             api_setCookie: false,
-            logPacket: JSON.stringify(linesToLog),
+            logPacket: `[${serializedLines.join(',')}]`,
         });
         if (!promise) {
             return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "date-fns-tz": "^3.2.0",
         "dom-serializer": "^0.2.2",
         "domhandler": "^5.0.3",
-        "expensify-common": "2.0.189",
+        "expensify-common": "2.0.191",
         "expo": "56.0.8",
         "expo-asset": "56.0.15",
         "expo-audio": "56.0.11",
@@ -24184,9 +24184,9 @@
       }
     },
     "node_modules/expensify-common": {
-      "version": "2.0.189",
-      "resolved": "https://registry.npmjs.org/expensify-common/-/expensify-common-2.0.189.tgz",
-      "integrity": "sha512-w7AJQDpRdeyCvWxOhGPeWTckmVKOH2RBN2/dwUkNCm5tszeS2ELissz3YoQt02Meon14CXEbC1SAqiUw7Kca8w==",
+      "version": "2.0.191",
+      "resolved": "https://registry.npmjs.org/expensify-common/-/expensify-common-2.0.191.tgz",
+      "integrity": "sha512-Krv7mK94THVjUVPRnUu7gqzMkz8dmQZ6iPz6hDpMF+QC08yDol9psQ3CpHXgs0DMAuz8vQG1RpD3lf1xyFGWEA==",
       "license": "MIT",
       "dependencies": {
         "awesome-phonenumber": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "date-fns-tz": "^3.2.0",
     "dom-serializer": "^0.2.2",
     "domhandler": "^5.0.3",
-    "expensify-common": "2.0.189",
+    "expensify-common": "2.0.191",
     "expo": "56.0.8",
     "expo-asset": "56.0.15",
     "expo-audio": "56.0.11",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Bumps `expensify-common` from [2.0.189 to 2.0.191](https://github.com/Expensify/expensify-common/compare/2.0.189...2.0.191), which includes these changes:

- https://github.com/Expensify/expensify-common/pull/925 (replaced by PR below)
- https://github.com/Expensify/expensify-common/pull/926

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95227
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. In `src/setup/addUtilsToWindow.ts` in E/App, import `Log` and add `window.Log = Log;` inside `addUtilsToWindow`.
3. **Under the limit (no truncation):** run `Log.info('A'.repeat(900_000), true);`. In VictoriaLogs, assert the message does **not** end with `...[truncated N bytes]`.
4. **Oversized message (truncated):** run `Log.info('A'.repeat(1_100_000), true);`. Assert the message ends with `...[truncated N bytes]`.
5. **Oversized parameters:** run `Log.info('parameters test', true, {blob: 'A'.repeat(1_100_000)});`. Assert the message is intact (`[info] parameters test`) and `parameters` will only include `truncated` and `originalByteSize`.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

N/A

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

**Under the limit (no truncation):**

<img width="1822" height="225" alt="Screenshot 2026-07-10 at 11 25 12" src="https://github.com/user-attachments/assets/e55c43d0-4625-479c-9b87-c8b81bd3478e" />

**Oversized message (truncated):**

<img width="1813" height="246" alt="Screenshot 2026-07-10 at 11 25 37" src="https://github.com/user-attachments/assets/ea59c0be-ac5e-4afe-afa7-0e962db47da3" />

**Oversized parameters:**

<img width="1714" height="57" alt="Screenshot 2026-07-10 at 11 26 23" src="https://github.com/user-attachments/assets/595c8184-fb59-4554-9885-10ea3958aebf" />


</details>
