### PR TITLE
Fix agent avatar CDN URL path in Share Code QR

### DIFF
--- a/src/libs/Avatars/AgentAvatarCatalog.ts
+++ b/src/libs/Avatars/AgentAvatarCatalog.ts
@@ -9,7 +9,7 @@ import {createAvatarCatalog} from './AvatarCatalog';
 
 type AgentAvatarID = 'bot-avatar--blue' | 'bot-avatar--green' | 'bot-avatar--ice' | 'bot-avatar--pink' | 'bot-avatar--tangerine' | 'bot-avatar--yellow';
 
-const CDN_BOT_AVATARS = `${CONST.CLOUDFRONT_URL}/images/avatars/bots`;
+const CDN_BOT_AVATARS = `${CONST.CLOUDFRONT_URL}/images/avatars`;
 
 const AGENT_AVATAR_ENTRIES: Record<AgentAvatarID, AvatarEntry> = {
     'bot-avatar--blue': {local: BotAvatarBlue, url: `${CDN_BOT_AVATARS}/bot-avatar--blue.png`},

--- a/tests/unit/UserAvatarUtilsTest.ts
+++ b/tests/unit/UserAvatarUtilsTest.ts
@@ -72,6 +72,13 @@ describe('UserAvatarUtils', () => {
 
             expect(avatarUrl).toEqual('https://test.com/images/some_avatar.png');
         });
+
+        it('should return the canonical CDN URL for an agent avatar', () => {
+            const avatarURL = 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/bot-avatar--blue.png';
+            const avatarUrl = UserAvatarUtils.getAvatarURL({avatarSource: avatarURL, accountID: 1});
+
+            expect(avatarUrl).toBe('https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/bot-avatar--blue.png');
+        });
     });
 
     describe('getPresetAvatarURL', () => {
@@ -176,7 +183,7 @@ describe('UserAvatarUtils', () => {
         });
 
         it('should return true for agent catalog avatar URLs', () => {
-            const botURL = 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/bots/bot-avatar--blue.png';
+            const botURL = 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/bot-avatar--blue.png';
             expect(UserAvatarUtils.isCatalogAvatar(botURL)).toBe(true);
         });
 
@@ -288,7 +295,7 @@ describe('UserAvatarUtils', () => {
         });
 
         it('should extract agent catalog avatar name from CloudFront URL', () => {
-            const url = 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/bots/bot-avatar--blue.png';
+            const url = 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/bot-avatar--blue.png';
             const result = UserAvatarUtils.getCatalogAvatarNameFromURL(url);
             expect(result).toBe('bot-avatar--blue');
         });


### PR DESCRIPTION
### Explanation of Change

The agent ("bot") avatar catalog in the App built CDN URLs under `images/avatars/bots/`, but the PNGs are published on CloudFront at `images/avatars/` (matching the backend's `AvatarCatalog.php`). The wrong path returns a 403, so any surface that uses the CDN URL instead of the bundled local SVG — like the Share Code QR logo via `getAvatarURL` — rendered a broken image.

This PR drops the `/bots` segment from the CDN base URL so `getAvatarURL` returns the canonical, working URL. Test fixtures are updated to the canonical path and a regression test is added asserting `getAvatarURL` returns the canonical CDN URL for an agent avatar.

### Fixed Issues

$ https://github.com/Expensify/App/issues/91561
PROPOSAL:

### Tests

1. Go to Account > Profile.
2. Click on the avatar.
3. Select an "Agent" avatar (any color) and click Save.
4. Click Share.
5. Verify the agent avatar renders correctly in the center of the QR code.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Go to Account > Profile and open the Share page.
3. Verify the previously selected agent avatar still renders in the QR code (the local SVG fallback is unaffected by this change).

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1471" height="871" alt="image" src="https://github.com/user-attachments/assets/f5d7fb66-abb5-4b41-a165-b695a6fa7773" />

</details>