### PR TITLE
fix: only treat a reachability confirmation as a recovery when the app was offline

### DIFF
--- a/contributingGuides/NETWORK_STATE_DETECTION.md
+++ b/contributingGuides/NETWORK_STATE_DETECTION.md
@@ -76,8 +76,7 @@ This layer uses `@react-native-community/netinfo` to detect whether the device h
 The NetInfo listener tracks `isInternetReachable` transitions in both directions:
 
 - **any non-`false` → `false`** (`true→false`, `null→false`, `undefined→false`) — `api/Ping` failed. Sets the `internetUnreachable` hard stop. Only `false→false` is skipped (already offline). This covers cold start with no internet (`null→false` after the initial indeterminate event), post-recovery resets, and normal online→offline transitions. Without this, an idle user would never see the offline indicator because no API requests are failing.
-- **`false` → `true`** and **`null` → `true`** — `api/Ping` succeeded after a previous failure. Triggers `onReachabilityRestored()` which clears all hard stops and fires reconnect listeners.
-- **`undefined` → `true`** — the initial event on subscribe, delivering current state. This is **not** treated as a recovery to prevent duplicate `openApp()`/`reconnectApp()` calls on boot.
+- **any non-`true` → `true`** — `api/Ping` succeeded. This counts as a recovery only when there is something to recover from: the app was offline at that moment, or a debug tool just cleared its own hard stop and asked for a recovery (`pendingReachabilityRecovery`). A recovery calls `onReachabilityRestored()`, which clears all hard stops and fires reconnect listeners. Any other confirmation (boot, re-subscription after a reconfigure, a `refresh()` re-emit) is a re-read of a network that never went down and is ignored, so it cannot fire duplicate `openApp()`/`reconnectApp()` calls.
 
 **Platform behavior:**
 

--- a/src/libs/NetworkState.ts
+++ b/src/libs/NetworkState.ts
@@ -24,7 +24,12 @@ let unsubscribeNetInfo: (() => void) | null = null;
 let prevIsInternetReachable: boolean | null | undefined;
 let isPoorConnectionSimulated: boolean | undefined;
 let networkTimeSkew = 0;
-let suppressNextReachabilityRestored = false;
+// Armed by the debug/simulation paths that clear an artificial hard stop and want the next
+// Ping-verified reachability confirmation to trigger a reconnect even though the app is
+// already back online by then. Without this token, a reachability re-confirmation that
+// arrives while the app was never offline is ignored (it's a re-read, not a recovery).
+let pendingReachabilityRecovery = false;
+let shouldUseStagingServer: boolean | undefined;
 
 // Subscriber sets
 const listeners = new Set<() => void>();
@@ -159,11 +164,13 @@ function setForceOffline(force: boolean) {
     updateState();
 
     if (!force) {
-        // Reset so the NetInfo listener sees a genuine transition (e.g. null→true)
-        // and fires onReachabilityRestored(). Without this, prevIsInternetReachable
-        // is already true (we track real state during force-offline) so the listener
-        // sees true→true and skips reconnect.
+        // Reset so the NetInfo listener sees a transition (e.g. null→true) — prevIsInternetReachable
+        // is already true (we track real state during force-offline) so the listener would see
+        // true→true and skip the recovery branch. The pending token authorizes the reconnect:
+        // by the time the refreshed Ping confirms reachability the app is already back online,
+        // and an unauthorized re-confirmation is otherwise ignored.
         prevIsInternetReachable = null;
+        pendingReachabilityRecovery = true;
         NetInfo.refresh();
     }
 }
@@ -187,6 +194,7 @@ function setFailAllRequests(failAll: boolean) {
         updateState();
 
         prevIsInternetReachable = null;
+        pendingReachabilityRecovery = true;
         NetInfo.refresh();
     }
 }
@@ -249,6 +257,7 @@ function simulatePoorConnection(shouldSimulate: boolean) {
 
         // Reset so NetInfo listener sees a transition and fires onReachabilityRestored().
         prevIsInternetReachable = null;
+        pendingReachabilityRecovery = true;
         NetInfo.refresh();
     }
 }
@@ -275,22 +284,9 @@ function setRandomNetworkStatus(initialCall = false) {
  * Must unsubscribe before calling configure() — configure tears down NetInfo internal state.
  */
 function configureAndSubscribe() {
-    // Treat this as a reconfigure (not an initial subscription) when there's already a listener.
-    // Reconfigure tears down NetInfo internal state, so the new subscription emits a synthetic
-    // null→true transition that would look like a recovery — suppress the next would-be recovery
-    // until reachability settles. Initial subscription is left untouched so boot behavior is
-    // unchanged (prev=undefined boot guard already covers it).
-    // Skip suppression when prev was already false: the app was genuinely offline before
-    // reconfigure, so the next true is a real recovery we must not drop (otherwise
-    // internetUnreachable stays set and the app is stuck offline until a new outage cycle).
-    const isReconfigure = unsubscribeNetInfo !== null;
     if (unsubscribeNetInfo) {
         unsubscribeNetInfo();
         unsubscribeNetInfo = null;
-    }
-
-    if (isReconfigure && prevIsInternetReachable !== false) {
-        suppressNextReachabilityRestored = true;
     }
 
     if (!CONFIG.IS_USING_LOCAL_WEB) {
@@ -329,23 +325,19 @@ function configureAndSubscribe() {
             setInternetUnreachable(true);
         }
 
-        // Treat false→true and null→true as genuine recovery. Both mean NetInfo previously
-        // lost reachability (false = confirmed unreachable, null = lost track during outage)
-        // and has now confirmed it's back. Only block undefined→true — that's the initial
-        // NetInfo event on subscribe which delivers current state, not a recovery. Firing
-        // onReachabilityRestored() on boot would duplicate openApp()/reconnectApp().
-        if (!shouldForceOffline && state.isInternetReachable === true && prevIsInternetReachable !== true && prevIsInternetReachable !== undefined) {
-            if (suppressNextReachabilityRestored) {
-                Log.info(`[NetworkState] Suppressing recovery on first stable state after reconfigure (${prevIsInternetReachable}→true)`);
-            } else {
+        // A confirmed-reachable event is only a recovery when the app was actually offline
+        // (a hard stop is active), or when a debug path explicitly requested one (the pending
+        // token). Anything else — boot's undefined→null→true sequence, a re-subscription after
+        // NetInfo.configure(), or NetInfo re-emitting its cached state on refresh() — is a
+        // re-read of an unchanged network, not a recovery, and must not fire reconnectApp.
+        if (!shouldForceOffline && state.isInternetReachable === true && prevIsInternetReachable !== true) {
+            if (getIsOffline() || pendingReachabilityRecovery) {
+                pendingReachabilityRecovery = false;
                 Log.info(`[NetworkState] Internet reachability restored (${prevIsInternetReachable}→true)`);
                 onReachabilityRestored();
+            } else {
+                Log.info(`[NetworkState] Ignoring reachability re-confirmation (${prevIsInternetReachable}→true) — app was never offline`);
             }
-        }
-        // End the post-reconfigure suppression window once reachability settles into a definitive
-        // state. Null/undefined are transient and should not end the window.
-        if (state.isInternetReachable === true || state.isInternetReachable === false) {
-            suppressNextReachabilityRestored = false;
         }
         prevIsInternetReachable = state.isInternetReachable;
     });
@@ -381,7 +373,14 @@ Onyx.connectWithoutView({
 // configureAndSubscribe to read the previous toggle state and invert the URL on every flip.
 Onyx.connectWithoutView({
     key: ONYXKEYS.SHOULD_USE_STAGING_SERVER,
-    callback: () => {
+    callback: (value) => {
+        // Rebuild only on an actual toggle flip. Rebuilding tears down NetInfo state and fires
+        // extra reachability Pings, so a same-value rewrite must not re-run it.
+        const next = !!value;
+        if (next === shouldUseStagingServer) {
+            return;
+        }
+        shouldUseStagingServer = next;
         queueMicrotask(configureAndSubscribe);
     },
 });

--- a/src/libs/NetworkState.ts
+++ b/src/libs/NetworkState.ts
@@ -24,12 +24,8 @@ let unsubscribeNetInfo: (() => void) | null = null;
 let prevIsInternetReachable: boolean | null | undefined;
 let isPoorConnectionSimulated: boolean | undefined;
 let networkTimeSkew = 0;
-// Armed by the debug/simulation paths that clear an artificial hard stop and want the next
-// Ping-verified reachability confirmation to trigger a reconnect even though the app is
-// already back online by then. Without this token, a reachability re-confirmation that
-// arrives while the app was never offline is ignored (it's a re-read, not a recovery).
 let pendingReachabilityRecovery = false;
-let shouldUseStagingServer: boolean | undefined;
+let configuredReachabilityUrl: string | undefined;
 
 // Subscriber sets
 const listeners = new Set<() => void>();
@@ -156,6 +152,19 @@ function setSustainedFailures(active: boolean) {
 }
 
 /**
+ * Arms a one-shot recovery for the debug/simulation paths that clear an artificial hard stop.
+ * They clear it synchronously, so by the time the refreshed Ping confirms reachability the app
+ * is already back online and the confirmation would be ignored as a re-read. The pending token
+ * authorizes that one recovery. Resetting prev lets the listener see a transition again — real
+ * state is tracked as true during the simulation, so it would otherwise see true→true and skip.
+ */
+function armReachabilityRecovery() {
+    prevIsInternetReachable = null;
+    pendingReachabilityRecovery = true;
+    NetInfo.refresh();
+}
+
+/**
  * Called when shouldForceOffline changes in Onyx (debug tool).
  */
 function setForceOffline(force: boolean) {
@@ -164,14 +173,7 @@ function setForceOffline(force: boolean) {
     updateState();
 
     if (!force) {
-        // Reset so the NetInfo listener sees a transition (e.g. null→true) — prevIsInternetReachable
-        // is already true (we track real state during force-offline) so the listener would see
-        // true→true and skip the recovery branch. The pending token authorizes the reconnect:
-        // by the time the refreshed Ping confirms reachability the app is already back online,
-        // and an unauthorized re-confirmation is otherwise ignored.
-        prevIsInternetReachable = null;
-        pendingReachabilityRecovery = true;
-        NetInfo.refresh();
+        armReachabilityRecovery();
     }
 }
 
@@ -193,9 +195,7 @@ function setFailAllRequests(failAll: boolean) {
         resetFailureCounters();
         updateState();
 
-        prevIsInternetReachable = null;
-        pendingReachabilityRecovery = true;
-        NetInfo.refresh();
+        armReachabilityRecovery();
     }
 }
 
@@ -255,10 +255,7 @@ function simulatePoorConnection(shouldSimulate: boolean) {
         simulatedOffline = false;
         updateState();
 
-        // Reset so NetInfo listener sees a transition and fires onReachabilityRestored().
-        prevIsInternetReachable = null;
-        pendingReachabilityRecovery = true;
-        NetInfo.refresh();
+        armReachabilityRecovery();
     }
 }
 
@@ -279,6 +276,10 @@ function setRandomNetworkStatus(initialCall = false) {
 
 // --- NetInfo configuration and subscription ---
 
+function buildReachabilityUrl(): string {
+    return `${getCommandURL({command: 'Ping'})}accountID=${accountID ?? 'unknown'}`;
+}
+
 /**
  * Configure NetInfo with the reachability URL and subscribe to state changes.
  * Must unsubscribe before calling configure() — configure tears down NetInfo internal state.
@@ -289,9 +290,11 @@ function configureAndSubscribe() {
         unsubscribeNetInfo = null;
     }
 
+    configuredReachabilityUrl = buildReachabilityUrl();
+
     if (!CONFIG.IS_USING_LOCAL_WEB) {
         NetInfo.configure({
-            reachabilityUrl: `${getCommandURL({command: 'Ping'})}accountID=${accountID ?? 'unknown'}`,
+            reachabilityUrl: configuredReachabilityUrl,
             reachabilityMethod: 'GET',
             reachabilityTest: (response) => {
                 if (!response.ok) {
@@ -367,21 +370,20 @@ Onyx.connectWithoutView({
 });
 
 // Re-target the reachability ping when the in-app staging-server toggle flips at runtime.
-// queueMicrotask defers configureAndSubscribe so ApiUtils' Onyx callback for the same key —
-// registered later and therefore firing later on the same tick — has already updated
-// shouldUseStagingServer before we re-sample getApiRoot(). Removing the defer causes
-// configureAndSubscribe to read the previous toggle state and invert the URL on every flip.
+// queueMicrotask defers past ApiUtils' Onyx callback for the same key — registered later and
+// therefore firing later on the same tick — which owns the effective flag getApiRoot() uses.
+// Rebuild only when the effective URL changed: rebuilding tears down NetInfo state and fires
+// extra reachability Pings, and the raw toggle value can change without changing the URL
+// (production forces the flag off; null falls back to the environment default).
 Onyx.connectWithoutView({
     key: ONYXKEYS.SHOULD_USE_STAGING_SERVER,
-    callback: (value) => {
-        // Rebuild only on an actual toggle flip. Rebuilding tears down NetInfo state and fires
-        // extra reachability Pings, so a same-value rewrite must not re-run it.
-        const next = !!value;
-        if (next === shouldUseStagingServer) {
-            return;
-        }
-        shouldUseStagingServer = next;
-        queueMicrotask(configureAndSubscribe);
+    callback: () => {
+        queueMicrotask(() => {
+            if (buildReachabilityUrl() === configuredReachabilityUrl) {
+                return;
+            }
+            configureAndSubscribe();
+        });
     },
 });
 

--- a/src/libs/NetworkState.ts
+++ b/src/libs/NetworkState.ts
@@ -152,11 +152,9 @@ function setSustainedFailures(active: boolean) {
 }
 
 /**
- * Arms a one-shot recovery for the debug/simulation paths that clear an artificial hard stop.
- * They clear it synchronously, so by the time the refreshed Ping confirms reachability the app
- * is already back online and the confirmation would be ignored as a re-read. The pending token
- * authorizes that one recovery. Resetting prev lets the listener see a transition again — real
- * state is tracked as true during the simulation, so it would otherwise see true→true and skip.
+ * The debug paths clear their hard stop right away, so when the refreshed Ping confirms
+ * reachability the app already looks online and the listener would ignore it. The token
+ * allows that one recovery. Resetting prev makes the listener see a transition again.
  */
 function armReachabilityRecovery() {
     prevIsInternetReachable = null;
@@ -328,18 +326,16 @@ function configureAndSubscribe() {
             setInternetUnreachable(true);
         }
 
-        // A confirmed-reachable event is only a recovery when the app was actually offline
-        // (a hard stop is active), or when a debug path explicitly requested one (the pending
-        // token). Anything else — boot's undefined→null→true sequence, a re-subscription after
-        // NetInfo.configure(), or NetInfo re-emitting its cached state on refresh() — is a
-        // re-read of an unchanged network, not a recovery, and must not fire reconnectApp.
+        // Treat a confirmed-reachable event as a recovery only when the app was actually offline
+        // or a debug path asked for one. Everything else (boot, re-subscription, refresh() re-emits)
+        // is a re-read of an unchanged network and must not fire reconnectApp.
         if (!shouldForceOffline && state.isInternetReachable === true && prevIsInternetReachable !== true) {
             if (getIsOffline() || pendingReachabilityRecovery) {
                 pendingReachabilityRecovery = false;
                 Log.info(`[NetworkState] Internet reachability restored (${prevIsInternetReachable}→true)`);
                 onReachabilityRestored();
             } else {
-                Log.info(`[NetworkState] Ignoring reachability re-confirmation (${prevIsInternetReachable}→true) — app was never offline`);
+                Log.info(`[NetworkState] Ignoring reachability re-confirmation (${prevIsInternetReachable}→true) since the app was never offline`);
             }
         }
         prevIsInternetReachable = state.isInternetReachable;
@@ -369,12 +365,10 @@ Onyx.connectWithoutView({
     },
 });
 
-// Re-target the reachability ping when the in-app staging-server toggle flips at runtime.
-// queueMicrotask defers past ApiUtils' Onyx callback for the same key — registered later and
-// therefore firing later on the same tick — which owns the effective flag getApiRoot() uses.
-// Rebuild only when the effective URL changed: rebuilding tears down NetInfo state and fires
-// extra reachability Pings, and the raw toggle value can change without changing the URL
-// (production forces the flag off; null falls back to the environment default).
+// Re-target the reachability ping when the staging-server toggle flips at runtime.
+// queueMicrotask waits for ApiUtils' callback on the same key, which owns the flag behind
+// getApiRoot(). Skip the rebuild when the URL is unchanged: rebuilding tears down NetInfo
+// state and fires extra Pings, and the raw toggle can flip without changing the URL.
 Onyx.connectWithoutView({
     key: ONYXKEYS.SHOULD_USE_STAGING_SERVER,
     callback: () => {

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -140,8 +140,7 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
     });
 
     test('repeated re-confirmations after a fake-recovery shape never fire reconnect', () => {
-        // The production storm: something keeps re-emitting null/true pairs with no real
-        // network change. None of them may fire a reconnect.
+        // Re-emitting null/true pairs should not result in a reconnect
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);
 

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -113,15 +113,45 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
         expect(reconnectListener).toHaveBeenCalledTimes(1);
     });
 
-    test('null→true fires reconnect listener', () => {
+    test('null→true does NOT fire reconnect listener when the app was never offline (fake recovery)', () => {
+        // This is the boot / post-configure / refresh() re-emit shape: NetInfo emits null while
+        // a Ping is in flight, then true when it succeeds. No hard stop was ever active, so
+        // there is nothing to reconnect from. Treating this as a recovery caused serial
+        // Ping+ReconnectApp storms in production (issue #2738).
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);
 
-        // Simulate losing reachability tracking (null) then recovering
+        fireNetInfoState({isInternetReachable: null});
+        fireNetInfoState({isInternetReachable: true});
+
+        expect(reconnectListener).not.toHaveBeenCalled();
+    });
+
+    test('false→null→true fires reconnect listener once (real outage with lost tracking)', () => {
+        const reconnectListener = jest.fn();
+        onReachabilityConfirmed(reconnectListener);
+
+        // Confirmed unreachable — the internetUnreachable hard stop is active
+        fireNetInfoState({isInternetReachable: false});
+        // Tracking lost mid-outage, then recovery confirmed
         fireNetInfoState({isInternetReachable: null});
         fireNetInfoState({isInternetReachable: true});
 
         expect(reconnectListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('repeated re-confirmations after a fake-recovery shape never fire reconnect', () => {
+        // The production storm: something keeps re-emitting null/true pairs with no real
+        // network change. None of them may fire a reconnect.
+        const reconnectListener = jest.fn();
+        onReachabilityConfirmed(reconnectListener);
+
+        for (let i = 0; i < 5; i++) {
+            fireNetInfoState({isInternetReachable: null});
+            fireNetInfoState({isInternetReachable: true});
+        }
+
+        expect(reconnectListener).not.toHaveBeenCalled();
     });
 
     test('undefined→true does NOT fire reconnect listener (boot event)', () => {

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -114,7 +114,7 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
     });
 
     test('null→true does NOT fire reconnect listener when the app was never offline (fake recovery)', () => {
-        // Boot, post-configure, and refresh() all look like this: 
+        // Boot, post-configure, and refresh() all look like this:
         // NetInfo emits null while a Ping is in flight, then true when it succeeds.
         // No hard stop was active, so there is nothing to recover from.
         const reconnectListener = jest.fn();

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -114,10 +114,9 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
     });
 
     test('null→true does NOT fire reconnect listener when the app was never offline (fake recovery)', () => {
-        // Boot, post-configure, and refresh() all look like this: NetInfo emits null while a Ping
-        // is in flight, then true when it succeeds. No hard stop was active, so there is nothing
-        // to recover from. Treating this as a recovery caused ReconnectApp storms in production
-        // (issue #2738).
+        // Boot, post-configure, and refresh() all look like this: 
+        // NetInfo emits null while a Ping is in flight, then true when it succeeds.
+        // No hard stop was active, so there is nothing to recover from.
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);
 

--- a/tests/unit/NetworkStateReachabilityTest.ts
+++ b/tests/unit/NetworkStateReachabilityTest.ts
@@ -114,10 +114,10 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
     });
 
     test('null→true does NOT fire reconnect listener when the app was never offline (fake recovery)', () => {
-        // This is the boot / post-configure / refresh() re-emit shape: NetInfo emits null while
-        // a Ping is in flight, then true when it succeeds. No hard stop was ever active, so
-        // there is nothing to reconnect from. Treating this as a recovery caused serial
-        // Ping+ReconnectApp storms in production (issue #2738).
+        // Boot, post-configure, and refresh() all look like this: NetInfo emits null while a Ping
+        // is in flight, then true when it succeeds. No hard stop was active, so there is nothing
+        // to recover from. Treating this as a recovery caused ReconnectApp storms in production
+        // (issue #2738).
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);
 
@@ -131,7 +131,7 @@ describe('NetworkState — reachability recovery triggers reconnect', () => {
         const reconnectListener = jest.fn();
         onReachabilityConfirmed(reconnectListener);
 
-        // Confirmed unreachable — the internetUnreachable hard stop is active
+        // Confirmed unreachable, so the internetUnreachable hard stop is active
         fireNetInfoState({isInternetReachable: false});
         // Tracking lost mid-outage, then recovery confirmed
         fireNetInfoState({isInternetReachable: null});

--- a/tests/unit/NetworkStateTest.ts
+++ b/tests/unit/NetworkStateTest.ts
@@ -1,3 +1,5 @@
+import {getCommandURL} from '@libs/ApiUtils';
+
 import {
     getDBTimeWithSkew,
     getIsOffline,
@@ -36,6 +38,7 @@ jest.mock('@react-native-community/netinfo', () => ({
 }));
 
 const mockPingUrl = 'https://test-api.expensify.com/api/Ping?';
+const mockStagingPingUrl = 'https://staging-test-api.expensify.com/api/Ping?';
 jest.mock('@libs/ApiUtils', () => ({
     __esModule: true,
     getApiRoot: jest.fn(() => 'https://test-api.expensify.com/'),
@@ -538,6 +541,7 @@ describe('NetworkState', () => {
         const configureMock = NetInfo.configure as jest.Mock<void, [{reachabilityUrl: string}]>;
 
         beforeEach(async () => {
+            jest.mocked(getCommandURL).mockReturnValue(mockPingUrl);
             configureMock.mockClear();
             await Onyx.clear();
             await waitForBatchedUpdates();
@@ -563,16 +567,19 @@ describe('NetworkState', () => {
             expect(configureMock.mock.calls.at(-1)?.[0].reachabilityUrl).toBe(`${mockPingUrl}accountID=2`);
         });
 
-        test('SHOULD_USE_STAGING_SERVER change triggers a reconfigure', async () => {
+        test('SHOULD_USE_STAGING_SERVER change triggers a reconfigure when the reachability URL changes', async () => {
             const callsBefore = configureMock.mock.calls.length;
+            jest.mocked(getCommandURL).mockReturnValue(mockStagingPingUrl);
 
             await Onyx.set(ONYXKEYS.SHOULD_USE_STAGING_SERVER, true);
             await waitForBatchedUpdates();
 
             expect(configureMock.mock.calls.length).toBeGreaterThan(callsBefore);
+            expect(configureMock.mock.calls.at(-1)?.[0].reachabilityUrl).toBe(`${mockStagingPingUrl}accountID=unknown`);
         });
 
         test('SHOULD_USE_STAGING_SERVER same-value rewrite does NOT reconfigure', async () => {
+            jest.mocked(getCommandURL).mockReturnValue(mockStagingPingUrl);
             await Onyx.set(ONYXKEYS.SHOULD_USE_STAGING_SERVER, true);
             await waitForBatchedUpdates();
             const callsAfterFlip = configureMock.mock.calls.length;
@@ -583,7 +590,20 @@ describe('NetworkState', () => {
             expect(configureMock.mock.calls.length).toBe(callsAfterFlip);
         });
 
+        test('SHOULD_USE_STAGING_SERVER flip that does not change the reachability URL does NOT reconfigure', async () => {
+            // e.g. production, where ApiUtils forces the effective flag off regardless of the toggle
+            const callsBefore = configureMock.mock.calls.length;
+
+            await Onyx.set(ONYXKEYS.SHOULD_USE_STAGING_SERVER, true);
+            await waitForBatchedUpdates();
+
+            expect(configureMock.mock.calls.length).toBe(callsBefore);
+        });
+
         test('reachability URL falls back to accountID=unknown when SESSION has no accountID', async () => {
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: 123});
+            await waitForBatchedUpdates();
+            await Onyx.set(ONYXKEYS.SESSION, null);
             await waitForBatchedUpdates();
 
             expect(configureMock.mock.calls.at(-1)?.[0].reachabilityUrl).toBe(`${mockPingUrl}accountID=unknown`);

--- a/tests/unit/NetworkStateTest.ts
+++ b/tests/unit/NetworkStateTest.ts
@@ -572,6 +572,17 @@ describe('NetworkState', () => {
             expect(configureMock.mock.calls.length).toBeGreaterThan(callsBefore);
         });
 
+        test('SHOULD_USE_STAGING_SERVER same-value rewrite does NOT reconfigure', async () => {
+            await Onyx.set(ONYXKEYS.SHOULD_USE_STAGING_SERVER, true);
+            await waitForBatchedUpdates();
+            const callsAfterFlip = configureMock.mock.calls.length;
+
+            await Onyx.set(ONYXKEYS.SHOULD_USE_STAGING_SERVER, true);
+            await waitForBatchedUpdates();
+
+            expect(configureMock.mock.calls.length).toBe(callsAfterFlip);
+        });
+
         test('reachability URL falls back to accountID=unknown when SESSION has no accountID', async () => {
             await waitForBatchedUpdates();
 


### PR DESCRIPTION


### Explanation of Change


Production traces show serial Ping+ReconnectApp storms (up to 23 ReconnectApp calls in 52 seconds in one session) where nothing about the network changed. Root cause: `NetworkState` fires `reconnectApp()` from raw NetInfo `null→true` transitions, and those get manufactured with no real connectivity change by:

1. Boot&#39;s real emission sequence `undefined→null→true` slipping past the dead `!== undefined` guard.
2. `NetInfo.refresh()` re-emitting cached state after the debug paths reset `prevIsInternetReachable = null`.
3. The `SHOULD_USE_STAGING_SERVER` Onyx callback rebuilding the NetInfo subscription on every write, where each rebuild fires its own extra Ping.

**Fix:**
1. The recovery branch fires only when `getIsOffline()` is true at the moment reachability is confirmed, or when a one-shot `pendingReachabilityRecovery` token was armed. The three debug paths (`setForceOffline(false)`, `setFailAllRequests(false)`, `simulatePoorConnection(false)`) arm the token instead of exploiting the transition loophole, so debug recovery stays Ping-verified.
2. Deleted `suppressNextReachabilityRestored`, the old post-reconfigure band-aid. The gate above covers it.
3. The `SHOULD_USE_STAGING_SERVER` callback rebuilds the subscription only when the effective reachability URL changed. Same-value rewrites, and toggle writes that do not change the URL (like on production, where the staging flag is forced off), no longer tear down NetInfo.

Tests: one existing test (`null→true fires reconnect listener`) asserted the buggy behavior and was inverted. New regression tests pin that a bare `null→true` and repeated fake pairs never fire a reconnect, that `false→true` and `false→null→true` fire exactly once, that force-offline debug recovery still works, and that staging toggle writes which do not change the URL do not reconfigure. All affected suites pass, including `SequentialQueueTest` and `APITest`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96634
PROPOSAL:




### Tests


1. Open the app and wait for boot to settle. Confirm no ReconnectApp fires from a reachability &#34;recovery&#34; on a healthy network (only the normal OpenApp/reconnect flow).
2. Toggle Force offline in the TestToolMenu on, then off. Confirm exactly one ReconnectApp fires after turning it off.
3. Turn airplane mode on, wait for the offline indicator, then turn it off. Confirm one ReconnectApp fires after connectivity returns.

- [x] Verify that no errors appear in the JS console

### Offline tests


Same as steps 2 and 3 above. Both exercise the offline→online recovery path.

### QA Steps


Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn&#39;t already exist
    - [x] The style can&#39;t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari






