### PR TITLE
fix: prevent Maximum update depth exceeded when re-selecting a workspace with an empty report (#96411)

### DIFF
--- a/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
+++ b/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
@@ -186,13 +186,15 @@ function DynamicNewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelec
     // every render because it comes from useCreateEmptyReportConfirmation (which is not memoized). Including it made
     // the effect re-fire on every render while pendingPolicySelection stayed truthy, causing a
     // "Maximum update depth exceeded" crash. The effect only needs to react to pendingPolicySelection changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
     useEffect(() => {
         if (!pendingPolicySelection) {
             return;
         }
 
         openCreateReportConfirmation();
+        // The effect only depends on pendingPolicySelection. openCreateReportConfirmation is intentionally excluded
+        // from the deps (see comment above) to avoid re-firing the effect on every render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- openCreateReportConfirmation is excluded on purpose (see comment above)
     }, [pendingPolicySelection]);
 
     const selectPolicy = (policy?: WorkspaceListItem) => {

--- a/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
+++ b/src/pages/DynamicNewReportWorkspaceSelectionPage.tsx
@@ -181,14 +181,19 @@ function DynamicNewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelec
         },
     });
 
-    // Open the confirmation modal after pendingPolicySelection is committed so the hook has the correct policyName
+    // Open the confirmation modal once after pendingPolicySelection is committed so the hook has the correct policyName.
+    // We intentionally do NOT list openCreateReportConfirmation in the dependency array: that function is recreated on
+    // every render because it comes from useCreateEmptyReportConfirmation (which is not memoized). Including it made
+    // the effect re-fire on every render while pendingPolicySelection stayed truthy, causing a
+    // "Maximum update depth exceeded" crash. The effect only needs to react to pendingPolicySelection changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
     useEffect(() => {
         if (!pendingPolicySelection) {
             return;
         }
 
         openCreateReportConfirmation();
-    }, [pendingPolicySelection, openCreateReportConfirmation]);
+    }, [pendingPolicySelection]);
 
     const selectPolicy = (policy?: WorkspaceListItem) => {
         if (!policy?.policyID) {


### PR DESCRIPTION
### Explanation of Change

The empty-report confirmation effect depended on `openCreateReportConfirmation`, whose identity changes when opening the modal rerenders the modal provider/hook chain. While `pendingPolicySelection` remained set awaiting confirm/cancel, that dependency change reopened the modal repeatedly and caused `Maximum update depth exceeded`.

This change wraps the callback in React 19 `useEffectEvent`. The effect remains reactive only to `pendingPolicySelection`, while the Effect Event always invokes the latest callback. Confirm/cancel continue clearing the selected policy at the existing safe point.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96411
PROPOSAL: https://github.com/Expensify/App/issues/96411#issuecomment-5023199031

### Tests

1. Run `eslint src/pages/DynamicNewReportWorkspaceSelectionPage.tsx` and verify it passes.
2. Run `jest tests/ui/NewReportWorkspaceSelectionPageTest.tsx --runInBand` and verify both tests pass.
3. Create a report for a workspace, then create another report and select the same workspace.
4. Verify the empty-report confirmation opens once and the app remains responsive.
5. Confirm creation and verify the report is created for the selected workspace.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same behavior: opening the local confirmation is not network-dependent.

### QA Steps

1. In OldDot, set the personal workspace as the default workspace.
2. Return to New Expensify.
3. Create a report and select that workspace.
4. Wait for the empty report to be created.
5. Create another report and select the same workspace.
6. Verify the confirmation opens once and the app does not crash.
7. Confirm and verify the second report is created successfully.
