### PR TITLE
fix: decode file:// URIs consistently before filesystem calls

### DIFF
--- a/src/components/AttachmentPicker/index.native.tsx
+++ b/src/components/AttachmentPicker/index.native.tsx
@@ -11,6 +11,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {cleanFileName, showCameraPermissionsAlert, verifyFileFormat} from '@libs/fileDownload/FileUtils';
+import fileURIToPath from '@libs/fileURIToPath';
 import Log from '@libs/Log';
 import moveReceiptToDurableStorage from '@libs/moveReceiptToDurableStorage';
 
@@ -128,7 +129,7 @@ const getDataForUpload = (fileData: FileResponse): Promise<FileObject> => {
 
     const fileWithSize = fileResult.size
         ? Promise.resolve(fileResult)
-        : RNFetchBlob.fs.stat(fileData.uri.replace('file://', '')).then((stats) => {
+        : RNFetchBlob.fs.stat(fileURIToPath(fileData.uri)).then((stats) => {
               fileResult.size = stats.size;
               return fileResult;
           });

--- a/src/components/FilePicker/index.native.tsx
+++ b/src/components/FilePicker/index.native.tsx
@@ -1,6 +1,7 @@
 import useLocalize from '@hooks/useLocalize';
 
 import {cleanFileName} from '@libs/fileDownload/FileUtils';
+import fileURIToPath from '@libs/fileURIToPath';
 
 import type {FileObject} from '@src/types/utils/Attachment';
 
@@ -35,7 +36,7 @@ const getDataForUpload = (fileData: LocalCopy): Promise<FileObject> => {
         return Promise.resolve(fileResult);
     }
 
-    return RNFetchBlob.fs.stat(fileData.uri.replace('file://', '')).then((stats) => {
+    return RNFetchBlob.fs.stat(fileURIToPath(fileData.uri)).then((stats) => {
         fileResult.size = stats.size;
         return fileResult;
     });

--- a/src/components/ImportOnyxState/index.native.tsx
+++ b/src/components/ImportOnyxState/index.native.tsx
@@ -3,6 +3,7 @@ import useOnyx from '@hooks/useOnyx';
 import {setIsUsingImportedState, setPreservedAccount, setPreservedUserSession} from '@libs/actions/App';
 import {setShouldForceOffline} from '@libs/actions/Network';
 import {rollbackOngoingRequest} from '@libs/actions/PersistedRequests';
+import fileURIToPath from '@libs/fileURIToPath';
 import {cleanAndTransformState, importState} from '@libs/ImportOnyxStateUtils';
 import Navigation from '@libs/Navigation/Navigation';
 
@@ -19,7 +20,7 @@ import type ImportOnyxStateProps from './types';
 import BaseImportOnyxState from './BaseImportOnyxState';
 
 function readOnyxFile(fileUri: string) {
-    const filePath = decodeURIComponent(fileUri.replace('file://', ''));
+    const filePath = fileURIToPath(fileUri);
 
     return ReactNativeBlobUtil.fs.exists(filePath).then((exists) => {
         if (!exists) {

--- a/src/libs/cropOrRotateImage/index.native.ts
+++ b/src/libs/cropOrRotateImage/index.native.ts
@@ -1,3 +1,4 @@
+import fileURIToPath from '@libs/fileURIToPath';
 import Log from '@libs/Log';
 
 import {ImageManipulator} from 'expo-image-manipulator';
@@ -32,7 +33,7 @@ const cropOrRotateImage: CropOrRotateImage = (uri, actions, options) =>
             // More info: https://github.com/Expensify/App/issues/37963#issuecomment-1989260033
             .then(({base64, ...result}) => {
                 RNFetchBlob.fs
-                    .stat(result.uri.replace('file://', ''))
+                    .stat(fileURIToPath(result.uri))
                     .then(({size}) => {
                         resolve({
                             ...result,
@@ -50,7 +51,7 @@ const cropOrRotateImage: CropOrRotateImage = (uri, actions, options) =>
                 }
 
                 Log.warn('Error cropping/rotating image, falling back to original', {error: error instanceof Error ? error.message : String(error)});
-                const filePath = uri.replace('file://', '');
+                const filePath = fileURIToPath(uri);
                 ImageSize.getSize(uri)
                     .then(({width, height}) => {
                         RNFetchBlob.fs

--- a/src/libs/fileDownload/FileUtils.ts
+++ b/src/libs/fileDownload/FileUtils.ts
@@ -1,6 +1,7 @@
 import type {LocalizedTranslate} from '@components/LocaleContextProvider';
 
 import DateUtils from '@libs/DateUtils';
+import fileURIToPath from '@libs/fileURIToPath';
 import getPlatform from '@libs/getPlatform';
 import Log from '@libs/Log';
 import saveLastRoute from '@libs/saveLastRoute';
@@ -407,7 +408,7 @@ function verifyFileFormat({fileUri, formatSignatures}: {fileUri: string; formatS
         return Promise.resolve(false);
     }
 
-    const cleanUri = fileUri.replace('file://', '');
+    const cleanUri = fileURIToPath(fileUri);
 
     if (Platform.OS === 'ios') {
         return ReactNativeBlobUtil.fs.readFile(cleanUri, 'base64').then((fullBase64Data: string) => {

--- a/src/libs/fileDownload/checkFileExists/index.ts
+++ b/src/libs/fileDownload/checkFileExists/index.ts
@@ -1,3 +1,5 @@
+import fileURIToPath from '@libs/fileURIToPath';
+
 import RNFS from 'react-native-fs';
 
 /**
@@ -12,17 +14,11 @@ function checkFileExists(path: string | undefined): Promise<boolean> {
         return Promise.resolve(false);
     }
 
-    // RNFS.stat expects a POSIX path, not a file:// URI.
     const rawPath = path.startsWith('file://') ? path.slice(7) : path;
 
-    // The share extension gives a percent-encoded URI, but moveReceiptToDurableStorage builds a
-    // file:// path from the raw filename, so a literal "%23" is ambiguous. Try decoded, then raw.
-    let decodedPath: string;
-    try {
-        decodedPath = decodeURIComponent(rawPath);
-    } catch {
-        decodedPath = rawPath;
-    }
+    // Receipts queued before moveReceiptToDurableStorage sanitized its filenames can still carry
+    // a literal "%23", which is indistinguishable from an encoded "#". Try decoded, then raw.
+    const decodedPath = fileURIToPath(path);
 
     const statIsFile = (candidate: string) => RNFS.stat(candidate).then((fileStat) => fileStat.isFile());
 

--- a/src/libs/fileDownload/index.android.ts
+++ b/src/libs/fileDownload/index.android.ts
@@ -1,5 +1,7 @@
 import type {LocalizedTranslate} from '@components/LocaleContextProvider';
 
+import fileURIToPath from '@libs/fileURIToPath';
+
 import CONST from '@src/CONST';
 
 import type {FetchBlobResponse} from 'react-native-blob-util';
@@ -53,7 +55,8 @@ function handleDownload(translate: LocalizedTranslate, url: string, fileName?: s
 
         const isLocalFile = url.startsWith('file://');
 
-        let attachmentPath = isLocalFile ? decodeURI(url) : undefined;
+        // copyToMediaStore and fs.unlink take a bare POSIX path, not a file:// URI.
+        let attachmentPath = isLocalFile ? fileURIToPath(url) : undefined;
         let fetchedAttachment: Promise<void | FetchBlobResponse> = Promise.resolve();
 
         if (!isLocalFile) {

--- a/src/libs/fileURIToPath.ts
+++ b/src/libs/fileURIToPath.ts
@@ -1,0 +1,24 @@
+/**
+ * Converts a file:// URI to the POSIX path that filesystem APIs (RNFS, ReactNativeBlobUtil) expect.
+ *
+ * Only file:// URIs are percent-decoded. The share extension emits them encoded (NSURL absoluteString
+ * on iOS, Uri.toString() on Android). Every other producer in the app stores raw decoded paths, so
+ * other schemes (content://, https://) and bare paths are returned untouched.
+ */
+function fileURIToPath(uri: string): string {
+    if (!uri.startsWith('file://')) {
+        return uri;
+    }
+
+    const path = uri.slice('file://'.length);
+
+    // A literal % that is not a valid escape sequence (e.g. a file named "Report 50%.pdf" written
+    // by a producer that does not encode) makes decodeURIComponent throw. Fall back to the raw path.
+    try {
+        return decodeURIComponent(path);
+    } catch {
+        return path;
+    }
+}
+
+export default fileURIToPath;

--- a/src/libs/moveReceiptToDurableStorage/index.native.ts
+++ b/src/libs/moveReceiptToDurableStorage/index.native.ts
@@ -1,3 +1,5 @@
+import {cleanFileName} from '@libs/fileDownload/FileUtils';
+import fileURIToPath from '@libs/fileURIToPath';
 import getReceiptsUploadFolderPath from '@libs/getReceiptsUploadFolderPath';
 import Log from '@libs/Log';
 import {rand64} from '@libs/NumberUtils';
@@ -27,9 +29,14 @@ const moveReceiptToDurableStorage: MoveReceiptToDurableStorage = async (sourceUr
             return sourceUri;
         }
 
-        const sourcePath = sourceUri.replace('file://', '');
-        const dotIndex = fileName.lastIndexOf('.');
-        const uniqueName = dotIndex > 0 ? `${fileName.slice(0, dotIndex)}_${rand64()}${fileName.slice(dotIndex)}` : `${fileName}_${rand64()}`;
+        const sourcePath = fileURIToPath(sourceUri);
+
+        // Sanitize the on-disk name so the returned file:// URI never contains characters (#, %, space)
+        // that make it ambiguous whether the string is percent-encoded. The user-visible filename
+        // travels separately on the file object's name field and is not affected.
+        const safeName = cleanFileName(fileName);
+        const dotIndex = safeName.lastIndexOf('.');
+        const uniqueName = dotIndex > 0 ? `${safeName.slice(0, dotIndex)}_${rand64()}${safeName.slice(dotIndex)}` : `${safeName}_${rand64()}`;
         const destPath = `${uploadFolder}/${uniqueName}`;
 
         await RNFS.moveFile(sourcePath, destPath);

--- a/src/pages/Share/getFileSize/index.native.ts
+++ b/src/pages/Share/getFileSize/index.native.ts
@@ -1,9 +1,11 @@
+import fileURIToPath from '@libs/fileURIToPath';
+
 import RNFS from 'react-native-fs';
 
 import type GetFileSizeType from './types';
 
 const getFileSize: GetFileSizeType = (uri: string) => {
-    return RNFS.stat(uri).then((fileStat) => {
+    return RNFS.stat(fileURIToPath(uri)).then((fileStat) => {
         return fileStat.size;
     });
 };

--- a/tests/unit/fileURIToPathTest.ts
+++ b/tests/unit/fileURIToPathTest.ts
@@ -1,0 +1,39 @@
+import fileURIToPath from '@libs/fileURIToPath';
+
+describe('fileURIToPath', () => {
+    it('returns an empty string unchanged', () => {
+        expect(fileURIToPath('')).toBe('');
+    });
+
+    it('strips the file:// prefix', () => {
+        expect(fileURIToPath('file:///var/mobile/Containers/receipt.pdf')).toBe('/var/mobile/Containers/receipt.pdf');
+    });
+
+    it('decodes %20 to a space', () => {
+        expect(fileURIToPath('file:///var/mobile/Containers/my%20receipt.pdf')).toBe('/var/mobile/Containers/my receipt.pdf');
+    });
+
+    it('decodes reserved characters like %23 to #', () => {
+        expect(fileURIToPath('file:///var/mobile/Containers/Receipt%20%2342.pdf')).toBe('/var/mobile/Containers/Receipt #42.pdf');
+    });
+
+    it('round-trips a literal % encoded by the share extension as %25', () => {
+        expect(fileURIToPath('file:///var/mobile/Containers/Report%2050%25.pdf')).toBe('/var/mobile/Containers/Report 50%.pdf');
+    });
+
+    it('falls back to the stripped raw path when the URI is not valid percent-encoding', () => {
+        expect(fileURIToPath('file:///var/mobile/Containers/Report 50%.pdf')).toBe('/var/mobile/Containers/Report 50%.pdf');
+    });
+
+    it('does not decode a content:// URI', () => {
+        expect(fileURIToPath('content://media/external/images/1%20a')).toBe('content://media/external/images/1%20a');
+    });
+
+    it('does not decode an https:// URL', () => {
+        expect(fileURIToPath('https://www.expensify.com/receipts/w_abc%20def.jpg')).toBe('https://www.expensify.com/receipts/w_abc%20def.jpg');
+    });
+
+    it('does not decode a path without the file:// scheme', () => {
+        expect(fileURIToPath('/var/mobile/Containers/Receipt%20%2342.pdf')).toBe('/var/mobile/Containers/Receipt%20%2342.pdf');
+    });
+});

--- a/tests/unit/getFileSizeTest.ts
+++ b/tests/unit/getFileSizeTest.ts
@@ -1,0 +1,34 @@
+import getFileSize from '@pages/Share/getFileSize/index.native';
+
+import type RNFS from 'react-native-fs';
+
+const mockStat = jest.fn<Promise<Partial<RNFS.StatResult>>, [string]>();
+
+jest.mock('react-native-fs', () => ({
+    stat: (...args: [string]) => mockStat(...args),
+}));
+
+describe('getFileSize', () => {
+    beforeEach(() => {
+        mockStat.mockReset();
+    });
+
+    it('stats the decoded POSIX path for an encoded share URI', async () => {
+        mockStat.mockResolvedValue({size: 1234});
+        const size = await getFileSize('file:///var/mobile/Containers/sharedFiles/Receipt%20%2342.pdf');
+        expect(size).toBe(1234);
+        expect(mockStat).toHaveBeenCalledWith('/var/mobile/Containers/sharedFiles/Receipt #42.pdf');
+    });
+
+    it('passes a plain path through unchanged', async () => {
+        mockStat.mockResolvedValue({size: 42});
+        const size = await getFileSize('/var/mobile/Containers/sharedFiles/receipt.pdf');
+        expect(size).toBe(42);
+        expect(mockStat).toHaveBeenCalledWith('/var/mobile/Containers/sharedFiles/receipt.pdf');
+    });
+
+    it('propagates a stat rejection so callers can handle it', async () => {
+        mockStat.mockRejectedValue(new Error('File not found'));
+        await expect(getFileSize('file:///var/mobile/Containers/sharedFiles/ghost.pdf')).rejects.toThrow('File not found');
+    });
+});

--- a/tests/unit/libs/receiptDurableStorageTest.ts
+++ b/tests/unit/libs/receiptDurableStorageTest.ts
@@ -1,62 +1,87 @@
+import fileURIToPath from '@libs/fileURIToPath';
+import moveReceiptToDurableStorage from '@libs/moveReceiptToDurableStorage/index.native';
+
+const mockMkdir = jest.fn<Promise<void>, [string]>();
+const mockExists = jest.fn<Promise<boolean>, [string]>();
+const mockMoveFile = jest.fn<Promise<void>, [string, string]>();
+
 jest.mock('react-native-fs', () => ({
-    exists: jest.fn(() => Promise.resolve(true)),
-    mkdir: jest.fn(() => Promise.resolve()),
-    moveFile: jest.fn(() => Promise.resolve()),
+    mkdir: (...args: [string]) => mockMkdir(...args),
+    exists: (...args: [string]) => mockExists(...args),
+    moveFile: (...args: [string, string]) => mockMoveFile(...args),
 }));
 
-const DURABLE_UPLOAD_DIR = '/var/mobile/Documents/Receipts-Upload';
+const mockGetReceiptsUploadFolderPath = jest.fn<string, []>();
+
 jest.mock('@libs/getReceiptsUploadFolderPath', () => ({
     __esModule: true,
-    default: () => DURABLE_UPLOAD_DIR,
+    default: () => mockGetReceiptsUploadFolderPath(),
 }));
 
-jest.mock('@libs/Log', () => ({
-    __esModule: true,
-    default: {warn: jest.fn(), alert: jest.fn()},
-}));
+const UPLOAD_FOLDER = '/var/mobile/Documents/Receipts-Upload';
 
-type MoveReceiptFn = (uri: string, fileName: string) => Promise<string>;
-
-// Bypass the global jest/setup.ts mock to test the real native implementation.
-
-const {default: moveReceiptToDurableStorage}: {default: MoveReceiptFn} = jest.requireActual('@libs/moveReceiptToDurableStorage/index.native.ts');
-
-describe('Receipt flows should persist to durable storage after crop/rotate', () => {
-    it('should move a cropped receipt out of ImageManipulator cache into Receipts-Upload', async () => {
-        const cachePath = 'file:///var/mobile/Library/Caches/ImageManipulator/cropped-abc123.jpg';
-
-        const result = await moveReceiptToDurableStorage(cachePath, 'receipt.jpg');
-
-        expect(result).toContain('Receipts-Upload');
-        expect(result).not.toContain('Library/Caches');
+describe('moveReceiptToDurableStorage', () => {
+    beforeEach(() => {
+        mockMkdir.mockReset().mockResolvedValue();
+        mockExists.mockReset().mockResolvedValue(true);
+        mockMoveFile.mockReset().mockResolvedValue();
+        mockGetReceiptsUploadFolderPath.mockReset().mockReturnValue(UPLOAD_FOLDER);
     });
 
-    it('should move a rotated receipt out of ImageManipulator cache into Receipts-Upload', async () => {
-        const cachePath = 'file:///var/mobile/Library/Caches/ImageManipulator/rotated-def456.jpg';
-
-        const result = await moveReceiptToDurableStorage(cachePath, 'rotated-receipt.jpg');
-
-        expect(result).toContain('Receipts-Upload');
-        expect(result).not.toContain('Library/Caches');
+    it('moves the file out of the cache into the upload folder and returns a file:// URI to the destination', async () => {
+        const result = await moveReceiptToDurableStorage('file:///var/mobile/Library/Caches/ImageManipulator/cropped-abc123.jpg', 'receipt.jpg');
+        const [sourcePath, destPath] = mockMoveFile.mock.calls.at(0) ?? [];
+        expect(sourcePath).toBe('/var/mobile/Library/Caches/ImageManipulator/cropped-abc123.jpg');
+        expect(destPath).toMatch(new RegExp(`^${UPLOAD_FOLDER}/receipt_\\d+\\.jpg$`));
+        expect(result).toBe(`file://${destPath}`);
     });
 
-    it('should generate unique destination paths to avoid filename collisions', async () => {
-        const cachePath1 = 'file:///var/mobile/Library/Caches/ImageManipulator/img1.jpg';
-        const cachePath2 = 'file:///var/mobile/Library/Caches/ImageManipulator/img2.jpg';
+    it('decodes an encoded source URI before moving', async () => {
+        await moveReceiptToDurableStorage('file:///cache/img%20%2342.jpg', 'receipt.jpg');
+        expect(mockMoveFile.mock.calls.at(0)?.at(0)).toBe('/cache/img #42.jpg');
+    });
 
-        const result1 = await moveReceiptToDurableStorage(cachePath1, 'receipt.jpg');
-        const result2 = await moveReceiptToDurableStorage(cachePath2, 'receipt.jpg');
+    it('sanitizes the on-disk name, keeping the extension', async () => {
+        await moveReceiptToDurableStorage('file:///cache/img.pdf', 'Receipt #42 50%.pdf');
+        const destPath = mockMoveFile.mock.calls.at(0)?.at(1) ?? '';
+        expect(destPath).toMatch(new RegExp(`^${UPLOAD_FOLDER}/Receipt__42_50__\\d+\\.pdf$`));
+        expect(destPath).not.toMatch(/[#% ]/);
+    });
 
+    it('returns a URI whose decoded and raw forms are identical', async () => {
+        const result = await moveReceiptToDurableStorage('file:///cache/img.pdf', 'Receipt from the store. #42.pdf');
+        const destPath = mockMoveFile.mock.calls.at(0)?.at(1);
+        expect(fileURIToPath(result)).toBe(destPath);
+    });
+
+    it('generates unique destination paths for the same filename', async () => {
+        const result1 = await moveReceiptToDurableStorage('file:///cache/img1.jpg', 'receipt.jpg');
+        const result2 = await moveReceiptToDurableStorage('file:///cache/img2.jpg', 'receipt.jpg');
         expect(result1).not.toBe(result2);
-        expect(result1).toMatch(/\.jpg$/);
-        expect(result2).toMatch(/\.jpg$/);
     });
 
-    it('should preserve receipts already in a durable directory', async () => {
-        const durablePath = `file://${DURABLE_UPLOAD_DIR}/existing-receipt.jpg`;
+    it('appends the unique suffix at the end when the filename has no extension', async () => {
+        await moveReceiptToDurableStorage('file:///cache/img', 'receipt');
+        expect(mockMoveFile.mock.calls.at(0)?.at(1)).toMatch(new RegExp(`^${UPLOAD_FOLDER}/receipt_\\d+$`));
+    });
 
-        const result = await moveReceiptToDurableStorage(durablePath, 'existing-receipt.jpg');
+    it('returns the source URI untouched when there is no upload folder', async () => {
+        mockGetReceiptsUploadFolderPath.mockReturnValue('');
+        const result = await moveReceiptToDurableStorage('file:///cache/img.jpg', 'receipt.jpg');
+        expect(result).toBe('file:///cache/img.jpg');
+        expect(mockMoveFile).not.toHaveBeenCalled();
+    });
 
-        expect(result).toContain('Receipts-Upload');
+    it('returns the source URI when the upload folder does not exist after mkdir', async () => {
+        mockExists.mockResolvedValue(false);
+        const result = await moveReceiptToDurableStorage('file:///cache/img.jpg', 'receipt.jpg');
+        expect(result).toBe('file:///cache/img.jpg');
+        expect(mockMoveFile).not.toHaveBeenCalled();
+    });
+
+    it('returns the source URI when the move fails', async () => {
+        mockMoveFile.mockRejectedValue(new Error('disk full'));
+        const result = await moveReceiptToDurableStorage('file:///cache/img.jpg', 'receipt.jpg');
+        expect(result).toBe('file:///cache/img.jpg');
     });
 });

--- a/tests/unit/verifyFileFormatTest.ts
+++ b/tests/unit/verifyFileFormatTest.ts
@@ -1,0 +1,33 @@
+import {verifyFileFormat} from '@libs/fileDownload/FileUtils';
+
+import {Platform} from 'react-native';
+
+const mockReadFile = jest.fn<Promise<string>, [string, string]>();
+
+jest.mock('react-native-blob-util', () => ({
+    __esModule: true,
+    default: {fs: {readFile: (...args: [string, string]) => mockReadFile(...args)}},
+}));
+
+describe('verifyFileFormat', () => {
+    let platformReplaceProperty: jest.ReplaceProperty<string>;
+
+    beforeEach(() => {
+        platformReplaceProperty = jest.replaceProperty(Platform, 'OS', 'ios');
+        mockReadFile.mockReset().mockResolvedValue(Buffer.from('0123456789abcdef').toString('base64'));
+    });
+
+    afterEach(() => {
+        platformReplaceProperty.restore();
+    });
+
+    it('reads the decoded POSIX path for an encoded file:// URI', async () => {
+        await verifyFileFormat({fileUri: 'file:///var/mobile/Containers/Receipt%20%2342.mov', formatSignatures: ['667479703flag']});
+        expect(mockReadFile).toHaveBeenCalledWith('/var/mobile/Containers/Receipt #42.mov', 'base64');
+    });
+
+    it('reads a raw path with only the scheme stripped when the URI is not percent-encoded', async () => {
+        await verifyFileFormat({fileUri: 'file:///var/mobile/Containers/video.mov', formatSignatures: ['667479703flag']});
+        expect(mockReadFile).toHaveBeenCalledWith('/var/mobile/Containers/video.mov', 'base64');
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Follow-up to #95852, which fixed one consumer (`checkFileExists`).

A file shared into the app arrives as a percent-encoded `file://` URI: a space becomes `%20` and a `#` becomes `%23`. Several consumers turned that URI into a filesystem path by only stripping the `file://` prefix, without decoding. Walk through a file named `Receipt #42.pdf`: it arrives as `.../Receipt%20%2342.pdf`, the consumer strips the prefix and hands the still-encoded string to the filesystem, and the lookup fails because no file with that literal name exists on disk.

Two changes close this class of bugs:

1. A new `fileURIToPath` helper turns a `file://` URI into the decoded path, and falls back to the raw path when the string is not valid percent-encoding. It replaces the one-off conversions in `getFileSize` (the confirmed break: `ShareRootPage` feeds it the encoded share URI), `verifyFileFormat`, `cropOrRotateImage`, `AttachmentPicker`, `FilePicker`, `ImportOnyxState`, the decode step of `checkFileExists`, and the Android local-file download branch, which used `decodeURI` and left `%23` encoded. Only `file://` URIs are decoded. `content://` URIs and remote URLs pass through untouched, so Android picker files and downloads behave exactly as before.
2. `moveReceiptToDurableStorage` now sanitizes the on-disk filename with the existing `cleanFileName` helper, so the `file://` URIs it produces never contain `#`, `%`, or a space. Without this, a file literally named `Receipt %2342.pdf` and an encoded `Receipt #42.pdf` are the same string, and no decode can tell them apart. The filename users see is not affected: it travels separately on the file object's `name` field (verified across receipt display, Onyx `receipt.filename`, and the upload payload).

Deliberately unchanged: `checkFileExists` keeps its stat-decoded-then-stat-raw fallback, because receipts queued offline before this change can still point at files with unsanitized names. The upload consumers (`readFileAsync` and the FormData `uri`) also stay on the encoded URI, which is the form `fetch` needs.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95673
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. On an iPhone, share a file whose name contains `#` and a space into Expensify (open an email in Gmail → Print → Share → Expensify, e.g. `Receipt #42.pdf`) and submit the expense. Verify the expense is created with the receipt attached, not $0.
2. Pick a receipt with a `#` in the filename via the in-app attachment picker and submit. Verify the receipt uploads and displays.
3. Verify unit tests pass: `npx jest tests/unit/fileURIToPathTest.ts tests/unit/getFileSizeTest.ts tests/unit/libs/receiptDurableStorageTest.ts tests/unit/verifyFileFormatTest.ts tests/unit/checkFileExistsTest.ts` (34 tests).

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Turn off the network. Share a file whose name contains `#` into Expensify and submit the expense. Turn the network back on. Verify the receipt uploads once the queue drains and the expense shows the receipt instead of $0.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as Tests steps 1-2 above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Logic-only fix, covered by unit tests.

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


