### PR TITLE
Remove workspaceRoomsPage beta and release Workspace Rooms page

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -992,7 +992,6 @@ const CONST = {
         BULK_EDIT_WORKSPACES: 'bulkEditWorkspaces',
         SUBMIT_2026: 'submit2026',
         BULK_SUBMIT_APPROVE_PAY: 'bulkSubmitApprovePay',
-        WORKSPACE_ROOMS_PAGE: 'workspaceRoomsPage',
         VENDOR_MATCHING: 'vendorMatching',
         RILLET: 'rillet',
         RULES_REVAMP: 'rulesRevamp',

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -284,17 +284,14 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
             screenName: SCREENS.WORKSPACE.MEMBERS,
             sentryLabel: CONST.SENTRY_LABEL.WORKSPACE.INITIAL.MEMBERS,
         },
-    ];
-
-    if (isBetaEnabled(CONST.BETAS.WORKSPACE_ROOMS_PAGE)) {
-        workspaceMenuItems.push({
+        {
             translationKey: 'workspace.common.rooms',
             icon: expensifyIcons.Hashtag,
             action: singleExecution(waitForNavigate(() => Navigation.navigate(ROUTES.WORKSPACE_ROOMS.getRoute(policyID)))),
             screenName: SCREENS.WORKSPACE.ROOMS,
             sentryLabel: CONST.SENTRY_LABEL.WORKSPACE.INITIAL.ROOMS,
-        });
-    }
+        },
+    ];
 
     if (isGroupPolicy(policy) && shouldShowProtectedItems) {
         if (canReadPolicyFeature(CONST.POLICY.POLICY_FEATURE.REPORT_FIELDS)) {

--- a/src/pages/workspace/rooms/WorkspaceRoomCreatePage.tsx
+++ b/src/pages/workspace/rooms/WorkspaceRoomCreatePage.tsx
@@ -1,12 +1,9 @@
-import usePermissions from '@hooks/usePermissions';
-
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import WorkspaceNewRoomPage from '@pages/workspace/WorkspaceNewRoomPage';
 
-import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
 
 import React from 'react';
@@ -14,12 +11,8 @@ import React from 'react';
 type WorkspaceRoomCreatePageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.ROOM_CREATE>;
 
 function WorkspaceRoomCreatePage({route}: WorkspaceRoomCreatePageProps) {
-    const {isBetaEnabled} = usePermissions();
     return (
-        <AccessOrNotFoundWrapper
-            policyID={route.params.policyID}
-            shouldBeBlocked={!isBetaEnabled(CONST.BETAS.WORKSPACE_ROOMS_PAGE)}
-        >
+        <AccessOrNotFoundWrapper policyID={route.params.policyID}>
             <WorkspaceNewRoomPage policyID={route.params.policyID} />
         </AccessOrNotFoundWrapper>
     );

--- a/src/pages/workspace/rooms/WorkspaceRoomsPage.tsx
+++ b/src/pages/workspace/rooms/WorkspaceRoomsPage.tsx
@@ -8,7 +8,6 @@ import type {WorkspaceRoomRowData} from '@components/Tables/WorkspaceRoomsTable'
 import {useMemoizedLazyExpensifyIcons, useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import usePermissions from '@hooks/usePermissions';
 import usePolicy from '@hooks/usePolicy';
 import useReportAttributes from '@hooks/useReportAttributes';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -28,7 +27,6 @@ import type {WorkspaceSplitNavigatorParamList} from '@navigation/types';
 
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 
-import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
@@ -44,7 +42,6 @@ function WorkspaceRoomsPage({route}: WorkspaceRoomsPageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
-    const {isBetaEnabled} = usePermissions();
     const headerIcons = useMemoizedLazyExpensifyIcons(['Plus']);
     const illustrations = useMemoizedLazyIllustrations(['Hashtag']);
     const policyID = route.params.policyID;
@@ -94,10 +91,7 @@ function WorkspaceRoomsPage({route}: WorkspaceRoomsPageProps) {
     });
 
     return (
-        <AccessOrNotFoundWrapper
-            policyID={policyID}
-            shouldBeBlocked={!isBetaEnabled(CONST.BETAS.WORKSPACE_ROOMS_PAGE)}
-        >
+        <AccessOrNotFoundWrapper policyID={policyID}>
             <ScreenWrapper
                 testID={WorkspaceRoomsPage.displayName}
                 style={[styles.defaultModalContainer]}


### PR DESCRIPTION
### Explanation of Change

This PR releases the Workspace Rooms feature to everyone by removing the `workspaceRoomsPage` beta flag:

- Removed `WORKSPACE_ROOMS_PAGE` from `CONST.BETAS`.
- The **Rooms** menu item on the workspace initial page (below **Members**) is now shown unconditionally instead of being gated behind `isBetaEnabled`.
- `WorkspaceRoomsPage` and `WorkspaceRoomCreatePage` no longer pass `shouldBeBlocked` to `AccessOrNotFoundWrapper` — access is now controlled only by the standard policy-access checks.

Since this releases the whole feature, the test steps below cover the full Workspace Rooms flow to ensure a complete review.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93416
PROPOSAL:

### Tests

Use an account that is **not** in the `workspaceRoomsPage` beta.

1. Sign in and go to **Workspaces**, then open a workspace where you are an **admin**.
2. Verify the **Rooms** menu item (with the `#` icon) appears in the left menu, directly below **Members**.
3. Click **Rooms** and verify the Rooms page opens, listing the workspace chat rooms (e.g. `#admins`, `#announce`) in alphabetical order, each row showing the room avatar, name and member count.
4. Click a room row and verify the room details RHP opens (as an admin you should land on details, not in the conversation).
5. Close the RHP, click the **Create** button and verify the create room form opens with the current workspace preselected.
6. Create a room and verify you are dropped back on the Rooms table and the newly created room row plays the highlight animation.
7. Verify the new room appears in the list in the correct alphabetical position with the correct member count.
8. Sign in as a **non-admin member** of the workspace, open **Workspaces > [workspace] > Rooms** and verify only rooms visible to that member are listed.
9. As the member, click a room row and verify you are taken to the room conversation (not the details RHP)
10. Verify that no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests

Unnecessary — this PR only removes a beta gate, no offline behavior changes.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/6af6309d-6f8b-48a1-9b17-a844a6bb6de7


</details>
