### PR TITLE
[CP Staging] Revert "Fix empty view shows briefly when sorting"

### DIFF
--- a/src/components/Search/SearchResultsProvider.tsx
+++ b/src/components/Search/SearchResultsProvider.tsx
@@ -28,8 +28,6 @@ type SearchResultsProviderProps = {
 const defaultSearchInfo: SearchResultsInfo = {
     offset: 0,
     hash: 0,
-    sortBy: CONST.SEARCH.TABLE_COLUMNS.DATE,
-    sortOrder: CONST.SEARCH.SORT_ORDER.DESC,
     type: CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT,
     hasMoreResults: false,
     hasResults: true,

--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -2536,7 +2536,6 @@ export {
     getDateRangeDisplayValueFromFormValue,
     getRangeBoundariesFromFormValue,
     getRangeQueryValue,
-    getQueryHashes,
     isSearchDatePreset,
     getDateRangeForPreset,
     getDateFilterRange,

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -185,7 +185,6 @@ import {
     getDateRangeDisplayValueFromFormValue,
     getDateRangeForPreset,
     getFilterFromQuery,
-    getQueryHashes,
     isFilterNegatable,
     isFilterSupported,
     isSearchDatePreset,
@@ -4825,16 +4824,9 @@ function shouldShowEmptyState(isDataLoaded: boolean, dataLength: number, type: S
 }
 
 function isSearchDataLoaded(searchResults: SearchResults | undefined, queryJSON: Readonly<SearchQueryJSON> | undefined) {
-    const queryJSONHash =
-        queryJSON && searchResults?.search
-            ? getQueryHashes({
-                  ...queryJSON,
-                  sortBy: searchResults.search.sortBy,
-                  sortOrder: searchResults.search.sortOrder,
-              }).primaryHash
-            : queryJSON?.hash;
+    const isDataLoaded = (searchResults?.data != null || searchResults?.errors != null) && searchResults?.search?.type === queryJSON?.type && searchResults?.search?.hash === queryJSON?.hash;
 
-    return (searchResults?.data != null || searchResults?.errors != null) && searchResults.search?.type === queryJSON?.type && searchResults.search?.hash === queryJSONHash;
+    return isDataLoaded;
 }
 
 function getValidGroupBy(groupBy: string | undefined): ValueOf<typeof CONST.SEARCH.GROUP_BY> | undefined {

--- a/src/types/onyx/SearchResults.ts
+++ b/src/types/onyx/SearchResults.ts
@@ -5,7 +5,7 @@ import type {
     TransactionListItemType,
     TransactionReportGroupListItemType,
 } from '@components/Search/SearchList/ListItem/types';
-import type {SearchGroupBy, SearchSortBy, SortOrder} from '@components/Search/types';
+import type {SearchGroupBy} from '@components/Search/types';
 
 import type CONST from '@src/CONST';
 import type ONYXKEYS from '@src/ONYXKEYS';
@@ -58,12 +58,6 @@ type SearchResultsInfo = {
 
     /** Whether the search results are currently loading */
     isLoading: boolean;
-
-    /** The sort by of the current search */
-    sortBy: SearchSortBy;
-
-    /** The sort order of the current search */
-    sortOrder: SortOrder;
 
     /** Explicit terminal lifecycle state of the most recent search request for this snapshot.
      * Optional because snapshots persisted before this field existed (and snapshots written by

--- a/tests/ui/SearchPageTest.tsx
+++ b/tests/ui/SearchPageTest.tsx
@@ -195,8 +195,6 @@ describe('SearchPageNarrow', () => {
                     type: CONST.SEARCH.DATA_TYPES.CHAT,
                     offset: 0,
                     hash: failedQueryJSON?.hash,
-                    sortBy: failedQueryJSON?.sortBy,
-                    sortOrder: failedQueryJSON?.sortOrder,
                     isLoading: false,
                     hasMoreResults: false,
                 },

--- a/tests/unit/HomePage/YourSpendSection/rowStateTest.ts
+++ b/tests/unit/HomePage/YourSpendSection/rowStateTest.ts
@@ -10,8 +10,6 @@ const makeSearchResults = (overrides: Partial<SearchResults> = {}): SearchResult
     search: {
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         type: 'expense',
         hasMoreResults: false,
         hasResults: true,
@@ -27,8 +25,6 @@ const makeSearchResultsWithCount = (count: number): SearchResults =>
         search: {
             offset: 0,
             hash: 0,
-            sortBy: 'date',
-            sortOrder: 'desc',
             type: 'expense',
             hasMoreResults: false,
             hasResults: count > 0,

--- a/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
+++ b/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
@@ -142,8 +142,6 @@ function makeSearchResultsWithCount(count: number): SearchResults {
             type: 'expense',
             offset: 0,
             hash: 0,
-            sortBy: 'date',
-            sortOrder: 'desc',
             hasMoreResults: false,
             hasResults: count > 0,
             isLoading: false,
@@ -593,19 +591,7 @@ describe('useYourSpendData — third-party cardRows', () => {
         mockedGetDisplayableThirdPartyCards.mockReturnValue(makeThirdPartyCards([{cardID: THIRD_PARTY_CARD_ID_1, lastFourPAN: THIRD_PARTY_LAST_FOUR_1}]));
         // First render: READY snapshot with count > 0 → row produced and total cached.
         setupCardSnapshot(THIRD_PARTY_CARD_ID_1, {
-            search: {
-                type: 'expense',
-                offset: 0,
-                hash: 0,
-                sortBy: 'date',
-                sortOrder: 'desc',
-                hasMoreResults: false,
-                hasResults: true,
-                isLoading: false,
-                count: 3,
-                total: 1234,
-                currency: 'USD',
-            },
+            search: {type: 'expense', offset: 0, hash: 0, hasMoreResults: false, hasResults: true, isLoading: false, count: 3, total: 1234, currency: 'USD'},
             data: {},
         });
         const {result, rerender} = renderHook(() => useYourSpendData());
@@ -613,19 +599,7 @@ describe('useYourSpendData — third-party cardRows', () => {
 
         // Search screen wipes count/total/currency on the shared snapshot.
         setupCardSnapshot(THIRD_PARTY_CARD_ID_1, {
-            search: {
-                type: 'expense',
-                offset: 0,
-                hash: 0,
-                sortBy: 'date',
-                sortOrder: 'desc',
-                hasMoreResults: false,
-                hasResults: true,
-                isLoading: false,
-                count: undefined,
-                total: undefined,
-                currency: undefined,
-            },
+            search: {type: 'expense', offset: 0, hash: 0, hasMoreResults: false, hasResults: true, isLoading: false, count: undefined, total: undefined, currency: undefined},
             data: {},
         });
         rerender(undefined);
@@ -657,35 +631,11 @@ describe('useYourSpendData — third-party cardRows', () => {
             ]),
         );
         setupCardSnapshot(THIRD_PARTY_CARD_ID_1, {
-            search: {
-                type: 'expense',
-                offset: 0,
-                hash: 0,
-                sortBy: 'date',
-                sortOrder: 'desc',
-                hasMoreResults: false,
-                hasResults: true,
-                isLoading: false,
-                count: 2,
-                total: 500,
-                currency: 'USD',
-            },
+            search: {type: 'expense', offset: 0, hash: 0, hasMoreResults: false, hasResults: true, isLoading: false, count: 2, total: 500, currency: 'USD'},
             data: {},
         });
         setupCardSnapshot(THIRD_PARTY_CARD_ID_2, {
-            search: {
-                type: 'expense',
-                offset: 0,
-                hash: 0,
-                sortBy: 'date',
-                sortOrder: 'desc',
-                hasMoreResults: false,
-                hasResults: true,
-                isLoading: false,
-                count: 3,
-                total: 2200,
-                currency: 'EUR',
-            },
+            search: {type: 'expense', offset: 0, hash: 0, hasMoreResults: false, hasResults: true, isLoading: false, count: 3, total: 2200, currency: 'EUR'},
             data: {},
         });
         const {result} = renderHook(() => useYourSpendData());

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -32,7 +32,7 @@ import IntlStore from '@src/languages/IntlStore';
 import type {CardFeedForDisplay} from '@src/libs/CardFeedUtils';
 import {getCardDescriptionForSearchTable} from '@src/libs/CardUtils';
 import DateUtils from '@src/libs/DateUtils';
-import {buildSearchQueryJSON, getDateRangeForPreset, getQueryHashes, getUserFriendlyValue} from '@src/libs/SearchQueryUtils';
+import {buildSearchQueryJSON, getDateRangeForPreset, getUserFriendlyValue} from '@src/libs/SearchQueryUtils';
 import * as SearchUIUtils from '@src/libs/SearchUIUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -552,8 +552,6 @@ const searchResults: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         isLoading: false,
         type: 'expense',
     },
@@ -611,8 +609,6 @@ const searchResultsGroupByFrom: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 100,
         isLoading: false,
         type: 'expense',
@@ -663,8 +659,6 @@ const searchResultsGroupByCard: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 60,
         isLoading: false,
         type: 'expense',
@@ -702,8 +696,6 @@ const searchResultsGroupByWithdrawalID: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 60,
         isLoading: false,
         type: 'expense',
@@ -736,8 +728,6 @@ const searchResultsGroupByCategory: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 325,
         isLoading: false,
         type: 'expense',
@@ -1967,8 +1957,6 @@ const searchResultsGroupByMerchant: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 470,
         isLoading: false,
         type: 'expense',
@@ -2026,8 +2014,6 @@ const searchResultsGroupByTag: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 325,
         isLoading: false,
         type: 'expense',
@@ -2109,8 +2095,6 @@ const searchResultsGroupByMonth: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 325,
         isLoading: false,
         type: 'expense',
@@ -2140,8 +2124,6 @@ const searchResultsGroupByYear: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 325,
         isLoading: false,
         type: 'expense',
@@ -2173,8 +2155,6 @@ const searchResultsGroupByQuarter: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 325,
         isLoading: false,
         type: 'expense',
@@ -2204,8 +2184,6 @@ const searchResultsGroupByWeek: OnyxTypes.SearchResults = {
         hasResults: true,
         offset: 0,
         hash: 0,
-        sortBy: 'date',
-        sortOrder: 'desc',
         total: 325,
         isLoading: false,
         type: 'expense',
@@ -8362,8 +8340,6 @@ describe('SearchUIUtils', () => {
                     hash: queryJSON?.hash ?? 0,
                     isLoading: false,
                     type: CONST.SEARCH.DATA_TYPES.EXPENSE,
-                    sortBy: queryJSON?.sortBy ?? 'date',
-                    sortOrder: queryJSON?.sortOrder ?? 'desc',
                 },
                 ...overrides,
             };
@@ -8385,44 +8361,16 @@ describe('SearchUIUtils', () => {
 
         it('should return false when the search type does not match the query type', () => {
             const results = makeSearchResults({
-                search: {
-                    hasMoreResults: false,
-                    hasResults: true,
-                    offset: 0,
-                    hash: queryJSON?.hash ?? 0,
-                    sortBy: 'date',
-                    sortOrder: 'desc',
-                    isLoading: false,
-                    type: CONST.SEARCH.DATA_TYPES.CHAT,
-                },
+                search: {hasMoreResults: false, hasResults: true, offset: 0, hash: queryJSON?.hash ?? 0, isLoading: false, type: CONST.SEARCH.DATA_TYPES.CHAT},
             });
             expect(SearchUIUtils.isSearchDataLoaded(results, queryJSON)).toBe(false);
         });
 
         it('should return false when the search hash does not match the query hash', () => {
             const results = makeSearchResults({
-                search: {
-                    hasMoreResults: false,
-                    hasResults: true,
-                    offset: 0,
-                    hash: (queryJSON?.hash ?? 0) + 1,
-                    sortBy: 'date',
-                    sortOrder: 'desc',
-                    isLoading: false,
-                    type: CONST.SEARCH.DATA_TYPES.EXPENSE,
-                },
+                search: {hasMoreResults: false, hasResults: true, offset: 0, hash: (queryJSON?.hash ?? 0) + 1, isLoading: false, type: CONST.SEARCH.DATA_TYPES.EXPENSE},
             });
             expect(SearchUIUtils.isSearchDataLoaded(results, queryJSON)).toBe(false);
-        });
-
-        it('should return true even when the search sortBy/sortOrder is different from the query', () => {
-            const sortBy = CONST.SEARCH.TABLE_COLUMNS.MERCHANT;
-            const sortOrder = CONST.SEARCH.SORT_ORDER.ASC;
-            const expectedHash = queryJSON ? getQueryHashes({...queryJSON, sortBy, sortOrder}).primaryHash : 0;
-            const results = makeSearchResults({
-                search: {hasMoreResults: false, hasResults: true, offset: 0, hash: expectedHash, isLoading: false, type: CONST.SEARCH.DATA_TYPES.EXPENSE, sortBy, sortOrder},
-            });
-            expect(SearchUIUtils.isSearchDataLoaded(results, queryJSON)).toBe(true);
         });
 
         it('should return false when searchResults is undefined', () => {
@@ -8476,8 +8424,6 @@ describe('SearchUIUtils', () => {
                     type: 'expense',
                     hash: 0,
                     offset: 0,
-                    sortBy: 'date',
-                    sortOrder: 'desc',
                     hasMoreResults: false,
                     hasResults: true,
                     isLoading: false,
@@ -8610,8 +8556,6 @@ describe('SearchUIUtils', () => {
                 type: 'expense',
                 hash: 0,
                 offset: 0,
-                sortBy: 'date',
-                sortOrder: 'desc',
                 hasMoreResults: false,
                 hasResults: true,
                 isLoading: false,

--- a/tests/unit/Search/getSpendOverTimeStateTest.ts
+++ b/tests/unit/Search/getSpendOverTimeStateTest.ts
@@ -7,9 +7,9 @@ import type SearchResults from '@src/types/onyx/SearchResults';
 
 const queryJSON: SearchQueryJSON = {
     inputQuery: '',
-    hash: 1261888645,
-    recentSearchHash: 1239358332,
-    similarSearchHash: 1141398512,
+    hash: 0,
+    recentSearchHash: 0,
+    similarSearchHash: 0,
     type: CONST.SEARCH.DATA_TYPES.EXPENSE,
     groupBy: CONST.SEARCH.GROUP_BY.MONTH,
     view: CONST.SEARCH.VIEW.LINE,
@@ -20,16 +20,7 @@ const queryJSON: SearchQueryJSON = {
 };
 
 const defaultSearchResults: SearchResults = {
-    search: {
-        offset: 0,
-        hash: 1261888645,
-        sortBy: CONST.SEARCH.TABLE_COLUMNS.GROUP_MONTH,
-        sortOrder: CONST.SEARCH.SORT_ORDER.ASC,
-        type: queryJSON.type,
-        hasMoreResults: false,
-        hasResults: true,
-        isLoading: false,
-    },
+    search: {offset: 0, hash: 0, type: queryJSON.type, hasMoreResults: false, hasResults: true, isLoading: false},
     data: {},
 };
 

--- a/tests/unit/hooks/useSearchBulkActionsExportTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsExportTest.ts
@@ -323,8 +323,6 @@ function makeSearchResults(reports: Report[]): SearchResults {
             type: CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT,
             hash: 0,
             offset: 0,
-            sortBy: 'date',
-            sortOrder: 'desc',
             hasMoreResults: false,
             hasResults: true,
             isLoading: false,

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -46,8 +46,6 @@ describe('useSearchHighlightAndScroll', () => {
                 hasResults: true,
                 offset: 0,
                 hash: 0,
-                sortBy: 'date',
-                sortOrder: 'desc',
                 type: 'expense',
                 isLoading: false,
             },


### PR DESCRIPTION
@mollfpr please review
cc @aimane-chnaif @dmkt9 

### Explanation of Change

Reverts [#96700](https://github.com/Expensify/App/pull/96700), which made `isSearchDataLoaded` recompute the search hash from the (mutable) `sortBy`/`sortOrder` snapshot fields instead of comparing directly against `queryJSON.hash`. During the optimistic empty-report-create flow those fields can be out of sync for a render or two, so the loaded/not-loaded check flips, the stable-data effect in `useSearchSnapshot`/`useStableOptimisticSortedData` re-fires every render, and the app hits `Maximum update depth exceeded` — a hard crash. This is the deploy blocker.

Because [#96918](https://github.com/Expensify/App/pull/96918) landed on top of #96700 to add null-safety around the same function, GitHub's automatic revert conflicted and couldn't be applied. The sort-hash recompute was undone by hand here while keeping #96918's optional chaining on `searchResults.search`.

Reverting reintroduces the original cosmetic bug from #96074 (the search results table can flash an empty state for a moment when changing sort) — an acceptable tradeoff against the crash.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96946

PROPOSAL: N/A

<!---
MOBILE-EXPENSIFY: N/A
--->

### Tests

1. Open Settings > Troubleshooting and force offline mode.
2. Create a new workspace, then delete the workspace that was your default before creating this one.
3. Create an empty report.
4. Go back to workspace settings, create another new workspace, and delete the default again.
5. Create another empty report.
6. Verify the app does not crash.
7. Turn network back on, go to Reports, and press a column header to sort.
8. Confirm the table can briefly show an empty state while re-sorting — this is the known, accepted regression from reverting #96700 (tracked by #96074).

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests — step 1 requires forcing offline mode to reach the pending-write path that crashes.

### QA Steps

1. Open Settings > Troubleshooting and force offline mode.
2. Create a new workspace, then delete the workspace that was your default before creating this one.
3. Create an empty report.
4. Go back to workspace settings, create another new workspace, and delete the default again.
5. Create another empty report.
6. Verify the app does not crash.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — revert.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — revert.

</details>

<details>
<summary>iOS: Native</summary>

N/A — revert.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — revert.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — revert.

</details>
