### PR TITLE
Fix: Home - Export not display on Home page when user having report waiting Export

### DIFF
--- a/src/libs/TodosUtils.ts
+++ b/src/libs/TodosUtils.ts
@@ -7,6 +7,7 @@ import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import type {SearchKey} from './SearchUIUtils';
 
 import {getLoginByAccountID} from './PersonalDetailsUtils';
+import {isPreferredExporter} from './PolicyUtils';
 import {isApproveAction, isExportAction, isPrimaryPayAction, isSubmitAction} from './ReportPrimaryActionUtils';
 import {hasOnlyHeldExpenses, hasOnlyNonReimbursableTransactions} from './ReportUtils';
 
@@ -122,7 +123,7 @@ function reportMatchesTodoBucket(
             );
         case CONST.SEARCH.SEARCH_KEYS.EXPORT: {
             const reportActions = Object.values(allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.reportID}`] ?? []);
-            return isExportAction(report, login, policy, reportActions) && policy?.exporter === login;
+            return isExportAction(report, login, policy, reportActions) && !!policy && isPreferredExporter(policy, login);
         }
         default:
             return false;


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/91559

Fixes an issue where reports awaiting export were not being correctly identified for display in the Home page (For You section). The previous logic checked `policy?.exporter === login`, which evaluated to false since `policy.exporter` is no longer populated at the root level. This updates the check to use the `isPreferredExporter` utility instead, correctly checking if the user is the preferred exporter for the connected integrations.
