### PR TITLE
feat(libs): add truncateMiddle helper to StringUtils

### DIFF
--- a/src/libs/StringUtils/index.ts
+++ b/src/libs/StringUtils/index.ts
@@ -212,6 +212,22 @@ function escapeRegExp(str: string): string {
     return str.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Truncates a string in the middle with an ellipsis if it exceeds maxLength.
+ * @param str - The input string to truncate.
+ * @param maxLength - Maximum allowed length of the resulting string.
+ * @returns The truncated string.
+ */
+function truncateMiddle(str: string, maxLength: number): string {
+    if (str.length <= maxLength || maxLength <= 3) {
+        return str;
+    }
+    const charsToShow = maxLength - 3;
+    const frontChars = Math.ceil(charsToShow / 2);
+    const backChars = Math.floor(charsToShow / 2);
+    return `${str.slice(0, frontChars)}...${str.slice(str.length - backChars)}`;
+}
+
 export default {
     sanitizeString,
     isEmptyString,
@@ -234,4 +250,5 @@ export default {
     camelToKebabCase,
     toLowerCase,
     escapeRegExp,
+    truncateMiddle,
 };


### PR DESCRIPTION
## Description
Adds a \	runcateMiddle\ utility helper function to \src/libs/StringUtils/index.ts\ to cleanly truncate long text strings and filenames in the middle with an ellipsis (\...\).

## Features
- Middle truncation helper \	runcateMiddle(str, maxLength)\.
- Useful for filename rendering and compact UI text displays where start and end identifiers must remain visible.