### PR TITLE
Defer mounting Search filter dropdown content until opened

### DIFF
--- a/src/components/Search/FilterDropdowns/FilterPopupButton.tsx
+++ b/src/components/Search/FilterDropdowns/FilterPopupButton.tsx
@@ -65,6 +65,10 @@ function FilterPopupButton({viewportOffsetTop, popoverWidth, wrapperStyle, popov
     const triggerRef = useRef<View | null>(null);
     const anchorRef = useRef<View | null>(null);
     const [isOverlayVisible, setIsOverlayVisible] = useState(false);
+    // Defer mounting the (potentially heavy) popover content until the dropdown is first opened, then keep it
+    // mounted so the close animation and reopening stay instant. The content is otherwise mounted eagerly on
+    // screen focus even while hidden, which runs each filter selector's expensive option-building on page load.
+    const [hasEverExpanded, setHasEverExpanded] = useState(false);
     const [customPopoverWidth, setCustomPopoverWidth] = useState<number | undefined>(undefined);
     const {calculatePopoverPosition} = usePopoverPosition();
 
@@ -88,6 +92,7 @@ function FilterPopupButton({viewportOffsetTop, popoverWidth, wrapperStyle, popov
     };
 
     const calculatePopoverPositionAndToggleOverlay = () => {
+        setHasEverExpanded(true);
         calculatePopoverPosition(anchorRef, popoverAnchorAlignment).then((position) => {
             setPopoverTriggerPosition({...position, vertical: position.vertical});
             toggleOverlay();
@@ -97,7 +102,7 @@ function FilterPopupButton({viewportOffsetTop, popoverWidth, wrapperStyle, popov
     const actualPopoverWidth = customPopoverWidth ?? popoverWidth ?? CONST.POPOVER_DROPDOWN_WIDTH;
     const containerStyles = isSmallScreenWidth ? styles.w100 : {width: actualPopoverWidth};
 
-    const popoverContent = PopoverComponent({closeOverlay: toggleOverlay, isExpanded: isOverlayVisible, setPopoverWidth: setCustomPopoverWidth});
+    const popoverContent = hasEverExpanded ? PopoverComponent({closeOverlay: toggleOverlay, isExpanded: isOverlayVisible, setPopoverWidth: setCustomPopoverWidth}) : null;
 
     return (
         <View

--- a/src/components/Search/FilterDropdowns/FilterPopupButton.tsx
+++ b/src/components/Search/FilterDropdowns/FilterPopupButton.tsx
@@ -102,7 +102,7 @@ function FilterPopupButton({viewportOffsetTop, popoverWidth, wrapperStyle, popov
     const actualPopoverWidth = customPopoverWidth ?? popoverWidth ?? CONST.POPOVER_DROPDOWN_WIDTH;
     const containerStyles = isSmallScreenWidth ? styles.w100 : {width: actualPopoverWidth};
 
-    const popoverContent = hasEverExpanded ? PopoverComponent({closeOverlay: toggleOverlay, isExpanded: isOverlayVisible, setPopoverWidth: setCustomPopoverWidth}) : null;
+    const popoverContent = PopoverComponent({closeOverlay: toggleOverlay, isExpanded: isOverlayVisible, setPopoverWidth: setCustomPopoverWidth});
 
     return (
         <View
@@ -112,8 +112,9 @@ function FilterPopupButton({viewportOffsetTop, popoverWidth, wrapperStyle, popov
             {/* Dropdown Trigger */}
             {renderButton({ref: triggerRef, onPress: calculatePopoverPositionAndToggleOverlay, isExpanded: isOverlayVisible})}
 
-            {/* Dropdown overlay */}
-            {isFocused && (
+            {/* Dropdown overlay. Gated on hasEverExpanded so the (potentially heavy) content subtree isn't mounted
+                until the dropdown is first opened — PopoverWithMeasuredContentBase mounts children even while hidden. */}
+            {isFocused && hasEverExpanded && (
                 <PopoverWithMeasuredContent
                     anchorRef={triggerRef}
                     avoidKeyboard

--- a/src/components/Search/FilterDropdowns/FilterPopupButton.tsx
+++ b/src/components/Search/FilterDropdowns/FilterPopupButton.tsx
@@ -92,9 +92,13 @@ function FilterPopupButton({viewportOffsetTop, popoverWidth, wrapperStyle, popov
     };
 
     const calculatePopoverPositionAndToggleOverlay = () => {
-        setHasEverExpanded(true);
         calculatePopoverPosition(anchorRef, popoverAnchorAlignment).then((position) => {
             setPopoverTriggerPosition({...position, vertical: position.vertical});
+            // Latch in the same batch as the open (and only when it will actually open, mirroring toggleOverlay's
+            // alert-modal guard) so the deferred subtree mounts together with the popover becoming visible.
+            if (!isOverlayVisible && !willAlertModalBecomeVisible) {
+                setHasEverExpanded(true);
+            }
             toggleOverlay();
         });
     };


### PR DESCRIPTION


### Explanation of Change



Opening a Search page (e.g. &#34;Needs approval&#34; with a `from:` filter set) rendered every active filter chip&#39;s dropdown body eagerly, before the dropdown was ever opened. This happened because `PopoverWithMeasuredContentBase` mounts its children even while `isVisible={false}`, so `FilterPopupButton` building `popoverContent` unconditionally on every render caused each filter selector (from/to/category/tag/…) to mount and run its option-list build on screen focus — including the expensive `usePersonalDetailSearchSelector` hook (~800ms on large accounts) used by the user selector.

This change defers mounting the popover content until the dropdown is first opened, latched via a new `hasEverExpanded` state so it stays mounted afterward (close animation and reopening remain instant). `popoverContent` is `null` until first open, so nothing heavy mounts on page load — the cost is paid once, on the user&#39;s first click, behind the existing loading placeholder.

**Performance impact:** On large customer account, this saves ~800ms of computations on opening Needs approval page. Computation on filter opening happened before anyway and it lasts ~200ms - nothing changed here

### Fixed Issues



$ https://github.com/Expensify/App/issues/96288
PROPOSAL:



### Tests



- [x] Verify that no errors appear in the JS console

1. Open Spend page
2. Open Needs Approval
3. Choose some account as a filter (for example report from someone)
4. open the filter modal/ popover
5. Make sure the modal opens and closes as expected

### Offline tests



N/A

### QA Steps



// TODO: These must be filled out, or the issue title must include &#34;[No QA].&#34;

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist



- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn&#39;t already exist
    - [x] The style can&#39;t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


Android: Native






Android: mWeb Chrome






iOS: Native



https://github.com/user-attachments/assets/b67b4321-7ccc-4948-b1cf-dda064c011d2





iOS: mWeb Safari






MacOS: Chrome / Safari

https://github.com/user-attachments/assets/3a7e82c2-c1b2-4846-b7a4-d200c40d0ba5





