### PR TITLE
Stage profile photo removal behind the Save button

### DIFF
--- a/src/pages/settings/Profile/Avatar/AvatarPreview.tsx
+++ b/src/pages/settings/Profile/Avatar/AvatarPreview.tsx
@@ -14,9 +14,7 @@ import {USER_AVATARS} from '@libs/Avatars/UserAvatarCatalog';
 import {validateAvatarImage} from '@libs/AvatarUtils';
 import type {CustomRNImageManipulatorResult} from '@libs/cropOrRotateImage/types';
 import type {AvatarSource} from '@libs/UserAvatarUtils';
-import {isCatalogAvatar, isGeneratedLetterAvatarURL, isLetterAvatar} from '@libs/UserAvatarUtils';
-
-import {deleteAvatar} from '@userActions/PersonalDetails';
+import {getDefaultAvatarURL, isCatalogAvatar, isGeneratedLetterAvatarURL, isLetterAvatar} from '@libs/UserAvatarUtils';
 
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
@@ -32,14 +30,14 @@ import AvatarCapture from './AvatarCapture';
 type AvatarPreviewProps = {
     /** The selected avatar ID */
     selected: string | undefined;
-    /** The function to set the selected avatar ID */
-    setSelected: (selected: string | undefined) => void;
+    /** Whether the current avatar is staged for removal */
+    isRemoved: boolean;
+    /** Callback when the current avatar photo is removed */
+    onImageRemoved: () => void;
     /** The ref to the avatar capture component */
     avatarCaptureRef: React.RefObject<AvatarCaptureHandle | null>;
     /** The image data */
     imageData: ImageData;
-    /** The function to set the image data */
-    setImageData: (imageData: ImageData) => void;
     /** The function to set the error */
     setError: (error: TranslationPaths | null, phraseParam: Record<string, unknown>) => void;
     /** Opens the avatar crop screen for the picked image */
@@ -53,9 +51,7 @@ type ImageData = {
     file: File | CustomRNImageManipulatorResult | null;
 };
 
-const EMPTY_FILE = {uri: '', name: '', type: '', file: null};
-
-function AvatarPreview({selected, avatarCaptureRef, setSelected, imageData, setImageData, setError, openCropper}: AvatarPreviewProps) {
+function AvatarPreview({selected, isRemoved, onImageRemoved, avatarCaptureRef, imageData, setError, openCropper}: AvatarPreviewProps) {
     const icons = useMemoizedLazyExpensifyIcons(['Upload']);
     const styles = useThemeStyles();
     const {translate} = useLocalize();
@@ -74,6 +70,11 @@ function AvatarPreview({selected, avatarCaptureRef, setSelected, imageData, setI
         avatarURL = avatars[selected];
     } else if (imageData.uri) {
         avatarURL = imageData.uri;
+    } else if (isRemoved) {
+        avatarURL = getDefaultAvatarURL({
+            accountID,
+            accountEmail: currentUserPersonalDetails?.email,
+        });
     } else {
         avatarURL = currentUserPersonalDetails?.avatar ?? '';
     }
@@ -83,7 +84,8 @@ function AvatarPreview({selected, avatarCaptureRef, setSelected, imageData, setI
             (isCatalogAvatar(currentUserPersonalDetails?.avatar) ||
                 isGeneratedLetterAvatarURL(currentUserPersonalDetails?.avatar) ||
                 isLetterAvatar(currentUserPersonalDetails?.originalFileName))) ||
-        !!selected;
+        !!selected ||
+        isRemoved;
 
     /**
      * Validates an image and opens avatar crop modal if valid
@@ -102,12 +104,6 @@ function AvatarPreview({selected, avatarCaptureRef, setSelected, imageData, setI
             .catch(() => {
                 setError('attachmentPicker.errorWhileSelectingCorruptedAttachment', {});
             });
-    };
-
-    const onImageRemoved = () => {
-        deleteAvatar(currentUserPersonalDetails);
-        setSelected(undefined);
-        setImageData({...EMPTY_FILE});
     };
 
     const clearError = () => {
@@ -166,7 +162,10 @@ function AvatarPreview({selected, avatarCaptureRef, setSelected, imageData, setI
                             success={false}
                             shouldUseOptionIcon
                             onPress={() => {}}
-                            anchorAlignment={{horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.CENTER, vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP}}
+                            anchorAlignment={{
+                                horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.CENTER,
+                                vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP,
+                            }}
                             customText={translate('common.edit')}
                             options={menuItems}
                             isSplitButton={false}

--- a/src/pages/settings/Profile/Avatar/UserProfileAvatar.tsx
+++ b/src/pages/settings/Profile/Avatar/UserProfileAvatar.tsx
@@ -21,15 +21,15 @@ function UserProfileAvatar() {
     const isInLandscapeMode = useIsInLandscapeMode();
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
 
-    const {errorData, selected, setSelected, imageData, setImageData, avatarCaptureRef, isDirty, setError, onSelectPreset, openCropper, save} = useProfileAvatarForm();
+    const {errorData, selected, imageData, avatarCaptureRef, isDirty, isRemoved, setError, onSelectPreset, onImageRemoved, openCropper, save} = useProfileAvatarForm();
 
     const renderPreview = () => (
         <AvatarPreview
             selected={selected}
-            setSelected={setSelected}
+            isRemoved={isRemoved}
+            onImageRemoved={onImageRemoved}
             avatarCaptureRef={avatarCaptureRef}
             imageData={imageData}
-            setImageData={setImageData}
             setError={setError}
             openCropper={openCropper}
         />

--- a/src/pages/settings/Profile/Avatar/useProfileAvatarForm.ts
+++ b/src/pages/settings/Profile/Avatar/useProfileAvatarForm.ts
@@ -6,7 +6,7 @@ import {USER_AVATARS} from '@libs/Avatars/UserAvatarCatalog';
 import type {CustomRNImageManipulatorResult} from '@libs/cropOrRotateImage/types';
 import Navigation from '@libs/Navigation/Navigation';
 
-import {updateAvatar} from '@userActions/PersonalDetails';
+import {deleteAvatar, updateAvatar} from '@userActions/PersonalDetails';
 
 import type {TranslationPaths} from '@src/languages/types';
 
@@ -19,16 +19,20 @@ const EMPTY_FILE = {uri: '', name: '', type: '', file: null};
 
 /** Owns the profile avatar form state (selection, picked image, validation errors) and the save flow. */
 function useProfileAvatarForm() {
-    const [errorData, setErrorData] = useState<ErrorData>({validationError: null, phraseParam: {}});
+    const [errorData, setErrorData] = useState<ErrorData>({
+        validationError: null,
+        phraseParam: {},
+    });
     const [selected, setSelected] = useState<string | undefined>();
     const [imageData, setImageData] = useState<ImageData>({...EMPTY_FILE});
+    const [isRemoved, setIsRemoved] = useState(false);
 
     const avatarCaptureRef = useRef<AvatarCaptureHandle>(null);
     const isSavingRef = useRef(false);
 
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
 
-    const isDirty = imageData.uri !== '' || !!selected;
+    const isDirty = imageData.uri !== '' || !!selected || isRemoved;
 
     useDiscardChangesConfirmation({
         getHasUnsavedChanges: () => !isSavingRef.current && isDirty,
@@ -39,6 +43,7 @@ function useProfileAvatarForm() {
     };
 
     const onImageSelected = (file: File | CustomRNImageManipulatorResult) => {
+        setIsRemoved(false);
         setSelected(undefined);
         setImageData({
             uri: file?.uri ?? '',
@@ -48,15 +53,32 @@ function useProfileAvatarForm() {
         });
     };
 
-    const {openCropper} = useAvatarCrop({buttonLabelKey: 'avatarPage.upload', onCropped: onImageSelected});
+    const {openCropper} = useAvatarCrop({
+        buttonLabelKey: 'avatarPage.upload',
+        onCropped: onImageSelected,
+    });
 
     const onSelectPreset = (id: string) => {
+        setIsRemoved(false);
         setImageData({...EMPTY_FILE});
         setSelected(id);
     };
 
+    const onImageRemoved = () => {
+        setIsRemoved(true);
+        setSelected(undefined);
+        setImageData({...EMPTY_FILE});
+    };
+
     const save = () => {
         isSavingRef.current = true;
+
+        if (isRemoved) {
+            deleteAvatar(currentUserPersonalDetails);
+            setIsRemoved(false);
+            Navigation.dismissModal();
+            return;
+        }
 
         const previousAvatar = {
             avatar: currentUserPersonalDetails?.avatar,
@@ -106,13 +128,13 @@ function useProfileAvatarForm() {
     return {
         errorData,
         selected,
-        setSelected,
         imageData,
-        setImageData,
         avatarCaptureRef,
         isDirty,
+        isRemoved,
         setError,
         onSelectPreset,
+        onImageRemoved,
         openCropper,
         save,
     };

--- a/tests/unit/useProfileAvatarFormTest.tsx
+++ b/tests/unit/useProfileAvatarFormTest.tsx
@@ -1,0 +1,60 @@
+import {act, renderHook} from '@testing-library/react-native';
+
+import Navigation from '@libs/Navigation/Navigation';
+
+import useProfileAvatarForm from '@pages/settings/Profile/Avatar/useProfileAvatarForm';
+
+import {deleteAvatar} from '@userActions/PersonalDetails';
+
+const currentUserPersonalDetails = {
+    accountID: 1,
+    email: 'user@example.com',
+    avatar: 'https://example.com/avatar.jpg',
+};
+
+jest.mock('@hooks/useCurrentUserPersonalDetails', () => () => currentUserPersonalDetails);
+jest.mock('@hooks/useDiscardChangesConfirmation', () => jest.fn());
+jest.mock('@hooks/useAvatarCrop', () => () => ({openCropper: jest.fn()}));
+jest.mock('@libs/Navigation/Navigation', () => ({dismissModal: jest.fn()}));
+jest.mock('@userActions/PersonalDetails', () => ({
+    deleteAvatar: jest.fn(),
+    updateAvatar: jest.fn(),
+}));
+
+describe('useProfileAvatarForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('marks the form dirty when the photo is removed', () => {
+        const {result} = renderHook(() => useProfileAvatarForm());
+        expect(result.current.isDirty).toBe(false);
+
+        act(() => result.current.onImageRemoved());
+
+        expect(result.current.isRemoved).toBe(true);
+        expect(result.current.isDirty).toBe(true);
+        expect(deleteAvatar).not.toHaveBeenCalled();
+    });
+
+    it('commits the removal on save and dismisses the modal', () => {
+        const {result} = renderHook(() => useProfileAvatarForm());
+
+        act(() => result.current.onImageRemoved());
+        act(() => result.current.save());
+
+        expect(deleteAvatar).toHaveBeenCalledWith(currentUserPersonalDetails);
+        expect(Navigation.dismissModal).toHaveBeenCalled();
+        expect(result.current.isRemoved).toBe(false);
+    });
+
+    it('clears a staged removal when a preset is selected instead', () => {
+        const {result} = renderHook(() => useProfileAvatarForm());
+
+        act(() => result.current.onImageRemoved());
+        act(() => result.current.onSelectPreset('default-avatar_1'));
+
+        expect(result.current.isRemoved).toBe(false);
+        expect(result.current.selected).toBe('default-avatar_1');
+    });
+});


### PR DESCRIPTION
### Explanation of Change
Removing a profile photo fired DeleteUserAvatar immediately, so the form was never dirty and Save sat disabled after removal. Removal is now staged like every other edit on this page, and Save commits it.

- Track staged removal in useProfileAvatarForm
- Save calls deleteAvatar, then dismisses
- Preview shows the default initials avatar meanwhile
- Picking a photo or preset clears staged removal
- Leaving without saving now asks to discard
- Regression tests for the removal flow

### Fixed Issues
$ https://github.com/Expensify/App/issues/95360
PROPOSAL:

### Tests
1. Upload a profile photo and save it.
2. Go to Settings > Profile and open the profile picture editor.
3. Click Edit > Remove photo.
4. Verify the preview shows the default initials avatar and the profile photo is not yet deleted.
5. Verify the Save button is enabled.
6. Click Save.
7. Verify the editor dismisses and the profile shows the default initials avatar.

- [X] Verify that no errors appear in the JS console

### Offline tests
1. Upload a profile photo and save it, then disconnect from the internet.
2. Go to Settings > Profile and open the profile picture editor.
3. Click Edit > Remove photo.
4. Verify the preview shows the default initials avatar and Save is enabled.
5. Click Save.
6. Verify the editor dismisses and the profile shows the default initials avatar.
7. Reconnect and verify the avatar stays the default initials avatar.

### QA Steps
Same as tests, including the offline steps.

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
