### PR TITLE
[No QA] Skip react-native-worklets Babel plugin in Jest to fix test slowdown and shard 7 test crash

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -104,7 +104,7 @@ const metro = {
                   [
                       'react-native-worklets/plugin',
                       {
-                          bundleMode: !isTestEnv,
+                          bundleMode: true,
                           // In Bundle Mode, an import that a worklet captures in its closure becomes a "remote function"
                           // and throws when called synchronously on a Worklet Runtime. The `react-native-live-markdown`
                           // ExpensiMark parser runs on the LiveMarkdownRuntime and directly imports `ExpensiMark`,

--- a/babel.config.js
+++ b/babel.config.js
@@ -96,8 +96,8 @@ const metro = {
         '@babel/plugin-transform-export-namespace-from',
         // The worklets babel plugin needs to be last, as stated here: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/
         // Skipped under Jest (isTestEnv): reanimated and worklets are fully mocked in jest/setup.ts, so the
-        // plugin's worklet transform is wasted work — and it is uncacheable, which re-runs a heavy nested
-        // Babel transform on every test run. See PR #96078 regression.
+        // plugin's worklet transform is wasted work - and it is uncacheable, which re-runs a heavy nested
+        // Babel transform on every test run.
         ...(isTestEnv
             ? []
             : [

--- a/babel.config.js
+++ b/babel.config.js
@@ -95,27 +95,34 @@ const metro = {
         ],
         '@babel/plugin-transform-export-namespace-from',
         // The worklets babel plugin needs to be last, as stated here: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/
-        [
-            'react-native-worklets/plugin',
-            {
-                bundleMode: !isTestEnv,
-                // In Bundle Mode, an import that a worklet captures in its closure becomes a "remote function"
-                // and throws when called synchronously on a Worklet Runtime. The `react-native-live-markdown`
-                // ExpensiMark parser runs on the LiveMarkdownRuntime and directly imports `ExpensiMark`,
-                // `unescapeText` (from `expensify-common/utils`) and `decode` (from `html-entities`) into its
-                // worklets, so those imports must be forwarded to avoid the "Tried to synchronously call a
-                // Remote Function" crash. Their transitive dependencies (expensify-common's `Str`, `punycode`,
-                // `awesome-phonenumber`, html-entities' internals, ...) do NOT need forwarding: metro bundles
-                // the whole `require()` graph onto the Worklet Runtime, so they resolve locally there.
-                // `relativePaths` only needs to cover live-markdown's own `./rangeUtils` (expensify-common and
-                // html-entities resolve to CommonJS, where `relativePaths` forwarding never fires).
-                // See https://docs.swmansion.com/react-native-worklets/docs/bundleMode/importForwarding
-                importForwarding: {
-                    moduleNames: ['expensify-common', 'expensify-common/utils', 'html-entities'],
-                    relativePaths: ['@expensify/react-native-live-markdown'],
-                },
-            },
-        ],
+        // Skipped under Jest (isTestEnv): reanimated and worklets are fully mocked in jest/setup.ts, so the
+        // plugin's worklet transform is wasted work — and it is uncacheable, which re-runs a heavy nested
+        // Babel transform on every test run. See PR #96078 regression.
+        ...(isTestEnv
+            ? []
+            : [
+                  [
+                      'react-native-worklets/plugin',
+                      {
+                          bundleMode: !isTestEnv,
+                          // In Bundle Mode, an import that a worklet captures in its closure becomes a "remote function"
+                          // and throws when called synchronously on a Worklet Runtime. The `react-native-live-markdown`
+                          // ExpensiMark parser runs on the LiveMarkdownRuntime and directly imports `ExpensiMark`,
+                          // `unescapeText` (from `expensify-common/utils`) and `decode` (from `html-entities`) into its
+                          // worklets, so those imports must be forwarded to avoid the "Tried to synchronously call a
+                          // Remote Function" crash. Their transitive dependencies (expensify-common's `Str`, `punycode`,
+                          // `awesome-phonenumber`, html-entities' internals, ...) do NOT need forwarding: metro bundles
+                          // the whole `require()` graph onto the Worklet Runtime, so they resolve locally there.
+                          // `relativePaths` only needs to cover live-markdown's own `./rangeUtils` (expensify-common and
+                          // html-entities resolve to CommonJS, where `relativePaths` forwarding never fires).
+                          // See https://docs.swmansion.com/react-native-worklets/docs/bundleMode/importForwarding
+                          importForwarding: {
+                              moduleNames: ['expensify-common', 'expensify-common/utils', 'html-entities'],
+                              relativePaths: ['@expensify/react-native-live-markdown'],
+                          },
+                      },
+                  ],
+              ]),
     ],
     env: {
         production: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -96,8 +96,8 @@ const metro = {
         '@babel/plugin-transform-export-namespace-from',
         // The worklets babel plugin needs to be last, as stated here: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/
         // Skipped under Jest (isTestEnv): reanimated and worklets are fully mocked in jest/setup.ts, so the
-        // plugin's worklet transform is wasted work - and it is uncacheable, which re-runs a heavy nested
-        // Babel transform on every test run.
+        // plugin's worklet transform is wasted work - and its output is not cached, so a heavy nested
+        // Babel transform re-runs on every test run.
         ...(isTestEnv
             ? []
             : [

--- a/src/types/utils/EmptyObject.ts
+++ b/src/types/utils/EmptyObject.ts
@@ -1,5 +1,6 @@
 import CONST from '@src/CONST';
 
+//trigg
 type EmptyObject = Record<string, never>;
 
 type EmptyValue = EmptyObject | null | undefined;

--- a/src/types/utils/EmptyObject.ts
+++ b/src/types/utils/EmptyObject.ts
@@ -1,6 +1,6 @@
 import CONST from '@src/CONST';
 
-//trigg
+// trigger
 type EmptyObject = Record<string, never>;
 
 type EmptyValue = EmptyObject | null | undefined;

--- a/src/types/utils/EmptyObject.ts
+++ b/src/types/utils/EmptyObject.ts
@@ -1,7 +1,5 @@
 import CONST from '@src/CONST';
 
-// trigger
-// trigger
 type EmptyObject = Record<string, never>;
 
 type EmptyValue = EmptyObject | null | undefined;

--- a/src/types/utils/EmptyObject.ts
+++ b/src/types/utils/EmptyObject.ts
@@ -1,6 +1,7 @@
 import CONST from '@src/CONST';
 
 // trigger
+// trigger
 type EmptyObject = Record<string, never>;
 
 type EmptyValue = EmptyObject | null | undefined;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Skip the `react-native-worklets/plugin` Babel plugin under Jest (`isTestEnv`), since reanimated and worklets are already fully mocked in `jest/setup.ts`. This fixes two problems introduced by the reanimated 4.5 / worklets 0.11 bump (#96078):

**1. Test-time regression (~2.7× slower CI).** The new worklets plugin runs a heavy nested Babel transform on every file, and its output is not cacheable - so `.jest-cache` no longer helps and the transform re-runs on every single test run. The Jest step jumped from ~1m20s to ~3m40s per shard. In tests this transform isn't needed: the worklet runtime is mocked, so worklets already run as plain synchronous functions and the transform is never used.

**2. Higher peak RAM -> shard 7 (test job 7) started failing.** The extra per-file transform work (large ASTs built on every run, never cached) raised peak heap per Jest worker, and slower tests kept workers alive longer so their memory peaks overlapped. On the heaviest shard (job 7) this tipped over the runner's RAM ceiling, so the process was OOM-killed / crashed (exit 143 / 139) - showing up as intermittent "shard 7" failures on `main` with no failing test in the logs.

Removing the plugin only in test env restores cacheability and speed and lowers memory. Native (metro) builds are unchanged.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/96985


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

No QA

- [x] Verify that no errors appear in the JS console

### Offline tests


### QA Steps

No QA

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
