### PR TITLE
fix: make SKIP_ONBOARDING actually skip onboarding for fresh signups

### DIFF
--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -98,6 +98,12 @@ function useOnboardingFlowRouter() {
                     return;
                 }
 
+                // Test builds skip the onboarding UI entirely; the flag is absent from production env files.
+                // Gate only the auto-entry into onboarding here so unrelated behaviour (e.g. hybrid-app transitions above) is unaffected.
+                if (CONFIG.SKIP_ONBOARDING) {
+                    return;
+                }
+
                 // Explicitly start the onboarding flow when onboarding is not completed.
                 // We use startOnboardingFlow (which calls resetRoot) instead of Navigation.navigate because
                 // navigate goes through the router where OnboardingGuard would block the navigation.

--- a/src/libs/Navigation/guards/OnboardingGuard.ts
+++ b/src/libs/Navigation/guards/OnboardingGuard.ts
@@ -185,6 +185,15 @@ const OnboardingGuard: NavigationGuard = {
             return {type: 'REDIRECT', route: ROUTES.HOME};
         }
 
+        // Test builds must never enter the onboarding UI. REPLACE into onboarding is normally
+        // admitted (real users advance between onboarding steps with forceReplace), but with
+        // SKIP_ONBOARDING there is no legitimate way to be mid-onboarding — bounce those too.
+        // Scoped to the flag so completed users' REPLACE behaviour is unchanged.
+        if (CONFIG.SKIP_ONBOARDING && isNavigatingToOnboardingFlowWithReplaceAction(action)) {
+            Log.info('[OnboardingGuard] SKIP_ONBOARDING: redirecting REPLACE into onboarding to home');
+            return {type: 'REDIRECT', route: ROUTES.HOME};
+        }
+
         const skipOnboardingConfig = CONFIG.SKIP_ONBOARDING;
         const isLoading = context.isLoading;
         const isNavigatingWithReplace = isNavigatingToOnboardingFlowWithReplaceAction(action);

--- a/tests/unit/Navigation/guards/OnboardingGuard.test.ts
+++ b/tests/unit/Navigation/guards/OnboardingGuard.test.ts
@@ -4,6 +4,7 @@ import type {GuardContext} from '@libs/Navigation/guards/types';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 
 import type {NavigationAction, NavigationState} from '@react-navigation/native';
@@ -11,6 +12,21 @@ import type {NavigationAction, NavigationState} from '@react-navigation/native';
 import Onyx from 'react-native-onyx';
 
 import waitForBatchedUpdates from '../../../utils/waitForBatchedUpdates';
+
+let mockSkipOnboarding = false;
+
+jest.mock('@src/CONFIG', () => {
+    const actualConfig = jest.requireActual<{default: Record<string, unknown>}>('@src/CONFIG').default;
+    return {
+        __esModule: true,
+        default: {
+            ...actualConfig,
+            get SKIP_ONBOARDING() {
+                return mockSkipOnboarding;
+            },
+        },
+    };
+});
 
 describe('OnboardingGuard', () => {
     const mockState: NavigationState = {
@@ -38,6 +54,7 @@ describe('OnboardingGuard', () => {
     });
 
     beforeEach(async () => {
+        mockSkipOnboarding = false;
         await Onyx.clear();
         await waitForBatchedUpdates();
     });
@@ -325,6 +342,56 @@ describe('OnboardingGuard', () => {
             const result = OnboardingGuard.evaluate(mockState, replaceAction, authenticatedContext);
 
             // Then navigation should be allowed because isNavigatingToOnboardingFlow only handles NAVIGATE and PUSH action types, not REPLACE
+            expect(result.type).toBe('ALLOW');
+        });
+    });
+
+    describe('SKIP_ONBOARDING test builds', () => {
+        it('should redirect NAVIGATE into onboarding to home when SKIP_ONBOARDING is set', () => {
+            // Given a test build with SKIP_ONBOARDING enabled and a user who has NOT completed onboarding
+            mockSkipOnboarding = true;
+
+            // When a NAVIGATE action targets the OnboardingModalNavigator
+            const navigateAction: NavigationAction = {
+                type: CONST.NAVIGATION.ACTION_TYPE.NAVIGATE,
+                payload: {name: NAVIGATORS.ONBOARDING_MODAL_NAVIGATOR},
+            };
+
+            const result = OnboardingGuard.evaluate(mockState, navigateAction, authenticatedContext);
+
+            // Then the user should be redirected to home because test builds never show the onboarding UI
+            expect(result).toEqual({type: 'REDIRECT', route: ROUTES.HOME});
+        });
+
+        it('should redirect REPLACE into onboarding to home when SKIP_ONBOARDING is set', () => {
+            // Given a test build with SKIP_ONBOARDING enabled and a user who has NOT completed onboarding
+            mockSkipOnboarding = true;
+
+            // When a REPLACE action targets the OnboardingModalNavigator (e.g. forceReplace navigation)
+            const replaceAction: NavigationAction = {
+                type: CONST.NAVIGATION.ACTION_TYPE.REPLACE,
+                payload: {name: NAVIGATORS.ONBOARDING_MODAL_NAVIGATOR},
+            };
+
+            const result = OnboardingGuard.evaluate(mockState, replaceAction, authenticatedContext);
+
+            // Then the user should be redirected to home; with SKIP_ONBOARDING there is no legitimate
+            // way to be mid-onboarding, so the usual REPLACE allowance does not apply
+            expect(result).toEqual({type: 'REDIRECT', route: ROUTES.HOME});
+        });
+
+        it('should NOT redirect an incomplete user REPLACE into onboarding when SKIP_ONBOARDING is off', () => {
+            // Given a regular build (flag off) and a user who has NOT completed onboarding
+
+            // When a REPLACE action targets the OnboardingModalNavigator (advancing between onboarding steps)
+            const replaceAction: NavigationAction = {
+                type: CONST.NAVIGATION.ACTION_TYPE.REPLACE,
+                payload: {name: NAVIGATORS.ONBOARDING_MODAL_NAVIGATOR},
+            };
+
+            const result = OnboardingGuard.evaluate(mockState, replaceAction, authenticatedContext);
+
+            // Then navigation should be allowed so real users can move through onboarding steps
             expect(result.type).toBe('ALLOW');
         });
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
`SKIP_ONBOARDING` is a test-build flag (absent from production/staging env files, build-time default `false`) meant to keep automated and manual test environments out of the onboarding UI. It never worked for fresh signups: the flag was consumed only by `OnboardingGuard`, but a fresh signup enters onboarding through `useOnboardingFlow` → `startOnboardingFlow` → `navigationRef.resetRoot`, which deliberately bypasses the router and therefore the guard. Every consumer of the flag — Playwright suites, e2e harnesses, local `.env` dev builds, agentic test drivers — still had to click through onboarding on each new account.

This PR makes the flag semantics actually hold: test builds with `SKIP_ONBOARDING=true` never enter the onboarding UI.

1. **Hook gate** — early-return on `CONFIG.SKIP_ONBOARDING` in `useOnboardingFlow`, placed after hybrid-app transition handling and migrated/invited-user early-returns. Gates only the auto-entry into onboarding; unrelated behaviour is untouched.
2. **Guard belt** — `OnboardingGuard` additionally redirects `REPLACE` actions targeting the `OnboardingModalNavigator` to home when the flag is set. `REPLACE` is normally admitted so real users can advance between onboarding steps, but with the flag on there is no legitimate way to be mid-onboarding. Scoped strictly to the flag, so behaviour without it (including completed users' `REPLACE` handling) is unchanged.

Production behaviour is identical — the flag is compile-time `false` in production builds.

Unit tests extend the existing `OnboardingGuard.test.ts`: flag on → `NAVIGATE` and `REPLACE` into onboarding redirect home; flag off → incomplete-user `REPLACE` still allowed. Existing suites green, typecheck + ESLint clean.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/654020
PROPOSAL:

### Tests
1. Verify that no errors appear in the JS console
2. Set `SKIP_ONBOARDING=true` in `.env`, rebuild
3. Sign up with a fresh account
4. Verify landing on Home/Inbox — no onboarding modal
5. Remove the flag from `.env` (or set `false`), rebuild, sign up with another fresh account
6. Verify onboarding shows as before

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A — navigation gating only, no network path.

### QA Steps
Flag absent from staging/production builds — regression check only:
1. Verify that no errors appear in the JS console
2. Sign up with a fresh account on staging
3. Verify onboarding shows as before (unchanged)

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
