### PR TITLE
[CP Staging] Revert "Show GL code when selecting a category"

### DIFF
--- a/src/components/CategoryPicker/index.tsx
+++ b/src/components/CategoryPicker/index.tsx
@@ -51,9 +51,6 @@ const getSelectedOptions = (selectedCategory?: string): Category[] => {
 function CategoryPicker({selectedCategory, policyID, onSubmit, shouldShowNoneOption = false, addBottomSafeAreaPadding = false}: CategoryPickerProps) {
     const styles = useThemeStyles();
     const {inputCallbackRef} = useAutoFocusInput();
-    const [shouldShowGLCode] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {
-        selector: (policy) => !!policy?.showCategoryGLCodes && !!policy?.glCodes,
-    });
     const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
     const [policyCategoriesDraft] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES_DRAFT}${policyID}`);
     const [policyRecentlyUsedCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_CATEGORIES}${policyID}`);
@@ -74,7 +71,6 @@ function CategoryPicker({selectedCategory, policyID, onSubmit, shouldShowNoneOpt
         localeCompare,
         recentlyUsedCategories: validPolicyRecentlyUsedCategories,
         translate,
-        shouldShowGLCode,
     });
 
     const noneOption: OptionTree[] = shouldShowNoneOption

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -5979,7 +5979,6 @@ _Für ausführlichere Anweisungen [besuchen Sie unsere Hilfeseite](${CONST.NETSU
             deleteFailureMessage: 'Beim Löschen der Kategorie ist ein Fehler aufgetreten, bitte versuche es erneut.',
             categoryName: 'Kategoriename',
             requiresCategory: 'Mitglieder müssen alle Ausgaben kategorisieren',
-            showCategoryGLCodes: 'Sachkonten beim Kategorisieren von Ausgaben anzeigen',
             needCategoryForExportToIntegration: (connectionName: string) => `Alle Ausgaben müssen kategorisiert werden, um nach ${connectionName} exportiert zu werden.`,
             subtitle: 'Verschaffe dir einen besseren Überblick darüber, wofür Geld ausgegeben wird. Verwende unsere Standardkategorien oder füge eigene hinzu.',
             emptyCategories: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6050,7 +6050,6 @@ const translations = {
             deleteFailureMessage: 'An error occurred while deleting the category, please try again',
             categoryName: 'Category name',
             requiresCategory: 'Members must categorize all expenses',
-            showCategoryGLCodes: 'Show GL codes when categorizing expenses',
             needCategoryForExportToIntegration: (connectionName: string) => `All expenses must be categorized in order to export to ${connectionName}.`,
             subtitle: 'Get a better overview of where money is being spent. Use our default categories or add your own.',
             emptyCategories: {

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -5800,7 +5800,6 @@ ${amount} para ${merchant} - ${date}`,
             deleteFailureMessage: 'Se ha producido un error al intentar eliminar la categoría. Por favor, inténtalo más tarde.',
             categoryName: 'Nombre de la categoría',
             requiresCategory: 'Los miembros deben clasificar todos los gastos',
-            showCategoryGLCodes: 'Mostrar códigos GL al categorizar gastos',
             needCategoryForExportToIntegration: (connectionName) => `Todos los gastos deben estar categorizados para poder exportar a ${connectionName}.`,
             subtitle: 'Obtén una visión general de dónde te gastas el dinero. Utiliza las categorías predeterminadas o añade las tuyas propias.',
             emptyCategories: {

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -5991,7 +5991,6 @@ _Pour des instructions plus détaillées, [visitez notre site d’aide](${CONST.
             deleteFailureMessage: "Une erreur s'est produite lors de la suppression de la catégorie, veuillez réessayer",
             categoryName: 'Nom de la catégorie',
             requiresCategory: 'Les membres doivent catégoriser toutes les dépenses',
-            showCategoryGLCodes: 'Afficher les codes de grand livre lors de la catégorisation des dépenses',
             needCategoryForExportToIntegration: (connectionName: string) => `Toutes les dépenses doivent être catégorisées afin de pouvoir être exportées vers ${connectionName}.`,
             subtitle: 'Obtenez une meilleure vue d’ensemble de l’endroit où l’argent est dépensé. Utilisez nos catégories par défaut ou ajoutez les vôtres.',
             emptyCategories: {

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -5953,7 +5953,6 @@ _Per istruzioni più dettagliate, [visita il nostro sito di assistenza](${CONST.
             deleteFailureMessage: 'Si è verificato un errore durante l’eliminazione della categoria, riprova per favore',
             categoryName: 'Nome categoria',
             requiresCategory: 'I membri devono categorizzare tutte le spese',
-            showCategoryGLCodes: 'Mostra i codici CO.GE. quando classifichi le spese',
             needCategoryForExportToIntegration: (connectionName: string) => `Tutte le spese devono essere categorizzate per poterle esportare su ${connectionName}.`,
             subtitle: 'Ottieni una panoramica migliore di dove viene speso il denaro. Usa le nostre categorie predefinite oppure aggiungi le tue.',
             emptyCategories: {

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -5892,7 +5892,6 @@ _詳しい手順については、[ヘルプサイトをご覧ください](${CO
             deleteFailureMessage: 'カテゴリの削除中にエラーが発生しました。もう一度お試しください',
             categoryName: 'カテゴリ名',
             requiresCategory: 'メンバーはすべての経費を分類する必要があります',
-            showCategoryGLCodes: '経費を分類するときに GL コードを表示する',
             needCategoryForExportToIntegration: (connectionName: string) => `${connectionName} にエクスポートするには、すべての経費にカテゴリを指定する必要があります。`,
             subtitle: 'お金がどこで使われているかを、より分かりやすく把握しましょう。デフォルトのカテゴリを使うか、自分用のカテゴリを追加できます。',
             emptyCategories: {

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -5946,7 +5946,6 @@ _Voor meer gedetailleerde instructies, [bezoek onze help-site](${CONST.NETSUITE_
             deleteFailureMessage: 'Er is een fout opgetreden bij het verwijderen van de categorie, probeer het opnieuw',
             categoryName: 'Categorienaam',
             requiresCategory: 'Leden moeten alle uitgaven categoriseren',
-            showCategoryGLCodes: 'Toon GL-codes bij het categoriseren van uitgaven',
             needCategoryForExportToIntegration: (connectionName: string) => `Alle onkosten moeten worden gecategoriseerd om te kunnen exporteren naar ${connectionName}.`,
             subtitle: 'Krijg beter inzicht in waar geld wordt uitgegeven. Gebruik onze standaardcategorieën of voeg je eigen categorieën toe.',
             emptyCategories: {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -5925,7 +5925,6 @@ _Aby uzyskać bardziej szczegółowe instrukcje, [odwiedź naszą stronę pomocy
             deleteFailureMessage: 'Wystąpił błąd podczas usuwania kategorii, spróbuj ponownie',
             categoryName: 'Nazwa kategorii',
             requiresCategory: 'Członkowie muszą kategoryzować wszystkie wydatki',
-            showCategoryGLCodes: 'Pokaż kody GL podczas kategoryzowania wydatków',
             needCategoryForExportToIntegration: (connectionName: string) => `Wszystkie wydatki muszą zostać skategoryzowane, aby można je było wyeksportować do ${connectionName}.`,
             subtitle: 'Uzyskaj lepszy wgląd w to, gdzie wydawane są pieniądze. Użyj naszych domyślnych kategorii lub dodaj własne.',
             emptyCategories: {

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -5935,7 +5935,6 @@ _Para instruções mais detalhadas, [visite nossa central de ajuda](${CONST.NETS
             deleteFailureMessage: 'Ocorreu um erro ao excluir a categoria, tente novamente',
             categoryName: 'Nome da categoria',
             requiresCategory: 'Os membros devem categorizar todas as despesas',
-            showCategoryGLCodes: 'Mostrar códigos GL ao categorizar despesas',
             needCategoryForExportToIntegration: (connectionName: string) => `Todas as despesas devem ser categorizadas para serem exportadas para ${connectionName}.`,
             subtitle: 'Tenha uma visão melhor de onde o dinheiro está sendo gasto. Use nossas categorias padrão ou adicione as suas.',
             emptyCategories: {

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -5764,7 +5764,6 @@ _如需更详细的说明，请[访问我们的帮助网站](${CONST.NETSUITE_IM
             deleteFailureMessage: '删除类别时出错，请重试',
             categoryName: '类别名称',
             requiresCategory: '成员必须为所有报销分类',
-            showCategoryGLCodes: '在分类报销时显示总账科目代码',
             needCategoryForExportToIntegration: (connectionName: string) => `要导出到 ${connectionName}，所有报销都必须先进行分类。`,
             subtitle: '更好地了解资金的支出去向。使用我们的默认类别或添加你自己的类别。',
             emptyCategories: {

--- a/src/libs/API/parameters/SetPolicyShowCategoryGLCodesParams.ts
+++ b/src/libs/API/parameters/SetPolicyShowCategoryGLCodesParams.ts
@@ -1,6 +1,0 @@
-type SetPolicyShowCategoryGLCodesParams = {
-    policyID: string;
-    enabled: boolean;
-};
-
-export default SetPolicyShowCategoryGLCodesParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -247,7 +247,6 @@ export type {default as SetWorkspaceCategoriesEnabledParams} from './SetWorkspac
 export type {default as CreateWorkspaceCategoriesParams} from './CreateWorkspaceCategoriesParams';
 export type {default as RenameWorkspaceCategoriesParams} from './RenameWorkspaceCategoriesParams';
 export type {default as SetWorkspaceRequiresCategoryParams} from './SetWorkspaceRequiresCategoryParams';
-export type {default as SetPolicyShowCategoryGLCodesParams} from './SetPolicyShowCategoryGLCodesParams';
 export type {default as DeleteWorkspaceCategoriesParams} from './DeleteWorkspaceCategoriesParams';
 export type {default as UpdatePolicyCategoryPayrollCodeParams} from './UpdatePolicyCategoryPayrollCodeParams';
 export type {default as UpdatePolicyCategoryGLCodeParams} from './UpdatePolicyCategoryGLCodeParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -186,7 +186,6 @@ const WRITE_COMMANDS = {
     CREATE_POLICY_TAG: 'CreatePolicyTag',
     RENAME_POLICY_TAG: 'RenamePolicyTag',
     SET_WORKSPACE_REQUIRES_CATEGORY: 'SetWorkspaceRequiresCategory',
-    SET_POLICY_SHOW_CATEGORY_GL_CODES: 'SetPolicyShowCategoryGLCodes',
     UPDATE_POLICY_CATEGORY_PAYROLL_CODE: 'UpdatePolicyCategoryPayrollCode',
     UPDATE_POLICY_CATEGORY_GL_CODE: 'UpdatePolicyCategoryGLCode',
     DELETE_WORKSPACE_CATEGORIES: 'DeleteWorkspaceCategories',
@@ -827,7 +826,6 @@ type WriteCommandParameters = {
     [WRITE_COMMANDS.EXPORT_REPORTS_TO_PDF]: Parameters.ExportReportsToPDFParams;
     [WRITE_COMMANDS.RENAME_WORKSPACE_CATEGORY]: Parameters.RenameWorkspaceCategoriesParams;
     [WRITE_COMMANDS.SET_WORKSPACE_REQUIRES_CATEGORY]: Parameters.SetWorkspaceRequiresCategoryParams;
-    [WRITE_COMMANDS.SET_POLICY_SHOW_CATEGORY_GL_CODES]: Parameters.SetPolicyShowCategoryGLCodesParams;
     [WRITE_COMMANDS.DELETE_WORKSPACE_CATEGORIES]: Parameters.DeleteWorkspaceCategoriesParams;
     [WRITE_COMMANDS.UPDATE_POLICY_CATEGORY_PAYROLL_CODE]: Parameters.UpdatePolicyCategoryPayrollCodeParams;
     [WRITE_COMMANDS.UPDATE_POLICY_CATEGORY_GL_CODE]: Parameters.UpdatePolicyCategoryGLCodeParams;

--- a/src/libs/CategoryOptionListUtils.ts
+++ b/src/libs/CategoryOptionListUtils.ts
@@ -13,7 +13,7 @@ import lodashSet from 'lodash/set';
 
 import type {OptionTree} from './OptionsListUtils';
 
-import {getCategoryGLCode, getDecodedCategoryName, processCategoryNameSegments} from './CategoryUtils';
+import {getDecodedCategoryName, processCategoryNameSegments} from './CategoryUtils';
 import tokenizedSearch from './tokenizedSearch';
 
 type CategoryTreeSection = Section<OptionTree>;
@@ -23,7 +23,6 @@ type Category = {
     enabled: boolean;
     isSelected?: boolean;
     pendingAction?: OnyxCommon.PendingAction;
-    glCode?: string;
 };
 
 type Hierarchy = Record<string, Category & {[key: string]: Hierarchy & Category}>;
@@ -35,7 +34,7 @@ type Hierarchy = Record<string, Category & {[key: string]: Hierarchy & Category}
  * @param options[].enabled - a flag to enable/disable option in a list
  * @param options[].name - a name of an option
  */
-function getCategoryOptionTree(options: Record<string, Category> | Category[], selectedOptions: Category[] = [], shouldShowGLCode = false): OptionTree[] {
+function getCategoryOptionTree(options: Record<string, Category> | Category[], selectedOptions: Category[] = []): OptionTree[] {
     const optionCollection = new Map<string, OptionTree>();
     for (const option of Object.values(options)) {
         const array = processCategoryNameSegments(option.name);
@@ -68,7 +67,6 @@ function getCategoryOptionTree(options: Record<string, Category> | Category[], s
             const shouldHideSelectionButton = !isChild && !parentOption;
             optionCollection.set(searchText, {
                 text: `${indents}${leafName}`,
-                ...(isChild && shouldShowGLCode && option.glCode ? {alternateText: option.glCode} : {}),
                 keyForList: searchText,
                 searchText,
                 tooltipText,
@@ -94,7 +92,6 @@ function getCategoryListSections({
     recentlyUsedCategories = [],
     maxRecentReportsToShow = CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
     translate,
-    shouldShowGLCode = false,
 }: {
     categories: PolicyCategories;
     localeCompare: LocaleContextProps['localeCompare'];
@@ -103,13 +100,9 @@ function getCategoryListSections({
     recentlyUsedCategories?: string[];
     maxRecentReportsToShow?: number;
     translate: LocalizedTranslate;
-    shouldShowGLCode?: boolean;
 }): CategoryTreeSection[] {
-    const withGLCode = (category: Category): Category => (shouldShowGLCode ? {...category, glCode: getCategoryGLCode(categories, category.name)} : category);
     const sortedCategories = sortCategories(categories, localeCompare);
-    const enabledCategories = Object.values(sortedCategories)
-        .filter((category) => category.enabled)
-        .map(withGLCode);
+    const enabledCategories = Object.values(sortedCategories).filter((category) => category.enabled);
     const enabledCategoriesNames = new Set(enabledCategories.map((category) => category.name));
     const selectedOptionsWithDisabledState: Category[] = [];
     const categorySections: CategoryTreeSection[] = [];
@@ -118,18 +111,14 @@ function getCategoryListSections({
     for (const option of selectedOptions) {
         if (enabledCategoriesNames.has(option.name)) {
             const categoryObj = enabledCategories.find((category) => category.name === option.name);
-            selectedOptionsWithDisabledState.push({
-                ...(categoryObj ?? option),
-                isSelected: true,
-                enabled: true,
-            });
+            selectedOptionsWithDisabledState.push({...(categoryObj ?? option), isSelected: true, enabled: true});
             continue;
         }
-        selectedOptionsWithDisabledState.push(withGLCode({...option, isSelected: true, enabled: false}));
+        selectedOptionsWithDisabledState.push({...option, isSelected: true, enabled: false});
     }
 
     if (numberOfEnabledCategories === 0 && selectedOptions.length > 0) {
-        const data = getCategoryOptionTree(selectedOptionsWithDisabledState, [], shouldShowGLCode);
+        const data = getCategoryOptionTree(selectedOptionsWithDisabledState);
         categorySections.push({
             // "Selected" section
             title: '',
@@ -145,13 +134,11 @@ function getCategoryListSections({
         const categoriesForSearch = [...selectedOptionsWithDisabledState, ...enabledCategories];
 
         // Step 2: Get search results using tokenizedSearch
-        let searchCategories: Category[] = tokenizedSearch(categoriesForSearch, searchValue, (category) => (shouldShowGLCode ? [category.name, category.glCode ?? ''] : [category.name])).map(
-            (category) => ({
-                ...category,
-                // Temporarily store if it was selected
-                wasSelected: selectedOptions.some((selectedOption) => selectedOption.name === category.name),
-            }),
-        );
+        let searchCategories: Category[] = tokenizedSearch(categoriesForSearch, searchValue, (category) => [category.name]).map((category) => ({
+            ...category,
+            // Temporarily store if it was selected
+            wasSelected: selectedOptions.some((selectedOption) => selectedOption.name === category.name),
+        }));
 
         // Step 3: Deduplicate by name (keep first occurrence, which is likely the selected one if present)
         const seen = new Set<string>();
@@ -171,14 +158,14 @@ function getCategoryListSections({
         }
         const searchSortedCategories = sortCategories(categoriesRecord, localeCompare);
 
-        // Step 5: Re-apply the isSelected flag and GL code (lost during sortCategories)
+        // Step 5: Re-apply the isSelected flag (lost during sortCategories)
         const finalSearchCategories: Category[] = searchSortedCategories.map((category) => ({
-            ...withGLCode(category),
+            ...category,
             isSelected: selectedOptions.some((selectedOption) => selectedOption.name === category.name),
         }));
 
         // Step 6: Generate the option tree and push the section
-        const data = getCategoryOptionTree(finalSearchCategories, [], shouldShowGLCode);
+        const data = getCategoryOptionTree(finalSearchCategories);
         categorySections.push({
             // "Search" section
             title: '',
@@ -190,7 +177,7 @@ function getCategoryListSections({
     }
 
     if (selectedOptions.length > 0) {
-        const data = getCategoryOptionTree(selectedOptionsWithDisabledState, [], shouldShowGLCode);
+        const data = getCategoryOptionTree(selectedOptionsWithDisabledState);
         categorySections.push({
             // "Selected" section
             title: '',
@@ -203,7 +190,7 @@ function getCategoryListSections({
     const filteredCategories = enabledCategories.filter((category) => !selectedOptionNames.has(category.name));
 
     if (numberOfEnabledCategories < CONST.STANDARD_LIST_ITEM_LIMIT) {
-        const data = getCategoryOptionTree(filteredCategories, selectedOptionsWithDisabledState, shouldShowGLCode);
+        const data = getCategoryOptionTree(filteredCategories, selectedOptionsWithDisabledState);
         categorySections.push({
             // "All" section when items amount less than the threshold
             title: '',
@@ -219,17 +206,15 @@ function getCategoryListSections({
             (categoryName) =>
                 !selectedOptionNames.has(categoryName) && categories[categoryName]?.enabled && categories[categoryName]?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
         )
-        .map((categoryName) =>
-            withGLCode({
-                name: categoryName,
-                enabled: categories[categoryName].enabled ?? false,
-            }),
-        );
+        .map((categoryName) => ({
+            name: categoryName,
+            enabled: categories[categoryName].enabled ?? false,
+        }));
 
     if (filteredRecentlyUsedCategories.length > 0) {
         const cutRecentlyUsedCategories = filteredRecentlyUsedCategories.slice(0, maxRecentReportsToShow);
 
-        const data = getCategoryOptionTree(cutRecentlyUsedCategories, [], shouldShowGLCode);
+        const data = getCategoryOptionTree(cutRecentlyUsedCategories);
         categorySections.push({
             // "Recent" section
             title: translate('common.recent'),
@@ -238,7 +223,7 @@ function getCategoryListSections({
         });
     }
 
-    const data = getCategoryOptionTree(filteredCategories, selectedOptionsWithDisabledState, shouldShowGLCode);
+    const data = getCategoryOptionTree(filteredCategories, selectedOptionsWithDisabledState);
     categorySections.push({
         // "All" section when items amount more than the threshold
         title: translate('common.all'),

--- a/src/libs/actions/Policy/Category.ts
+++ b/src/libs/actions/Policy/Category.ts
@@ -18,7 +18,6 @@ import type {
     SetPolicyCategoryReceiptsAndItemizedReceiptRequiredParams,
     SetPolicyCategoryReceiptsRequiredParams,
     SetPolicyCategoryTaxParams,
-    SetPolicyShowCategoryGLCodesParams,
     SetWorkspaceCategoryDescriptionHintParams,
     UpdatePolicyCategoryGLCodeParams,
 } from '@libs/API/parameters';
@@ -1269,66 +1268,6 @@ function setWorkspaceRequiresCategory(policyData: PolicyData, requiresCategory: 
     API.write(WRITE_COMMANDS.SET_WORKSPACE_REQUIRES_CATEGORY, parameters, onyxData);
 }
 
-function setPolicyShowCategoryGLCodes(policyID: string | undefined, showCategoryGLCodes: boolean) {
-    if (!policyID) {
-        return;
-    }
-
-    const onyxData: OnyxData<typeof ONYXKEYS.COLLECTION.POLICY> = {
-        optimisticData: [
-            {
-                onyxMethod: Onyx.METHOD.MERGE,
-                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-                value: {
-                    showCategoryGLCodes,
-                    errorFields: {
-                        showCategoryGLCodes: null,
-                    },
-                    pendingFields: {
-                        showCategoryGLCodes: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                    },
-                },
-            },
-        ],
-        successData: [
-            {
-                onyxMethod: Onyx.METHOD.MERGE,
-                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-                value: {
-                    errorFields: {
-                        showCategoryGLCodes: null,
-                    },
-                    pendingFields: {
-                        showCategoryGLCodes: null,
-                    },
-                },
-            },
-        ],
-        failureData: [
-            {
-                onyxMethod: Onyx.METHOD.MERGE,
-                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-                value: {
-                    showCategoryGLCodes: !showCategoryGLCodes,
-                    errorFields: {
-                        showCategoryGLCodes: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workspace.categories.updateFailureMessage'),
-                    },
-                    pendingFields: {
-                        showCategoryGLCodes: null,
-                    },
-                },
-            },
-        ],
-    };
-
-    const parameters: SetPolicyShowCategoryGLCodesParams = {
-        policyID,
-        enabled: showCategoryGLCodes,
-    };
-
-    API.write(WRITE_COMMANDS.SET_POLICY_SHOW_CATEGORY_GL_CODES, parameters, onyxData);
-}
-
 function clearCategoryErrors(policyID: string, categoryName: string, policyCategories: PolicyCategories = {}) {
     const category = policyCategories?.[categoryName];
 
@@ -1989,5 +1928,4 @@ export {
     setWorkspaceCategoryDescriptionHint,
     setWorkspaceCategoryEnabled,
     setWorkspaceRequiresCategory,
-    setPolicyShowCategoryGLCodes,
 };

--- a/src/pages/workspace/categories/DynamicWorkspaceCategoriesSettingsPage.tsx
+++ b/src/pages/workspace/categories/DynamicWorkspaceCategoriesSettingsPage.tsx
@@ -23,7 +23,7 @@ import type {WithPolicyConnectionsProps} from '@pages/workspace/withPolicyConnec
 import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 
-import {setPolicyShowCategoryGLCodes, setWorkspaceRequiresCategory} from '@userActions/Policy/Category';
+import {setWorkspaceRequiresCategory} from '@userActions/Policy/Category';
 import {clearPolicyErrorField} from '@userActions/Policy/Policy';
 
 import CONST from '@src/CONST';
@@ -56,10 +56,6 @@ function DynamicWorkspaceCategoriesSettingsPage({policy, route}: DynamicWorkspac
         },
         [policyData],
     );
-
-    const updateShowCategoryGLCodes = (value: boolean) => {
-        setPolicyShowCategoryGLCodes(policyID, value);
-    };
 
     const data = useMemo(() => {
         if (!policyData.policy?.mccGroup) {
@@ -129,19 +125,6 @@ function DynamicWorkspaceCategoriesSettingsPage({policy, route}: DynamicWorkspac
                         onCloseError={() => clearPolicyErrorField(policy?.id, 'requiresCategory')}
                         shouldPlaceSubtitleBelowSwitch
                     />
-                    {!!policy?.glCodes && (
-                        <ToggleSettingOptionRow
-                            title={translate('workspace.categories.showCategoryGLCodes')}
-                            switchAccessibilityLabel={translate('workspace.categories.showCategoryGLCodes')}
-                            isActive={policy?.showCategoryGLCodes ?? false}
-                            onToggle={updateShowCategoryGLCodes}
-                            pendingAction={policy?.pendingFields?.showCategoryGLCodes}
-                            disabled={!policy?.areCategoriesEnabled}
-                            wrapperStyle={[styles.pv2, styles.mh5]}
-                            errors={policy?.errorFields?.showCategoryGLCodes ?? undefined}
-                            onCloseError={() => clearPolicyErrorField(policy?.id, 'showCategoryGLCodes')}
-                        />
-                    )}
                     <View style={[styles.sectionDividerLine, styles.mh5, styles.mv6]} />
                     <View style={[styles.containerWithSpaceBetween]}>
                         {!!policyData.policy && (data?.length ?? 0) > 0 && (

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -2608,9 +2608,6 @@ type Policy = OnyxCommon.OnyxValueWithOfflineFeedback<
         /** Whether new transactions need to be categorized */
         requiresCategory?: boolean;
 
-        /** Whether to show category GL codes when selecting a category */
-        showCategoryGLCodes?: boolean;
-
         /**
          * Policy Receipt Partners
          */


### PR DESCRIPTION
This reverts Expensify/App#94596.

### Explanation of Change

Reverts Expensify/App#94596 ("Show GL code when selecting a category"). That PR added the "Show GL codes when categorizing expenses" toggle and surfaced GL codes in the category picker, and it caused several deploy blockers on staging. Reverting it restores the previous behavior while the issues are addressed.

### Fixed Issues

$ [https://github.com/Expensify/App/issues/96799](<https://github.com/Expensify/App/issues/96799>)<br>$ [https://github.com/Expensify/App/issues/96808](<https://github.com/Expensify/App/issues/96808>)<br>$ [https://github.com/Expensify/App/issues/96810](<https://github.com/Expensify/App/issues/96810>)<br>$ [https://github.com/Expensify/App/issues/96816](<https://github.com/Expensify/App/issues/96816>)

### Tests

**Precondition:** Use an account that does NOT have the `rulesRevamp` beta enabled. With `rulesRevamp` on (as on Applause accounts with all betas enabled), the Categories **Settings** option is hidden and the GL codes toggle can't be reached.

1. Open a Control workspace that has GL codes enabled
2. Go to Workspace > Categories > Settings
3. Verify the "Show GL codes when categorizing expenses" toggle is no longer present
4. Create/edit an expense and open the category picker
5. Verify GL codes are no longer shown in the category picker and the regression from Expensify/App#96816 no longer reproduces

- [X] Verify that no errors appear in the JS console

### Offline tests

Same as above.

### QA Steps

**Precondition:** Use an account that does NOT have the `rulesRevamp` beta enabled. With `rulesRevamp` on (as on Applause accounts with all betas enabled), the Categories **Settings** option is hidden and the GL codes toggle can't be reached.

1. Open a Control workspace that has GL codes enabled
2. Go to Workspace > Categories > Settings
3. Verify the "Show GL codes when categorizing expenses" toggle is no longer present
4. Create/edit an expense and open the category picker
5. Verify GL codes are no longer shown in the category picker and the regression from Expensify/App#96816 no longer reproduces

- [X] Verify that no errors appear in the JS console

## Author Checklist

- [X] I have verified the author checklist is complete (all boxes are checked off).
- [X] I verified the correct issue is linked in the `### Fixed Issues` section above
- [X] I verified testing steps are clear and they cover the changes made in this PR
  - [X] I verified the steps for local testing are in the `Tests` section
  - [X] I verified the steps for Staging and/or Production testing are in the `QA steps` section
  - [X] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [X] I checked that screenshots or videos are included for tests on [all platforms](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms>)
- [X] I included screenshots or videos for tests on [all platforms](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms>)
- [X] I verified that the composer does not automatically focus or open the keyboard on mobile unless explicitly intended. This includes checking that returning the app from the background does not unexpectedly open the keyboard.
- [X] I verified tests pass on **all platforms** & I tested again on:
  - [X] Android: HybridApp
  - [X] Android: mWeb Chrome
  - [X] iOS: HybridApp
  - [X] iOS: mWeb Safari
  - [X] MacOS: Chrome / Safari
- [X] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [X] I verified proper code patterns were followed (see [Reviewing the code](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code>))
  - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
  - [X] I verified that comments were added to code that is not self explanatory
  - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I verified that this PR follows the guidelines as stated in the [Review Guidelines](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md>)
- [X] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [X] If a new component is created I verified that:
  - [X] A similar component doesn't exist in the codebase
  - [X] All props are defined accurately and each prop has a `/** comment above it */`
  - [X] The file is named correctly
  - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
  - [X] The only data being stored in the state is data necessary for rendering and nothing else
  - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
  - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
  - [X] All JSX used for rendering exists in the render method
  - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
  - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
  - [X] A similar style doesn't already exist
  - [X] The style can't be created with an existing [StyleUtils](<https://github.com/Expensify/App/blob/main/src/utils/index.ts>) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [X] I verified that all the inputs inside a form are aligned with each other.
  - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] For any bug fix or new feature in this PR, I verified that sufficient [unit tests](<https://github.com/Expensify/App/blob/main/tests/README.md>) are included to prevent regressions in this flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details><summary>Android: HybridApp</summary>

</details>

<details><summary>Android: mWeb Chrome</summary>

</details>

<details><summary>iOS: HybridApp</summary>

</details>

<details><summary>iOS: mWeb Safari</summary>

</details>

<details><summary>MacOS: Chrome / Safari</summary>

</details>