### PR TITLE
[CP Staging] Fix Season F1 custom avatars rendering partially black in Share QR code

### DIFF
--- a/src/pages/ShareCodePage.tsx
+++ b/src/pages/ShareCodePage.tsx
@@ -78,6 +78,25 @@ function getLogoForWorkspace(report: OnyxEntry<Report>, policy?: OnyxEntry<Polic
     return policy.avatarURL as ImageSourcePropType;
 }
 
+/**
+ * The QR library spreads its `fill` prop onto the SVG logo even when it's undefined, which strips root
+ * attributes like fill="none" that some avatars need (their stroke-only paths would fill black otherwise),
+ * so only forward `fill` when it's actually set.
+ */
+function createAvatarQRLogo(LocalAvatarLogo: React.FC<SvgProps>): React.FC<SvgProps> {
+    function AvatarQRLogo({fill, ...rest}: SvgProps) {
+        return fill == null ? (
+            <LocalAvatarLogo {...rest} />
+        ) : (
+            <LocalAvatarLogo
+                fill={fill}
+                {...rest}
+            />
+        );
+    }
+    return AvatarQRLogo;
+}
+
 function ShareCodePage({report, policy, backTo}: ShareCodePageProps) {
     const icons = useMemoizedLazyExpensifyIcons(['Cash', 'Checkmark', 'Copy', 'Download', 'FallbackAvatar']);
     const themeStyles = useThemeStyles();
@@ -125,17 +144,17 @@ function ShareCodePage({report, policy, backTo}: ShareCodePageProps) {
 
     // Catalog-backed avatars (agent/default user avatars) have a bundled local SVG. Render the profile QR logo from
     // that SVG rather than the CDN URL so it still shows offline; only user-uploaded avatars fall back to the URL.
-    const localAvatarLogo = isReport ? undefined : findLocalAvatarForURL(currentUserPersonalDetails?.avatar);
+    const LocalAvatarLogo = isReport ? undefined : findLocalAvatarForURL(currentUserPersonalDetails?.avatar);
 
     let logo: ImageSourcePropType | undefined;
     if (isReport) {
         logo = getLogoForWorkspace(report, policy);
-    } else if (!localAvatarLogo) {
+    } else if (!LocalAvatarLogo) {
         logo = getAvatarURL({avatarSource: currentUserPersonalDetails?.avatar, accountID: currentUserPersonalDetails?.accountID}) as ImageSourcePropType;
     }
 
     // Default logos (avatars) are SVG and they require some special logic to display correctly
-    let svgLogo: React.FC<SvgProps> | undefined = localAvatarLogo;
+    let svgLogo: React.FC<SvgProps> | undefined = LocalAvatarLogo ? createAvatarQRLogo(LocalAvatarLogo) : undefined;
     let logoBackgroundColor: string | undefined;
     let svgLogoFillColor: string | undefined;
 

--- a/tests/unit/ShareCodePageTranslateTest.tsx
+++ b/tests/unit/ShareCodePageTranslateTest.tsx
@@ -5,6 +5,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import QRShareWithDownload from '@components/QRShare/QRShareWithDownload';
 
 import {findLocalAvatarForURL} from '@libs/Avatars/AvatarLookup';
+import type * as AvatarLookup from '@libs/Avatars/AvatarLookup';
 import {getDisplayNameForParticipant} from '@libs/ReportUtils';
 
 import ShareCodePage from '@pages/ShareCodePage';
@@ -36,8 +37,7 @@ jest.mock('@components/ContextMenuItem', () => jest.fn(() => null));
 jest.mock('@components/MenuItem', () => jest.fn(() => null));
 
 jest.mock('@libs/Avatars/AvatarLookup', () => ({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    ...jest.requireActual('@libs/Avatars/AvatarLookup'),
+    ...jest.requireActual<typeof AvatarLookup>('@libs/Avatars/AvatarLookup'),
     findLocalAvatarForURL: jest.fn(),
 }));
 

--- a/tests/unit/ShareCodePageTranslateTest.tsx
+++ b/tests/unit/ShareCodePageTranslateTest.tsx
@@ -1,7 +1,10 @@
 import {render} from '@testing-library/react-native';
 
+import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersonalDetailsProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import QRShareWithDownload from '@components/QRShare/QRShareWithDownload';
 
+import {findLocalAvatarForURL} from '@libs/Avatars/AvatarLookup';
 import {getDisplayNameForParticipant} from '@libs/ReportUtils';
 
 import ShareCodePage from '@pages/ShareCodePage';
@@ -9,6 +12,8 @@ import ShareCodePage from '@pages/ShareCodePage';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
+
+import type {SvgProps} from 'react-native-svg';
 
 import React from 'react';
 import Onyx from 'react-native-onyx';
@@ -30,6 +35,12 @@ jest.mock('@components/QRShare/QRShareWithDownload', () => jest.fn(() => null));
 jest.mock('@components/ContextMenuItem', () => jest.fn(() => null));
 jest.mock('@components/MenuItem', () => jest.fn(() => null));
 
+jest.mock('@libs/Avatars/AvatarLookup', () => ({
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    ...jest.requireActual('@libs/Avatars/AvatarLookup'),
+    findLocalAvatarForURL: jest.fn(),
+}));
+
 jest.mock('@libs/ReportUtils', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const actual = jest.requireActual('@libs/ReportUtils');
@@ -42,6 +53,8 @@ jest.mock('@libs/ReportUtils', () => {
 });
 
 const mockGetDisplayNameForParticipant = jest.mocked(getDisplayNameForParticipant);
+const mockFindLocalAvatarForURL = jest.mocked(findLocalAvatarForURL);
+const mockQRShareWithDownload = jest.mocked(QRShareWithDownload);
 
 const PARTICIPANT_A = 717001;
 const PARTICIPANT_B = 717002;
@@ -76,5 +89,74 @@ describe('ShareCodePage', () => {
 
         // Each participant's name resolves via getDisplayNameForParticipant, which must receive the translate from useLocalize.
         expect(mockGetDisplayNameForParticipant).toHaveBeenCalledWith(expect.objectContaining({translate: mockTranslate}));
+    });
+
+    describe('profile QR code avatar logo', () => {
+        it('wraps catalog-backed avatars in an SVG logo that only forwards an explicitly set fill', async () => {
+            const localAvatar: React.FC<SvgProps> = jest.fn(() => null);
+            const localAvatarMock = jest.mocked(localAvatar);
+            mockFindLocalAvatarForURL.mockReturnValue(localAvatar);
+
+            render(
+                <OnyxListItemProvider>
+                    <ShareCodePage />
+                </OnyxListItemProvider>,
+            );
+            await waitForBatchedUpdates();
+
+            const qrProps = mockQRShareWithDownload.mock.calls.at(-1)?.[0];
+            // A locally bundled avatar renders as an SVG logo instead of a URL-based logo.
+            expect(qrProps?.logo).toBeUndefined();
+            const SvgLogo = qrProps?.svgLogo;
+            if (!SvgLogo) {
+                throw new Error('Expected QRShareWithDownload to receive an svgLogo');
+            }
+
+            // Without a fill prop, the wrapper must not spread fill onto the avatar — an undefined fill
+            // would strip root attributes like fill="none" and paint stroke-only paths black.
+            render(
+                <SvgLogo
+                    width={24}
+                    height={24}
+                />,
+            );
+            expect(localAvatarMock).toHaveBeenCalled();
+            expect(localAvatarMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('fill');
+            expect(localAvatarMock.mock.calls.at(-1)?.[0]).toMatchObject({width: 24, height: 24});
+
+            // An explicitly set fill is forwarded unchanged.
+            render(
+                <SvgLogo
+                    fill="#00FF00"
+                    width={24}
+                    height={24}
+                />,
+            );
+            expect(localAvatarMock.mock.calls.at(-1)?.[0]).toMatchObject({fill: '#00FF00', width: 24, height: 24});
+        });
+
+        it('falls back to the avatar URL logo when no local catalog avatar matches', async () => {
+            mockFindLocalAvatarForURL.mockReturnValue(undefined);
+
+            // A user-uploaded avatar has no bundled local SVG, so the QR logo must come from its URL.
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: PARTICIPANT_A, email: 'user@example.com'});
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+                [PARTICIPANT_A]: {accountID: PARTICIPANT_A, avatar: 'https://example.com/images/avatar_custom.png'},
+            });
+            await waitForBatchedUpdates();
+
+            render(
+                <OnyxListItemProvider>
+                    <CurrentUserPersonalDetailsProvider>
+                        <ShareCodePage />
+                    </CurrentUserPersonalDetailsProvider>
+                </OnyxListItemProvider>,
+            );
+            await waitForBatchedUpdates();
+
+            const qrProps = mockQRShareWithDownload.mock.calls.at(-1)?.[0];
+            expect(qrProps?.svgLogo).toBeUndefined();
+            expect(qrProps?.logo).toBeDefined();
+        });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

After [#96112](https://github.com/Expensify/App/pull/96112), catalog-backed avatars (agent, default user, and Season F1 custom avatars) render in the center of the Share QR code from their bundled local SVG via the `svgLogo` prop. `react-native-qrcode-svg`'s `LogoSVG` always spreads its `fill` prop onto that component — even when it's `undefined`. Spreading `fill={undefined}` onto the SVG root erases root attributes like `fill="none"`.

The Season F1 custom avatars rely on that root `fill="none"`: they contain stroke-only paths with no explicit fill of their own. With the attribute erased, those paths fall back to SVG's default fill (black), which made those avatars render partially black in the QR code. Agent and numbered default avatars were unaffected because every one of their paths gets its fill from CSS classes.

This change wraps the local avatar logo in a small module-level component that only forwards `fill` when it's actually set. The wrapper is scoped to `ShareCodePage`; the workspace share QR (which always provides `svgLogoFillColor`) and all other QR usages are untouched, and the offline behavior added by [#96112](https://github.com/Expensify/App/pull/96112) is preserved for all catalog avatars.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96254

### Tests

1. Go to Account > Profile.
2. Click the profile avatar and select a Season F1 custom avatar that has outlined artwork (e.g. the gas pump on the tangerine background), then click Save.
3. Click Share.
4. Verify the avatar in the center of the QR code renders with its correct colors and no black shapes.
5. Repeat steps 2-4 with a numbered default avatar and with an Agent avatar, and verify both render correctly.
6. Open a workspace's Share page and verify the workspace default avatar still renders correctly in the QR code.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Select a Season F1 custom avatar and save it (while online).
2. Go offline.
3. Open Account > Profile > Share.
4. Verify the avatar still renders in the center of the QR code with its correct colors.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1613" height="797" alt="CleanShot 2026-07-16 at 10 38 37" src="https://github.com/user-attachments/assets/f8cdf6d7-d2bc-4e52-a3cd-d9b1c1c7a2d4" />

<img width="1651" height="1029" alt="CleanShot 2026-07-16 at 10 40 58" src="https://github.com/user-attachments/assets/c3559f83-337e-47f8-b534-f00d75d5b76d" />


</details>