### PR TITLE
Sort Search transactions by date using created, with inserted/transactionID tiebreakers

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -282,7 +282,7 @@ type GetTransactionSectionsParams = {
 const transactionColumnNamesToSortingProperty: TransactionSorting = {
     [CONST.SEARCH.TABLE_COLUMNS.TO]: 'formattedTo' as const,
     [CONST.SEARCH.TABLE_COLUMNS.FROM]: 'formattedFrom' as const,
-    [CONST.SEARCH.TABLE_COLUMNS.DATE]: 'date' as const,
+    [CONST.SEARCH.TABLE_COLUMNS.DATE]: 'created' as const,
     [CONST.SEARCH.TABLE_COLUMNS.SUBMITTED]: 'submitted' as const,
     [CONST.SEARCH.TABLE_COLUMNS.APPROVED]: 'approved' as const,
     [CONST.SEARCH.TABLE_COLUMNS.POSTED]: 'posted' as const,
@@ -4067,6 +4067,17 @@ function getSortedTransactionData(
         // with only empty values is a no-op and sorts identically for asc and desc.
         if (isEmptyValue(aValue) && isEmptyValue(bValue)) {
             return 0;
+        }
+
+        // When sorting by date (created), created values are already equal, so tie-break on inserted before transactionID.
+        if (sortingProperty === 'created') {
+            const insertedComparison = compareValues(a.inserted, b.inserted, sortOrder, 'inserted', localeCompare);
+
+            if (insertedComparison !== 0) {
+                return insertedComparison;
+            }
+
+            return compareValues(a.transactionID, b.transactionID, sortOrder, 'transactionID', localeCompare);
         }
 
         // Values are present but equal (e.g. the boolean Reimbursable/Billable columns), so we add a tie breaker on

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -4070,13 +4070,7 @@ function getSortedTransactionData(
         }
 
         // Values are present but equal (e.g. the boolean Reimbursable/Billable columns), so we add tiebreakers on
-        // created, inserted, and transactionID as a last resort to make the sort deterministic.
-        const createdComparison = compareValues(a.created, b.created, sortOrder, 'created', localeCompare);
-
-        if (createdComparison !== 0) {
-            return createdComparison;
-        }
-
+        // inserted and transactionID as a last resort to make the sort deterministic.
         const insertedComparison = compareValues(a.inserted, b.inserted, sortOrder, 'inserted', localeCompare);
 
         if (insertedComparison !== 0) {

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -282,7 +282,7 @@ type GetTransactionSectionsParams = {
 const transactionColumnNamesToSortingProperty: TransactionSorting = {
     [CONST.SEARCH.TABLE_COLUMNS.TO]: 'formattedTo' as const,
     [CONST.SEARCH.TABLE_COLUMNS.FROM]: 'formattedFrom' as const,
-    [CONST.SEARCH.TABLE_COLUMNS.DATE]: 'created' as const,
+    [CONST.SEARCH.TABLE_COLUMNS.DATE]: 'date' as const,
     [CONST.SEARCH.TABLE_COLUMNS.SUBMITTED]: 'submitted' as const,
     [CONST.SEARCH.TABLE_COLUMNS.APPROVED]: 'approved' as const,
     [CONST.SEARCH.TABLE_COLUMNS.POSTED]: 'posted' as const,
@@ -4069,23 +4069,18 @@ function getSortedTransactionData(
             return 0;
         }
 
-        // When sorting by date (created), created values are already equal, so tie-break on inserted before transactionID.
-        if (sortingProperty === 'created') {
-            const insertedComparison = compareValues(a.inserted, b.inserted, sortOrder, 'inserted', localeCompare);
-
-            if (insertedComparison !== 0) {
-                return insertedComparison;
-            }
-
-            return compareValues(a.transactionID, b.transactionID, sortOrder, 'transactionID', localeCompare);
-        }
-
-        // Values are present but equal (e.g. the boolean Reimbursable/Billable columns), so we add a tie breaker on
-        // created and/or transactionID as a last resort to make the sort deterministic.
+        // Values are present but equal (e.g. the boolean Reimbursable/Billable columns), so we add tiebreakers on
+        // created, inserted, and transactionID as a last resort to make the sort deterministic.
         const createdComparison = compareValues(a.created, b.created, sortOrder, 'created', localeCompare);
 
         if (createdComparison !== 0) {
             return createdComparison;
+        }
+
+        const insertedComparison = compareValues(a.inserted, b.inserted, sortOrder, 'inserted', localeCompare);
+
+        if (insertedComparison !== 0) {
+            return insertedComparison;
         }
 
         return compareValues(a.transactionID, b.transactionID, sortOrder, 'transactionID', localeCompare);

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -6404,18 +6404,18 @@ describe('SearchUIUtils', () => {
         it.each([
             {columnName: 'Reimbursable', sortBy: CONST.SEARCH.TABLE_COLUMNS.REIMBURSABLE, boolOverride: {reimbursable: true}},
             {columnName: 'Billable', sortBy: CONST.SEARCH.TABLE_COLUMNS.BILLABLE, boolOverride: {billable: true}},
-        ])('should still tie-break tied $columnName rows by created honoring sortOrder (boolean-column behavior from #77800 is preserved)', ({sortBy, boolOverride}) => {
+        ])('should still tie-break tied $columnName rows by inserted honoring sortOrder', ({sortBy, boolOverride}) => {
             // Guards against this fix over-reaching: boolean columns resolve to a non-empty "yes"/"no" value, so every row
-            // ties on the primary comparison but is NOT empty — the created/transactionID tie breaker must still run and
-            // still honor sortOrder. `created` is intentionally unsorted in the input.
+            // ties on the primary comparison but is NOT empty — the inserted/transactionID tie breaker must still run and
+            // still honor sortOrder. `inserted` is intentionally unsorted in the input.
             const baseTransaction = transactionsListItems.at(0);
             if (!baseTransaction) {
                 throw new Error('Missing base transaction fixture');
             }
             const tiedTransactions = [
-                {...baseTransaction, ...boolOverride, transactionID: 'bool-mar', keyForList: 'bool-mar', created: '2024-03-03'},
-                {...baseTransaction, ...boolOverride, transactionID: 'bool-jan', keyForList: 'bool-jan', created: '2024-01-01'},
-                {...baseTransaction, ...boolOverride, transactionID: 'bool-feb', keyForList: 'bool-feb', created: '2024-02-02'},
+                {...baseTransaction, ...boolOverride, transactionID: 'bool-mar', keyForList: 'bool-mar', inserted: '2024-03-03'},
+                {...baseTransaction, ...boolOverride, transactionID: 'bool-jan', keyForList: 'bool-jan', inserted: '2024-01-01'},
+                {...baseTransaction, ...boolOverride, transactionID: 'bool-feb', keyForList: 'bool-feb', inserted: '2024-02-02'},
             ] as TransactionListItemType[];
 
             const ascendingResult = SearchUIUtils.getSortedSections(


### PR DESCRIPTION
### Explanation of Change
The `created` tiebreaker is not unique since manually created transactions just use a date, no timestamp.

This adds a tiebreaker chain of `inserted` instead.

### Fixed Issues
$ https://github.com/Expensify/App/issues/95839

### Tests
- [ ] Verify that no errors appear in the JS console
1. Go to Search (Reports/Expenses view).
2. Sort by Date, ascending and descending.
3. Create multiple transactions with the same date (or same Reimbursable/Billable value) and confirm they sort consistently and don't jump around between re-renders/refreshes.
4. Verify expense-report groupings still order transactions within a report by date descending as before.

### Offline tests
- [ ] Verify that no errors appear in the JS console
1. Same as Tests, performed while offline.

### QA Steps
- [ ] Verify that no errors appear in the JS console
Same as tests.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).

https://github.com/user-attachments/assets/1fb6828d-d093-469e-ae2c-4588f693d9d4

