### PR TITLE
Fix receipt hover preview opening on the wrong side of the thumbnail

### DIFF
--- a/src/components/TransactionItemRow/ReceiptPreview/getAnchoredPreviewPosition.ts
+++ b/src/components/TransactionItemRow/ReceiptPreview/getAnchoredPreviewPosition.ts
@@ -32,6 +32,7 @@ function getAnchoredPreviewPosition(anchorPosition: AnchorPosition | undefined, 
     const rightOfThumbnail = anchorPosition.left + anchorPosition.width + RECEIPT_PREVIEW_GAP;
     const fitsLeft = leftOfThumbnail >= RECEIPT_PREVIEW_EDGE_MARGIN;
     const preferredLeft = fitsLeft ? leftOfThumbnail : rightOfThumbnail;
+
     // Clamp so the preview stays on-screen even when neither side has enough room (narrow viewports).
     const maxLeft = windowWidth - RECEIPT_PREVIEW_WIDTH - RECEIPT_PREVIEW_EDGE_MARGIN;
     const left = Math.max(RECEIPT_PREVIEW_EDGE_MARGIN, Math.min(preferredLeft, maxLeft));

--- a/src/components/TransactionItemRow/ReceiptPreview/getAnchoredPreviewPosition.ts
+++ b/src/components/TransactionItemRow/ReceiptPreview/getAnchoredPreviewPosition.ts
@@ -31,7 +31,10 @@ function getAnchoredPreviewPosition(anchorPosition: AnchorPosition | undefined, 
     const leftOfThumbnail = anchorPosition.left - RECEIPT_PREVIEW_WIDTH - RECEIPT_PREVIEW_GAP;
     const rightOfThumbnail = anchorPosition.left + anchorPosition.width + RECEIPT_PREVIEW_GAP;
     const fitsLeft = leftOfThumbnail >= RECEIPT_PREVIEW_EDGE_MARGIN;
-    const left = fitsLeft ? leftOfThumbnail : rightOfThumbnail;
+    const preferredLeft = fitsLeft ? leftOfThumbnail : rightOfThumbnail;
+    // Clamp so the preview stays on-screen even when neither side has enough room (narrow viewports).
+    const maxLeft = windowWidth - RECEIPT_PREVIEW_WIDTH - RECEIPT_PREVIEW_EDGE_MARGIN;
+    const left = Math.max(RECEIPT_PREVIEW_EDGE_MARGIN, Math.min(preferredLeft, maxLeft));
 
     // Before it's measured we can't bottom-align, so keep a minimum slice on-screen relative to the row top.
     if (previewHeight <= 0) {

--- a/src/components/TransactionItemRow/ReceiptPreview/getAnchoredPreviewPosition.ts
+++ b/src/components/TransactionItemRow/ReceiptPreview/getAnchoredPreviewPosition.ts
@@ -15,10 +15,10 @@ const RECEIPT_PREVIEW_EDGE_MARGIN = 24;
 const RECEIPT_PREVIEW_MIN_VISIBLE_HEIGHT = 160;
 
 /**
- * Anchors the preview's bottom-left corner to the right of the hovered thumbnail, so the preview grows upward
- * from the row. If there isn't room on the right, it flips to the left of the thumbnail. The top is clamped to a
- * viewport margin so a tall receipt near the top of the screen never runs off the top edge. Returns undefined
- * when there is no anchor, so the caller keeps the static style.
+ * Anchors the preview's bottom-left corner beside the hovered thumbnail, so the preview grows upward from the
+ * row. It prefers the left of the thumbnail and only flips to the right when there isn't room on the left. The
+ * top is clamped to a viewport margin so a tall receipt near the top of the screen never runs off the top edge.
+ * Returns undefined when there is no anchor, so the caller keeps the static style.
  *
  * @param previewHeight Measured height of the preview. 0 means "not measured yet" — we can't bottom-align without
  * it, so we fall back to aligning the top with the row (keeping a minimum slice on-screen) for the first frame.
@@ -28,9 +28,10 @@ function getAnchoredPreviewPosition(anchorPosition: AnchorPosition | undefined, 
         return undefined;
     }
 
+    const leftOfThumbnail = anchorPosition.left - RECEIPT_PREVIEW_WIDTH - RECEIPT_PREVIEW_GAP;
     const rightOfThumbnail = anchorPosition.left + anchorPosition.width + RECEIPT_PREVIEW_GAP;
-    const overflowsRight = windowWidth > 0 && rightOfThumbnail + RECEIPT_PREVIEW_WIDTH + RECEIPT_PREVIEW_EDGE_MARGIN > windowWidth;
-    const left = overflowsRight ? Math.max(RECEIPT_PREVIEW_EDGE_MARGIN, anchorPosition.left - RECEIPT_PREVIEW_WIDTH - RECEIPT_PREVIEW_GAP) : rightOfThumbnail;
+    const fitsLeft = leftOfThumbnail >= RECEIPT_PREVIEW_EDGE_MARGIN;
+    const left = fitsLeft ? leftOfThumbnail : rightOfThumbnail;
 
     // Before it's measured we can't bottom-align, so keep a minimum slice on-screen relative to the row top.
     if (previewHeight <= 0) {

--- a/tests/unit/components/ReceiptPreviewPositionTest.ts
+++ b/tests/unit/components/ReceiptPreviewPositionTest.ts
@@ -13,7 +13,17 @@ describe('getAnchoredPreviewPosition', () => {
         expect(getAnchoredPreviewPosition(undefined, WINDOW_WIDTH, WINDOW_HEIGHT)).toBeUndefined();
     });
 
-    it('places the preview just to the right of the hovered thumbnail', () => {
+    it('places the preview just to the left of the hovered thumbnail when there is room', () => {
+        const anchor = {top: 300, left: 500, width: 68, height: 64};
+
+        const position = getAnchoredPreviewPosition(anchor, WINDOW_WIDTH, WINDOW_HEIGHT);
+
+        expect(position?.left).toBe(anchor.left - RECEIPT_PREVIEW_WIDTH - RECEIPT_PREVIEW_GAP);
+        expect(position?.left).toBeLessThan(anchor.left);
+    });
+
+    it('flips to the right of the thumbnail when there is not enough room on the left', () => {
+        // A thumbnail hugging the left edge leaves no room for the preview to its left.
         const anchor = {top: 300, left: 120, width: 68, height: 64};
 
         const position = getAnchoredPreviewPosition(anchor, WINDOW_WIDTH, WINDOW_HEIGHT);
@@ -27,8 +37,7 @@ describe('getAnchoredPreviewPosition', () => {
         expect(getAnchoredPreviewPosition(anchor, WINDOW_WIDTH, WINDOW_HEIGHT)?.top).toBe(420);
     });
 
-    it('flips to the left of the thumbnail when there is not enough room on the right', () => {
-        // A thumbnail hugging the right edge leaves no room for a 380px-wide preview to its right.
+    it('keeps the preview to the left of a thumbnail near the right edge', () => {
         const anchor = {top: 300, left: WINDOW_WIDTH - 80, width: 68, height: 64};
 
         const position = getAnchoredPreviewPosition(anchor, WINDOW_WIDTH, WINDOW_HEIGHT);

--- a/tests/unit/components/ReceiptPreviewPositionTest.ts
+++ b/tests/unit/components/ReceiptPreviewPositionTest.ts
@@ -31,6 +31,17 @@ describe('getAnchoredPreviewPosition', () => {
         expect(position?.left).toBe(anchor.left + anchor.width + RECEIPT_PREVIEW_GAP);
     });
 
+    it('clamps the preview to the right edge when neither side fits on a narrow viewport', () => {
+        const narrowWidth = 801;
+        // Neither side has room: too little space on the left, and flipping right would overflow the edge.
+        const anchor = {top: 300, left: 400, width: 68, height: 64};
+
+        const position = getAnchoredPreviewPosition(anchor, narrowWidth, WINDOW_HEIGHT);
+
+        expect(position?.left).toBe(narrowWidth - RECEIPT_PREVIEW_WIDTH - RECEIPT_PREVIEW_EDGE_MARGIN);
+        expect((position?.left ?? 0) + RECEIPT_PREVIEW_WIDTH).toBeLessThanOrEqual(narrowWidth - RECEIPT_PREVIEW_EDGE_MARGIN);
+    });
+
     it('aligns the preview top with the hovered row before it has been measured', () => {
         const anchor = {top: 420, left: 120, width: 68, height: 64};
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

- Receipt hover preview now prefers opening to the left of the thumbnail, flipping right only when there isn't room on the left.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95975
PROPOSAL:


<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

### Offline tests

### QA Steps

1. Open a report/spend view that shows expense rows with receipt thumbnails.
2. Hover over a receipt thumbnail that has room to its left and verify the preview opens to the left of the thumbnail.
3. Hover over a receipt thumbnail hugging the left edge of the screen and verify the preview flips to the right, and that a tall receipt near the top stays fully on-screen.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/90a50e05-8ab9-45be-a539-f665442a5bd4

<!-- add screenshots or videos here -->

</details>
