### PR TITLE
fix: keep task report intact when assignee leaves it (not-here page) #96421

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -149,6 +149,7 @@ import {
     isAdminRoom,
     isChatThread as isChatThreadReportUtils,
     isConciergeChatReport,
+    isTaskReport as isTaskReportReportUtils,
     isCurrentUserSubmitter,
     isExpenseReport,
     isGroupChat as isGroupChatReportUtils,
@@ -4785,7 +4786,7 @@ function navigateToMostRecentReport(
 }
 
 function getSearchThreadLeaveRoute(report: Report, activeRoute: string): Route | undefined {
-    if (!isSearchTopmostFullScreenRoute() || !isChatThreadReportUtils(report) || !report.parentReportID || !report.parentReportActionID) {
+    if (!isSearchTopmostFullScreenRoute() || (!isChatThreadReportUtils(report) && !isTaskReportReportUtils(report)) || !report.parentReportID || !report.parentReportActionID) {
         return undefined;
     }
 
@@ -4891,6 +4892,7 @@ function leaveRoom(
 ) {
     const reportID = report.reportID;
     const isChatThread = isChatThreadReportUtils(report);
+    const isTaskReport = isTaskReportReportUtils(report);
     const activeRoute = Navigation.getActiveRoute();
 
     // Pusher's leavingStatus should be sent earlier.
@@ -4906,7 +4908,7 @@ function leaveRoom(
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
             value:
-                isWorkspaceMemberLeavingWorkspaceRoom || isChatThread
+                isWorkspaceMemberLeavingWorkspaceRoom || isChatThread || isTaskReport
                     ? {
                           participants: {
                               [currentUserAccountID]: {
@@ -4928,7 +4930,7 @@ function leaveRoom(
     ];
 
     const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS>> = [];
-    if (isWorkspaceMemberLeavingWorkspaceRoom || isChatThread) {
+    if (isWorkspaceMemberLeavingWorkspaceRoom || isChatThread || isTaskReport) {
         successData.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -6830,6 +6830,36 @@ describe('actions/Report', () => {
             await waitForBatchedUpdates();
             TestHelper.expectAPICommandToHaveBeenCalled(WRITE_COMMANDS.LEAVE_ROOM, 1);
         });
+
+        it('should only hide notification preference when leaving a task report (not null it)', async () => {
+            TestHelper.getGlobalFetchMock();
+
+            const parentReport = createRandomReport(Number(PARENT_REPORT_ID), undefined);
+            const taskReport = {
+                ...createRandomReport(Number(ROOM_REPORT_ID), undefined),
+                type: CONST.REPORT.TYPE.TASK,
+                parentReportID: PARENT_REPORT_ID,
+                parentReportActionID: PARENT_REPORT_ACTION_ID,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                participants: {
+                    [TEST_CURRENT_USER_ACCOUNT_ID]: {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS},
+                },
+            };
+
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${PARENT_REPORT_ID}`, parentReport);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${ROOM_REPORT_ID}`, taskReport);
+            await waitForBatchedUpdates();
+
+            Report.leaveRoom(taskReport, TEST_CURRENT_USER_ACCOUNT_ID, TEST_CONCIERGE_REPORT_ID, TEST_INTRO_SELECTED, undefined, false);
+            await waitForBatchedUpdates();
+
+            const updatedReport = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${ROOM_REPORT_ID}` as const);
+            // A task report is a thread-like report: leaving it should only hide the notification
+            // preference and keep the report object intact, so the report screen won't show "Not here".
+            expect(updatedReport?.participants?.[TEST_CURRENT_USER_ACCOUNT_ID]?.notificationPreference).toBe(CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN);
+            expect(updatedReport?.reportID).toBe(ROOM_REPORT_ID);
+            expect(updatedReport?.statusNum).toBe(CONST.REPORT.STATUS_NUM.OPEN);
+        });
     });
 
     describe('leaveGroupChat with introSelected', () => {


### PR DESCRIPTION
### Explanation of Change

When a task assignee leaves a task report, the app was showing the "Not here" (`notFound.noAccess`) page instead of cleanly navigating them away.

Root cause: `leaveRoom()` in `src/libs/actions/Report/index.ts` only keeps the report object intact (by merely hiding the notification preference via `notificationPreference: hidden`) when leaving a **workspace room** or a **chat thread**. A task report is a thread-like report, but `isChatThread()` requires `type === CONST.REPORT.TYPE.CHAT`, while a task's type is `TASK`, so `isChatThread(taskReport)` is `false`. The task therefore fell into the destructive `else` branch:

- Optimistic: `{reportID: null, stateNum: APPROVED, statusNum: CLOSED, ...}`
- Success (Onyx.SET): the report is reduced to just `{reportName}`, dropping `reportID` and `statusNum`.

`ReportNotFoundGuard` then evaluates `reportExists = !!reportID || isOptimisticDelete || userLeavingStatus`. After a successful leave the report has no `reportID` and no `statusNum` (so `isOptimisticDelete` is false) and `userLeavingStatus` has cleared → all three terms are false → `shouldShowNotFoundPage` becomes true → the "Not here" page.

Fix: treat a task report the same way as a chat thread / workspace room in `leaveRoom` so that leaving only hides the notification preference and keeps the report object intact. Concretely:

1. Import `isTaskReport` from `ReportUtils`.
2. In `leaveRoom()`, compute `const isTaskReport = isTaskReportReportUtils(report)` and use it in the branch condition for both the optimistic value and the `successData` set (so the report is no longer nulled/reduced on leave).
3. Extend `getSearchThreadLeaveRoute()` so a task report opened from Search is correctly dismissed on leave (apply the same thread recognition: chat thread OR task report).

This keeps the report object intact after leaving, so `ReportNotFoundGuard.reportExists` stays true and the user is navigated away cleanly rather than landing on "Not here".

### Fixed Issues

$ https://github.com/Expensify/App/issues/96421
PROPOSAL: https://github.com/Expensify/App/issues/96421#issuecomment-5006616119

### Tests

1. New unit test `should only hide notification preference when leaving a task report (not null it)` in `tests/actions/ReportTest.ts` (`describe('leaveRoom')`) asserts that after leaving a task report:
   - the current user's `notificationPreference` becomes `HIDDEN`, and
   - `reportID` and `statusNum` remain intact (not nulled/reduced), which is what prevents `ReportNotFoundGuard` from showing "Not here".
2. Run `npm run test -- tests/actions/ReportTest.ts -t "leaveRoom"`. The new test `should only hide notification preference when leaving a task report (not null it)` passes locally (15 passed, 245 skipped, 0 failed) under the repo's required Node 20.20.2.

### Offline tests

- Leaving a task report while offline: optimistic update hides the notification preference and keeps the report object intact; on reconnect the `LEAVE_ROOM` success path applies the same `MERGE` (no `SET`-to-`reportName`). Behavior is unchanged for network failures because `failureData` restores the original report.

### QA Steps

Reproduce the issue from #96421:
1. As User B, open a group chat with User A and User C.
2. Create a task in the group chat, assign it to User A.
3. As User B, leave the group chat.
4. As User A, go to Reports > Task, open the task, open details, and tap **Leave**.
5. Expected: User A is navigated away cleanly. Actual before fix: "Not here" page appears. After fix: no "Not here" page.

- [ ] Verify that no errors appear in the JS console
