### PR TITLE
Fix: Apply formatPhoneNumber to displayName for phone number users in ConfirmDelegatePage

### DIFF
--- a/src/pages/settings/Security/AddDelegate/ConfirmDelegatePage.tsx
+++ b/src/pages/settings/Security/AddDelegate/ConfirmDelegatePage.tsx
@@ -37,7 +37,7 @@ function ConfirmDelegatePage({route}: ConfirmDelegatePageProps) {
     const personalDetails = getPersonalDetailByEmail(login);
     const avatarIcon = personalDetails?.avatar ?? icons.FallbackAvatar;
     const formattedLogin = formatPhoneNumber(login ?? '');
-    const displayName = personalDetails?.displayName ?? formattedLogin;
+    const displayName = personalDetails?.displayName ? formatPhoneNumber(personalDetails.displayName) : formattedLogin;
 
     const submitButton = (
         <Button


### PR DESCRIPTION
### $ Expensify/App#96868

### Details

Phone number users have their `personalDetails.displayName` set to the raw phone number (e.g., `+158****7441`). The `ConfirmDelegatePage` was displaying this raw value directly in the title field because the `??` fallback to `formattedLogin` was never reached when `displayName` existed.

This fix applies `formatPhoneNumber` to the `displayName` value as well, which:

* Formats phone numbers into a clean display format (e.g., `(581) ***-7441`)
* Returns non-phone strings unchanged (safe for regular users)

### Fixed Issues

$250 — [https://github.com/Expensify/App/issues/96868](<https://github.com/Expensify/App/issues/96868>)

### Tests

1. Open Delegate settings for a phone number user
2. Verify the display name shows the formatted phone number (e.g., `(581) ***-7441`) instead of `+158****7441`
3. Verify regular email users are unaffected
4. Verify the login/description field still shows the formatted phone number