### PR TITLE
Fix -  Split Expense - Splitting is possible when the sum of splits is not equal to the total

### DIFF
--- a/src/components/MoneyRequestConfirmationList/hooks/useFormErrorManagement.ts
+++ b/src/components/MoneyRequestConfirmationList/hooks/useFormErrorManagement.ts
@@ -203,6 +203,13 @@ function useFormErrorManagement({
     }, [formError]);
 
     useEffect(() => {
+        if (formErrorRef.current !== 'iou.error.invalidMerchant' || !isMerchantFieldValid) {
+            return;
+        }
+        setFormError('');
+    }, [isMerchantFieldValid, setFormError]);
+
+    useEffect(() => {
         const currentFormError = formErrorRef.current;
         if (shouldDisplayFieldError && didConfirmSplit) {
             setFormError('iou.error.genericSmartscanFailureMessage');
@@ -210,10 +217,6 @@ function useFormErrorManagement({
         }
         if (shouldDisplayFieldError && hasSmartScanFailed) {
             setFormError('iou.receiptScanningFailed');
-            return;
-        }
-        if (currentFormError === 'iou.error.invalidMerchant' && isMerchantFieldValid) {
-            setFormError('');
             return;
         }
         // Check 1: If formError does NOT start with "violations.", clear it and return
@@ -229,7 +232,7 @@ function useFormErrorManagement({
         if (isViolationFixed) {
             setFormError('');
         }
-    }, [isFocused, shouldDisplayFieldError, hasSmartScanFailed, didConfirmSplit, isViolationFixed, isMerchantFieldValid, setFormError]);
+    }, [isFocused, shouldDisplayFieldError, hasSmartScanFailed, didConfirmSplit, isViolationFixed, setFormError]);
 
     const computeErrorMessage = (): string | undefined => {
         if (routeError) {


### PR DESCRIPTION
### Explanation of Change

The merchant live-clear was sharing the focus-reset effect in `useFormErrorManagement`, which put `isMerchantFieldValid` in that effect's dependencies. Saving a merchant therefore re-ran the focus-reset, whose blanket "clear every non-`violations.` error" wiped the still-valid split error, letting a mismatched split through.

Moved the merchant live-clear into its own effect and removed `isMerchantFieldValid` from the focus-reset dependencies, so a merchant edit can no longer trigger that clear.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94572
PROPOSAL: https://github.com/Expensify/App/issues/94572#issuecomment-4812235086

### Tests

1. Go to a group chat
2. Click **+** > **Split expense** > **Manual**
3. Enter amount > **Next**
4. On confirmation page, enter 0 on the split input on each participant
5. Click **Merchant**
6. Enter any merchant and save it
7. Click **Split**
8. Verify the error is still there and nothing happens when clicking the confirm button

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests.

### QA Steps

1. Go to a group chat
2. Click **+** > **Split expense** > **Manual**
3. Enter amount > **Next**
4. On confirmation page, enter 0 on the split input on each participant
5. Click **Merchant**
6. Enter any merchant and save it
7. Click **Split**
8. Verify the error is still there and nothing happens when clicking the confirm button

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/1d6b3fe2-a3dd-481a-a677-69b14e0da790


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/3a07f944-19a4-431e-a172-6e34b1be874f


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a707d25e-32b3-4dd2-bd52-71c31e244b7c


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/583f5dca-1db9-4d34-a800-0e310cee580b


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/8050f0cf-03cb-4ede-9d6b-1a3fa01f066a


</details>
