### PR TITLE
fix: [$250] Approval workflow mismatch between New Expensify and 

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #94891
+
+[$250] Approval workflow mismatch between New Expensify and Old Expensify causes report submission failure


### PR DESCRIPTION
$ #94891

[$250] Approval workflow mismatch between New Expensify and Old Expensify causes report submission failure

/claim #94891