### PR TITLE
fix: [Exploratory] Members - Invited member's details page turns 

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #94902
+
+[Exploratory] Members - Invited member's details page turns into "Not here"


### PR DESCRIPTION
$ #94902

[Exploratory] Members - Invited member's details page turns into "Not here"

/claim #94902