### PR TITLE
Allow re-verifying an already-validated domain for non-admin domain members instead of showing a NotFoundPage page

### DIFF
--- a/src/pages/domain/BaseVerifyDomainPage.tsx
+++ b/src/pages/domain/BaseVerifyDomainPage.tsx
@@ -10,6 +10,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import {useMemoizedLazyAsset} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
@@ -26,6 +27,7 @@ import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
+import {isAdminSelector} from '@src/selectors/Domain';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
 import type {PropsWithChildren} from 'react';
@@ -57,10 +59,14 @@ function BaseVerifyDomainPage({domainAccountID, forwardTo}: BaseVerifyDomainPage
     const styles = useThemeStyles();
     const theme = useTheme();
     const {translate} = useLocalize();
+    const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
     const [domain, domainMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.DOMAIN}${domainAccountID}`);
     const domainName = domain ? Str.extractEmailDomain(domain.email) : '';
     const doesDomainExist = !!domain;
+
+    // A domain admin has nothing to verify once the domain is validated, so keep them out of the flow if they deep-link; non-admins still land here to re-verify
+    const isVerifiedDomainAdmin = !!domain?.validated && isAdminSelector(currentUserAccountID)(domain);
 
     const {asset: Exclamation} = useMemoizedLazyAsset(() => loadExpensifyIcon('Exclamation'));
 
@@ -72,7 +78,7 @@ function BaseVerifyDomainPage({domainAccountID, forwardTo}: BaseVerifyDomainPage
     }, [domainAccountID, domain?.hasValidationSucceeded, forwardTo]);
 
     useFocusEffect(() => {
-        if (!doesDomainExist || domain?.validateCode || domain?.isValidateCodeLoading || domain?.validateCodeError) {
+        if (isVerifiedDomainAdmin || !doesDomainExist || domain?.validateCode || domain?.isValidateCodeLoading || domain?.validateCodeError) {
             return;
         }
         getDomainValidationCode(domainAccountID, domainName);
@@ -96,6 +102,15 @@ function BaseVerifyDomainPage({domainAccountID, forwardTo}: BaseVerifyDomainPage
 
     if (!domain) {
         return <NotFoundPage onLinkPress={() => Navigation.dismissModal()} />;
+    }
+
+    if (isVerifiedDomainAdmin) {
+        return (
+            <NotFoundPage
+                onLinkPress={() => Navigation.dismissModal()}
+                shouldForceFullScreen
+            />
+        );
     }
 
     return (

--- a/src/pages/domain/BaseVerifyDomainPage.tsx
+++ b/src/pages/domain/BaseVerifyDomainPage.tsx
@@ -72,18 +72,18 @@ function BaseVerifyDomainPage({domainAccountID, forwardTo}: BaseVerifyDomainPage
     }, [domainAccountID, domain?.hasValidationSucceeded, forwardTo]);
 
     useFocusEffect(() => {
-        if (!doesDomainExist || domain?.validated || domain?.validateCode || domain?.isValidateCodeLoading || domain?.validateCodeError) {
+        if (!doesDomainExist || domain?.validateCode || domain?.isValidateCodeLoading || domain?.validateCodeError) {
             return;
         }
         getDomainValidationCode(domainAccountID, domainName);
     });
 
     useEffect(() => {
-        if (!doesDomainExist || domain?.validated) {
+        if (!doesDomainExist) {
             return;
         }
         resetDomainValidationError(domainAccountID);
-    }, [domainAccountID, doesDomainExist, domain?.validated]);
+    }, [domainAccountID, doesDomainExist]);
 
     const isLoadingDomain = isLoadingOnyxValue(domainMetadata);
     if (isLoadingDomain) {
@@ -96,15 +96,6 @@ function BaseVerifyDomainPage({domainAccountID, forwardTo}: BaseVerifyDomainPage
 
     if (!domain) {
         return <NotFoundPage onLinkPress={() => Navigation.dismissModal()} />;
-    }
-
-    if (domain.validated) {
-        return (
-            <NotFoundPage
-                onLinkPress={() => Navigation.dismissModal()}
-                shouldForceFullScreen
-            />
-        );
     }
 
     return (

--- a/tests/ui/BaseVerifyDomainPageTest.tsx
+++ b/tests/ui/BaseVerifyDomainPageTest.tsx
@@ -25,17 +25,7 @@ import Onyx from 'react-native-onyx';
 import * as TestHelper from '../utils/TestHelper';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
 
-jest.mock('@components/RenderHTML', () => {
-    const ReactMock = require('react') as typeof React;
-    const {Text} = require('react-native') as {
-        Text: React.ComponentType<{children?: React.ReactNode}>;
-    };
-
-    return ({html}: {html: string}) => {
-        const plainText = html.replaceAll(/<[^>]*>/g, '');
-        return ReactMock.createElement(Text, null, plainText);
-    };
-});
+jest.mock('@components/RenderHTML', () => () => null);
 
 const DOMAIN_ACCOUNT_ID = 123456;
 const DOMAIN_EMAIL = 'user@test.com';

--- a/tests/ui/BaseVerifyDomainPageTest.tsx
+++ b/tests/ui/BaseVerifyDomainPageTest.tsx
@@ -130,4 +130,26 @@ describe('BaseVerifyDomainPage', () => {
         expect(screen.queryByTestId('BaseVerifyDomainPage')).toBeNull();
         expect(apiReadSpy).not.toHaveBeenCalledWith(READ_COMMANDS.GET_DOMAIN_VALIDATE_CODE, expect.anything(), expect.anything());
     });
+
+    it('renders the DNS verification screen for an admin on a not-yet-validated domain', async () => {
+        // Given a domain the current user is an admin of but that is NOT yet validated
+        await TestHelper.signInWithTestUser(TEST_USER_ACCOUNT_ID);
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.DOMAIN}${DOMAIN_ACCOUNT_ID}`, {
+                accountID: DOMAIN_ACCOUNT_ID,
+                email: DOMAIN_EMAIL,
+                validated: false,
+                ...DOMAIN_ADMIN_ACCESS,
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        // When the verify-domain page is opened
+        renderVerifyDomainPage();
+        await waitForBatchedUpdatesWithAct();
+
+        // Then the verify screen renders
+        expect(screen.getByTestId('BaseVerifyDomainPage')).toBeTruthy();
+        expect(apiReadSpy).toHaveBeenCalledWith(READ_COMMANDS.GET_DOMAIN_VALIDATE_CODE, {domainName: DOMAIN_NAME}, expect.anything());
+    });
 });

--- a/tests/ui/BaseVerifyDomainPageTest.tsx
+++ b/tests/ui/BaseVerifyDomainPageTest.tsx
@@ -108,4 +108,26 @@ describe('BaseVerifyDomainPage', () => {
         // And the validation code is fetched, so the DNS TXT field is not left empty
         expect(apiReadSpy).toHaveBeenCalledWith(READ_COMMANDS.GET_DOMAIN_VALIDATE_CODE, {domainName: DOMAIN_NAME}, expect.anything());
     });
+
+    it('renders NotFoundPage for an admin on an already-validated domain and skips the code fetch', async () => {
+        // Given an already-validated domain the current user is an admin of
+        await TestHelper.signInWithTestUser(TEST_USER_ACCOUNT_ID);
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.DOMAIN}${DOMAIN_ACCOUNT_ID}`, {
+                accountID: DOMAIN_ACCOUNT_ID,
+                email: DOMAIN_EMAIL,
+                validated: true,
+                ...DOMAIN_ADMIN_ACCESS,
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        // When the verify-domain page is deep-linked
+        renderVerifyDomainPage();
+        await waitForBatchedUpdatesWithAct();
+
+        // Then the verify screen is not shown (NotFoundPage), and no validation code is fetched
+        expect(screen.queryByTestId('BaseVerifyDomainPage')).toBeNull();
+        expect(apiReadSpy).not.toHaveBeenCalledWith(READ_COMMANDS.GET_DOMAIN_VALIDATE_CODE, expect.anything(), expect.anything());
+    });
 });

--- a/tests/ui/BaseVerifyDomainPageTest.tsx
+++ b/tests/ui/BaseVerifyDomainPageTest.tsx
@@ -1,0 +1,111 @@
+import {act, render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersonalDetailsProvider';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
+import * as API from '@libs/API';
+import {READ_COMMANDS} from '@libs/API/types';
+import {navigationRef} from '@libs/Navigation/Navigation';
+import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
+import type {WorkspacesDomainModalNavigatorParamList} from '@libs/Navigation/types';
+
+import WorkspacesVerifyDomainPage from '@pages/domain/WorkspacesVerifyDomainPage';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+
+import {PortalProvider} from '@gorhom/portal';
+import {NavigationContainer} from '@react-navigation/native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('@components/RenderHTML', () => {
+    const ReactMock = require('react') as typeof React;
+    const {Text} = require('react-native') as {
+        Text: React.ComponentType<{children?: React.ReactNode}>;
+    };
+
+    return ({html}: {html: string}) => {
+        const plainText = html.replaceAll(/<[^>]*>/g, '');
+        return ReactMock.createElement(Text, null, plainText);
+    };
+});
+
+const DOMAIN_ACCOUNT_ID = 123456;
+const DOMAIN_EMAIL = 'user@test.com';
+const DOMAIN_NAME = 'test.com';
+const TEST_USER_ACCOUNT_ID = 1;
+
+// Makes the signed-in test user an admin of the domain
+const DOMAIN_ADMIN_ACCESS = {
+    [`${CONST.DOMAIN.EXPENSIFY_ADMIN_ACCESS_PREFIX}0`]: TEST_USER_ACCOUNT_ID,
+};
+
+const apiReadSpy = jest.spyOn(API, 'read').mockImplementation(() => {});
+
+const Stack = createPlatformStackNavigator<WorkspacesDomainModalNavigatorParamList>();
+
+function renderVerifyDomainPage() {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider, CurrentUserPersonalDetailsProvider, LocaleContextProvider]}>
+            <PortalProvider>
+                <NavigationContainer ref={navigationRef}>
+                    <Stack.Navigator initialRouteName={SCREENS.WORKSPACES_VERIFY_DOMAIN}>
+                        <Stack.Screen
+                            name={SCREENS.WORKSPACES_VERIFY_DOMAIN}
+                            component={WorkspacesVerifyDomainPage}
+                            initialParams={{domainAccountID: DOMAIN_ACCOUNT_ID}}
+                        />
+                    </Stack.Navigator>
+                </NavigationContainer>
+            </PortalProvider>
+        </ComposeProviders>,
+    );
+}
+
+describe('BaseVerifyDomainPage', () => {
+    beforeAll(async () => {
+        Onyx.init({keys: ONYXKEYS});
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, CONST.LOCALES.EN);
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    afterEach(async () => {
+        apiReadSpy.mockClear();
+        await act(async () => {
+            await Onyx.clear();
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    it('renders the DNS verification screen for a non-admin on an already-validated domain instead of NotFoundPage', async () => {
+        // Given an already-validated domain the current user is not an admin of
+        await TestHelper.signInWithTestUser();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.DOMAIN}${DOMAIN_ACCOUNT_ID}`, {
+                accountID: DOMAIN_ACCOUNT_ID,
+                email: DOMAIN_EMAIL,
+                validated: true,
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        // When the verify-domain page is opened
+        renderVerifyDomainPage();
+        await waitForBatchedUpdatesWithAct();
+
+        // Then the verify screen renders (a validated domain must not dead-end on NotFoundPage)
+        expect(screen.getByTestId('BaseVerifyDomainPage')).toBeTruthy();
+
+        // And the validation code is fetched, so the DNS TXT field is not left empty
+        expect(apiReadSpy).toHaveBeenCalledWith(READ_COMMANDS.GET_DOMAIN_VALIDATE_CODE, {domainName: DOMAIN_NAME}, expect.anything());
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

On an already-verified domain, clicking **Verify** (by a non-admin domain member) took the user to the not found page instead of the verify screen. This was because the code treated a verified domain as a dead end. With this PR, The DNS verify screen opens and works for verified domains too, just like in Classic. the BE commands to get the code and verify the domain already work for non-admins.

- Removed the check that sent verified domains to the error page.
- Removed the `validated` check that stopped the app from fetching the verify code (without this, the code field showed empty).
- Removed the same `validated` check from the effect that clears old verify errors.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/96688
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


1. Log in to New Expensify as a user who is not an admin of an already-verified domain.
2. Open the already-verified domain and confirm you land on the Access restricted page (`.../workspaces/domain-access-restricted/<domainAccountID>`).
3. Click the **Verify** button at the bottom.
4. Verify the DNS verification screen renders instead of an error/NotFoundPage.
5. Verify the TXT record value (validation code) is populated in the copyable field and is not empty.

<img width="954" height="866" alt="Screenshot 2026-07-22 at 9 22 21 AM" src="https://github.com/user-attachments/assets/bfe5e12d-7bde-4478-90c7-326720d0f171" />



- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
