### PR TITLE
Fix filter pill overflow by restoring the 256px max width cap

### DIFF
--- a/src/components/Search/FilterDropdowns/DropdownButton.tsx
+++ b/src/components/Search/FilterDropdowns/DropdownButton.tsx
@@ -70,7 +70,7 @@ function DropdownButton({label, value, medium = false, labelStyle, innerStyles, 
                     <Button
                         ref={ref}
                         style={styles.flexShrink1}
-                        innerStyles={[isExpanded && styles.buttonHoveredBG, {maxWidth: 256}, styles.mw100, styles.flexShrink1, innerStyles, shouldShowCloseButton && styles.pr2]}
+                        innerStyles={[isExpanded && styles.buttonHoveredBG, {maxWidth: variables.filterPillMaxWidth}, styles.flexShrink1, innerStyles, shouldShowCloseButton && styles.pr2]}
                         onPress={onPress}
                         sentryLabel={sentryLabel}
                         shouldRemoveRightBorderRadius={shouldShowCloseButton}

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -222,6 +222,7 @@ export default {
     tabSelectorButtonPadding: 12,
     tabSelectorScrollMarginInline: 20,
     tabSelectorMaxTabLabelWidth: 256,
+    filterPillMaxWidth: 256,
     lhnLogoWidth: 95.09,
     lhnLogoHeight: 22.33,
     signInLogoWidthLargeScreenPill: 162,


### PR DESCRIPTION
### Explanation of Change

The selected filter pill in the Spend/Search filter bar is rendered by `DropdownButton`. Its label is a single joined string (`Category: A, B, C, …`) that grows with every selected value. The pill is meant to be capped at `256px` via `{maxWidth: 256}` on the button's `innerStyles`, but `styles.mw100` (`maxWidth: '100%'`) was listed after it in the same style array. React Native flattens style arrays last-wins, so the effective cap became `100%`, which resolves against the growing content and never bounds the pill — so the label runs off the right edge and the filter bar overflows the viewport.

This removes `styles.mw100` from that `innerStyles` array so the `256px` cap wins again and the existing `numberOfLines={1}` truncates the label with an ellipsis.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95850
PROPOSAL: https://github.com/Expensify/App/issues/95850#issuecomment-4937684363

### Tests

1. Go to the Spend tab.
2. Click Filters and open the Category filter.
3. Select enough categories that the joined label is longer than the pill.
4. Verify the Category pill truncates with an ellipsis at a fixed max width and does not overflow the viewport.
5. Verify the filter bar stays within the page boundaries, and pills still wrap to a new line when several filters are applied.

- [x] Verify that no errors appear in the JS console

### Offline tests

This is a UI-only style change with no network dependency, so it behaves identically offline. Same as the Tests above.

### QA Steps

1. Go to the Spend tab.
2. Click Filters and open the Category filter.
3. Select enough categories that the joined label is longer than the pill.
4. Verify the Category pill truncates with an ellipsis at a fixed max width and does not overflow the viewport.
5. Verify the filter bar stays within the page boundaries, and pills still wrap to a new line when several filters are applied.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="408" height="930" alt="Screenshot 2026-07-14 at 6 51 55 PM" src="https://github.com/user-attachments/assets/63a08b52-7a67-475f-b414-c8ca175107fb" />

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="408" height="930" alt="Screenshot 2026-07-14 at 6 57 51 PM" src="https://github.com/user-attachments/assets/5d6b0bff-cf32-4e9b-be99-f66c28f4cc07" />

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-07-14 at 18 29 31" src="https://github.com/user-attachments/assets/f994ba1a-4321-4601-b8bf-fec7665af2dc" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="1206" height="2622" alt="simulator_screenshot_E8BD5825-7E6D-4173-AD37-593902CBDDC4" src="https://github.com/user-attachments/assets/3b7f6aca-0edc-41eb-b8f3-aebbacb31ee3" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c936ba5d-5e33-4c88-92a8-bb6d1be73b0f


</details>
