### PR TITLE
Fix magic code navigates back on payment (SettlementButton) v2

### DIFF
--- a/src/components/SettlementButton/index.tsx
+++ b/src/components/SettlementButton/index.tsx
@@ -20,12 +20,12 @@ import useOnyx from '@hooks/useOnyx';
 import usePermissions from '@hooks/usePermissions';
 import usePolicy from '@hooks/usePolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useVerifyAccountAndResume from '@hooks/useVerifyAccountAndResume';
 
 import {createWorkspace, generateDefaultWorkspaceName, isCurrencySupportedForDirectReimbursement, isCurrencySupportedForGlobalReimbursement} from '@libs/actions/Policy/Policy';
 import {navigateToBankAccountRoute} from '@libs/actions/ReimbursementAccount';
 import {getLastPolicyBankAccountID, getLastPolicyPaymentMethod} from '@libs/actions/Search';
 import {isBankAccountPartiallySetup} from '@libs/BankAccountUtils';
-import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import {isTrackOnboardingChoice} from '@libs/OnboardingUtils';
 import {formatPaymentMethods, getActivePaymentType, getBusinessBankAccountOptions, matchesCurrency} from '@libs/PaymentUtils';
@@ -50,7 +50,7 @@ import {navigateToConciergeChat} from '@userActions/Report';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
+import ROUTES from '@src/ROUTES';
 import type {AccountData, BankAccount, LastPaymentMethodType, Policy} from '@src/types/onyx';
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
@@ -58,11 +58,11 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type {GestureResponderEvent} from 'react-native';
 import type {TupleToUnion} from 'type-fest';
 
-import {delegateEmailSelector, isUserValidatedSelector} from '@selectors/Account';
+import {delegateEmailSelector} from '@selectors/Account';
 import {hasSeenTourSelector} from '@selectors/Onboarding';
 import {personalDetailsLoginSelector} from '@selectors/PersonalDetails';
 import truncate from 'lodash/truncate';
-import React, {useCallback, useContext} from 'react';
+import React, {useContext} from 'react';
 import {View} from 'react-native';
 
 import type SettlementButtonProps from './types';
@@ -128,7 +128,6 @@ function SettlementButton({
     const [conciergeChat] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${conciergeReportID}`);
     const [iouReportNextStep] = useOnyx(`${ONYXKEYS.COLLECTION.NEXT_STEP}${iouReport?.reportID}`);
     const [ownerLogin] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: personalDetailsLoginSelector(iouReport?.ownerAccountID)});
-    const [isUserValidated] = useOnyx(ONYXKEYS.ACCOUNT, {selector: isUserValidatedSelector});
     const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
     const reportBelongsToWorkspace = policyID ? doesReportBelongToWorkspace(chatReport, policyID, conciergeReportID) : false;
     const policyIDKey = reportBelongsToWorkspace ? policyID : (iouReport?.policyID ?? CONST.POLICY.ID_FAKE);
@@ -200,76 +199,73 @@ function SettlementButton({
         return formattedPaymentMethods.filter((ba) => (ba.accountData as AccountData)?.type === CONST.BANK_ACCOUNT.TYPE.PERSONAL);
     }
 
-    const checkForNecessaryAction = useCallback(
-        (paymentMethodType?: PaymentMethodType) => {
-            if (isDelegateAccessRestricted) {
-                showDelegateNoAccessModal();
-                return true;
-            }
+    // The guards checked after the account-validation gate. Also re-checked when a payment
+    // interrupted by account validation resumes, since the validation gate skipped them.
+    const checkForPostValidationBlockers = () => {
+        if (isBankAccountLocked) {
+            showConfirmModal({
+                title: translate('bankAccount.lockedBankAccount'),
+                prompt: (
+                    <View style={[styles.renderHTML, styles.flexRow]}>
+                        <RenderHTML html={translate('bankAccount.youCantPayThis')} />
+                    </View>
+                ),
+                confirmText: translate('bankAccount.unlockBankAccount'),
+                cancelText: translate('common.cancel'),
+            }).then(({action}) => {
+                if (action !== ModalActions.CONFIRM) {
+                    return;
+                }
+                if (policy?.achAccount?.bankAccountID === undefined) {
+                    return;
+                }
+                pressLockedBankAccount(policy?.achAccount?.bankAccountID, translate, conciergeReportID, delegateAccountID);
+                navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas);
+            });
+            return true;
+        }
 
-            if (isAccountLocked) {
-                showLockedAccountModal();
-                return true;
-            }
+        if (policy && shouldRestrictUserBillableActions(policy, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, amountOwed, currentUserAccountID)) {
+            Navigation.navigate(ROUTES.RESTRICTED_ACTION.getRoute(policy.id));
+            return true;
+        }
 
-            if (!isUserValidated && paymentMethodType !== CONST.IOU.PAYMENT_TYPE.ELSEWHERE) {
-                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.VERIFY_ACCOUNT.path));
-                return true;
-            }
+        return false;
+    };
 
-            if (isBankAccountLocked) {
-                showConfirmModal({
-                    title: translate('bankAccount.lockedBankAccount'),
-                    prompt: (
-                        <View style={[styles.renderHTML, styles.flexRow]}>
-                            <RenderHTML html={translate('bankAccount.youCantPayThis')} />
-                        </View>
-                    ),
-                    confirmText: translate('bankAccount.unlockBankAccount'),
-                    cancelText: translate('common.cancel'),
-                }).then(({action}) => {
-                    if (action !== ModalActions.CONFIRM) {
-                        return;
-                    }
-                    if (policy?.achAccount?.bankAccountID === undefined) {
-                        return;
-                    }
-                    pressLockedBankAccount(policy?.achAccount?.bankAccountID, translate, conciergeReportID, delegateAccountID);
-                    navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas);
-                });
-                return true;
-            }
+    const {isUserValidated, verifyAccountAndResume} = useVerifyAccountAndResume((retry?: () => void) => {
+        // The validation gate returned before these guards could run, so apply them to the resumed.
+        if (checkForPostValidationBlockers()) {
+            return;
+        }
+        retry?.();
+    });
 
-            if (policy && shouldRestrictUserBillableActions(policy, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, amountOwed, currentUserAccountID)) {
-                Navigation.navigate(ROUTES.RESTRICTED_ACTION.getRoute(policy.id));
-                return true;
-            }
+    const checkForNecessaryAction = (paymentMethodType?: PaymentMethodType, retry?: () => void) => {
+        if (isDelegateAccessRestricted) {
+            showDelegateNoAccessModal();
+            return true;
+        }
 
-            return false;
-        },
-        [
-            isDelegateAccessRestricted,
-            isAccountLocked,
-            isUserValidated,
-            isBankAccountLocked,
-            policy,
-            userBillingGracePeriodEnds,
-            ownerBillingGracePeriodEnd,
-            showDelegateNoAccessModal,
-            showLockedAccountModal,
-            showConfirmModal,
-            translate,
-            styles.renderHTML,
-            styles.flexRow,
-            conciergeReportID,
-            introSelected,
-            currentUserAccountID,
-            isSelfTourViewed,
-            betas,
-            amountOwed,
-            delegateAccountID,
-        ],
-    );
+        if (isAccountLocked) {
+            showLockedAccountModal();
+            return true;
+        }
+
+        if (!isUserValidated && paymentMethodType !== CONST.IOU.PAYMENT_TYPE.ELSEWHERE) {
+            verifyAccountAndResume(retry);
+            return true;
+        }
+
+        return checkForPostValidationBlockers();
+    };
+
+    const runPaymentAction = (paymentMethodType: PaymentMethodType | undefined, action: () => void) => {
+        if (checkForNecessaryAction(paymentMethodType, action)) {
+            return;
+        }
+        action();
+    };
 
     const shortFormPayElsewhereButton = {
         text: translate('iou.pay'),
@@ -340,17 +336,15 @@ function SettlementButton({
                         value: CONST.PAYMENT_METHODS.BUSINESS_BANK_ACCOUNT,
                         description: account.description,
                         shouldIgnoreCompactStyle: true,
-                        onSelected: () => {
-                            if (checkForNecessaryAction(CONST.IOU.PAYMENT_TYPE.VBBA)) {
-                                return;
-                            }
-                            onPress({
-                                paymentType: CONST.IOU.PAYMENT_TYPE.VBBA,
-                                payAsBusiness: true,
-                                methodID: account.methodID,
-                                paymentMethod: CONST.PAYMENT_METHODS.BUSINESS_BANK_ACCOUNT,
-                            });
-                        },
+                        onSelected: () =>
+                            runPaymentAction(CONST.IOU.PAYMENT_TYPE.VBBA, () =>
+                                onPress({
+                                    paymentType: CONST.IOU.PAYMENT_TYPE.VBBA,
+                                    payAsBusiness: true,
+                                    methodID: account.methodID,
+                                    paymentMethod: CONST.PAYMENT_METHODS.BUSINESS_BANK_ACCOUNT,
+                                }),
+                            ),
                     });
                 }
             }
@@ -403,17 +397,15 @@ function SettlementButton({
                         description: formattedPaymentMethod?.description ?? '',
                         icon: formattedPaymentMethod?.icon,
                         shouldUpdateSelectedIndex: true,
-                        onSelected: () => {
-                            if (checkForNecessaryAction(CONST.IOU.PAYMENT_TYPE.EXPENSIFY)) {
-                                return;
-                            }
-                            onPress({
-                                paymentType: CONST.IOU.PAYMENT_TYPE.EXPENSIFY,
-                                payAsBusiness,
-                                methodID: formattedPaymentMethod.methodID,
-                                paymentMethod: formattedPaymentMethod.accountType,
-                            });
-                        },
+                        onSelected: () =>
+                            runPaymentAction(CONST.IOU.PAYMENT_TYPE.EXPENSIFY, () =>
+                                onPress({
+                                    paymentType: CONST.IOU.PAYMENT_TYPE.EXPENSIFY,
+                                    payAsBusiness,
+                                    methodID: formattedPaymentMethod.methodID,
+                                    paymentMethod: formattedPaymentMethod.accountType,
+                                }),
+                            ),
                         iconStyles: formattedPaymentMethod?.iconStyles,
                         iconHeight: formattedPaymentMethod?.iconSize,
                         iconWidth: formattedPaymentMethod?.iconSize,
@@ -466,12 +458,7 @@ function SettlementButton({
                         icon: icons.Cash,
                         value: CONST.IOU.PAYMENT_TYPE.ELSEWHERE,
                         shouldUpdateSelectedIndex: true,
-                        onSelected: () => {
-                            if (checkForNecessaryAction(CONST.IOU.PAYMENT_TYPE.ELSEWHERE)) {
-                                return;
-                            }
-                            onPress({paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE, payAsBusiness});
-                        },
+                        onSelected: () => runPaymentAction(CONST.IOU.PAYMENT_TYPE.ELSEWHERE, () => onPress({paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE, payAsBusiness})),
                     },
                 ];
             };
@@ -578,17 +565,8 @@ function SettlementButton({
         });
     };
 
-    const handlePaymentSelection = (event: GestureResponderEvent | KeyboardEvent | undefined, selectedOption: string, triggerKYCFlow: (params: ContinueActionParams) => void) => {
-        const {paymentType, policyFromPaymentMethod, policyFromContext, shouldSelectPaymentMethod} = getActivePaymentType(
-            selectedOption,
-            activeAdminPolicies,
-            businessBankAccountOptions,
-            policyIDKey,
-        );
-
-        if (checkForNecessaryAction(paymentType)) {
-            return;
-        }
+    const executePaymentSelection = (event: KYCFlowEvent, selectedOption: string, triggerKYCFlow: TriggerKYCFlow, activePaymentType: ReturnType<typeof getActivePaymentType>) => {
+        const {paymentType, policyFromPaymentMethod, policyFromContext, shouldSelectPaymentMethod} = activePaymentType;
         const isPayingWithMethod = paymentType !== CONST.IOU.PAYMENT_TYPE.ELSEWHERE;
 
         if ((!!policyFromPaymentMethod || shouldSelectPaymentMethod) && (isPayingWithMethod || !!policyFromPaymentMethod)) {
@@ -597,6 +575,12 @@ function SettlementButton({
         }
 
         selectPaymentType(event, selectedOption as PaymentMethodType);
+    };
+
+    const handlePaymentSelection = (event: KYCFlowEvent, selectedOption: string, triggerKYCFlow: TriggerKYCFlow) => {
+        const activePaymentType = getActivePaymentType(selectedOption, activeAdminPolicies, businessBankAccountOptions, policyIDKey);
+
+        runPaymentAction(activePaymentType.paymentType, () => executePaymentSelection(event, selectedOption, triggerKYCFlow, activePaymentType));
     };
 
     let customText: string;

--- a/src/components/WideRHPContextProvider/useShouldRenderOverlay.ts
+++ b/src/components/WideRHPContextProvider/useShouldRenderOverlay.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
@@ -9,7 +9,12 @@ const OVERLAY_TIMING_DURATION = 300;
 function useShouldRenderOverlay(condition: boolean, overlayProgress: Animated.Value) {
     const [shouldRenderOverlay, setShouldRenderOverlay] = useState(false);
 
+    // Holds the latest `condition` so the async hide callback can read it.
+    const conditionRef = useRef(condition);
+
     useEffect(() => {
+        conditionRef.current = condition;
+
         if (condition) {
             setShouldRenderOverlay(true);
             Animated.timing(overlayProgress, {
@@ -23,6 +28,9 @@ function useShouldRenderOverlay(condition: boolean, overlayProgress: Animated.Va
                 duration: OVERLAY_TIMING_DURATION,
                 useNativeDriver: false,
             }).start(() => {
+                if (conditionRef.current) {
+                    return;
+                }
                 setShouldRenderOverlay(false);
             });
         }

--- a/src/hooks/useVerifyAccountAndResume.ts
+++ b/src/hooks/useVerifyAccountAndResume.ts
@@ -1,0 +1,67 @@
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
+import splitPathAndQuery from '@libs/Navigation/helpers/dynamicRoutesUtils/splitPathAndQuery';
+import Navigation from '@libs/Navigation/Navigation';
+import navigationRef from '@libs/Navigation/navigationRef';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
+
+import {isUserValidatedSelector} from '@selectors/Account';
+import {useEffect, useEffectEvent, useState} from 'react';
+
+import useOnyx from './useOnyx';
+
+type ResumePayload = (() => void) | undefined;
+
+/**
+ * Returns a trigger that sends an unvalidated user to the verify-account (magic code) screen and,
+ * once they validate there, calls `onResume` with the payload the trigger stored.
+ */
+function useVerifyAccountAndResume(onResume: (payload: ResumePayload) => void) {
+    const [isUserValidated] = useOnyx(ONYXKEYS.ACCOUNT, {selector: isUserValidatedSelector});
+    const [pendingAction, setPendingAction] = useState<{payload: ResumePayload; verifyAccountPath: string} | null>(null);
+
+    // Effect event, so the resume runs the latest `onResume` (a press-time closure would see pre-validation state).
+    const resumeAction = useEffectEvent(onResume);
+
+    // Effect event, so the listener reads the freshest validation state and doesn't mistake the success-driven close of the verify-account page for an abandon.
+    const handleNavigationStateChange = useEffectEvent(() => {
+        if (!pendingAction || isUserValidated || Navigation.getActiveRouteWithoutParams() === pendingAction.verifyAccountPath) {
+            return;
+        }
+        setPendingAction(null);
+    });
+
+    useEffect(() => {
+        if (!pendingAction) {
+            return;
+        }
+
+        // Leaving the verify-account screen without validating abandons the action, which is what makes resuming below safe without a route check.
+        if (!isUserValidated) {
+            return navigationRef.addListener('state', handleNavigationStateChange);
+        }
+
+        // Validation succeeded — resume even if the verify-account page already dismissed itself.
+        const isVerifyAccountScreenStillOpen = Navigation.getActiveRouteWithoutParams() === pendingAction.verifyAccountPath;
+        const resume = () => {
+            setPendingAction(null);
+            resumeAction(pendingAction.payload);
+        };
+        // While the page is still open its closing transition hasn't been dispatched yet, so wait for the upcoming one; otherwise the close is already in flight (or done), so only wait out active transitions.
+        const handle = isVerifyAccountScreenStillOpen ? Navigation.runAfterUpcomingTransition(resume) : Navigation.runAfterTransition(resume);
+
+        return () => handle.cancel();
+    }, [isUserValidated, pendingAction]);
+
+    const verifyAccountAndResume = (payload: ResumePayload) => {
+        const verifyAccountRoute = createDynamicRoute(DYNAMIC_ROUTES.VERIFY_ACCOUNT.path);
+        const [verifyAccountPath] = splitPathAndQuery(verifyAccountRoute);
+        setPendingAction(verifyAccountPath ? {payload, verifyAccountPath} : null);
+        Navigation.navigate(verifyAccountRoute);
+    };
+
+    return {isUserValidated, verifyAccountAndResume};
+}
+
+export default useVerifyAccountAndResume;

--- a/tests/ui/components/SettlementButtonTest.tsx
+++ b/tests/ui/components/SettlementButtonTest.tsx
@@ -81,6 +81,16 @@ jest.mock('@libs/actions/Policy/Policy', () => ({
     createWorkspace: jest.fn(() => ({policyID: 'mock-created-policy-id'})),
 }));
 
+const mockVerifyAccountAndResume = jest.fn();
+
+jest.mock('@hooks/useVerifyAccountAndResume', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        isUserValidated: true,
+        verifyAccountAndResume: mockVerifyAccountAndResume,
+    })),
+}));
+
 const ACCOUNT_ID = 1;
 const ACCOUNT_LOGIN = 'test@user.com';
 const REPORT_ID = '100';

--- a/tests/unit/hooks/useVerifyAccountAndResume.test.ts
+++ b/tests/unit/hooks/useVerifyAccountAndResume.test.ts
@@ -1,0 +1,200 @@
+import {act, renderHook, waitFor} from '@testing-library/react-native';
+
+import useVerifyAccountAndResume from '@hooks/useVerifyAccountAndResume';
+
+import Navigation from '@libs/Navigation/Navigation';
+import navigationRef from '@libs/Navigation/navigationRef';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import Onyx from 'react-native-onyx';
+
+import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
+
+type ResumePayload = (() => void) | undefined;
+
+const mockVerifyAccountRoute = 'r/123/verify-account?source=pay';
+const mockVerifyAccountPath = 'r/123/verify-account';
+const mockCancelTransition = jest.fn();
+const mockNavigationStateListeners = new Set<() => void>();
+let mockPendingTransitionCallbacks: Array<() => void> = [];
+
+jest.mock('@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute', () => ({
+    __esModule: true,
+    default: jest.fn(() => 'r/123/verify-account?source=pay'),
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => {
+    const mockNavigationModule = {
+        navigate: jest.fn(),
+        runAfterTransition: jest.fn(),
+        runAfterUpcomingTransition: jest.fn(),
+        getActiveRouteWithoutParams: jest.fn(),
+    };
+    return {
+        __esModule: true,
+        default: mockNavigationModule,
+        ...mockNavigationModule,
+    };
+});
+
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    __esModule: true,
+    default: {
+        addListener: jest.fn(),
+    },
+}));
+
+const mockedNavigation = jest.mocked(Navigation);
+const mockedNavigationRef = jest.mocked(navigationRef);
+
+function emitNavigationStateChange() {
+    for (const listener of mockNavigationStateListeners) {
+        listener();
+    }
+}
+
+async function setIsUserValidated(validated: boolean) {
+    await act(async () => {
+        await Onyx.merge(ONYXKEYS.ACCOUNT, {validated});
+    });
+    await waitForBatchedUpdatesWithAct();
+}
+
+async function clearOnyx() {
+    await act(async () => {
+        await Onyx.clear();
+    });
+    await waitForBatchedUpdatesWithAct();
+}
+
+describe('useVerifyAccountAndResume', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await clearOnyx();
+
+        jest.clearAllMocks();
+        mockNavigationStateListeners.clear();
+        mockPendingTransitionCallbacks = [];
+        mockedNavigation.getActiveRouteWithoutParams.mockReturnValue(mockVerifyAccountPath);
+        mockedNavigation.runAfterTransition.mockImplementation((callback: () => void) => {
+            mockPendingTransitionCallbacks.push(callback);
+            return {cancel: mockCancelTransition};
+        });
+        mockedNavigation.runAfterUpcomingTransition.mockImplementation((callback: () => void) => {
+            mockPendingTransitionCallbacks.push(callback);
+            return {cancel: mockCancelTransition};
+        });
+        mockedNavigationRef.addListener.mockImplementation((_eventName, listener) => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            const stateListener = listener as () => void;
+            mockNavigationStateListeners.add(stateListener);
+            return () => {
+                mockNavigationStateListeners.delete(stateListener);
+            };
+        });
+
+        await setIsUserValidated(false);
+    });
+
+    afterEach(async () => {
+        await clearOnyx();
+    });
+
+    it('navigates to verify account and exposes validation state', async () => {
+        const onResume = jest.fn();
+        const {result} = renderHook(() => useVerifyAccountAndResume(onResume));
+
+        await waitFor(() => {
+            expect(result.current.isUserValidated).toBe(false);
+        });
+
+        act(() => {
+            result.current.verifyAccountAndResume(jest.fn());
+        });
+
+        expect(mockedNavigation.navigate).toHaveBeenCalledWith(mockVerifyAccountRoute);
+        expect(onResume).not.toHaveBeenCalled();
+    });
+
+    it('resumes the stored payload after validation on the same verify account route', async () => {
+        const initialOnResume = jest.fn();
+        const latestOnResume = jest.fn();
+        const retryAction = jest.fn();
+        const {result, rerender} = renderHook(({onResume}: {onResume: (payload: ResumePayload) => void}) => useVerifyAccountAndResume(onResume), {
+            initialProps: {onResume: initialOnResume},
+        });
+
+        act(() => {
+            result.current.verifyAccountAndResume(retryAction);
+        });
+        rerender({onResume: latestOnResume});
+
+        await setIsUserValidated(true);
+
+        await waitFor(() => {
+            expect(mockedNavigation.runAfterUpcomingTransition).toHaveBeenCalledTimes(1);
+        });
+        expect(latestOnResume).not.toHaveBeenCalled();
+
+        act(() => {
+            mockPendingTransitionCallbacks.at(0)?.();
+        });
+
+        expect(initialOnResume).not.toHaveBeenCalled();
+        expect(latestOnResume).toHaveBeenCalledWith(retryAction);
+    });
+
+    it('resumes when the verify account route already closed itself before validation was observed', async () => {
+        const onResume = jest.fn();
+        const retryAction = jest.fn();
+        const {result} = renderHook(() => useVerifyAccountAndResume(onResume));
+
+        act(() => {
+            result.current.verifyAccountAndResume(retryAction);
+        });
+
+        // The verify page's success effect navigates back as soon as validation succeeds, so by the time
+        // this hook observes the validated state the active route is already the originating screen.
+        mockedNavigation.getActiveRouteWithoutParams.mockReturnValue('r/123');
+        await setIsUserValidated(true);
+
+        await waitFor(() => {
+            expect(mockedNavigation.runAfterTransition).toHaveBeenCalledTimes(1);
+        });
+        expect(mockedNavigation.runAfterUpcomingTransition).not.toHaveBeenCalled();
+
+        act(() => {
+            mockPendingTransitionCallbacks.at(0)?.();
+        });
+
+        expect(onResume).toHaveBeenCalledWith(retryAction);
+    });
+
+    it('drops the pending resume when the user leaves the verify account route before validation', async () => {
+        const onResume = jest.fn();
+        const {result} = renderHook(() => useVerifyAccountAndResume(onResume));
+
+        act(() => {
+            result.current.verifyAccountAndResume(jest.fn());
+        });
+
+        await waitFor(() => {
+            expect(mockNavigationStateListeners.size).toBe(1);
+        });
+
+        mockedNavigation.getActiveRouteWithoutParams.mockReturnValue('r/123');
+        act(() => {
+            emitNavigationStateChange();
+        });
+
+        mockedNavigation.getActiveRouteWithoutParams.mockReturnValue(mockVerifyAccountPath);
+        await setIsUserValidated(true);
+
+        expect(mockedNavigation.runAfterUpcomingTransition).not.toHaveBeenCalled();
+        expect(onResume).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

When an unvalidated user triggers a payment, the new `useVerifyAccountAndResume` hook stores the pending payment action, sends the user to the dynamic verify-account (magic code) page, and resumes the stored action once validation succeeds — while dropping it if the user leaves the page without validating. 



### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/72980
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Pre requisite:
1. Log in with a new account and don't verify it with a magic code

Then:

a) `ROUTES.SEARCH_ROOT`

2. Create a workspace as admin (via green "+" button)
3. Navigate to the Inbox tab and create an expense
4. Submit and Approve the expense
5. Navigate to the Spend tab > Ready to pay
6. Click on the Pay Button > Pay with business account
7. Verify that the magic code verification modal slides out. 
8. Provide Magic Code 
9. Verify that account setup modal slides out.


b) `ROUTES.SEARCH_MONEY_REQUEST_REPORT`

2. Create a workspace as admin (via green "+" button)
3. Navigate to the Inbox tab and create an expense
4. Submit and Approve the expense
5. Navigate to the Spend tab > Expenses
6. Click on the Expense
7. Click on the Pay Button > Pay with business account
8. Verify that the magic code verification modal slides out. 
9. Provide Magic Code 
10. Verify that account setup modal slides out.

c) `ROUTES.REPORT_WITH_ID` with the reportID

2. Create a workspace as admin (via green "+" button)
3. Navigate to the Inbox tab and create an expense
4. Submit and Approve the expense
5. Click on the Report
6. Click on the Pay Button > Pay with business account 
7. Verify that the magic code verification modal slides out. 
8. Provide Magic Code 
9. Verify that account setup modal slides out.


d) https://github.com/Expensify/App/issues/96091 regression test

1. Open app
2. Go to workspace chat.
3. Create a report.
4. Open the report.
5. Click on the report header.
6. Click on the blue link under "From".
7. Click on the report.
8. Verify that no overlay (covering the whole screen) will appear when report RHP is opened.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/0c16e8ea-a271-42f7-8deb-0e361f610746



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/116266f3-07aa-4249-a73e-1c2a140f0797


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/08bb5562-d6f2-453f-918a-d4fe11f330c1



</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/f85d59fb-68bd-4e71-a855-0ed6927ce914


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/34ca6f8b-1f95-447e-9962-f233e0bdb063


https://github.com/user-attachments/assets/79de4aa3-f7a0-40c3-8ced-250f82b6443b




<!-- add screenshots or videos here -->

</details>
