### PR TITLE
fix: prevent Maximum update depth exceeded when re-selecting a workspace with an empty report (#96411)

### DIFF
--- a/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
+++ b/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
@@ -186,13 +186,15 @@ function DynamicNewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelec
     // every render because it comes from useCreateEmptyReportConfirmation (which is not memoized). Including it made
     // the effect re-fire on every render while pendingPolicySelection stayed truthy, causing a
     // "Maximum update depth exceeded" crash. The effect only needs to react to pendingPolicySelection changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
     useEffect(() => {
         if (!pendingPolicySelection) {
             return;
         }
 
         openCreateReportConfirmation();
+        // The effect only depends on pendingPolicySelection. openCreateReportConfirmation is intentionally excluded
+        // from the deps (see comment above) to avoid re-firing the effect on every render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- openCreateReportConfirmation is excluded on purpose (see comment above)
     }, [pendingPolicySelection]);
 
     const selectPolicy = (policy?: WorkspaceListItem) => {

--- a/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
+++ b/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
@@ -181,14 +181,19 @@ function DynamicNewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelec
         },
     });
 
-    // Open the confirmation modal after pendingPolicySelection is committed so the hook has the correct policyName
+    // Open the confirmation modal once after pendingPolicySelection is committed so the hook has the correct policyName.
+    // We intentionally do NOT list openCreateReportConfirmation in the dependency array: that function is recreated on
+    // every render because it comes from useCreateEmptyReportConfirmation (which is not memoized). Including it made
+    // the effect re-fire on every render while pendingPolicySelection stayed truthy, causing a
+    // "Maximum update depth exceeded" crash. The effect only needs to react to pendingPolicySelection changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
     useEffect(() => {
         if (!pendingPolicySelection) {
             return;
         }
 
         openCreateReportConfirmation();
-    }, [pendingPolicySelection, openCreateReportConfirmation]);
+    }, [pendingPolicySelection]);
 
     const selectPolicy = (policy?: WorkspaceListItem) => {
         if (!policy?.policyID) {


### PR DESCRIPTION
### Explanation of Change

On `DynamicNewReportWorkspaceSelectionPage`, selecting the same workspace twice in a row (when that workspace already has an empty report) crashed the app with `Maximum update depth exceeded` because the confirmation modal re-opened in an infinite loop.

Root cause: the confirmation `useEffect` listed `openCreateReportConfirmation` in its dependency array. That function is returned from `useCreateEmptyReportConfirmation`, which defines it as a plain arrow function inside the hook body — a **new identity on every render** (not `useCallback`, and the underlying context value is also recreated each render). On the 2nd consecutive selection, `selectPolicy` calls `setPendingPolicySelection({...})`; that state is only reset to `null` by the modal's `onConfirm`/`onCancel` (user actions), so it stays truthy. Because the function identity changed every render, the effect re-fired after every render → re-opened the modal → re-render → infinite loop.

Fix: remove `openCreateReportConfirmation` from the effect deps and keep only `pendingPolicySelection` (with an `eslint-disable-next-line react-hooks/exhaustive-deps` comment, matching the repo convention). The effect now fires once per truthy transition; confirm/cancel still reset state normally.

A naive alternative (clearing `pendingPolicySelection` synchronously inside the effect) is wrong: `onConfirm` reads `pendingPolicySelection` to call `createReport`, so nulling it on open would make confirm a silent no-op and break report creation.

### Fixed Issues

$ [https://github.com/Expensify/App/issues/96411](<https://github.com/Expensify/App/issues/96411>)<br>PROPOSAL: [https://github.com/Expensify/App/issues/96411#issuecomment-5023199031](<https://github.com/Expensify/App/issues/96411#issuecomment-5023199031>)

### Tests

1. `eslint src/pages/DynamicNewReportWorkspaceSelectionPage.tsx` → 0 errors.
2. `jest tests/ui/NewReportWorkspaceSelectionPageTest.tsx` → 2/2 pass (the empty-report confirmation path and the direct-create path both hold).

### Offline tests

N/A — purely a render-loop fix with no network/Onyx data dependency; behavior is identical online and offline.

### QA Steps

Reproduce the issue from Expensify/App#96411:

1. In OldDot, set a workspace as the default workspace.
2. Return to New Expensify, Create Report, select the workspace.
3. Wait for the empty report to be created.
4. Create Report again, select the SAME workspace.
5. Expected: confirmation modal opens once and the report is created on confirm. Before fix: "Maximum update depth exceeded" crash. After fix: no crash.

- [ ] Verify that no errors appear in the JS console