### PR TITLE
perf: use per-login selector for DelegateOnBehalfOfText personal details

### DIFF
--- a/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
+++ b/src/pages/inbox/report/DelegateOnBehalfOfText.tsx
@@ -2,13 +2,12 @@ import Text from '@components/Text';
 
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import usePersonalDetailsByLogin from '@hooks/usePersonalDetailsByLogin';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
-import {personalDetailsSelector} from '@selectors/PersonalDetails';
+import {personalDetailByLoginSelector, personalDetailsSelector} from '@selectors/PersonalDetails';
 import React from 'react';
 
 type DelegateOnBehalfOfTextFallbackProps = {
@@ -19,8 +18,7 @@ type DelegateOnBehalfOfTextFallbackProps = {
 function DelegateOnBehalfOfTextFallback({fallbackLogin}: DelegateOnBehalfOfTextFallbackProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const personalDetailsByLogin = usePersonalDetailsByLogin();
-    const detail = personalDetailsByLogin[fallbackLogin?.toLowerCase() ?? ''];
+    const [detail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: personalDetailByLoginSelector(fallbackLogin)});
     return <Text style={[styles.chatDelegateMessage]}>{translate('delegate.onBehalfOfMessage', detail?.displayName ?? '')}</Text>;
 }
 

--- a/src/selectors/PersonalDetails.ts
+++ b/src/selectors/PersonalDetails.ts
@@ -25,6 +25,16 @@ const personalDetailsListSelector = (accountIDs: Array<number | undefined> | und
 
 const personalDetailsLoginSelector = (accountID: number | undefined) => (personalDetailsList: OnyxEntry<PersonalDetailsList>) => getLoginByAccountID(accountID, personalDetailsList);
 
+const personalDetailByLoginSelector =
+    (login: string | undefined) =>
+    (personalDetailsList: OnyxEntry<PersonalDetailsList>): PersonalDetails | undefined => {
+        if (!login) {
+            return undefined;
+        }
+        const lowerLogin = login.toLowerCase();
+        return Object.values(personalDetailsList ?? {}).find((detail) => detail?.login?.toLowerCase() === lowerLogin) ?? undefined;
+    };
+
 const avatarStyleColorSelector = (accountID: number | undefined) => (personalDetailsList: OnyxEntry<PersonalDetailsList>) =>
     accountID ? personalDetailsList?.[accountID]?.avatarStyle?.color : undefined;
 
@@ -102,6 +112,7 @@ export {
     personalDetailsListSelector,
     personalDetailsDisplayNameSelector,
     personalDetailsLoginSelector,
+    personalDetailByLoginSelector,
     personalDetailsLoginsSelector,
     conciergePersonalDetailSelector,
     doesPersonalDetailExistSelector,

--- a/tests/unit/PersonalDetailsSelectorTest.ts
+++ b/tests/unit/PersonalDetailsSelectorTest.ts
@@ -8,6 +8,7 @@ import type {PersonalDetails, PersonalDetailsList} from '@src/types/onyx';
 import {
     createDisplayDetailsByAccountIDsSelector,
     multiPersonalDetailsSelector,
+    personalDetailByLoginSelector,
     personalDetailsDisplayNameSelector,
     personalDetailsListSelector,
     personalDetailsLoginSelector,
@@ -143,6 +144,41 @@ describe('PersonalDetailsSelector', () => {
         it('should return an empty array if none of the accountIDs exist in the list', () => {
             const result = personalDetailsLoginsSelector([888, 999])(multiPersonalDetailsList);
             expect(result).toEqual([]);
+        });
+    });
+
+    describe('personalDetailByLoginSelector', () => {
+        it('should return the personal details for the given login', () => {
+            const result = personalDetailByLoginSelector('test@user.com')(personalDetailsList);
+            expect(result).toEqual(personalDetails);
+        });
+
+        it('should match the login case-insensitively', () => {
+            const result = personalDetailByLoginSelector('TEST@USER.COM')(personalDetailsList);
+            expect(result).toEqual(personalDetails);
+        });
+
+        it('should return undefined if the login is not in the list', () => {
+            const result = personalDetailByLoginSelector('missing@user.com')(personalDetailsList);
+            expect(result).toBeUndefined();
+        });
+
+        it('should return undefined if the login is undefined', () => {
+            const result = personalDetailByLoginSelector(undefined)(personalDetailsList);
+            expect(result).toBeUndefined();
+        });
+
+        it('should return undefined if the personalDetailsList is undefined', () => {
+            const result = personalDetailByLoginSelector('test@user.com')(undefined);
+            expect(result).toBeUndefined();
+        });
+
+        it('should skip null entries in the list', () => {
+            const listWithNull: PersonalDetailsList = {
+                [accountID]: null,
+            };
+            const result = personalDetailByLoginSelector('test@user.com')(listWithNull);
+            expect(result).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
### Explanation of Change

The chat `DelegateOnBehalfOfText` component renders once per relevant report action. Its fallback path called `usePersonalDetailsByLogin`, which subscribes to the whole `PERSONAL_DETAILS_LIST` **without a selector** and rebuilds a full login→details map (`Object.values().reduce()`) per instance.

Two consequences that scale badly with the number of delegate messages on screen:

1. **Re-renders**: a selectorless `useOnyx` returns a new reference on every write to the key, so _every_ instance re-rendered whenever _anyone&#39;s_ personal details changed.
2. **Memory/allocation**: each instance held a map of _all_ logins.

This replaces that call with a `useOnyx` selector that returns only the single detail the component needs:

- `personalDetailByLoginSelector(login)` — single detail (used by `DelegateOnBehalfOfText`&#39;s fallback), with `.find` early-exit.

Measured on a screen with many delegate messages: render time **~290ms → ~110ms** (~2.6x).

### Fixed Issues

$ https://github.com/Expensify/App/issues/96727
PROPOSAL:

### Tests

1. Open a chat that contains a &#34;on behalf of&#34; delegate message (e.g. by using supportal account).
2. Verify the message shows the correct delegate display name.
3. Verify that no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English &gt; Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named &#34;index.js&#34;. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn&#39;t include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function&#39;s arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn&#39;t already exist
    - [x] The style can&#39;t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it&#39;s using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari





