### PR TITLE
Revert "[Submit] Update \"Submit to someone\" to two options to allow for Submit workspace creation"

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -3748,11 +3748,6 @@ const CONST = {
             CATEGORIZE: 'categorize',
             SHARE: 'share',
         },
-        // Destination chosen from the track-expense "Submit" whisper on the Submit (submit2026) plan.
-        SUBMIT_DESTINATION: {
-            FRIEND: 'friend',
-            EMPLOYER: 'employer',
-        },
         DEFAULT_AMOUNT: 0,
         TYPE: {
             SEND: 'send',

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -2113,10 +2113,8 @@ const ROUTES = {
     },
     MONEY_REQUEST_STEP_PARTICIPANTS: {
         route: ':action/:iouType/participants/:transactionID/:reportID',
-        getRoute: (iouType: IOUType, transactionID: string | undefined, reportID: string | undefined, backTo = '', action: IOUAction = 'create', isWorkspacesOnly = false) => {
-            const queryParams = isWorkspacesOnly ? '?isWorkspacesOnly=true' : '';
-            return getUrlWithBackToParam(`${action as string}/${iouType as string}/participants/${transactionID}/${reportID}${queryParams}`, backTo);
-        },
+        getRoute: (iouType: IOUType, transactionID: string | undefined, reportID: string | undefined, backTo = '', action: IOUAction = 'create') =>
+            getUrlWithBackToParam(`${action as string}/${iouType as string}/participants/${transactionID}/${reportID}`, backTo),
     },
     MONEY_REQUEST_STEP_SCAN: {
         route: ':action/:iouType/scan/:transactionID/:reportID',

--- a/src/components/MoneyRequestConfirmationList/hooks/useConfirmationValidation.ts
+++ b/src/components/MoneyRequestConfirmationList/hooks/useConfirmationValidation.ts
@@ -2,7 +2,6 @@ import {useCurrencyListActions} from '@hooks/useCurrencyList';
 
 import {isValidPerDiemExpenseAmount} from '@libs/actions/IOU/PerDiem';
 import {getIsMissingAttendeesViolation} from '@libs/AttendeeUtils';
-import {isCategoryMissing} from '@libs/CategoryUtils';
 import {convertToFrontendAmountAsString} from '@libs/CurrencyUtils';
 import {isTaxAmountInvalid, isValidMoneyRequestAmount, validateAmount} from '@libs/MoneyRequestUtils';
 import type {getTagLists as getTagListsFn} from '@libs/PolicyUtils';
@@ -231,9 +230,7 @@ function useConfirmationValidation({
 
         const isCategoryBeingCreated = policyCategories?.[iouCategory]?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD;
 
-        // The 'Uncategorized'/'none' sentinel means no category, so treat it as missing (not out of policy) here, mirroring
-        // isCategoryMissing/ViolationsUtils. Otherwise it wrongly blocks confirmation when the policy lacks that literal category.
-        if (iouCategory && !isCategoryMissing(iouCategory) && policyCategories && !policyCategories[iouCategory]?.enabled && !isCategoryBeingCreated) {
+        if (iouCategory && policyCategories && !policyCategories[iouCategory]?.enabled && !isCategoryBeingCreated) {
             return {errorKey: 'violations.categoryOutOfPolicy'};
         }
 

--- a/src/components/MoneyRequestConfirmationList/hooks/useConfirmationValidation.ts
+++ b/src/components/MoneyRequestConfirmationList/hooks/useConfirmationValidation.ts
@@ -2,6 +2,7 @@ import {useCurrencyListActions} from '@hooks/useCurrencyList';
 
 import {isValidPerDiemExpenseAmount} from '@libs/actions/IOU/PerDiem';
 import {getIsMissingAttendeesViolation} from '@libs/AttendeeUtils';
+import {isCategoryMissing} from '@libs/CategoryUtils';
 import {convertToFrontendAmountAsString} from '@libs/CurrencyUtils';
 import {isTaxAmountInvalid, isValidMoneyRequestAmount, validateAmount} from '@libs/MoneyRequestUtils';
 import type {getTagLists as getTagListsFn} from '@libs/PolicyUtils';
@@ -230,7 +231,9 @@ function useConfirmationValidation({
 
         const isCategoryBeingCreated = policyCategories?.[iouCategory]?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD;
 
-        if (iouCategory && policyCategories && !policyCategories[iouCategory]?.enabled && !isCategoryBeingCreated) {
+        // The 'Uncategorized'/'none' sentinel means no category, so treat it as missing (not out of policy) here, mirroring
+        // isCategoryMissing/ViolationsUtils. Otherwise it wrongly blocks confirmation when the policy lacks that literal category.
+        if (iouCategory && !isCategoryMissing(iouCategory) && policyCategories && !policyCategories[iouCategory]?.enabled && !isCategoryBeingCreated) {
             return {errorKey: 'violations.categoryOutOfPolicy'};
         }
 

--- a/src/components/MoneyRequestConfirmationListFooter/hooks/useFooterDerivedFlags.ts
+++ b/src/components/MoneyRequestConfirmationListFooter/hooks/useFooterDerivedFlags.ts
@@ -5,7 +5,6 @@ import usePolicyForMovingExpenses from '@hooks/usePolicyForMovingExpenses';
 
 import {isBillableEnabledOnPolicy} from '@libs/MoneyRequestReportUtils';
 import {shouldShowConfirmationDate} from '@libs/MoneyRequestUtils';
-import {isSubmitPolicy} from '@libs/PolicyUtils';
 import {hasEnabledTags} from '@libs/TagsOptionsListUtils';
 import {getCurrency, isManagedCardTransaction, isScanRequest, shouldShowAttendees as shouldShowAttendeesTransactionUtils} from '@libs/TransactionUtils';
 
@@ -68,7 +67,7 @@ function useFooterDerivedFlags({
     isTypeInvoice,
     shouldShowSmartScanFields,
 }: UseFooterDerivedFlagsParams) {
-    const {policyForMovingExpenses, shouldSelectPolicy, shouldNavigateToUpgradePath: canNavigateToUpgradePath} = usePolicyForMovingExpenses();
+    const {policyForMovingExpenses, shouldSelectPolicy, shouldNavigateToUpgradePath} = usePolicyForMovingExpenses();
 
     const transaction = useTransactionSelector(transactionID, derivedFlagsSliceSelector);
 
@@ -96,9 +95,6 @@ function useFooterDerivedFlags({
     const shouldShowBillable = isBillableEnabledOnPolicy(policy);
     const shouldShowReimbursable =
         (isPolicyExpenseChat || isTrackExpense) && !!policy && policy?.disabledFields?.reimbursable !== true && !isManagedCardTransaction(transaction) && !isTypeInvoice;
-    // Submit workspaces ship Categories/Distance enabled by default, so never route their fields to the upgrade gate.
-    const isSubmitWorkspace = isSubmitPolicy(policy);
-    const shouldNavigateToUpgradePath = !isSubmitWorkspace && canNavigateToUpgradePath;
     const shouldShowTimeRequestFields = isTimeRequest && action === CONST.IOU.ACTION.CREATE;
 
     return {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -9218,8 +9218,6 @@ Fügen Sie weitere Ausgabelimits hinzu, um den Cashflow Ihres Unternehmens zu sc
     },
     actionableMentionTrackExpense: {
         submit: 'An jemanden senden',
-        submitToFriend: 'An einen Freund senden',
-        submitToEmployer: 'An meinen Arbeitgeber senden',
         categorize: 'Kategorisieren',
         share: 'Mit meinem Steuerberater teilen',
         nothing: 'Im Moment nichts',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -9331,8 +9331,6 @@ const translations = {
     },
     actionableMentionTrackExpense: {
         submit: 'Submit it to someone',
-        submitToFriend: 'Submit to a friend',
-        submitToEmployer: 'Submit to my employer',
         categorize: 'Categorize it',
         share: 'Share it with my accountant',
         nothing: 'Nothing for now',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -9442,8 +9442,6 @@ El plan Controlar empieza en 9 $ por miembro activo al mes.`,
     },
     actionableMentionTrackExpense: {
         submit: 'Pedirle a alguien que lo pague',
-        submitToFriend: 'Enviar a un amigo',
-        submitToEmployer: 'Enviar a mi empleador',
         categorize: 'Categorizarlo',
         share: 'Compartirlo con mi contador',
         nothing: 'Por ahora, nada',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -9254,8 +9254,6 @@ Ajoutez davantage de règles de dépenses pour protéger la trésorerie de l’e
     },
     actionableMentionTrackExpense: {
         submit: 'Soumettre à quelqu’un',
-        submitToFriend: 'Soumettre à un ami',
-        submitToEmployer: 'Soumettre à mon employeur',
         categorize: 'Catégorisez-la',
         share: 'Partager avec mon comptable',
         nothing: 'Rien pour l’instant',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -9207,8 +9207,6 @@ Aggiungi altre regole di spesa per proteggere il flusso di cassa aziendale.`,
     },
     actionableMentionTrackExpense: {
         submit: 'Invialo a qualcuno',
-        submitToFriend: 'Invia a un amico',
-        submitToEmployer: 'Invia al mio datore di lavoro',
         categorize: 'Classificala',
         share: 'Condividilo con il mio commercialista',
         nothing: 'Niente per ora',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -9078,8 +9078,6 @@ ${reportName}`,
     },
     actionableMentionTrackExpense: {
         submit: '誰かに送信する',
-        submitToFriend: '友達に送信する',
-        submitToEmployer: '勤務先に送信する',
         categorize: '仕分けする',
         share: '会計士と共有する',
         nothing: '今のところ何もありません',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -9176,8 +9176,6 @@ er bestedingsregels toe om de kasstroom van het bedrijf te beschermen.`,
     },
     actionableMentionTrackExpense: {
         submit: 'Dien het bij iemand in',
-        submitToFriend: 'Indienen bij een vriend',
-        submitToEmployer: 'Indienen bij mijn werkgever',
         categorize: 'Categoriseer het',
         share: 'Deel het met mijn accountant',
         nothing: 'Niets voor nu',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -9154,8 +9154,6 @@ Dodaj więcej zasad wydatków, żeby chronić płynność finansową firmy.`,
     },
     actionableMentionTrackExpense: {
         submit: 'Prześlij to do kogoś',
-        submitToFriend: 'Prześlij do znajomego',
-        submitToEmployer: 'Prześlij do mojego pracodawcy',
         categorize: 'Skategoryzuj to',
         share: 'Udostępnij to mojemu księgowemu',
         nothing: 'Na razie nic',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -9164,8 +9164,6 @@ Adicione mais regras de gasto para proteger o fluxo de caixa da empresa.`,
     },
     actionableMentionTrackExpense: {
         submit: 'Enviar para alguém',
-        submitToFriend: 'Enviar para um amigo',
-        submitToEmployer: 'Enviar para meu empregador',
         categorize: 'Classificar isso',
         share: 'Compartilhar com meu contador',
         nothing: 'Nada por enquanto',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -8887,8 +8887,6 @@ ${reportName}`,
     },
     actionableMentionTrackExpense: {
         submit: '提交给某人',
-        submitToFriend: '提交给朋友',
-        submitToEmployer: '提交给我的雇主',
         categorize: '对其分类',
         share: '与我的会计共享',
         nothing: '现在没有任何内容',

--- a/src/libs/API/parameters/AddTrackedExpenseToPolicyParams.ts
+++ b/src/libs/API/parameters/AddTrackedExpenseToPolicyParams.ts
@@ -1,20 +1,29 @@
-import type CONST from '@src/CONST';
+import type {Receipt} from '@src/types/onyx/Transaction';
 
-import type {ValueOf} from 'type-fest';
-
-import type CategorizeTrackedExpenseParams from './CategorizeTrackedExpenseParams';
-
-// AddTrackedExpenseToPolicy is a backend alias of CategorizeTrackedExpense, so it accepts the same
-// parameters (including the optional workspace-creation params used when moving a tracked expense into
-// a newly created draft workspace).
-type AddTrackedExpenseToPolicyParams = CategorizeTrackedExpenseParams & {
-    reimbursable?: boolean;
-    distance?: number;
+type AddTrackedExpenseToPolicyParams = {
+    amount: number;
+    currency: string;
+    created: string;
+    comment?: string;
+    merchant?: string;
+    category: string | undefined;
+    tag: string | undefined;
+    taxCode: string;
+    taxAmount: number;
+    reimbursable: boolean;
+    billable: boolean | undefined;
+    receipt: Receipt | undefined;
+    waypoints?: string;
+    customUnitRateID?: string;
+    policyID: string;
+    transactionID: string;
+    actionableWhisperReportActionID: string | undefined;
+    moneyRequestReportID: string;
+    reportPreviewReportActionID: string;
+    modifiedExpenseReportActionID: string;
+    moneyRequestCreatedReportActionID: string | undefined;
+    moneyRequestPreviewReportActionID: string;
     shouldDeferAutoSubmit?: boolean;
-    /** Name to give the workspace when one is created as part of this request, so the backend matches the optimistic name. */
-    policyName?: string;
-    /** Policy type to create when a workspace is created as part of this request (e.g. submit2026 for "Submit to my employer"). */
-    type?: ValueOf<typeof CONST.POLICY.TYPE>;
 };
 
 export default AddTrackedExpenseToPolicyParams;

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -1974,8 +1974,6 @@ type MoneyRequestNavigatorParamList = {
         iouType: Exclude<IOUType, typeof CONST.IOU.TYPE.REQUEST | typeof CONST.IOU.TYPE.SEND>;
         transactionID: string;
         reportID: string;
-        /** Whether to limit the destination list to workspaces only (e.g. "Submit to my employer" on the Submit plan) */
-        isWorkspacesOnly?: string;
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes;
     };

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1404,7 +1404,13 @@ function getPolicyName(params: GetPolicyNameParams): string {
     const noPolicyFound = params.returnEmptyIfNotFound ? '' : (params.unavailableTranslation ?? unavailableTranslation);
     const parentReport = report ? getRootParentReport({report, reports}) : undefined;
 
-    if ((!report?.policyName && !parentReport?.policyName && isEmptyObject(policies) && isEmptyObject(allPolicies)) || isEmptyObject(report)) {
+    // Bail only when none of the sources used below can resolve a name. oldPolicyName is included because it's a valid
+    // fallback (see below) and is the only name a draft workspace's expense chat carries with no persisted policies.
+    // Without it this returned "Unavailable workspace" for those drafts.
+    if (
+        (!report?.policyName && !report?.oldPolicyName && !parentReport?.policyName && !parentReport?.oldPolicyName && isEmptyObject(policies) && isEmptyObject(allPolicies)) ||
+        isEmptyObject(report)
+    ) {
         return noPolicyFound;
     }
     const finalPolicy = (() => {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -65,7 +65,7 @@ import type {
     PaymentMethodType,
 } from '@src/types/onyx/OriginalMessage';
 import type {Status, Timezone} from '@src/types/onyx/PersonalDetails';
-import type {AllConnectionName, ConnectionName, CreatableWorkspaceType} from '@src/types/onyx/Policy';
+import type {AllConnectionName, ConnectionName} from '@src/types/onyx/Policy';
 import type {NotificationPreference, Participants, Participant as ReportParticipant} from '@src/types/onyx/Report';
 import type {Message, OldDotReportAction, ReportActions} from '@src/types/onyx/ReportAction';
 import type {PendingChatMember} from '@src/types/onyx/ReportMetadata';
@@ -1404,13 +1404,7 @@ function getPolicyName(params: GetPolicyNameParams): string {
     const noPolicyFound = params.returnEmptyIfNotFound ? '' : (params.unavailableTranslation ?? unavailableTranslation);
     const parentReport = report ? getRootParentReport({report, reports}) : undefined;
 
-    // Bail only when none of the sources used below can resolve a name. oldPolicyName is included because it's a valid
-    // fallback (see below) and is the only name a draft workspace's expense chat carries (e.g. "Submit to my employer"
-    // with no persisted policies) — without it this returned "Unavailable workspace" for those drafts.
-    if (
-        (!report?.policyName && !report?.oldPolicyName && !parentReport?.policyName && !parentReport?.oldPolicyName && isEmptyObject(policies) && isEmptyObject(allPolicies)) ||
-        isEmptyObject(report)
-    ) {
+    if ((!report?.policyName && !parentReport?.policyName && isEmptyObject(policies) && isEmptyObject(allPolicies)) || isEmptyObject(report)) {
         return noPolicyFound;
     }
     const finalPolicy = (() => {
@@ -11363,8 +11357,6 @@ function createDraftWorkspaceAndNavigateToConfirmationScreen(
     currentUserAccountID: number,
     currentUserEmail: string,
     currentUserLocalCurrency: string,
-    policyType?: CreatableWorkspaceType,
-    backToReportID?: string,
 ): void {
     const isCategorizing = actionName === CONST.IOU.ACTION.CATEGORIZE;
     const {expenseChatReportID, policyID, policyName} = createDraftWorkspace({
@@ -11373,7 +11365,6 @@ function createDraftWorkspaceAndNavigateToConfirmationScreen(
         currentUserAccountID,
         currentUserEmail,
         currency: currentUserLocalCurrency,
-        type: policyType,
     });
     setMoneyRequestParticipants(transactionID, [
         {
@@ -11389,11 +11380,7 @@ function createDraftWorkspaceAndNavigateToConfirmationScreen(
     if (isCategorizing) {
         Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CATEGORY.getRoute(actionName, CONST.IOU.TYPE.SUBMIT, transactionID, expenseChatReportID));
     } else {
-        // The confirmation route needs a `:reportID`, so it points at the (draft) workspace expense chat to resolve the
-        // draft policy/destination. That report only lives in REPORT_DRAFT. Send back to the origin report (e.g. the
-        // self-DM the track expense came from) so navigateBack returns there instead of the draft report's start step.
-        const backTo = backToReportID ? ROUTES.REPORT_WITH_ID.getRoute(backToReportID) : undefined;
-        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(actionName, CONST.IOU.TYPE.SUBMIT, transactionID, expenseChatReportID, undefined, true, backTo));
+        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(actionName, CONST.IOU.TYPE.SUBMIT, transactionID, expenseChatReportID, undefined, true));
     }
 }
 
@@ -11413,14 +11400,6 @@ type CreateDraftTransactionParams = {
     currentUserAccountID: number;
     currentUserEmail: string;
     currentUserLocalCurrency: string;
-    /**
-     * For the SUBMIT action, which destination the user picked from the track-expense whisper:
-     * - 'friend' (default): show the existing recipient picker (individuals + workspaces).
-     * - 'employer': route to a submit-enabled workspace, auto-selecting/creating one as needed.
-     */
-    submitDestination?: ValueOf<typeof CONST.IOU.SUBMIT_DESTINATION>;
-    /** Localized default name for a workspace created on the fly (e.g. "Submit to my employer" with no existing workspace). */
-    defaultWorkspaceName?: string;
     filteredPoliciesCount: number;
     firstPolicyID: string | undefined;
 };
@@ -11441,8 +11420,6 @@ function createDraftTransactionAndNavigateToParticipantSelector({
     currentUserAccountID,
     currentUserEmail,
     currentUserLocalCurrency,
-    submitDestination = CONST.IOU.SUBMIT_DESTINATION.FRIEND,
-    defaultWorkspaceName = '',
     filteredPoliciesCount,
     firstPolicyID,
 }: CreateDraftTransactionParams): void {
@@ -11554,42 +11531,6 @@ function createDraftTransactionAndNavigateToParticipantSelector({
 
     if (actionName === CONST.IOU.ACTION.SHARE) {
         Navigation.navigate(ROUTES.MONEY_REQUEST_ACCOUNTANT.getRoute(actionName, CONST.IOU.TYPE.SUBMIT, transactionID, reportID, Navigation.getActiveRoute()));
-        return;
-    }
-
-    // "Submit to my employer" routes the expense into a workspace the user can submit to, based on how many they belong to.
-    // Per issue #92704 the count spans every paid workspace the user is a member of (Collect/Control/Submit), so we reuse the
-    // shared shouldShowPolicy-based count (filteredPoliciesCount/firstPolicyID) that also backs the workspaces-only picker.
-    if (actionName === CONST.IOU.ACTION.SUBMIT && submitDestination === CONST.IOU.SUBMIT_DESTINATION.EMPLOYER) {
-        // No accessible workspace: spin up a new Submit (submit2026) workspace and drop the expense into its draft report.
-        if (filteredPoliciesCount === 0) {
-            createDraftWorkspaceAndNavigateToConfirmationScreen(
-                introSelected,
-                transactionID,
-                actionName,
-                defaultWorkspaceName,
-                currentUserAccountID,
-                currentUserEmail,
-                currentUserLocalCurrency,
-                CONST.POLICY.TYPE.SUBMIT,
-                reportID,
-            );
-            return;
-        }
-
-        // Exactly one accessible workspace: skip the destination picker and submit straight to that workspace.
-        if (filteredPoliciesCount === 1 && firstPolicyID) {
-            const policyExpenseReport = getPolicyExpenseChat(deprecatedCurrentUserAccountID, firstPolicyID);
-            if (policyExpenseReport) {
-                setMoneyRequestParticipantsFromReport(transactionID, policyExpenseReport, deprecatedCurrentUserAccountID).then(() => {
-                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(CONST.IOU.ACTION.SUBMIT, CONST.IOU.TYPE.SUBMIT, transactionID, policyExpenseReport.reportID));
-                });
-                return;
-            }
-        }
-
-        // Multiple accessible workspaces: show the destination picker limited to workspaces only (no individual recipients).
-        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_PARTICIPANTS.getRoute(CONST.IOU.TYPE.SUBMIT, transactionID, reportID, undefined, actionName, true));
         return;
     }
 

--- a/src/libs/actions/IOU/TrackExpense.ts
+++ b/src/libs/actions/IOU/TrackExpense.ts
@@ -1,7 +1,14 @@
 import ReceiptGeneric from '@assets/images/receipt-generic.png';
 
 import * as API from '@libs/API';
-import type {AddTrackedExpenseToPolicyParams, CreateWorkspaceParams, DeleteMoneyRequestParams, RequestMoneyParams, ShareTrackedExpenseParams, TrackExpenseParams} from '@libs/API/parameters';
+import type {
+    CategorizeTrackedExpenseParams as CategorizeTrackedExpenseApiParams,
+    CreateWorkspaceParams,
+    DeleteMoneyRequestParams,
+    RequestMoneyParams,
+    ShareTrackedExpenseParams,
+    TrackExpenseParams,
+} from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import DateUtils from '@libs/DateUtils';
 import {deferOrExecuteWrite} from '@libs/deferredLayoutWrite';
@@ -92,7 +99,6 @@ import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import type * as OnyxTypes from '@src/types/onyx';
 import type {Attendee, Participant} from '@src/types/onyx/IOU';
-import type {CreatableWorkspaceType} from '@src/types/onyx/Policy';
 import type {QuickActionName} from '@src/types/onyx/QuickAction';
 import type ReportAction from '@src/types/onyx/ReportAction';
 import type {OnyxData} from '@src/types/onyx/Request';
@@ -192,8 +198,6 @@ type GetTrackExpenseInformationParams = {
     optimisticChatReportID?: string;
     currentUserLocalCurrency: string | undefined;
     delegateAccountID: number | undefined;
-    /** Policy type for the workspace created from a draft report (e.g. submit2026 for the "Submit to my employer" flow). Defaults to a team workspace. */
-    policyType?: CreatableWorkspaceType;
     // TODO: Remove optional (?) once all callers are updated in follow-up PRs of https://github.com/Expensify/App/issues/66414
     isDraftChatReport?: boolean;
 };
@@ -859,7 +863,6 @@ function getTrackExpenseInformation(params: GetTrackExpenseInformationParams): T
         delegateAccountID,
         isDraftChatReport,
         currentUserLocalCurrency,
-        policyType,
     } = params;
     const {payeeAccountID = currentUserAccountIDParam, payeeEmail = currentUserEmailParam, participant} = participantParams;
     const {policy} = policyParams;
@@ -997,10 +1000,7 @@ function getTrackExpenseInformation(params: GetTrackExpenseInformationParams): T
             policyName: policy?.name ?? defaultWorkspaceName ?? '',
             policyID: policy?.id,
             expenseReportId: chatReport?.reportID,
-            // Submit workspaces need the EMPLOYER choice so the backend applies ADVANCED approval (shows "Submit", not "Mark as done").
-            engagementChoice: policyType === CONST.POLICY.TYPE.SUBMIT ? CONST.ONBOARDING_CHOICES.EMPLOYER : CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE,
-            // "Submit to my employer" with no existing workspace creates a Submit (submit2026) workspace; categorize/share default to a team workspace.
-            type: policyType,
+            engagementChoice: CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE,
             currency: currentUserLocalCurrency,
             currentUserAccountIDParam,
             currentUserEmailParam,
@@ -2134,23 +2134,7 @@ function convertBulkTrackedExpensesToIOU({
     }
 }
 
-type MoveTrackedExpenseToPolicyConfig = {
-    /** Tracked-expense action this move represents; drives getConvertTrackedExpenseInformation. */
-    action: typeof CONST.IOU.ACTION.CATEGORIZE | typeof CONST.IOU.ACTION.SUBMIT;
-
-    /** API command to write: CategorizeTrackedExpense or its AddTrackedExpenseToPolicy alias. */
-    command: typeof WRITE_COMMANDS.CATEGORIZE_TRACKED_EXPENSE | typeof WRITE_COMMANDS.ADD_TRACKED_EXPENSE_TO_POLICY;
-
-    /** Command-specific params merged over the shared ones (e.g. policyName/type for AddTrackedExpenseToPolicy, distance custom unit). */
-    extraParams?: Partial<AddTrackedExpenseToPolicyParams>;
-};
-
-/**
- * Shared implementation for moving a tracked expense into a policy. categorizeTrackedExpense (CategorizeTrackedExpense)
- * and submitTrackedExpenseToPolicy (AddTrackedExpenseToPolicy, a backend alias) only differ by the action passed to
- * getConvertTrackedExpenseInformation, the write command, and a few command-specific params, so they share this body.
- */
-function moveTrackedExpenseToPolicy(trackedExpenseParams: TrackedExpenseParams, {action, command, extraParams}: MoveTrackedExpenseToPolicyConfig) {
+function categorizeTrackedExpense(trackedExpenseParams: TrackedExpenseParams) {
     const {onyxData, reportInformation, transactionParams, policyParams, createdWorkspaceParams, currentUser} = trackedExpenseParams;
     const {accountID: currentUserAccountID} = currentUser;
     const {optimisticData, successData, failureData} = onyxData ?? {};
@@ -2176,7 +2160,7 @@ function moveTrackedExpenseToPolicy(trackedExpenseParams: TrackedExpenseParams, 
         linkedTrackedExpenseReportAction,
         linkedTrackedExpenseReportID,
         transactionThreadReportID,
-        action,
+        CONST.IOU.ACTION.CATEGORIZE,
         isLinkedTrackedExpenseReportArchived,
         currentUserAccountID,
     );
@@ -2185,7 +2169,7 @@ function moveTrackedExpenseToPolicy(trackedExpenseParams: TrackedExpenseParams, 
     successData?.push(...moveTransactionSuccessData);
     failureData?.push(...moveTransactionFailureData);
 
-    const parameters: AddTrackedExpenseToPolicyParams = {
+    const parameters: CategorizeTrackedExpenseApiParams = {
         ...{
             ...reportInformation,
             linkedTrackedExpenseReportAction: undefined,
@@ -2200,54 +2184,19 @@ function moveTrackedExpenseToPolicy(trackedExpenseParams: TrackedExpenseParams, 
         engagementChoice: createdWorkspaceParams?.engagementChoice,
         guidedSetupData: createdWorkspaceParams?.guidedSetupData,
         description: transactionParams.comment,
+        customUnitID: createdWorkspaceParams?.customUnitID,
+        customUnitRateID: createdWorkspaceParams?.customUnitRateID ?? transactionParams.customUnitRateID,
         attendees: transactionParams.attendees ? JSON.stringify(transactionParams.attendees) : undefined,
-        ...extraParams,
     };
 
-    API.write(command, parameters, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.CATEGORIZE_TRACKED_EXPENSE, parameters, {optimisticData, successData, failureData});
 
-    // If a draft policy was used, the command will create a real one, so track that conversion here.
+    // If a draft policy was used, then the CategorizeTrackedExpense command will create a real one
+    // so let's track that conversion here
     if (isDraftPolicy) {
         const workspaceCreatedEvent = getWorkspaceCreatedAnalyticsEvent(createdWorkspaceParams?.engagementChoice, createdWorkspaceParams?.companySize, currentUser.email ?? '');
         GoogleTagManager.publishEvent(workspaceCreatedEvent, currentUserAccountID, currentUser.email ?? '');
     }
-}
-
-function categorizeTrackedExpense(trackedExpenseParams: TrackedExpenseParams) {
-    const {transactionParams, createdWorkspaceParams} = trackedExpenseParams;
-    moveTrackedExpenseToPolicy(trackedExpenseParams, {
-        action: CONST.IOU.ACTION.CATEGORIZE,
-        command: WRITE_COMMANDS.CATEGORIZE_TRACKED_EXPENSE,
-        extraParams: {
-            customUnitID: createdWorkspaceParams?.customUnitID,
-            customUnitRateID: createdWorkspaceParams?.customUnitRateID ?? transactionParams.customUnitRateID,
-        },
-    });
-}
-
-/**
- * Submit a tracked expense ("Submit to my employer") into a workspace. Uses AddTrackedExpenseToPolicy, which is a
- * backend alias of CategorizeTrackedExpense, so it can both create a Submit (submit2026) workspace from a draft and
- * move the tracked expense into it in a single request.
- */
-function submitTrackedExpenseToPolicy(trackedExpenseParams: TrackedExpenseParams) {
-    const {transactionParams, createdWorkspaceParams, isDistanceRequest} = trackedExpenseParams;
-    moveTrackedExpenseToPolicy(trackedExpenseParams, {
-        action: CONST.IOU.ACTION.SUBMIT,
-        command: WRITE_COMMANDS.ADD_TRACKED_EXPENSE_TO_POLICY,
-        extraParams: {
-            // Forward the optimistic workspace name so the backend-created workspace matches what the user sees offline
-            // (e.g. "Test's Workspace") instead of falling back to a backend-generated default.
-            policyName: createdWorkspaceParams?.policyName,
-            // Only forward the (new) workspace's distance custom unit for actual distance expenses. For a manual/scan expense,
-            // sending them would tell the backend to treat the moved expense as a 0-mile distance request and wipe the amount.
-            customUnitID: isDistanceRequest ? createdWorkspaceParams?.customUnitID : undefined,
-            customUnitRateID: isDistanceRequest ? (createdWorkspaceParams?.customUnitRateID ?? transactionParams.customUnitRateID) : undefined,
-            // Reached only for the submit2026 draft flow (gated in useExpenseSubmission and getTrackExpenseInformation), so a
-            // workspace created here must be a Submit (submit2026) workspace.
-            type: createdWorkspaceParams ? CONST.POLICY.TYPE.SUBMIT : undefined,
-        },
-    });
 }
 
 function shareTrackedExpense(trackedExpenseParams: TrackedExpenseParams) {
@@ -2578,8 +2527,6 @@ function trackExpense(params: CreateTrackExpenseParams) {
         delegateAccountID,
         isDraftChatReport,
         currentUserLocalCurrency,
-        // Only "Submit to my employer" creates a Submit (submit2026) workspace from a draft; everything else keeps the default (team) type.
-        policyType: action === CONST.IOU.ACTION.SUBMIT && policy?.type === CONST.POLICY.TYPE.SUBMIT ? CONST.POLICY.TYPE.SUBMIT : undefined,
     }) ?? {};
     const activeReportID = isMoneyRequestReport ? report?.reportID : chatReport?.reportID;
     const onyxData: TrackedExpenseParams['onyxData'] = trackExpenseInformationOnyxData;
@@ -2727,60 +2674,6 @@ function trackExpense(params: CreateTrackExpenseParams) {
                 personalDetailsList,
             };
             shareTrackedExpense(trackedExpenseParams);
-            break;
-        }
-        case CONST.IOU.ACTION.SUBMIT: {
-            if (!linkedTrackedExpenseReportAction || !linkedTrackedExpenseReportID) {
-                return;
-            }
-            const transactionParams: TrackedExpenseTransactionParams = {
-                transactionID: transaction?.transactionID,
-                amount,
-                currency,
-                comment,
-                distance,
-                merchant,
-                created,
-                taxCode,
-                taxAmount,
-                category,
-                tag,
-                billable,
-                reimbursable,
-                receipt: isFileUploadable(trackedReceipt) ? trackedReceipt : undefined,
-                waypoints: sanitizedWaypoints,
-                customUnitRateID: mileageRate,
-                attendees,
-            };
-            const policyParams: TrackedExpensePolicyParams = {
-                policyID: chatReport?.policyID,
-                policy,
-                isDraftPolicy,
-            };
-            const reportInformation: TrackedExpenseReportInformation = {
-                moneyRequestPreviewReportActionID: iouAction?.reportActionID,
-                moneyRequestReportID: iouReport?.reportID,
-                moneyRequestCreatedReportActionID: createdIOUReportActionID,
-                actionableWhisperReportActionID,
-                linkedTrackedExpenseReportAction,
-                linkedTrackedExpenseReportID,
-                transactionThreadReportID,
-                reportPreviewReportActionID: reportPreviewAction?.reportActionID,
-                chatReportID: chatReport?.reportID,
-                isLinkedTrackedExpenseReportArchived: transactionData.isLinkedTrackedExpenseReportArchived,
-            };
-            const trackedExpenseParams: TrackedExpenseParams = {
-                onyxData,
-                reportInformation,
-                transactionParams,
-                policyParams,
-                createdWorkspaceParams,
-                isDistanceRequest,
-                currentUser: {accountID: currentUserAccountIDParam, email: currentUserEmailParam},
-                reportActionsList,
-            };
-
-            submitTrackedExpenseToPolicy(trackedExpenseParams);
             break;
         }
         default: {

--- a/src/libs/actions/IOU/types/TrackedExpenseParams.ts
+++ b/src/libs/actions/IOU/types/TrackedExpenseParams.ts
@@ -68,8 +68,6 @@ type TrackedExpenseParams = {
     policyParams: TrackedExpensePolicyParams;
     createdWorkspaceParams?: CreateWorkspaceParams;
     accountantParams?: TrackExpenseAccountantParams;
-    /** Whether the tracked expense is a distance request. Used to decide if a created workspace's distance custom unit should be applied to the transaction. */
-    isDistanceRequest?: boolean;
     currentUser: CurrentUser;
     reportActionsList: OnyxCollection<OnyxTypes.ReportActions>;
     // Personal details list is optional here because we only use/pass it for SHARE case

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -136,7 +136,6 @@ import type {
     Attributes,
     AutoReportingOffset,
     CompanyAddress,
-    CreatableWorkspaceType,
     CustomUnit,
     NetSuiteCustomList,
     NetSuiteCustomSegment,
@@ -264,7 +263,7 @@ type BuildPolicyDataOptions = {
     onboardingPurposeSelected?: OnboardingPurpose;
     shouldAddGuideWelcomeMessage?: boolean;
     shouldCreateControlPolicy?: boolean;
-    type?: CreatableWorkspaceType;
+    type?: typeof CONST.POLICY.TYPE.TEAM | typeof CONST.POLICY.TYPE.CORPORATE | typeof CONST.POLICY.TYPE.SUBMIT;
     // TODO: Make it required once we complete refactoring the buildPolicyData function to use isSelfTourViewed. Refactor issue: https://github.com/Expensify/App/issues/66424
     isSelfTourViewed?: boolean;
     hasActiveAdminPolicies: boolean | undefined;
@@ -2443,7 +2442,7 @@ type CreateDraftInitialWorkspaceParams = {
     policyID?: string;
     makeMeAdmin?: boolean;
     file?: File;
-    type?: CreatableWorkspaceType;
+    type?: typeof CONST.POLICY.TYPE.TEAM | typeof CONST.POLICY.TYPE.CORPORATE | typeof CONST.POLICY.TYPE.SUBMIT;
     isAnnualSubscription?: boolean;
 };
 
@@ -3187,7 +3186,6 @@ type CreateDraftWorkspaceParams = {
     makeMeAdmin?: boolean;
     policyID?: string;
     file?: File;
-    type?: CreatableWorkspaceType;
 };
 
 function createDraftWorkspace({
@@ -3200,11 +3198,8 @@ function createDraftWorkspace({
     makeMeAdmin = false,
     policyID = generatePolicyID(),
     file,
-    type = CONST.POLICY.TYPE.TEAM,
 }: CreateDraftWorkspaceParams): CreateWorkspaceParams {
     const {customUnits, customUnitID, customUnitRateID, outputCurrency} = buildOptimisticDistanceRateCustomUnits(currency);
-    // Submit (submit2026) workspaces ship with Categories, Tags, Workflows (manual submission), and Distance enabled by default.
-    const isSubmitWorkspace = type === CONST.POLICY.TYPE.SUBMIT;
 
     const {expenseChatData, adminsChatReportID, adminsCreatedReportActionID, expenseChatReportID, expenseCreatedReportActionID} = ReportUtils.buildOptimisticWorkspaceChats(
         policyID,
@@ -3216,20 +3211,13 @@ function createDraftWorkspace({
     const shouldEnableWorkflowsByDefault =
         !introSelected?.choice || introSelected.choice === CONST.ONBOARDING_CHOICES.MANAGE_TEAM || introSelected.choice === CONST.ONBOARDING_CHOICES.LOOKING_AROUND;
 
-    let draftApprovalMode: ValueOf<typeof CONST.POLICY.APPROVAL_MODE> = CONST.POLICY.APPROVAL_MODE.OPTIONAL;
-    if (isSubmitWorkspace) {
-        draftApprovalMode = CONST.POLICY.APPROVAL_MODE.ADVANCED;
-    } else if (shouldEnableWorkflowsByDefault) {
-        draftApprovalMode = CONST.POLICY.APPROVAL_MODE.BASIC;
-    }
-
     const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.POLICY_DRAFTS | typeof ONYXKEYS.COLLECTION.REPORT_DRAFT | typeof ONYXKEYS.COLLECTION.POLICY_CATEGORIES_DRAFT>> = [
         {
             onyxMethod: Onyx.METHOD.SET,
             key: `${ONYXKEYS.COLLECTION.POLICY_DRAFTS}${policyID}`,
             value: {
                 id: policyID,
-                type,
+                type: CONST.POLICY.TYPE.TEAM,
                 name: workspaceName,
                 role: CONST.POLICY.ROLE.ADMIN,
                 owner: currentUserEmail,
@@ -3239,18 +3227,17 @@ function createDraftWorkspace({
                 pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
                 autoReporting: true,
                 approver: currentUserEmail,
-                autoReportingFrequency:
-                    shouldEnableWorkflowsByDefault || isSubmitWorkspace ? CONST.POLICY.AUTO_REPORTING_FREQUENCIES.IMMEDIATE : CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT,
+                autoReportingFrequency: shouldEnableWorkflowsByDefault ? CONST.POLICY.AUTO_REPORTING_FREQUENCIES.IMMEDIATE : CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT,
                 harvesting: {
-                    enabled: !shouldEnableWorkflowsByDefault && !isSubmitWorkspace,
+                    enabled: !shouldEnableWorkflowsByDefault,
                 },
-                approvalMode: draftApprovalMode,
+                approvalMode: shouldEnableWorkflowsByDefault ? CONST.POLICY.APPROVAL_MODE.BASIC : CONST.POLICY.APPROVAL_MODE.OPTIONAL,
                 customUnits,
                 areCategoriesEnabled: true,
-                areWorkflowsEnabled: shouldEnableWorkflowsByDefault || isSubmitWorkspace,
+                areWorkflowsEnabled: shouldEnableWorkflowsByDefault,
                 areCompanyCardsEnabled: true,
-                areTagsEnabled: isSubmitWorkspace,
-                areDistanceRatesEnabled: isSubmitWorkspace,
+                areTagsEnabled: false,
+                areDistanceRatesEnabled: false,
                 areReportFieldsEnabled: false,
                 areConnectionsEnabled: false,
                 areExpensifyCardsEnabled: false,
@@ -3304,7 +3291,7 @@ function createDraftWorkspace({
         ownerEmail: policyOwnerEmail,
         makeMeAdmin,
         policyName: workspaceName,
-        type,
+        type: CONST.POLICY.TYPE.TEAM,
         adminsCreatedReportActionID,
         expenseCreatedReportActionID,
         customUnitID,

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -97,7 +97,6 @@ function ReportFetchHandler() {
     const didSubscribeToReportLeavingEvents = useRef(false);
 
     const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [reportDraftOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_DRAFT}${reportIDFromRoute}`);
     const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportOnyx?.chatReportID}`);
     const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
     const [reportLoadingState = defaultReportLoadingState] = useOnyx(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${reportIDFromRoute}`);
@@ -148,14 +147,6 @@ function ReportFetchHandler() {
 
     const fetchReport = useEffectEvent(() => {
         if (reportMetadata.isOptimisticReport && report?.type === CONST.REPORT.TYPE.CHAT && !isPolicyExpenseChat(report)) {
-            return;
-        }
-
-        // A draft-only report (created optimistically via createDraftWorkspace, e.g. the "Submit to my employer" Submit
-        // workspace when the user has none) exists only in REPORT_DRAFT and has no server counterpart. openReport would
-        // 403 "Report not found" and merge an errorFields.notFound stub into REPORT, shadowing the draft. It's persisted
-        // later by the confirmation's AddTrackedExpenseToPolicy request, so never openReport it here.
-        if (!reportOnyx?.reportID && !!reportDraftOnyx?.reportID) {
             return;
         }
 

--- a/src/pages/inbox/report/actionContents/ChatActionableButtons.tsx
+++ b/src/pages/inbox/report/actionContents/ChatActionableButtons.tsx
@@ -5,14 +5,10 @@ import FollowupListSkeleton from '@components/ReportActionItem/FollowupListSkele
 import useActivePolicy from '@hooks/useActivePolicy';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDelegateAccountID from '@hooks/useDelegateAccountID';
-import useLastWorkspaceNumber from '@hooks/useLastWorkspaceNumber';
-import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import usePermissions from '@hooks/usePermissions';
 import usePreferredPolicy from '@hooks/usePreferredPolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {generateDefaultWorkspaceName} from '@libs/actions/Policy/Policy';
 import {resolveSuggestedFollowup} from '@libs/actions/Report/SuggestedFollowup';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
@@ -40,8 +36,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type * as OnyxTypes from '@src/types/onyx';
 
-import type {ValueOf} from 'type-fest';
-
 import {createFilteredPoliciesInfoSelector} from '@selectors/Policy';
 import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
 import React from 'react';
@@ -55,16 +49,12 @@ type ChatActionableButtonsProps = {
 
 function ChatActionableButtons({action, originalReportID, reportID, hasPendingFollowupListSkeleton}: ChatActionableButtonsProps) {
     const styles = useThemeStyles();
-    const {translate} = useLocalize();
-    const lastWorkspaceNumber = useLastWorkspaceNumber();
     const actionOwnerReportID = originalReportID ?? reportID;
     const [originalReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(originalReportID)}`);
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
     const actionOwnerReport = originalReport ?? report;
     const personalDetail = useCurrentUserPersonalDetails();
     const {isRestrictedToPreferredPolicy, preferredPolicyID} = usePreferredPolicy();
-    const {isBetaEnabled} = usePermissions();
-    const canUseSubmit2026 = isBetaEnabled(CONST.BETAS.SUBMIT_2026);
     const activePolicy = useActivePolicy();
 
     const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {
@@ -216,34 +206,12 @@ function ChatActionableButtons({action, originalReportID, reportID, hasPendingFo
                     });
                 },
             });
-            // On the Submit (submit2026) plan, "Submit it to someone" splits into two destinations:
-            // submit to an individual ("a friend") or route to a submit-enabled workspace ("my employer").
-            const prepareSubmitDestinationButton = (destination: ValueOf<typeof CONST.IOU.SUBMIT_DESTINATION>, textKey: 'submitToFriend' | 'submitToEmployer'): ActionableItem => ({
-                text: `actionableMentionTrackExpense.${textKey}`,
-                key: `${action.reportActionID}-actionableMentionTrackExpense-${textKey}`,
-                onPress: () => {
-                    createDraftTransactionAndNavigateToParticipantSelector({
-                        ...baseDraftTransactionParams,
-                        isRestrictedToPreferredPolicy,
-                        preferredPolicyID,
-                        actionName: CONST.IOU.ACTION.SUBMIT,
-                        submitDestination: destination,
-                        defaultWorkspaceName: generateDefaultWorkspaceName(personalDetail.email ?? '', lastWorkspaceNumber, translate, personalDetail.displayName),
-                    });
-                },
-            });
-            const submitButtons: ActionableItem[] = canUseSubmit2026
-                ? [
-                      prepareSubmitDestinationButton(CONST.IOU.SUBMIT_DESTINATION.FRIEND, 'submitToFriend'),
-                      prepareSubmitDestinationButton(CONST.IOU.SUBMIT_DESTINATION.EMPLOYER, 'submitToEmployer'),
-                  ]
-                : [
-                      prepareTrackExpenseButton('submit', {
-                          isRestrictedToPreferredPolicy,
-                          preferredPolicyID,
-                      }),
-                  ];
-            const options = [...submitButtons];
+            const options = [
+                prepareTrackExpenseButton('submit', {
+                    isRestrictedToPreferredPolicy,
+                    preferredPolicyID,
+                }),
+            ];
 
             if (Permissions.canUseTrackFlows()) {
                 options.push(prepareTrackExpenseButton('categorize'), prepareTrackExpenseButton('share'));

--- a/src/pages/iou/request/ParticipantSearchResults.tsx
+++ b/src/pages/iou/request/ParticipantSearchResults.tsx
@@ -307,17 +307,15 @@ function ParticipantSearchResults({
         );
         sections.push({...formatResults.section, sectionIndex: 0});
 
-        const workspaceChats = (availableOptions.workspaceChats ?? []).filter((option) => !selectedParticipantKeys.has(getParticipantOptionKey(option)));
-        if (workspaceChats.length > 0) {
+        if ((availableOptions.workspaceChats ?? []).length > 0) {
             sections.push({
                 title: translate('workspace.common.workspace'),
-                data: workspaceChats,
+                data: (availableOptions.workspaceChats ?? []).filter((option) => !selectedParticipantKeys.has(getParticipantOptionKey(option))),
                 sectionIndex: 1,
             });
         }
 
-        // The self-DM is never a valid destination for the workspaces-only picker (e.g. "Submit to my employer"), so keep it out.
-        if (!isWorkspacesOnly && availableOptions.selfDMChat) {
+        if (availableOptions.selfDMChat) {
             sections.push({
                 title: translate('workspace.invoices.paymentMethods.personal'),
                 data: availableOptions.selfDMChat ? [availableOptions.selfDMChat] : [],

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -189,10 +189,6 @@ function IOURequestStepConfirmation({
         reportPolicyID: realPolicyID ?? draftPolicyID,
         action,
         iouType,
-        // Forward the draft policy so a freshly created draft workspace (e.g. "Submit to my employer" with no existing
-        // workspace) resolves here. Without it `policy` is undefined for drafts, `isDraftPolicy` is false, and the submit
-        // is routed to ConvertTrackedExpenseToRequest (which needs a real payer) instead of AddTrackedExpenseToPolicy.
-        policyDraft,
         isPerDiemRequest,
     });
     const policyID = policy?.id;

--- a/src/pages/iou/request/step/IOURequestStepParticipants.tsx
+++ b/src/pages/iou/request/step/IOURequestStepParticipants.tsx
@@ -34,12 +34,10 @@ type IOURequestStepParticipantsProps = WithWritableReportOrNotFoundProps<typeof 
 
 function IOURequestStepParticipants({
     route: {
-        params: {iouType, reportID, transactionID: initialTransactionID, action, backTo, isWorkspacesOnly: isWorkspacesOnlyParam},
+        params: {iouType, reportID, transactionID: initialTransactionID, action, backTo},
     },
     transaction: initialTransaction,
 }: IOURequestStepParticipantsProps) {
-    // "Submit to my employer" with multiple submit-enabled workspaces passes isWorkspacesOnly=true to limit the picker to workspaces.
-    const isWorkspacesOnlyFromRoute = isWorkspacesOnlyParam === 'true';
     const participants = initialTransaction?.participants;
     const {translate} = useLocalize();
     const styles = useThemeStyles();
@@ -127,8 +125,7 @@ function IOURequestStepParticipants({
     };
 
     // In new flow - the amount step is skipped, so we need to include the recents for all the cases.
-    // Submit-only implies workspaces-only (we still hide individuals/recents in the Submit-to-employer picker).
-    const isWorkspacesOnly = isWorkspacesOnlyFromRoute || (isNewManualExpenseFlowEnabled ? false : getIsWorkspacesOnlyForTransaction(initialTransaction, iouRequestType));
+    const isWorkspacesOnly = isNewManualExpenseFlowEnabled ? false : getIsWorkspacesOnlyForTransaction(initialTransaction, iouRequestType);
     const selectedParticipant = isSplitRequest ? undefined : participants?.find((participant) => participant.selected && !participant.isSender);
     // Participants with a reportID are found in the list and highlighted via initiallySelectedReportID.
     // Those without one (e.g. users to invite who don't have an account yet) must be passed explicitly

--- a/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
+++ b/src/pages/iou/request/step/confirmation/useExpenseSubmission.ts
@@ -639,8 +639,8 @@ function useExpenseSubmission(params: UseExpenseSubmissionParams) {
         if (!participant) {
             return;
         }
-        // trackExpense bails per-item on malformed CATEGORIZE/SHARE/SUBMIT too late for UI cleanup — reject the batch upfront.
-        const requiresLinkedTracked = action === CONST.IOU.ACTION.CATEGORIZE || action === CONST.IOU.ACTION.SHARE || action === CONST.IOU.ACTION.SUBMIT;
+        // trackExpense bails per-item on malformed CATEGORIZE/SHARE too late for UI cleanup — reject the batch upfront.
+        const requiresLinkedTracked = action === CONST.IOU.ACTION.CATEGORIZE || action === CONST.IOU.ACTION.SHARE;
         if (requiresLinkedTracked && !transactions.every((item) => item.linkedTrackedExpenseReportAction && item.linkedTrackedExpenseReportID)) {
             return;
         }
@@ -995,16 +995,10 @@ function useExpenseSubmission(params: UseExpenseSubmissionParams) {
             return;
         }
 
-        // "Submit to my employer" with no existing workspace creates a draft Submit (submit2026) workspace. Route it
-        // through trackExpense (AddTrackedExpenseToPolicy) so the workspace is created and the expense submitted
-        // atomically, instead of requestMoney/ConvertTrackedExpenseToRequest which can't create a workspace.
-        // Scoped to submit2026 drafts only so other (team/corporate) draft flows keep their existing behavior.
-        const isSubmittingExpenseToDraftWorkspace = action === CONST.IOU.ACTION.SUBMIT && isDraftPolicy && policy?.type === CONST.POLICY.TYPE.SUBMIT;
-
-        if (!isPerDiemRequest && (isTrackExpense || isCategorizingTrackExpense || isSharingTrackExpense || isSelfDMDestination || isSubmittingExpenseToDraftWorkspace)) {
+        if (!isPerDiemRequest && (isTrackExpense || isCategorizingTrackExpense || isSharingTrackExpense || isSelfDMDestination)) {
             if (Object.values(receiptFiles).filter((receipt) => !!receipt).length && transaction) {
                 // If the transaction amount is zero, then the money is being requested through the "Scan" flow and the GPS coordinates need to be included.
-                if (transaction.amount === 0 && !isSharingTrackExpense && !isCategorizingTrackExpense && !isSubmittingExpenseToDraftWorkspace && locationPermissionGranted) {
+                if (transaction.amount === 0 && !isSharingTrackExpense && !isCategorizingTrackExpense && locationPermissionGranted) {
                     if (userLocation) {
                         trackExpense(shouldHandleNavigation, {
                             gpsPoint: {lat: userLocation.latitude, long: userLocation.longitude},

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -2803,13 +2803,9 @@ type PolicyConnectionSyncProgress = {
     result?: HrSyncResult;
 };
 
-/** Workspace types a user can create directly (Team/Corporate/Submit), e.g. when creating a draft workspace on the fly. */
-type CreatableWorkspaceType = typeof CONST.POLICY.TYPE.TEAM | typeof CONST.POLICY.TYPE.CORPORATE | typeof CONST.POLICY.TYPE.SUBMIT;
-
 export default Policy;
 
 export type {
-    CreatableWorkspaceType,
     AutoReportingOffset,
     PolicyReportField,
     PolicyReportFieldType,


### PR DESCRIPTION
### Explanation of Change

Reverts [#94319](https://github.com/Expensify/App/pull/94319) ("[Submit] Update 'Submit to someone' to two options to allow for Submit workspace creation").

That PR changed the "Submit to someone" flow to offer two options and route the "no existing workspace" case through `trackExpense` so a draft Submit (submit2026) workspace gets created and the expense submitted together. We're backing it out.

What this revert does:
- Restores the trackExpense branch condition in `useExpenseSubmission` to its pre-PR form, dropping `isSubmittingExpenseToDraftWorkspace`.
- Removes the `SUBMIT_DESTINATION` CONST and the related copy/routes/types the PR added.
- Keeps `isSelfDMDestination` in that same condition (added by a later PR, not this one).
- Keeps `CONST.POLICY.TYPE.SUBMIT` (submit2026), which predates this PR and is still used elsewhere.

Note: 818 commits landed on `main` after the original merge, so this is a manual revert. The only real conflict was in `useExpenseSubmission.ts` (resolved as above), the rest applied cleanly.

### Fixed Issues
$ https://github.com/Expensify/App/issues/96117

PROPOSAL:

### Tests

1. Open the FAB and start an expense.
2. Choose "Submit" and pick a recipient who has no existing workspace with you.
3. Confirm the flow behaves as it did before [#94319](https://github.com/Expensify/App/pull/94319): no draft Submit workspace is auto-created from this path.
4. Submit an expense from Self DM and confirm it still works (trackExpense path intact).
- [ ] Verify that no errors appear in the JS console

### Offline tests

Same as tests.

### QA Steps

1. Open the FAB and start an expense.
2. Choose "Submit" and pick a recipient who has no existing workspace with you.
3. Confirm the pre-[#94319](https://github.com/Expensify/App/pull/94319) behavior is back.
4. Submit an expense from Self DM and confirm it still works.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English.
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
