### PR TITLE
[NoQA] Receipt follow up - dedup receipt commands

### DIFF
--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -561,8 +561,6 @@ async function push<TKey extends OnyxKey>(newRequest: OnyxRequest<TKey>): Promis
             transactionID?: string;
             receipt?: {receiptTraceId?: string};
         };
-        // Only log when there is a receipt at data.receipt. SplitBill nests it in the splits JSON, and SendMoney and
-        // friends can run without one. A row without a trace id cannot be joined to the capture log, so it is just noise.
         if (data.receipt) {
             logReceiptEnqueued({
                 receiptTraceId: data.receipt.receiptTraceId,
@@ -573,9 +571,6 @@ async function push<TKey extends OnyxKey>(newRequest: OnyxRequest<TKey>): Promis
         }
     }
 
-    // Save the request to the persisted queue. The in-memory update inside save()
-    // happens synchronously, so flush() below will see the new request immediately.
-    // The returned promise resolves when disk persistence completes.
     let persistencePromise: Promise<void>;
 
     if (newRequest.checkAndFixConflictingRequest) {

--- a/src/libs/savePendingReceiptsToGallery/getPendingReceiptRequests.native.ts
+++ b/src/libs/savePendingReceiptsToGallery/getPendingReceiptRequests.native.ts
@@ -1,24 +1,10 @@
-import {WRITE_COMMANDS} from '@libs/API/types';
 import {isLocalFile} from '@libs/fileDownload/FileUtils';
 import {isRecord} from '@libs/ObjectUtils';
+import {RECEIPT_BEARING_COMMANDS} from '@libs/telemetry/ReceiptObservability';
 
 import {getAll, getOngoingRequest} from '@userActions/PersistedRequests';
 
 import type {PendingReceipt} from './types';
-
-const RECEIPT_BEARING_COMMANDS = new Set<string>([
-    WRITE_COMMANDS.REQUEST_MONEY,
-    WRITE_COMMANDS.TRACK_EXPENSE,
-    WRITE_COMMANDS.SPLIT_BILL,
-    WRITE_COMMANDS.SPLIT_BILL_AND_OPEN_REPORT,
-    WRITE_COMMANDS.START_SPLIT_BILL,
-    WRITE_COMMANDS.REPLACE_RECEIPT,
-    WRITE_COMMANDS.SEND_MONEY_ELSEWHERE,
-    WRITE_COMMANDS.SEND_MONEY_WITH_WALLET,
-    WRITE_COMMANDS.SHARE_TRACKED_EXPENSE,
-    WRITE_COMMANDS.CATEGORIZE_TRACKED_EXPENSE,
-    WRITE_COMMANDS.ADD_TRACKED_EXPENSE_TO_POLICY,
-]);
 
 function toPendingReceipt(receipt: unknown): PendingReceipt | undefined {
     if (!isRecord(receipt)) {

--- a/src/libs/telemetry/ReceiptObservability.ts
+++ b/src/libs/telemetry/ReceiptObservability.ts
@@ -34,22 +34,21 @@ type ReceiptEnqueuedParams = {
 };
 
 /**
- * Write commands whose params can carry a captured receipt. A pending request with one of these commands is a receipt
- * that has not reached the server yet. Keep this in sync with the durability slice so the two features agree on which
- * queued requests own a local receipt file.
+ * Write commands whose params carry a captured receipt at data.receipt. A pending request with one of these commands
+ * owns a local receipt file that has not reached the server yet. This is the single source of truth shared by the
+ * receipt observability logs and the sign-out gallery save, so both features agree on which queued requests own a
+ * receipt
  */
 const RECEIPT_BEARING_COMMANDS = new Set<string>([
     WRITE_COMMANDS.REQUEST_MONEY,
     WRITE_COMMANDS.TRACK_EXPENSE,
-    WRITE_COMMANDS.SPLIT_BILL,
-    WRITE_COMMANDS.SPLIT_BILL_AND_OPEN_REPORT,
     WRITE_COMMANDS.START_SPLIT_BILL,
-    WRITE_COMMANDS.COMPLETE_SPLIT_BILL,
     WRITE_COMMANDS.REPLACE_RECEIPT,
     WRITE_COMMANDS.SEND_MONEY_ELSEWHERE,
     WRITE_COMMANDS.SEND_MONEY_WITH_WALLET,
     WRITE_COMMANDS.CATEGORIZE_TRACKED_EXPENSE,
     WRITE_COMMANDS.SHARE_TRACKED_EXPENSE,
+    WRITE_COMMANDS.ADD_TRACKED_EXPENSE_TO_POLICY,
 ]);
 
 /** When each receipt was enqueued, keyed by transaction id, so a snapshot can report how long it has waited. */

--- a/tests/unit/ReceiptObservabilityTest.ts
+++ b/tests/unit/ReceiptObservabilityTest.ts
@@ -124,13 +124,11 @@ describe('ReceiptObservability', () => {
         });
 
         it.each([
-            WRITE_COMMANDS.SPLIT_BILL,
-            WRITE_COMMANDS.SPLIT_BILL_AND_OPEN_REPORT,
-            WRITE_COMMANDS.COMPLETE_SPLIT_BILL,
             WRITE_COMMANDS.SEND_MONEY_ELSEWHERE,
             WRITE_COMMANDS.SEND_MONEY_WITH_WALLET,
             WRITE_COMMANDS.CATEGORIZE_TRACKED_EXPENSE,
             WRITE_COMMANDS.SHARE_TRACKED_EXPENSE,
+            WRITE_COMMANDS.ADD_TRACKED_EXPENSE_TO_POLICY,
         ])('includes %s in the receipt-bearing set', (command) => {
             // Given a queued request for a receipt-bearing command outside the original 4-command allow-list
             getAllSpy.mockReturnValue([{command, data: {transactionID: '300', receipt: {source: 'file://300.png', receiptTraceId: 'trace-C'}}}]);
@@ -144,10 +142,10 @@ describe('ReceiptObservability', () => {
             expect(snapshots.at(0)?.params).toMatchObject({command, transactionID: '300', receiptTraceId: 'trace-C'});
         });
 
-        it('skips receipt-bearing commands whose data.receipt is missing (e.g. SplitBill, SendMoney without receipt)', () => {
-            // Given a receipt-bearing command queued WITHOUT a top-level data.receipt — SplitBill nests it in the splits
-            // JSON; SendMoney can be issued with no receipt at all. A snapshot row with no trace id is not joinable to
-            // the capture log and would only add noise.
+        it('skips requests with no top-level data.receipt (e.g. SplitBill, SendMoney without receipt)', () => {
+            // Given two requests with no top-level data.receipt: a split bill, which is left out of the receipt-bearing
+            // set because it nests its receipt inside the splits payload, and a send money request issued with no
+            // receipt at all. A snapshot row with no trace id cannot be joined to the capture log and would only add noise.
             getAllSpy.mockReturnValue([
                 {command: WRITE_COMMANDS.SPLIT_BILL, data: {transactionID: '500', splits: '[...]'}},
                 {command: WRITE_COMMANDS.SEND_MONEY_WITH_WALLET, data: {transactionID: '501'}},

--- a/tests/unit/savePendingReceiptsToGalleryTest.ts
+++ b/tests/unit/savePendingReceiptsToGalleryTest.ts
@@ -47,7 +47,7 @@ describe('getPendingReceiptRequests', () => {
             buildRequest(WRITE_COMMANDS.REQUEST_MONEY, {source: 'file:///receipt-a.jpg', filename: 'a.jpg', type: 'image/jpeg'}),
             buildRequest(WRITE_COMMANDS.TRACK_EXPENSE, {localSource: 'file:///receipt-b.jpg', source: 'https://remote.example/b.jpg', filename: 'b.jpg', type: 'image/png'}),
             buildRequest(WRITE_COMMANDS.REPLACE_RECEIPT, {source: 'file:///receipt-c.jpg'}),
-            buildRequest(WRITE_COMMANDS.SPLIT_BILL, {source: 'https://remote.example/d.jpg'}),
+            buildRequest(WRITE_COMMANDS.TRACK_EXPENSE, {source: 'https://remote.example/d.jpg'}),
             buildRequest(WRITE_COMMANDS.REQUEST_MONEY),
             buildRequest('OpenReport', {source: 'file:///not-a-receipt.jpg'}),
         ]);
@@ -71,7 +71,7 @@ describe('getPendingReceiptRequests', () => {
     });
 
     it('returns nothing when no receipt requests are pending', () => {
-        mockedGetAll.mockReturnValue([buildRequest('OpenReport'), buildRequest(WRITE_COMMANDS.SPLIT_BILL, {source: 'https://remote.example/x.jpg'})]);
+        mockedGetAll.mockReturnValue([buildRequest('OpenReport'), buildRequest(WRITE_COMMANDS.TRACK_EXPENSE, {source: 'https://remote.example/x.jpg'})]);
 
         expect(getPendingReceiptRequests()).toEqual([]);
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
Follow up -> https://github.com/Expensify/App/pull/94950#discussion_r3554062581

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Deduplicated **RECEIPT_BEARING_COMMANDS** into a single source of truth, removed outdated entries and simplified the comment.


Why the three split commands were removed

**SPLIT_BILL / SPLIT_BILL_AND_OPEN_REPORT** – these don't have a top-level receipt (data.receipt). Any receipt is stored inside the splits JSON, so data.receipt is always empty. They were already skipped by this check.
COMPLETE_SPLIT_BILL – this command doesn't include a receipt at all.

These commands were effectively unused in this list. Removing them doesn't change behavior - it just makes the list simpler

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/92139
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    -  [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
