### PR TITLE
fix: task assignee resolution for composer short mentions

### DIFF
--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -28,11 +28,13 @@ type FirstAndLastName = {
 
 let allPersonalDetails: OnyxEntry<PersonalDetailsList> = {};
 let emailToPersonalDetailsCache: Record<string, PersonalDetails> = {};
+let allPersonalDetailLogins: string[] = [];
 Onyx.connect({
     key: ONYXKEYS.PERSONAL_DETAILS_LIST,
     callback: (val) => {
         const personalDetails = Object.values(val ?? {});
         allPersonalDetails = val;
+        allPersonalDetailLogins = personalDetails.map((detail) => detail?.login ?? '');
         emailToPersonalDetailsCache = personalDetails.reduce((acc: Record<string, PersonalDetails>, detail) => {
             if (detail?.login) {
                 acc[detail.login.toLowerCase()] = detail;
@@ -265,7 +267,7 @@ function getPersonalDetailByEmail(email: string | undefined): PersonalDetails | 
 }
 
 function getAllPersonalDetailLogins(): string[] {
-    return Object.values(allPersonalDetails ?? {}).map((personalDetail) => personalDetail?.login ?? '');
+    return allPersonalDetailLogins;
 }
 
 /**

--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -264,6 +264,10 @@ function getPersonalDetailByEmail(email: string | undefined): PersonalDetails | 
     return emailToPersonalDetailsCache[email.toLowerCase()];
 }
 
+function getAllPersonalDetailLogins(): string[] {
+    return Object.values(allPersonalDetails ?? {}).map((personalDetail) => personalDetail?.login ?? '');
+}
+
 /**
  * Returns the accountID for a login only when it exists in personal details.
  * Unlike getAccountIDsByLogins, does not fabricate optimistic account IDs for unknown logins.
@@ -625,6 +629,7 @@ export {
     getParticipantsPersonalDetails,
     getPersonalDetailsListByIDs,
     getDisplayNameOrYou,
+    getAllPersonalDetailLogins,
     getPersonalDetailByEmail,
     getKnownAccountIDByLogin,
     getAccountIDsByLogins,

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -144,7 +144,14 @@ import Parser from './Parser';
 import {getParsedMessageWithShortMentions} from './ParsingUtils';
 import {getBankAccountLastFourDigits} from './PaymentUtils';
 import Permissions from './Permissions';
-import {getAccountIDsByLogins, getDisplayNameOrDefault, getLoginByAccountID, getPersonalDetailByEmail, temporaryGetDisplayNameOrDefault} from './PersonalDetailsUtils';
+import {
+    getAccountIDsByLogins,
+    getAllPersonalDetailLogins,
+    getDisplayNameOrDefault,
+    getLoginByAccountID,
+    getPersonalDetailByEmail,
+    temporaryGetDisplayNameOrDefault,
+} from './PersonalDetailsUtils';
 import {
     canSendInvoiceFromWorkspace,
     getActivePolicies,
@@ -1041,7 +1048,6 @@ Onyx.connect({
 });
 
 let allPersonalDetails: OnyxEntry<PersonalDetailsList>;
-let allPersonalDetailLogins: string[];
 let currentUserPersonalDetails: OnyxEntry<PersonalDetails>;
 Onyx.connect({
     key: ONYXKEYS.PERSONAL_DETAILS_LIST,
@@ -1050,7 +1056,6 @@ Onyx.connect({
             currentUserPersonalDetails = value?.[deprecatedCurrentUserAccountID] ?? undefined;
         }
         allPersonalDetails = value ?? {};
-        allPersonalDetailLogins = Object.values(allPersonalDetails).map((personalDetail) => personalDetail?.login ?? '');
     },
 });
 
@@ -6537,7 +6542,7 @@ function getParsedComment(
 
     return getParsedMessageWithShortMentions({
         text,
-        availableMentionLogins: allPersonalDetailLogins,
+        availableMentionLogins: getAllPersonalDetailLogins(),
         userEmailDomain,
         parserOptions: {
             disabledRules: isGroupPolicyReport ? [...rules] : ['reportMentions', ...rules],

--- a/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
+++ b/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
@@ -1,17 +1,15 @@
-import {usePersonalDetails} from '@components/OnyxListItemProvider';
-
 import useAncestors from '@hooks/useAncestors';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDelegateAccountID from '@hooks/useDelegateAccountID';
 import useIsInSidePanel from '@hooks/useIsInSidePanel';
 import useOnyx from '@hooks/useOnyx';
-import useShortMentionsList from '@hooks/useShortMentionsList';
 
 import {addAttachmentWithComment, addComment, clearAgentZeroProcessingIndicator} from '@libs/actions/Report';
 import {createTaskAndNavigate, setNewOptimisticAssignee} from '@libs/actions/Task';
 import {isEmailPublicDomain} from '@libs/LoginUtils';
 import {rand64} from '@libs/NumberUtils';
 import {addDomainToShortMention} from '@libs/ParsingUtils';
+import {getAllPersonalDetailLogins, getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
 import {isConciergeChatReport} from '@libs/ReportUtils';
 import {startSpan} from '@libs/telemetry/activeSpans';
 import getSendMessageSource from '@libs/telemetry/getSendMessageSource';
@@ -36,8 +34,6 @@ import useSidePanelContext from './useSidePanelContext';
 
 function useComposerSubmit(reportID: string) {
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
-    const personalDetails = usePersonalDetails();
-    const {availableLoginsList} = useShortMentionsList();
     const isInSidePanel = useIsInSidePanel();
     const sidePanelContext = useSidePanelContext(reportID);
     const route = useRoute();
@@ -110,15 +106,15 @@ function useComposerSubmit(reportID: string) {
             if (taskTitle) {
                 const mention = taskMatch[1] ? taskMatch[1].trim() : '';
                 const currentUserPrivateDomain = isEmailPublicDomain(currentUserEmail) ? '' : Str.extractEmailDomain(currentUserEmail);
-                const mentionWithDomain = addDomainToShortMention(mention, availableLoginsList, currentUserPrivateDomain) ?? mention;
+                const mentionWithDomain = addDomainToShortMention(mention, getAllPersonalDetailLogins(), currentUserPrivateDomain) ?? mention;
                 const isValidMention = Str.isValidEmail(mentionWithDomain);
 
                 let assignee: OnyxEntry<OnyxTypes.PersonalDetails>;
                 let assigneeChatReport;
                 if (mentionWithDomain) {
                     if (isValidMention) {
-                        assignee = Object.values(personalDetails ?? {}).find((value) => value?.login === mentionWithDomain) ?? undefined;
-                        if (!Object.keys(assignee ?? {}).length) {
+                        assignee = getPersonalDetailByEmail(mentionWithDomain);
+                        if (!assignee) {
                             const optimisticDataForNewAssignee = setNewOptimisticAssignee(currentUserPersonalDetails.accountID, {
                                 accountID: generateAccountID(mentionWithDomain),
                                 login: mentionWithDomain,

--- a/tests/ui/ReportActionComposeTest.tsx
+++ b/tests/ui/ReportActionComposeTest.tsx
@@ -1,9 +1,13 @@
 import {act, fireEvent, render, screen, waitFor} from '@testing-library/react-native';
 
 import ComposeProviders from '@components/ComposeProviders';
+import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersonalDetailsProvider';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {KeyboardStateProvider} from '@components/withKeyboardState';
+
+import type * as TaskActions from '@libs/actions/Task';
+import {createTaskAndNavigate} from '@libs/actions/Task';
 
 import type {ReportActionComposeProps} from '@pages/inbox/report/ReportActionCompose/ReportActionCompose';
 import ReportActionCompose from '@pages/inbox/report/ReportActionCompose/ReportActionCompose';
@@ -24,6 +28,11 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 
 jest.mock('@libs/ComponentUtils', () => ({
     forceClearInput: jest.fn(),
+}));
+
+jest.mock('@libs/actions/Task', () => ({
+    ...jest.requireActual<typeof TaskActions>('@libs/actions/Task'),
+    createTaskAndNavigate: jest.fn(),
 }));
 
 jest.mock('@hooks/useLocalize', () =>
@@ -70,7 +79,13 @@ function ReportActionEditMessageContextProviderForReport({children}: PropsWithCh
 }
 
 function ReportScreenProviders({children}: PropsWithChildren) {
-    return <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, KeyboardStateProvider, ReportActionEditMessageContextProviderForReport]}>{children}</ComposeProviders>;
+    return (
+        <ComposeProviders
+            components={[OnyxListItemProvider, CurrentUserPersonalDetailsProvider, LocaleContextProvider, KeyboardStateProvider, ReportActionEditMessageContextProviderForReport]}
+        >
+            {children}
+        </ComposeProviders>
+    );
 }
 
 const renderReportActionCompose = (props?: Partial<ReportActionComposeProps>) => {
@@ -435,6 +450,42 @@ describe('ReportActionCompose Integration Tests', () => {
             );
 
             unmount();
+        });
+    });
+
+    describe('Task creation with a short mention', () => {
+        it('assigns the task to the user resolved from a same-private-domain short mention', async () => {
+            // Given a current user on a private domain and a coworker on the same domain
+            const coworkerAccountID = 2;
+            await TestHelper.signInWithTestUser(1, 'user@domain.com');
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+                    [coworkerAccountID]: TestHelper.buildPersonalDetails('mat@domain.com', coworkerAccountID, 'Mat'),
+                });
+            });
+
+            const {unmount} = renderReportActionCompose();
+            await waitForBatchedUpdatesWithAct();
+
+            // When a task with a short mention of the coworker is typed and submitted
+            // (the composer submits by clearing the input, which hands the draft to validateAndSubmitDraft)
+            const composer = screen.getByTestId('composer');
+            fireEvent.changeText(composer, '[] @mat Buy milk');
+            fireEvent(composer, 'clear', {nativeEvent: {text: '[] @mat Buy milk'}});
+
+            // Then the task is created with the mention resolved to the coworker's full login
+            await waitFor(() => {
+                expect(createTaskAndNavigate).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        title: 'Buy milk',
+                        assigneeEmail: 'mat@domain.com',
+                        assigneeAccountID: coworkerAccountID,
+                    }),
+                );
+            });
+
+            unmount();
+            await waitForBatchedUpdatesWithAct();
         });
     });
 });


### PR DESCRIPTION


### Explanation of Change

Creating a task with a short mention (`[] @name Task title`) has not assigned the task since July 2025 (4688d4ee3370). The composer passed bare usernames (`name`) into `addDomainToShortMention`, which checks full logins (`name@domain.com`). This check never matched, so the task was created unassigned with `@name` left in the title.

The fix feeds `addDomainToShortMention` the full logins list, via a new `getAllPersonalDetailLogins()` in `PersonalDetailsUtils`, and looks up the assignee with the existing `getPersonalDetailByEmail`. 

Both reads happen at submit time, so the composer input and send button no longer subscribe to the personal details collection on render.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96612
PROPOSAL:




### Tests

1. Sign in with an account on a private email domain that shares the domain with a coworker (e.g. you@company.com and coworker@company.com).
2. In any report, send `[] @coworker Some task` (short mention, without the domain).
3. Verify the task &#34;Some task&#34; is created and assigned to the coworker.
4. Send `[] @nosuchuser Some task` and verify the task is created unassigned, titled `@nosuchuser Some task`.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Same as Tests. Task creation is optimistic and works offline.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn&#39;t already exist
    - [x] The style can&#39;t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari





