### PR TITLE
[$250] Fix CSV export omitting columns with no data in the current view

### DIFF
--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -701,11 +701,16 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
             });
 
             const exportColumnLabels: Partial<Record<SearchColumnType, string>> = {};
-            for (const column of columnsToExport) {
+            // Always include user-selected visible columns, even if they have no data
+            const allColumnsForExport = new Set(columnsToExport);
+            for (const column of visibleColumns) {
+                allColumnsForExport.add(column);
+            }
+            for (const column of allColumnsForExport) {
                 exportColumnLabels[column] = translate(getSearchColumnTranslationKey(column));
             }
 
-            const jsonQuery = queryJSONToExport ? serializeQueryJSONForBackend({...queryJSONToExport, columns: columnsToExport}) : (JSON.stringify(queryJSONToExport) ?? '');
+            const jsonQuery = queryJSONToExport ? serializeQueryJSONForBackend({...queryJSONToExport, columns: [...allColumnsForExport]}) : (JSON.stringify(queryJSONToExport) ?? '');
 
             return {
                 jsonQuery,


### PR DESCRIPTION
### Details\nWhen exporting the current view to CSV, columns that contain no data in the filtered results are omitted entirely from the exported file. The expected behavior is that all columns in the current view should appear in the CSV, even if they have no data.\n\n### Explanation of Change\nThe root cause is in `getCSVExportParameters()` in `src/hooks/useSearchBulkActions.ts`. It builds the column list for CSV export using the result of `getColumnsToShow()`. That function filters out columns that have no data, which is correct for the UI table but incorrect for CSV exports — all user-selected columns should appear in the exported file regardless of whether they have data.\n\nThis change ensures `visibleColumns` are always included in the `exportColumnLabels` sent to the server by taking the union of the filtered result and the user's explicitly selected columns.\n\n### Fixed Issues\n$ https://github.com/Expensify/App/issues/96969\nPROPOSAL: https://github.com/Expensify/App/issues/96969#issuecomment-5085742440\n\n### Tests\nSame as QA Steps\n\n### QA Steps\n1. Open the Expensify app and navigate to Search\n2. Configure visible columns to include a column that will have no data (e.g., Tag or Category)\n3. Apply filters so the selected column contains no values in the results\n4. Export the current view to CSV\n5. Open the CSV and verify all configured columns appear, including those with no data