### PR TITLE
Fix `HeaderWithBackButton` header buttons remounts which causes modals closing on orientation change

### DIFF
--- a/src/components/HeaderWithBackButton/index.tsx
+++ b/src/components/HeaderWithBackButton/index.tsx
@@ -82,6 +82,10 @@ function HeaderWithBackButton({
     shouldDisplaySearchRouter = false,
     progressBarPercentage,
     style,
+    shouldDisplayResponsiveChildrenInSeparateLine = false,
+    responsiveChildren,
+    responsiveChildrenContainerStyle,
+    bottomContent,
     subTitleLink = '',
     shouldMinimizeMenuButton = false,
     openParentReportInCurrentTab = false,
@@ -232,22 +236,55 @@ function HeaderWithBackButton({
         shouldSetModalVisibility,
     ]);
 
+    const shouldUseMultiLineLayout = shouldDisplayResponsiveChildrenInSeparateLine || !!bottomContent;
+    const movableChildrenContent = !!responsiveChildren && (
+        <View
+            key="movableChildren"
+            style={[
+                !shouldDisplayResponsiveChildrenInSeparateLine && styles.reportOptions,
+                !shouldDisplayResponsiveChildrenInSeparateLine && styles.flexRow,
+                styles.flexShrink0,
+                !shouldDisplayResponsiveChildrenInSeparateLine && styles.alignItemsCenter,
+                !shouldDisplayResponsiveChildrenInSeparateLine && shouldUseMultiLineLayout && styles.headerBarHeight,
+                shouldDisplayResponsiveChildrenInSeparateLine && styles.headerBarSeparateLineChildren,
+                responsiveChildrenContainerStyle,
+            ]}
+        >
+            {responsiveChildren}
+        </View>
+    );
+
     return (
         <View
             style={[
                 styles.headerBar,
+                styles.flexRow,
+                styles.alignItemsCenter,
                 shouldUseHeadlineHeader && styles.headerBarHeight,
                 shouldShowBorderBottom && styles.borderBottom,
                 // progressBarPercentage can be 0 which would
                 // be falsy, hence using !== undefined explicitly
                 progressBarPercentage !== undefined && styles.pl0,
                 shouldShowBackButton && [styles.pl2],
+                shouldUseMultiLineLayout && styles.headerBarWithSeparateLine,
                 shouldOverlay && StyleSheet.absoluteFill,
                 style,
             ]}
             onTouchStart={isInLandscapeMode ? () => Keyboard.dismiss() : undefined}
         >
-            <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter, styles.flexGrow1, styles.justifyContentBetween, styles.overflowHidden, styles.mr3]}>
+            <View
+                key="mainContent"
+                style={[
+                    styles.dFlex,
+                    styles.flexRow,
+                    styles.alignItemsCenter,
+                    styles.flex1,
+                    styles.overflowHidden,
+                    shouldUseMultiLineLayout && styles.mr3,
+                    shouldUseMultiLineLayout && styles.headerBarHeight,
+                    shouldUseMultiLineLayout && (shouldShowBackButton ? styles.pl2 : styles.pl5),
+                ]}
+            >
                 {shouldShowBackButton && (
                     <Tooltip text={translate('common.back')}>
                         <PressableWithoutFeedback
@@ -294,7 +331,13 @@ function HeaderWithBackButton({
                     />
                 )}
                 {middleContent}
-                <View style={[styles.reportOptions, styles.flexRow, styles.alignItemsCenter]}>
+            </View>
+            {!shouldDisplayResponsiveChildrenInSeparateLine && movableChildrenContent}
+            <View
+                key="systemActions"
+                style={[styles.flexRow, styles.flexShrink0, styles.alignItemsCenter, styles.mr3, shouldUseMultiLineLayout && styles.headerBarHeight]}
+            >
+                <View style={[styles.flexRow, styles.alignItemsCenter]}>
                     <View style={[styles.pr2, styles.flexRow, styles.alignItemsCenter]}>
                         {children}
                         {shouldShowDownloadButton &&
@@ -375,6 +418,15 @@ function HeaderWithBackButton({
                 {shouldDisplaySearchRouter && <SearchButton />}
                 {shouldDisplayHelpButton && <SidePanelButton />}
             </View>
+            {!!bottomContent && (
+                <View
+                    key="bottomContent"
+                    style={[styles.flexShrink0, styles.w100]}
+                >
+                    {bottomContent}
+                </View>
+            )}
+            {shouldDisplayResponsiveChildrenInSeparateLine && movableChildrenContent}
         </View>
     );
 }

--- a/src/components/HeaderWithBackButton/types.ts
+++ b/src/components/HeaderWithBackButton/types.ts
@@ -166,6 +166,18 @@ type HeaderWithBackButtonProps = Partial<ChildrenProps> & {
     /** Additional styles to add to the component */
     style?: StyleProp<ViewStyle>;
 
+    /** Whether responsive children should be displayed in a full-width line below the main header row */
+    shouldDisplayResponsiveChildrenInSeparateLine?: boolean;
+
+    /** Header actions that can move to a separate line. Regular children always stay in the main row. */
+    responsiveChildren?: ReactNode;
+
+    /** Additional styles for the responsive children container */
+    responsiveChildrenContainerStyle?: StyleProp<ViewStyle>;
+
+    /** Full-width content displayed below the main header row and above responsive children */
+    bottomContent?: ReactNode;
+
     /** The URL link associated with the attachment's subtitle, if available */
     subTitleLink?: string;
 

--- a/src/components/MoneyReportHeader.tsx
+++ b/src/components/MoneyReportHeader.tsx
@@ -131,24 +131,17 @@ function MoneyReportHeaderContent({reportID: reportIDProp, shouldDisplayBackButt
                 shouldShowBorderBottom={false}
                 shouldEnableDetailPageNavigation
                 openParentReportInCurrentTab
-            >
-                {shouldShowHeaderButtonsInHeaderRow && (
+                shouldDisplayResponsiveChildrenInSeparateLine={!shouldShowHeaderButtonsInHeaderRow}
+                responsiveChildrenContainerStyle={!shouldShowHeaderButtonsInHeaderRow && styles.ph0}
+                responsiveChildren={
                     <MoneyReportHeaderActions
                         reportID={reportIDProp}
                         primaryAction={primaryAction}
                         isReportInSearch={isReportInSearch}
                         backTo={backTo}
                     />
-                )}
-            </HeaderWithBackButton>
-            {!shouldShowHeaderButtonsInHeaderRow && (
-                <MoneyReportHeaderActions
-                    reportID={reportIDProp}
-                    primaryAction={primaryAction}
-                    isReportInSearch={isReportInSearch}
-                    backTo={backTo}
-                />
-            )}
+                }
+            />
             <MoneyReportHeaderMoreContent reportID={reportIDProp} />
             <HeaderLoadingBar />
         </View>

--- a/src/components/MoneyRequestHeader.tsx
+++ b/src/components/MoneyRequestHeader.tsx
@@ -178,13 +178,14 @@ function MoneyRequestHeader({reportID: reportIDProp, onBackButtonPress}: MoneyRe
                 onBackButtonPress={() => onBackButtonPress(isFromReviewDuplicates)}
                 shouldEnableDetailPageNavigation
                 openParentReportInCurrentTab={shouldOpenParentReportInCurrentTab}
-            >
-                {!shouldDisplayButtonsInSeparateLine && (
+                shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                responsiveChildren={
                     <MoneyRequestHeaderActions
                         reportID={reportID}
                         onBackButtonPress={onBackButtonPress}
                     />
-                )}
+                }
+            >
                 {shouldDisplayTransactionNavigation && !!transaction && (
                     <MoneyRequestReportTransactionsNavigation
                         currentTransactionID={transaction.transactionID}
@@ -192,12 +193,6 @@ function MoneyRequestHeader({reportID: reportIDProp, onBackButtonPress}: MoneyRe
                     />
                 )}
             </HeaderWithBackButton>
-            {shouldDisplayButtonsInSeparateLine && (
-                <MoneyRequestHeaderActions
-                    reportID={reportID}
-                    onBackButtonPress={onBackButtonPress}
-                />
-            )}
             {!!statusBarProps && (
                 <View style={[styles.ph5, styles.pb3]}>
                     <MoneyRequestHeaderStatusBar

--- a/src/pages/domain/Admins/DomainAdminsPage.tsx
+++ b/src/pages/domain/Admins/DomainAdminsPage.tsx
@@ -145,10 +145,9 @@ function DomainAdminsPage({route}: DomainAdminsPageProps) {
                     shouldShowBackButton={shouldUseNarrowLayout}
                     shouldUseHeadlineHeader
                     shouldDisplayHelpButton
-                >
-                    {!shouldDisplayButtonsInSeparateLine && headerContent}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && !!headerContent && <View style={[styles.ph5, styles.flexRow, styles.gap2]}>{headerContent}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={headerContent}
+                />
                 <DomainAdminsTable
                     domainAccountID={domainAccountID}
                     admins={admins}

--- a/src/pages/domain/BaseDomainMembersPage.tsx
+++ b/src/pages/domain/BaseDomainMembersPage.tsx
@@ -94,10 +94,9 @@ function BaseDomainMembersPage({
                     shouldShowBackButton={shouldUseNarrowLayout}
                     shouldUseHeadlineHeader={!useSelectionModeHeader}
                     shouldDisplayHelpButton
-                >
-                    {!shouldDisplayButtonsInSeparateLine && !!headerContent && <View style={[styles.flexRow, styles.gap2]}>{headerContent}</View>}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && !!headerContent && <View style={[styles.ph5, styles.flexRow, styles.gap2]}>{headerContent}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={!!headerContent && <View style={[styles.flexRow, styles.gap2]}>{headerContent}</View>}
+                />
                 <DomainMembersTable
                     domainAccountID={domainAccountID}
                     members={members}

--- a/src/pages/domain/Groups/DomainGroupsPage.tsx
+++ b/src/pages/domain/Groups/DomainGroupsPage.tsx
@@ -116,10 +116,9 @@ function DomainGroupsPage({route}: DomainGroupsPageProps) {
                     icon={illustrations.Members}
                     shouldShowBackButton={shouldUseNarrowLayout}
                     shouldUseHeadlineHeader
-                >
-                    {!shouldDisplayButtonsInSeparateLine && <View style={[styles.flexRow, styles.gap2]}>{createGroupHeaderButton}</View>}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && <View style={[styles.pl5, styles.pr5]}>{createGroupHeaderButton}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={createGroupHeaderButton}
+                />
 
                 <DomainGroupsTable
                     domainAccountID={domainAccountID}

--- a/src/pages/settings/Rules/ExpenseRulesPage.tsx
+++ b/src/pages/settings/Rules/ExpenseRulesPage.tsx
@@ -188,10 +188,9 @@ function ExpenseRulesPage() {
                 shouldUseHeadlineHeader={!selectionModeHeader}
                 shouldDisplayHelpButton
                 title={selectionModeHeader ? translate('common.selectMultiple') : translate('expenseRulesPage.title')}
-            >
-                {!shouldDisplayButtonsInSeparateLine && hasRules && headerButton}
-            </HeaderWithBackButton>
-            {shouldDisplayButtonsInSeparateLine && hasRules && <View style={[styles.pl5, styles.pr5]}>{headerButton}</View>}
+                shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                responsiveChildren={hasRules && headerButton}
+            />
 
             <View style={[styles.ph5, styles.pb5, styles.pt3, shouldUseNarrowLayout && styles.workspaceSectionMobile]}>
                 <Text style={[styles.textNormal, styles.colorMuted]}>{translate('expenseRulesPage.subtitle')}</Text>

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -702,11 +702,10 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
 
     const shouldDisplayButtonsInSeparateLine = useShouldDisplayButtonsInSeparateLine();
 
-    const getHeaderButtons = () => {
-        if (!canWriteMembers) {
-            return null;
-        }
-        return (shouldUseNarrowLayout ? canSelectMultiple : selectedEmployees.length > 0) ? (
+    const shouldShowBulkActions = shouldUseNarrowLayout ? canSelectMultiple : selectedEmployees.length > 0;
+    let headerButtons = null;
+    if (canWriteMembers) {
+        headerButtons = shouldShowBulkActions ? (
             <ButtonWithDropdownMenu<WorkspaceMemberBulkActionType>
                 variant={CONST.BUTTON_VARIANT.SUCCESS}
                 shouldAlwaysShowDropdownMenu
@@ -742,7 +741,7 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
                 />
             </View>
         );
-    };
+    }
 
     const selectionModeHeader = isMobileSelectionModeEnabled && shouldUseNarrowLayout;
 
@@ -751,7 +750,8 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
             headerText={selectionModeHeader ? translate('common.selectMultiple') : translate('workspace.common.members')}
             route={route}
             icon={!selectionModeHeader ? illustrations.ReceiptWrangler : undefined}
-            headerContent={!shouldDisplayButtonsInSeparateLine && getHeaderButtons()}
+            headerContent={headerButtons}
+            shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
             testID="WorkspaceMembersPage"
             shouldShowLoading={false}
             shouldUseHeadlineHeader={!selectionModeHeader}
@@ -769,7 +769,6 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
         >
             {() => (
                 <>
-                    {shouldDisplayButtonsInSeparateLine && <View style={[styles.pl5, styles.pr5]}>{getHeaderButtons()}</View>}
                     <DecisionModal
                         title={translate('common.downloadFailedTitle')}
                         prompt={translate('common.downloadFailedDescription')}

--- a/src/pages/workspace/WorkspaceOverviewPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewPage.tsx
@@ -509,11 +509,11 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
             shouldShowNotFoundPage={policy === undefined}
             onBackButtonPress={handleBackButtonPress}
             addBottomSafeAreaPadding
-            headerContent={!shouldDisplayButtonsInSeparateLine && headerButtons}
+            headerContent={headerButtons}
+            shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
             modals={modals}
         >
             <View style={[styles.flex1, styles.mt3, shouldUseNarrowLayout ? styles.workspaceSectionMobile : styles.workspaceSection]}>
-                {shouldDisplayButtonsInSeparateLine && <View style={[styles.pl5, styles.pr5, styles.pb5]}>{headerButtons}</View>}
                 <Section
                     isCentralPane
                     title=""

--- a/src/pages/workspace/WorkspacePageWithSections.tsx
+++ b/src/pages/workspace/WorkspacePageWithSections.tsx
@@ -40,7 +40,16 @@ import type {WithPolicyAndFullscreenLoadingProps} from './withPolicyAndFullscree
 import withPolicyAndFullscreenLoading from './withPolicyAndFullscreenLoading';
 
 type WorkspacePageWithSectionsProps = WithPolicyAndFullscreenLoadingProps &
-    Pick<HeaderWithBackButtonProps, 'shouldShowThreeDotsButton' | 'threeDotsMenuItems' | 'shouldShowBackButton' | 'onBackButtonPress'> & {
+    Pick<
+        HeaderWithBackButtonProps,
+        | 'shouldShowThreeDotsButton'
+        | 'threeDotsMenuItems'
+        | 'shouldShowBackButton'
+        | 'onBackButtonPress'
+        | 'shouldDisplayResponsiveChildrenInSeparateLine'
+        | 'responsiveChildrenContainerStyle'
+        | 'bottomContent'
+    > & {
         shouldSkipVBBACall?: boolean;
 
         /** The text to display in the header */
@@ -146,6 +155,9 @@ function WorkspacePageWithSections({
     shouldUseHeadlineHeader = true,
     addBottomSafeAreaPadding = false,
     modals,
+    shouldDisplayResponsiveChildrenInSeparateLine = false,
+    responsiveChildrenContainerStyle,
+    bottomContent,
 }: WorkspacePageWithSectionsProps) {
     const styles = useThemeStyles();
     const policyID = route.params?.policyID;
@@ -246,9 +258,11 @@ function WorkspacePageWithSections({
                     threeDotsMenuItems={threeDotsMenuItems}
                     shouldUseHeadlineHeader={shouldUseHeadlineHeader}
                     shouldDisplayHelpButton
-                >
-                    {headerContent}
-                </HeaderWithBackButton>
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayResponsiveChildrenInSeparateLine}
+                    responsiveChildrenContainerStyle={responsiveChildrenContainerStyle}
+                    responsiveChildren={headerContent}
+                    bottomContent={bottomContent}
+                />
                 {!isOffline && (isLoading || shouldShowInitialLoading) && shouldShowLoading && isFocused ? (
                     <View style={[styles.flex1, styles.fullScreenLoading]}>
                         <ActivityIndicator

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -660,6 +660,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                     icon={!selectionModeHeader ? illustrations.FolderOpen : undefined}
                     shouldUseHeadlineHeader={!selectionModeHeader}
                     shouldDisplayHelpButton
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
                     onBackButtonPress={() => {
                         if (isMobileSelectionModeEnabled) {
                             clearTableSelection();
@@ -674,10 +675,8 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
 
                         Navigation.goBack();
                     }}
-                >
-                    {!shouldDisplayButtonsInSeparateLine && getHeaderButtons()}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && !!getHeaderButtons() && <View style={[styles.pl5, styles.pr5]}>{getHeaderButtons()}</View>}
+                    responsiveChildren={getHeaderButtons()}
+                />
 
                 {(!hasVisibleCategories || isLoading) && headerContent}
 

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -470,10 +470,9 @@ function PolicyDistanceRatesPage({
                         }
                         Navigation.goBack();
                     }}
-                >
-                    {!shouldDisplayButtonsInSeparateLine && headerButtons}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && !!headerButtons && <View style={[styles.ph5]}>{headerButtons}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={headerButtons}
+                />
                 {isLoading && (
                     <ActivityIndicator
                         size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE}

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
@@ -305,10 +305,9 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldDisplayHelpButton
                 onBackButtonPress={handleBackButtonPress}
-            >
-                {!shouldShowSelector && !shouldDisplayButtonsInSeparateLine && isBankAccountVerified && shouldShowHeaderButtons && getHeaderButtons()}
-            </HeaderWithBackButton>
-            {!shouldShowSelector && shouldDisplayButtonsInSeparateLine && isBankAccountVerified && shouldShowHeaderButtons && <View style={styles.ph5}>{getHeaderButtons()}</View>}
+                shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                responsiveChildren={!shouldShowSelector && isBankAccountVerified && shouldShowHeaderButtons && getHeaderButtons()}
+            />
             {shouldShowSelector && (
                 <View style={[styles.w100, styles.ph5, styles.pb3, (!shouldChangeLayout || isInLandscapeMode) && [styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween]]}>
                     <FeedSelector

--- a/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
+++ b/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
@@ -404,10 +404,9 @@ function WorkspacePerDiemPage({route}: WorkspacePerDiemPageProps) {
 
                         Navigation.goBack();
                     }}
-                >
-                    {!shouldDisplayButtonsInSeparateLine && headerButtons}
-                </HeaderWithBackButton>
-                {!!headerButtons && shouldDisplayButtonsInSeparateLine && <View style={[styles.pl5, styles.pr5]}>{headerButtons}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={headerButtons}
+                />
                 {(!hasVisibleSubRates || isLoading) && subtitleContent}
                 {isLoading && (
                     <ActivityIndicator

--- a/src/pages/workspace/reports/ReportFieldsListValuesPage.tsx
+++ b/src/pages/workspace/reports/ReportFieldsListValuesPage.tsx
@@ -341,10 +341,9 @@ function ReportFieldsListValuesPage({
                         }
                         Navigation.goBack();
                     }}
-                >
-                    {!shouldDisplayButtonsInSeparateLine && headerButtons}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && <View style={[styles.pl5, styles.pr5]}>{headerButtons}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={headerButtons}
+                />
                 <View style={[styles.ph5, styles.pb5, styles.pt3]}>
                     <Text style={[styles.sidebarLinkText, styles.optionAlternateText]}>{translate('workspace.reportFields.listInputSubtitle')}</Text>
                 </View>

--- a/src/pages/workspace/rules/PolicyRulesPage.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPage.tsx
@@ -59,6 +59,7 @@ function PolicyRulesPage(props: PolicyRulesPageProps) {
     const {canWrite: canWriteRules, showReadOnlyModal, withReadOnlyFallback} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.RULES);
     const {isBetaEnabled} = usePermissions();
     const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
+
     const isCustomAgentBetaEnabled = isBetaEnabled(CONST.BETAS.CUSTOM_AGENT);
     const [isAgentsRulesBannerDismissed = false] = useOnyx(ONYXKEYS.NVP_DISMISSED_PRODUCT_TRAINING, {selector: agentsRulesBannerDismissedSelector});
 

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -315,28 +315,29 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
                 shouldShowNotFoundPage={false}
                 shouldShowLoading={false}
                 addBottomSafeAreaPadding
-                headerContent={!shouldDisplayButtonsInSeparateLine && headerButtons}
+                headerContent={headerButtons}
+                shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                responsiveChildrenContainerStyle={shouldDisplayButtonsInSeparateLine && styles.pb5}
+                bottomContent={
+                    <View style={[styles.flexRow, styles.mb1, styles.w100]}>
+                        <TabSelectorContextProvider activeTabKey={activeTab}>
+                            <TabSelectorBase
+                                tabs={tabs}
+                                activeTabKey={activeTab}
+                                onTabPress={(key) => {
+                                    if (!isRulesTab(key)) {
+                                        return;
+                                    }
+                                    setSelectedRuleKeysByTab({});
+                                    turnOffMobileSelectionMode();
+                                    Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, key);
+                                }}
+                            />
+                        </TabSelectorContextProvider>
+                    </View>
+                }
             >
                 <View style={[styles.flex1, styles.w100, styles.mnh0]}>
-                    <View style={[styles.flexShrink0, styles.w100]}>
-                        <View style={[styles.flexRow, styles.mb1, styles.w100]}>
-                            <TabSelectorContextProvider activeTabKey={activeTab}>
-                                <TabSelectorBase
-                                    tabs={tabs}
-                                    activeTabKey={activeTab}
-                                    onTabPress={(key) => {
-                                        if (!isRulesTab(key)) {
-                                            return;
-                                        }
-                                        setSelectedRuleKeysByTab({});
-                                        turnOffMobileSelectionMode();
-                                        Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, key);
-                                    }}
-                                />
-                            </TabSelectorContextProvider>
-                        </View>
-                    </View>
-                    {shouldDisplayButtonsInSeparateLine && !!headerButtons && <View style={[styles.flexShrink0, styles.pl5, styles.pr5, styles.pb5, styles.w100]}>{headerButtons}</View>}
                     <View style={[styles.flex1, styles.mnh0, styles.w100, shouldUseNarrowLayout ? styles.workspaceSectionMobile : styles.workspaceSection, isTableTab && styles.mw100]}>
                         {activeTab === RULES_TAB.GENERAL && (
                             <RulesGeneralTab

--- a/src/pages/workspace/tags/DynamicWorkspaceViewTagsPage.tsx
+++ b/src/pages/workspace/tags/DynamicWorkspaceViewTagsPage.tsx
@@ -357,10 +357,9 @@ function DynamicWorkspaceViewTagsPage({route}: DynamicWorkspaceViewTagsProps) {
                         }
                         Navigation.goBack(backPath);
                     }}
-                >
-                    {!shouldDisplayButtonsInSeparateLine && headerButtons}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && !!headerButtons && <View style={[styles.pl5, styles.pr5]}>{headerButtons}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={headerButtons}
+                />
                 {!hasDependentTags && (
                     <View style={[styles.pv4, styles.ph5]}>
                         <ToggleSettingOptionRow

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -862,10 +862,9 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
 
                             Navigation.goBack();
                         }}
-                    >
-                        {!shouldDisplayButtonsInSeparateLine && getHeaderButtons()}
-                    </HeaderWithBackButton>
-                    {shouldDisplayButtonsInSeparateLine && !!getHeaderButtons() && <View style={[styles.pl5, styles.pr5]}>{getHeaderButtons()}</View>}
+                        shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                        responsiveChildren={getHeaderButtons()}
+                    />
                     {(!hasVisibleTags || isLoading) && headerContent}
                     {isLoading && (
                         <ActivityIndicator

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -399,10 +399,9 @@ function WorkspaceTaxesPage({
                         }
                         Navigation.goBack();
                     }}
-                >
-                    {!shouldDisplayButtonsInSeparateLine && headerButtons}
-                </HeaderWithBackButton>
-                {shouldDisplayButtonsInSeparateLine && !!headerButtons && <View style={[styles.pl5, styles.pr5]}>{headerButtons}</View>}
+                    shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayButtonsInSeparateLine}
+                    responsiveChildren={headerButtons}
+                />
                 {(!hasVisibleTaxes || isLoading) && headerContent}
                 {isLoading && (
                     <ActivityIndicator

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -2739,6 +2739,18 @@ const staticStyles = (theme: ThemeColors) =>
             width: '100%',
         },
 
+        headerBarWithSeparateLine: {
+            height: 'auto',
+            flexWrap: 'wrap',
+            alignItems: 'flex-start',
+            paddingLeft: 0,
+        },
+
+        headerBarSeparateLineChildren: {
+            width: '100%',
+            paddingHorizontal: 20,
+        },
+
         reportSearchHeaderBar: {
             justifyContent: 'center',
             display: 'flex',

--- a/tests/ui/WorkspaceMembersTest.tsx
+++ b/tests/ui/WorkspaceMembersTest.tsx
@@ -8,6 +8,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 import * as useResponsiveLayoutModule from '@hooks/useResponsiveLayout';
 import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
+import * as useShouldDisplayButtonsInSeparateLineModule from '@hooks/useShouldDisplayButtonsInSeparateLine';
 
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 
@@ -34,25 +35,34 @@ TestHelper.setupGlobalFetchMock();
 
 const Stack = createPlatformStackNavigator<WorkspaceSplitNavigatorParamList>();
 
+const getPage = (initialRouteName: typeof SCREENS.WORKSPACE.MEMBERS, initialParams: WorkspaceSplitNavigatorParamList[typeof SCREENS.WORKSPACE.MEMBERS]) => (
+    <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, CurrentReportIDContextProvider, ModalProvider]}>
+        <PortalProvider>
+            <NavigationContainer>
+                <Stack.Navigator initialRouteName={initialRouteName}>
+                    <Stack.Screen
+                        name={SCREENS.WORKSPACE.MEMBERS}
+                        component={WorkspaceMembersPage}
+                        initialParams={initialParams}
+                    />
+                </Stack.Navigator>
+            </NavigationContainer>
+        </PortalProvider>
+    </ComposeProviders>
+);
+
 const renderPage = (initialRouteName: typeof SCREENS.WORKSPACE.MEMBERS, initialParams: WorkspaceSplitNavigatorParamList[typeof SCREENS.WORKSPACE.MEMBERS]) => {
-    return render(
-        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, CurrentReportIDContextProvider, ModalProvider]}>
-            <PortalProvider>
-                <NavigationContainer>
-                    <Stack.Navigator initialRouteName={initialRouteName}>
-                        <Stack.Screen
-                            name={SCREENS.WORKSPACE.MEMBERS}
-                            component={WorkspaceMembersPage}
-                            initialParams={initialParams}
-                        />
-                    </Stack.Navigator>
-                </NavigationContainer>
-            </PortalProvider>
-        </ComposeProviders>,
-    );
+    return render(getPage(initialRouteName, initialParams));
 };
 
-const selectCheckboxByMemberName = (memberName: string) => {
+const defaultResponsiveLayout = {
+    isSmallScreenWidth: false,
+    shouldUseNarrowLayout: false,
+} as ResponsiveLayoutResult;
+let responsiveLayout = defaultResponsiveLayout;
+let shouldDisplayButtonsInSeparateLine = false;
+
+const getRowByMemberName = (memberName: string) => {
     const memberEmailByName: Record<string, string> = {
         Owner: 'owner@gmail.com',
         Admin: 'admin@example.com',
@@ -61,7 +71,11 @@ const selectCheckboxByMemberName = (memberName: string) => {
         Self: 'test@example.com',
     };
     const displayName = memberName === 'Owner' || memberName === 'Self' ? memberName : `${memberName} User`;
-    const row = screen.getByLabelText(new RegExp(`^${displayName}, ${memberEmailByName[memberName]}`));
+    return screen.getByLabelText(new RegExp(`^${displayName}, ${memberEmailByName[memberName]}`));
+};
+
+const selectCheckboxByMemberName = (memberName: string) => {
+    const row = getRowByMemberName(memberName);
     fireEvent.press(within(row).getByLabelText(TestHelper.translateLocal('common.select')));
 };
 
@@ -114,10 +128,10 @@ describe('WorkspaceMembers', () => {
             });
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
         });
-        jest.spyOn(useResponsiveLayoutModule, 'default').mockReturnValue({
-            isSmallScreenWidth: false,
-            shouldUseNarrowLayout: false,
-        } as ResponsiveLayoutResult);
+        responsiveLayout = defaultResponsiveLayout;
+        shouldDisplayButtonsInSeparateLine = false;
+        jest.spyOn(useResponsiveLayoutModule, 'default').mockImplementation(() => responsiveLayout);
+        jest.spyOn(useShouldDisplayButtonsInSeparateLineModule, 'default').mockImplementation(() => shouldDisplayButtonsInSeparateLine);
     });
 
     afterEach(async () => {
@@ -427,6 +441,35 @@ describe('WorkspaceMembers', () => {
     });
 
     describe('Removing members who are approvers and non-approvers', () => {
+        it('keeps the bulk menu action working after an orientation change', async () => {
+            const routeParams = {policyID: policy.id};
+            const {rerender, unmount} = renderPage(SCREENS.WORKSPACE.MEMBERS, routeParams);
+            await waitForBatchedUpdatesWithAct();
+            await screen.findByText(ADMIN_OPTION);
+
+            selectCheckboxByMemberName('Admin');
+            fireEvent.press(await screen.findByTestId('WorkspaceMembersPage-header-dropdown-menu-button'));
+            await waitForBatchedUpdatesWithAct();
+
+            const removeText = TestHelper.translateLocal('workspace.people.removeMembersTitle', {count: 1});
+            expect(screen.getByTestId(`PopoverMenuItem-${removeText}`)).toBeOnTheScreen();
+
+            shouldDisplayButtonsInSeparateLine = true;
+            rerender(getPage(SCREENS.WORKSPACE.MEMBERS, routeParams));
+
+            const removeMenuItem = await screen.findByTestId(`PopoverMenuItem-${removeText}`);
+            fireEvent.press(removeMenuItem, {
+                nativeEvent: {},
+                type: 'press',
+                target: removeMenuItem,
+                currentTarget: removeMenuItem,
+            });
+            await waitForBatchedUpdatesWithAct();
+
+            expect(await screen.findByLabelText(TestHelper.translateLocal('common.remove'))).toBeOnTheScreen();
+            unmount();
+        });
+
         it('should call workflow actions once when removing multiple members including an approver', async () => {
             const {unmount} = renderPage(SCREENS.WORKSPACE.MEMBERS, {policyID: policy.id});
             await waitForBatchedUpdatesWithAct();

--- a/tests/ui/components/ButtonWithDropdownMenuTest.tsx
+++ b/tests/ui/components/ButtonWithDropdownMenuTest.tsx
@@ -1,8 +1,11 @@
-import {fireEvent, render, renderHook, screen} from '@testing-library/react-native';
+import {fireEvent, render, renderHook, screen, waitFor} from '@testing-library/react-native';
 
 import ButtonWithDropdownMenu from '@components/ButtonWithDropdownMenu';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
 
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import * as usePopoverPositionModule from '@hooks/usePopoverPosition';
+import * as useWindowDimensionsModule from '@hooks/useWindowDimensions';
 
 import CONST from '@src/CONST';
 
@@ -125,5 +128,73 @@ describe('ButtonWithDropdownMenu (dropdown arrow flip)', () => {
             fireEvent.press(buttonToPress);
         }
         expect(arrowIcon).not.toHaveStyle({transform: 'rotate(180deg)'});
+    });
+});
+
+describe('ButtonWithDropdownMenu in a responsive header', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('stays open and keeps its action when moved to a separate line', () => {
+        const onSelected = jest.fn();
+        const options = [{value: 'action', text: 'Responsive action', onSelected, shouldCloseModalOnSelect: false}];
+        const renderHeader = (shouldDisplayResponsiveChildrenInSeparateLine: boolean) => (
+            <HeaderWithBackButton
+                title="Responsive header"
+                shouldShowBackButton={false}
+                shouldDisplayResponsiveChildrenInSeparateLine={shouldDisplayResponsiveChildrenInSeparateLine}
+                responsiveChildren={
+                    <ButtonWithDropdownMenu
+                        options={options}
+                        onPress={() => {}}
+                        customText="More"
+                        shouldAlwaysShowDropdownMenu
+                        isSplitButton={false}
+                    />
+                }
+            />
+        );
+        const {rerender} = render(renderHeader(false));
+
+        fireEvent.press(screen.getByText('More'));
+        expect(screen.getByText('Responsive action')).toBeOnTheScreen();
+
+        rerender(renderHeader(true));
+        expect(screen.getByText('Responsive action')).toBeOnTheScreen();
+
+        const menuItem = screen.getByTestId('PopoverMenuItem-Responsive action');
+        fireEvent.press(menuItem, {
+            nativeEvent: {},
+            type: 'press',
+            target: menuItem,
+            currentTarget: menuItem,
+        });
+        expect(onSelected).toHaveBeenCalledTimes(1);
+    });
+
+    it('remeasures an open menu when the window dimensions change', async () => {
+        const calculatePopoverPosition = jest.fn().mockResolvedValue({horizontal: 100, vertical: 100, width: 40, height: 40});
+        let windowDimensions = {windowWidth: 800, windowHeight: 600};
+        jest.spyOn(usePopoverPositionModule, 'default').mockReturnValue({calculatePopoverPosition});
+        jest.spyOn(useWindowDimensionsModule, 'default').mockImplementation(() => windowDimensions);
+        const renderDropdown = () => (
+            <ButtonWithDropdownMenu
+                options={[{value: 'action', text: 'Responsive action'}]}
+                onPress={() => {}}
+                customText="More"
+                shouldAlwaysShowDropdownMenu
+                isSplitButton={false}
+            />
+        );
+        const {rerender} = render(renderDropdown());
+
+        fireEvent.press(screen.getByText('More'));
+        await waitFor(() => expect(calculatePopoverPosition).toHaveBeenCalledTimes(1));
+
+        windowDimensions = {windowWidth: 600, windowHeight: 800};
+        rerender(renderDropdown());
+
+        await waitFor(() => expect(calculatePopoverPosition).toHaveBeenCalledTimes(2));
     });
 });


### PR DESCRIPTION
### Explanation of Change

Updates `HeaderWithBackButton` to keep responsive header actions mounted while moving them between header row and below the header, preventing open dropdowns from losing state during orientation changes. Adding `bottomContent` to `HeaderWithBackButton` to allow putting tabs row on the new Workspace Rules page (`PolicyRulesPageRevamp`) between header buttons when they are shown below the header (to keep the current layout)

Discussed [here](https://github.com/Expensify/App/pull/95276#issuecomment-4915699632) 

### Fixed Issues
$ https://github.com/Expensify/App/issues/77280 and discussed [here](https://github.com/Expensify/App/pull/95276#issuecomment-4915699632)
PROPOSAL: N/A

### Tests


- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
