### PR TITLE
Keep the background expense receipt visible when a wide RHP opens

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -145,6 +145,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 
+import {useRoute} from '@react-navigation/native';
 import {isTrackIntentUserSelector} from '@selectors/Onboarding';
 import {policyTypeSelector} from '@selectors/Policy';
 import {Str} from 'expensify-common';
@@ -1139,6 +1140,11 @@ function MoneyRequestView({
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth} = useResponsiveLayout();
     const {wideRHPRouteKeys} = useWideRHPState();
+    const route = useRoute();
+    // The receipt is hidden only for the MoneyRequestView rendered inside a wide RHP, where the wide RHP's left
+    // receipt panel already shows it. Instances mounted on other screens (e.g. the central report pane behind
+    // the RHP) must keep their inline receipt, so the check is scoped to this view's own route key.
+    const isInWideRHP = wideRHPRouteKeys.includes(route.key);
 
     // If the view is readonly, we don't need the transactionThread dependency
     if ((!readonly && !transactionThreadReport?.reportID) || !transaction?.transactionID) {
@@ -1149,7 +1155,7 @@ function MoneyRequestView({
         <View style={[styles.moneyRequestView]}>
             {shouldShowAnimatedBackground && <AnimatedEmptyStateBackground />}
             <>
-                {(wideRHPRouteKeys.length === 0 || isSmallScreenWidth || isFromReviewDuplicates || isFromMergeTransaction) && (
+                {(!isInWideRHP || isSmallScreenWidth || isFromReviewDuplicates || isFromMergeTransaction) && (
                     <MoneyRequestReceiptView
                         report={transactionThreadReport ?? parentReport}
                         readonly={readonly}

--- a/tests/ui/MoneyRequestViewReceiptTest.tsx
+++ b/tests/ui/MoneyRequestViewReceiptTest.tsx
@@ -1,0 +1,251 @@
+import {act, render, screen, waitFor} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import MoneyRequestView from '@components/ReportActionItem/MoneyRequestView';
+import {useWideRHPState} from '@components/WideRHPContextProvider';
+import {defaultWideRHPStateContextValue} from '@components/WideRHPContextProvider/default';
+
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Policy} from '@src/types/onyx';
+
+import type * as NativeNavigation from '@react-navigation/native';
+
+import {useRoute} from '@react-navigation/native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import createRandomPolicy from '../utils/collections/policies';
+import * as LHNTestUtils from '../utils/LHNTestUtils';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: jest.fn((key: string) => key),
+        numberFormat: jest.fn((num: number) => num.toString()),
+        toLocaleDigit: jest.fn((digit: string) => digit),
+    })),
+);
+
+jest.mock('@react-navigation/native', () => ({
+    ...((): typeof NativeNavigation => {
+        return jest.requireActual('@react-navigation/native');
+    })(),
+    useNavigation: jest.fn(() => ({
+        navigate: jest.fn(),
+        addListener: jest.fn(() => jest.fn()),
+    })),
+    useIsFocused: jest.fn(() => true),
+    useRoute: jest.fn(() => ({key: 'central-report', name: '', params: {reportID: '1'}})),
+}));
+
+// `useResponsiveLayout` is mocked to a wide layout so `isSmallScreenWidth` is false; on a narrow layout the
+// receipt is always shown, which would mask the wide-RHP scoping the tests below verify.
+jest.mock('@hooks/useResponsiveLayout', () => jest.fn());
+
+// The receipt visibility is driven by `wideRHPRouteKeys`; control it explicitly per test.
+jest.mock('@components/WideRHPContextProvider', () => ({
+    ...jest.requireActual<Record<string, unknown>>('@components/WideRHPContextProvider'),
+    useWideRHPState: jest.fn(),
+}));
+
+// Render the receipt as a lightweight probe so its presence/absence is assertable.
+jest.mock('@components/ReportActionItem/MoneyRequestReceiptView', () => {
+    const RN = jest.requireActual<Record<string, React.ComponentType<{testID?: string}>>>('react-native');
+    return () => <RN.View testID="money-request-receipt-view" />;
+});
+
+jest.mock('@pages/inbox/report/AnimatedEmptyStateBackground', () => {
+    const RN = jest.requireActual<Record<string, React.ComponentType<{testID?: string}>>>('react-native');
+    return () => <RN.View testID="animated-bg" />;
+});
+
+jest.mock('@components/MenuItemWithTopDescription', () => {
+    const RN = jest.requireActual<Record<string, React.ComponentType<{testID?: string; children?: React.ReactNode}>>>('react-native');
+    return ({description}: {description?: string}) => <RN.View testID={`menu-item-${description}`} />;
+});
+
+jest.mock('@components/MenuItem', () => {
+    const RN = jest.requireActual<Record<string, React.ComponentType<{testID?: string; children?: React.ReactNode}>>>('react-native');
+    return ({title}: {title?: string}) => <RN.Text testID={`menu-item-simple-${title}`}>{title}</RN.Text>;
+});
+
+jest.mock('@hooks/useCardFeedsForDisplay', () => jest.fn(() => ({defaultCardFeed: null, cardFeedsByPolicy: {}})));
+
+jest.mock('@hooks/useCurrencyList', () => ({
+    useCurrencyListActions: jest.fn(() => ({
+        convertToDisplayString: jest.fn((amountInCents = 0, currency = '') => `${currency}${amountInCents}`),
+        getCurrencySymbol: jest.fn((currency = '') => `${currency}`),
+        getCurrencyDecimals: jest.fn(() => 2),
+        convertToDisplayStringWithoutCurrency: jest.fn((amountInCents = 0) => `${amountInCents}`),
+    })),
+    useCurrencyListState: jest.fn(() => ({})),
+}));
+
+TestHelper.setupGlobalFetchMock();
+
+const mockedUseResponsiveLayout = jest.mocked(useResponsiveLayout);
+const mockedUseWideRHPState = jest.mocked(useWideRHPState);
+const mockedUseRoute = jest.mocked(useRoute);
+
+const WIDE_LAYOUT = {
+    isLargeScreenWidth: true,
+    shouldUseNarrowLayout: false,
+    isSmallScreenWidth: false,
+    isMediumScreenWidth: false,
+    isExtraSmallScreenWidth: false,
+    isExtraSmallScreenHeight: false,
+    isExtraLargeScreenWidth: true,
+    isSmallScreen: false,
+    isInNarrowPaneModal: false,
+    onboardingIsMediumOrLargerScreenWidth: true,
+    isInLandscapeMode: false,
+} as ReturnType<typeof useResponsiveLayout>;
+
+const WIDE_RHP_ROUTE_KEY = 'wide-rhp-report';
+
+const currentUserAccountID = 10;
+const currentUserEmail = 'test@test.com';
+const policyID = 'policy_mrv_receipt_test';
+const expenseReportID = 'expense_mrv_receipt_123';
+const parentReportActionID = 'parent_action_mrv_receipt';
+const transactionID = 'txn_mrv_receipt_test';
+
+const threadReport = {
+    ...LHNTestUtils.getFakeReport(),
+    parentReportID: expenseReportID,
+    parentReportActionID,
+};
+
+const expensePolicy: Policy = {
+    ...createRandomPolicy(0, CONST.POLICY.TYPE.TEAM, 'Test Policy'),
+    id: policyID,
+    role: CONST.POLICY.ROLE.ADMIN,
+    owner: currentUserEmail,
+    outputCurrency: CONST.CURRENCY.USD,
+    isPolicyExpenseChatEnabled: true,
+};
+
+const renderMoneyRequestView = () =>
+    render(
+        <ComposeProviders components={[OnyxListItemProvider]}>
+            <MoneyRequestView
+                transactionThreadReport={threadReport}
+                parentReportID={expenseReportID}
+                expensePolicy={expensePolicy}
+                shouldShowAnimatedBackground={false}
+            />
+        </ComposeProviders>,
+    );
+
+const setupTestData = async () => {
+    const iouReportAction = {
+        ...LHNTestUtils.getFakeReportAction(),
+        reportActionID: parentReportActionID,
+        reportID: expenseReportID,
+        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+        actorAccountID: currentUserAccountID,
+        originalMessage: {
+            type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+            IOUTransactionID: transactionID,
+            amount: 5000,
+            currency: CONST.CURRENCY.USD,
+        },
+    };
+
+    const transaction = {
+        transactionID,
+        reportID: expenseReportID,
+        amount: 5000,
+        currency: CONST.CURRENCY.USD,
+        created: '2025-06-01',
+        merchant: 'Coffee Shop',
+        comment: {},
+    };
+
+    await act(async () => {
+        await Onyx.merge(ONYXKEYS.SESSION, {accountID: currentUserAccountID, email: currentUserEmail});
+        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+            [currentUserAccountID]: {accountID: currentUserAccountID, login: currentUserEmail, displayName: 'Test User'},
+        });
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {
+            id: policyID,
+            type: CONST.POLICY.TYPE.TEAM,
+            role: CONST.POLICY.ROLE.ADMIN,
+            name: 'Test Policy',
+            owner: currentUserEmail,
+            outputCurrency: CONST.CURRENCY.USD,
+            isPolicyExpenseChatEnabled: true,
+        });
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${expenseReportID}`, {
+            reportID: expenseReportID,
+            type: CONST.REPORT.TYPE.EXPENSE,
+            policyID,
+            ownerAccountID: currentUserAccountID,
+            managerID: currentUserAccountID,
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+        });
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${expenseReportID}`, {
+            [parentReportActionID]: iouReportAction,
+        });
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, transaction);
+    });
+    await waitForBatchedUpdatesWithAct();
+};
+
+describe('MoneyRequestView receipt visibility with a wide RHP open', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+            evictableKeys: [ONYXKEYS.COLLECTION.REPORT_ACTIONS],
+        });
+    });
+
+    beforeEach(() => {
+        mockedUseResponsiveLayout.mockReturnValue(WIDE_LAYOUT);
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await Onyx.clear();
+        });
+        jest.clearAllMocks();
+    });
+
+    it('shows the inline receipt on a background report screen while another screen owns the wide RHP', async () => {
+        // The bug: a wide RHP registered by another screen hid the receipt on this background view. `route.key` is not
+        // in `wideRHPRouteKeys`, so the receipt must stay visible (this assertion fails on the pre-fix global check).
+        mockedUseWideRHPState.mockReturnValue({...defaultWideRHPStateContextValue, wideRHPRouteKeys: [WIDE_RHP_ROUTE_KEY]});
+        mockedUseRoute.mockReturnValue({key: 'central-report', name: '', params: {reportID: expenseReportID}} as ReturnType<typeof useRoute>);
+
+        await setupTestData();
+        renderMoneyRequestView();
+        await waitForBatchedUpdatesWithAct();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('money-request-receipt-view')).toBeOnTheScreen();
+        });
+    });
+
+    it('hides the inline receipt for the view that owns the wide RHP', async () => {
+        // The original intent: the MoneyRequestView inside the wide RHP hides its inline receipt because the wide RHP's
+        // left panel shows it. `route.key` matches the registered wide-RHP key.
+        mockedUseWideRHPState.mockReturnValue({...defaultWideRHPStateContextValue, wideRHPRouteKeys: [WIDE_RHP_ROUTE_KEY]});
+        mockedUseRoute.mockReturnValue({key: WIDE_RHP_ROUTE_KEY, name: '', params: {reportID: expenseReportID}} as ReturnType<typeof useRoute>);
+
+        await setupTestData();
+        renderMoneyRequestView();
+        await waitForBatchedUpdatesWithAct();
+
+        await waitFor(() => {
+            // Anchor on an always-rendered field so the absence below reflects the hidden receipt, not an unrendered view.
+            expect(screen.getByTestId('menu-item-common.merchant')).toBeOnTheScreen();
+            expect(screen.queryByTestId('money-request-receipt-view')).not.toBeOnTheScreen();
+        });
+    });
+});

--- a/tests/ui/MoneyRequestViewReceiptTest.tsx
+++ b/tests/ui/MoneyRequestViewReceiptTest.tsx
@@ -53,7 +53,7 @@ jest.mock('@components/WideRHPContextProvider', () => ({
     useWideRHPState: jest.fn(),
 }));
 
-// Render the receipt as a lightweight probe so its presence/absence is assertable.
+// Render the receipt as a lightweight probe so the test can assert its presence or absence.
 jest.mock('@components/ReportActionItem/MoneyRequestReceiptView', () => {
     const RN = jest.requireActual<Record<string, React.ComponentType<{testID?: string}>>>('react-native');
     return () => <RN.View testID="money-request-receipt-view" />;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

`MoneyRequestView` hides its inline receipt while a wide RHP is open so the receipt is not duplicated next to the wide RHP's left receipt panel. That condition checked `wideRHPRouteKeys.length === 0`, which is global: once any wide RHP registers, every mounted `MoneyRequestView` hides its receipt — including instances on screens behind the RHP. After #95131, report hyperlinks can open a wide RHP over a central-pane expense view, so the background expense view loses its receipt box and its content shifts up (the regression from #95131 reported in the linked issue).

This PR scopes the condition to the view's own screen: the receipt is hidden only when the view's `route.key` is registered in `wideRHPRouteKeys` (`!wideRHPRouteKeys.includes(route.key)` instead of `wideRHPRouteKeys.length === 0`). The `MoneyRequestView` inside the wide RHP keeps hiding its inline receipt (the wide RHP's left panel shows it), while instances mounted on other screens — such as the central report pane behind the RHP — keep their inline receipt. The small-screen, review-duplicates, and merge-transaction short-circuits are unchanged.

A unit test (`tests/ui/MoneyRequestViewReceiptTest.tsx`) locks the behavior: it asserts the inline receipt stays visible on a background report screen while another screen owns the wide RHP (this assertion fails against the pre-fix global check), and that the view owning the wide RHP still hides its inline receipt.

cc @blimpich

### Fixed Issues

$ https://github.com/Expensify/App/issues/96118
PROPOSAL: https://github.com/Expensify/App/issues/96118#issuecomment-4973168500

### Tests

1. Verify that no errors appear in the JS console.
2. On a wide layout, go to a workspace chat and create a manual expense.
3. Open the expense and click Report > Remove from report.
4. Go to the self DM and open the (now unreported) expense so its details page shows in the central pane with the receipt box at the top.
5. Click the report hyperlink in the "moved this expense from …" system message. The linked report opens in the wide expense-report RHP.
6. Verify the expense details page in the background keeps its receipt box and does not shift up while the RHP is open, and still has it after closing the RHP.
7. From the Search tab, open a single-transaction expense report row (wide RHP) and click the expense to open the transaction thread in the RHP. Verify the receipt appears only once — in the RHP's left receipt panel — and the thread body does not show a duplicate inline receipt box, including during the drill-in transition. Then press the RHP back button and verify the revealed report view does not flash a duplicate inline receipt next to its left receipt panel.
8. From Search, open a multi-transaction report (super-wide RHP, table view) and drill into one transaction (opens a wide thread stacked on top). Verify the super-wide report table behind is unaffected — no missing/duplicated receipt and no upward content shift — and returns to normal on back.
9. Open the Review duplicates confirmation page and the Merge expenses confirmation page for a transaction with a receipt. Verify the receipt still renders on each (these paths force-show it), with no wide-RHP interaction removing it.
10. On a narrow layout, open an expense's details page and verify the inline receipt box shows as before.

- [x] Verify that no errors appear in the JS console

### Offline tests

This is a render-only condition fix in `MoneyRequestView`; it does not alter optimistic data, queued requests, or API behavior. Offline check: with the network off, create/scan an expense so its transaction carries a pending receipt, then open a wide RHP over an unrelated report showing that pending receipt on a background screen. Verify the pending receipt stays visible on the background view with the correct grayed offline styling, and going back online settles without the receipt flashing or disappearing.

### QA Steps

1. Verify that no errors appear in the JS console.
2. On a wide layout: workspace chat → create an expense → open it → Report > Remove from report → go to self DM → open the expense → click the report hyperlink in the "moved this expense from …" message.
3. Verify the expense details page in the background keeps its receipt box and does not move up when the report RHP opens (regression check for this issue's repro).
4. From Search, open an expense report and click into one of its expenses. Verify the receipt shows once in the RHP's left panel with no duplicate inline receipt in the thread view.
5. From Search, open a multi-transaction report (super-wide RHP) and drill into a transaction; verify the super-wide report table behind is unaffected (no missing/duplicate receipt, no content shift).
6. Open the Review duplicates and Merge expenses confirmation pages for a transaction with a receipt and verify the receipt still renders on each.
7. On a narrow layout, open an expense's details page and verify the receipt box renders as before.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/30c329f5-21d0-4847-87d6-5680580df173



</details>
