### PR TITLE
[Onyx bump] Bump react-native-onyx from 3.0.86 to 3.0.88

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "react-native-localize": "^3.5.4",
         "react-native-nitro-modules": "0.35.0",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.86",
+        "react-native-onyx": "3.0.88",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -36004,9 +36004,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.86",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.86.tgz",
-      "integrity": "sha512-P10auM8ZZHZrZmu/reg0EiuNq4AhZN3hmDoV5+QdEUsm2j5t2XCKWmU73ogFpL6fLCUQaxvzMmLEL84+nIhb2Q==",
+      "version": "3.0.88",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.88.tgz",
+      "integrity": "sha512-wCNHe+Kc6DX3yYVZxrITZdunu74P2x0XE7t8FGkpjEQdCRnlJhCTxn4NvxWZkURFxn5IRvIlVCGU8OdZhFNoOg==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "react-native-localize": "^3.5.4",
     "react-native-nitro-modules": "0.35.0",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.86",
+    "react-native-onyx": "3.0.88",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",


### PR DESCRIPTION
### Explanation of Change

This PR bumps Onyx from 3.0.86 to 3.0.88 ([diff](https://github.com/Expensify/react-native-onyx/compare/3.0.86...3.0.88)), which includes the following changes:

- [react-native-onyx#798](https://github.com/Expensify/react-native-onyx/pull/798) (3.0.87) — Add a proactive `visibilitychange` probe for IDB health, building on the reactive heal from #780. Safari kills IDB connections for backgrounded tabs, so on return the burst of reconnect writes hits a dead cached `dbp` and every write fails before the reactive heal can fire. A `visibilitychange` listener registered in `createStore()` runs a lightweight readonly `count()` probe when the tab becomes visible; if it detects a stale connection it drops `dbp` _before_ the write burst arrives, so the first real op opens a fresh connection. Adds `isStaleConnectionError()` (union detector for InvalidStateError / backing-store corruption / connection-lost), a `probePromise` guard so a stale probe can't clear a `dbp` already replaced by a concurrent heal, classified `req.onerror` (only drops `dbp` for genuine stale-connection errors), and diagnostic logging.
- [react-native-onyx#797](https://github.com/Expensify/react-native-onyx/pull/797) (3.0.88) — Replace the brittle string-matching storage-error retry logic with a layered design: classify the error → route it to exactly one recovery owner → stop session-wide storms with a circuit breaker. (1) Error classification moves into each storage provider's `classifyError`, mapping engine dialects to a shared taxonomy (`TRANSIENT`, `CAPACITY`, `INVALID_DATA`, `FATAL`, `UNKNOWN`) in `lib/storage/errors.ts`. (2) Single-owner recovery: `TRANSIENT`/`FATAL` → connection layer reopens/heals (retry skips them quietly), `CAPACITY` → operation layer evicts LRU + retries, `INVALID_DATA` → throws, `UNKNOWN` → logs the full error shape once then bounded retry. (3) A session-level circuit breaker (`lib/StorageCircuitBreaker.ts`) trips when capacity failures storm (>50/60s) or evictions repeatedly free nothing (5 consecutive no-progress cycles), halting eviction/retry and emitting exactly one alert per window instead of one log line per failed write.

### Fixed Issues

$ https://github.com/Expensify/App/issues/87864
$ https://github.com/Expensify/App/issues/87873
PROPOSAL: N/A — Onyx version bump. The bundled Onyx changes resolve these storage-error investigations:

- [react-native-onyx#798](https://github.com/Expensify/react-native-onyx/pull/798) $ [#87864](https://github.com/Expensify/App/issues/87864) (IndexedDB connection-lost) — companion testing PR [Expensify/App#92762](https://github.com/Expensify/App/pull/92762).
- [react-native-onyx#797](https://github.com/Expensify/react-native-onyx/pull/797) $ [#87873](https://github.com/Expensify/App/issues/87873) (QuotaExceededError) — proposal [#94069](https://github.com/Expensify/App/issues/94069); companion testing PR [Expensify/App#92931](https://github.com/Expensify/App/pull/92931).

### Tests

Testing steps taken verbatim from the two bundled Onyx PRs.

**Storage circuit breaker — [react-native-onyx#797](https://github.com/Expensify/react-native-onyx/pull/797):**

Prerequisites: put Chrome into insufficient storage situation by going to Console -> Application -> Storage and enable `Simulate custom storage quota`. Set a value lower than used by the application.

1. Open console and optionally filter logs by `Onyx`
2. Go to inbox and switch between various reports observe logs
3. Notice that there are no uncatched storm of logs
4. Notice that proper logs about circut breaker are logged: `Storage circuit breaker tripped: 5 consecutive evictions freed no usable space. Halting eviction/retry for 60s to stop a storage failure storm.`

**visibilitychange probe — [react-native-onyx#798](https://github.com/Expensify/react-native-onyx/pull/798) (Simulating Safari connection lost):**

1. Open the app in Safari, log in
2. Switch to a different tab and wait 30+ seconds (Safari may kill IDB connections for backgrounded tabs)
3. Switch back to the tab
4. Verify in console: `IDB visibilitychange probe: stale connection detected, dropping cached connection` appears (if Safari killed the connection)
5. Interact with the app — it should recover seamlessly

- [x] Verify that no errors appear in the JS console

### Offline tests

This PR is an Onyx version bump; there is no new offline behavior beyond the existing Onyx offline-first invariants. Spot-check:

1. Toggle "Offline" in the DevTools Network tab.
2. Send a chat message → appears optimistically.
3. Toggle back online → message confirms via Pusher.
4. Verify no white screen, no stale UI.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
        - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — Onyx web IDB storage paths; no native-specific changes.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

N/A — Onyx web IDB storage paths; no native-specific changes.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Behavioral recordings carried over from the bundled Onyx PRs.

**Storage circuit breaker — [react-native-onyx#797](https://github.com/Expensify/react-native-onyx/pull/797):**

Before:

https://github.com/user-attachments/assets/4668b079-4e70-41ee-920c-c668b4065247

After:

https://github.com/user-attachments/assets/b71da3b9-7fc8-46e9-9383-404bfd1cd383

**visibilitychange probe / heal — [react-native-onyx#798](https://github.com/Expensify/react-native-onyx/pull/798):**

Probe on Safari (primary target platform):

https://github.com/user-attachments/assets/9a5dbf0d-f868-4449-955c-b6588ae75888

Healed (simulated error):

https://github.com/user-attachments/assets/e42fc3c0-38ca-416a-882e-89f907b77270

Killed connection (simulated error):

https://github.com/user-attachments/assets/f154bdae-4968-4152-9fc8-034dc95a6566

Exhausted (simulated error):

https://github.com/user-attachments/assets/6021d445-b871-43e8-b844-47c8ef8d73aa

Healed (simulated on Safari):

https://github.com/user-attachments/assets/6f2375fc-78b9-48be-b90e-d904ac939805

Killed connection (simulated on Safari):

https://github.com/user-attachments/assets/f7e6df4a-5b22-4415-aee1-fbaaae442567

Exhausted (simulated on Safari):

https://github.com/user-attachments/assets/38578b0f-6553-4183-8066-0bbc0fa07c66

Healed offline (simulated on Chrome):

https://github.com/user-attachments/assets/3106976c-e980-498c-a70e-8e8ca7c1ccda

</details>
