### PR TITLE
Prevent a background avatar picker from adopting a live crop draft

### DIFF
--- a/src/hooks/useAvatarCrop.ts
+++ b/src/hooks/useAvatarCrop.ts
@@ -18,6 +18,13 @@ import useOnyx from './useOnyx';
 
 const CROP_SUFFIX = `/${DYNAMIC_ROUTES.AVATAR_CROP.path}`;
 
+/**
+ * Token of the crop the opener started in this session. Adoption below exists only to recover a draft
+ * orphaned by a page refresh, which resets this back to null. While the opener is still alive it holds
+ * the token in its own ref, so any other mounted instance seeing this token must not adopt the draft.
+ */
+let sessionOwnedToken: string | null = null;
+
 /** The opener's route, used to tie a persisted crop draft back to the opener that started it. */
 function getOpenerKey(route: string): string {
     return splitPathAndQuery(route).at(0) ?? '';
@@ -43,6 +50,8 @@ function useAvatarCrop({maskType, buttonLabelKey, onCropped}: UseAvatarCropParam
     const openCropper = (image: FileObject) => {
         const token = rand64();
         tokenRef.current = token;
+        // Claim the token synchronously, before the draft is written, so no other mounted instance can adopt it.
+        sessionOwnedToken = token;
         // Capture the opener's route now: serialization below is async (slow on web) and the active
         // route can change if the user navigates away before it resolves.
         const baseRoute = Navigation.getActiveRoute();
@@ -61,7 +70,7 @@ function useAvatarCrop({maskType, buttonLabelKey, onCropped}: UseAvatarCropParam
     // draft's token if it was opened from this opener's route (the focused crop route minus the
     // `/avatar-crop` suffix), so the cropped result is still delivered to this opener when the user saves.
     useEffect(() => {
-        if (tokenRef.current || !draft?.token || !draft.openerKey) {
+        if (tokenRef.current || !draft?.token || !draft.openerKey || draft.token === sessionOwnedToken) {
             return;
         }
         const draftToken = draft.token;

--- a/tests/unit/useAvatarCropTest.tsx
+++ b/tests/unit/useAvatarCropTest.tsx
@@ -1,0 +1,83 @@
+import {act, renderHook, waitFor} from '@testing-library/react-native';
+
+import useAvatarCrop from '@hooks/useAvatarCrop';
+
+import type {AvatarCropDraft, AvatarCropResult} from '@src/types/onyx';
+
+const OPENER_ROUTE = '/settings/profile';
+
+/** Token handed out by `openCropper`, i.e. one this session owns. */
+const LIVE_TOKEN = 'live-token';
+
+/** Token of a draft left behind by a page refresh, which no live instance owns. */
+const ORPHANED_TOKEN = 'orphaned-token';
+
+let mockOnyxValues: {draft?: AvatarCropDraft; result?: AvatarCropResult} = {};
+let mockActiveRoute = OPENER_ROUTE;
+
+jest.mock('@hooks/useOnyx', () => (key: string) => [key === 'avatarCropDraft' ? mockOnyxValues.draft : mockOnyxValues.result]);
+jest.mock('@libs/NumberUtils', () => ({rand64: () => 'live-token'}));
+jest.mock('@libs/actions/AvatarCrop', () => ({
+    setAvatarCropDraft: jest.fn(() => Promise.resolve()),
+    clearAvatarCropResult: jest.fn(),
+}));
+jest.mock('@libs/AvatarCropUtils', () => ({buildFileFromAvatarCropResult: (result: AvatarCropResult) => ({name: result.name})}));
+jest.mock('@libs/Navigation/Navigation', () => ({
+    getActiveRoute: () => mockActiveRoute,
+    navigate: jest.fn(),
+    isNavigationReady: () => Promise.resolve(),
+}));
+
+const buildDraft = (token: string): AvatarCropDraft => ({token, uri: 'data:image/jpeg;base64,x', name: 'picked.jpg', type: 'image/jpeg', openerKey: OPENER_ROUTE});
+const buildResult = (token: string): AvatarCropResult => ({token, uri: 'data:image/jpeg;base64,y', name: 'cropped.jpg', type: 'image/jpeg'});
+
+const flush = () =>
+    act(async () => {
+        await Promise.resolve();
+    });
+
+describe('useAvatarCrop', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockOnyxValues = {};
+        mockActiveRoute = OPENER_ROUTE;
+    });
+
+    it('does not let a second mounted picker adopt a draft the opener is still using', async () => {
+        const openerOnCropped = jest.fn();
+        const backgroundOnCropped = jest.fn();
+
+        // The opener (e.g. the profile avatar) starts a crop, claiming the token.
+        const opener = renderHook(() => useAvatarCrop({onCropped: openerOnCropped}));
+        act(() => opener.result.current.openCropper({name: 'picked.jpg'}));
+        await flush();
+        mockOnyxValues.draft = buildDraft(LIVE_TOKEN);
+
+        // A picker already mounted underneath (e.g. the workspace avatar) sees the same global draft.
+        const background = renderHook(() => useAvatarCrop({onCropped: backgroundOnCropped}));
+        await flush();
+
+        // The crop screen writes the result back.
+        mockOnyxValues.result = buildResult(LIVE_TOKEN);
+        opener.rerender({});
+        background.rerender({});
+
+        await waitFor(() => expect(openerOnCropped).toHaveBeenCalledTimes(1));
+        expect(backgroundOnCropped).not.toHaveBeenCalled();
+    });
+
+    it('still adopts a draft orphaned by a page refresh', async () => {
+        // After a refresh the draft survives but no live instance owns its token, so the opener re-adopts it.
+        const onCropped = jest.fn();
+        mockOnyxValues.draft = buildDraft(ORPHANED_TOKEN);
+        mockActiveRoute = `${OPENER_ROUTE}/avatar-crop`;
+
+        const opener = renderHook(() => useAvatarCrop({onCropped}));
+        await flush();
+
+        mockOnyxValues.result = buildResult(ORPHANED_TOKEN);
+        opener.rerender({});
+
+        await waitFor(() => expect(onCropped).toHaveBeenCalledTimes(1));
+    });
+});


### PR DESCRIPTION
### Explanation of Change

The avatar crop screen hands the cropped image back to its opener through the global `AVATAR_CROP_DRAFT` / `AVATAR_CROP_RESULT` Onyx keys, paired with a token. `useAvatarCrop` also re-adopts a draft's token so a crop survives a page refresh, but that adoption was instance-blind: every mounted instance of the hook subscribes to the same global draft, and the only guard compared `Navigation.getActiveRoute()` against `draft.openerKey` — two global strings that are identical for every instance.

So when a second picker was already mounted (creating a workspace lands on Workspace Overview, which renders its own `AvatarWithImagePicker`, and Account > Profile is then pushed on top while that stays mounted), the background picker adopted the profile crop's token and uploaded the cropped image as the workspace avatar via `UpdateWorkspaceAvatar`.

Adoption only exists to recover a draft orphaned by a page refresh — in a live session the opener already holds the token in its own `tokenRef`. This records live ownership in a module-scope `sessionOwnedToken`, set synchronously in `openCropper` before the draft is written, and refuses adoption of a token that is still owned. After a refresh the module resets to `null`, the draft is genuinely orphaned, and the existing `openerKey` route check re-ties it to the true opener exactly as before.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95854
PROPOSAL: https://github.com/Expensify/App/issues/95854#issuecomment-4937957587

### Tests

1. Go to Account > Profile and note your current profile photo.
2. Create a workspace (this lands on Workspace Overview, which mounts its own avatar picker) and note that its avatar is the default letter avatar.
3. Without navigating away from the workspace, go to Account > Profile.
4. Click the profile avatar, click Upload photo, choose a photo, and save it on the crop screen.
5. Verify the profile avatar updates to the photo you uploaded.
6. Go back to the workspace's Overview page and verify its avatar is unchanged (still the default letter avatar).
7. Verify the workspace avatar is also unchanged in the workspace chat and in the workspace list.

Refresh recovery (must keep working): 8. Start an avatar crop from Account > Profile, and while the crop screen is open, refresh the page. 9. Verify the crop screen still comes back with your image and that saving it applies the photo to your profile avatar.

- [x] Verify that no errors appear in the JS console

### Offline tests

The change only affects which mounted picker claims an in-progress crop; it adds no new network calls. Uploading an avatar while offline behaves as before — the request is queued and applied when back online, and the workspace avatar is still not affected.

### QA Steps

1. Go to Account > Profile and note your current profile photo.
2. Create a workspace and note that its avatar is the default letter avatar.
3. Without navigating away from the workspace, go to Account > Profile.
4. Click the profile avatar, click Upload photo, choose a photo, and save it on the crop screen.
5. Verify the profile avatar updates to the photo you uploaded.
6. Go back to the workspace's Overview page and verify its avatar is unchanged (still the default letter avatar).
7. Verify the workspace avatar is also unchanged in the workspace chat and in the workspace list.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/3ff1b0ad-3469-48bc-bc06-73362377b97c


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/da953107-4184-4477-851e-b7b72c572618

</details>



<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c1821dec-a943-4cf1-95e6-0829718957a4


</details>



<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/5cec99e9-541b-45c3-8525-7be1da246761

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/35fd0a38-484c-421d-ad76-e18d5240fd23


<!-- add screenshots or videos here -->

</details>
