### PR TITLE
[CP Staging][Home] Stop nudging approvers to submit reports they don't own

### DIFF
--- a/src/libs/TodosUtils.ts
+++ b/src/libs/TodosUtils.ts
@@ -103,7 +103,12 @@ function reportMatchesTodoBucket(
 ): boolean {
     switch (searchKey) {
         case CONST.SEARCH.SEARCH_KEYS.SUBMIT:
-            return isSubmitAction(report, reportTransactions, reportMetadata, ownerLogin, policy, reportNameValuePair, undefined, login, currentUserAccountID) && !allExpensesHeld;
+            // isSubmitAction also allows workflow approvers to submit on the owner's behalf; the to-do only nudges the owner.
+            return (
+                report.ownerAccountID === currentUserAccountID &&
+                isSubmitAction(report, reportTransactions, reportMetadata, ownerLogin, policy, reportNameValuePair, undefined, login, currentUserAccountID) &&
+                !allExpensesHeld
+            );
         case CONST.SEARCH.SEARCH_KEYS.APPROVE:
             return isApproveAction(report, reportTransactions, currentUserAccountID, reportMetadata, policy) && !allExpensesHeld;
         case CONST.SEARCH.SEARCH_KEYS.PAY:

--- a/tests/unit/TodosUtilsTest.ts
+++ b/tests/unit/TodosUtilsTest.ts
@@ -235,6 +235,34 @@ describe('TodosUtils', () => {
             });
         });
 
+        it('excludes a report the current user approves for but does not own from the submit bucket', async () => {
+            const OTHER_USER_EMAIL = 'owner@mail.com';
+            const personalDetailsList = {
+                [CURRENT_USER_ACCOUNT_ID]: {accountID: CURRENT_USER_ACCOUNT_ID, login: CURRENT_USER_EMAIL},
+                [OTHER_USER_ACCOUNT_ID]: {accountID: OTHER_USER_ACCOUNT_ID, login: OTHER_USER_EMAIL},
+            };
+            await Onyx.set(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+            await waitForBatchedUpdates();
+
+            const approverSubmitReport = createMockReport('approver_submit', {
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                ownerAccountID: OTHER_USER_ACCOUNT_ID,
+                managerID: CURRENT_USER_ACCOUNT_ID,
+            });
+            const policy = createMockPolicy(POLICY_ID, {approver: CURRENT_USER_EMAIL});
+
+            const result = createTodosReportsAndTransactions({
+                ...baseParams,
+                personalDetailsList,
+                allReports: toReportsCollection([approverSubmitReport]),
+                allTransactions: toTransactionsCollection([createMockTransaction('trans_approver_submit', 'approver_submit')]),
+                allPolicies: toPoliciesCollection([policy]),
+            });
+
+            expect(result.reportsToSubmit).toEqual([]);
+        });
+
         it('excludes a report whose expenses are all on hold', () => {
             const heldOverride: Partial<Transaction> = {comment: {hold: 'HOLD_ACTION_ID'}};
             const submitReport = createMockReport('held_submit', {stateNum: CONST.REPORT.STATE_NUM.OPEN, statusNum: CONST.REPORT.STATUS_NUM.OPEN, ownerAccountID: CURRENT_USER_ACCOUNT_ID});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The home page Submit to-do and its search now only include reports you own.

Since [PR #79300](https://github.com/Expensify/App/pull/79300), approvers were prompted to submit reports they don't own: the home page showed "Submit N reports" for a submitter's unsubmitted report, and the Submit search listed it despite filtering on `from:` you. That PR intentionally lets an approver submit on the submitter's behalf; the bug is that the home to-do count reuses the same check (`isSubmitAction`), so "can submit" became "asked to submit".

- Submit on the report itself unchanged for approvers
- Regression test covers the approver case

### Fixed Issues
$ https://expensify.slack.com/archives/C03U7DCU4/p1784628693644249


### Tests
1. On a workspace with approvals enabled, sign in as an employee, create an expense on a new report, and do not submit it.
2. Sign in as that employee's approver.
3. Open the home page.
4. Verify the "For you" section shows no Submit to-do for the employee's open report.
5. Open the employee's report directly and verify the approver still sees the Submit button on the report.
6. Sign in as the employee and verify their own home page still shows the Submit to-do for the report.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Same as Tests. The to-do counts are computed locally from Onyx data, so the Submit to-do behaves the same offline.

### QA Steps
1. Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
