### PR TITLE
[CP Staging] Fix e-card search not working

### DIFF
--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -61,9 +61,8 @@ function TableBody<DataType extends TableData>({contentContainerStyle, style, ..
         hasActiveFilters,
         hasSearchString,
         isEmptyResult,
-        originalDataLength,
     } = useTableContext<DataType>();
-    const {contentContainerStyle: listContentContainerStyle, ListEmptyComponent, ...restListProps} = listProps ?? {};
+    const {contentContainerStyle: listContentContainerStyle, ListEmptyComponent, ListHeaderComponent, ...restListProps} = listProps ?? {};
 
     const tableBodyContentContainerStyle = useBottomSafeSafeAreaPaddingStyle({
         addBottomSafeAreaPadding: true,
@@ -88,7 +87,7 @@ function TableBody<DataType extends TableData>({contentContainerStyle, style, ..
 
     useDebouncedAccessibilityAnnouncement(message, isEmptyResult, activeSearchString);
 
-    if (isEmptyResult || (!originalDataLength && !ListEmptyComponent)) {
+    if (isEmptyResult && !ListEmptyComponent && !ListHeaderComponent) {
         return null;
     }
 
@@ -113,6 +112,7 @@ function TableBody<DataType extends TableData>({contentContainerStyle, style, ..
                         typeof tableBodyBottomPadding === 'number' && {minHeight: contentMinHeight + tableBodyBottomPadding},
                 ]}
                 keyboardShouldPersistTaps="handled"
+                ListHeaderComponent={ListHeaderComponent}
                 ListEmptyComponent={ListEmptyComponent}
                 {...restListProps}
             />

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -61,6 +61,7 @@ function TableBody<DataType extends TableData>({contentContainerStyle, style, ..
         hasActiveFilters,
         hasSearchString,
         isEmptyResult,
+        originalDataLength,
     } = useTableContext<DataType>();
     const {contentContainerStyle: listContentContainerStyle, ListEmptyComponent, ListHeaderComponent, ...restListProps} = listProps ?? {};
 
@@ -87,7 +88,7 @@ function TableBody<DataType extends TableData>({contentContainerStyle, style, ..
 
     useDebouncedAccessibilityAnnouncement(message, isEmptyResult, activeSearchString);
 
-    if (isEmptyResult && !ListEmptyComponent && !ListHeaderComponent) {
+    if ((isEmptyResult || !originalDataLength) && !ListEmptyComponent && !ListHeaderComponent) {
         return null;
     }
 

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -216,9 +216,6 @@ export default function WorkspaceExpensifyCardsTable({
                     </View>
                 )}
             </View>
-            <Table.FilterBar label={translate('workspace.expensifyCard.findCard')} />
-            <Table.NoResultsState />
-            <Table.Header />
         </>
     );
 
@@ -240,6 +237,9 @@ export default function WorkspaceExpensifyCardsTable({
             ListFooterComponentStyle={listFooterComponentStyle}
             ListHeaderComponent={cardListHeaderContent}
         >
+            <Table.FilterBar label={translate('workspace.expensifyCard.findCard')} />
+            <Table.NoResultsState />
+            <Table.Header />
             <Table.Body contentContainerStyle={listContentContainerStyle} />
         </Table>
     );

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -201,22 +201,20 @@ export default function WorkspaceExpensifyCardsTable({
     );
 
     const cardListHeaderContent = (
-        <>
-            <View style={[styles.appBG, styles.flexShrink0, styles.flexGrow1, styles.mb5]}>
-                <WorkspaceCardListLabels
-                    policyID={policyID}
-                    cardSettings={cardSettingsBase}
-                />
-                {!!errorMessage && (
-                    <View style={[styles.mh5, styles.pr4, styles.mt2]}>
-                        <FormHelpMessage
-                            isError
-                            message={errorMessage}
-                        />
-                    </View>
-                )}
-            </View>
-        </>
+        <View style={[styles.appBG, styles.flexShrink0, styles.flexGrow1, styles.mb5]}>
+            <WorkspaceCardListLabels
+                policyID={policyID}
+                cardSettings={cardSettingsBase}
+            />
+            {!!errorMessage && (
+                <View style={[styles.mh5, styles.pr4, styles.mt2]}>
+                    <FormHelpMessage
+                        isError
+                        message={errorMessage}
+                    />
+                </View>
+            )}
+        </View>
     );
 
     return (

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -201,20 +201,25 @@ export default function WorkspaceExpensifyCardsTable({
     );
 
     const cardListHeaderContent = (
-        <View style={[styles.appBG, styles.flexShrink0, styles.flexGrow1, styles.mb5]}>
-            <WorkspaceCardListLabels
-                policyID={policyID}
-                cardSettings={cardSettingsBase}
-            />
-            {!!errorMessage && (
-                <View style={[styles.mh5, styles.pr4, styles.mt2]}>
-                    <FormHelpMessage
-                        isError
-                        message={errorMessage}
-                    />
-                </View>
-            )}
-        </View>
+        <>
+            <View style={[styles.appBG, styles.flexShrink0, styles.flexGrow1, styles.mb5]}>
+                <WorkspaceCardListLabels
+                    policyID={policyID}
+                    cardSettings={cardSettingsBase}
+                />
+                {!!errorMessage && (
+                    <View style={[styles.mh5, styles.pr4, styles.mt2]}>
+                        <FormHelpMessage
+                            isError
+                            message={errorMessage}
+                        />
+                    </View>
+                )}
+            </View>
+            <Table.FilterBar label={translate('workspace.expensifyCard.findCard')} />
+            <Table.NoResultsState />
+            <Table.Header />
+        </>
     );
 
     return (
@@ -235,9 +240,6 @@ export default function WorkspaceExpensifyCardsTable({
             ListFooterComponentStyle={listFooterComponentStyle}
             ListHeaderComponent={cardListHeaderContent}
         >
-            <Table.FilterBar label={translate('workspace.expensifyCard.findCard')} />
-            <Table.NoResultsState />
-            <Table.Header />
             <Table.Body contentContainerStyle={listContentContainerStyle} />
         </Table>
     );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/95960

### Tests
Precondition:
Workspace has at least one Expensify Card.
Go to workspace settings > Expensify Card.
Click on the search field.
Enter anything that will not return result.
Ensure that an empty state is shown


- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
## Reviewer Checklist

- [x] I have verified the author checklist is complete (all boxes are checked off).
- [x] I verified the correct issue is linked in the `### Fixed Issues` section above
- [x] I verified testing steps are clear and they cover the changes made in this PR
    - [x] I verified the steps for local testing are in the `Tests` section
    - [x] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [x] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I verified that the composer does not automatically focus or open the keyboard on mobile unless explicitly intended. This includes checking that returning the app from the background does not unexpectedly open the keyboard.
- [x] I verified tests pass on **all platforms** & I tested again on:
    - [x] Android: HybridApp
    - [x] Android: mWeb Chrome
    - [x] iOS: HybridApp
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [x] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] For any bug fix or new feature in this PR, I verified that sufficient [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) are included to prevent regressions in this flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

### Screenshots/Videos

https://github.com/user-attachments/assets/15544122-6211-4a7c-90e6-7bef32f244b5


