### PR TITLE
fix: restore illustrations blanked by OXC element memoization

### DIFF
--- a/src/hooks/useLazyAsset.ts
+++ b/src/hooks/useLazyAsset.ts
@@ -9,8 +9,18 @@ import type IconAsset from '@src/types/utils/IconAsset';
 import {isValidElement, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 function resolveIconComponent(asset: IconAsset | undefined, fallback: IconAsset = PlaceholderIcon): IconAsset {
-    if (asset == null || isValidElement(asset)) {
+    if (asset == null) {
         return fallback;
+    }
+
+    // OXC may memoize SVG assets into pre-rendered elements. ImageSVG needs a component
+    // reference, so unwrap the element type instead of dropping to the empty placeholder.
+    if (isValidElement(asset)) {
+        const componentType = asset.type;
+        if (typeof componentType === 'string' || componentType == null) {
+            return fallback;
+        }
+        return componentType as IconAsset;
     }
 
     return asset;

--- a/tests/unit/hooks/useLazyAsset.test.ts
+++ b/tests/unit/hooks/useLazyAsset.test.ts
@@ -335,6 +335,21 @@ describe('useMemoizedLazyAsset', () => {
         expect(result.current.asset).toBe(mockAsset);
         expect(importFn).toHaveBeenCalled();
     });
+
+    it('unwraps OXC-memoized SVG elements to their component type', async () => {
+        function MockIllustration(_props: SvgProps) {
+            return null;
+        }
+        // OXC can cache a pre-rendered element instead of the component reference.
+        const memoizedElement = React.createElement(MockIllustration);
+        const importFn = jest.fn(() => Promise.resolve({default: memoizedElement as unknown as IconAsset}));
+
+        const {result} = renderHook(() => useMemoizedLazyAsset(importFn));
+
+        await waitFor(() => {
+            expect(result.current.asset).toBe(MockIllustration);
+        });
+    });
 });
 
 describe('useMemoizedLazyExpensifyIcons', () => {


### PR DESCRIPTION
### Explanation of Change

[#96164](https://github.com/Expensify/App/pull/96164) made `resolveIconComponent` treat any `isValidElement(asset)` as invalid and fall back to empty `PlaceholderIcon`. On web, OXC can memoize illustration SVGs into pre-rendered elements, so `useMemoizedLazyAsset(() => loadIllustration(...))` callers (including the Allow location access modal) rendered a blank icon.

Instead of dropping to the placeholder, unwrap the element’s component type (`asset.type`) so `ImageSVG` still receives a component reference. That restores illustrations without reintroducing the Account-tab crashes fixed by #96164.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96207
PROPOSAL: https://github.com/Expensify/App/issues/96207#issuecomment-4984394805

### Tests

1. Open an incognito window on web (so the browser has not already granted location permission).
2. Sign in and open your self DM.
3. Click `+` → Create expense → Scan.
4. Upload a receipt with no amount (or otherwise reach Create expense such that GPS permission is required).
5. Click Create expense.
6. Verify the Allow location access modal shows the ReceiptLocationMarker illustration (not blank space).
7. Verify Account tab icons still render (no crash / blank icons regression from #96158/#96159/#96161).

- [x] Verify that no errors appear in the JS console

### Offline tests

1. With the app online, load any screen that uses a lazy illustration once so the chunk is cached.
2. Go offline.
3. Trigger the Allow location access modal again (incognito / cleared permission).
4. Verify the illustration still renders from the cached chunk (or placeholder only briefly while loading, never permanently blank once loaded).

### QA Steps

Same as Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- N/A web-only OXC regression; native uses Babel -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- N/A web-only OXC regression; native uses Babel -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here after local repro verification -->

</details>
