### PR TITLE
[Payment due @daledah] Bring back validateCode reasonCode

### DIFF
--- a/src/libs/API/parameters/RequestNewValidateCodeParams.ts
+++ b/src/libs/API/parameters/RequestNewValidateCodeParams.ts
@@ -1,6 +1,8 @@
+import type ResendValidateCodeParams from './ResendValidateCodeParams';
+
 type RequestNewValidateCodeParams = {
     email?: string;
     deviceInfo: string;
-};
+} & ResendValidateCodeParams;
 
 export default RequestNewValidateCodeParams;

--- a/src/libs/API/parameters/ResendValidateCodeParams.ts
+++ b/src/libs/API/parameters/ResendValidateCodeParams.ts
@@ -1,0 +1,21 @@
+import type {CONST} from 'expensify-common';
+import type {ValueOf} from 'type-fest';
+
+type ResendValidateCodeBaseParams = {
+    // Exclude reasons that require parameters - redefine them as separate types below to enforce their parameters are always passed
+    reasonCode: Exclude<ValueOf<typeof CONST.VALIDATE_CODE_REASONS>, typeof CONST.VALIDATE_CODE_REASONS.REVEAL_CARD_DETAILS>;
+};
+
+type ResendValidateCodeForRevealCardDetailsParams = {
+    reasonCode: typeof CONST.VALIDATE_CODE_REASONS.REVEAL_CARD_DETAILS;
+    reasonCardID: number;
+};
+
+// Will be removed eventually
+type ResendValidateCodeNotYetImplementedParams = {
+    reasonCode: null;
+};
+
+type ResendValidateCodeParams = ResendValidateCodeBaseParams | ResendValidateCodeNotYetImplementedParams | ResendValidateCodeForRevealCardDetailsParams;
+
+export default ResendValidateCodeParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -572,6 +572,7 @@ export type {default as UpdateAgentNameParams} from './UpdateAgentNameParams';
 export type {default as UpdateAgentPromptParams} from './UpdateAgentPromptParams';
 export type {default as UpdateAgentAvatarParams} from './UpdateAgentAvatarParams';
 export type {default as DeleteAgentParams} from './DeleteAgentParams';
+export type {default as ResendValidateCodeParams} from './ResendValidateCodeParams';
 export type {default as SendExportFileFromConciergeParams} from './SendExportFileFromConciergeParams';
 export type {default as ClearExportDownloadParams} from './ClearExportDownloadParams';
 export type {default as UpgradeSubmitParams} from './UpgradeSubmitParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -759,7 +759,7 @@ type WriteCommandParameters = {
     [WRITE_COMMANDS.UPDATE_PERSONAL_BANK_ACCOUNT_INFO]: Parameters.UpdatePersonalBankAccountInfoParams;
     [WRITE_COMMANDS.RESTART_BANK_ACCOUNT_SETUP]: Parameters.RestartBankAccountSetupParams;
     [WRITE_COMMANDS.INITIATE_BANK_ACCOUNT_UNLOCK]: Parameters.InitiateBankAccountUnlockParams;
-    [WRITE_COMMANDS.RESEND_VALIDATE_CODE]: null;
+    [WRITE_COMMANDS.RESEND_VALIDATE_CODE]: Parameters.ResendValidateCodeParams | null;
     [WRITE_COMMANDS.READ_NEWEST_ACTION]: Parameters.ReadNewestActionParams;
     [WRITE_COMMANDS.MARK_ALL_MESSAGES_AS_READ]: Parameters.MarkAllMessagesAsReadParams;
     [WRITE_COMMANDS.MARK_AS_UNREAD]: Parameters.MarkAsUnreadParams;

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -11,6 +11,7 @@ import type {
     ReplaceTwoFactorDeviceParams,
     RequestNewValidateCodeParams,
     RequestUnlinkValidationLinkParams,
+    ResendValidateCodeParams,
     ResetSMSDeliveryFailureStatusParams,
     SignInUserWithLinkParams,
     SignUpUserParams,
@@ -528,7 +529,7 @@ function callFunctionIfActionIsAllowed<TCallback extends ((...args: any[]) => an
 /**
  * Request a new validate / magic code for user to sign in via passwordless flow
  */
-function resendValidateCode(login = credentials.login) {
+function resendValidateCode(reasonParams: ResendValidateCodeParams, login = credentials.login) {
     const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.ACCOUNT>> = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
@@ -550,7 +551,7 @@ function resendValidateCode(login = credentials.login) {
     ];
 
     Device.getDeviceInfoWithID().then((deviceInfo) => {
-        const params: RequestNewValidateCodeParams = {email: login, deviceInfo};
+        const params: RequestNewValidateCodeParams = {email: login, deviceInfo, ...reasonParams};
         API.write(WRITE_COMMANDS.REQUEST_NEW_VALIDATE_CODE, params, {optimisticData, finallyData});
     });
 }

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -9,6 +9,7 @@ import type {
     GetStatementPDFParams,
     PusherPingParams,
     RequestContactMethodValidateCodeParams,
+    ResendValidateCodeParams,
     RevokeDeviceParams,
     SetContactMethodAsDefaultParams,
     SetNameValuePairParams,
@@ -204,8 +205,8 @@ function closeAccount(reason: string) {
 /**
  * Resend a validation link to a given login
  */
-function resendValidateCode(login: string) {
-    sessionResendValidateCode(login);
+function resendValidateCode(reasonParams: ResendValidateCodeParams, login: string) {
+    sessionResendValidateCode(reasonParams, login);
 }
 
 /**
@@ -514,7 +515,7 @@ function addNewContactMethod(contactMethod: string, validateCode = '') {
 /**
  * Requests a magic code to verify current user
  */
-function requestValidateCodeAction() {
+function requestValidateCodeAction(params?: ResendValidateCodeParams) {
     const requestedAt = Date.now();
     const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.VALIDATE_ACTION_CODE>> = [
         {
@@ -566,7 +567,7 @@ function requestValidateCodeAction() {
         },
     ];
 
-    API.write(WRITE_COMMANDS.RESEND_VALIDATE_CODE, null, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.RESEND_VALIDATE_CODE, params ?? null, {optimisticData, successData, failureData});
 }
 
 /**

--- a/src/pages/OnboardingPrivateDomain/BaseOnboardingPrivateDomain.tsx
+++ b/src/pages/OnboardingPrivateDomain/BaseOnboardingPrivateDomain.tsx
@@ -25,6 +25,7 @@ import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 
+import {CONST as COMMON_CONST} from 'expensify-common';
 import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 
@@ -65,7 +66,7 @@ function BaseOnboardingPrivateDomain({shouldUseNativeStyles, route}: BaseOnboard
         if (!email) {
             return;
         }
-        resendValidateCode(email);
+        resendValidateCode({reasonCode: COMMON_CONST.VALIDATE_CODE_REASONS.VALIDATE_ACCOUNT}, email);
     }, [email]);
 
     const handleBackButtonPress = useCallback(() => {

--- a/src/pages/OnboardingWorkEmailValidation/BaseOnboardingWorkEmailValidation.tsx
+++ b/src/pages/OnboardingWorkEmailValidation/BaseOnboardingWorkEmailValidation.tsx
@@ -75,7 +75,7 @@ function BaseOnboardingWorkEmailValidation({shouldUseNativeStyles}: BaseOnboardi
         if (!credentials?.login) {
             return;
         }
-        resendValidateCode(credentials.login);
+        resendValidateCode({reasonCode: null}, credentials.login);
     };
 
     const validateAccountAndMerge = (validateCode: string) => {

--- a/src/pages/settings/Profile/Contacts/NewContactMethodConfirmMagicCodePage.tsx
+++ b/src/pages/settings/Profile/Contacts/NewContactMethodConfirmMagicCodePage.tsx
@@ -14,6 +14,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 
+import {CONST as COMMON_CONST} from 'expensify-common';
 import React, {useEffect} from 'react';
 
 type NewContactMethodConfirmMagicCodePageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.PROFILE.NEW_CONTACT_METHOD_CONFIRM_MAGIC_CODE>;
@@ -37,7 +38,7 @@ function NewContactMethodConfirmMagicCodePage({route}: NewContactMethodConfirmMa
     return (
         <ValidateCodeActionContent
             title={translate('delegate.makeSureItIsYou')}
-            sendValidateCode={() => requestValidateCodeAction()}
+            sendValidateCode={() => requestValidateCodeAction({reasonCode: COMMON_CONST.VALIDATE_CODE_REASONS.ADD_CONTACT_METHOD})}
             descriptionPrimary={translate('contacts.enterMagicCode', contactMethod)}
             validateCodeActionErrorField="addedLogin"
             validateError={validateCodeError}

--- a/src/pages/settings/VerifyAccountPageBase.tsx
+++ b/src/pages/settings/VerifyAccountPageBase.tsx
@@ -19,6 +19,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
+import {CONST as COMMON_CONST} from 'expensify-common';
 import React, {useCallback, useEffect} from 'react';
 import {View} from 'react-native';
 
@@ -47,6 +48,8 @@ function VerifyAccountPageBase({navigateBackTo, navigateForwardTo, handleClose, 
     const isUserValidated = account?.validated ?? false;
 
     useEffect(() => () => clearUnvalidatedNewContactMethodAction(), []);
+
+    const sendValidateCode = () => requestValidateCodeAction({reasonCode: COMMON_CONST.VALIDATE_CODE_REASONS.VALIDATE_ACCOUNT});
 
     const handleSubmitForm = useCallback(
         (validateCode: string) => {
@@ -104,7 +107,7 @@ function VerifyAccountPageBase({navigateBackTo, navigateForwardTo, handleClose, 
             title={translate('contacts.validateAccount')}
             descriptionPrimary={translate('contacts.featureRequiresValidate')}
             descriptionSecondary={translate('contacts.enterMagicCode', contactMethod)}
-            sendValidateCode={requestValidateCodeAction}
+            sendValidateCode={sendValidateCode}
             validateCodeActionErrorField="validateLogin"
             validatePendingAction={loginData?.pendingFields?.validateCodeSent}
             handleSubmitForm={handleSubmitForm}

--- a/src/pages/settings/Wallet/ExpensifyCardPage/ExpensifyCardVerifyAccountPage.tsx
+++ b/src/pages/settings/Wallet/ExpensifyCardPage/ExpensifyCardVerifyAccountPage.tsx
@@ -21,6 +21,7 @@ import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Errors} from '@src/types/onyx/OnyxCommon';
 
+import {CONST as COMMON_CONST} from 'expensify-common';
 import React, {useState} from 'react';
 
 type ExpensifyCardVerifyAccountPageProps =
@@ -68,7 +69,7 @@ function ExpensifyCardVerifyAccountPage({route}: ExpensifyCardVerifyAccountPageP
         <ValidateCodeActionContent
             title={translate('cardPage.validateCardTitle')}
             descriptionPrimary={translate('cardPage.enterMagicCode', primaryLogin)}
-            sendValidateCode={() => requestValidateCodeAction()}
+            sendValidateCode={() => requestValidateCodeAction({reasonCode: COMMON_CONST.VALIDATE_CODE_REASONS.REVEAL_CARD_DETAILS, reasonCardID: Number.parseInt(cardID, 10)})}
             validateCodeActionErrorField="revealExpensifyCardDetails"
             handleSubmitForm={handleRevealCardDetails}
             validateError={validateError}

--- a/src/pages/settings/Wallet/TravelCVVPage/TravelCVVVerifyAccountPage.tsx
+++ b/src/pages/settings/Wallet/TravelCVVPage/TravelCVVVerifyAccountPage.tsx
@@ -14,6 +14,7 @@ import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 
+import {CONST} from 'expensify-common';
 import React, {useCallback} from 'react';
 
 import {useTravelCVVActions, useTravelCVVState} from './TravelCVVContextProvider';
@@ -56,11 +57,15 @@ function TravelCVVVerifyAccountPage() {
             });
     };
 
+    if (!travelCard) {
+        return null;
+    }
+
     return (
         <ValidateCodeActionContent
             title={translate('cardPage.validateCardTitle')}
             descriptionPrimary={translate('cardPage.enterMagicCode', primaryLogin ?? '')}
-            sendValidateCode={() => requestValidateCodeAction()}
+            sendValidateCode={() => requestValidateCodeAction({reasonCode: CONST.VALIDATE_CODE_REASONS.REVEAL_CARD_DETAILS, reasonCardID: travelCard.cardID})}
             validateCodeActionErrorField="revealExpensifyCardDetails"
             handleSubmitForm={handleRevealCardDetails}
             validateError={validateError}

--- a/src/pages/signin/ChooseSSOOrMagicCode.tsx
+++ b/src/pages/signin/ChooseSSOOrMagicCode.tsx
@@ -19,6 +19,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
+import {CONST as COMMON_CONST} from 'expensify-common';
 import React, {useEffect} from 'react';
 import {Keyboard, View} from 'react-native';
 
@@ -77,7 +78,7 @@ function ChooseSSOOrMagicCode({setIsUsingMagicCode}: ChooseSSOOrMagicCodeProps) 
                     text={translate('samlSignIn.useMagicCode')}
                     isLoading={account?.isLoading && account?.loadingForm === (account?.requiresTwoFactorAuth ? CONST.FORMS.VALIDATE_TFA_CODE_FORM : CONST.FORMS.VALIDATE_CODE_FORM)}
                     onPress={() => {
-                        resendValidateCode(credentials?.login);
+                        resendValidateCode({reasonCode: COMMON_CONST.VALIDATE_CODE_REASONS.SIGN_IN}, credentials?.login);
                         setIsUsingMagicCode(true);
                     }}
                     sentryLabel={CONST.SENTRY_LABEL.SIGN_IN.MAGIC_CODE}

--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.tsx
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.tsx
@@ -39,6 +39,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 import {useIsFocused} from '@react-navigation/native';
+import {CONST as COMMON_CONST} from 'expensify-common';
 import React, {useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import {View} from 'react-native';
 
@@ -158,7 +159,7 @@ function BaseValidateCodeForm({autoComplete, isUsingRecoveryCode, setIsUsingReco
      * Trigger the reset validate code flow and ensure the 2FA input field is reset to avoid it being permanently hidden
      */
     const resendValidateCode = () => {
-        userActionsResendValidateCode(credentials?.login ?? '');
+        userActionsResendValidateCode({reasonCode: COMMON_CONST.VALIDATE_CODE_REASONS.SIGN_IN}, credentials?.login ?? '');
         inputValidateCodeRef.current?.clear();
         // Give feedback to the user to let them know the email was sent so that they don't spam the button.
         countdownRef.current?.resetCountdown();

--- a/src/pages/workspace/companyCards/WorkspaceVerifyWorkAccountPage.tsx
+++ b/src/pages/workspace/companyCards/WorkspaceVerifyWorkAccountPage.tsx
@@ -51,7 +51,7 @@ function WorkspaceVerifyWorkAccountPageContent({route}: WorkspaceVerifyWorkAccou
         if (!workEmail) {
             return;
         }
-        resendValidateCode(workEmail);
+        resendValidateCode({reasonCode: null}, workEmail);
     };
 
     const validateAccountAndMerge = (validateCode: string) => {

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardVerifyWorkAccountPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardVerifyWorkAccountPage.tsx
@@ -44,7 +44,7 @@ function WorkspaceExpensifyCardVerifyWorkAccountPageContent({route}: WorkspaceEx
         if (!workEmail) {
             return;
         }
-        resendValidateCode(workEmail);
+        resendValidateCode({reasonCode: null}, workEmail);
     };
 
     const validateAccountAndMerge = (validateCode: string) => {


### PR DESCRIPTION
Revert https://github.com/Expensify/App/pull/96134, thus un-reverting https://github.com/Expensify/App/pull/90726. It's the same exact changeset as before, but the backend handling is fixed for the reveal card details case. The original PR description is reproduced below.

### Explanation of Change


Magic code emails currently show a generic line _"This code was requested because someone is trying to log in to your account or access a secure feature"_. The goal is to show the reason the code was requested (with instance-specific data where applicable) and to omit the sign-in button when the request isn't a login.

To do that, the backend needs to know why a magic code was requested. This PR plumbs a `reasonCode` (and, where required, supporting params like `reasonCardID`) from each App call site that triggers a magic code, through `resendValidateCode` / `requestValidateCodeAction`, into the `RESEND_VALIDATE_CODE` / `REQUEST_NEW_VALIDATE_CODE` API commands. The backend uses the `reasonCode` to build the per-reason email copy and show or hide the signin button

**Reason codes covered in this PR:**

| `reasonCode`                             | Resulting email copy                                                                | Sign-in button | Call sites                                                                                                                                                                                                                                                                                                                                                                                     |
| ---------------------------------------- | ----------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `sign_in`                                | "Sign in to your Expensify account"                                                 | shown          | `ChooseSSOOrMagicCode`, `BaseValidateCodeForm`                                                                                                                                                                                                                                                                                                                                                 |
| `validate_account`                       | "Verify that this contact method can be used to reach you"                          | hidden         | `VerifyAccountPageBase` (see note — fans out to ~15 account-level gates), `BaseOnboardingPrivateDomain`                                                                                                                                                                                                                                                                                         |
| `add_contact_method`                     | "Add a new contact method to your account"                                          | hidden         | `NewContactMethodConfirmMagicCodePage`                                                                                                                                                                                                                                                                                                                                                         |
| `reveal_card_details` (+ `reasonCardID`) | "Reveal details for your Expensify card ending in NNNN" or "Reveal your Travel CVV" | hidden         | `ExpensifyCardVerifyAccountPage`, `TravelCVVVerifyAccountPage`                                                                                                                                                                                                                                                                                                                                 |
| `null` (explicitly passed)               | generic fallback ("...log in to your account or access a secure feature")           | hidden         | `BaseOnboardingWorkEmailValidation`, `WorkspaceVerifyWorkAccountPage`, `WorkspaceExpensifyCardVerifyWorkAccountPage` (all work-email account merge — not yet implemented)                                                                                                                                                                                                                        |
| none (`requestValidateCodeAction()` with no args) | generic fallback (same as above)                        | hidden         | `ConfirmDelegateMagicCodePage`, `UpdateDelegateMagicCodePage`, `PrivatePersonalDetailsConfirmMagicCodePage`, `SetDefaultContactMethodConfirmMagicCodePage`, `ReportVirtualCardFraudVerifyAccountPage`, `ReportCardLostConfirmMagicCodePage`, `MissingPersonalDetailsMagicCodePage`, `IssueNewCardConfirmMagicCodePage`, `MultifactorAuthentication/ValidateCodePage`, `MultifactorAuthenticationMainContext` |

**Type safety:** `ResendValidateCodeParams` is a discriminated union. `reveal_card_details` requires a `reasonCardID`; the other reasons forbid extra params; `null` is a temporary escape hatch (`ResendValidateCodeNotYetImplementedParams`) for the one flow whose reason isn't modeled yet. This makes it a compile error to request a card-reveal code without a card ID.

> [!NOTE]
> **`VerifyAccountPageBase` coverage is broad.** It exposes no `sendValidateCode` prop — the `validate_account` reason is set internally — so the single change there covers **every** account-level one-time validation gate that wraps it (~15 routes): add delegate/copilot, enable 2FA, company-card feed, bank account for wallet/reimbursements, invoicing bank account, workspace domain, international deposit country, travel access, create/confirm money request, report/expense-report/search actions, and enable wallet. Testing one of these wrappers exercises them all; the rest only need a spot check.

> [!NOTE]
> This is intentionally **not** a complete migration of every magic-code call site. Auth/Web-E treat an empty/`null` `reasonCode` as legacy and fall back to the generic copy, so un-migrated callers are unaffected. A follow-up will cover the remaining reasons and then tighten `reasonCode` to required on the backend.
>
> **Known deferred gate:** "Verify a newly added contact method" (`ContactMethodDetailsPage`) is a `validate_account`-semantics email that this PR leaves on the generic fallback. It calls `requestContactMethodValidateCode`, which writes the separate **`REQUEST_CONTACT_METHOD_VALIDATE_CODE`** command — a different command/param type than the `RESEND_VALIDATE_CODE` / `REQUEST_NEW_VALIDATE_CODE` paths this PR plumbs. Carrying a reason there requires plumbing that third command, deferred to the follow-up.


### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/623748
PROPOSAL:



### Tests

**1. `sign_in` — login via magic code (resend)**

1. Sign out. On the sign-in page, enter an email and continue to the magic code step.
2. On the magic code form, click **Resend** (`BaseValidateCodeForm`).
3. Verify the email reads _"...someone is trying to: • Sign in to your Expensify account"_.
4. Verify the **sign-in button is present** at the bottom and the _"Or just sign in below."_ line is shown.
5. Verify that the magic code is accepted.

**2. `sign_in` — SSO "Use magic code"**

1. Sign out. Enter an email on an SSO-enabled domain and continue.
2. On the "Choose SSO or magic code" screen, click **Use magic code** (`ChooseSSOOrMagicCode`).
3. Verify the email reads _"...someone is trying to: • Sign in to your Expensify account"_.
4. Verify the **sign-in button is present** at the bottom and the _"Or just sign in below."_ line is shown.
5. Verify that the magic code is accepted.

**3. `add_contact_method` — add a new contact method**

1. Settings > Profile > Contact methods > **New contact method**.
2. Verify the email you receive reads _"...trying to: • Add a new contact method to your account"_.
4. Verify **no sign-in button** is rendered.
5. Verify that the magic code is accepted.

**4. `validate_account` — validate the newly-added contact method**

1. Continuing from step 5 of the test above, enter an email or phone number
2. Enter a new email/phone and continue to the magic code confirmation page
3. Verify the email you receive has the subject "Verify secondary email for Expensify" and looks different from all the other magic code emails
4. Verify that the magic code is accepted

**5. `reveal_card_details` — virtual Expensify card**

1. Settings > Wallet > a virtual Expensify card > press **Reveal** under Virtual card number.
2. Verify the email reads _"...trying to: • Reveal details for your Expensify card ending in NNNN"_, where `NNNN` matches the last four of the card.
3. Verify **no sign-in button** is rendered.
4. Verify that the magic code is accepted.

**6. `reveal_card_details` — Travel CVV**

1. With a travel-invoicing card present, go to Wallet > Travel CVV
2. Verify the email reads _"...trying to: • Reveal your Travel CVV"_.
3. Verify **no sign-in button** is rendered.
4. Verify that the magic code is accepted.

> The four cases below all send `validate_account`. Each ends with the same three assertions:
> **(A)** the email reads _"...someone is trying to: • Verify that this contact method can be used to reach you"_
> **(B)** **no sign-in button** is rendered
> **(C)** the magic code is accepted
> All of these gates only fire for an account whose login is **not yet validated** — use a freshly created test account so the gate appears.

**7. `validate_account` — account-level gate via `VerifyAccountPageBase` (represented by Enable 2FA)**

Every account-level gate in the coverage note routes through `VerifyAccountPageBase`, so this one case represents all 15. 2FA is the easiest to reach.

1. Sign in as an **unvalidated** account.
2. Go to **Settings > Security > Two-factor authentication**.
3. Make sure that you are prompted for a magic code.
4. Assert (A) and (B) and (C).
5. _Spot check (optional):_ repeat via one other wrapper — e.g. **Settings > Security > Add copilot** (`settings/security/delegate/verify-account`) and confirm identical copy, proving the shared path.

**8. `validate_account` — onboarding private domain (`BaseOnboardingPrivateDomain`)**

This page only renders during onboarding when the account is on a **private domain that already has at least one accessible workspace**, and of course if the account is unvalidated. That's tricky because if the domain is validated, App will challenge you for a magic code at signin time because your account is considered domainControlled. So you need a private domain that is _not_ validated but you can actually receive emails to.

1. Ensure your test domain already has a workspace with at least one member on that domain.
2. Sign up / onboard a **new** account using a different email on that **same private domain**
3. Proceed through onboarding until the "private domain" validation step appears.
4. Assert (A) and (B) and (C).

- [x] Verify that no errors appear in the JS console


### Offline tests
None

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
All tests were re-performed today, 2026-07-15

<details>
<summary>1. Sign in</summary>


https://github.com/user-attachments/assets/04766f6d-caf4-4970-8fc0-8b9c9ab7b52f



</details>

<details>
<summary>2. sign in on SSO enabled domain</summary>

https://github.com/user-attachments/assets/1e4808a9-7623-4d5a-a4d2-f58bbde07a21


</details>

<details>
<summary>3. add contact method gate</summary>


https://github.com/user-attachments/assets/2940a79c-3052-4c75-95b6-f0566caa4b35


</details>

<details>
<summary>4. validate newly added contact method</summary>


https://github.com/user-attachments/assets/b86eb1d5-1ece-4654-8a17-2ffcdd5010ba


</details>

<details>
<summary>5. reveal card details</summary>

https://github.com/user-attachments/assets/a00eef9a-e7fa-4dc3-aa02-c27ec587f727



</details>

<details>
<summary>6. reveal travel CVV</summary>

Note that this one isn't really testable in dev, but it's enough to check the notification in the db and that the form doesn't immediately reject the validate code

https://github.com/user-attachments/assets/c5ad6789-75f0-44b2-9692-5c6a75b7c6be

</details>

<details>
<summary>7. unverified account validation gate</summary>

https://github.com/user-attachments/assets/9c92585c-92e8-4e98-b82f-24caf389b3f3

</details>

<details>
<summary>8. private domain onboarding</summary>


https://github.com/user-attachments/assets/bdbce492-4643-4c2d-8557-c44951d73f7f



</details>