### PR TITLE
Ignore pasted files in the composer while editing a comment

### DIFF
--- a/src/pages/inbox/report/ReportActionCompose/ComposerInput.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerInput.tsx
@@ -25,7 +25,7 @@ import type {MeasureInWindowOnSuccessCallback} from 'react-native';
 
 import React from 'react';
 
-import {useComposerActions, useComposerMeta, useComposerSendState, useComposerState} from './ComposerContext';
+import {useComposerActions, useComposerEditState, useComposerMeta, useComposerSendState, useComposerState} from './ComposerContext';
 import ComposerWithSuggestions from './ComposerWithSuggestions';
 import useAttachmentPicker from './useAttachmentPicker';
 import useComposerSubmit from './useComposerSubmit';
@@ -44,6 +44,8 @@ function ComposerInput() {
     const {isBlockedFromConcierge, debouncedCommentMaxLengthValidation} = useComposerSendState();
     const {setIsFullComposerAvailable, onBlur, onFocus, setComposerRef} = useComposerActions();
     const {containerRef, suggestionsRef, isNextModalWillOpenRef} = useComposerMeta();
+    const {isEditingInComposer, didResetComposerHeightWhileEditing} = useComposerEditState();
+    const isSubmittingEdit = isEditingInComposer || didResetComposerHeightWhileEditing;
 
     const {submitDraftAndClearComposer, validateAndSubmitDraft} = useComposerSubmit(reportID);
     const {pickAttachments, PDFValidationComponent, ErrorModal} = useAttachmentPicker(reportID);
@@ -98,7 +100,12 @@ function ComposerInput() {
                 inputPlaceholder={inputPlaceholder}
                 isComposerFullSize={isComposerFullSize}
                 setIsFullComposerAvailable={setIsFullComposerAvailable}
-                onPasteFile={(files) => pickAttachments({files})}
+                onPasteFile={(files) => {
+                    if (isSubmittingEdit) {
+                        return;
+                    }
+                    pickAttachments({files});
+                }}
                 onClear={validateAndSubmitDraft}
                 disabled={isBlockedFromConcierge || isEmojiPickerVisible()}
                 onEnterKeyPress={submitDraftAndClearComposer}

--- a/tests/ui/ReportActionComposeTest.tsx
+++ b/tests/ui/ReportActionComposeTest.tsx
@@ -11,6 +11,7 @@ import {createTaskAndNavigate} from '@libs/actions/Task';
 
 import type {ReportActionComposeProps} from '@pages/inbox/report/ReportActionCompose/ReportActionCompose';
 import ReportActionCompose from '@pages/inbox/report/ReportActionCompose/ReportActionCompose';
+import useAttachmentPicker from '@pages/inbox/report/ReportActionCompose/useAttachmentPicker';
 import {ReportActionEditMessageContextProvider} from '@pages/inbox/report/ReportActionEditMessageContext';
 
 import CONST from '@src/CONST';
@@ -20,6 +21,7 @@ import type * as NativeNavigation from '@react-navigation/native';
 import type {PropsWithChildren} from 'react';
 
 import React from 'react';
+import {View} from 'react-native';
 import Onyx from 'react-native-onyx';
 
 import * as LHNTestUtils from '../utils/LHNTestUtils';
@@ -47,6 +49,16 @@ jest.mock('@hooks/useParentReportAction', () => jest.fn(() => null));
 jest.mock('@hooks/useReportTransactionsCollection', () => jest.fn(() => ({})));
 jest.mock('@hooks/useShortMentionsList', () => jest.fn(() => ({availableLoginsList: []})));
 jest.mock('@hooks/useSidePanelState', () => jest.fn(() => ({sessionStartTime: null})));
+
+jest.mock('@pages/inbox/report/ReportActionCompose/useAttachmentPicker', () => jest.fn());
+
+jest.mock('@pages/Share/getFileSize', () => jest.fn(() => Promise.resolve(100)));
+
+// The composer ref rendered by the test renderer has no native `setSelection` implementation
+jest.mock('@pages/inbox/report/ReportActionCompose/ReportActionComposeUtils', () => ({
+    __esModule: true,
+    default: {updateNativeSelectionValue: jest.fn()},
+}));
 
 jest.mock('@components/DropZone/DualDropZone', () => {
     const RN = jest.requireActual<Record<string, React.ComponentType<{testID?: string; children?: React.ReactNode}>>>('react-native');
@@ -106,6 +118,14 @@ const simulateSelection = (composer: ReturnType<typeof screen.getByTestId>, star
     });
 };
 
+const mockPickAttachments = jest.fn();
+const mockUseAttachmentPicker = jest.mocked(useAttachmentPicker);
+
+// Helper function to simulate pasting an image from the clipboard
+const simulateImagePaste = (composer: ReturnType<typeof screen.getByTestId>) => {
+    fireEvent(composer, 'paste', {nativeEvent: {items: [{type: 'image/png', data: 'file:///image.png'}]}});
+};
+
 describe('ReportActionCompose Integration Tests', () => {
     beforeAll(() => {
         Onyx.init({
@@ -115,6 +135,7 @@ describe('ReportActionCompose Integration Tests', () => {
     });
 
     beforeEach(async () => {
+        mockUseAttachmentPicker.mockReturnValue({pickAttachments: mockPickAttachments, PDFValidationComponent: undefined, ErrorModal: <View />});
         await act(async () => {
             await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${defaultReport.reportID}`, defaultReport);
         });
@@ -450,6 +471,53 @@ describe('ReportActionCompose Integration Tests', () => {
             );
 
             unmount();
+        });
+    });
+
+    describe('Pasting a file', () => {
+        const startEditingMessage = async () => {
+            const reportAction = LHNTestUtils.getFakeReportAction();
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${defaultReport.reportID}`, {[reportAction.reportActionID]: reportAction});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_DRAFTS}${defaultReport.reportID}`, {[reportAction.reportActionID]: {message: 'Message being edited'}});
+            });
+        };
+
+        it('sends the pasted file to the attachment picker when not editing a message', async () => {
+            const {unmount} = renderReportActionCompose();
+            await waitForBatchedUpdatesWithAct();
+
+            // When an image is pasted into the composer
+            simulateImagePaste(screen.getByTestId('composer'));
+
+            // Then the attachment flow is started
+            await waitFor(() => {
+                expect(mockPickAttachments).toHaveBeenCalled();
+            });
+
+            unmount();
+            await waitForBatchedUpdatesWithAct();
+        });
+
+        it('ignores the pasted file while a message is being edited in the composer', async () => {
+            const {unmount} = renderReportActionCompose();
+            await waitForBatchedUpdatesWithAct();
+
+            // When a message is being edited in the composer
+            await startEditingMessage();
+            await waitFor(() => {
+                expect(screen.getByTestId('composer').props.value).toBe('Message being edited');
+            });
+
+            // And an image is pasted into the composer
+            simulateImagePaste(screen.getByTestId('composer'));
+            await waitForBatchedUpdatesWithAct();
+
+            // Then the attachment flow is not started, so saving the edit can't turn into a separate attachment message
+            expect(mockPickAttachments).not.toHaveBeenCalled();
+
+            unmount();
+            await waitForBatchedUpdatesWithAct();
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/94879
PROPOSAL: https://github.com/Expensify/App/issues/94879#issuecomment-4835004056


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a chat
2. Send a message
3. Open edit comment and paste the image
- Verify you cannot paste an image while editing a comment.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/73a619bb-4ec7-43af-a539-90d9740f6246


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/f4aaf7f5-4434-4e0d-9cf7-d47c80880530


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/6e3a194d-09db-497a-b8d9-7edc2364036b


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/e25ced01-581a-462a-bb99-160c96c90f17


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/c3d95e4b-25b5-4272-a781-39353f727a8a


<!-- add screenshots or videos here -->

</details> 