### PR TITLE
[No QA] Remove rental cars from Consolidated Travel Billing help doc

### DIFF
--- a/docs/articles/travel/consolidated-travel-billing/Book-Travel-Using-Consolidated-Travel-Billing.md
+++ b/docs/articles/travel/consolidated-travel-billing/Book-Travel-Using-Consolidated-Travel-Billing.md
@@ -34,7 +34,7 @@ Workspace Admins can [learn how to enable Travel on a Workspace](/articles/trave
 1. Click the navigation tabs (on the left on web, on the bottom on mobile).
 2. Select **Travel**.
 3. Click **Book travel**.
-4. Search for flights, hotels, rental cars or rail tickets. 
+4. Search for flights, hotels, or rail tickets. 
 5. Select your preferred itinerary.
 6. Continue to checkout.
 7. In the **Payment method** section, select **Expensify Travel Card**.
@@ -53,7 +53,7 @@ Workspace Admins can [learn how to enable Travel on a Workspace](/articles/trave
 - Your booking is confirmed through Expensify Travel.
 - The payment is charged to your company’s Consolidated Travel Billing account.
 - For flights and rail tickets, the expense and receipt are automatically added to your Expensify account.
-- For hotel and car bookings, upload the receipt after checkout or after returning the vehicle.
+- For hotel bookings, upload the receipt after checkout.
 - The charge appears in your company’s Consolidated Travel Billing statement
 
 ---


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The [Book Travel Using Consolidated Travel Billing](https://help.expensify.com/articles/travel/consolidated-travel-billing/Book-Travel-Using-Consolidated-Travel-Billing) help doc told employees they could book rental cars using Consolidated Travel Billing. That's incorrect — car bookings aren't supported by CTB. This removes rental cars from the list of bookable travel types and from the post-booking receipt guidance.

### Fixed Issues
$ https://expensify.slack.com/archives/C05S5EV2JTX/p1784690321172779?thread_ts=1784667244.731329&cid=C05S5EV2JTX
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests

### QA Steps
See [No QA] in title.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A - docs-only content change.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A - docs-only content change.

</details>

<details>
<summary>iOS: Native</summary>

N/A - docs-only content change.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A - docs-only content change.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A - docs-only content change.

</details>
