### PR TITLE
Fix Expensify Card search field auto-clearing on no results

### DIFF
--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -238,8 +238,8 @@ export default function WorkspaceExpensifyCardsTable({
             onRowSelectionChange={onRowSelectionChange}
             ListFooterComponent={listFooterComponent}
             ListFooterComponentStyle={listFooterComponentStyle}
-            ListHeaderComponent={cardListHeaderContent}
         >
+            {cardListHeaderContent}
             <Table.Body contentContainerStyle={listContentContainerStyle} />
         </Table>
     );


### PR DESCRIPTION
### Explanation of Change
`WorkspaceExpensifyCardsTable` was the only `Table` consumer nesting `Table.FilterBar`/`Table.NoResultsState`/`Table.Header` inside `ListHeaderComponent` instead of rendering them as direct `<Table>` children.

Since #94705, `TableBody` returns `null` (unmounting the FlashList + `ListHeaderComponent`) when a search yields no results. That unmounted the search input, whose unmount effect resets the search string, flipping the empty state back off and remounting with a cleared field.

Fix: render the header content as a direct `<Table>` child, matching every other table.

### Fixed Issues
$ https://github.com/Expensify/App/issues/95960
PROPOSAL:

### Tests
1. Workspace Settings > Expensify Card
2. Search for a term with no matches
3. Verify "no results" state shows and the search field keeps the typed text

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as Tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the tests on **all platforms** & verified they passed
- [ ] I verified there are no console errors
- [x] I followed proper code patterns
- [x] I tested other components that can be impacted by my changes
- [ ] I added unit tests for any new feature or bug fix in this PR

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
