### PR TITLE
Fix insufficient spacing between card name and issue card button on resize

### DIFF
--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
@@ -208,12 +208,7 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
           ]
         : [];
     const getHeaderButtons = () => {
-        const headerButtonsRowStyle = [
-            styles.flexRow,
-            styles.gap2,
-            !shouldShowSelector && shouldDisplayButtonsInSeparateLine && styles.mb3,
-            shouldShowSelector && shouldDisplayButtonsInSeparateLine && styles.mt3,
-        ];
+        const headerButtonsRowStyle = [styles.flexRow, styles.gap2, !shouldShowSelector && shouldDisplayButtonsInSeparateLine && styles.mb3];
 
         const shouldShowBulkSelectionDropdown = shouldUseNarrowLayout ? isMobileSelectionModeEnabled : selectedCardIDs.length > 0;
 
@@ -310,7 +305,15 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
             </HeaderWithBackButton>
             {!shouldShowSelector && shouldDisplayButtonsInSeparateLine && isBankAccountVerified && shouldShowHeaderButtons && <View style={styles.ph5}>{getHeaderButtons()}</View>}
             {shouldShowSelector && (
-                <View style={[styles.w100, styles.ph5, styles.pb3, (!shouldChangeLayout || isInLandscapeMode) && [styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween]]}>
+                <View
+                    style={[
+                        styles.w100,
+                        styles.ph5,
+                        styles.pb3,
+                        styles.gap3,
+                        (!shouldChangeLayout || isInLandscapeMode) && [styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween],
+                    ]}
+                >
                     <FeedSelector
                         wrapperStyle={isInLandscapeMode ? styles.flex1 : undefined}
                         onFeedSelect={() => Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_EXPENSIFY_CARD_SELECT_FEED.path))}


### PR DESCRIPTION
### Explanation of Change

On the Expensify Card list page, the gap between the feed selector (Card name) and the header buttons collapses when you resize the window to a medium width. At medium width the buttons stack onto a separate line (`shouldChangeLayout`), but the margin that created the gap (`styles.mt3`) sits behind `shouldDisplayButtonsInSeparateLine`, which only turns true in the narrow-portrait layout. So at medium width no spacing applies and the Card name and buttons touch.

This PR puts a permanent flex `gap` on the shared parent that wraps the `FeedSelector` and the header buttons. One `styles.gap3` (12px, the same value as the old `mt3`) holds the separation in both layouts: horizontal when the row is side-by-side, vertical when it stacks. The stale `mt3` line is removed.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94988
PROPOSAL: https://github.com/Expensify/App/issues/94988#issuecomment-4845541493

### Tests

1. Navigate to Workspace > Expensify Card.
2. Resize the browser window to a narrower width.
3. Verify adequate spacing is maintained between the Card name label and the Issue card button at all supported window sizes.

- [x] Verify that no errors appear in the JS console

### Offline tests

No offline-specific behavior. The change is layout only.

- [x] Verify that no errors appear in the JS console

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Videos will be added in a few hours.

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="395" height="916" alt="94988-android-native" src="https://github.com/user-attachments/assets/8f3129ef-f992-4004-a8a1-2bb679e1296b" />

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="414" height="925" alt="94988-android-mweb" src="https://github.com/user-attachments/assets/acc3df11-2986-40de-9cf2-e92f71b192a6" />
</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="1206" height="2622" alt="94988-ios-native" src="https://github.com/user-attachments/assets/f5fec94b-a163-431d-92da-95c822a7c11a" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="1206" height="2622" alt="94988-ios-mweb" src="https://github.com/user-attachments/assets/2dc5e0d9-cf67-4304-ae7a-2d8015099b56" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add the resize video (wide to narrow) here -->
<img width="1002" height="1222" alt="94988-macos-chrome" src="https://github.com/user-attachments/assets/32eccb02-b324-497f-bdcc-8c0b7c1d5a5b" />

</details>
