### PR TITLE
Fix donut chart intermittently rendering blank on first mount

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/BaseVictoryChartRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/BaseVictoryChartRenderer.tsx
@@ -10,9 +10,32 @@ import type {VictoryChartRendererProps} from './types';
 
 import VictoryChartContainer from './components/VictoryChartContainer';
 import VictoryChartContent from './components/VictoryChartContent';
-import {VictoryChartProvider} from './context/VictoryChartContext';
+import {useVictoryChartContext, VictoryChartProvider} from './context/VictoryChartContext';
 import processVictoryChartTree from './parsers/processVictoryChartTree';
 import resolveVictoryChartType from './utils/resolveVictoryChartType';
+
+/**
+ * Passes the chart's known design size straight to victory-native as `explicitSize`. Without it, victory-native
+ * only draws chart content once its own `onLayout` measurement fires, which can race with the surrounding
+ * chat layout settling (and Skia-web's async WASM mount) and get stuck reporting a stale/zero size — a blank
+ * chart until something (remount, resize) forces a fresh measurement. The design size is already known
+ * synchronously from the chart's HTML style attributes, so there's nothing to wait for.
+ */
+function VictoryChartBody() {
+    const {chartContentStyles} = useVictoryChartContext();
+    const designWidth = typeof chartContentStyles.width === 'number' ? chartContentStyles.width : undefined;
+    const designHeight = typeof chartContentStyles.height === 'number' ? chartContentStyles.height : undefined;
+    const explicitSize = designWidth !== undefined && designHeight !== undefined ? {width: designWidth, height: designHeight} : undefined;
+
+    return (
+        <VictoryChartContainer>
+            <VictoryChartContent
+                explicitSize={explicitSize}
+                headless={false}
+            />
+        </VictoryChartContainer>
+    );
+}
 
 function BaseVictoryChartRenderer({tnode}: VictoryChartRendererProps) {
     const fonts = useChartFonts();
@@ -39,9 +62,7 @@ function BaseVictoryChartRenderer({tnode}: VictoryChartRendererProps) {
                 processedResult={processedResult}
                 type={type}
             >
-                <VictoryChartContainer>
-                    <VictoryChartContent />
-                </VictoryChartContainer>
+                <VictoryChartBody />
             </VictoryChartProvider>
         </ChartFontsProvider>
     );


### PR DESCRIPTION
### Explanation of Change
Donut chart blank on first load because `victory-native` waits for its own `onLayout` measurement before drawing anything (`hasMeasuredLayoutSize`). On web this races with the chart's async Skia-WASM mount and the surrounding chat layout still settling, and gets stuck at zero size until remount/resize forces a re-measure.

Fix: pass the chart's already-known design width/height (from `chartContentStyles`) as `explicitSize`, so victory-native skips the measurement gate and draws immediately. `headless` explicitly kept `false` to preserve gestures/font loader. Container's own responsive scaling untouched.

### Fixed Issues
$ https://github.com/Expensify/App/issues/96699
PROPOSAL:

### Tests
1. Open a Concierge chat/DM containing a donut/pie chart with categories (e.g. "expenses broken down by category").
2. Reload/open the chat fresh several times in a row.
3. Verify the chart renders correctly on first load every time, without needing to navigate away and back or resize the window.
4. Verify the chart is still interactive (pinch/zoom/tooltip gestures work as before).
5. Verify a Concierge cartesian chart (e.g. a bar/line spend trend chart) still renders correctly on first load.
6. Verify no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
1. Open a Concierge chat/DM containing a donut/pie chart with categories on staging.
2. Reload/open the chat fresh several times in a row.
3. Verify the chart renders correctly on first load every time, without needing to navigate away and back or resize the window.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior
    - [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors
- [x] I followed proper code patterns
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why"
- [x] I tested other components that can be impacted by my changes (Cartesian charts share the same `explicitSize`/`headless` code path)

**Draft PR — not yet manually tested in the browser/on device. Opening for early visibility while I complete testing.**

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
