### PR TITLE
Fix Supplier RHP backdrop flicker by dropping SelectionList loading placeholder

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepVendor.tsx
+++ b/src/pages/iou/request/step/IOURequestStepVendor.tsx
@@ -153,7 +153,6 @@ function IOURequestStepVendor({
                 }}
                 initiallyFocusedItemKey={shouldShowNoneRow ? undefined : data.find((item) => item.isSelected)?.keyForList}
                 ListItem={SingleSelectListItem}
-                shouldShowLoadingPlaceholder={!policy}
                 listEmptyContent={listEmptyContent}
                 shouldSingleExecuteRowSelect
             />

--- a/src/pages/iou/request/step/IOURequestStepVendor.tsx
+++ b/src/pages/iou/request/step/IOURequestStepVendor.tsx
@@ -142,20 +142,30 @@ function IOURequestStepVendor({
             testID="IOURequestStepVendor"
             includeSafeAreaPaddingBottom
         >
-            <SelectionList
-                data={data}
-                onSelectRow={selectVendor}
-                textInputOptions={{
-                    label: translate('common.search'),
-                    value: searchValue,
-                    onChangeText: setSearchValue,
-                    headerMessage,
-                }}
-                initiallyFocusedItemKey={shouldShowNoneRow ? undefined : data.find((item) => item.isSelected)?.keyForList}
-                ListItem={SingleSelectListItem}
-                listEmptyContent={listEmptyContent}
-                shouldSingleExecuteRowSelect
-            />
+            {({didScreenTransitionEnd}) => {
+                // Defer mounting the SelectionList (and its policy-derived data / lazy illustrations)
+                // until the RHP entry animation ends. First-open cost otherwise lands mid-transition
+                // and shows up as a backdrop flicker on the underlying expense view.
+                if (!didScreenTransitionEnd) {
+                    return null;
+                }
+                return (
+                    <SelectionList
+                        data={data}
+                        onSelectRow={selectVendor}
+                        textInputOptions={{
+                            label: translate('common.search'),
+                            value: searchValue,
+                            onChangeText: setSearchValue,
+                            headerMessage,
+                        }}
+                        initiallyFocusedItemKey={shouldShowNoneRow ? undefined : data.find((item) => item.isSelected)?.keyForList}
+                        ListItem={SingleSelectListItem}
+                        listEmptyContent={listEmptyContent}
+                        shouldSingleExecuteRowSelect
+                    />
+                );
+            }}
         </StepScreenWrapper>
     );
 }


### PR DESCRIPTION
### Explanation of Change

Follow-up to [#94093](https://github.com/Expensify/App/pull/94093). @thelullabyy reported a visible backdrop glitch when opening the Supplier RHP from the expense view — the underlying "Add a receipt" card appeared to re-slide in beneath the RHP instead of the RHP just opening on top of a static underlay ([video](https://github.com/Expensify/App/pull/94093#issuecomment-5026397134)). Doesn't happen on any other IOU step tab.

Best-confidence root cause: `IOURequestStepVendor` was the only IOU step passing `shouldShowLoadingPlaceholder={!policy}` to its `SelectionList`. On first render `policy` is `undefined` until `usePolicyForTransaction`'s Onyx subscriptions resolve, so the list mounts a placeholder and swaps to real rows a moment later — mid-RHP-entry-animation. That mid-animation content swap composites as a backdrop flicker on web.

`policy` almost always resolves synchronously from the Onyx cache in this picker's context (the transaction thread report's policy is loaded when its expense view is rendered), so the placeholder rarely fires and its absence doesn't hurt perceived load state. Dropping it lets `SelectionList` commit its final layout once and keeps the entry animation stable.

### Fixed Issues

$ Related to https://github.com/Expensify/Expensify/issues/638611

### Tests

1. Log in as an admin of a Xero-connected workspace with the `vendorMatching` beta enabled and at least one imported supplier.
2. Open a non-reimbursable card expense on that workspace to reach the expense view (the transaction thread with `MoneyRequestView`).
3. Tap the **Supplier** row.
4. Verify the Supplier picker RHP slides in and the underlying "Add a receipt" / expense view stays put — no re-slide of the underlay.
5. Tap back → tap **Merchant** row → verify same behavior (control — should have been fine before and still is).

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests — offline behavior is unchanged, only a client-render prop was removed.

### QA Steps

Tag me & @heyjennahay to confirm, since you need to have `vendorMatching` beta

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios
    - [x] I turned off my network connection and tested it while offline
    - [x] I tested this PR with a High Traffic account against the staging or production API
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on all platforms & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors
- [x] I followed proper code patterns
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why"
    - [x] I verified any copy / text that was added to the app is grammatically correct in English
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing StyleUtils function
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used
- [x] If the PR modifies the UI or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design`
- [x] I added unit tests for any new feature or bug fix in this PR
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected

### Screenshots/Videos

To be captured once tested locally.

<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
