### PR TITLE
Bump Android module targetSdkVersion and compileSdkVersion to 36

### DIFF
--- a/modules/ExpensifyNitroUtils/android/gradle.properties
+++ b/modules/ExpensifyNitroUtils/android/gradle.properties
@@ -1,5 +1,5 @@
 ContactsModule_kotlinVersion=2.0.21
 ContactsModule_minSdkVersion=24
-ContactsModule_targetSdkVersion=35
-ContactsModule_compileSdkVersion=35
+ContactsModule_targetSdkVersion=36
+ContactsModule_compileSdkVersion=36
 ContactsModule_ndkVersion=27.1.12297006

--- a/modules/background-task/android/gradle.properties
+++ b/modules/background-task/android/gradle.properties
@@ -1,5 +1,5 @@
 ReactNativeBackgroundTask_kotlinVersion=2.0.21
 ReactNativeBackgroundTask_minSdkVersion=24
-ReactNativeBackgroundTask_targetSdkVersion=35
-ReactNativeBackgroundTask_compileSdkVersion=35
+ReactNativeBackgroundTask_targetSdkVersion=36
+ReactNativeBackgroundTask_compileSdkVersion=36
 ReactNativeBackgroundTask_ndkversion=27.1.12297006

--- a/modules/hybrid-app/android/gradle.properties
+++ b/modules/hybrid-app/android/gradle.properties
@@ -1,5 +1,5 @@
 ReactNativeHybridApp_kotlinVersion=2.0.21
 ReactNativeHybridApp_minSdkVersion=24
-ReactNativeHybridApp_targetSdkVersion=35
-ReactNativeHybridApp_compileSdkVersion=35
+ReactNativeHybridApp_targetSdkVersion=36
+ReactNativeHybridApp_compileSdkVersion=36
 ReactNativeHybridApp_ndkVersion=27.1.12297006


### PR DESCRIPTION
### Explanation of Change
Bumps \`targetSdkVersion\` and \`compileSdkVersion\` from 35 to 36 in the \`gradle.properties\` files for the \`ExpensifyNitroUtils\`, \`hybrid-app\`, and \`background-task\` Android modules. Companion to the Mobile-Expensify PR that bumps the main app target SDK to meet Google Play's API 36 requirement.

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/14025

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/662541
PROPOSAL:

### Tests
- [x] Verify that no errors appear in the JS console

### Offline tests
N/A — no behavior change.

### QA Steps
[No QA] - Build config only. No user-facing behavior changes.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like \`Avatar\`, I verified the components using \`Avatar\` are working as expected)
- [x] If a new CSS style is added I verified that: [N/A]
- [x] If new assets were added or existing ones were modified: [N/A]
- [x] If the PR modifies code that runs when editing or sending messages: [N/A]
- [x] If the PR modifies a generic component: [N/A]
- [x] If the PR modifies a component related to any of the existing Storybook stories: [N/A]
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink: [N/A]
- [x] If the PR modifies the UI: [N/A]
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow. [N/A - build config]
- [x] If the \`main\` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the \`Test\` steps.

### Screenshots/Videos
N/A — no UI changes.