### PR TITLE
perf: scope reportAttributes error propagation to changed chats

### DIFF
--- a/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
@@ -35,6 +35,52 @@ let previousDisplayNames: Record<string, string> = {};
 let previousPersonalDetails: OnyxEntry<PersonalDetailsList> | undefined;
 let previousPolicies: OnyxCollection<Policy>;
 
+// Which chat each child report belongs to, and the reverse. Kept in sync incrementally so
+// error propagation doesn't have to walk every report on each compute.
+const childToChat = new Map<string, string>();
+const childrenByChat = new Map<string, Set<string>>();
+
+const rebuildChildChatIndex = (reports: OnyxCollection<Report>) => {
+    childToChat.clear();
+    childrenByChat.clear();
+    for (const report of Object.values(reports ?? {})) {
+        if (!report?.reportID || !report.chatReportID || report.reportID === report.chatReportID) {
+            continue;
+        }
+        childToChat.set(report.reportID, report.chatReportID);
+        const children = childrenByChat.get(report.chatReportID) ?? new Set<string>();
+        children.add(report.reportID);
+        childrenByChat.set(report.chatReportID, children);
+    }
+};
+
+// Points a child at its (possibly new) chat. Returns the chats whose child list changed —
+// a chat a child left may need its propagated error cleared, so callers must re-enqueue them.
+const updateChildChatIndex = (childReportID: string, chatReportID: string | undefined): string[] => {
+    const previousChatReportID = childToChat.get(childReportID);
+    if (previousChatReportID === chatReportID) {
+        return [];
+    }
+    const affectedChatIDs: string[] = [];
+    if (previousChatReportID) {
+        childToChat.delete(childReportID);
+        const previousChildren = childrenByChat.get(previousChatReportID);
+        previousChildren?.delete(childReportID);
+        if (previousChildren?.size === 0) {
+            childrenByChat.delete(previousChatReportID);
+        }
+        affectedChatIDs.push(previousChatReportID);
+    }
+    if (chatReportID) {
+        childToChat.set(childReportID, chatReportID);
+        const children = childrenByChat.get(chatReportID) ?? new Set<string>();
+        children.add(childReportID);
+        childrenByChat.set(chatReportID, children);
+        affectedChatIDs.push(chatReportID);
+    }
+    return affectedChatIDs;
+};
+
 const RECOMPUTE_ALL = 'all' as const;
 
 const prepareReportKeys = (keys: string[]) => {
@@ -157,7 +203,12 @@ const reportReferencesAccountIDs = (report: Report, accountIDs: Set<number>): bo
 
 // Returns the report-preview action ID of the oldest child in `reportIDs` matching `predicate`
 // (oldest by preview-action creation time), or undefined when none match.
-const getOldestPreviewActionID = (chatReportID: string, reportIDs: string[] | undefined, reports: OnyxCollection<Report>, predicate?: (childReport: OnyxEntry<Report>) => boolean) => {
+const getOldestPreviewActionID = (
+    chatReportID: string,
+    reportIDs: Iterable<string> | undefined,
+    reports: OnyxCollection<Report>,
+    predicate?: (childReport: OnyxEntry<Report>) => boolean,
+) => {
     let oldestCreated: string | undefined;
     let targetReportActionID: string | undefined;
     for (const childReportID of reportIDs ?? []) {
@@ -310,6 +361,23 @@ export default createOnyxDerivedValueConfig({
         const transactionViolationsUpdates = sourceValues?.[ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS];
         const policyTagsUpdates = sourceValues?.[ONYXKEYS.COLLECTION.POLICY_TAGS];
 
+        // Keep the chat → children index in sync. A child that was deleted or moved to another chat
+        // changes the error state of the chat it left, which nothing else re-enqueues — collect those
+        // chats so they are recomputed (and their stale propagated error cleared) in this pass.
+        const indexAffectedChatKeys: string[] = [];
+        if (useIncrementalUpdates) {
+            for (const reportKey of Object.keys(reportUpdates)) {
+                const report = reports[reportKey];
+                const reportID = reportKey.replace(ONYXKEYS.COLLECTION.REPORT, '');
+                const chatReportID = report?.chatReportID && report.chatReportID !== report.reportID ? report.chatReportID : undefined;
+                for (const affectedChatID of updateChildChatIndex(reportID, chatReportID)) {
+                    indexAffectedChatKeys.push(`${ONYXKEYS.COLLECTION.REPORT}${affectedChatID}`);
+                }
+            }
+        } else {
+            rebuildChildChatIndex(reports);
+        }
+
         let dataToIterate = Object.keys(reports);
         // check if there are any report-related updates
 
@@ -347,6 +415,7 @@ export default createOnyxDerivedValueConfig({
             ...Array.from(reportUpdatesRelatedToReportActions),
             ...policyChangedReportKeys,
             ...personalDetailsChangedReportKeys,
+            ...indexAffectedChatKeys,
         ];
 
         if (useIncrementalUpdates) {
@@ -355,18 +424,6 @@ export default createOnyxDerivedValueConfig({
                 dataToIterate = [];
                 if (updates.length > 0) {
                     dataToIterate = prepareReportKeys(updates);
-
-                    // When an IOU report changes, we need to re-evaluate its parent chat report as well.
-                    const parentChatReportIDsToUpdate = new Set<string>();
-                    for (const reportKey of dataToIterate) {
-                        const report = reports[reportKey];
-                        if (report?.chatReportID && report.reportID !== report.chatReportID) {
-                            parentChatReportIDsToUpdate.add(`${ONYXKEYS.COLLECTION.REPORT}${report.chatReportID}`);
-                        }
-                    }
-                    if (parentChatReportIDsToUpdate.size > 0) {
-                        dataToIterate.push(...Array.from(parentChatReportIDsToUpdate));
-                    }
                 }
                 if (!!transactionsUpdates || !!transactionViolationsUpdates) {
                     let transactionReportIDs: string[] = [];
@@ -405,15 +462,7 @@ export default createOnyxDerivedValueConfig({
                         transactionReportIDs = [...transactionReportIDs, ...violationReportIDs, ...chatReportIDs];
                     }
 
-                    // A transaction change (e.g. a card expense going from pending to posted) can flip whether its
-                    // expense report requires attention, but the to-do/GBR render on the parent workspace chat.
-                    // Enqueue those parent chats too so their attributes don't stay stale after the transaction updates.
-                    const transactionParentChatReportIDs = transactionReportIDs
-                        .map((reportKey) => reports?.[reportKey]?.chatReportID)
-                        .filter(Boolean)
-                        .map((chatReportID) => `${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`);
-
-                    dataToIterate.push(...prepareReportKeys([...transactionReportIDs, ...transactionParentChatReportIDs]));
+                    dataToIterate.push(...prepareReportKeys(transactionReportIDs));
                 }
                 if (policyTagsUpdates) {
                     const changedPolicyIDs = new Set(Object.keys(policyTagsUpdates).map((key) => key.replace(ONYXKEYS.COLLECTION.POLICY_TAGS, '')));
@@ -421,6 +470,20 @@ export default createOnyxDerivedValueConfig({
                         .filter((report) => !!report?.policyID && changedPolicyIDs.has(report.policyID))
                         .map((report) => `${ONYXKEYS.COLLECTION.REPORT}${report?.reportID}`);
                     dataToIterate.push(...prepareReportKeys(affectedReportKeys));
+                }
+
+                // Whatever caused a child report to be recomputed can also change whether its parent chat
+                // shows the error indicator — always recompute the parent chat in the same pass. The scoped
+                // error propagation below relies on this: it only re-checks chats present in dataToIterate.
+                const parentChatReportIDsToUpdate = new Set<string>();
+                for (const reportKey of dataToIterate) {
+                    const report = reports[reportKey];
+                    if (report?.chatReportID && report.reportID !== report.chatReportID) {
+                        parentChatReportIDsToUpdate.add(`${ONYXKEYS.COLLECTION.REPORT}${report.chatReportID}`);
+                    }
+                }
+                if (parentChatReportIDsToUpdate.size > 0) {
+                    dataToIterate.push(...Array.from(parentChatReportIDsToUpdate));
                 }
             } else {
                 // No updates to process, return current value to prevent unnecessary computation
@@ -547,45 +610,39 @@ export default createOnyxDerivedValueConfig({
             currentValue?.reports ? {...currentValue.reports} : {},
         );
 
-        // Propagate errors from IOU reports to their parent chat reports.
+        // Propagate errors from IOU reports to their parent chat reports — but only for chats
+        // recomputed in this pass. Every path that enqueues a child report also enqueues its parent
+        // chat (see parentChatReportIDsToUpdate and indexAffectedChatKeys above), so any chat whose
+        // aggregate error state could have changed is in dataToIterate, freshly recomputed and
+        // unstamped — a chat with no remaining errored children needs no explicit clearing.
         const currentUserAccountID = session?.accountID ?? CONST.DEFAULT_NUMBER_ID;
         const currentUserEmail = session?.email ?? '';
-        const erroredChildReportIDsByChat = new Map<string, string[]>();
-        const childReportIDsByChat = new Map<string, string[]>();
-        for (const report of Object.values(reports)) {
-            if (!report?.reportID || !report.chatReportID || report.reportID === report.chatReportID) {
+        for (const key of new Set(dataToIterate)) {
+            const chatReportID = key.replace(ONYXKEYS.COLLECTION.REPORT, '');
+            const childReportIDs = childrenByChat.get(chatReportID);
+            const chatAttributes = reportAttributes[chatReportID];
+            if (!childReportIDs || !chatAttributes) {
                 continue;
             }
 
-            const childReportIDs = childReportIDsByChat.get(report.chatReportID) ?? [];
-            childReportIDs.push(report.reportID);
-            childReportIDsByChat.set(report.chatReportID, childReportIDs);
-
-            // If this is an IOU report and its calculated attributes have an error,
-            // then we need to mark its parent chat report.
             // We read `needsParentChatErrorPropagation` rather than `brickRoadStatus` because the per-report
             // pass suppresses the child's own brickRoadStatus when the parent workspace chat is accessible —
             // we still need to propagate the error up so the parent shows the indicator.
-            const attributes = reportAttributes[report.reportID];
-            if (attributes?.needsParentChatErrorPropagation || attributes?.brickRoadStatus === CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR) {
-                const erroredChildReportIDs = erroredChildReportIDsByChat.get(report.chatReportID) ?? [];
-                erroredChildReportIDs.push(report.reportID);
-                erroredChildReportIDsByChat.set(report.chatReportID, erroredChildReportIDs);
+            const erroredChildReportIDs: string[] = [];
+            for (const childReportID of childReportIDs) {
+                const attributes = reportAttributes[childReportID];
+                if (attributes?.needsParentChatErrorPropagation || attributes?.brickRoadStatus === CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR) {
+                    erroredChildReportIDs.push(childReportID);
+                }
             }
-        }
-
-        // Apply the error status to the parent chat reports.
-        for (const [chatReportID, erroredChildReportIDs] of erroredChildReportIDsByChat) {
-            if (!reportAttributes[chatReportID]) {
+            if (erroredChildReportIDs.length === 0) {
                 continue;
             }
 
-            const chatAttributes = reportAttributes[chatReportID];
             let actionTargetReportActionID = chatAttributes.actionTargetReportActionID;
-
             actionTargetReportActionID =
                 getOldestPreviewActionID(chatReportID, erroredChildReportIDs, reports, isActionable) ??
-                getOldestPreviewActionID(chatReportID, childReportIDsByChat.get(chatReportID), reports, (childReport) =>
+                getOldestPreviewActionID(chatReportID, childReportIDs, reports, (childReport) =>
                     needsViolationFix(childReport, policies, transactionViolations, currentUserAccountID, currentUserEmail),
                 ) ??
                 getOldestPreviewActionID(chatReportID, erroredChildReportIDs, reports) ??

--- a/tests/unit/reportAttributesTest.ts
+++ b/tests/unit/reportAttributesTest.ts
@@ -1,5 +1,4 @@
-import type reportAttributesModuleDefault from '@userActions/OnyxDerived/configs/reportAttributes';
-import {hasPolicyRelevantFieldChanged} from '@userActions/OnyxDerived/configs/reportAttributes';
+import reportAttributesModuleDefault, {hasPolicyRelevantFieldChanged} from '@userActions/OnyxDerived/configs/reportAttributes';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -26,12 +25,20 @@ jest.mock('@libs/ReportUtils', () => ({
     isArchivedReport: jest.fn(() => false),
     isValidReport: jest.fn(() => true),
     parseReportRouteParams: jest.fn(() => ({reportID: ''})),
+    isOpenReport: jest.fn(() => true),
+    isProcessingReport: jest.fn(() => false),
+    isPolicyExpenseChat: jest.fn(() => false),
+    isPolicyAdmin: jest.fn(() => false),
+    hasViolations: jest.fn(() => false),
 }));
+
+// Report IDs the mocked getReasonAndReportActionThatHasRedBrickRoad treats as errored.
+const mockErroredReportIDs = new Set<string>();
 
 jest.mock('@libs/SidebarUtils', () => ({
     __esModule: true,
     default: {
-        getReasonAndReportActionThatHasRedBrickRoad: jest.fn(() => undefined),
+        getReasonAndReportActionThatHasRedBrickRoad: jest.fn((report: Report) => (mockErroredReportIDs.has(report.reportID) ? {reason: 'hasErrors', reportAction: undefined} : undefined)),
     },
 }));
 
@@ -369,5 +376,128 @@ describe('reportAttributes compute — policy change code flow', () => {
         // so both pick up the recomputed name instead of keeping their stale seeded value.
         expect(result?.reports.expense1?.reportName).toBe('Test Report');
         expect(result?.reports.chat1?.reportName).toBe('Test Report');
+    });
+});
+
+describe('reportAttributes compute — error propagation to parent chats', () => {
+    // Static import instead of the re-require pattern above: every test here starts with a full
+    // compute (seedFullCompute), which rebuilds all of the config's module-level state anyway.
+    const config = reportAttributesModuleDefault;
+
+    const chatA: Report = {...createRandomReport(1, CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT), reportID: 'chatA', policyID: 'policy1', chatReportID: undefined};
+    const chatB: Report = {...createRandomReport(2, CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT), reportID: 'chatB', policyID: 'policy1', chatReportID: undefined};
+    const childA1: Report = {...createRandomReport(3, undefined), reportID: 'childA1', policyID: 'policy1', chatReportID: 'chatA'};
+    const childA2: Report = {...createRandomReport(4, undefined), reportID: 'childA2', policyID: 'policy1', chatReportID: 'chatA'};
+    const childB1: Report = {...createRandomReport(5, undefined), reportID: 'childB1', policyID: 'policy1', chatReportID: 'chatB'};
+
+    const baseReports: OnyxCollection<Report> = {
+        [`${ONYXKEYS.COLLECTION.REPORT}chatA`]: chatA,
+        [`${ONYXKEYS.COLLECTION.REPORT}chatB`]: chatB,
+        [`${ONYXKEYS.COLLECTION.REPORT}childA1`]: childA1,
+        [`${ONYXKEYS.COLLECTION.REPORT}childA2`]: childA2,
+        [`${ONYXKEYS.COLLECTION.REPORT}childB1`]: childB1,
+    };
+
+    beforeEach(() => {
+        mockErroredReportIDs.clear();
+    });
+
+    const buildArgs = (reportsArg: OnyxCollection<Report>): Parameters<ReportAttributesConfig['compute']>[0] => [
+        reportsArg,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+    ];
+
+    // A full compute (no currentValue) — seeds the module-level chat → children index too.
+    const seedFullCompute = (reportsArg: OnyxCollection<Report>) => config.compute(buildArgs(reportsArg), {currentValue: undefined, sourceValues: undefined});
+
+    const computeReportDelta = (reportsArg: OnyxCollection<Report>, currentValue: ReportAttributesDerivedValue, delta: OnyxCollection<Report>) =>
+        config.compute(buildArgs(reportsArg), {
+            currentValue,
+            sourceValues: {[ONYXKEYS.COLLECTION.REPORT]: delta},
+        });
+
+    it('flags the parent chat when a child report has errors', () => {
+        mockErroredReportIDs.add('childA1');
+
+        const result = seedFullCompute(baseReports);
+
+        expect(result?.reports.chatA?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+        expect(result?.reports.chatA?.actionBadge).toBe(CONST.REPORT.ACTION_BADGE.FIX);
+        expect(result?.reports.chatB?.brickRoadStatus).toBeUndefined();
+    });
+
+    it('keeps the parent flagged when one child clears but a sibling is still errored', () => {
+        mockErroredReportIDs.add('childA1');
+        mockErroredReportIDs.add('childA2');
+        const seeded = seedFullCompute(baseReports);
+        expect(seeded?.reports.chatA?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+
+        mockErroredReportIDs.delete('childA1');
+        const result = computeReportDelta(baseReports, seeded, {[`${ONYXKEYS.COLLECTION.REPORT}childA1`]: childA1});
+
+        expect(result?.reports.childA1?.brickRoadStatus).toBeUndefined();
+        expect(result?.reports.chatA?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+    });
+
+    it('unflags the parent when the last errored child clears', () => {
+        mockErroredReportIDs.add('childA1');
+        const seeded = seedFullCompute(baseReports);
+        expect(seeded?.reports.chatA?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+
+        mockErroredReportIDs.delete('childA1');
+        const result = computeReportDelta(baseReports, seeded, {[`${ONYXKEYS.COLLECTION.REPORT}childA1`]: childA1});
+
+        expect(result?.reports.chatA?.brickRoadStatus).toBeUndefined();
+        expect(result?.reports.chatA?.actionBadge).toBeUndefined();
+    });
+
+    it('moves the flag when an errored child moves to another chat', () => {
+        mockErroredReportIDs.add('childA1');
+        const seeded = seedFullCompute(baseReports);
+        expect(seeded?.reports.chatA?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+        expect(seeded?.reports.chatB?.brickRoadStatus).toBeUndefined();
+
+        const movedChild: Report = {...childA1, chatReportID: 'chatB'};
+        const movedReports: OnyxCollection<Report> = {...baseReports, [`${ONYXKEYS.COLLECTION.REPORT}childA1`]: movedChild};
+        const result = computeReportDelta(movedReports, seeded, {[`${ONYXKEYS.COLLECTION.REPORT}childA1`]: movedChild});
+
+        expect(result?.reports.chatA?.brickRoadStatus).toBeUndefined();
+        expect(result?.reports.chatB?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+    });
+
+    it('unflags the parent when its only errored child is deleted', () => {
+        mockErroredReportIDs.add('childA1');
+        const seeded = seedFullCompute(baseReports);
+        expect(seeded?.reports.chatA?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+
+        const {[`${ONYXKEYS.COLLECTION.REPORT}childA1`]: deletedChild, ...remainingReports} = baseReports;
+        const result = computeReportDelta(remainingReports, seeded, {[`${ONYXKEYS.COLLECTION.REPORT}childA1`]: undefined});
+
+        expect(result?.reports.childA1).toBeUndefined();
+        expect(result?.reports.chatA?.brickRoadStatus).toBeUndefined();
+    });
+
+    it('does not touch unrelated errored chats on a single-report update', () => {
+        mockErroredReportIDs.add('childB1');
+        const seeded = seedFullCompute(baseReports);
+        const chatBBefore = seeded?.reports.chatB;
+        expect(chatBBefore?.brickRoadStatus).toBe(CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR);
+
+        const result = computeReportDelta(baseReports, seeded, {[`${ONYXKEYS.COLLECTION.REPORT}childA1`]: childA1});
+
+        // chatB was not part of the update — its entry must be carried over by reference, not restamped.
+        expect(result?.reports.chatB).toBe(chatBBefore);
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The `reportAttributes` Onyx derived value recomputes on every change to any of its 14 dependency keys (every chat message, transaction, or violation tick). Its per-report pass is incremental, but the "propagate errors from IOU reports to parent chats" pass that runs after it walked **all** reports on every compute (building two full maps) and re-stamped every errored chat each pass. On large accounts (30-50k reports) this is a constant O(all reports) tax per tick — the hottest remaining full scan after PRs #95944 and #95931.

Fix: a module-level chat→children index (`childToChat` / `childrenByChat`) is rebuilt on full recomputes and patched incrementally from `sourceValues` report deltas — the same pattern already used by the sibling derived value `reportTransactionsAndViolations.ts` (PR #65247). The propagation pass now only re-checks chats present in `dataToIterate` instead of every report in the account.

Safety invariant: every code path that enqueues a child report for recompute must also enqueue its parent chat. This already held for report/transaction/violation updates; the parent-chat enqueue was moved to run after all update branches so it also covers the policy-tags path. A child that is deleted or moves to another chat now re-enqueues the chat it left, so that chat's propagated error is re-evaluated instead of going stale.

Net effect: full recomputes behave exactly as before (`dataToIterate` = all reports); single-report/incremental updates on large accounts no longer pay the full-account scan.

### Fixed Issues
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. On a workspace with an expense report carrying an error/violation, verify the workspace chat shows the RBR/Fix badge.
2. Clear the error on that expense and verify the chat's error indicator clears.
3. Delete the errored expense offline and verify the chat's error indicator clears once the delete syncs.
4. `tests/unit/reportAttributesTest.ts`: 27/27 passing (21 existing + 6 new covering: parent flagged by errored child; parent stays flagged while a sibling is errored; parent unflagged when all children clear; flag moves when a child moves chats; flag cleared when an errored child is deleted; unrelated errored chat entries carried by reference on single-report updates). 3 of the new tests fail against `main`'s implementation — they document the behavior change (stale-dot fix) this PR makes.
5. Verified locally: full jest suite green, `eslint` 0 errors (seatbelt budget unchanged at 24 — new tests written cast-free), `typecheck-tsgo` clean for the changed files.

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same unit suite as above — the propagation logic is offline-first client code that runs entirely from local Onyx state, with no network dependency.

### QA Steps
Same as tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
