### PR TITLE
[No QA] Reduce unsafe type assertions in add Root History Router Extension tests

### DIFF
--- a/tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts
+++ b/tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts
@@ -1,18 +1,18 @@
 import type {RootStackNavigatorAction} from '@libs/Navigation/AppNavigator/createRootStackNavigator/types';
 import addRootHistoryRouterExtension from '@libs/Navigation/AppNavigator/routerExtensions/addRootHistoryRouterExtension';
 import type {CustomHistoryEntry} from '@libs/Navigation/AppNavigator/routerExtensions/types';
-import type {PlatformStackRouterOptions} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {PlatformStackNavigationState, PlatformStackRouterOptions} from '@libs/Navigation/PlatformStackNavigation/types';
 
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 
-import type {NavigationRoute, ParamListBase, PartialState, Router, RouterConfigOptions, StackNavigationState} from '@react-navigation/native';
+import type {NavigationRoute, ParamListBase, PartialState, Router, RouterConfigOptions} from '@react-navigation/native';
 
 import createMock from '../../../utils/createMock';
 
-type TestState = StackNavigationState<ParamListBase> & {history?: CustomHistoryEntry[]};
+type TestState = PlatformStackNavigationState<ParamListBase>;
 
 const SIDE_PANEL = CONST.NAVIGATION.CUSTOM_HISTORY_ENTRY_SIDE_PANEL;
 const REVEAL_PADDING = CONST.NAVIGATION.CUSTOM_HISTORY_ENTRY_REVEAL_PADDING;
@@ -45,6 +45,10 @@ function makeState(routes: Array<NavigationRoute<ParamListBase, string>>, overri
     };
 }
 
+function isCustomHistoryEntry(entry: unknown): entry is CustomHistoryEntry {
+    return typeof entry === 'string' || (typeof entry === 'object' && entry !== null && 'key' in entry && 'name' in entry);
+}
+
 const CONFIG_OPTIONS: RouterConfigOptions = {
     routeNames: ['ScreenA', 'ScreenB'],
     routeParamList: {},
@@ -68,7 +72,7 @@ function createMockRouterFactory(actionHandler?: (state: TestState, action: Root
                     params: r.params,
                 }));
                 return makeState(routes, {
-                    history: partialState.history as CustomHistoryEntry[] | undefined,
+                    history: partialState.history?.filter(isCustomHistoryEntry),
                 });
             },
 
@@ -104,12 +108,12 @@ function createMockRouterFactory(actionHandler?: (state: TestState, action: Root
     return mockRouterFactory;
 }
 
-function expectRouteEntry(entry: CustomHistoryEntry | undefined): asserts entry is NavigationRoute<ParamListBase, string> {
+function expectRouteEntry(entry: unknown): asserts entry is NavigationRoute<ParamListBase, string> {
     expect(entry).toBeDefined();
     expect(typeof entry).not.toBe('string');
 }
 
-function expectTestState(state: TestState | null): asserts state is TestState {
+function expectTestState(state: unknown): asserts state is TestState {
     expect(state).not.toBeNull();
 }
 

--- a/tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts
+++ b/tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts
@@ -5,6 +5,7 @@ import type {PlatformStackRouterOptions} from '@libs/Navigation/PlatformStackNav
 
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
+import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 
 import type {NavigationRoute, ParamListBase, PartialState, Router, RouterConfigOptions, StackNavigationState} from '@react-navigation/native';
@@ -27,7 +28,7 @@ function nextTestKey(prefix: string): string {
     return `${prefix}-${testKeyCounter}`;
 }
 
-function makeRoute(name: string, key?: string, params?: Record<string, unknown>): NavigationRoute<ParamListBase, string> {
+function makeRoute(name: string, key?: string, params?: NavigationRoute<ParamListBase, string>['params']): NavigationRoute<ParamListBase, string> {
     return createMock<NavigationRoute<ParamListBase, string>>({key: key ?? nextTestKey(name), name, params});
 }
 
@@ -65,7 +66,7 @@ function createMockRouterFactory(actionHandler?: (state: TestState, action: Root
                     key: r.key ?? `${r.name}-rehydrated`,
                     name: r.name,
                     params: r.params,
-                })) as Array<NavigationRoute<ParamListBase, string>>;
+                }));
                 return makeState(routes, {
                     history: partialState.history as CustomHistoryEntry[] | undefined,
                 });
@@ -85,8 +86,7 @@ function createMockRouterFactory(actionHandler?: (state: TestState, action: Root
                 }
 
                 if (action.type === 'NAVIGATE') {
-                    const payload = action.payload as {name: string; params?: Record<string, unknown>};
-                    const newRoute = makeRoute(payload.name, nextTestKey(payload.name), payload.params);
+                    const newRoute = makeRoute(action.payload.name, nextTestKey(action.payload.name), action.payload.params);
                     return makeState([...state.routes, newRoute]);
                 }
 
@@ -104,15 +104,22 @@ function createMockRouterFactory(actionHandler?: (state: TestState, action: Root
     return mockRouterFactory;
 }
 
-function asRouteEntry(entry: CustomHistoryEntry): NavigationRoute<ParamListBase, string> {
-    return entry as NavigationRoute<ParamListBase, string>;
+function expectRouteEntry(entry: CustomHistoryEntry | undefined): asserts entry is NavigationRoute<ParamListBase, string> {
+    expect(entry).toBeDefined();
+    expect(typeof entry).not.toBe('string');
 }
 
-// Typed action factories. The extension only inspects `action.type` (and snapshots the top
-// route's key on REPLACE), so the payload shape is a no-op for these tests; we use the
-// minimum-shape `Route` placeholder ({name: '/'}) to satisfy the production action contract
-// without forcing test code to fabricate full route objects.
-const PLACEHOLDER_ROUTE = '/' as Route;
+function expectTestState(state: TestState | null): asserts state is TestState {
+    expect(state).not.toBeNull();
+}
+
+function getTestStateForAction(router: Router<TestState, RootStackNavigatorAction>, state: TestState, action: RootStackNavigatorAction): TestState {
+    const newState = router.getStateForAction(state, action, CONFIG_OPTIONS);
+    expectTestState(newState);
+    return newState;
+}
+
+const PLACEHOLDER_ROUTE: Route = ROUTES.HOME;
 const makeReplaceAction = (): RootStackNavigatorAction => ({type: REPLACE_FULLSCREEN_UNDER_RHP, payload: {route: PLACEHOLDER_ROUTE}});
 const makeRemoveAction = (): RootStackNavigatorAction => ({type: REMOVE_FULLSCREEN_UNDER_RHP, payload: {expectedRouteName: 'X'}});
 const makeDismissAction = (): RootStackNavigatorAction => ({type: DISMISS_MODAL});
@@ -151,7 +158,8 @@ describe('addRootHistoryRouterExtension', () => {
         expect(state.history).toBeDefined();
         expect(state.history).toHaveLength(state.routes.length);
         for (const [i, route] of state.routes.entries()) {
-            const entry = asRouteEntry(state.history?.at(i) as CustomHistoryEntry);
+            const entry = state.history?.at(i);
+            expectRouteEntry(entry);
             expect(entry.key).toBe(route.key);
             expect(entry.name).toBe(route.name);
         }
@@ -161,7 +169,7 @@ describe('addRootHistoryRouterExtension', () => {
         const factory = createMockRouterFactory();
         const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
-        const partialState = {
+        const partialState: PartialState<TestState> = {
             routes: [
                 {name: 'ScreenA', key: 'a-1', params: {foo: 1}},
                 {name: 'ScreenB', key: 'b-1'},
@@ -169,25 +177,29 @@ describe('addRootHistoryRouterExtension', () => {
             stale: true as const,
         };
 
-        const state = enhancedRouter.getRehydratedState(partialState as PartialState<TestState>, CONFIG_OPTIONS);
+        const state = enhancedRouter.getRehydratedState(partialState, CONFIG_OPTIONS);
 
         expect(state.history).toBeDefined();
         expect(state.history).toHaveLength(2);
-        expect(asRouteEntry(state.history?.at(0) as CustomHistoryEntry).key).toBe('a-1');
-        expect(asRouteEntry(state.history?.at(1) as CustomHistoryEntry).key).toBe('b-1');
+        const firstEntry = state.history?.at(0);
+        expectRouteEntry(firstEntry);
+        expect(firstEntry.key).toBe('a-1');
+        const secondEntry = state.history?.at(1);
+        expectRouteEntry(secondEntry);
+        expect(secondEntry.key).toBe('b-1');
     });
 
     it('getRehydratedState preserves CUSTOM_HISTORY_ENTRY_SIDE_PANEL when present as last entry in partial state history', () => {
         const factory = createMockRouterFactory();
         const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
-        const partialState = {
+        const partialState: PartialState<TestState> = {
             routes: [{name: 'ScreenA', key: 'a-1'}],
             stale: true as const,
             history: [{key: 'a-1', name: 'ScreenA'}, SIDE_PANEL],
         };
 
-        const state = enhancedRouter.getRehydratedState(partialState as PartialState<TestState>, CONFIG_OPTIONS);
+        const state = enhancedRouter.getRehydratedState(partialState, CONFIG_OPTIONS);
 
         expect(state.history).toBeDefined();
         expect(state.history?.at(-1)).toBe(SIDE_PANEL);
@@ -199,13 +211,13 @@ describe('addRootHistoryRouterExtension', () => {
         const factory = createMockRouterFactory();
         const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
-        const partialState = {
+        const partialState: PartialState<TestState> = {
             routes: [{name: 'ScreenA', key: 'a-1'}],
             stale: true as const,
             history: [{key: 'a-1', name: 'ScreenA'}],
         };
 
-        const state = enhancedRouter.getRehydratedState(partialState as PartialState<TestState>, CONFIG_OPTIONS);
+        const state = enhancedRouter.getRehydratedState(partialState, CONFIG_OPTIONS);
 
         expect(state.history?.every((e) => e !== SIDE_PANEL)).toBe(true);
     });
@@ -227,7 +239,8 @@ describe('addRootHistoryRouterExtension', () => {
         expect(newState?.history).toBeDefined();
         expect(newState?.history).toHaveLength(newState?.routes.length ?? -1);
         for (const [i, r] of (newState?.routes ?? []).entries()) {
-            const entry = asRouteEntry(newState?.history?.at(i) as CustomHistoryEntry);
+            const entry = newState?.history?.at(i);
+            expectRouteEntry(entry);
             expect(entry.key).toBe(r.key);
         }
     });
@@ -297,8 +310,7 @@ describe('addRootHistoryRouterExtension', () => {
                     return withRoutes(state, state.routes.slice(0, -1));
                 }
                 if (action.type === 'NAVIGATE') {
-                    const payload = action.payload as {name: string; params?: Record<string, unknown>};
-                    const newRoute = makeRoute(payload.name, nextTestKey(payload.name), payload.params);
+                    const newRoute = makeRoute(action.payload.name, nextTestKey(action.payload.name), action.payload.params);
                     return withRoutes(state, [...state.routes, newRoute]);
                 }
                 return state;
@@ -326,7 +338,8 @@ describe('addRootHistoryRouterExtension', () => {
             expect(afterReplace).not.toBeNull();
             expect(afterReplace?.history?.length).toBe(3);
 
-            const afterDismiss = enhancedRouter.getStateForAction(afterReplace as TestState, makeDismissAction(), CONFIG_OPTIONS);
+            expectTestState(afterReplace);
+            const afterDismiss = enhancedRouter.getStateForAction(afterReplace, makeDismissAction(), CONFIG_OPTIONS);
             expect(afterDismiss).not.toBeNull();
             // Routes shrunk by 1 (modal popped)…
             expect(afterDismiss?.routes.length).toBe(1);
@@ -335,7 +348,9 @@ describe('addRootHistoryRouterExtension', () => {
             // The phantom entries are now sentinel padding at the front, NOT stale route mirrors.
             expect(countLeadingPadding(afterDismiss?.history)).toBe(2);
             // Trailing entries reflect the new (post-dismiss) routes.
-            expect(asRouteEntry(afterDismiss?.history?.at(-1) as CustomHistoryEntry).key).toBe('tab-b-1');
+            const lastHistoryEntry = afterDismiss?.history?.at(-1);
+            expectRouteEntry(lastHistoryEntry);
+            expect(lastHistoryEntry.key).toBe('tab-b-1');
         });
 
         it('maintains the reveal-induced length offset across subsequent inner navigations', () => {
@@ -353,15 +368,15 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterReplace = enhancedRouter.getStateForAction(stateWithRHP, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
-            const afterDismiss = enhancedRouter.getStateForAction(afterReplace, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterReplace = getTestStateForAction(enhancedRouter, stateWithRHP, makeReplaceAction());
+            const afterDismiss = getTestStateForAction(enhancedRouter, afterReplace, makeDismissAction());
 
             // Sanity: offset of 2.
             expect(countLeadingPadding(afterDismiss.history)).toBe(2);
             expect(afterDismiss.history?.length).toBe(3);
 
             // Inner NAVIGATE - routes grow by 1; offset must persist.
-            const afterNavigate = enhancedRouter.getStateForAction(afterDismiss, makeNavigateAction('TabC'), CONFIG_OPTIONS) as TestState;
+            const afterNavigate = getTestStateForAction(enhancedRouter, afterDismiss, makeNavigateAction('TabC'));
             expect(afterNavigate.routes.length).toBe(2);
             expect(afterNavigate.history?.length).toBe(4);
             expect(countLeadingPadding(afterNavigate.history)).toBe(2);
@@ -386,7 +401,7 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterDismiss = enhancedRouter.getStateForAction(stateWithRHP, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterDismiss = getTestStateForAction(enhancedRouter, stateWithRHP, makeDismissAction());
 
             expect(afterDismiss.routes.length).toBe(1);
             expect(afterDismiss.history?.length).toBe(1);
@@ -421,15 +436,15 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterReplace = enhancedRouter.getStateForAction(stateWithRHP, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
-            const afterRemove = enhancedRouter.getStateForAction(afterReplace, makeRemoveAction(), CONFIG_OPTIONS) as TestState;
+            const afterReplace = getTestStateForAction(enhancedRouter, stateWithRHP, makeReplaceAction());
+            const afterRemove = getTestStateForAction(enhancedRouter, afterReplace, makeRemoveAction());
 
             // REMOVE freezes too (same intermediate-frame rationale as REPLACE).
             expect(afterRemove.history?.length).toBe(2);
             expect(countLeadingPadding(afterRemove.history)).toBe(0);
 
             // Now dismiss the modal normally - must NOT engage the freeze logic.
-            const afterDismiss = enhancedRouter.getStateForAction(afterRemove, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterDismiss = getTestStateForAction(enhancedRouter, afterRemove, makeDismissAction());
             expect(afterDismiss.routes.length).toBe(1);
             expect(afterDismiss.history?.length).toBe(1);
             expect(countLeadingPadding(afterDismiss.history)).toBe(0);
@@ -465,8 +480,8 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterFirstReplace = enhancedRouter.getStateForAction(initialState, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
-            const afterFirstDismiss = enhancedRouter.getStateForAction(afterFirstReplace, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterFirstReplace = getTestStateForAction(enhancedRouter, initialState, makeReplaceAction());
+            const afterFirstDismiss = getTestStateForAction(enhancedRouter, afterFirstReplace, makeDismissAction());
             expect(afterFirstDismiss.history?.length).toBe(3);
             expect(countLeadingPadding(afterFirstDismiss.history)).toBe(2);
 
@@ -476,15 +491,17 @@ describe('addRootHistoryRouterExtension', () => {
             });
             // Second reveal: replace TabB → TabC, then dismiss rhp2.
             replaceTarget = tabC;
-            const afterSecondReplace = enhancedRouter.getStateForAction(stateWithRhp2, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
-            const afterSecondDismiss = enhancedRouter.getStateForAction(afterSecondReplace, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterSecondReplace = getTestStateForAction(enhancedRouter, stateWithRhp2, makeReplaceAction());
+            const afterSecondDismiss = getTestStateForAction(enhancedRouter, afterSecondReplace, makeDismissAction());
 
             // Pre-second-dismiss history length was 4 (2 padding + tabB + rhp2). Post-dismiss
             // routes length is 1 (tabC). Offset must be 4 - 1 = 3.
             expect(afterSecondDismiss.routes.length).toBe(1);
             expect(afterSecondDismiss.history?.length).toBe(4);
             expect(countLeadingPadding(afterSecondDismiss.history)).toBe(3);
-            expect(asRouteEntry(afterSecondDismiss.history?.at(-1) as CustomHistoryEntry).key).toBe('tab-c-1');
+            const lastHistoryEntry = afterSecondDismiss.history?.at(-1);
+            expectRouteEntry(lastHistoryEntry);
+            expect(lastHistoryEntry.key).toBe('tab-c-1');
         });
 
         it('does NOT commit a reveal when an unrelated modal is dismissed between REPLACE and the matching DISMISS', () => {
@@ -504,8 +521,7 @@ describe('addRootHistoryRouterExtension', () => {
                     return makeState(state.routes.slice(0, -1));
                 }
                 if (action.type === 'NAVIGATE') {
-                    const payload = action.payload as {name: string; params?: Record<string, unknown>};
-                    const newRoute = payload.name === 'OTHER_MODAL' ? otherModal : makeRoute(payload.name, nextTestKey(payload.name), payload.params);
+                    const newRoute = action.payload.name === 'OTHER_MODAL' ? otherModal : makeRoute(action.payload.name, nextTestKey(action.payload.name), action.payload.params);
                     return makeState([...state.routes, newRoute]);
                 }
                 return state;
@@ -519,20 +535,20 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterReplace = enhancedRouter.getStateForAction(stateWithRHP, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
+            const afterReplace = getTestStateForAction(enhancedRouter, stateWithRHP, makeReplaceAction());
             // Open an *unrelated* modal on top of the in-flight reveal.
-            const stateAfterOpeningOtherModal = enhancedRouter.getStateForAction(afterReplace, makeNavigateAction('OTHER_MODAL'), CONFIG_OPTIONS) as TestState;
+            const stateAfterOpeningOtherModal = getTestStateForAction(enhancedRouter, afterReplace, makeNavigateAction('OTHER_MODAL'));
             expect(stateAfterOpeningOtherModal.routes.length).toBe(3);
             expect(stateAfterOpeningOtherModal.routes.at(-1)?.key).toBe('rhp-other');
 
             // Dismiss the OTHER modal - must NOT commit the in-flight reveal (key mismatch),
             // i.e. no offset is set, history shrinks naturally.
-            const afterDismissOther = enhancedRouter.getStateForAction(stateAfterOpeningOtherModal, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterDismissOther = getTestStateForAction(enhancedRouter, stateAfterOpeningOtherModal, makeDismissAction());
             expect(afterDismissOther.routes.length).toBe(2);
             expect(countLeadingPadding(afterDismissOther.history)).toBe(0);
 
             // Now dismiss the *real* RHP - that's the protocol's second frame; commit the reveal.
-            const afterDismissReal = enhancedRouter.getStateForAction(afterDismissOther, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterDismissReal = getTestStateForAction(enhancedRouter, afterDismissOther, makeDismissAction());
             expect(afterDismissReal.routes.length).toBe(1);
             expect(countLeadingPadding(afterDismissReal.history)).toBeGreaterThan(0);
         });
@@ -553,12 +569,11 @@ describe('addRootHistoryRouterExtension', () => {
                     return makeState(state.routes.slice(0, -1));
                 }
                 if (action.type === 'NAVIGATE') {
-                    const payload = action.payload as {name: string};
-                    if (payload.name === '__POP_RHP__') {
+                    if (action.payload.name === '__POP_RHP__') {
                         // Simulate a non-DISMISS_MODAL action that removes the snapshotted RHP.
                         return makeState(state.routes.filter((r) => r.key !== 'rhp-1'));
                     }
-                    if (payload.name === '__OPEN_OTHER_RHP__') {
+                    if (action.payload.name === '__OPEN_OTHER_RHP__') {
                         return makeState([...state.routes, otherRhp]);
                     }
                     return state;
@@ -575,15 +590,15 @@ describe('addRootHistoryRouterExtension', () => {
             });
 
             // REPLACE snapshots rhp-1.
-            const afterReplace = enhancedRouter.getStateForAction(stateWithRHP, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
+            const afterReplace = getTestStateForAction(enhancedRouter, stateWithRHP, makeReplaceAction());
             // Some external action removes rhp-1 without going through DISMISS_MODAL.
-            const afterPop = enhancedRouter.getStateForAction(afterReplace, makeNavigateAction('__POP_RHP__'), CONFIG_OPTIONS) as TestState;
+            const afterPop = getTestStateForAction(enhancedRouter, afterReplace, makeNavigateAction('__POP_RHP__'));
             expect(afterPop.routes.find((r) => r.key === 'rhp-1')).toBeUndefined();
 
             // Open a different RHP.
-            const afterSecondRhpOpen = enhancedRouter.getStateForAction(afterPop, makeNavigateAction('__OPEN_OTHER_RHP__'), CONFIG_OPTIONS) as TestState;
+            const afterSecondRhpOpen = getTestStateForAction(enhancedRouter, afterPop, makeNavigateAction('__OPEN_OTHER_RHP__'));
             // Dismiss it. Snapshot was cleared by the sanity reset, so this must NOT freeze.
-            const afterSecondRhpDismiss = enhancedRouter.getStateForAction(afterSecondRhpOpen, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterSecondRhpDismiss = getTestStateForAction(enhancedRouter, afterSecondRhpOpen, makeDismissAction());
             expect(countLeadingPadding(afterSecondRhpDismiss.history)).toBe(0);
         });
 
@@ -605,8 +620,8 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterReplace = enhancedRouter.getStateForAction(stateWithRHP, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
-            const afterDismiss = enhancedRouter.getStateForAction(afterReplace, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterReplace = getTestStateForAction(enhancedRouter, stateWithRHP, makeReplaceAction());
+            const afterDismiss = getTestStateForAction(enhancedRouter, afterReplace, makeDismissAction());
 
             // pre-dismiss state.history.length = 2; post-dismiss rehydrated.history.length = 1.
             // lengthDelta = 1 → freeze with offset 1 (one sentinel padding entry).
@@ -637,8 +652,8 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterReplace = enhancedRouter.getStateForAction(stateWithRHP, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
-            const afterDismiss = enhancedRouter.getStateForAction(afterReplace, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterReplace = getTestStateForAction(enhancedRouter, stateWithRHP, makeReplaceAction());
+            const afterDismiss = getTestStateForAction(enhancedRouter, afterReplace, makeDismissAction());
 
             // Post-dismiss: routes=[TabB], rehydrated.history=[TabB-mirror, SIDE_PANEL] (length 2).
             // lengthDelta = 4 - 2 = 2 sentinel padding entries. Final shape:
@@ -667,7 +682,7 @@ describe('addRootHistoryRouterExtension', () => {
                 ]),
             });
 
-            const afterReplace = enhancedRouter.getStateForAction(stateWithRHP, makeReplaceAction(), CONFIG_OPTIONS) as TestState;
+            const afterReplace = getTestStateForAction(enhancedRouter, stateWithRHP, makeReplaceAction());
 
             // Simulate an out-of-band history mutation: append an extra route entry without
             // changing routes. Pre-DISMISS state.history.length is now 4 instead of the
@@ -677,7 +692,7 @@ describe('addRootHistoryRouterExtension', () => {
                 history: [...(afterReplace.history ?? []), createMock<CustomHistoryEntry>({key: 'rogue-1', name: 'Rogue'})],
             };
 
-            const afterDismiss = enhancedRouter.getStateForAction(tamperedState, makeDismissAction(), CONFIG_OPTIONS) as TestState;
+            const afterDismiss = getTestStateForAction(enhancedRouter, tamperedState, makeDismissAction());
 
             // Freeze is rejected (history depth mismatch); routes shrink naturally,
             // history is rebuilt from routes (no padding sentinels).
@@ -693,13 +708,13 @@ describe('addRootHistoryRouterExtension', () => {
             const factory = createMockRouterFactory();
             const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
-            const partialState = {
+            const partialState: PartialState<TestState> = {
                 routes: [{name: 'ScreenA', key: 'a-1'}],
                 stale: true as const,
                 // partial state arrives WITHOUT padding sentinels (i.e., a fresh resetRoot).
             };
 
-            const rehydrated = enhancedRouter.getRehydratedState(partialState as PartialState<TestState>, CONFIG_OPTIONS);
+            const rehydrated = enhancedRouter.getRehydratedState(partialState, CONFIG_OPTIONS);
 
             // No padding survived rehydration - the history mirrors the routes only.
             expect(countLeadingPadding(rehydrated.history)).toBe(0);
@@ -714,13 +729,13 @@ describe('addRootHistoryRouterExtension', () => {
             const factory = createMockRouterFactory();
             const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
-            const partialState = {
+            const partialState: PartialState<TestState> = {
                 routes: [{name: 'ScreenA', key: 'a-1'}],
                 stale: true as const,
                 history: createMock<CustomHistoryEntry[]>([REVEAL_PADDING, REVEAL_PADDING, {key: 'a-1', name: 'ScreenA'}]),
             };
 
-            const rehydrated = enhancedRouter.getRehydratedState(partialState as PartialState<TestState>, CONFIG_OPTIONS);
+            const rehydrated = enhancedRouter.getRehydratedState(partialState, CONFIG_OPTIONS);
 
             // enhanceStateWithHistory rebuilds history from routes by default, so leading
             // padding is dropped at the rehydration boundary - this is the conservative
@@ -731,15 +746,14 @@ describe('addRootHistoryRouterExtension', () => {
 
     describe('modal back-guard sentinel (#90776)', () => {
         const MODAL = CONST.NAVIGATION.CUSTOM_HISTORY_ENTRY_MODAL;
-        const modalTag = (modalId: string) => `${MODAL}:${modalId}` as CustomHistoryEntry;
+        const modalTag = (modalId: string): CustomHistoryEntry => `${MODAL}:${modalId}`;
 
         // Mirrors production RN StackRouter: spreads `state` so the custom `history` field is carried
         // forward through a forward navigation (the reason the sentinel would otherwise be re-appended).
         function makeForwardNavRouter() {
             return createMockRouterFactory((state, action) => {
                 if (action.type === 'NAVIGATE') {
-                    const payload = action.payload as {name: string};
-                    const newRoute = makeRoute(payload.name, nextTestKey(payload.name));
+                    const newRoute = makeRoute(action.payload.name, nextTestKey(action.payload.name));
                     const routes = [...state.routes, newRoute];
                     return {...state, routes, routeNames: routes.map((r) => r.name), index: routes.length - 1};
                 }
@@ -749,15 +763,15 @@ describe('addRootHistoryRouterExtension', () => {
 
         it('preserves a trailing modal sentinel through getRehydratedState (RESET/resize parity)', () => {
             const factory = createMockRouterFactory();
-            const enhancedRouter = addRootHistoryRouterExtension(factory)({} as PlatformStackRouterOptions);
+            const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
-            const partialState = {
+            const partialState: PartialState<TestState> = {
                 routes: [{name: 'ScreenA', key: 'a-1'}],
                 stale: true as const,
                 history: [{key: 'a-1', name: 'ScreenA'}, modalTag('m1')],
             };
 
-            const state = enhancedRouter.getRehydratedState(partialState as PartialState<TestState>, CONFIG_OPTIONS);
+            const state = enhancedRouter.getRehydratedState(partialState, CONFIG_OPTIONS);
 
             expect(state.history?.at(-1)).toBe(modalTag('m1'));
             const routeEntries = state.history?.filter((e): e is NavigationRoute<ParamListBase, string> => typeof e !== 'string') ?? [];
@@ -766,24 +780,24 @@ describe('addRootHistoryRouterExtension', () => {
 
         it('preserves multiple trailing modal sentinels (nested modals) through getRehydratedState', () => {
             const factory = createMockRouterFactory();
-            const enhancedRouter = addRootHistoryRouterExtension(factory)({} as PlatformStackRouterOptions);
+            const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
-            const partialState = {
+            const partialState: PartialState<TestState> = {
                 routes: [{name: 'ScreenA', key: 'a-1'}],
                 stale: true as const,
                 history: [{key: 'a-1', name: 'ScreenA'}, modalTag('m1'), modalTag('m2')],
             };
 
-            const state = enhancedRouter.getRehydratedState(partialState as PartialState<TestState>, CONFIG_OPTIONS);
+            const state = enhancedRouter.getRehydratedState(partialState, CONFIG_OPTIONS);
 
             expect(state.history?.slice(-2)).toEqual([modalTag('m1'), modalTag('m2')]);
         });
 
         it('consumes the trailing modal sentinel on forward navigation so historyDelta === 0 (replaceState)', () => {
-            const enhancedRouter = addRootHistoryRouterExtension(makeForwardNavRouter())({} as PlatformStackRouterOptions);
+            const enhancedRouter = addRootHistoryRouterExtension(makeForwardNavRouter())(createMock<PlatformStackRouterOptions>({}));
 
             const routeA = makeRoute('ScreenA', 'a-1');
-            const state = makeState([routeA], {history: [{key: 'a-1', name: 'ScreenA'}, modalTag('m1')] as CustomHistoryEntry[]});
+            const state = makeState([routeA], {history: createMock<CustomHistoryEntry[]>([{key: 'a-1', name: 'ScreenA'}, modalTag('m1')])});
 
             const newState = enhancedRouter.getStateForAction(state, makeNavigateAction('ScreenB'), CONFIG_OPTIONS);
 
@@ -797,10 +811,10 @@ describe('addRootHistoryRouterExtension', () => {
         it('does NOT consume the sentinel on a non-forward action (e.g. side panel toggle)', () => {
             // A passthrough router that keeps history intact for non-NAVIGATE actions.
             const factory = createMockRouterFactory((state) => state);
-            const enhancedRouter = addRootHistoryRouterExtension(factory)({} as PlatformStackRouterOptions);
+            const enhancedRouter = addRootHistoryRouterExtension(factory)(createMock<PlatformStackRouterOptions>({}));
 
             const routeA = makeRoute('ScreenA', 'a-1');
-            const state = makeState([routeA], {history: [{key: 'a-1', name: 'ScreenA'}, modalTag('m1')] as CustomHistoryEntry[]});
+            const state = makeState([routeA], {history: createMock<CustomHistoryEntry[]>([{key: 'a-1', name: 'ScreenA'}, modalTag('m1')])});
 
             const newState = enhancedRouter.getStateForAction(state, makeDismissAction(), CONFIG_OPTIONS);
 


### PR DESCRIPTION
### Explanation of Change

This is a test-only TypeScript cleanup for https://github.com/Expensify/App/issues/94739. It removes the remaining @typescript-eslint/no-unsafe-type-assertion warnings from tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts without changing the router extension implementation or the scenarios covered by the tests.

What changed:
  * Typed test route params from NavigationRoute instead of using a loose Record shape.
  * Replaced repeated route-entry casts with an expectRouteEntry assertion helper that narrows CustomHistoryEntry before accessing route fields.
  * Added an expectTestState/getTestStateForAction helper so getStateForAction results are narrowed after null checks instead of cast back to TestState.
  * Used the typed RootStackNavigatorAction payload directly in mock NAVIGATE handlers instead of asserting custom payload shapes.
  * Replaced the placeholder route assertion with ROUTES.HOME typed as Route, and used createMock for PlatformStackRouterOptions/history fixtures where the test needs typed mock objects.

Why this approach is safe:
  * Only the unit test file is changed; production navigation code is untouched.
  * The existing test scenarios, assertions, route names, sentinel checks, and reveal/modal behaviors remain the same.
  * Runtime behavior of the tests is preserved because the changes are type-narrowing and fixture typing, not logic changes.
  * No QA is needed because this is a test-only cleanup.

Reviewer focus:
  1. Check that the new assertion helpers narrow only after the same expectations the tests already made, especially around nullable getStateForAction results.
  2. Check that ROUTES.HOME is an appropriate typed placeholder for the replace action payload used by these tests.
  3. Check that the typed NAVIGATE payload access still matches RootStackNavigatorAction for every mock router branch touched here.

Safety checks:
  * Targeted lint was run for tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts.
  * The eslint report was regenerated to confirm the target-rule cleanup.
  * Formatting was run on tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts.
### Fixed Issues
$ https://github.com/Expensify/App/issues/94739
PROPOSAL:
Replace broad unsafe assertions in the addRootHistoryRouterExtension tests with typed helpers, typed fixtures, and assertion functions so the test code proves route and state shapes before reading from them.

### Count change

Current baseline source:

- config/eslint/eslint.seatbelt.tsv
- Target files: tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts
- Target Rule: @typescript-eslint/no-unsafe-type-assertion

Before:

- Target before warnings: 37
- Before warnings: 5300

After:

- Target after warnings: 0
- After warnings: 5263

Net reduction:

- Target warning reduction: 37
- Net warning reduction: 37

TSV evidence:

- OSBotify note: TSV row deletions were restored before commit because OSBotify tightens the baseline.

Exact verification commands:
- npm run lint -- --no-cache --show-warnings tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts
- npm run eslint-report
- npm run fmt -- tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts

### Tests

1. Run:

         npm run lint -- --no-cache --show-warnings tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts

   Verify the command succeeds and produces the expected evidence.
2. Run:

         npm run eslint-report

   Verify the command succeeds and produces the expected evidence.
3. Run:

         npm run fmt -- tests/unit/Navigation/routerExtensions/addRootHistoryRouterExtension.test.ts

   Verify the command succeeds and produces the expected evidence.
4. Verify the target count decreased from 37 to 0, and total warnings decreased from 5300 to 5263.
### Offline tests

Not applicable: this cleanup changes only a TypeScript test file and has no network-dependent runtime behavior.
### QA Steps

[No QA]

Not applicable: this is a test-only cleanup with no staging UI or production workflow change.
### PR Author Checklist

For checklist items that are not applicable to this cleanup, checked means the item was considered and determined not applicable.
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline tests` section — Not applicable to this test-only cleanup.
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section — Not applicable to this test-only cleanup.
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct) — Not applicable to this test-only cleanup.
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline) — Not applicable to this test-only cleanup.
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability). — Not applicable to this test-only cleanup.
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — Not applicable to this test-only cleanup.
- [x] I ran the tests on **all platforms** & verified they passed on: — Not applicable to this test-only cleanup.
    - [x] Android: Native — Not applicable to this test-only cleanup.
    - [x] Android: mWeb Chrome — Not applicable to this test-only cleanup.
    - [x] iOS: Native — Not applicable to this test-only cleanup.
    - [x] iOS: mWeb Safari — Not applicable to this test-only cleanup.
    - [x] MacOS: Chrome / Safari — Not applicable to this test-only cleanup.
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed) — Not applicable to this test-only cleanup.
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory — Not applicable to this test-only cleanup.
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing. — Not applicable to this test-only cleanup.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue) — Not applicable to this test-only cleanup.
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers — Not applicable to this test-only cleanup.
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md) — Not applicable to this test-only cleanup.
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) — Not applicable to this test-only cleanup.
- [x] If a new CSS style is added I verified that: — Not applicable to this test-only cleanup.
    - [x] A similar style doesn't already exist — Not applicable to this test-only cleanup.
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`) — Not applicable to this test-only cleanup.
- [x] If new assets were added or existing ones were modified, I verified that: — Not applicable to this test-only cleanup.
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`) — Not applicable to this test-only cleanup.
    - [x] The assets load correctly across all supported platforms. — Not applicable to this test-only cleanup.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. — Not applicable to this test-only cleanup.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) — Not applicable to this test-only cleanup.
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. — Not applicable to this test-only cleanup.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account. — Not applicable to this test-only cleanup.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles: — Not applicable to this test-only cleanup.
    - [x] I verified that all the inputs inside a form are aligned with each other. — Not applicable to this test-only cleanup.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes. — Not applicable to this test-only cleanup.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps. — Not applicable to this test-only cleanup.

### Screenshots/Videos

Not applicable: no UI or visual behavior changed.