### PR TITLE
[NoQA] Skip forwarding `Reauthenticate` logs to sentry

### DIFF
--- a/src/libs/telemetry/forwardLogsToSentry.ts
+++ b/src/libs/telemetry/forwardLogsToSentry.ts
@@ -32,7 +32,7 @@ const PARAMETERS_WHITELIST: ReadonlyArray<string | RegExp> = [
 /**
  * Only log lines whose message contains one of these prefixes are forwarded to Sentry.
  */
-const FORWARDED_LOG_PREFIXES = ['[Reauthenticate]', '[MFA]', '[OnyxUpdateManagerError]', '[Receipt]'] as const;
+const FORWARDED_LOG_PREFIXES = ['[MFA]', '[OnyxUpdateManagerError]', '[Receipt]'] as const;
 
 type ForwardedLogPrefix = TupleToUnion<typeof FORWARDED_LOG_PREFIXES>;
 

--- a/tests/unit/forwardLogsToSentryTest.ts
+++ b/tests/unit/forwardLogsToSentryTest.ts
@@ -48,7 +48,7 @@ describe('forwardLogsToSentry', () => {
         const packet = packetWith('[info] [MFA] verifying code', {
             event: 'something-unrelated',
             transactionID: 'should-not-leak',
-            command: 'ValidateTwoFactorAuth',
+            command: 'TestCommand',
         });
 
         // When the packet is mirrored to Sentry
@@ -56,7 +56,7 @@ describe('forwardLogsToSentry', () => {
 
         // Then the globally whitelisted key is forwarded, but the receipt-scoped keys are not
         const breadcrumb = jest.mocked(Sentry.addBreadcrumb).mock.calls.at(0)?.[0];
-        expect(breadcrumb?.data).toEqual(expect.objectContaining({command: 'ValidateTwoFactorAuth'}));
+        expect(breadcrumb?.data).toEqual(expect.objectContaining({command: 'TestCommand'}));
         expect(breadcrumb?.data).not.toHaveProperty('event');
         expect(breadcrumb?.data).not.toHaveProperty('transactionID');
     });

--- a/tests/unit/forwardLogsToSentryTest.ts
+++ b/tests/unit/forwardLogsToSentryTest.ts
@@ -44,11 +44,11 @@ describe('forwardLogsToSentry', () => {
     });
 
     it('does not forward the receipt-scoped params (event/transactionID) for a different prefix', () => {
-        // Given a [Reauthenticate] line that happens to carry generic `event`/`transactionID` params
-        const packet = packetWith('[info] [Reauthenticate] refreshing token', {
+        // Given a forwarded [MFA] line that happens to carry the receipt-scoped `event`/`transactionID` params
+        const packet = packetWith('[info] [MFA] verifying code', {
             event: 'something-unrelated',
             transactionID: 'should-not-leak',
-            command: 'Reauthenticate',
+            command: 'ValidateTwoFactorAuth',
         });
 
         // When the packet is mirrored to Sentry
@@ -56,7 +56,7 @@ describe('forwardLogsToSentry', () => {
 
         // Then the globally whitelisted key is forwarded, but the receipt-scoped keys are not
         const breadcrumb = jest.mocked(Sentry.addBreadcrumb).mock.calls.at(0)?.[0];
-        expect(breadcrumb?.data).toEqual(expect.objectContaining({command: 'Reauthenticate'}));
+        expect(breadcrumb?.data).toEqual(expect.objectContaining({command: 'ValidateTwoFactorAuth'}));
         expect(breadcrumb?.data).not.toHaveProperty('event');
         expect(breadcrumb?.data).not.toHaveProperty('transactionID');
     });


### PR DESCRIPTION


### Explanation of Change


Skip forwarding [Reauthenticate] logs to Sentry.

Slack:  https://expensify.slack.com/archives/C05LX9D6E07/p1783705142727319

### Fixed Issues

$ https://github.com/Expensify/App/issues/95929
PROPOSAL:




### Tests


- [x] Verify that no errors appear in the JS console

N/A

### Offline tests


N/A

### QA Steps

// TODO: These must be filled out, or the issue title must include &#34;[No QA].&#34;

- [x] Verify that no errors appear in the JS console

N/A

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn&#39;t already exist
    - [x] The style can&#39;t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
