### PR TITLE
Fix: Saved search item remains highlighted after delete confirmation modal is dismissed

### DIFF
--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -14,7 +14,7 @@ type MouseEvents = 'onMouseEnter' | 'onMouseLeave' | 'onMouseMove';
 
 type OnMouseEvents = Record<MouseEvents, (e: React.MouseEvent) => void>;
 
-function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, isFocused = true, shouldFreezeCapture, children, ref}: ActiveHoverableProps) {
+function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, isFocused = true, shouldFreezeCapture, shouldUseNativeHoverEvents = false, children, ref}: ActiveHoverableProps) {
     const [isHovered, setIsHovered] = useState(false);
     const elementRef = useRef<HTMLElement | null>(null);
     const isScrollingRef = useRef(false);
@@ -102,6 +102,21 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, isFocused =
         [shouldFreezeCapture, updateIsHovered],
     );
 
+    useEffect(() => {
+        const element = elementRef.current;
+        if (!shouldUseNativeHoverEvents || !element) {
+            return;
+        }
+        const handleNativeEnter = handleMouseEvents('enter');
+        const handleNativeLeave = handleMouseEvents('leave');
+        element.addEventListener('mouseenter', handleNativeEnter);
+        element.addEventListener('mouseleave', handleNativeLeave);
+        return () => {
+            element.removeEventListener('mouseenter', handleNativeEnter);
+            element.removeEventListener('mouseleave', handleNativeLeave);
+        };
+    }, [shouldUseNativeHoverEvents, handleMouseEvents]);
+
     const child = useMemo(() => getReturnValue(children, isHovered), [children, isHovered]);
 
     const {onMouseEnter, onMouseLeave} = child.props as OnMouseEvents;
@@ -109,11 +124,15 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, isFocused =
     return cloneElement(child, {
         ref: mergeRefs(elementRef, ref, child.props.ref),
         onMouseEnter: (e: React.MouseEvent) => {
-            handleMouseEvents('enter')();
+            if (!shouldUseNativeHoverEvents) {
+                handleMouseEvents('enter')();
+            }
             onMouseEnter?.(e);
         },
         onMouseLeave: (e: React.MouseEvent) => {
-            handleMouseEvents('leave')();
+            if (!shouldUseNativeHoverEvents) {
+                handleMouseEvents('leave')();
+            }
             onMouseLeave?.(e);
         },
     } as React.HTMLAttributes<HTMLElement>);

--- a/src/components/Hoverable/types.ts
+++ b/src/components/Hoverable/types.ts
@@ -29,6 +29,15 @@ type HoverableProps = {
     /** Decides whether to freeze the capture of the hover event */
     shouldFreezeCapture?: boolean;
 
+    /**
+     * When true, hover is tracked with native DOM mouseenter/mouseleave listeners on the element
+     * instead of React's synthetic onMouseEnter/onMouseLeave. React delegates synthetic mouse events
+     * at the root, so a portalled popover opening over the element can deliver a synthetic mouseenter
+     * (setting a stale hover) or skip the synthetic mouseleave (stranding the hover). Native listeners
+     * fire on the element itself and are immune to that. Opt in per-surface — not applied globally. (web only)
+     */
+    shouldUseNativeHoverEvents?: boolean;
+
     /** Reference to the outer element */
     ref?: Ref<HTMLElement>;
 };

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -451,6 +451,9 @@ type MenuItemBaseProps = ForwardedFSClassProps &
         /** Whether the screen containing the item is focused */
         isFocused?: boolean;
 
+        /** Track hover with native DOM listeners instead of React synthetic events for rows that open a portalled popover (web only). */
+        shouldUseNativeHoverEvents?: boolean;
+
         /** Additional styles for the root wrapper View */
         rootWrapperStyle?: StyleProp<ViewStyle>;
 
@@ -616,6 +619,7 @@ function MenuItem({
     forwardedFSClass,
     ref,
     isFocused,
+    shouldUseNativeHoverEvents = false,
     sentryLabel,
     rootWrapperStyle,
     role = CONST.ROLE.BUTTON,
@@ -866,7 +870,10 @@ function MenuItem({
                 shouldHideOnScroll={shouldHideOnScroll}
             >
                 <View>
-                    <Hoverable isFocused={isFocused}>
+                    <Hoverable
+                        isFocused={isFocused}
+                        shouldUseNativeHoverEvents={shouldUseNativeHoverEvents}
+                    >
                         {(isHovered) => (
                             <PressableWithSecondaryInteraction
                                 onPress={shouldCheckActionAllowedOnPress ? callFunctionIfActionIsAllowed(onPressAction, isAnonymousAction) : onPressAction}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -39,6 +39,7 @@ import React, {useEffect, useMemo, useRef} from 'react';
 import {View} from 'react-native';
 
 import type {DisplayNameWithTooltip} from './DisplayNames/types';
+import type HoverableProps from './Hoverable/types';
 import type {PressableRef} from './Pressable/GenericPressable/types';
 
 import ActivityIndicator from './ActivityIndicator';
@@ -82,7 +83,8 @@ type NoIcon = {
 };
 
 type MenuItemBaseProps = ForwardedFSClassProps &
-    WithSentryLabel & {
+    WithSentryLabel &
+    Pick<HoverableProps, 'shouldUseNativeHoverEvents'> & {
         /** Reference to the outer element */
         ref?: PressableRef | Ref<View>;
 
@@ -450,9 +452,6 @@ type MenuItemBaseProps = ForwardedFSClassProps &
 
         /** Whether the screen containing the item is focused */
         isFocused?: boolean;
-
-        /** Track hover with native DOM listeners instead of React synthetic events for rows that open a portalled popover (web only). */
-        shouldUseNativeHoverEvents?: boolean;
 
         /** Additional styles for the root wrapper View */
         rootWrapperStyle?: StyleProp<ViewStyle>;

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -4786,6 +4786,7 @@ function createBaseSavedSearchMenuItem(item: SaveSearchItem, key: string, index:
         pendingAction: item.pendingAction,
         disabled: item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
         shouldIconUseAutoWidthStyle: true,
+        shouldUseNativeHoverEvents: true,
     };
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Track the row's hover with the native mouseenter/mouseleave events instead of the synthetic ones, behind a new opt-in prop. Native boundary events fire only when the pointer actually crosses the row's real DOM boundary, so the portalled popover can neither deliver a false enter to latch nor swallow the real leave — every dismissal (Delete, Share, Escape, click-outside) clears it. 
Add an opt-in shouldUseNativeHoverEvents prop (default false) to Hoverable/ActiveHoverable.   
 In ActiveHoverable, conditionally subscribe to EITHER native OR synthetic — never both (addressing "we don't subscribe to native mouseenter" and "we still subscribe to React's").  
  Thread the prop MenuItem → Hoverable, and enable it only for the saved-search rows in createBaseSavedSearchMenuItem (used by SavedSearchList) — flowing through MenuItemList's existing props spread — so every other Hoverable keeps the synthetic behavio.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95617
PROPOSAL: https://github.com/Expensify/App/issues/95617#issuecomment-4922596942


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Navigate to the Spend > Saved Searches list.
2. Select a saved search.
3. Click on the 3dot menu of other saved search.
4. Choose the Delete option.
5. When the confirmation modal appears, dismiss it (click outside the modal).
6. Observe the saved search item in the list.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Navigate to the Spend > Saved Searches list.
2. Select a saved search.
3. Click on the 3dot menu of other saved search.
4. Choose the Delete option.
5. When the confirmation modal appears, dismiss it (click outside the modal).
6. Observe the saved search item in the list.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
1. Navigate to the Spend > Saved Searches list.
2. Select a saved search.
3. Click on the 3dot menu of other saved search.
4. Choose the Delete option.
5. When the confirmation modal appears, dismiss it (click outside the modal).
6. Observe the saved search item in the list.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/0324fa03-9ff1-4bdf-96ee-d30d6d0ee110


<!-- add screenshots or videos here -->

</details>
