### PR TITLE
Remove duplicate useOnyx call in MoneyRequestView

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -878,8 +878,6 @@ function MoneyRequestView({
         });
     };
 
-    const [reportPolicyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${getNonEmptyStringOnyxID(parentReport?.policyID)}`);
-
     const showTagDisabledAlert = (tagListIndex: number) => {
         const transactionID = transaction?.transactionID;
         if (!transactionID) {


### PR DESCRIPTION

### Explanation of Change
Removed a duplicate, unused `useOnyx(POLICY_TAGS)` call in `MoneyRequestView` that was left over and breaking the build.

### Fixed Issues
$ https://github.com/Expensify/App/pull/94621#issuecomment-4982472420

### Tests
- [x] Verify `MoneyRequestView` renders correctly (tags, categories, etc. on a money request) with no console errors or build errors.

### Offline tests
Same as Tests.

### QA Steps
N/A 