### PR TITLE
[CP Staging] [Payment due @huult] Coalesce concurrent SAML reauthentication redirects to fix SSO sign-in flashing

### DIFF
--- a/src/libs/Reauthentication.ts
+++ b/src/libs/Reauthentication.ts
@@ -39,6 +39,14 @@ let isAuthenticatingWithShortLivedToken = false;
 let isSupportAuthTokenUsed = false;
 let isSupportSession = false;
 
+// A SAML-required account cannot silently reauthenticate (there is no stored password), so an expired
+// session sends the user back through their IdP. When the token expires, the app fires several requests
+// at once (ReconnectApp, OpenApp, AuthenticatePusher, ...) and they all get a 407 in the same tick, so
+// each one would call redirectToSignIn on its own and the sign-in page would flash and re-initiate SAML
+// several times. This lets the first expired request trigger the redirect and skips the rest until the
+// next SAML sign-in begins.
+let hasQueuedSAMLReauthRedirect = false;
+
 // These session values are only used to help the user authentication with the API.
 // Since they aren't connected to a UI anywhere, it's OK to use connectWithoutView()
 Onyx.connectWithoutView({
@@ -59,6 +67,12 @@ Onyx.connectWithoutView({
     key: ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN,
     callback: (value) => {
         isAuthenticatingWithShortLivedToken = !!value;
+
+        // A new short-lived-token SAML sign-in has begun, so allow the redirect again the next time
+        // this session's token expires.
+        if (value) {
+            hasQueuedSAMLReauthRedirect = false;
+        }
     },
 });
 
@@ -206,8 +220,17 @@ function reauthenticate(command = ''): Promise<boolean> {
         // customer's SAML flow. Skipping the SAML redirect lets a support session fall through to the normal
         // sign-in redirect below instead of bouncing the agent to the customer's IdP (e.g. Okta).
         if (account?.isSAMLRequired && !isSupportSession && !isSupportAuthTokenUsed) {
-            Log.info(`[Reauthenticate] Redirecting to Sign In because SAML is required`);
             setIsAuthenticating(false);
+
+            // Skip the redirect if an earlier expired request in this same burst already queued it, so the
+            // sign-in page is not torn down and re-mounted (and SAML re-initiated) once per concurrent 407.
+            if (hasQueuedSAMLReauthRedirect) {
+                Log.info('[Reauthenticate] SAML sign-in redirect already queued, skipping duplicate redirect');
+                return false;
+            }
+
+            hasQueuedSAMLReauthRedirect = true;
+            Log.info(`[Reauthenticate] Redirecting to Sign In because SAML is required`);
             redirectToSignIn(undefined, true);
             return false;
         }

--- a/tests/actions/SessionTest.ts
+++ b/tests/actions/SessionTest.ts
@@ -154,6 +154,66 @@ describe('Session', () => {
         redirectToSignInSpy.mockRestore();
     });
 
+    describe('SAML reauthentication redirect coalescing', () => {
+        beforeEach(async () => {
+            // Reset the module-level coalescing guard between tests. Setting the short-lived-token flag to
+            // true is what clears the guard, so toggle it on and back off to start each test from a clean state.
+            await Onyx.set(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN, true);
+            await Onyx.set(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN, false);
+            await waitForBatchedUpdates();
+        });
+
+        test('coalesces a burst of concurrent SAML reauthentication calls into a single sign-in redirect', async () => {
+            // Given a SAML-required account whose session token has expired
+            await Onyx.set(ONYXKEYS.ACCOUNT, {isSAMLRequired: true, isLoading: true});
+            await waitForBatchedUpdates();
+
+            const redirectToSignInSpy = jest.spyOn(SignInRedirect, 'default').mockImplementation(() => Promise.resolve());
+
+            // When several requests fail with 407 in the same tick and each triggers reauthenticate
+            const results = await Promise.all([reauthenticate('ReconnectApp'), reauthenticate('OpenApp'), reauthenticate('AuthenticatePusher')]);
+            await waitForBatchedUpdates();
+
+            // Then only the first request redirects to the SAML sign-in page; the rest are skipped, so the page
+            // is not torn down and re-mounted (and SAML re-initiated) once per concurrent 407
+            expect(results).toEqual([false, false, false]);
+            expect(redirectToSignInSpy).toHaveBeenCalledTimes(1);
+            expect(redirectToSignInSpy).toHaveBeenCalledWith(undefined, true);
+
+            redirectToSignInSpy.mockRestore();
+        });
+
+        test('allows a fresh SAML sign-in redirect once a new short-lived-token exchange has begun', async () => {
+            // Given a SAML-required account that has already been redirected to sign in
+            await Onyx.set(ONYXKEYS.ACCOUNT, {isSAMLRequired: true, isLoading: true});
+            await waitForBatchedUpdates();
+
+            const redirectToSignInSpy = jest.spyOn(SignInRedirect, 'default').mockImplementation(() => Promise.resolve());
+
+            await reauthenticate('ReconnectApp');
+            await waitForBatchedUpdates();
+            expect(redirectToSignInSpy).toHaveBeenCalledTimes(1);
+
+            // A later 407 in the same burst is still coalesced and does not redirect again
+            await reauthenticate('OpenApp');
+            await waitForBatchedUpdates();
+            expect(redirectToSignInSpy).toHaveBeenCalledTimes(1);
+
+            // When the user begins a new SAML sign-in, the short-lived-token exchange starts and then settles
+            await Onyx.set(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN, true);
+            await waitForBatchedUpdates();
+            await Onyx.set(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN, false);
+            await waitForBatchedUpdates();
+
+            // Then a later token expiry is allowed to redirect to SAML again
+            await reauthenticate('ReconnectApp');
+            await waitForBatchedUpdates();
+            expect(redirectToSignInSpy).toHaveBeenCalledTimes(2);
+
+            redirectToSignInSpy.mockRestore();
+        });
+    });
+
     test('Authenticate is called with saved credentials when a session expires', async () => {
         // Given a test user and set of authToken with subscriptions to session and credentials
         const TEST_USER_LOGIN = 'test@testguy.com';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

SSO users on a SAML-required domain are sent back to their identity provider when their session token expires. The bug is that the sign-in page flashes and the SSO prompt fires several times in a row instead of once.

When the token expires the app sends a burst of requests at the same time (reconnectApp, openApp, AuthenticatePusher and so on) and they all come back `407` in the same tick. In `reauthenticate()` a SAML-required account cannot silently reauthenticate because there is no stored password, so every one of those `407`s takes the `account.isSAMLRequired` branch and calls `redirectToSignIn()` on its own. Each call clears the session and re-mounts the sign-in page, and each mount re-initiates SAML, so the user sees the screen flash and the IdP prompt open several times.

Production logs from an affected account (anonymized) show the pattern. On reconnect, three commands hit the expired token and `407` inside the same half second:

```
15:14:32.979  ReconnectApp        ->  407 Unauthorized - Invalid token   (AuthTokenExpired: "Your session has expired")
15:14:33.368  OpenApp             ->  407 Unauthorized - Invalid token   (AuthTokenExpired)
15:14:33.523  AuthenticatePusher  ->  407 Unauthorized - Invalid token   (AuthTokenExpired)
```

Each of those `407`s then drives its own `reauthenticate()` -> `redirectToSignIn()`, firing in the same instant (this is the flash):

```
12:20:59.258  [info] [Reauthenticate] Redirecting to Sign In because SAML is required
12:20:59.375  [info] [Reauthenticate] Redirecting to Sign In because SAML is required
12:20:59.376  [info] [Reauthenticate] Redirecting to Sign In because SAML is required
```

This coalesces those redirects. The first expired request in a burst queues the redirect and the rest are skipped, until the next SAML sign-in begins. The reset is keyed on the existing `RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN` flag, which flips on when a new short-lived-token exchange starts, so a later token expiry is still allowed to redirect. The result is one clean redirect and one SSO prompt per expiry instead of a flashing burst.

This does not change the redirect behaviour for non-SAML accounts, and it does not change how often a session expires.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/Expensify/issues/659015
PROPOSAL: N/A (internal fix)


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. On the native app, sign in as a user whose domain has SAML/SSO set to required.
2. Use the app until the session auth token expires, or force the next reconnect to receive a `407`.
3. Bring the app back to the foreground so it reconnects.
4. Verify you are sent to the SSO sign-in once, with a single IdP prompt and no repeated screen flashing.
5. Complete SSO and verify you land back in the app signed in.
6. Let the new session expire and repeat, and verify each expiry produces a single prompt rather than a burst.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

SAML sign-in needs a network connection. While offline the requests never reach the server, so no `407` and no reauthentication redirect is triggered. There is no offline-specific behaviour for this change.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as the Tests section above. Requires a test account on a domain with SAML/SSO set to required, since the flow cannot be reproduced without one.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

