### PR TITLE
fix: [$250] iOS-Expense-The share screen does not close when swip

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #94908
+
+[$250] iOS-Expense-The share screen does not close when swiping back


### PR DESCRIPTION
$ #94908

[$250] iOS-Expense-The share screen does not close when swiping back

/claim #94908