### PR TITLE
[No QA] Parallelize deploy PR comments with PromisePool

### DIFF
--- a/.github/actions/javascript/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/index.js
@@ -13584,7 +13584,9 @@ class PromisePool {
      * wait for one to finish before starting another.
      */
     async add(task) {
-        if (this.executing.size >= this.concurrency) {
+        // Recheck after each wait: when many add() callers resume from the same
+        // Promise.race, only the first few should start; the rest must wait again.
+        while (this.executing.size >= this.concurrency) {
             await Promise.race(this.executing);
         }
         const p = task();

--- a/.github/actions/javascript/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/index.js
@@ -12752,6 +12752,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const ActionUtils = __importStar(__nccwpck_require__(6981));
 const CONST_1 = __importDefault(__nccwpck_require__(9873));
 const GithubUtils_1 = __importDefault(__nccwpck_require__(9296));
+const PromisePool_1 = __importDefault(__nccwpck_require__(6468));
 const core = __importStar(__nccwpck_require__(2186));
 const github_1 = __nccwpck_require__(5438);
 const memoize_1 = __importDefault(__nccwpck_require__(9885));
@@ -12789,7 +12790,8 @@ const getCommit = (0, memoize_1.default)(GithubUtils_1.default.octokit.git.getCo
  * Process deploy checklist comments for a list of PRs
  */
 async function commentOnDeployChecklistPRs(prList, repoName, recentTags, getDeployMessage) {
-    for (const prNumber of prList) {
+    const pool = new PromisePool_1.default(8);
+    const commentPromises = prList.map((prNumber) => pool.add(async () => {
         try {
             const { data: pr } = await GithubUtils_1.default.octokit.pulls.get({
                 owner: CONST_1.default.GITHUB_OWNER,
@@ -12831,7 +12833,8 @@ async function commentOnDeployChecklistPRs(prList, repoName, recentTags, getDepl
                 throw error;
             }
         }
-    }
+    }));
+    await Promise.all(commentPromises);
 }
 async function run() {
     const prList = ActionUtils.getJSONInput('PR_LIST', { required: true }).map((num) => Number.parseInt(num, 10));
@@ -12886,16 +12889,13 @@ async function run() {
         }
         // who closed the last deploy checklist?
         const deployer = await GithubUtils_1.default.getActorWhoClosedIssue(previousChecklistID);
-        // Create comment on each pull request (one at a time to avoid throttling issues)
+        // Create comment on each pull request (up to 8 at a time via PromisePool to avoid throttling issues)
         const deployMessage = getDeployMessage(deployer, 'Deployed');
-        for (const pr of prList) {
-            await commentPR(pr, deployMessage);
-        }
+        const pool = new PromisePool_1.default(8);
+        await Promise.all(prList.map((pr) => pool.add(() => commentPR(pr, deployMessage))));
         console.log(`✅ Added production deploy comment on ${prList.length} App PRs`);
         // Comment on Mobile-Expensify PRs as well
-        for (const pr of mobileExpensifyPRList) {
-            await commentPR(pr, deployMessage, CONST_1.default.MOBILE_EXPENSIFY_REPO);
-        }
+        await Promise.all(mobileExpensifyPRList.map((pr) => pool.add(() => commentPR(pr, deployMessage, CONST_1.default.MOBILE_EXPENSIFY_REPO))));
         if (mobileExpensifyPRList.length > 0) {
             console.log(`✅ Added production deploy comment on ${mobileExpensifyPRList.length} Mobile-Expensify PRs`);
         }
@@ -13556,6 +13556,45 @@ class GithubUtils {
     }
 }
 exports["default"] = GithubUtils;
+
+
+/***/ }),
+
+/***/ 6468:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+class PromisePool {
+    /**
+     * The maximum number of concurrent async operations.
+     */
+    concurrency;
+    /**
+     * The set of currently-executing async operations.
+     */
+    executing = new Set();
+    constructor(concurrency = 8) {
+        this.concurrency = concurrency;
+    }
+    /**
+     * Execute an async task and return a promise with the result.
+     * If there are more async operations in the pool than allowed when this function is called,
+     * wait for one to finish before starting another.
+     */
+    async add(task) {
+        if (this.executing.size >= this.concurrency) {
+            await Promise.race(this.executing);
+        }
+        const p = task();
+        this.executing.add(p);
+        return p.finally(() => {
+            this.executing.delete(p);
+        });
+    }
+}
+exports["default"] = PromisePool;
 
 
 /***/ }),

--- a/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.ts
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.ts
@@ -3,6 +3,8 @@ import * as ActionUtils from '@github/libs/ActionUtils';
 import CONST from '@github/libs/CONST';
 import GithubUtils from '@github/libs/GithubUtils';
 
+import PromisePool from '@scripts/utils/PromisePool';
+
 import type {RequestError} from '@octokit/types';
 
 import * as core from '@actions/core';
@@ -53,48 +55,53 @@ async function commentOnDeployChecklistPRs(
     recentTags: Awaited<ReturnType<typeof GithubUtils.octokit.repos.listTags>>['data'],
     getDeployMessage: (deployer: string, deployVerb: string, prTitle?: string) => string,
 ) {
-    for (const prNumber of prList) {
-        try {
-            const {data: pr} = await GithubUtils.octokit.pulls.get({
-                owner: CONST.GITHUB_OWNER,
-                repo: repoName,
-                pull_number: prNumber,
-            });
+    const pool = new PromisePool<void>(8);
+    const commentPromises = prList.map((prNumber) =>
+        pool.add(async () => {
+            try {
+                const {data: pr} = await GithubUtils.octokit.pulls.get({
+                    owner: CONST.GITHUB_OWNER,
+                    repo: repoName,
+                    pull_number: prNumber,
+                });
 
-            // Find the deployer: either the merger, or for CPs, the tag creator
-            const isCP = pr.labels.some(({name: labelName}) => labelName === CONST.LABELS.CP_STAGING);
-            let deployer = pr.merged_by?.login;
-            if (isCP) {
-                for (const tag of recentTags) {
-                    const {data: commit} = await getCommit({
-                        owner: CONST.GITHUB_OWNER,
-                        repo: repoName,
-                        commit_sha: tag.commit.sha,
-                    });
-                    const prNumForCPMergeCommit = commit.message.match(/Merge pull request #(\d+)[\S\s]*\(cherry picked from commit .*\)/);
-                    if (prNumForCPMergeCommit?.at(1) === String(prNumber)) {
-                        const cpActor = commit.message.match(/.*\(cherry-picked to .* by (.*)\)/)?.at(1);
-                        if (cpActor) {
-                            deployer = cpActor;
+                // Find the deployer: either the merger, or for CPs, the tag creator
+                const isCP = pr.labels.some(({name: labelName}) => labelName === CONST.LABELS.CP_STAGING);
+                let deployer = pr.merged_by?.login;
+                if (isCP) {
+                    for (const tag of recentTags) {
+                        const {data: commit} = await getCommit({
+                            owner: CONST.GITHUB_OWNER,
+                            repo: repoName,
+                            commit_sha: tag.commit.sha,
+                        });
+                        const prNumForCPMergeCommit = commit.message.match(/Merge pull request #(\d+)[\S\s]*\(cherry picked from commit .*\)/);
+                        if (prNumForCPMergeCommit?.at(1) === String(prNumber)) {
+                            const cpActor = commit.message.match(/.*\(cherry-picked to .* by (.*)\)/)?.at(1);
+                            if (cpActor) {
+                                deployer = cpActor;
+                            }
+                            break;
                         }
-                        break;
                     }
                 }
-            }
 
-            const title = pr.title;
-            const deployMessage = deployer ? getDeployMessage(deployer, isCP ? 'Cherry-picked' : 'Deployed', title) : '';
-            await commentPR(prNumber, deployMessage, repoName);
-        } catch (error) {
-            if ((error as RequestError).status === 404) {
-                console.log(`Unable to comment on ${repoName} PR #${prNumber}. GitHub responded with 404.`);
-            } else if (repoName === CONST.MOBILE_EXPENSIFY_REPO && process.env.GITHUB_REPOSITORY !== `${CONST.GITHUB_OWNER}/${CONST.APP_REPO}`) {
-                console.warn(`Unable to comment on ${repoName} PR #${prNumber} from forked repository. This is expected.`);
-            } else {
-                throw error;
+                const title = pr.title;
+                const deployMessage = deployer ? getDeployMessage(deployer, isCP ? 'Cherry-picked' : 'Deployed', title) : '';
+                await commentPR(prNumber, deployMessage, repoName);
+            } catch (error) {
+                if ((error as RequestError).status === 404) {
+                    console.log(`Unable to comment on ${repoName} PR #${prNumber}. GitHub responded with 404.`);
+                } else if (repoName === CONST.MOBILE_EXPENSIFY_REPO && process.env.GITHUB_REPOSITORY !== `${CONST.GITHUB_OWNER}/${CONST.APP_REPO}`) {
+                    console.warn(`Unable to comment on ${repoName} PR #${prNumber} from forked repository. This is expected.`);
+                } else {
+                    throw error;
+                }
             }
-        }
-    }
+        }),
+    );
+
+    await Promise.all(commentPromises);
 }
 
 async function run() {
@@ -159,17 +166,14 @@ async function run() {
         // who closed the last deploy checklist?
         const deployer = await GithubUtils.getActorWhoClosedIssue(previousChecklistID);
 
-        // Create comment on each pull request (one at a time to avoid throttling issues)
+        // Create comment on each pull request (up to 8 at a time via PromisePool to avoid throttling issues)
         const deployMessage = getDeployMessage(deployer, 'Deployed');
-        for (const pr of prList) {
-            await commentPR(pr, deployMessage);
-        }
+        const pool = new PromisePool<void>(8);
+        await Promise.all(prList.map((pr) => pool.add(() => commentPR(pr, deployMessage))));
         console.log(`✅ Added production deploy comment on ${prList.length} App PRs`);
 
         // Comment on Mobile-Expensify PRs as well
-        for (const pr of mobileExpensifyPRList) {
-            await commentPR(pr, deployMessage, CONST.MOBILE_EXPENSIFY_REPO);
-        }
+        await Promise.all(mobileExpensifyPRList.map((pr) => pool.add(() => commentPR(pr, deployMessage, CONST.MOBILE_EXPENSIFY_REPO))));
         if (mobileExpensifyPRList.length > 0) {
             console.log(`✅ Added production deploy comment on ${mobileExpensifyPRList.length} Mobile-Expensify PRs`);
         }

--- a/scripts/utils/PromisePool.ts
+++ b/scripts/utils/PromisePool.ts
@@ -19,7 +19,9 @@ class PromisePool<T> {
      * wait for one to finish before starting another.
      */
     public async add(task: () => Promise<T>): Promise<T> {
-        if (this.executing.size >= this.concurrency) {
+        // Recheck after each wait: when many add() callers resume from the same
+        // Promise.race, only the first few should start; the rest must wait again.
+        while (this.executing.size >= this.concurrency) {
             await Promise.race(this.executing);
         }
         const p = task();

--- a/tests/unit/PromisePoolTest.ts
+++ b/tests/unit/PromisePoolTest.ts
@@ -40,4 +40,28 @@ describe('PromisePool', () => {
         // Now C and D should have finished
         expect(completedTasks).toEqual(['A', 'B', 'C', 'D']);
     });
+
+    it('does not exceed concurrency when many tasks are enqueued at once', async () => {
+        let currentlyRunning = 0;
+        let maxObserved = 0;
+
+        const makeTask = () => () =>
+            new Promise<string>((resolve) => {
+                currentlyRunning++;
+                maxObserved = Math.max(maxObserved, currentlyRunning);
+                setTimeout(() => {
+                    currentlyRunning--;
+                    resolve('done');
+                }, 1000);
+            });
+
+        // Same pattern as markPullRequestsAsDeployed / generateTranslations: fire all add() calls via map
+        const promises = Array.from({length: 20}, () => pool.add(makeTask()));
+
+        // Drive all timer waves (20 tasks / concurrency 2 = 10 waves)
+        await jest.advanceTimersByTimeAsync(10_000);
+        await Promise.all(promises);
+
+        expect(maxObserved).toBeLessThanOrEqual(2);
+    });
 });


### PR DESCRIPTION
### Explanation of Change
Yesterday I noticed deploy comments taking ~5 minutes. If there are N pull requests in a deploy, we currently do at least 2N API requests in serial. Long ago we made them run in serial to avoid rate-limiting, but since then we:

1. Added a throttling plugin for octokit which will automatically handle retries from rate-limiting w/ exponential backoff.
1. Added a useful PromisePool util to do a set of async tasks, with a maximum of X running in parallel at once. That way it's not like we send 2N API requests all at once. Instead, we send up to 8 at a time, and as soon as one finishes, we start the next.

### Fixed Issues
$

### Tests
Not tested locally.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — GitHub Actions only.

### QA Steps

N/A — [No QA]. This only affects the post-deploy GitHub comment action; no app UI changes.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>
