### PR TITLE
[No QA] Reduce unsafe type assertions in use Other Feeds For Feed Selector tests

### DIFF
--- a/tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx
+++ b/tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx
@@ -1,16 +1,9 @@
 import {renderHook} from '@testing-library/react-native';
 
-import useCardFeedErrors from '@hooks/useCardFeedErrors';
-import {useCompanyCardFeedIcons} from '@hooks/useCompanyCardIcons';
-import useCompanyCards from '@hooks/useCompanyCards';
-import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
-import useFeedKeysWithAssignedCards from '@hooks/useFeedKeysWithAssignedCards';
-import useLocalize from '@hooks/useLocalize';
 import useOtherFeedsForFeedSelector from '@hooks/useOtherFeedsForFeedSelector';
-import useThemeIllustrations from '@hooks/useThemeIllustrations';
-import useThemeStyles from '@hooks/useThemeStyles';
 
-import * as CardFeedUtilsModule from '@libs/CardFeedUtils';
+import {getVisibleCompanyCardFeedsForSelector} from '@libs/CardFeedUtils';
+import type {CardFeedForDisplay} from '@libs/CardFeedUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -29,61 +22,103 @@ const mockPolicyCollection = {
     [`${ONYXKEYS.COLLECTION.POLICY}${otherPolicyID.toUpperCase()}`]: {name: 'Other workspace'},
 };
 
-const mockUseOnyx = jest.fn();
+type MockUseOnyxReturn = [unknown, {status?: string}];
+type MockUseLocalizeReturn = {translate: (phrase: string) => string};
+type MockUseThemeStylesReturn = {mr3: {marginRight: number}; cardIcon: Record<string, never>};
+type MockUseCardFeedErrorsReturn = {shouldShowRbrForFeedNameWithDomainID: Record<string, boolean>};
+type MockUseCompanyCardsReturn = {feedName?: string; companyCardFeeds: Record<string, {feed: string}>};
+type MockUseCurrentUserPersonalDetailsReturn = {accountID: number};
+type MockUseFeedKeysWithAssignedCardsReturn = Record<string, true> | undefined;
+
+const mockUseOnyx = jest.fn<MockUseOnyxReturn, [key: string]>();
+const mockUseCardFeedErrors = jest.fn<MockUseCardFeedErrorsReturn, []>();
+const mockUseCompanyCardFeedIcons = jest.fn<Record<string, never>, []>();
+const mockUseCompanyCards = jest.fn<MockUseCompanyCardsReturn, [{policyID: string}]>();
+const mockUseCurrentUserPersonalDetails = jest.fn<MockUseCurrentUserPersonalDetailsReturn, []>();
+const mockUseFeedKeysWithAssignedCards = jest.fn<MockUseFeedKeysWithAssignedCardsReturn, []>();
+const mockUseLocalize = jest.fn<MockUseLocalizeReturn, []>();
+const mockUseThemeIllustrations = jest.fn<Record<string, never>, []>();
+const mockUseThemeStyles = jest.fn<MockUseThemeStylesReturn, []>();
+const mockGetCardFeedIcon = jest.fn<string, []>();
+const mockGetCardFeedWithDomainID = jest.fn<string, [feed: string, fundID: number]>();
+const mockGetCustomOrFormattedFeedName = jest.fn<string, [translate: MockUseLocalizeReturn['translate'], feedName: string, customName?: string]>();
+const mockGetDomainByFundID = jest.fn<{email?: string} | undefined, [allDomains: Record<string, {email?: string}> | undefined, fundID: number]>();
+const mockGetPlaidInstitutionIconUrl = jest.fn<string | undefined, [feedName: string]>();
 
 jest.mock('@hooks/useOnyx', () => ({
     __esModule: true,
-    default: (...args: unknown[]): [unknown, {status?: string}] => mockUseOnyx(...args) as [unknown, {status?: string}],
+    default: (key: string): MockUseOnyxReturn => mockUseOnyx(key),
 }));
 
 jest.mock('@libs/CardFeedUtils', () => ({
     __esModule: true,
-    ...jest.requireActual<typeof CardFeedUtilsModule>('@libs/CardFeedUtils'),
     getVisibleCompanyCardFeedsForSelector: jest.fn(),
+}));
+
+jest.mock('@libs/CardUtils', () => ({
+    __esModule: true,
+    getCardFeedIcon: (): string => mockGetCardFeedIcon(),
+    getCardFeedWithDomainID: (feed: string, fundID: number): string => mockGetCardFeedWithDomainID(feed, fundID),
+    getCustomOrFormattedFeedName: (translate: MockUseLocalizeReturn['translate'], feedName: string, customName?: string): string =>
+        mockGetCustomOrFormattedFeedName(translate, feedName, customName),
+    getDomainByFundID: (allDomains: Record<string, {email?: string}> | undefined, fundID: number): {email?: string} | undefined => mockGetDomainByFundID(allDomains, fundID),
+    getPlaidInstitutionIconUrl: (feedName: string): string | undefined => mockGetPlaidInstitutionIconUrl(feedName),
+}));
+
+jest.mock('@components/Icon', () => ({
+    __esModule: true,
+    default: 'Icon',
+}));
+
+jest.mock('@components/PlaidCardFeedIcon', () => ({
+    __esModule: true,
+    default: 'PlaidCardFeedIcon',
 }));
 
 jest.mock('@hooks/useCompanyCards', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: ({policyID}: {policyID: string}): MockUseCompanyCardsReturn => mockUseCompanyCards({policyID}),
 }));
 
 jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: (): MockUseCurrentUserPersonalDetailsReturn => mockUseCurrentUserPersonalDetails(),
 }));
 
 jest.mock('@hooks/useFeedKeysWithAssignedCards', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: (): MockUseFeedKeysWithAssignedCardsReturn => mockUseFeedKeysWithAssignedCards(),
 }));
 
 jest.mock('@hooks/useCardFeedErrors', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: (): MockUseCardFeedErrorsReturn => mockUseCardFeedErrors(),
 }));
 
 jest.mock('@hooks/useLocalize', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: (): MockUseLocalizeReturn => mockUseLocalize(),
 }));
 
 jest.mock('@hooks/useThemeStyles', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: (): MockUseThemeStylesReturn => mockUseThemeStyles(),
 }));
 
 jest.mock('@hooks/useThemeIllustrations', () => ({
     __esModule: true,
-    default: jest.fn(),
+    default: (): Record<string, never> => mockUseThemeIllustrations(),
 }));
 
 jest.mock('@hooks/useCompanyCardIcons', () => ({
     __esModule: true,
-    useCompanyCardFeedIcons: jest.fn(),
+    useCompanyCardFeedIcons: (): Record<string, never> => mockUseCompanyCardFeedIcons(),
 }));
 
-const mockVisibleFeeds = (feeds: CardFeedUtilsModule.CardFeedForDisplay[]): void => {
-    (CardFeedUtilsModule.getVisibleCompanyCardFeedsForSelector as jest.Mock).mockReturnValue(feeds);
+const mockGetVisibleCompanyCardFeedsForSelector = jest.mocked(getVisibleCompanyCardFeedsForSelector);
+
+const mockVisibleFeeds = (feeds: CardFeedForDisplay[]): void => {
+    mockGetVisibleCompanyCardFeedsForSelector.mockReturnValue(feeds);
 };
 
 describe('useOtherFeedsForFeedSelector', () => {
@@ -100,14 +135,19 @@ describe('useOtherFeedsForFeedSelector', () => {
             return [undefined, {}];
         });
 
-        (useLocalize as jest.Mock).mockReturnValue({translate: (phrase: string) => phrase});
-        (useThemeStyles as jest.Mock).mockReturnValue({mr3: {marginRight: 12}, cardIcon: {}});
-        (useThemeIllustrations as jest.Mock).mockReturnValue({});
-        (useCompanyCardFeedIcons as jest.Mock).mockReturnValue({});
-        (useCardFeedErrors as jest.Mock).mockReturnValue({shouldShowRbrForFeedNameWithDomainID: {}});
-        (useCompanyCards as jest.Mock).mockReturnValue({feedName: undefined, companyCardFeeds: {}});
-        (useCurrentUserPersonalDetails as jest.Mock).mockReturnValue({accountID: 999});
-        (useFeedKeysWithAssignedCards as jest.Mock).mockReturnValue(undefined);
+        mockUseLocalize.mockReturnValue({translate: (phrase: string) => phrase});
+        mockUseThemeStyles.mockReturnValue({mr3: {marginRight: 12}, cardIcon: {}});
+        mockUseThemeIllustrations.mockReturnValue({});
+        mockUseCompanyCardFeedIcons.mockReturnValue({});
+        mockUseCardFeedErrors.mockReturnValue({shouldShowRbrForFeedNameWithDomainID: {}});
+        mockUseCompanyCards.mockReturnValue({feedName: undefined, companyCardFeeds: {}});
+        mockUseCurrentUserPersonalDetails.mockReturnValue({accountID: 999});
+        mockUseFeedKeysWithAssignedCards.mockReturnValue(undefined);
+        mockGetCardFeedIcon.mockReturnValue('mock-icon');
+        mockGetCardFeedWithDomainID.mockImplementation((feed: string, fundID: number) => `${feed}${CONST.COMPANY_CARD.FEED_KEY_SEPARATOR}${fundID}`);
+        mockGetCustomOrFormattedFeedName.mockImplementation((translate: MockUseLocalizeReturn['translate'], feedName: string, customName?: string) => customName ?? translate(feedName));
+        mockGetDomainByFundID.mockImplementation((allDomains: Record<string, {email?: string}> | undefined, fundID: number) => allDomains?.[`${ONYXKEYS.COLLECTION.DOMAIN}${fundID}`]);
+        mockGetPlaidInstitutionIconUrl.mockReturnValue(undefined);
         mockVisibleFeeds([]);
     });
 
@@ -138,7 +178,7 @@ describe('useOtherFeedsForFeedSelector', () => {
         // Build the key the same way production does (`${feed}${separator}${fundID}`) via a computed property name,
         // which keeps the dotted feed key out of a string literal and avoids a naming-convention violation.
         const activePolicyFeedKey = `oauth.chase.com${CONST.COMPANY_CARD.FEED_KEY_SEPARATOR}999`;
-        (useCompanyCards as jest.Mock).mockReturnValue({feedName: undefined, companyCardFeeds: {[activePolicyFeedKey]: {feed: 'oauth.chase.com'}}});
+        mockUseCompanyCards.mockReturnValue({feedName: undefined, companyCardFeeds: {[activePolicyFeedKey]: {feed: 'oauth.chase.com'}}});
         mockVisibleFeeds([
             {
                 id: '999_oauth.chase.com',
@@ -185,7 +225,7 @@ describe('useOtherFeedsForFeedSelector', () => {
 
     it('should set isSelected when feed id matches the selected feed from useCompanyCards', () => {
         const feedId = '999_oauth.chase.com';
-        (useCompanyCards as jest.Mock).mockReturnValue({feedName: feedId, companyCardFeeds: {}});
+        mockUseCompanyCards.mockReturnValue({feedName: feedId, companyCardFeeds: {}});
         mockVisibleFeeds([
             {
                 id: feedId,
@@ -203,7 +243,7 @@ describe('useOtherFeedsForFeedSelector', () => {
 
     it('should surface RBR when shouldShowRbrForFeedNameWithDomainID is true for the feed id', () => {
         const feedId = '999_visa';
-        (useCardFeedErrors as jest.Mock).mockReturnValue({
+        mockUseCardFeedErrors.mockReturnValue({
             shouldShowRbrForFeedNameWithDomainID: {[feedId]: true},
         });
         mockVisibleFeeds([


### PR DESCRIPTION
### Explanation of Change

Reduced `@typescript-eslint/no-unsafe-type-assertion` violations in `tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx` as part of the cleanup for Expensify/App issue #94739.

What changed:
  * Replaced broad Jest mock casts with explicitly typed `jest.fn` mocks and `jest.mocked(...)` for the card feed selector helper.
  * Moved mocked hook dependencies behind typed mock functions so each mock return value matches the shape consumed by `useOtherFeedsForFeedSelector`.
  * Added direct typed mocks for the card utility and icon dependencies needed by this hook test, preserving the existing selector assertions.

Why this approach is safe:
  * Test-only change; no product or runtime code changed.
  * The existing scenarios and expected hook outputs were preserved: empty state, current-policy exclusion, active-policy exclusion, inclusion, selected state, RBR state, and alternate text fallback.
  * Typed mocks keep the same test data flow while removing unsafe test casts.

Reviewer focus:
  1. Start with `tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx` and confirm the cleanup does not hide unsafe casts behind another helper.
  2. Check that the card utility mocks cover only the behavior the hook needs for these tests.
  3. Confirm the rendered hook assertions still exercise the same selector behavior as before.

Safety checks:
  * No new `eslint-disable` for `@typescript-eslint/no-unsafe-type-assertion`.
  * No broad `as unknown as` substitutions.
  * No `@ts-expect-error` comments.
  * No generic unsafe helper that hides casts.
  * No production source files changed.
### Fixed Issues
$ https://github.com/Expensify/App/issues/94739
PROPOSAL:
$ https://github.com/Expensify/App/issues/94739

### Count change

Current baseline source:

- config/eslint/eslint.seatbelt.tsv
- Target files: tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx
- Target Rule: @typescript-eslint/no-unsafe-type-assertion

Before:

- Target before warnings: 13
- Before warnings: 5295

After:

- Target after warnings: 0
- After warnings: 5282

Net reduction:

- Target warning reduction: 13
- Net warning reduction: 13

TSV evidence:

- OSBotify note: TSV row deletions were restored before commit because OSBotify tightens the baseline.

Exact verification commands:
- npm run typecheck
- npm run lint -- --no-cache --show-warnings tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx
- npm run eslint-report
- npm run fmt -- tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx

### Tests

1. Run:

         npm run typecheck

   Verify the command succeeds and produces the expected evidence.
2. Run:

         npm run lint -- --no-cache --show-warnings tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx

   Verify the command succeeds and produces the expected evidence.
3. Run:

         npm run eslint-report

   Verify the command succeeds and produces the expected evidence.
4. Run:

         npm run fmt -- tests/unit/hooks/useOtherFeedsForFeedSelector.test.tsx

   Verify the command succeeds and produces the expected evidence.
5. Verify the target count decreased from 13 to 0, and total warnings decreased from 5295 to 5282.
### Offline tests

Not applicable: this cleanup changes only a TypeScript test file and has no network-dependent runtime behavior.
### QA Steps

[No QA]

Not applicable: this is a test-only cleanup with no staging UI or production workflow change.
### PR Author Checklist

For checklist items that are not applicable to this cleanup, checked means the item was considered and determined not applicable.
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline tests` section — Not applicable to this test-only cleanup.
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section — Not applicable to this test-only cleanup.
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct) — Not applicable to this test-only cleanup.
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline) — Not applicable to this test-only cleanup.
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability). — Not applicable to this test-only cleanup.
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — Not applicable to this test-only cleanup.
- [x] I ran the tests on **all platforms** & verified they passed on: — Not applicable to this test-only cleanup.
    - [x] Android: Native — Not applicable to this test-only cleanup.
    - [x] Android: mWeb Chrome — Not applicable to this test-only cleanup.
    - [x] iOS: Native — Not applicable to this test-only cleanup.
    - [x] iOS: mWeb Safari — Not applicable to this test-only cleanup.
    - [x] MacOS: Chrome / Safari — Not applicable to this test-only cleanup.
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed) — Not applicable to this test-only cleanup.
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory — Not applicable to this test-only cleanup.
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing. — Not applicable to this test-only cleanup.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue) — Not applicable to this test-only cleanup.
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers — Not applicable to this test-only cleanup.
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md) — Not applicable to this test-only cleanup.
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) — Not applicable to this test-only cleanup.
- [x] If a new CSS style is added I verified that: — Not applicable to this test-only cleanup.
    - [x] A similar style doesn't already exist — Not applicable to this test-only cleanup.
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`) — Not applicable to this test-only cleanup.
- [x] If new assets were added or existing ones were modified, I verified that: — Not applicable to this test-only cleanup.
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`) — Not applicable to this test-only cleanup.
    - [x] The assets load correctly across all supported platforms. — Not applicable to this test-only cleanup.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. — Not applicable to this test-only cleanup.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) — Not applicable to this test-only cleanup.
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. — Not applicable to this test-only cleanup.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account. — Not applicable to this test-only cleanup.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles: — Not applicable to this test-only cleanup.
    - [x] I verified that all the inputs inside a form are aligned with each other. — Not applicable to this test-only cleanup.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes. — Not applicable to this test-only cleanup.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps. — Not applicable to this test-only cleanup.

### Screenshots/Videos

Not applicable: no UI or visual behavior changed.