### PR TITLE
fix: [$250] iOS-Expense-"Track distance" screen briefly appears a

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #94904
+
+[$250] iOS-Expense-"Track distance" screen briefly appears after swiping back


### PR DESCRIPTION
$ #94904

[$250] iOS-Expense-"Track distance" screen briefly appears after swiping back

/claim #94904