### PR TITLE
Scope reportAttributes recompute to reports referencing changed display names

### DIFF
--- a/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
@@ -70,10 +70,12 @@ const hasPolicyRelevantFieldChanged = (prev: Policy | null | undefined, next: Po
     );
 };
 
-// Signature of the fields a report's display name is derived from: displayName (primary), firstName
-// (group-chat short form), and login (fallback when no name is set). A change to any of them can change a
-// report name, so all three are diffed — not just displayName. See getDisplayNameForParticipant/getDisplayNameOrDefault.
-const displayNameSignature = (details: PersonalDetails | null): string => JSON.stringify([details?.displayName ?? '', details?.firstName ?? '', details?.login ?? '']);
+// Signature of the fields that independently affect a report's display name: displayName (primary) and
+// firstName (used directly for group-chat short names, even when displayName is set — see getDisplayNameForParticipant).
+// login is intentionally excluded: it only feeds a name as a fallback when displayName is empty, and such
+// accounts keep displayName in sync with login, so a real login-driven name change always arrives with a
+// displayName change. Tracking login would just cause wasted recomputes on the common (named-account) path.
+const displayNameSignature = (details: PersonalDetails | null): string => JSON.stringify([details?.displayName ?? '', details?.firstName ?? '']);
 
 const snapshotDisplayNames = (personalDetails: PersonalDetailsList): Record<string, string> => {
     const snapshot: Record<string, string> = {};

--- a/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
@@ -30,14 +30,11 @@ import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 
 import {isTrackIntentUserSelector} from '@selectors/Onboarding';
 
-// Per-account signature of the fields that feed a report's display name, keyed by accountID. See
-// snapshotDisplayNames for which fields, and getDisplayNameForParticipant/getDisplayNameOrDefault for why.
+// The name-related fields we saw for each account last time, so we can spot which accounts changed.
 let previousDisplayNames: Record<string, string> = {};
 let previousPersonalDetails: OnyxEntry<PersonalDetailsList> | undefined;
 let previousPolicies: OnyxCollection<Policy>;
 
-// Sentinel returned by getDisplayNameChanges when we can't scope the change to specific accounts
-// (first load this session) and must recompute every report's name.
 const RECOMPUTE_ALL = 'all' as const;
 
 const prepareReportKeys = (keys: string[]) => {
@@ -70,11 +67,7 @@ const hasPolicyRelevantFieldChanged = (prev: Policy | null | undefined, next: Po
     );
 };
 
-// Signature of the fields that independently affect a report's display name: displayName (primary) and
-// firstName (used directly for group-chat short names, even when displayName is set — see getDisplayNameForParticipant).
-// login is intentionally excluded: it only feeds a name as a fallback when displayName is empty, and such
-// accounts keep displayName in sync with login, so a real login-driven name change always arrives with a
-// displayName change. Tracking login would just cause wasted recomputes on the common (named-account) path.
+// A short string built from the fields a report name can come from: displayName and firstName.
 const displayNameSignature = (details: PersonalDetails | null): string => JSON.stringify([details?.displayName ?? '', details?.firstName ?? '']);
 
 const snapshotDisplayNames = (personalDetails: PersonalDetailsList): Record<string, string> => {
@@ -85,17 +78,16 @@ const snapshotDisplayNames = (personalDetails: PersonalDetailsList): Record<stri
     return snapshot;
 };
 
-// Records the personal-details snapshot that report names were last computed against. Kept as a single
-// helper so the two correlated module vars can't drift out of sync.
+// Remembers the personal details we just used, so the next change can be compared against them.
+// Updating both variables together here keeps them from getting out of sync.
 const commitDisplayNamesBaseline = (personalDetails: OnyxEntry<PersonalDetailsList>, snapshot: Record<string, string>) => {
     previousDisplayNames = snapshot;
     previousPersonalDetails = personalDetails;
 };
 
-// Seeds the display-name baseline from the current personal details without recomputing. Used on the first
-// pass that has personal details but wasn't triggered by them: currentValue's names were already computed
-// against these same details, so establishing the baseline here lets the *next* personal-details change be
-// diffed and scoped to affected reports, instead of hitting the empty-baseline full-recompute path.
+// Records the current names the first time we have them on a pass that wasn't itself a personal-details
+// change. The report names already match these names, so there's nothing to recompute — we just save them
+// so the next personal-details change can be compared and narrowed to the reports it actually affects.
 const seedDisplayNamesBaseline = (personalDetails: OnyxEntry<PersonalDetailsList>) => {
     if (!personalDetails || previousPersonalDetails === personalDetails || Object.keys(previousDisplayNames).length > 0) {
         return;
@@ -103,17 +95,14 @@ const seedDisplayNamesBaseline = (personalDetails: OnyxEntry<PersonalDetailsList
     commitDisplayNamesBaseline(personalDetails, snapshotDisplayNames(personalDetails));
 };
 
-// Returns the set of accountIDs whose display-name signature changed since the last compute, or:
-//   - null   → nothing changed (caller can early-return)
-//   - 'all'  → no baseline to diff against yet; recompute every report
-// Scoping to changed accountIDs lets the caller recompute only the reports that reference them,
-// instead of every report in the store.
+// Works out which accounts had a name change since last time. Returns the set of those accountIDs, or null
+// when nothing changed, or 'all' when there's no previous data to compare against yet and every report needs
+// refreshing.
 const getDisplayNameChanges = (personalDetails: OnyxEntry<PersonalDetailsList>): Set<number> | typeof RECOMPUTE_ALL | null => {
     if (!personalDetails) {
         return null;
     }
 
-    // Fast path: if reference hasn't changed, display names are definitely the same
     if (previousPersonalDetails === personalDetails) {
         return null;
     }
@@ -122,7 +111,7 @@ const getDisplayNameChanges = (personalDetails: OnyxEntry<PersonalDetailsList>):
     const nextSnapshot: Record<string, string> = {};
     const changedAccountIDs = new Set<number>();
 
-    // Single pass: build the new baseline signature and diff it against the previous one at the same time.
+    // Build the new snapshot and compare it against the old one in the same loop.
     for (const [key, value] of Object.entries(personalDetails)) {
         const signature = displayNameSignature(value);
         nextSnapshot[key] = signature;
@@ -130,7 +119,7 @@ const getDisplayNameChanges = (personalDetails: OnyxEntry<PersonalDetailsList>):
             changedAccountIDs.add(Number(key));
         }
     }
-    // Account IDs present before but gone now also invalidate any report name that referenced them.
+    // An account that existed before but is gone now also affects any report name that used it.
     if (hadBaseline) {
         for (const key of Object.keys(previousDisplayNames)) {
             if (!(key in nextSnapshot)) {
@@ -147,9 +136,7 @@ const getDisplayNameChanges = (personalDetails: OnyxEntry<PersonalDetailsList>):
     return changedAccountIDs.size > 0 ? changedAccountIDs : null;
 };
 
-// The report-record fields whose accountIDs feed a report's display name: owner, manager, individual invoice
-// receiver, and participants. This intentionally does not cover thread names derived from parent-report data
-// (see computeReportNameBasedOnReportAction) — those are re-evaluated when the parent's own data changes.
+// True when the report's name could depend on one of these accounts. We look at the accounts stored on the report itself.
 const reportReferencesAccountIDs = (report: Report, accountIDs: Set<number>): boolean => {
     if (report.ownerAccountID !== undefined && accountIDs.has(report.ownerAccountID)) {
         return true;
@@ -259,15 +246,13 @@ export default createOnyxDerivedValueConfig({
             previousDisplayNames = {};
             previousPersonalDetails = undefined;
         } else {
-            // Establish the baseline early (before the first personal-details change) so that change can be scoped.
+            // Save the current names now, so the first real name change can be narrowed to the reports it affects.
             seedDisplayNamesBaseline(personalDetails);
         }
 
-        // A full recompute is needed when locale changes (report names are locale-dependent) or on the first
-        // personal-details load (no baseline to diff against). A scoped display-name change does NOT force a
-        // full recompute — only the reports referencing the changed accounts are recomputed (see below).
-        // We compare preferredLocale against currentValue?.locale so that the first locale load on startup
-        // (where both equal the same persisted value) does not trigger an unnecessary full recompute.
+        // Refresh every report when the language changes (names depend on it) or on the very first personal-details
+        // load, when there's nothing to compare against. A normal name change does not land here — it only refreshes
+        // the reports that use the changed accounts (further down).
         let needsFullRecompute =
             (hasKeyTriggeredCompute(ONYXKEYS.NVP_PREFERRED_LOCALE, sourceValues) && preferredLocale !== currentValue?.locale) ||
             displayNameChanges === RECOMPUTE_ALL ||
@@ -332,10 +317,9 @@ export default createOnyxDerivedValueConfig({
             }
         }
 
-        // When display names changed for a specific set of accounts, only the reports that reference one of
-        // those accounts need their name recomputed — mirrors the incremental treatment of POLICY above.
-        // Skipped when a full recompute is already scheduled (e.g. first personal-details load or locale change).
-        // useIncrementalUpdates already implies !needsFullRecompute; when it's false we do a full scan anyway.
+        // When only some accounts changed their name, refresh just the reports that use those accounts
+        // Skipped when we're already refreshing everything (first load or a
+        // locale change); in that case useIncrementalUpdates is false and the full scan below handles it.
         const personalDetailsChangedReportKeys: string[] = [];
         if (displayNameChanges instanceof Set && useIncrementalUpdates) {
             for (const [reportKey, report] of Object.entries(reports)) {

--- a/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
@@ -30,9 +30,15 @@ import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 
 import {isTrackIntentUserSelector} from '@selectors/Onboarding';
 
-let previousDisplayNames: Record<string, string | undefined> = {};
+// Per-account signature of the fields that feed a report's display name, keyed by accountID. See
+// snapshotDisplayNames for which fields, and getDisplayNameForParticipant/getDisplayNameOrDefault for why.
+let previousDisplayNames: Record<string, string> = {};
 let previousPersonalDetails: OnyxEntry<PersonalDetailsList> | undefined;
 let previousPolicies: OnyxCollection<Policy>;
+
+// Sentinel returned by getDisplayNameChanges when we can't scope the change to specific accounts
+// (first load this session) and must recompute every report's name.
+const RECOMPUTE_ALL = 'all' as const;
 
 const prepareReportKeys = (keys: string[]) => {
     return [
@@ -64,33 +70,89 @@ const hasPolicyRelevantFieldChanged = (prev: Policy | null | undefined, next: Po
     );
 };
 
-const checkDisplayNamesChanged = (personalDetails: OnyxEntry<PersonalDetailsList>) => {
+// Builds a per-account signature from the fields that a report's display name is derived from:
+// displayName (primary), firstName (group-chat short form), and login (fallback when no name is set).
+// A change to any of them can change a report name, so all three must be diffed — not just displayName.
+const snapshotDisplayNames = (personalDetails: PersonalDetailsList): Record<string, string> => {
+    const snapshot: Record<string, string> = {};
+    for (const [key, value] of Object.entries(personalDetails)) {
+        snapshot[key] = JSON.stringify([value?.displayName ?? '', value?.firstName ?? '', value?.login ?? '']);
+    }
+    return snapshot;
+};
+
+// Seeds the display-name baseline from the current personal details without recomputing. Used on the first
+// pass that has personal details but wasn't triggered by them: currentValue's names were already computed
+// against these same details, so establishing the baseline here lets the *next* personal-details change be
+// diffed and scoped to affected reports, instead of hitting the empty-baseline full-recompute path.
+const seedDisplayNamesBaseline = (personalDetails: OnyxEntry<PersonalDetailsList>) => {
+    if (!personalDetails || previousPersonalDetails === personalDetails || Object.keys(previousDisplayNames).length > 0) {
+        return;
+    }
+    previousDisplayNames = snapshotDisplayNames(personalDetails);
+    previousPersonalDetails = personalDetails;
+};
+
+// Returns the set of accountIDs whose display name changed since the last compute, or:
+//   - null   → nothing changed (caller can early-return)
+//   - 'all'  → no baseline to diff against yet; recompute every report
+// Scoping to changed accountIDs lets the caller recompute only the reports that reference them,
+// instead of every report in the store.
+const getDisplayNameChanges = (personalDetails: OnyxEntry<PersonalDetailsList>): Set<number> | typeof RECOMPUTE_ALL | null => {
     if (!personalDetails) {
-        return false;
+        return null;
     }
 
     // Fast path: if reference hasn't changed, display names are definitely the same
     if (previousPersonalDetails === personalDetails) {
-        return false;
+        return null;
     }
 
-    const currentDisplayNames = Object.fromEntries(Object.entries(personalDetails).map(([key, value]) => [key, value?.displayName]));
+    const currentDisplayNames = snapshotDisplayNames(personalDetails);
 
     if (Object.keys(previousDisplayNames).length === 0) {
         previousDisplayNames = currentDisplayNames;
         previousPersonalDetails = personalDetails;
-        return Object.keys(currentDisplayNames).length > 0;
+        return Object.keys(currentDisplayNames).length > 0 ? RECOMPUTE_ALL : null;
     }
 
-    const currentKeys = Object.keys(currentDisplayNames);
-    const previousKeys = Object.keys(previousDisplayNames);
-
-    const displayNamesChanged = currentKeys.length !== previousKeys.length || currentKeys.some((key) => currentDisplayNames[key] !== previousDisplayNames[key]);
+    const changedAccountIDs = new Set<number>();
+    for (const [key, name] of Object.entries(currentDisplayNames)) {
+        if (name !== previousDisplayNames[key]) {
+            changedAccountIDs.add(Number(key));
+        }
+    }
+    // Account IDs present before but gone now also invalidate any report name that referenced them.
+    for (const key of Object.keys(previousDisplayNames)) {
+        if (!(key in currentDisplayNames)) {
+            changedAccountIDs.add(Number(key));
+        }
+    }
 
     previousDisplayNames = currentDisplayNames;
     previousPersonalDetails = personalDetails;
 
-    return displayNamesChanged;
+    return changedAccountIDs.size > 0 ? changedAccountIDs : null;
+};
+
+// A report's display name is derived from personal details of its participants, owner, and (for invoices)
+// its individual receiver. These are the reference points that make a display-name change relevant to a report.
+const reportReferencesAccountIDs = (report: Report, accountIDs: Set<number>): boolean => {
+    if (report.ownerAccountID !== undefined && accountIDs.has(report.ownerAccountID)) {
+        return true;
+    }
+    if (report.managerID !== undefined && accountIDs.has(report.managerID)) {
+        return true;
+    }
+    if (report.invoiceReceiver?.type === CONST.REPORT.INVOICE_RECEIVER_TYPE.INDIVIDUAL && accountIDs.has(report.invoiceReceiver.accountID)) {
+        return true;
+    }
+    for (const participantID of Object.keys(report.participants ?? {})) {
+        if (accountIDs.has(Number(participantID))) {
+            return true;
+        }
+    }
+    return false;
 };
 
 // Returns the report-preview action ID of the oldest child in `reportIDs` matching `predicate`
@@ -174,24 +236,28 @@ export default createOnyxDerivedValueConfig({
         const isOffline = getIsOffline();
         const translate: LocalizedTranslate = (path, ...parameters) => translateForLocale(preferredLocale, path, ...parameters);
         // Check if display names changed when personal details are updated
-        let displayNamesChanged = false;
+        let displayNameChanges: Set<number> | typeof RECOMPUTE_ALL | null = null;
         if (hasKeyTriggeredCompute(ONYXKEYS.PERSONAL_DETAILS_LIST, sourceValues)) {
-            displayNamesChanged = checkDisplayNamesChanged(personalDetails);
-
-            if (!displayNamesChanged) {
+            displayNameChanges = getDisplayNameChanges(personalDetails);
+            if (!displayNameChanges) {
                 return currentValue ?? {reports: {}, locale: null};
             }
         } else if (!sourceValues) {
             previousDisplayNames = {};
             previousPersonalDetails = undefined;
+        } else {
+            // Establish the baseline early (before the first personal-details change) so that change can be scoped.
+            seedDisplayNamesBaseline(personalDetails);
         }
 
-        // A full recompute is needed when locale changes (report names are locale-dependent) or display names change.
+        // A full recompute is needed when locale changes (report names are locale-dependent) or on the first
+        // personal-details load (no baseline to diff against). A scoped display-name change does NOT force a
+        // full recompute — only the reports referencing the changed accounts are recomputed (see below).
         // We compare preferredLocale against currentValue?.locale so that the first locale load on startup
         // (where both equal the same persisted value) does not trigger an unnecessary full recompute.
         let needsFullRecompute =
             (hasKeyTriggeredCompute(ONYXKEYS.NVP_PREFERRED_LOCALE, sourceValues) && preferredLocale !== currentValue?.locale) ||
-            displayNamesChanged ||
+            displayNameChanges === RECOMPUTE_ALL ||
             hasKeyTriggeredCompute(ONYXKEYS.CONCIERGE_REPORT_ID, sourceValues) ||
             hasKeyTriggeredCompute(ONYXKEYS.NVP_INTRO_SELECTED, sourceValues);
 
@@ -253,6 +319,19 @@ export default createOnyxDerivedValueConfig({
             }
         }
 
+        // When display names changed for a specific set of accounts, only the reports that reference one of
+        // those accounts need their name recomputed — mirrors the incremental treatment of POLICY above.
+        // Skipped when a full recompute is already scheduled (e.g. first personal-details load or locale change).
+        // useIncrementalUpdates already implies !needsFullRecompute; when it's false we do a full scan anyway.
+        const personalDetailsChangedReportKeys: string[] = [];
+        if (displayNameChanges instanceof Set && useIncrementalUpdates) {
+            for (const [reportKey, report] of Object.entries(reports)) {
+                if (report && reportReferencesAccountIDs(report, displayNameChanges)) {
+                    personalDetailsChangedReportKeys.push(reportKey);
+                }
+            }
+        }
+
         const updates = [
             ...Object.keys(reportUpdates),
             ...Object.keys(reportMetadataUpdates),
@@ -260,6 +339,7 @@ export default createOnyxDerivedValueConfig({
             ...Object.keys(reportNameValuePairsUpdates),
             ...Array.from(reportUpdatesRelatedToReportActions),
             ...policyChangedReportKeys,
+            ...personalDetailsChangedReportKeys,
         ];
 
         if (useIncrementalUpdates) {

--- a/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
@@ -24,7 +24,7 @@ import {hasKeyTriggeredCompute} from '@userActions/OnyxDerived/utils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {PersonalDetailsList, Policy, Report, ReportAttributesDerivedValue, TransactionViolation} from '@src/types/onyx';
+import type {PersonalDetails, PersonalDetailsList, Policy, Report, ReportAttributesDerivedValue, TransactionViolation} from '@src/types/onyx';
 
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 
@@ -70,15 +70,24 @@ const hasPolicyRelevantFieldChanged = (prev: Policy | null | undefined, next: Po
     );
 };
 
-// Builds a per-account signature from the fields that a report's display name is derived from:
-// displayName (primary), firstName (group-chat short form), and login (fallback when no name is set).
-// A change to any of them can change a report name, so all three must be diffed — not just displayName.
+// Signature of the fields a report's display name is derived from: displayName (primary), firstName
+// (group-chat short form), and login (fallback when no name is set). A change to any of them can change a
+// report name, so all three are diffed — not just displayName. See getDisplayNameForParticipant/getDisplayNameOrDefault.
+const displayNameSignature = (details: PersonalDetails | null): string => JSON.stringify([details?.displayName ?? '', details?.firstName ?? '', details?.login ?? '']);
+
 const snapshotDisplayNames = (personalDetails: PersonalDetailsList): Record<string, string> => {
     const snapshot: Record<string, string> = {};
     for (const [key, value] of Object.entries(personalDetails)) {
-        snapshot[key] = JSON.stringify([value?.displayName ?? '', value?.firstName ?? '', value?.login ?? '']);
+        snapshot[key] = displayNameSignature(value);
     }
     return snapshot;
+};
+
+// Records the personal-details snapshot that report names were last computed against. Kept as a single
+// helper so the two correlated module vars can't drift out of sync.
+const commitDisplayNamesBaseline = (personalDetails: OnyxEntry<PersonalDetailsList>, snapshot: Record<string, string>) => {
+    previousDisplayNames = snapshot;
+    previousPersonalDetails = personalDetails;
 };
 
 // Seeds the display-name baseline from the current personal details without recomputing. Used on the first
@@ -89,11 +98,10 @@ const seedDisplayNamesBaseline = (personalDetails: OnyxEntry<PersonalDetailsList
     if (!personalDetails || previousPersonalDetails === personalDetails || Object.keys(previousDisplayNames).length > 0) {
         return;
     }
-    previousDisplayNames = snapshotDisplayNames(personalDetails);
-    previousPersonalDetails = personalDetails;
+    commitDisplayNamesBaseline(personalDetails, snapshotDisplayNames(personalDetails));
 };
 
-// Returns the set of accountIDs whose display name changed since the last compute, or:
+// Returns the set of accountIDs whose display-name signature changed since the last compute, or:
 //   - null   → nothing changed (caller can early-return)
 //   - 'all'  → no baseline to diff against yet; recompute every report
 // Scoping to changed accountIDs lets the caller recompute only the reports that reference them,
@@ -108,35 +116,38 @@ const getDisplayNameChanges = (personalDetails: OnyxEntry<PersonalDetailsList>):
         return null;
     }
 
-    const currentDisplayNames = snapshotDisplayNames(personalDetails);
-
-    if (Object.keys(previousDisplayNames).length === 0) {
-        previousDisplayNames = currentDisplayNames;
-        previousPersonalDetails = personalDetails;
-        return Object.keys(currentDisplayNames).length > 0 ? RECOMPUTE_ALL : null;
-    }
-
+    const hadBaseline = Object.keys(previousDisplayNames).length > 0;
+    const nextSnapshot: Record<string, string> = {};
     const changedAccountIDs = new Set<number>();
-    for (const [key, name] of Object.entries(currentDisplayNames)) {
-        if (name !== previousDisplayNames[key]) {
+
+    // Single pass: build the new baseline signature and diff it against the previous one at the same time.
+    for (const [key, value] of Object.entries(personalDetails)) {
+        const signature = displayNameSignature(value);
+        nextSnapshot[key] = signature;
+        if (hadBaseline && signature !== previousDisplayNames[key]) {
             changedAccountIDs.add(Number(key));
         }
     }
     // Account IDs present before but gone now also invalidate any report name that referenced them.
-    for (const key of Object.keys(previousDisplayNames)) {
-        if (!(key in currentDisplayNames)) {
-            changedAccountIDs.add(Number(key));
+    if (hadBaseline) {
+        for (const key of Object.keys(previousDisplayNames)) {
+            if (!(key in nextSnapshot)) {
+                changedAccountIDs.add(Number(key));
+            }
         }
     }
 
-    previousDisplayNames = currentDisplayNames;
-    previousPersonalDetails = personalDetails;
+    commitDisplayNamesBaseline(personalDetails, nextSnapshot);
 
+    if (!hadBaseline) {
+        return Object.keys(nextSnapshot).length > 0 ? RECOMPUTE_ALL : null;
+    }
     return changedAccountIDs.size > 0 ? changedAccountIDs : null;
 };
 
-// A report's display name is derived from personal details of its participants, owner, and (for invoices)
-// its individual receiver. These are the reference points that make a display-name change relevant to a report.
+// The report-record fields whose accountIDs feed a report's display name: owner, manager, individual invoice
+// receiver, and participants. This intentionally does not cover thread names derived from parent-report data
+// (see computeReportNameBasedOnReportAction) — those are re-evaluated when the parent's own data changes.
 const reportReferencesAccountIDs = (report: Report, accountIDs: Set<number>): boolean => {
     if (report.ownerAccountID !== undefined && accountIDs.has(report.ownerAccountID)) {
         return true;

--- a/tests/unit/OnyxDerivedTest.tsx
+++ b/tests/unit/OnyxDerivedTest.tsx
@@ -225,6 +225,44 @@ describe('OnyxDerived', () => {
             expect(derivedReportAttributesAfterDisplayNameChange).not.toBe(initialDerivedReportAttributes);
         });
 
+        it('should only recompute reports that reference the changed accountID when a display name changes', () => {
+            // Two reports: one owned by account 2, the other owned by account 3.
+            const reports: OnyxCollection<Report> = {
+                [`${ONYXKEYS.COLLECTION.REPORT}ref_report`]: {...mockReport, reportID: 'ref_report', ownerAccountID: 2},
+                [`${ONYXKEYS.COLLECTION.REPORT}unrelated_report`]: {...mockReport, reportID: 'unrelated_report', policyID: '456', ownerAccountID: 3},
+            };
+            const personalDetails = {
+                '2': {accountID: 2, displayName: 'Alice', login: 'alice@example.com'},
+                '3': {accountID: 3, displayName: 'Bob', login: 'bob@example.com'},
+            };
+            const changedPersonalDetails = {...personalDetails, '2': {accountID: 2, displayName: 'Alice Smith', login: 'alice@example.com'}};
+
+            // PERSONAL_DETAILS_LIST is a valid runtime source key (hasKeyTriggeredCompute reads it), but the
+            // sourceValues type only models collection keys, so there's no representable type for this marker.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- non-collection source keys aren't modeled by DerivedSourceValues
+            const personalDetailsSource = {sourceValues: {[ONYXKEYS.PERSONAL_DETAILS_LIST]: true}} as unknown as Parameters<typeof reportAttributes.compute>[1];
+
+            // Reset the module-level diff baseline (no sourceValues clears it) so the seed below is deterministic.
+            reportAttributes.compute(
+                [reports, undefined, undefined, undefined, undefined, undefined, personalDetails, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
+                {},
+            );
+            // First personal-details compute computes both reports (no prior currentValue) and seeds the baseline.
+            const initial = reportAttributes.compute(
+                [reports, undefined, undefined, undefined, undefined, undefined, personalDetails, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
+                personalDetailsSource,
+            );
+            // Changing only account 2's display name should recompute just its report, carrying the other by reference.
+            const afterChange = reportAttributes.compute(
+                [reports, undefined, undefined, undefined, undefined, undefined, changedPersonalDetails, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
+                {...personalDetailsSource, currentValue: initial},
+            );
+
+            // A recomputed report gets a brand-new object; an untouched report is carried over by reference.
+            expect(afterChange.reports.ref_report).not.toBe(initial.reports.ref_report);
+            expect(afterChange.reports.unrelated_report).toBe(initial.reports.unrelated_report);
+        });
+
         describe('reportErrors', () => {
             it('returns empty errors when no errors exist', async () => {
                 const report = createRandomReport(1, undefined);


### PR DESCRIPTION
### Explanation of Change

**Problem:** On a `personalDetailsList` change, `reportAttributes` did a **full recompute** of every report's attributes, calling `computeReportName` for all reports. Profiling a ~6,200-report account showed this single pass taking **~13.6s** at report-open, while every other derived-value pass was ~16ms.

**Root cause:** `checkDisplayNamesChanged` returned a boolean, so _any_ display-name change escalated to recomputing _all_ reports — including reports that don't reference the changed account.

**Fix:**

1. Replaced `checkDisplayNamesChanged` with `getDisplayNameChanges`, which returns the **set of accountIDs** whose name-relevant signature changed. The signature is `displayName` + `firstName`, because group-chat short names use `firstName` (see `getDisplayNameForParticipant` / `getDisplayNameOrDefault`). A `RECOMPUTE_ALL` sentinel is returned only for the genuine no-baseline first compute.
2. Only reports that reference a changed account — via `participants`, `ownerAccountID`, `managerID`, or an individual `invoiceReceiver` — are added to the incremental `updates` list. This mirrors the incremental treatment already applied to `POLICY` changes in the same file.
3. Added `seedDisplayNamesBaseline` so the display-name baseline is established early (on the first non-personal-details pass that has personal details). This lets the first _real_ personal-details change of a session be scoped, instead of falling into a full recompute for lack of a baseline.

**Correctness:** Scoping preserves correctness regardless of which account changes. If a very common account (e.g. the current user) changes, all reports referencing it are still recomputed — necessary because unnamed group chats can include the current user's name.

**Performance impact:** When opening report on a large customer account, time spent on recomputing derived value caused by update to personal details went from **13s** to **0s** as there was no reports affected by this change

### Fixed Issues
$ https://github.com/Expensify/App/issues/95933
PROPOSAL:

### Tests
1. Open two accounts: A and B
2. Using account A create a 1:1 chat between A and B
3. Using account A create a group chat including account B
4. Go to account B -> Account -> Profile -> Display name
5. Change the first name and save
6. Go back to account A
7. Verify the report names for 1:1 and group chat display new first name in both LHN and header
- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named &#34;index.js&#34;. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn&#39;t include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function&#39;s arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn&#39;t already exist
    - [x] The style can&#39;t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it&#39;s using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native



https://github.com/user-attachments/assets/83ea1151-d74b-4074-bd9b-3aab0cb5df3a







iOS: mWeb Safari






MacOS: Chrome / Safari




https://github.com/user-attachments/assets/06dac4e4-0205-4dc6-b905-d84988d61d18




