### PR TITLE
Backport missing ViewState guard for updateOverflowInset

### DIFF
--- a/patches/react-native/details.md
+++ b/patches/react-native/details.md
@@ -192,9 +192,9 @@
 
 ### [react-native+0.85.3+025+log-soft-exception-if-viewState-not-found.patch](react-native+0.85.3+025+log-soft-exception-if-viewState-not-found.patch)
 
-- Reason: This patch prevents app crashes by soft-logging the exception when JS try to send events to native views even if they are removed from view hierarchy. The approach follows existing patterns in the same file where similar events are already handled this way and is based on suggestions from other developers in upstream discussions.
-- Upstream PR/issue: [#49077](https://github.com/facebook/react-native/issues/49077) [#7493](https://github.com/software-mansion/react-native-reanimated/issues/7493)
-- E/App issue: [#82611](https://github.com/Expensify/App/issues/82611)
+- Reason: This patch prevents app crashes by soft-logging missing view-state exceptions when JS sends events or Fabric mount instructions for native views that have already been removed from the hierarchy. It includes the upstream `updateOverflowInset` guard so stale batch mount items return safely instead of throwing `RetryableMountingLayerException`.
+- Upstream PR/issue: [#49077](https://github.com/facebook/react-native/issues/49077) [#56762](https://github.com/facebook/react-native/pull/56762) [#7493](https://github.com/software-mansion/react-native-reanimated/issues/7493)
+- E/App issues: [#82611](https://github.com/Expensify/App/issues/82611) [#93833](https://github.com/Expensify/App/issues/93833)
 - PR introducing patch: [#84303](https://github.com/Expensify/App/pull/84303)
 
 ### [react-native+0.85.3+026+fix-view-stealing-first-responder.patch](react-native+0.85.3+026+fix-view-stealing-first-responder.patch)

--- a/patches/react-native/react-native+0.85.3+025+log-soft-exception-if-viewState-not-found.patch
+++ b/patches/react-native/react-native+0.85.3+025+log-soft-exception-if-viewState-not-found.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
-index eb0b519..50bffae 100644
+index eb0b519..1ddcbe2 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
 +++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
 @@ -281,15 +281,33 @@ internal constructor(
@@ -69,6 +69,21 @@ index eb0b519..50bffae 100644
 +        ReactNoCrashSoftException(
 +          "Unable to find viewState for tag: $reactTag for updateLayout"
 +        )
++      )
++      return
++    }
+     // Do not layout Root Views
+     if (viewState.isRoot) {
+       return
+@@ -840,4 +876,13 @@ internal constructor(
+-    val viewState = getViewState(reactTag)
++    val viewState = getNullableViewState(reactTag)
++    if (viewState == null) {
++      ReactSoftExceptionLogger.logSoftException(
++          ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE,
++          ReactNoCrashSoftException(
++              "Unable to find viewState for tag $reactTag for updateOverflowInset"
++          ),
 +      )
 +      return
 +    }


### PR DESCRIPTION
### Explanation of Change

Backports React Native's missing-`ViewState` guard for
`SurfaceMountingManager.updateOverflowInset()` into the existing React Native 0.85.3
patch. A stale Fabric batch mount item can reference a view that has already been
removed; the patched method now soft-logs that condition and returns instead of
throwing `RetryableMountingLayerException`.

The existing `addViewAt`, `updateProps`, and `updateLayout` protections remain in
place. The combined patch can be removed when App upgrades to a React Native release
that contains all four upstream guards.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93833
PROPOSAL: https://github.com/Expensify/App/issues/93833#issuecomment-5043690538

### Tests

The original production race has no known deterministic reproduction. The following
validation was performed:

1. A clean remote dependency installation applied the combined React Native 0.85.3
   patch without warnings or errors.
2. The upstream `validate-patches` check passed.
3. Targeted format, ESLint, and React Compiler checks passed.
4. `git diff --check` and a reverse-apply check against the installed patched React
   Native source passed.

Manual Android smoke is not claimed as deterministic proof; the repeatable smoke flow
is listed under QA Steps, and final effectiveness will be confirmed by monitoring
APP-3E3 after deployment.

- [x] Verify that no errors appear in the JS console — N/A for the automated checks:
      this changes Kotlin inside React Native and introduces no JS/TS execution path.

### Offline tests

N/A. The guard runs in React Native's Fabric mounting layer and does not read network,
Onyx, account, or permission state. No offline manual run is claimed.

### QA Steps

The crash is not deterministically reproducible. Use these steps as regression smoke
coverage; production effectiveness will be confirmed by monitoring APP-3E3.

1. Sign in to the Android HybridApp with an account containing many reports and expenses.
2. Open the Search tab and open a report from the search results.
3. Scroll quickly through the results and repeatedly expand and collapse grouped report rows.
4. Verify the app remains responsive and does not crash.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

Checked boxes below confirm that every current template item was reviewed. Items marked
N/A were not performed and are not claimed as test evidence. This is an Android-only
React Native Kotlin patch with no App UI, product copy, assets, CSS, message composer,
Storybook, deeplink, or JS/TS behavior change.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct) — N/A: there is no input or user-facing error state; the missing native view is the failure path handled by the guard.
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline) — N/A: network state cannot reach this Fabric guard, and no offline manual run is claimed.
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability). — N/A: no account or API behavior changes, and no high-traffic manual run is claimed.
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — N/A: there is no visual change.
- [x] I ran the tests on **all platforms** & verified they passed on: — N/A: this is an Android-only React Native Kotlin patch; cross-platform manual testing is not claimed.
    - [x] Android: Native — automated patch/install validation passed; nondeterministic manual smoke remains for QA.
    - [x] Android: mWeb Chrome — N/A.
    - [x] iOS: Native — N/A.
    - [x] iOS: mWeb Safari — N/A.
    - [x] MacOS: Chrome / Safari — N/A.
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed) — N/A: no JS/TS path changed, and no manual console run is claimed.
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory — N/A: no explanatory code comment was needed for the exact upstream guard.
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing. — N/A: no code comments changed.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue) — N/A: no product copy changed; the diagnostic string matches upstream exactly.
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers — N/A: this uses the existing upstream missing-view-state guard pattern.
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) — N/A: no App component changed.
- [x] If a new CSS style is added I verified that: — N/A.
    - [x] A similar style doesn't already exist — N/A.
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`) — N/A.
- [x] If new assets were added or existing ones were modified, I verified that: — N/A.
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`) — N/A.
    - [x] The assets load correctly across all supported platforms. — N/A.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. — N/A.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) — N/A.
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. — N/A.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account. — N/A.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles: — N/A.
    - [x] I verified that all the inputs inside a form are aligned with each other. — N/A.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes. — N/A.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow. — N/A: there is no App JS/TS test seam for this Kotlin React Native patch; patch integrity and CI cover the backport.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps. — N/A: `main` has not been merged after review and the branch is still based on current `main`.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — no visual change.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — Android native-only change with no visual effect.

</details>

<details>
<summary>iOS: Native</summary>

N/A — Android native-only change with no visual effect.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — Android native-only change with no visual effect.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — Android native-only change with no visual effect.

</details>
