### PR TITLE
[No QA] Render the in-app travel nudge on out-of-platform travel expenses

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -1651,6 +1651,7 @@ const CONST = {
                 TASK_COMPLETED: 'TASKCOMPLETED',
                 TASK_EDITED: 'TASKEDITED',
                 TASK_REOPENED: 'TASKREOPENED',
+                TRAVEL_NUDGE: 'TRAVELNUDGE',
                 TRAVEL_UPDATE: 'TRAVEL_TRIP_ROOM_UPDATE',
                 TRIP_PREVIEW: 'TRIPPREVIEW',
                 UNAPPROVED: 'UNAPPROVED',

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -6500,6 +6500,13 @@ const CONST = {
         TRAIN: 'train',
     },
 
+    TRAVEL_NUDGE: {
+        ORIGINATION: {
+            CARD: 'card',
+            MANUAL: 'manual',
+        },
+    },
+
     PNR_STATUS: {
         CANCELLED: 'CANCELLED',
         CANCELLED_STATUS: 'CANCELLED_STATUS',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -4425,6 +4425,22 @@ ${amount} für ${merchant} – ${date}`,
             inputLabel: 'Steuer-ID der juristischen Person',
             error: {required: 'Bitte geben Sie die Steuernummer Ihrer juristischen Person ein.'},
         },
+        nudge: {
+            airfareManual:
+                'Wussten Sie, dass Sie Flüge direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel ✈️',
+            airfareCard:
+                'Wussten Sie schon, dass Sie Flüge direkt in Expensify buchen und verwalten können? Und dass Belege dabei automatisch für Sie hochgeladen werden? Buchen Sie das nächste Mal einfach über Expensify Travel ✈️',
+            hotelManual:
+                'Wussten Sie schon, dass Sie Hotelaufenthalte direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel 🏨',
+            hotelCard: 'Wussten Sie schon, dass Sie Hotelaufenthalte direkt in Expensify buchen und verwalten können? Buchen Sie das nächste Mal einfach über Expensify Travel 🏨',
+            carManual:
+                'Wussten Sie schon, dass Sie Mietwagen direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel 🚗',
+            carCard: 'Wussten Sie schon, dass Sie Mietwagen direkt in Expensify buchen und verwalten können? Buchen Sie das nächste Mal einfach über Expensify Travel 🚗',
+            railManual:
+                'Wussten Sie schon, dass Sie Zugfahrten direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel 🚂',
+            railCard:
+                'Wussten Sie schon, dass Sie Zugfahrten direkt in Expensify buchen und verwalten können? Und dass Belege dabei automatisch für Sie hochgeladen werden? Buchen Sie Ihre nächste Fahrt einfach über Expensify Travel 🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -4427,19 +4427,21 @@ ${amount} für ${merchant} – ${date}`,
         },
         nudge: {
             airfareManual:
-                'Wussten Sie, dass Sie Flüge direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel ✈️',
+                'Wussten Sie schon, dass Sie Flüge direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                'Wussten Sie schon, dass Sie Flüge direkt in Expensify buchen und verwalten können? Und dass Belege dabei automatisch für Sie hochgeladen werden? Buchen Sie das nächste Mal einfach über Expensify Travel ✈️',
+                'Wussten Sie schon, dass Sie Flüge direkt in Expensify buchen und verwalten können? Und dass Belege dabei automatisch für Sie hochgeladen werden? Buchen Sie das nächste Mal einfach über <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                'Wussten Sie schon, dass Sie Hotelaufenthalte direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel 🏨',
-            hotelCard: 'Wussten Sie schon, dass Sie Hotelaufenthalte direkt in Expensify buchen und verwalten können? Buchen Sie das nächste Mal einfach über Expensify Travel 🏨',
+                'Hallo! Wussten Sie, dass Sie Hotelübernachtungen direkt in Expensify buchen und verwalten können? Vermeiden Sie beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
+            hotelCard:
+                'Wussten Sie schon, dass Sie Hotelaufenthalte direkt in Expensify buchen und verwalten können? Buchen Sie das nächste Mal einfach über <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                'Wussten Sie schon, dass Sie Mietwagen direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel 🚗',
-            carCard: 'Wussten Sie schon, dass Sie Mietwagen direkt in Expensify buchen und verwalten können? Buchen Sie das nächste Mal einfach über Expensify Travel 🚗',
+                'Wussten Sie schon, dass Sie Mietwagen direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
+            carCard:
+                'Wussten Sie schon, dass Sie Mietwagen direkt in Expensify buchen und verwalten können? Buchen Sie das nächste Mal einfach über <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                'Wussten Sie schon, dass Sie Zugfahrten direkt in Expensify buchen und verwalten können? Sparen Sie sich beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über Expensify Travel 🚂',
+                'Wussten Sie, dass Sie Zugfahrten direkt in Expensify buchen und verwalten können? Vermeiden Sie beim nächsten Mal den Aufwand, Ihre Ausgabe manuell zu erstellen, und buchen Sie einfach über <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                'Wussten Sie schon, dass Sie Zugfahrten direkt in Expensify buchen und verwalten können? Und dass Belege dabei automatisch für Sie hochgeladen werden? Buchen Sie Ihre nächste Fahrt einfach über Expensify Travel 🚂',
+                'Wussten Sie schon, dass Sie Zugfahrten direkt in Expensify buchen und verwalten können? Und dass Belege dabei automatisch für Sie hochgeladen werden? Buchen Sie das nächste Mal einfach über <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
     },
     workspace: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -4508,6 +4508,22 @@ const translations = {
             railTicketUpdate: (origin: string, destination: string, startDate: string) => `Your rail ticket for ${origin} → ${destination} on ${startDate} has been updated.`,
             defaultUpdate: (type: string) => `Your ${type} reservation was updated.`,
         },
+        nudge: {
+            airfareManual:
+                'Hey there! Did you know you can book and manage flights right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel ✈️',
+            airfareCard:
+                'Hey there! Did you know you can book and manage flights right in Expensify? And it automatically uploads receipts for you? Next time simply book via Expensify Travel ✈️',
+            hotelManual:
+                'Hey there! Did you know you can book and manage hotel stays right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel 🏨',
+            hotelCard: 'Hey there! Did you know you can book and manage hotel stays right in Expensify? Next time simply book via Expensify Travel 🏨',
+            carManual:
+                'Hey there! Did you know you can book and manage car rentals right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel 🚗',
+            carCard: 'Hey there! Did you know you can book and manage car rentals right in Expensify? Next time simply book via Expensify Travel 🚗',
+            railManual:
+                'Hey there! Did you know you can book and manage train rides right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel 🚂',
+            railCard:
+                'Hey there! Did you know you can book and manage train rides right in Expensify? And it automatically uploads receipts for you? Next time simply book via Expensify Travel 🚂',
+        },
         flightTo: 'Flight to',
         trainTo: 'Train to',
         carRental: ' car rental',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -4510,19 +4510,21 @@ const translations = {
         },
         nudge: {
             airfareManual:
-                'Hey there! Did you know you can book and manage flights right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel ✈️',
+                'Hey there! Did you know you can book and manage flights right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                'Hey there! Did you know you can book and manage flights right in Expensify? And it automatically uploads receipts for you? Next time simply book via Expensify Travel ✈️',
+                'Hey there! Did you know you can book and manage flights right in Expensify? And it automatically uploads receipts for you? Next time simply book via <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                'Hey there! Did you know you can book and manage hotel stays right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel 🏨',
-            hotelCard: 'Hey there! Did you know you can book and manage hotel stays right in Expensify? Next time simply book via Expensify Travel 🏨',
+                'Hey there! Did you know you can book and manage hotel stays right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
+            hotelCard:
+                'Hey there! Did you know you can book and manage hotel stays right in Expensify? Next time simply book via <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                'Hey there! Did you know you can book and manage car rentals right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel 🚗',
-            carCard: 'Hey there! Did you know you can book and manage car rentals right in Expensify? Next time simply book via Expensify Travel 🚗',
+                'Hey there! Did you know you can book and manage car rentals right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
+            carCard:
+                'Hey there! Did you know you can book and manage car rentals right in Expensify? Next time simply book via <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                'Hey there! Did you know you can book and manage train rides right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via Expensify Travel 🚂',
+                'Hey there! Did you know you can book and manage train rides right in Expensify? Next time avoid the hassle of creating your expense manually and simply book via <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                'Hey there! Did you know you can book and manage train rides right in Expensify? And it automatically uploads receipts for you? Next time simply book via Expensify Travel 🚂',
+                'Hey there! Did you know you can book and manage train rides right in Expensify? And it automatically uploads receipts for you? Next time simply book via <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
         flightTo: 'Flight to',
         trainTo: 'Train to',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -4288,19 +4288,21 @@ ${amount} para ${merchant} - ${date}`,
         nightsIn: 'noches en',
         nudge: {
             airfareManual:
-                '¡Hola! ¿Sabías que puedes reservar y gestionar vuelos directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel ✈️',
+                '¡Hola! ¿Sabías que puedes reservar y gestionar vuelos directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                '¡Hola! ¿Sabías que puedes reservar y gestionar vuelos directamente en Expensify? ¿Y que además sube los recibos automáticamente por ti? La próxima vez simplemente reserva a través de Expensify Travel ✈️',
+                '¡Hola! ¿Sabías que puedes reservar y gestionar vuelos directamente en Expensify? ¿Y que además sube los recibos automáticamente por ti? La próxima vez simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                '¡Hola! ¿Sabías que puedes reservar y gestionar estancias en hoteles directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel 🏨',
-            hotelCard: '¡Hola! ¿Sabías que puedes reservar y gestionar estancias en hoteles directamente en Expensify? La próxima vez simplemente reserva a través de Expensify Travel 🏨',
+                '¡Hola! ¿Sabías que puedes reservar y gestionar estancias de hotel directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
+            hotelCard:
+                '¡Hola! ¿Sabías que puedes reservar y gestionar estancias en hoteles directamente en Expensify? La próxima vez simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                '¡Hola! ¿Sabías que puedes reservar y gestionar coches de alquiler directamente en Expensify? La próxima vez, evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel 🚗',
-            carCard: '¡Hola! ¿Sabías que puedes reservar y gestionar alquileres de coche directamente en Expensify? La próxima vez simplemente reserva a través de Expensify Travel 🚗',
+                '¡Hola! ¿Sabías que puedes reservar y gestionar alquileres de coche directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
+            carCard:
+                'Hola, ¿sabías que puedes reservar y gestionar coches de alquiler directamente en Expensify? La próxima vez, simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                '¡Hola! ¿Sabías que puedes reservar y gestionar viajes en tren directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel 🚂',
+                'Hola, ¿sabías que puedes reservar y gestionar viajes en tren directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                '¡Hola! ¿Sabías que puedes reservar y gestionar viajes en tren directamente en Expensify? ¿Y que además sube los recibos automáticamente por ti? La próxima vez simplemente reserva a través de Expensify Travel 🚂',
+                '¡Hola! ¿Sabías que puedes reservar y gestionar viajes en tren directamente en Expensify? ¿Y que además sube automáticamente los recibos por ti? La próxima vez simplemente reserva a través de <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
     },
     proactiveAppReview: {

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -4286,6 +4286,22 @@ ${amount} para ${merchant} - ${date}`,
         carRental: ' de alquiler de coche',
         nightIn: 'noche en',
         nightsIn: 'noches en',
+        nudge: {
+            airfareManual:
+                '¡Hola! ¿Sabías que puedes reservar y gestionar vuelos directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel ✈️',
+            airfareCard:
+                '¡Hola! ¿Sabías que puedes reservar y gestionar vuelos directamente en Expensify? ¿Y que además sube los recibos automáticamente por ti? La próxima vez simplemente reserva a través de Expensify Travel ✈️',
+            hotelManual:
+                '¡Hola! ¿Sabías que puedes reservar y gestionar estancias en hoteles directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel 🏨',
+            hotelCard: '¡Hola! ¿Sabías que puedes reservar y gestionar estancias en hoteles directamente en Expensify? La próxima vez simplemente reserva a través de Expensify Travel 🏨',
+            carManual:
+                '¡Hola! ¿Sabías que puedes reservar y gestionar coches de alquiler directamente en Expensify? La próxima vez, evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel 🚗',
+            carCard: '¡Hola! ¿Sabías que puedes reservar y gestionar alquileres de coche directamente en Expensify? La próxima vez simplemente reserva a través de Expensify Travel 🚗',
+            railManual:
+                '¡Hola! ¿Sabías que puedes reservar y gestionar viajes en tren directamente en Expensify? La próxima vez evita la molestia de crear tu gasto manualmente y simplemente reserva a través de Expensify Travel 🚂',
+            railCard:
+                '¡Hola! ¿Sabías que puedes reservar y gestionar viajes en tren directamente en Expensify? ¿Y que además sube los recibos automáticamente por ti? La próxima vez simplemente reserva a través de Expensify Travel 🚂',
+        },
     },
     proactiveAppReview: {
         title: '¿Te gusta New Expensify?',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -4437,21 +4437,21 @@ ${amount} pour ${merchant} - ${date}`,
         },
         nudge: {
             airfareManual:
-                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos vols directement dans Expensify ? La prochaine fois, évitez les tracas de création manuelle de votre dépense et réservez simplement via Expensify Travel ✈️',
+                'Salut ! Saviez-vous que vous pouvez réserver et gérer vos vols directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                'Salut ! Saviez-vous que vous pouvez réserver et gérer vos vols directement dans Expensify ? Et que les reçus sont automatiquement téléchargés pour vous ? La prochaine fois, réservez simplement via Expensify Travel ✈️',
+                'Salut ! Saviez-vous que vous pouvez réserver et gérer vos vols directement dans Expensify ? Et que les reçus sont automatiquement téléchargés pour vous ? La prochaine fois, réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                "Salut ! Saviez-vous que vous pouvez réserver et gérer vos séjours à l'hôtel directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via Expensify Travel 🏨",
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos séjours à l’hôtel directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             hotelCard:
-                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos séjours à l’hôtel directement dans Expensify ? La prochaine fois, réservez simplement via Expensify Travel 🏨',
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos séjours à l’hôtel directement dans Expensify ? La prochaine fois, réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                'Salut ! Saviez-vous que vous pouvez réserver et gérer des locations de voiture directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via Expensify Travel 🚗',
+                'Salut ! Saviez-vous que vous pouvez réserver et gérer des locations de voiture directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             carCard:
-                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos locations de voiture directement dans Expensify ? La prochaine fois, réservez simplement via Expensify Travel 🚗',
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer des locations de voiture directement dans Expensify ? La prochaine fois, réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                'Salut ! Saviez-vous que vous pouvez réserver et gérer vos trajets en train directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via Expensify Travel 🚂',
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos trajets en train directement dans Expensify ? La prochaine fois, évitez les tracas de créer votre dépense manuellement et réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos trajets en train directement dans Expensify ? Et que les reçus y sont automatiquement téléchargés pour vous ? La prochaine fois, réservez simplement via Expensify Travel 🚂',
+                'Salut ! Saviez-vous que vous pouvez réserver et gérer vos trajets en train directement dans Expensify ? Et que les reçus sont automatiquement téléchargés pour vous ? La prochaine fois, réservez simplement via <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
     },
     workspace: {

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -4435,6 +4435,24 @@ ${amount} pour ${merchant} - ${date}`,
             inputLabel: 'Identifiant fiscal de l’entité juridique',
             error: {required: 'Veuillez saisir l’identifiant fiscal de votre entité légale.'},
         },
+        nudge: {
+            airfareManual:
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos vols directement dans Expensify ? La prochaine fois, évitez les tracas de création manuelle de votre dépense et réservez simplement via Expensify Travel ✈️',
+            airfareCard:
+                'Salut ! Saviez-vous que vous pouvez réserver et gérer vos vols directement dans Expensify ? Et que les reçus sont automatiquement téléchargés pour vous ? La prochaine fois, réservez simplement via Expensify Travel ✈️',
+            hotelManual:
+                "Salut ! Saviez-vous que vous pouvez réserver et gérer vos séjours à l'hôtel directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via Expensify Travel 🏨",
+            hotelCard:
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos séjours à l’hôtel directement dans Expensify ? La prochaine fois, réservez simplement via Expensify Travel 🏨',
+            carManual:
+                'Salut ! Saviez-vous que vous pouvez réserver et gérer des locations de voiture directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via Expensify Travel 🚗',
+            carCard:
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos locations de voiture directement dans Expensify ? La prochaine fois, réservez simplement via Expensify Travel 🚗',
+            railManual:
+                'Salut ! Saviez-vous que vous pouvez réserver et gérer vos trajets en train directement dans Expensify ? La prochaine fois, évitez la corvée de créer votre dépense manuellement et réservez simplement via Expensify Travel 🚂',
+            railCard:
+                'Bonjour ! Saviez-vous que vous pouvez réserver et gérer vos trajets en train directement dans Expensify ? Et que les reçus y sont automatiquement téléchargés pour vous ? La prochaine fois, réservez simplement via Expensify Travel 🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -4412,19 +4412,21 @@ ${amount} per ${merchant} - ${date}`,
         },
         nudge: {
             airfareManual:
-                'Ehi! Sapevi che puoi prenotare e gestire i voli direttamente in Expensify? La prossima volta evita la seccatura di creare la spesa manualmente e prenota semplicemente tramite Expensify Travel ✈️',
+                'Ciao! Sapevi che puoi prenotare e gestire i voli direttamente in Expensify? La prossima volta evita la seccatura di creare la spesa manualmente e prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                'Ehi! Sapevi che puoi prenotare e gestire i voli direttamente in Expensify? E che carica automaticamente le ricevute per te? La prossima volta prenota semplicemente con Expensify Travel ✈️',
+                'Ehi! Sapevi che puoi prenotare e gestire i voli direttamente in Expensify? E che carica automaticamente le ricevute per te? La prossima volta prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                'Ciao! Lo sapevi che puoi prenotare e gestire i soggiorni in hotel direttamente in Expensify? La prossima volta evita la seccatura di creare la spesa manualmente e prenota semplicemente tramite Expensify Travel 🏨',
-            hotelCard: 'Ciao! Lo sapevi che puoi prenotare e gestire i soggiorni in hotel direttamente in Expensify? La prossima volta prenota semplicemente tramite Expensify Travel 🏨',
+                'Ciao! Sapevi che puoi prenotare e gestire i tuoi soggiorni in hotel direttamente in Expensify? La prossima volta evita la seccatura di creare la tua spesa manualmente e prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
+            hotelCard:
+                'Ehi! Sapevi che puoi prenotare e gestire i soggiorni in hotel direttamente in Expensify? La prossima volta prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                'Ehi! Sapevi che puoi prenotare e gestire il noleggio auto direttamente in Expensify? La prossima volta evita il fastidio di creare la tua spesa manualmente e prenota semplicemente tramite Expensify Travel 🚗',
-            carCard: 'Ehi! Sapevi che puoi prenotare e gestire il noleggio auto direttamente in Expensify? La prossima volta prenota semplicemente tramite Expensify Travel 🚗',
+                'Ehi! Sapevi che puoi prenotare e gestire il noleggio auto direttamente in Expensify? La prossima volta evita il fastidio di creare la spesa manualmente e prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
+            carCard:
+                'Ehi! Lo sapevi che puoi prenotare e gestire il noleggio auto direttamente in Expensify? La prossima volta prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                'Ehi! Sapevi che puoi prenotare e gestire i viaggi in treno direttamente in Expensify? La prossima volta evita la seccatura di creare la spesa manualmente e prenota semplicemente tramite Expensify Travel 🚂',
+                'Ehi! Sapevi che puoi prenotare e gestire i viaggi in treno direttamente in Expensify? La prossima volta evita il fastidio di creare la tua spesa manualmente e prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                'Ehi! Sapevi che puoi prenotare e gestire i viaggi in treno direttamente in Expensify? E che carica automaticamente le ricevute per te? La prossima volta prenota semplicemente tramite Expensify Travel 🚂',
+                'Ciao! Lo sai che puoi prenotare e gestire i viaggi in treno direttamente in Expensify? E che carica automaticamente le ricevute per te? La prossima volta prenota semplicemente tramite <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
     },
     workspace: {

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -4410,6 +4410,22 @@ ${amount} per ${merchant} - ${date}`,
             inputLabel: 'Partita IVA dell’entità legale',
             error: {required: 'Inserisci il codice fiscale/partita IVA della tua entità legale.'},
         },
+        nudge: {
+            airfareManual:
+                'Ehi! Sapevi che puoi prenotare e gestire i voli direttamente in Expensify? La prossima volta evita la seccatura di creare la spesa manualmente e prenota semplicemente tramite Expensify Travel ✈️',
+            airfareCard:
+                'Ehi! Sapevi che puoi prenotare e gestire i voli direttamente in Expensify? E che carica automaticamente le ricevute per te? La prossima volta prenota semplicemente con Expensify Travel ✈️',
+            hotelManual:
+                'Ciao! Lo sapevi che puoi prenotare e gestire i soggiorni in hotel direttamente in Expensify? La prossima volta evita la seccatura di creare la spesa manualmente e prenota semplicemente tramite Expensify Travel 🏨',
+            hotelCard: 'Ciao! Lo sapevi che puoi prenotare e gestire i soggiorni in hotel direttamente in Expensify? La prossima volta prenota semplicemente tramite Expensify Travel 🏨',
+            carManual:
+                'Ehi! Sapevi che puoi prenotare e gestire il noleggio auto direttamente in Expensify? La prossima volta evita il fastidio di creare la tua spesa manualmente e prenota semplicemente tramite Expensify Travel 🚗',
+            carCard: 'Ehi! Sapevi che puoi prenotare e gestire il noleggio auto direttamente in Expensify? La prossima volta prenota semplicemente tramite Expensify Travel 🚗',
+            railManual:
+                'Ehi! Sapevi che puoi prenotare e gestire i viaggi in treno direttamente in Expensify? La prossima volta evita la seccatura di creare la spesa manualmente e prenota semplicemente tramite Expensify Travel 🚂',
+            railCard:
+                'Ehi! Sapevi che puoi prenotare e gestire i viaggi in treno direttamente in Expensify? E che carica automaticamente le ricevute per te? La prossima volta prenota semplicemente tramite Expensify Travel 🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -4376,16 +4376,21 @@ ${integrationName === CONST.ONBOARDING_ACCOUNTING_MAPPING.other ? 'あなたの'
         },
         nudge: {
             airfareManual:
-                'こんにちは！Expensify では、アプリ内で直接フライトの予約や管理ができることをご存じでしたか？次回からは出費を手入力する手間を省いて、Expensify Travel で簡単に予約しましょう ✈️',
+                'こんにちは！Expensify でフライトの予約や管理ができることをご存じでしたか？次回からは経費を手動で作成する手間を省き、<a href="https://travel.expensify.com">Expensify Travel</a> から予約するだけで大丈夫です ✈️',
             airfareCard:
-                'ご存じでしたか？Expensify から直接、航空券の予約や管理ができるのです。そして、領収書も自動でアップロードされます。次回からは Expensify Travel で簡単に予約しましょう ✈️',
+                'こんにちは！Expensify でフライトの予約と管理ができるのをご存じでしたか？しかも、領収書は自動でアップロードされます。次回からは、ぜひ <a href="https://travel.expensify.com">Expensify Travel</a> から予約してください ✈️',
             hotelManual:
-                'こんにちは！Expensify でホテルの予約や滞在の管理ができることをご存じでしたか？次回からは経費を手入力する手間を省き、Expensify Travel からかんたんに予約しましょう 🏨',
-            hotelCard: 'ご存じでしたか？Expensify から直接ホテルの予約や管理ができるようになりました。次回からは Expensify Travel でかんたんに予約しましょう 🏨',
-            carManual: 'こんにちは！Expensify でレンタカーの予約と管理ができることをご存じでしたか？次回からは経費を手入力する手間を省き、Expensify Travel から簡単に予約しましょう。',
-            carCard: 'こんにちは！Expensify でレンタカーの予約や管理ができることをご存じでしたか？次回からは Expensify Travel 経由でかんたんに予約しましょう 🚗',
-            railManual: 'こんにちは！Expensify なら電車の予約や管理もできることをご存じでしたか？次回からは経費を手入力する手間を省いて、Expensify Travel でそのまま予約しましょう 🚂',
-            railCard: 'こんにちは！Expensify で電車の予約や管理ができることをご存じでしたか？しかも領収書も自動でアップロードされます。次回からは Expensify Travel で予約しましょう🚂',
+                'こんにちは！Expensify でホテルの予約や宿泊の管理ができることをご存じでしたか？次回からは、経費を手動で作成する手間を省き、<a href="https://travel.expensify.com">Expensify Travel</a> から予約するだけで済みます。',
+            hotelCard:
+                'こんにちは！Expensify でホテルの予約や宿泊管理ができることをご存じでしたか？次回からは <a href="https://travel.expensify.com">Expensify Travel</a> からかんたんに予約できます。',
+            carManual:
+                'こんにちは！Expensify でレンタカーの予約と管理ができることをご存じでしたか？次回からは経費を手動で作成する手間を省き、ぜひ <a href="https://travel.expensify.com">Expensify Travel</a> から予約してください 🚗',
+            carCard:
+                'こんにちは！Expensify でレンタカーの予約や管理ができることをご存じでしたか？次回からは <a href="https://travel.expensify.com">Expensify Travel</a> から簡単に予約できます。',
+            railManual:
+                'Expensify で電車の予約や管理ができることをご存じでしたか？次回からは手動で経費を作成する手間を省き、ぜひ <a href="https://travel.expensify.com">Expensify Travel</a> から予約してください。',
+            railCard:
+                'Expensify で電車の予約や管理ができることをご存じでしたか？しかも、領収書は自動でアップロードされます。次回からは <a href="https://travel.expensify.com">Expensify Travel</a> 経由で予約しましょう。',
         },
     },
     workspace: {

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -4374,6 +4374,19 @@ ${integrationName === CONST.ONBOARDING_ACCOUNTING_MAPPING.other ? 'あなたの'
             inputLabel: '法人納税者番号',
             error: {required: '法的事業体の納税者番号を入力してください。'},
         },
+        nudge: {
+            airfareManual:
+                'こんにちは！Expensify では、アプリ内で直接フライトの予約や管理ができることをご存じでしたか？次回からは出費を手入力する手間を省いて、Expensify Travel で簡単に予約しましょう ✈️',
+            airfareCard:
+                'ご存じでしたか？Expensify から直接、航空券の予約や管理ができるのです。そして、領収書も自動でアップロードされます。次回からは Expensify Travel で簡単に予約しましょう ✈️',
+            hotelManual:
+                'こんにちは！Expensify でホテルの予約や滞在の管理ができることをご存じでしたか？次回からは経費を手入力する手間を省き、Expensify Travel からかんたんに予約しましょう 🏨',
+            hotelCard: 'ご存じでしたか？Expensify から直接ホテルの予約や管理ができるようになりました。次回からは Expensify Travel でかんたんに予約しましょう 🏨',
+            carManual: 'こんにちは！Expensify でレンタカーの予約と管理ができることをご存じでしたか？次回からは経費を手入力する手間を省き、Expensify Travel から簡単に予約しましょう。',
+            carCard: 'こんにちは！Expensify でレンタカーの予約や管理ができることをご存じでしたか？次回からは Expensify Travel 経由でかんたんに予約しましょう 🚗',
+            railManual: 'こんにちは！Expensify なら電車の予約や管理もできることをご存じでしたか？次回からは経費を手入力する手間を省いて、Expensify Travel でそのまま予約しましょう 🚂',
+            railCard: 'こんにちは！Expensify で電車の予約や管理ができることをご存じでしたか？しかも領収書も自動でアップロードされます。次回からは Expensify Travel で予約しましょう🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -4405,6 +4405,22 @@ ${amount} voor ${merchant} - ${date}`,
             inputLabel: 'Belastingnummer rechtspersoon',
             error: {required: 'Vul het fiscale identificatienummer van je rechtspersoon in.'},
         },
+        nudge: {
+            airfareManual:
+                'Hoi! Wist je dat je rechtstreeks in Expensify vluchten kunt boeken en beheren? Vermijd de volgende keer het gedoe van het handmatig aanmaken van je uitgave en boek gewoon via Expensify Travel ✈️',
+            airfareCard:
+                'Hoi! Wist je dat je direct in Expensify vluchten kunt boeken en beheren? En dat het automatisch bonnetjes voor je uploadt? Boek de volgende keer gewoon via Expensify Travel ✈️',
+            hotelManual:
+                'Hoi! Wist je dat je hotelverblijven rechtstreeks in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van handmatig een uitgave aanmaken en boek gewoon via Expensify Travel 🏨',
+            hotelCard: 'Hoi! Wist je dat je hotelovernachtingen rechtstreeks in Expensify kunt boeken en beheren? Boek de volgende keer gewoon via Expensify Travel 🏨',
+            carManual:
+                'Hoi! Wist je dat je autoverhuur direct in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van je uitgave handmatig aanmaken en boek gewoon via Expensify Travel 🚗',
+            carCard: 'Hoi! Wist je dat je autoverhuur direct in Expensify kunt boeken en beheren? Boek de volgende keer gewoon via Expensify Travel 🚗',
+            railManual:
+                'Hoi! Wist je dat je treinreizen direct in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van handmatig een uitgave aanmaken en boek gewoon via Expensify Travel 🚂',
+            railCard:
+                'Hoi! Wist je dat je treinreizen rechtstreeks in Expensify kunt boeken en beheren? En dat bonnetjes automatisch voor je worden geüpload? Boek de volgende keer gewoon via Expensify Travel 🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -4407,19 +4407,21 @@ ${amount} voor ${merchant} - ${date}`,
         },
         nudge: {
             airfareManual:
-                'Hoi! Wist je dat je rechtstreeks in Expensify vluchten kunt boeken en beheren? Vermijd de volgende keer het gedoe van het handmatig aanmaken van je uitgave en boek gewoon via Expensify Travel ✈️',
+                'Hoi! Wist je dat je vluchten direct in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van handmatig een uitgave aanmaken en boek gewoon via <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                'Hoi! Wist je dat je direct in Expensify vluchten kunt boeken en beheren? En dat het automatisch bonnetjes voor je uploadt? Boek de volgende keer gewoon via Expensify Travel ✈️',
+                'Hoi! Wist je dat je vluchten rechtstreeks in Expensify kunt boeken en beheren? En dat bonnetjes automatisch voor je worden geüpload? Boek de volgende keer gewoon via <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                'Hoi! Wist je dat je hotelverblijven rechtstreeks in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van handmatig een uitgave aanmaken en boek gewoon via Expensify Travel 🏨',
-            hotelCard: 'Hoi! Wist je dat je hotelovernachtingen rechtstreeks in Expensify kunt boeken en beheren? Boek de volgende keer gewoon via Expensify Travel 🏨',
+                'Hoi! Wist je dat je hotelverblijven rechtstreeks in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van het handmatig aanmaken van je uitgave en boek gewoon via <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
+            hotelCard:
+                'Hoi! Wist je dat je hotelverblijven rechtstreeks in Expensify kunt boeken en beheren? Boek de volgende keer gewoon via <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                'Hoi! Wist je dat je autoverhuur direct in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van je uitgave handmatig aanmaken en boek gewoon via Expensify Travel 🚗',
-            carCard: 'Hoi! Wist je dat je autoverhuur direct in Expensify kunt boeken en beheren? Boek de volgende keer gewoon via Expensify Travel 🚗',
+                'Hoi! Wist je dat je autoverhuur direct in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van het handmatig aanmaken van je uitgave en boek gewoon via <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
+            carCard:
+                'Hoi! Wist je dat je rechtstreeks in Expensify auto\'s kunt huren en beheren? Boek de volgende keer gewoon via <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                'Hoi! Wist je dat je treinreizen direct in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van handmatig een uitgave aanmaken en boek gewoon via Expensify Travel 🚂',
+                'Hoi! Wist je dat je treinreizen gewoon in Expensify kunt boeken en beheren? Vermijd de volgende keer het gedoe van je uitgave handmatig aanmaken en boek simpelweg via <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                'Hoi! Wist je dat je treinreizen rechtstreeks in Expensify kunt boeken en beheren? En dat bonnetjes automatisch voor je worden geüpload? Boek de volgende keer gewoon via Expensify Travel 🚂',
+                'Hoi! Wist je dat je treinreizen rechtstreeks in Expensify kunt boeken en beheren? En dat de bonnetjes automatisch voor je worden geüpload? Boek de volgende keer gewoon via <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
     },
     workspace: {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -4393,19 +4393,21 @@ ${amount} dla ${merchant} - ${date}`,
         },
         nudge: {
             airfareManual:
-                'Cześć! Wiesz, że możesz rezerwować i zarządzać lotami bezpośrednio w Expensify? Następnym razem uniknij kłopotu ręcznego tworzenia wydatku i po prostu zarezerwuj podróż przez Expensify Travel ✈️',
+                'Hej! Wiedziałeś, że możesz rezerwować i zarządzać lotami bezpośrednio w Expensify? Następnym razem uniknij zachodu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przez <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać lotami bezpośrednio w Expensify? I że paragony są automatycznie przesyłane za Ciebie? Następnym razem po prostu zarezerwuj przez Expensify Travel ✈️',
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać lotami bezpośrednio w Expensify? I że paragony są automatycznie przesyłane za Ciebie? Następnym razem po prostu zarezerwuj przez <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                'Hej! Wiedziałeś, że możesz rezerwować i zarządzać pobytami w hotelach bezpośrednio w Expensify? Następnym razem uniknij kłopotu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przez Expensify Travel 🏨',
-            hotelCard: 'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać pobytami w hotelu bezpośrednio w Expensify? Następnym razem po prostu zarezerwuj przez Expensify Travel 🏨',
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać pobytami w hotelu bezpośrednio w Expensify? Następnym razem uniknij kłopotu ręcznego tworzenia wydatku i po prostu zarezerwuj przez <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
+            hotelCard:
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać pobytami w hotelach bezpośrednio w Expensify? Następnym razem po prostu zarezerwuj przez <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać wynajmem samochodów bezpośrednio w Expensify? Następnym razem uniknij kłopotu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przez Expensify Travel 🚗',
-            carCard: 'Cześć! Czy wiesz, że możesz rezerwować i zarządzać wynajmem samochodów bezpośrednio w Expensify? Następnym razem po prostu zarezerwuj przez Expensify Travel 🚗',
+                'Hej! Wiedziałeś, że możesz rezerwować i zarządzać wynajmem samochodów bezpośrednio w Expensify? Następnym razem uniknij zachodu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przez <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
+            carCard:
+                'Hej! Wiedziałeś, że możesz rezerwować i zarządzać wynajmem samochodów bezpośrednio w Expensify? Następnym razem po prostu zarezerwuj przez <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać przejazdami pociągiem bezpośrednio w Expensify? Następnym razem uniknij kłopotu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przejazd przez Expensify Travel 🚂',
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać przejazdami pociągiem bezpośrednio w Expensify? Następnym razem uniknij zachodu z ręcznym tworzeniem wydatku i po prostu zarezerwuj podróż przez <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                'Hej! Wiedziałeś, że możesz rezerwować i zarządzać przejazdami pociągiem bezpośrednio w Expensify? I że aplikacja automatycznie przesyła za ciebie paragony? Następnym razem po prostu zarezerwuj przez Expensify Travel 🚂',
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać przejazdami pociągiem bezpośrednio w Expensify? I że aplikacja automatycznie przesyła za ciebie paragony? Następnym razem po prostu zarezerwuj podróż przez <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
     },
     workspace: {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -4391,6 +4391,22 @@ ${amount} dla ${merchant} - ${date}`,
             inputLabel: 'NIP podmiotu prawnego',
             error: {required: 'Podaj swój identyfikator podatkowy podmiotu prawnego.'},
         },
+        nudge: {
+            airfareManual:
+                'Cześć! Wiesz, że możesz rezerwować i zarządzać lotami bezpośrednio w Expensify? Następnym razem uniknij kłopotu ręcznego tworzenia wydatku i po prostu zarezerwuj podróż przez Expensify Travel ✈️',
+            airfareCard:
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać lotami bezpośrednio w Expensify? I że paragony są automatycznie przesyłane za Ciebie? Następnym razem po prostu zarezerwuj przez Expensify Travel ✈️',
+            hotelManual:
+                'Hej! Wiedziałeś, że możesz rezerwować i zarządzać pobytami w hotelach bezpośrednio w Expensify? Następnym razem uniknij kłopotu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przez Expensify Travel 🏨',
+            hotelCard: 'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać pobytami w hotelu bezpośrednio w Expensify? Następnym razem po prostu zarezerwuj przez Expensify Travel 🏨',
+            carManual:
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać wynajmem samochodów bezpośrednio w Expensify? Następnym razem uniknij kłopotu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przez Expensify Travel 🚗',
+            carCard: 'Cześć! Czy wiesz, że możesz rezerwować i zarządzać wynajmem samochodów bezpośrednio w Expensify? Następnym razem po prostu zarezerwuj przez Expensify Travel 🚗',
+            railManual:
+                'Cześć! Wiedziałeś, że możesz rezerwować i zarządzać przejazdami pociągiem bezpośrednio w Expensify? Następnym razem uniknij kłopotu z ręcznym tworzeniem wydatku i po prostu zarezerwuj przejazd przez Expensify Travel 🚂',
+            railCard:
+                'Hej! Wiedziałeś, że możesz rezerwować i zarządzać przejazdami pociągiem bezpośrednio w Expensify? I że aplikacja automatycznie przesyła za ciebie paragony? Następnym razem po prostu zarezerwuj przez Expensify Travel 🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -4397,19 +4397,21 @@ ${amount} para ${merchant} - ${date}`,
         },
         nudge: {
             airfareManual:
-                'Ei! Sabia que você pode reservar e gerenciar voos direto no Expensify? Da próxima vez, evite o trabalho de criar a despesa manualmente e simplesmente reserve pelo Expensify Travel ✈️',
+                'Ei! Sabia que você pode reservar e gerenciar voos direto no Expensify? Da próxima vez, evite o trabalho de criar sua despesa manualmente e simplesmente reserve pelo <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             airfareCard:
-                'Oi! Você sabia que dá para reservar e gerenciar voos direto no Expensify? E que os recibos são enviados automaticamente para você? Da próxima vez, simplesmente reserve pela Expensify Travel ✈️',
+                'Oi! Você sabia que pode reservar e gerenciar voos direto no Expensify? E que ele envia os recibos automaticamente pra você? Na próxima vez, simplesmente reserve pelo <a href="https://travel.expensify.com">Expensify Travel</a> ✈️',
             hotelManual:
-                'Oi! Sabia que você pode reservar e gerenciar suas estadias em hotel direto pelo Expensify? Da próxima vez, evite o trabalho de criar a despesa manualmente e simplesmente reserve pelo Expensify Travel 🏨',
-            hotelCard: 'Olá! Você sabia que pode reservar e gerenciar hospedagens em hotel direto no Expensify? Da próxima vez, simplesmente reserve pelo Expensify Travel 🏨',
+                'Oi! Sabia que você pode reservar e gerenciar estadias em hotéis direto no Expensify? Da próxima vez, evite o trabalho de criar sua despesa manualmente e simplesmente reserve pelo <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
+            hotelCard:
+                'Oi! Você sabia que pode reservar e gerenciar estadias em hotéis direto no Expensify? Da próxima vez, simplesmente reserve pela <a href="https://travel.expensify.com">Expensify Travel</a> 🏨',
             carManual:
-                'Oi! Sabia que você pode reservar e gerenciar aluguel de carro direto no Expensify? Da próxima vez, evite o trabalho de criar sua despesa manualmente e simplesmente reserve pela Expensify Travel 🚗',
-            carCard: 'Olá! Sabia que você pode reservar e gerenciar aluguel de carros direto no Expensify? Da próxima vez, simplesmente reserve pelo Expensify Travel 🚗',
+                'Oi! Sabia que você pode reservar e gerenciar aluguel de carros direto no Expensify? Da próxima vez, evite o trabalho de criar a despesa manualmente e simplesmente reserve pelo <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
+            carCard:
+                'Oi! Você sabia que pode reservar e gerenciar aluguel de carros diretamente no Expensify? Da próxima vez, simplesmente reserve pelo <a href="https://travel.expensify.com">Expensify Travel</a> 🚗',
             railManual:
-                'Oi! Sabia que você pode reservar e gerenciar viagens de trem direto no Expensify? Da próxima vez, evite o trabalho de criar sua despesa manualmente e simplesmente reserve pelo Expensify Travel 🚂',
+                'Olá! Você sabia que pode reservar e gerenciar viagens de trem direto no Expensify? Da próxima vez, evite o trabalho de criar sua despesa manualmente e simplesmente reserve pela <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
             railCard:
-                'Oi! Você sabia que pode reservar e gerenciar viagens de trem direto pelo Expensify? E que os recibos são enviados automaticamente para você? Da próxima vez, é só reservar pelo Expensify Travel 🚂',
+                'Oi! Sabia que você pode reservar e gerenciar viagens de trem direto no Expensify? E que os recibos são carregados automaticamente pra você? Na próxima vez, simplesmente reserve pelo <a href="https://travel.expensify.com">Expensify Travel</a> 🚂',
         },
     },
     workspace: {

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -4395,6 +4395,22 @@ ${amount} para ${merchant} - ${date}`,
             inputLabel: 'CNPJ da pessoa jurídica',
             error: {required: 'Insira o CNPJ da sua entidade legal.'},
         },
+        nudge: {
+            airfareManual:
+                'Ei! Sabia que você pode reservar e gerenciar voos direto no Expensify? Da próxima vez, evite o trabalho de criar a despesa manualmente e simplesmente reserve pelo Expensify Travel ✈️',
+            airfareCard:
+                'Oi! Você sabia que dá para reservar e gerenciar voos direto no Expensify? E que os recibos são enviados automaticamente para você? Da próxima vez, simplesmente reserve pela Expensify Travel ✈️',
+            hotelManual:
+                'Oi! Sabia que você pode reservar e gerenciar suas estadias em hotel direto pelo Expensify? Da próxima vez, evite o trabalho de criar a despesa manualmente e simplesmente reserve pelo Expensify Travel 🏨',
+            hotelCard: 'Olá! Você sabia que pode reservar e gerenciar hospedagens em hotel direto no Expensify? Da próxima vez, simplesmente reserve pelo Expensify Travel 🏨',
+            carManual:
+                'Oi! Sabia que você pode reservar e gerenciar aluguel de carro direto no Expensify? Da próxima vez, evite o trabalho de criar sua despesa manualmente e simplesmente reserve pela Expensify Travel 🚗',
+            carCard: 'Olá! Sabia que você pode reservar e gerenciar aluguel de carros direto no Expensify? Da próxima vez, simplesmente reserve pelo Expensify Travel 🚗',
+            railManual:
+                'Oi! Sabia que você pode reservar e gerenciar viagens de trem direto no Expensify? Da próxima vez, evite o trabalho de criar sua despesa manualmente e simplesmente reserve pelo Expensify Travel 🚂',
+            railCard:
+                'Oi! Você sabia que pode reservar e gerenciar viagens de trem direto pelo Expensify? E que os recibos são enviados automaticamente para você? Da próxima vez, é só reservar pelo Expensify Travel 🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -4284,14 +4284,18 @@ ${amount}，商户：${merchant} - 日期：${date}`,
         nightsIn: '入住晚数',
         taxID: {title: '税号', subtitle: '请输入您法人的税号，以便我们以本地货币为您设置差旅结算。', inputLabel: '法人税号', error: {required: '请输入您的法人税号。'}},
         nudge: {
-            airfareManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理机票。下次就不用再费劲手动创建报销单了，直接通过 Expensify Travel 预订即可 ✈️',
-            airfareCard: '你好！你知道吗？你可以直接在 Expensify 中预订和管理机票，而且系统会自动为你上传收据。下次只需通过 Expensify Travel 预订即可 ✈️',
-            hotelManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理酒店住宿。下次只需通过 Expensify Travel 预订酒店 🏨，就能省去手动创建报销的麻烦。',
-            hotelCard: '你好！你知道吗？你可以直接在 Expensify 中预订和管理酒店住宿。下次只需通过 Expensify Travel 预订即可 🏨',
-            carManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理租车。下次就不用再手动创建报销了，只需通过 Expensify Travel 预订即可。',
-            carCard: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理租车。下次只需通过 Expensify Travel 预订即可 🚗',
-            railManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理火车行程。下次就不用再手动创建报销了，只需通过 Expensify Travel 预订即可🚂',
-            railCard: '嗨！你知道吗，现在你可以直接在 Expensify 预订和管理火车行程，而且还会自动为你上传票据？下次直接通过 Expensify Travel 预订吧 🚂',
+            airfareManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理机票。下次无需再手动创建报销，只需通过 <a href="https://travel.expensify.com">Expensify Travel</a> 预订即可 ✈️',
+            airfareCard:
+                '嗨！你知道吗？你可以直接在 Expensify 里预订和管理航班，而且还能自动帮你上传收据。下次只需通过 <a href="https://travel.expensify.com">Expensify Travel</a> 预订即可 ✈️',
+            hotelManual:
+                '嗨！你知道吗，现在你可以直接在 Expensify 预订和管理酒店住宿？下次就不用再手动创建报销，直接通过 <a href="https://travel.expensify.com">Expensify Travel</a> 预订就行了 🏨',
+            hotelCard: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理酒店住宿。下次只需通过 <a href="https://travel.expensify.com">Expensify Travel</a> 进行预订即可 🏨',
+            carManual: '嗨！你知道吗？你可以直接在 Expensify 里预订和管理租车。下次就不用再手动创建报销，直接通过 <a href="https://travel.expensify.com">Expensify Travel</a> 预订即可 🚗',
+            carCard: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理租车服务。下次只需通过 <a href="https://travel.expensify.com">Expensify Travel</a> 预订即可 🚗',
+            railManual:
+                '嗨！你知道吗？你可以直接在 Expensify 里预订和管理火车行程。下次就不用再手动创建报销了，只需通过 <a href="https://travel.expensify.com">Expensify Travel</a> 预订即可。',
+            railCard:
+                '嗨！你知道吗？你可以直接在 Expensify 里预订和管理火车行程，而且还会自动为你上传收据。下次只需通过 <a href="https://travel.expensify.com">Expensify Travel</a> 预订即可 🚂',
         },
     },
     workspace: {

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -4283,6 +4283,16 @@ ${amount}，商户：${merchant} - 日期：${date}`,
         nightIn: '夜宿',
         nightsIn: '入住晚数',
         taxID: {title: '税号', subtitle: '请输入您法人的税号，以便我们以本地货币为您设置差旅结算。', inputLabel: '法人税号', error: {required: '请输入您的法人税号。'}},
+        nudge: {
+            airfareManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理机票。下次就不用再费劲手动创建报销单了，直接通过 Expensify Travel 预订即可 ✈️',
+            airfareCard: '你好！你知道吗？你可以直接在 Expensify 中预订和管理机票，而且系统会自动为你上传收据。下次只需通过 Expensify Travel 预订即可 ✈️',
+            hotelManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理酒店住宿。下次只需通过 Expensify Travel 预订酒店 🏨，就能省去手动创建报销的麻烦。',
+            hotelCard: '你好！你知道吗？你可以直接在 Expensify 中预订和管理酒店住宿。下次只需通过 Expensify Travel 预订即可 🏨',
+            carManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理租车。下次就不用再手动创建报销了，只需通过 Expensify Travel 预订即可。',
+            carCard: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理租车。下次只需通过 Expensify Travel 预订即可 🚗',
+            railManual: '嗨！你知道吗？你可以直接在 Expensify 中预订和管理火车行程。下次就不用再手动创建报销了，只需通过 Expensify Travel 预订即可🚂',
+            railCard: '嗨！你知道吗，现在你可以直接在 Expensify 预订和管理火车行程，而且还会自动为你上传票据？下次直接通过 Expensify Travel 预订吧 🚂',
+        },
     },
     workspace: {
         common: {

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -4621,6 +4621,27 @@ function getActionableCard3DSTransactionApprovalMessage(
     return translate('report.actions.type.actionableCard3DSTransactionApproval', formattedAmount, merchant);
 }
 
+// Renders content of TRAVEL_NUDGE reportActions
+function getTravelNudgeMessage(translate: LocalizedTranslate, reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE>) {
+    const originalMessage = getOriginalMessage(reportAction);
+    if (!originalMessage) {
+        return '';
+    }
+    const isCardCreated = originalMessage.origination === 'card';
+    switch (originalMessage.travelType) {
+        case 'airfare':
+            return translate(isCardCreated ? 'travel.nudge.airfareCard' : 'travel.nudge.airfareManual');
+        case 'hotel':
+            return translate(isCardCreated ? 'travel.nudge.hotelCard' : 'travel.nudge.hotelManual');
+        case 'carRental':
+            return translate(isCardCreated ? 'travel.nudge.carCard' : 'travel.nudge.carManual');
+        case 'rail':
+            return translate(isCardCreated ? 'travel.nudge.railCard' : 'travel.nudge.railManual');
+        default:
+            return '';
+    }
+}
+
 /**
  * @private
  */
@@ -4979,6 +5000,7 @@ export {
     getWorkspaceCustomUnitUpdatedMessage,
     getRoomChangeLogMessage,
     getActionableCard3DSTransactionApprovalMessage,
+    getTravelNudgeMessage,
     shouldShowActivateCard,
     isRejectedAction,
     isReopenedAction,

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -4631,7 +4631,7 @@ function getTravelNudgeMessage(translate: LocalizedTranslate, reportAction: Repo
     if (!originalMessage) {
         return '';
     }
-    const isCardCreated = originalMessage.origination === 'card';
+    const isCardCreated = originalMessage.origination === CONST.TRAVEL_NUDGE.ORIGINATION.CARD;
     switch (originalMessage.travelType) {
         case CONST.RESERVATION_TYPE.FLIGHT:
             return translate(isCardCreated ? 'travel.nudge.airfareCard' : 'travel.nudge.airfareManual');

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -626,6 +626,10 @@ function isTravelUpdate(reportAction: OnyxInputOrEntry<ReportAction>): reportAct
     return isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.TRAVEL_UPDATE);
 }
 
+function isTravelNudge(reportAction: OnyxInputOrEntry<ReportAction>): reportAction is ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE> {
+    return isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE);
+}
+
 /**
  * We are in the process of deprecating reportAction.originalMessage and will be setting the db version of "message" to reportAction.message in the future see: https://github.com/Expensify/App/issues/39797
  * In the interim, we must check to see if we have an object or array for the reportAction.message, if we have an array we will use the originalMessage as this means we have not yet migrated.
@@ -1293,7 +1297,7 @@ function shouldReportActionBeVisible(reportAction: OnyxEntry<ReportAction>, key:
         return false;
     }
 
-    if (isTripPreview(reportAction) || isTravelUpdate(reportAction)) {
+    if (isTripPreview(reportAction) || isTravelUpdate(reportAction) || isTravelNudge(reportAction)) {
         return true;
     }
 

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -4625,7 +4625,6 @@ function getActionableCard3DSTransactionApprovalMessage(
     return translate('report.actions.type.actionableCard3DSTransactionApproval', formattedAmount, merchant);
 }
 
-// Renders content of TRAVEL_NUDGE reportActions
 function getTravelNudgeMessage(translate: LocalizedTranslate, reportAction: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE>) {
     const originalMessage = getOriginalMessage(reportAction);
     if (!originalMessage) {

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -4629,13 +4629,13 @@ function getTravelNudgeMessage(translate: LocalizedTranslate, reportAction: Repo
     }
     const isCardCreated = originalMessage.origination === 'card';
     switch (originalMessage.travelType) {
-        case 'airfare':
+        case CONST.RESERVATION_TYPE.FLIGHT:
             return translate(isCardCreated ? 'travel.nudge.airfareCard' : 'travel.nudge.airfareManual');
-        case 'hotel':
+        case CONST.RESERVATION_TYPE.HOTEL:
             return translate(isCardCreated ? 'travel.nudge.hotelCard' : 'travel.nudge.hotelManual');
-        case 'carRental':
+        case CONST.RESERVATION_TYPE.CAR:
             return translate(isCardCreated ? 'travel.nudge.carCard' : 'travel.nudge.carManual');
-        case 'rail':
+        case CONST.RESERVATION_TYPE.TRAIN:
             return translate(isCardCreated ? 'travel.nudge.railCard' : 'travel.nudge.railManual');
         default:
             return '';

--- a/src/pages/inbox/report/actionContents/ActionContentRouter.tsx
+++ b/src/pages/inbox/report/actionContents/ActionContentRouter.tsx
@@ -24,6 +24,7 @@ import {
     getRenamedAction,
     getReportActionHtml,
     getSettlementAccountLockedMessage,
+    getTravelNudgeMessage,
     getTravelUpdateMessage,
     isActionableCardFraudAlert,
     isActionableJoinRequest,
@@ -352,6 +353,13 @@ function ActionContentRouter({
         return (
             <ReportActionItemBasicMessage message="">
                 <RenderHTML html={`<comment><muted-text>${getTravelUpdateMessage(translate, action, formatTravelDate)}</muted-text></comment>`} />
+            </ReportActionItemBasicMessage>
+        );
+    }
+    if (isActionOfType(action, CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE)) {
+        return (
+            <ReportActionItemBasicMessage message="">
+                <RenderHTML html={`<comment><muted-text>${getTravelNudgeMessage(translate, action)}</muted-text></comment>`} />
             </ReportActionItemBasicMessage>
         );
     }

--- a/src/pages/inbox/report/actionContents/SimpleMessageContent.tsx
+++ b/src/pages/inbox/report/actionContents/SimpleMessageContent.tsx
@@ -8,7 +8,6 @@ import {
     getMessageOfOldDotReportAction,
     getOriginalMessage,
     getReportActionText,
-    getTravelNudgeMessage,
     isActionOfType,
     isRejectedAction,
     isUnapprovedAction,
@@ -43,7 +42,6 @@ const SIMPLE_MESSAGE_ACTION_TYPES = new Set<string>([
     CONST.REPORT.ACTIONS.TYPE.DEMOTED_FROM_WORKSPACE,
     CONST.REPORT.ACTIONS.TYPE.ACTIONABLE_CARD_3DS_TRANSACTION_APPROVAL,
     CONST.REPORT.ACTIONS.TYPE.MARK_REIMBURSED_FROM_INTEGRATION,
-    CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE,
 ]);
 
 function isSimpleMessageAction(action: OnyxTypes.ReportAction): boolean {
@@ -106,9 +104,6 @@ function SimpleMessageContent({action}: SimpleMessageContentProps) {
     }
     if (isActionOfType(action, CONST.REPORT.ACTIONS.TYPE.MARK_REIMBURSED_FROM_INTEGRATION)) {
         return <ReportActionItemBasicMessage message={getMessageOfOldDotReportAction(translate, action)} />;
-    }
-    if (isActionOfType(action, CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE)) {
-        return <ReportActionItemBasicMessage message={getTravelNudgeMessage(translate, action)} />;
     }
 
     return null;

--- a/src/pages/inbox/report/actionContents/SimpleMessageContent.tsx
+++ b/src/pages/inbox/report/actionContents/SimpleMessageContent.tsx
@@ -8,6 +8,7 @@ import {
     getMessageOfOldDotReportAction,
     getOriginalMessage,
     getReportActionText,
+    getTravelNudgeMessage,
     isActionOfType,
     isRejectedAction,
     isUnapprovedAction,
@@ -42,6 +43,7 @@ const SIMPLE_MESSAGE_ACTION_TYPES = new Set<string>([
     CONST.REPORT.ACTIONS.TYPE.DEMOTED_FROM_WORKSPACE,
     CONST.REPORT.ACTIONS.TYPE.ACTIONABLE_CARD_3DS_TRANSACTION_APPROVAL,
     CONST.REPORT.ACTIONS.TYPE.MARK_REIMBURSED_FROM_INTEGRATION,
+    CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE,
 ]);
 
 function isSimpleMessageAction(action: OnyxTypes.ReportAction): boolean {
@@ -104,6 +106,9 @@ function SimpleMessageContent({action}: SimpleMessageContentProps) {
     }
     if (isActionOfType(action, CONST.REPORT.ACTIONS.TYPE.MARK_REIMBURSED_FROM_INTEGRATION)) {
         return <ReportActionItemBasicMessage message={getMessageOfOldDotReportAction(translate, action)} />;
+    }
+    if (isActionOfType(action, CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE)) {
+        return <ReportActionItemBasicMessage message={getTravelNudgeMessage(translate, action)} />;
     }
 
     return null;

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -1646,6 +1646,17 @@ type OriginalMessageReimbursementDirectorInformationRequired = {
     completed: boolean;
 };
 
+/**
+ * Model of the travel nudge report action Concierge posts on an out-of-platform travel expense.
+ */
+type OriginalMessageTravelNudge = {
+    /** The kind of bookable travel the expense was classified as */
+    travelType: 'airfare' | 'hotel' | 'carRental' | 'rail';
+
+    /** Whether the expense was created from a card import or manually */
+    origination: 'manual' | 'card';
+};
+
 /** The map type of original message */
 /* eslint-disable jsdoc/require-jsdoc */
 type OriginalMessageMap = {
@@ -1715,6 +1726,7 @@ type OriginalMessageMap = {
     [CONST.REPORT.ACTIONS.TYPE.TASK_EDITED]: never;
     [CONST.REPORT.ACTIONS.TYPE.TASK_REOPENED]: never;
     [CONST.REPORT.ACTIONS.TYPE.TAKE_CONTROL]: OriginalMessageTakeControl;
+    [CONST.REPORT.ACTIONS.TYPE.TRAVEL_NUDGE]: OriginalMessageTravelNudge;
     [CONST.REPORT.ACTIONS.TYPE.TRAVEL_UPDATE]: OriginalMessageTravelUpdate;
     [CONST.REPORT.ACTIONS.TYPE.UNAPPROVED]: OriginalMessageUnapproved;
     [CONST.REPORT.ACTIONS.TYPE.UNHOLD]: never;

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -1651,7 +1651,7 @@ type OriginalMessageReimbursementDirectorInformationRequired = {
  */
 type OriginalMessageTravelNudge = {
     /** The kind of bookable travel the expense was classified as */
-    travelType: 'airfare' | 'hotel' | 'carRental' | 'rail';
+    travelType: ValueOf<typeof CONST.RESERVATION_TYPE>;
 
     /** Whether the expense was created from a card import or manually */
     origination: 'manual' | 'card';

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -1654,7 +1654,7 @@ type OriginalMessageTravelNudge = {
     travelType: ValueOf<typeof CONST.RESERVATION_TYPE>;
 
     /** Whether the expense was created from a card import or manually */
-    origination: 'manual' | 'card';
+    origination: ValueOf<typeof CONST.TRAVEL_NUDGE.ORIGINATION>;
 };
 
 /** The map type of original message */


### PR DESCRIPTION
### Explanation of Change

Part of the in-app travel nudge ([#657018](https://github.com/Expensify/Expensify/issues/657018)): when a traveler expenses out-of-platform travel (flight/hotel/car/rail) on an Expensify Travel–enabled workspace, Concierge posts a nudge on the expense encouraging them to book in-platform next time.

This is the NewDot rendering. It adds a `TRAVEL_NUDGE` report action type and renders localized copy from the action's `travelType` and `origination` (manually created vs. card), mirroring how the `ACTIONABLE_CARD_3DS_TRANSACTION_APPROVAL` message is translated client-side from its original message.

Only the English strings are added here (under `travel.nudge`); the translation bot fills the other locales once this PR is open. Until it does, typecheck is red on the missing-locale keys — that is expected and not a code issue.

Companion PRs: Auth [#22890](https://github.com/Expensify/Auth/pull/22890) creates the action, and Web-Expensify [#54497](https://github.com/Expensify/Web-Expensify/pull/54497) triggers it. This renderer is safe to merge on its own — it only takes effect once the backend posts the action.

### Fixed Issues
$
PROPOSAL:

Part of https://github.com/Expensify/Expensify/issues/657018

### Tests
Draft — not yet enabled for customers. End-to-end verification is pending the companion Auth + Web PRs and offline validation of the classification prompt.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests.

### QA Steps
[No QA] — the renderer produces nothing on its own until the backend posts the action, so there is nothing to QA in isolation. QA steps will be defined when the nudge is enabled.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).

– written by Claude on Ben's behalf
