### PR TITLE
[$250] Fix Not here page flash when deleting workspace from Overview

### DIFF
--- a/src/pages/workspace/WorkspaceOverviewPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewPage.tsx
@@ -504,7 +504,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
             shouldShowNonAdmin
             policyFeature={CONST.POLICY.POLICY_FEATURE.OVERVIEW}
             icon={illustrationIcons.Building}
-            shouldShowNotFoundPage={policy === undefined}
+            shouldShowNotFoundPage={policy === undefined && !isPendingDelete}
             onBackButtonPress={handleBackButtonPress}
             addBottomSafeAreaPadding
             headerContent={!shouldDisplayButtonsInSeparateLine && headerButtons}


### PR DESCRIPTION
### Details\nWhen deleting a workspace from the Overview page, the "Not here" (NotFoundPage) appears briefly before the deletion completes and navigation occurs.\n\n### Explanation of Change\nThe root cause is in WorkspaceOverviewPage.tsx. The `shouldShowNotFoundPage` prop was set to `policy === undefined`, which becomes true during the optimistic update window when the policy object is briefly undefined before the Onyx optimistic merge finishes propagating.\n\nThe fix adds `\u0026\u0026 !isPendingDelete` to the condition, suppressing the NotFoundPage while a workspace deletion is in progress. `isPendingDeletePolicy()` is already computed in the component scope.\n\n### Fixed Issues\n$ https://github.com/Expensify/App/issues/96977\nPROPOSAL: https://github.com/Expensify/App/issues/96977#issuecomment-5086155775\n\n### Tests\n1. Open the Expensify app and navigate to a Workspace Overview\n2. Tap More \u003E Delete \u003E Delete\n3. Verify no "Not here" page flashes during the deletion\n4. Verify normal navigation occurs after deletion completes