### PR TITLE
[$250] Fix read-only Role selector displaying at 50% opacityFix read-only Role selector displaying at 50 percent opacity

### DIFF
--- a/src/pages/workspace/members/WorkspaceMemberDetailsPage.tsx
+++ b/src/pages/workspace/members/WorkspaceMemberDetailsPage.tsx
@@ -364,7 +364,7 @@ function WorkspaceMemberDetailsPage({personalDetails, policy, route}: WorkspaceM
                                 copyable
                             />
                             <MenuItemWithTopDescription
-                                disabled={isSelectedMemberOwner || isSelectedMemberCurrentUser || !canManageSelectedMemberRole}
+                                disabled={isSelectedMemberOwner || isSelectedMemberCurrentUser}
                                 title={translate(`workspace.common.roleName`, member?.role)}
                                 interactive={!isReimburser && canManageSelectedMemberRole}
                                 description={translate('common.role')}


### PR DESCRIPTION
### Details
The read-only Role selector in the Member details panel was displayed at 50% opacity, making it appear disabled. The caret is already hidden for read-only roles, but the field should also display at full opacity, matching other read-only fields like Email.

### Explanation of Change
The `disabled` prop included `!canManageSelectedMemberRole`, which applied disabled styling when the role couldn't be changed due to permissions. The `interactive={false}` prop already prevents interaction, so the disabled styling was redundant.

Fix: removed `|| !canManageSelectedMemberRole` from the disabled condition.

### Fixed Issues
$ https://github.com/Expensify/App/issues/96791