### PR TITLE
[No QA] Update Workspace-Rules.md

### DIFF
--- a/docs/articles/new-expensify/workspaces/Workspace-Rules.md
+++ b/docs/articles/new-expensify/workspaces/Workspace-Rules.md
@@ -1,7 +1,7 @@
 ---
 title: Workspace Rules
 description: Configure and manage rules for your workspace to enforce expense policies and automate compliance.
-keywords: [New Expensify, workspace rules, expense rules, receipt requirements, category rules, self-approvals, prohibited expenses, disable Smartscan, automate expenses, subscription expense, non-reimbursable, default expense handling, control expenses, expense categorization, rule-based expenses, compliance, itemized receipt, itemized receipts required over, merchant rules, workspace merchant rules, auto-categorize by merchant, spend rules, Expensify Card spend rules, block transactions, approve transactions]
+keywords: [New Expensify, workspace rules, expense rules, receipt requirements, category rules, self-approvals, prohibited expenses, disable Smartscan, automate expenses, subscription expense, non-reimbursable, default expense handling, control expenses, expense categorization, rule-based expenses, compliance, itemized receipt, itemized receipts required over, merchant rules, workspace merchant rules, auto-categorize by merchant, spend rules, Expensify Card spend rules, block transactions, approve transactions, billable]
 internalScope: Audience is Workspace Admins on the Control plan. Covers enabling and managing workspace-level rules such as expense rules, merchant rules, prohibited expenses, category rules, tag rules, report rules, and Expensify Card spend rules. Does not cover personal expense rules, Workspace Merchant Rules setup details, or troubleshooting specific rule outcomes.
 ---
 


### PR DESCRIPTION
### Explanation of Change

Follow-up help site update for [Part 1 - [Rules Revamp] Clean-up and Polish (Expensify/App#95289)](https://github.com/Expensify/App/pull/95289).

That PR moves the **Track billable expenses** toggle and the billable default (Billable / Non-billable) out of **Tags > Settings** and into **Rules**, on the new **Billable expenses** page (accessible from the **Rules** tab). The help article [`Workspace-Rules.md`](https://github.com/Expensify/App/blob/main/docs/articles/new-expensify/workspaces/Workspace-Rules.md) still told users to configure billable expenses under **Tags > Settings**, which no longer reflects the revamped location.

This PR updates that one line to point to **Rules > Billable expenses** and mentions the **Track billable expenses** toggle, using the exact UI labels from the app (`Track billable expenses`, `Billable expenses`).

### What changed

- `docs/articles/new-expensify/workspaces/Workspace-Rules.md` — under **How to manage default categories and billable behavior**, the **Billable expenses** bullet now points to **Rules > Billable expenses** instead of **Tags > Settings**.

### ⚠️ Merge timing — gated behind the `rulesRevamp` beta

All UI changes in Expensify/App#95289 are gated behind the `rulesRevamp` beta and are **not yet generally available**. The help site documents current GA behavior, so **this PR should stay in draft and only be merged once the Rules Revamp ships to all users.**

### Deliberately not changed (deferred)

Expensify/App#95289 also (behind the same beta) removes the **Settings** option from the Categories and Tags menus and removes the **Require tags** toggle from **Tags > Settings**. This is explicitly labeled "Part 1", and where those settings ultimately land in the new information architecture is not established in this PR. I did **not** touch the following articles to avoid documenting a destination that isn't finalized:

- `docs/articles/new-expensify/workspaces/Require-tags-and-categories-for-expenses.md` (Require tags location)
- `docs/articles/new-expensify/workspaces/Create-expense-categories.md` (category Settings)
- `docs/articles/new-expensify/workspaces/Create-and-manage-expense-tags.md`

These should be revisited when the later parts of the revamp land and the final navigation is confirmed.

---


