### PR TITLE
[CP Staging] Fix focus trap tab registration loop

### DIFF
--- a/src/libs/Navigation/OnyxTabNavigator.tsx
+++ b/src/libs/Navigation/OnyxTabNavigator.tsx
@@ -137,8 +137,14 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
     }, [styles.fullScreenLoading, styles.w100]);
 
     // This callback is used to register the focus trap container element of each available tab screen
-    const setTabFocusTrapContainerElement = (tabName: string, containerElement: HTMLElement | null) => {
+    const setTabFocusTrapContainerElement = useCallback((tabName: string, containerElement: HTMLElement | null) => {
         setFocusTrapContainerElementMapping((prevMapping) => {
+            if (prevMapping[tabName] === containerElement) {
+                return prevMapping;
+            }
+            if (!containerElement && !(tabName in prevMapping)) {
+                return prevMapping;
+            }
             const resultMapping = {...prevMapping};
             if (containerElement) {
                 resultMapping[tabName] = containerElement;
@@ -147,7 +153,7 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
             }
             return resultMapping;
         });
-    };
+    }, []);
 
     const {translate} = useLocalize();
     const {showConfirmModal} = useConfirmModal();
@@ -155,7 +161,7 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
     const guardsRef = useRef<Map<string, TabSwitchGuard>>(new Map());
     const isDiscardModalOpenRef = useRef(false);
 
-    const registerTabGuard: RegisterTabSwitchGuard = (guard) => {
+    const registerTabGuard = useCallback<RegisterTabSwitchGuard>((guard) => {
         guardsRef.current.set(guard.tabName, guard);
         return () => {
             // Only clear if this exact guard is still registered, so a re-registration from another mount isn't wiped.
@@ -164,46 +170,49 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
             }
             guardsRef.current.delete(guard.tabName);
         };
-    };
+    }, []);
 
-    const handleTabPress = (navigation: NavigationProp<ParamListBase>, event: EventArg<'tabPress', true, undefined>) => {
-        if (isDiscardModalOpenRef.current) {
-            event.preventDefault();
-            return;
-        }
-        const navState = navigation.getState();
-        const currentRouteName = navState.routes.at(navState.index)?.name;
-        const guard = currentRouteName ? guardsRef.current.get(currentRouteName) : undefined;
-        if (!guard || !guard.getHasUnsavedChanges()) {
-            return;
-        }
-        const targetRoute = navState.routes.find((tabRoute) => tabRoute.key === event.target);
-        if (!targetRoute || targetRoute.name === currentRouteName) {
-            return;
-        }
-        event.preventDefault();
-        isDiscardModalOpenRef.current = true;
-        showConfirmModal({
-            ...getDiscardChangesModalConfig(translate),
-            shouldIgnoreBackHandlerDuringTransition: true,
-        }).then((result) => {
-            isDiscardModalOpenRef.current = false;
-            if (result.action !== ModalActions.CONFIRM) {
-                guard.onCancel?.();
+    const handleTabPress = useCallback(
+        (navigation: NavigationProp<ParamListBase>, event: EventArg<'tabPress', true, undefined>) => {
+            if (isDiscardModalOpenRef.current) {
+                event.preventDefault();
                 return;
             }
-            // User confirmed: always jump to the target tab, even if onDiscard fails, rather than stranding them with no feedback.
-            Promise.resolve()
-                .then(() => guard.onDiscard())
-                .catch((error: unknown) => {
-                    Log.warn('[OnyxTabNavigator] Failed to run tab-switch onDiscard callback', {error});
-                    Growl.error(translate('common.genericErrorMessage'));
-                })
-                .then(() => {
-                    navigation.dispatch(TabActions.jumpTo(targetRoute.name));
-                });
-        });
-    };
+            const navState = navigation.getState();
+            const currentRouteName = navState.routes.at(navState.index)?.name;
+            const guard = currentRouteName ? guardsRef.current.get(currentRouteName) : undefined;
+            if (!guard || !guard.getHasUnsavedChanges()) {
+                return;
+            }
+            const targetRoute = navState.routes.find((tabRoute) => tabRoute.key === event.target);
+            if (!targetRoute || targetRoute.name === currentRouteName) {
+                return;
+            }
+            event.preventDefault();
+            isDiscardModalOpenRef.current = true;
+            showConfirmModal({
+                ...getDiscardChangesModalConfig(translate),
+                shouldIgnoreBackHandlerDuringTransition: true,
+            }).then((result) => {
+                isDiscardModalOpenRef.current = false;
+                if (result.action !== ModalActions.CONFIRM) {
+                    guard.onCancel?.();
+                    return;
+                }
+                // User confirmed: always jump to the target tab, even if onDiscard fails, rather than stranding them with no feedback.
+                Promise.resolve()
+                    .then(() => guard.onDiscard())
+                    .catch((error: unknown) => {
+                        Log.warn('[OnyxTabNavigator] Failed to run tab-switch onDiscard callback', {error});
+                        Growl.error(translate('common.genericErrorMessage'));
+                    })
+                    .then(() => {
+                        navigation.dispatch(TabActions.jumpTo(targetRoute.name));
+                    });
+            });
+        },
+        [showConfirmModal, translate],
+    );
 
     /**
      * This is a TabBar wrapper component that includes the focus trap container element callback.
@@ -311,9 +320,12 @@ function TabScreenWithFocusTrapWrapper({children}: {children?: React.ReactNode})
     const route = useRoute();
     const styles = useThemeStyles();
     const setTabContainerElement = useContext(TabFocusTrapContext);
-    const handleContainerElementChanged = (element: HTMLElement | null) => {
-        setTabContainerElement(route.name, element);
-    };
+    const handleContainerElementChanged = useCallback(
+        (element: HTMLElement | null) => {
+            setTabContainerElement(route.name, element);
+        },
+        [setTabContainerElement, route.name],
+    );
 
     return (
         <FocusTrapContainerElement

--- a/src/libs/Navigation/OnyxTabNavigator.tsx
+++ b/src/libs/Navigation/OnyxTabNavigator.tsx
@@ -137,7 +137,7 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
     }, [styles.fullScreenLoading, styles.w100]);
 
     // This callback is used to register the focus trap container element of each available tab screen
-    const setTabFocusTrapContainerElement = useCallback((tabName: string, containerElement: HTMLElement | null) => {
+    const setTabFocusTrapContainerElement = (tabName: string, containerElement: HTMLElement | null) => {
         setFocusTrapContainerElementMapping((prevMapping) => {
             if (prevMapping[tabName] === containerElement) {
                 return prevMapping;
@@ -153,7 +153,7 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
             }
             return resultMapping;
         });
-    }, []);
+    };
 
     const {translate} = useLocalize();
     const {showConfirmModal} = useConfirmModal();
@@ -161,7 +161,7 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
     const guardsRef = useRef<Map<string, TabSwitchGuard>>(new Map());
     const isDiscardModalOpenRef = useRef(false);
 
-    const registerTabGuard = useCallback<RegisterTabSwitchGuard>((guard) => {
+    const registerTabGuard: RegisterTabSwitchGuard = (guard) => {
         guardsRef.current.set(guard.tabName, guard);
         return () => {
             // Only clear if this exact guard is still registered, so a re-registration from another mount isn't wiped.
@@ -170,49 +170,46 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
             }
             guardsRef.current.delete(guard.tabName);
         };
-    }, []);
+    };
 
-    const handleTabPress = useCallback(
-        (navigation: NavigationProp<ParamListBase>, event: EventArg<'tabPress', true, undefined>) => {
-            if (isDiscardModalOpenRef.current) {
-                event.preventDefault();
-                return;
-            }
-            const navState = navigation.getState();
-            const currentRouteName = navState.routes.at(navState.index)?.name;
-            const guard = currentRouteName ? guardsRef.current.get(currentRouteName) : undefined;
-            if (!guard || !guard.getHasUnsavedChanges()) {
-                return;
-            }
-            const targetRoute = navState.routes.find((tabRoute) => tabRoute.key === event.target);
-            if (!targetRoute || targetRoute.name === currentRouteName) {
-                return;
-            }
+    const handleTabPress = (navigation: NavigationProp<ParamListBase>, event: EventArg<'tabPress', true, undefined>) => {
+        if (isDiscardModalOpenRef.current) {
             event.preventDefault();
-            isDiscardModalOpenRef.current = true;
-            showConfirmModal({
-                ...getDiscardChangesModalConfig(translate),
-                shouldIgnoreBackHandlerDuringTransition: true,
-            }).then((result) => {
-                isDiscardModalOpenRef.current = false;
-                if (result.action !== ModalActions.CONFIRM) {
-                    guard.onCancel?.();
-                    return;
-                }
-                // User confirmed: always jump to the target tab, even if onDiscard fails, rather than stranding them with no feedback.
-                Promise.resolve()
-                    .then(() => guard.onDiscard())
-                    .catch((error: unknown) => {
-                        Log.warn('[OnyxTabNavigator] Failed to run tab-switch onDiscard callback', {error});
-                        Growl.error(translate('common.genericErrorMessage'));
-                    })
-                    .then(() => {
-                        navigation.dispatch(TabActions.jumpTo(targetRoute.name));
-                    });
-            });
-        },
-        [showConfirmModal, translate],
-    );
+            return;
+        }
+        const navState = navigation.getState();
+        const currentRouteName = navState.routes.at(navState.index)?.name;
+        const guard = currentRouteName ? guardsRef.current.get(currentRouteName) : undefined;
+        if (!guard || !guard.getHasUnsavedChanges()) {
+            return;
+        }
+        const targetRoute = navState.routes.find((tabRoute) => tabRoute.key === event.target);
+        if (!targetRoute || targetRoute.name === currentRouteName) {
+            return;
+        }
+        event.preventDefault();
+        isDiscardModalOpenRef.current = true;
+        showConfirmModal({
+            ...getDiscardChangesModalConfig(translate),
+            shouldIgnoreBackHandlerDuringTransition: true,
+        }).then((result) => {
+            isDiscardModalOpenRef.current = false;
+            if (result.action !== ModalActions.CONFIRM) {
+                guard.onCancel?.();
+                return;
+            }
+            // User confirmed: always jump to the target tab, even if onDiscard fails, rather than stranding them with no feedback.
+            Promise.resolve()
+                .then(() => guard.onDiscard())
+                .catch((error: unknown) => {
+                    Log.warn('[OnyxTabNavigator] Failed to run tab-switch onDiscard callback', {error});
+                    Growl.error(translate('common.genericErrorMessage'));
+                })
+                .then(() => {
+                    navigation.dispatch(TabActions.jumpTo(targetRoute.name));
+                });
+        });
+    };
 
     /**
      * This is a TabBar wrapper component that includes the focus trap container element callback.
@@ -231,6 +228,11 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
         },
         [TabBar, onTabBarFocusTrapContainerElementChanged, shouldShowLabelWhenInactive, equalWidth],
     );
+
+    // Keep the generic type casts outside the nested screenListeners callback because OXC cannot hoist
+    // type-parameter references while outlining that callback.
+    const persistSelectedTab = Tab.setSelectedTab as (tabID: string, tabName: string) => void;
+    const notifyTabSelected = onTabSelected as (newTabName: string | undefined) => void;
 
     // If the selected tab changes, we need to update the focus trap container element of the active tab
     useEffect(() => {
@@ -271,9 +273,9 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
                                     return;
                                 }
                                 if (newSelectedTab) {
-                                    Tab.setSelectedTab<TTabName>(id, newSelectedTab as TTabName);
+                                    persistSelectedTab(id, newSelectedTab);
                                 }
-                                onTabSelected(newSelectedTab as TTabName);
+                                notifyTabSelected(newSelectedTab);
                             },
                             tabPress: (e) => {
                                 // Let a caller's own tabPress run first; if it blocked the switch, don't also run the guard.
@@ -320,12 +322,9 @@ function TabScreenWithFocusTrapWrapper({children}: {children?: React.ReactNode})
     const route = useRoute();
     const styles = useThemeStyles();
     const setTabContainerElement = useContext(TabFocusTrapContext);
-    const handleContainerElementChanged = useCallback(
-        (element: HTMLElement | null) => {
-            setTabContainerElement(route.name, element);
-        },
-        [setTabContainerElement, route.name],
-    );
+    const handleContainerElementChanged = (element: HTMLElement | null) => {
+        setTabContainerElement(route.name, element);
+    };
 
     return (
         <FocusTrapContainerElement

--- a/src/libs/Navigation/OnyxTabNavigator.tsx
+++ b/src/libs/Navigation/OnyxTabNavigator.tsx
@@ -139,12 +139,6 @@ function OnyxTabNavigator<TTabName extends string = SelectedTabRequest>({
     // This callback is used to register the focus trap container element of each available tab screen
     const setTabFocusTrapContainerElement = (tabName: string, containerElement: HTMLElement | null) => {
         setFocusTrapContainerElementMapping((prevMapping) => {
-            if (prevMapping[tabName] === containerElement) {
-                return prevMapping;
-            }
-            if (!containerElement && !(tabName in prevMapping)) {
-                return prevMapping;
-            }
             const resultMapping = {...prevMapping};
             if (containerElement) {
                 resultMapping[tabName] = containerElement;


### PR DESCRIPTION
### Explanation of Change

Fixes a web crash when opening the create expense flow.

The tab focus-trap registration in `OnyxTabNavigator` was updating state every time the ref callback fired, even when the registered container element had not changed. After the web build pipeline change to OXC React Compiler, this unstable callback/ref path could repeatedly re-render until React threw `Maximum update depth exceeded`.

This PR makes the registration callbacks stable and prevents redundant focus-trap mapping updates when the container element is unchanged or already absent.

### Fixed Issues

$ [https://github.com/Expensify/App/issues/96035](<https://github.com/Expensify/App/issues/96035>)<br>PROPOSAL:

### Tests

1. Open the app on web.
2. Sign in.
3. Navigate to a report.
4. Click the create/add expense action.
5. Verify the create expense flow opens without crashing.

- [X] Verify that no errors appear in the JS console

### Offline tests

Same as Tests.

### QA Steps

Same as Tests

// TODO: These must be filled out, or the issue title must include "\[No QA\]."

- [X] Verify that no errors appear in the JS console

### PR Author Checklist

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
  - [X] I added steps for local testing in the `Tests` section
  - [X] I added steps for the expected offline behavior in the `Offline steps` section
  - [X] I added steps for Staging and/or Production testing in the `QA steps` section
  - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [X] I tested this PR with a [High Traffic account](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts>) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms>)
- [X] I ran the tests on **all platforms** & verified they passed on:
  - [X] Android: Native
  - [X] Android: mWeb Chrome
  - [X] iOS: Native
  - [X] iOS: mWeb Safari
  - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code>))
  - [X] I verified that comments were added to code that is not self explanatory
  - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md>)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] If a new CSS style is added I verified that:
  - [X] A similar style doesn't already exist
  - [X] The style can't be created with an existing [StyleUtils](<https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts>) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
  - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [X] I verified that all the inputs inside a form are aligned with each other.
  - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] I added [unit tests](<https://github.com/Expensify/App/blob/main/tests/README.md>) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native

> 

https://github.com/user-attachments/assets/9e14a154-9d99-4865-92ef-ff3457634e09

Android: mWeb Chrome

> 

https://github.com/user-attachments/assets/e6be3b21-ff35-49ee-b8d9-3d870e36de8d

iOS: Native

> 

https://github.com/user-attachments/assets/3d8d5a99-9f44-45ef-a107-7715e15d06f1

iOS: mWeb Safari

> 

https://github.com/user-attachments/assets/d013dce3-5a03-4e2b-a72a-f7f4d195a363

MacOS: Chrome / Safari

> 

https://github.com/user-attachments/assets/85661a15-eb8a-4bc2-8cc4-dc4082e787cf