### PR TITLE
fix: [$250] chat-Image paste is allowed in Edit Comment, resultin

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #94879
+
+[$250] chat-Image paste is allowed in Edit Comment, resulting in a separate attachment message


### PR DESCRIPTION
$ #94879

[$250] chat-Image paste is allowed in Edit Comment, resulting in a separate attachment message

/claim #94879