### PR TITLE
Add truncated-text tooltips to remaining workspace table rows.

### DIFF
--- a/src/components/Tables/WorkspaceDistanceRatesTable/WorkspaceDistanceRatesTableRow.tsx
+++ b/src/components/Tables/WorkspaceDistanceRatesTable/WorkspaceDistanceRatesTableRow.tsx
@@ -62,7 +62,10 @@ function getRateStatusColors(status: string, theme: ReturnType<typeof useTheme>,
             return theme.reportStatusBadge.outstanding;
         case CONST.CUSTOM_UNITS.RATE_STATUS.INACTIVE:
         default:
-            return {backgroundColor: isSelected ? theme.buttonHoveredBG : theme.badgeDefaultBG, textColor: theme.text};
+            return {
+                backgroundColor: isSelected ? theme.buttonHoveredBG : theme.badgeDefaultBG,
+                textColor: theme.text,
+            };
     }
 }
 
@@ -102,6 +105,7 @@ function WorkspaceDistanceRatesTableRow({item, rowIndex, shouldUseNarrowTableLay
                     {shouldUseNarrowTableLayout && (
                         <View style={[styles.flex1, styles.justifyContentCenter]}>
                             <TextWithTooltip
+                                shouldShowTooltip
                                 text={rate.name ?? ''}
                                 style={[styles.optionDisplayName, styles.pre]}
                             />
@@ -112,6 +116,7 @@ function WorkspaceDistanceRatesTableRow({item, rowIndex, shouldUseNarrowTableLay
                                     textColor={statusColors.textColor}
                                 />
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     text={[formattedRate, dateLabelText].filter(Boolean).join(` ${CONST.DOT_SEPARATOR} `)}
                                     numberOfLines={1}
                                     style={[styles.textLabelSupporting, styles.lh16, styles.pre, styles.flexShrink1]}
@@ -133,6 +138,7 @@ function WorkspaceDistanceRatesTableRow({item, rowIndex, shouldUseNarrowTableLay
                     {!shouldUseNarrowTableLayout && (
                         <View style={[styles.flex1]}>
                             <TextWithTooltip
+                                shouldShowTooltip
                                 numberOfLines={1}
                                 text={rate.name ?? ''}
                                 style={[styles.lh16, styles.optionDisplayName, styles.pre]}
@@ -143,6 +149,7 @@ function WorkspaceDistanceRatesTableRow({item, rowIndex, shouldUseNarrowTableLay
                     {!shouldUseNarrowTableLayout && (
                         <View style={[styles.flex1]}>
                             <TextWithTooltip
+                                shouldShowTooltip
                                 numberOfLines={1}
                                 text={formattedRate}
                                 style={[styles.lh16, styles.optionDisplayName, styles.pre]}
@@ -153,6 +160,7 @@ function WorkspaceDistanceRatesTableRow({item, rowIndex, shouldUseNarrowTableLay
                     {!shouldUseNarrowTableLayout && shouldShowDateColumns && (
                         <View style={[styles.flex1]}>
                             <TextWithTooltip
+                                shouldShowTooltip
                                 numberOfLines={1}
                                 text={formatDate(rate.startDate)}
                                 style={[styles.lh16, styles.optionDisplayName, styles.pre]}
@@ -163,6 +171,7 @@ function WorkspaceDistanceRatesTableRow({item, rowIndex, shouldUseNarrowTableLay
                     {!shouldUseNarrowTableLayout && shouldShowDateColumns && (
                         <View style={[styles.flex1]}>
                             <TextWithTooltip
+                                shouldShowTooltip
                                 numberOfLines={1}
                                 text={formatDate(rate.endDate)}
                                 style={[styles.lh16, styles.optionDisplayName, styles.pre]}

--- a/src/components/Tables/WorkspaceExpenseDefaultsTable/WorkspaceExpenseDefaultsTableRow.tsx
+++ b/src/components/Tables/WorkspaceExpenseDefaultsTable/WorkspaceExpenseDefaultsTableRow.tsx
@@ -87,7 +87,12 @@ function WorkspaceExpenseDefaultsTableRow({item, rowIndex, shouldUseNarrowTableL
                 disabled={isDeleting}
                 accessibilityLabel={accessibilityLabel}
                 sentryLabel={item.isMerchantType ? CONST.SENTRY_LABEL.WORKSPACE.RULES.MERCHANT_TYPE_RULE_ITEM : CONST.SENTRY_LABEL.WORKSPACE.RULES.MERCHANT_RULE_ITEM}
-                offlineWithFeedback={{pendingAction: item.pendingAction, shouldHideOnDelete: false, errors: item.errors, onClose: item.onCloseError}}
+                offlineWithFeedback={{
+                    pendingAction: item.pendingAction,
+                    shouldHideOnDelete: false,
+                    errors: item.errors,
+                    onClose: item.onCloseError,
+                }}
                 onPress={item.action}
                 checkboxReplacementElement={lockIcon}
             >
@@ -111,12 +116,14 @@ function WorkspaceExpenseDefaultsTableRow({item, rowIndex, shouldUseNarrowTableL
                                         isCondensed
                                     />
                                     <TextWithTooltip
+                                        shouldShowTooltip
                                         text={item.conditionText}
                                         numberOfLines={1}
                                         style={[styles.optionDisplayName, styles.pre, styles.flexShrink1]}
                                     />
                                 </View>
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     text={item.ruleDescription}
                                     numberOfLines={1}
                                     style={[styles.textLabelSupporting, styles.lh16, styles.pre, styles.mt1]}
@@ -144,6 +151,7 @@ function WorkspaceExpenseDefaultsTableRow({item, rowIndex, shouldUseNarrowTableL
                                 </View>
                                 <View style={[styles.flex1]}>
                                     <TextWithTooltip
+                                        shouldShowTooltip
                                         numberOfLines={1}
                                         text={item.conditionText}
                                         style={[styles.lh16, styles.optionDisplayName, styles.pre]}
@@ -151,6 +159,7 @@ function WorkspaceExpenseDefaultsTableRow({item, rowIndex, shouldUseNarrowTableL
                                 </View>
                                 <View style={[styles.flex1]}>
                                     <TextWithTooltip
+                                        shouldShowTooltip
                                         numberOfLines={1}
                                         text={item.ruleDescription}
                                         style={[styles.lh16, styles.optionDisplayName, styles.pre]}

--- a/src/components/Tables/WorkspaceFlagForReviewTable/WorkspaceFlagForReviewTableRow.tsx
+++ b/src/components/Tables/WorkspaceFlagForReviewTable/WorkspaceFlagForReviewTableRow.tsx
@@ -42,7 +42,10 @@ function WorkspaceFlagForReviewTableRow({item, rowIndex, shouldUseNarrowTableLay
             disabled={item.disabled}
             accessibilityLabel={accessibilityLabel}
             sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.FLAG_FOR_REVIEW_RULE_ITEM}
-            offlineWithFeedback={{pendingAction: item.pendingAction, shouldHideOnDelete: false}}
+            offlineWithFeedback={{
+                pendingAction: item.pendingAction,
+                shouldHideOnDelete: false,
+            }}
             onPress={item.action}
         >
             {({hovered}) => (
@@ -65,12 +68,14 @@ function WorkspaceFlagForReviewTableRow({item, rowIndex, shouldUseNarrowTableLay
                                     isCondensed
                                 />
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     text={item.conditionText}
                                     numberOfLines={1}
                                     style={[styles.optionDisplayName, styles.pre, styles.flexShrink1]}
                                 />
                             </View>
                             <TextWithTooltip
+                                shouldShowTooltip
                                 text={item.ruleDescription}
                                 numberOfLines={1}
                                 style={[styles.textLabelSupporting, styles.lh16, styles.pre, styles.mt1]}
@@ -98,6 +103,7 @@ function WorkspaceFlagForReviewTableRow({item, rowIndex, shouldUseNarrowTableLay
                             </View>
                             <View style={[styles.flex1]}>
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     numberOfLines={1}
                                     text={item.conditionText}
                                     style={[styles.lh16, styles.optionDisplayName, styles.pre]}
@@ -105,6 +111,7 @@ function WorkspaceFlagForReviewTableRow({item, rowIndex, shouldUseNarrowTableLay
                             </View>
                             <View style={[styles.flex1]}>
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     numberOfLines={1}
                                     text={item.ruleDescription}
                                     style={[styles.lh16, styles.optionDisplayName, styles.pre]}

--- a/src/components/Tables/WorkspaceMembersTable/WorkspaceMembersTableRow.tsx
+++ b/src/components/Tables/WorkspaceMembersTable/WorkspaceMembersTableRow.tsx
@@ -94,23 +94,27 @@ export default function WorkspaceMembersTableRow({item, rowIndex, shouldShowCust
 
                     {!shouldUseNarrowTableLayout && shouldShowCustomField1Column && (
                         <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
-                            <TextWithTooltip
-                                shouldShowTooltip
-                                numberOfLines={1}
-                                text={item.employeeUserID ?? ''}
-                                style={[styles.lh16, styles.optionDisplayName, styles.pre]}
-                            />
+                            {!!item.employeeUserID && (
+                                <TextWithTooltip
+                                    shouldShowTooltip
+                                    numberOfLines={1}
+                                    text={item.employeeUserID}
+                                    style={[styles.lh16, styles.optionDisplayName, styles.pre]}
+                                />
+                            )}
                         </View>
                     )}
 
                     {!shouldUseNarrowTableLayout && shouldShowCustomField2Column && (
                         <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
-                            <TextWithTooltip
-                                shouldShowTooltip
-                                numberOfLines={1}
-                                text={item.employeePayrollID ?? ''}
-                                style={[styles.lh16, styles.optionDisplayName, styles.pre]}
-                            />
+                            {!!item.employeePayrollID && (
+                                <TextWithTooltip
+                                    shouldShowTooltip
+                                    numberOfLines={1}
+                                    text={item.employeePayrollID}
+                                    style={[styles.lh16, styles.optionDisplayName, styles.pre]}
+                                />
+                            )}
                         </View>
                     )}
 

--- a/src/components/Tables/WorkspaceMembersTable/WorkspaceMembersTableRow.tsx
+++ b/src/components/Tables/WorkspaceMembersTable/WorkspaceMembersTableRow.tsx
@@ -60,7 +60,11 @@ export default function WorkspaceMembersTableRow({item, rowIndex, shouldShowCust
             disabled={item.disabled}
             accessibilityLabel={accessibilityLabel}
             sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.MEMBERS.LIST_ROW}
-            offlineWithFeedback={{errors: item.errors, pendingAction: item.pendingAction, onClose: item.dismissError}}
+            offlineWithFeedback={{
+                errors: item.errors,
+                pendingAction: item.pendingAction,
+                onClose: item.dismissError,
+            }}
             onPress={item.action}
         >
             {(hovered) => (
@@ -90,13 +94,23 @@ export default function WorkspaceMembersTableRow({item, rowIndex, shouldShowCust
 
                     {!shouldUseNarrowTableLayout && shouldShowCustomField1Column && (
                         <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
-                            <Text numberOfLines={1}>{item.employeeUserID}</Text>
+                            <TextWithTooltip
+                                shouldShowTooltip
+                                numberOfLines={1}
+                                text={item.employeeUserID ?? ''}
+                                style={[styles.lh16, styles.optionDisplayName, styles.pre]}
+                            />
                         </View>
                     )}
 
                     {!shouldUseNarrowTableLayout && shouldShowCustomField2Column && (
                         <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
-                            <Text numberOfLines={1}>{item.employeePayrollID}</Text>
+                            <TextWithTooltip
+                                shouldShowTooltip
+                                numberOfLines={1}
+                                text={item.employeePayrollID ?? ''}
+                                style={[styles.lh16, styles.optionDisplayName, styles.pre]}
+                            />
                         </View>
                     )}
 

--- a/src/components/Tables/WorkspaceRequireFieldsTable/WorkspaceRequireFieldsTableRow.tsx
+++ b/src/components/Tables/WorkspaceRequireFieldsTable/WorkspaceRequireFieldsTableRow.tsx
@@ -39,7 +39,10 @@ function WorkspaceRequireFieldsTableRow({item, rowIndex, shouldUseNarrowTableLay
             disabled={item.disabled}
             accessibilityLabel={accessibilityLabel}
             sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.REQUIRE_FIELDS_RULE_ITEM}
-            offlineWithFeedback={{pendingAction: item.pendingAction, shouldHideOnDelete: false}}
+            offlineWithFeedback={{
+                pendingAction: item.pendingAction,
+                shouldHideOnDelete: false,
+            }}
             onPress={item.action}
         >
             {({hovered}) => (
@@ -62,12 +65,14 @@ function WorkspaceRequireFieldsTableRow({item, rowIndex, shouldUseNarrowTableLay
                                     isCondensed
                                 />
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     text={item.conditionText}
                                     numberOfLines={1}
                                     style={[styles.optionDisplayName, styles.pre, styles.flexShrink1]}
                                 />
                             </View>
                             <TextWithTooltip
+                                shouldShowTooltip
                                 text={item.ruleDescription}
                                 numberOfLines={1}
                                 style={[styles.textLabelSupporting, styles.lh16, styles.pre, styles.mt1]}
@@ -95,6 +100,7 @@ function WorkspaceRequireFieldsTableRow({item, rowIndex, shouldUseNarrowTableLay
                             </View>
                             <View style={[styles.flex1]}>
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     numberOfLines={1}
                                     text={item.conditionText}
                                     style={[styles.lh16, styles.optionDisplayName, styles.pre]}
@@ -102,6 +108,7 @@ function WorkspaceRequireFieldsTableRow({item, rowIndex, shouldUseNarrowTableLay
                             </View>
                             <View style={[styles.flex1]}>
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     numberOfLines={1}
                                     text={item.ruleDescription}
                                     style={[styles.lh16, styles.optionDisplayName, styles.pre]}

--- a/src/components/Tables/WorkspaceSpendRulesTable/WorkspaceSpendRulesTableRow.tsx
+++ b/src/components/Tables/WorkspaceSpendRulesTable/WorkspaceSpendRulesTableRow.tsx
@@ -82,7 +82,10 @@ function WorkspaceSpendRulesTableRow({item, rowIndex, shouldUseNarrowTableLayout
                 disabled={isDeleting}
                 accessibilityLabel={accessibilityLabel}
                 sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.RULES.SPEND_RULE_ITEM}
-                offlineWithFeedback={{pendingAction: item.pendingAction, shouldHideOnDelete: false}}
+                offlineWithFeedback={{
+                    pendingAction: item.pendingAction,
+                    shouldHideOnDelete: false,
+                }}
                 onPress={item.action}
                 checkboxReplacementElement={lockIcon}
             >
@@ -100,12 +103,14 @@ function WorkspaceSpendRulesTableRow({item, rowIndex, shouldUseNarrowTableLayout
                                         isCondensed
                                     />
                                     <TextWithTooltip
+                                        shouldShowTooltip
                                         text={item.cardSummary}
                                         numberOfLines={1}
                                         style={[styles.optionDisplayName, styles.pre, styles.flexShrink1]}
                                     />
                                 </View>
                                 <TextWithTooltip
+                                    shouldShowTooltip
                                     text={item.ruleSummary}
                                     numberOfLines={1}
                                     style={[styles.textLabelSupporting, styles.lh16, styles.pre, styles.mt1]}
@@ -127,6 +132,7 @@ function WorkspaceSpendRulesTableRow({item, rowIndex, shouldUseNarrowTableLayout
                                 </View>
                                 <View style={[styles.flex1]}>
                                     <TextWithTooltip
+                                        shouldShowTooltip
                                         numberOfLines={1}
                                         text={item.cardSummary}
                                         style={[styles.lh16, styles.optionDisplayName, styles.pre]}
@@ -134,6 +140,7 @@ function WorkspaceSpendRulesTableRow({item, rowIndex, shouldUseNarrowTableLayout
                                 </View>
                                 <View style={[styles.flex1]}>
                                     <TextWithTooltip
+                                        shouldShowTooltip
                                         numberOfLines={1}
                                         text={item.ruleSummary}
                                         style={[styles.lh16, styles.optionDisplayName, styles.pre]}


### PR DESCRIPTION
### Explanation of Change

### Fixed Issues

$ [https://github.com/Expensify/App/issues/95886](<https://github.com/Expensify/App/issues/95886>)<br>PROPOSAL:

### Tests

- For each table, narrow the browser until text ellipsizes, then hover to confirm the tooltip shows the full value:

1. Workspace → Distance rates
2. Workspace → Rules → Spend rules / Flag for review / Require fields / Expense defaults
3. Workspace → Members (with custom field columns enabled)

- [X] Verify that no errors appear in the JS console

### Offline tests

- Same as tests

### QA Steps

- Same as tests
- [X] Verify that no errors appear in the JS console

### PR Author Checklist

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
  - [X] I added steps for local testing in the `Tests` section
  - [X] I added steps for the expected offline behavior in the `Offline steps` section
  - [X] I added steps for Staging and/or Production testing in the `QA steps` section
  - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [X] I tested this PR with a [High Traffic account](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts>) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms>)
- [X] I ran the tests on **all platforms** & verified they passed on:
  - [X] Android: Native
  - [X] Android: mWeb Chrome
  - [X] iOS: Native
  - [X] iOS: mWeb Safari
  - [X] MacOS: Chrome / Safari
  - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code>))
  - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [X] I verified that comments were added to code that is not self explanatory
  - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](<https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80>)
    - [X] If any non-english text was added/modified, I used [JaimeGPT](<https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt>) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](<https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123>)
  - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](<https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs>)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md>)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
  - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
  - [X] A similar style doesn't already exist
  - [X] The style can't be created with an existing [StyleUtils](<https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts>) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
  - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [X] I verified that all the inputs inside a form are aligned with each other.
  - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](<https://github.com/Expensify/App/blob/main/tests/README.md>) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details><summary>Android: Native</summary>

</details>

<details><summary>Android: mWeb Chrome</summary>

</details>

<details><summary>iOS: Native</summary>

</details>

<details><summary>iOS: mWeb Safari</summary>

</details>

<details><summary>MacOS: Chrome / Safari</summary>

</details>

https://github.com/user-attachments/assets/e29692d5-99b9-4d83-bde8-b24d5f542d8d