### PR TITLE
[DOLLAR250] Fix read-only Role selector displaying at 50 percent opacity

### DIFF
--- a/src/pages/workspace/members/WorkspaceMemberDetailsPage.tsx
+++ b/src/pages/workspace/members/WorkspaceMemberDetailsPage.tsx
@@ -364,7 +364,7 @@ function WorkspaceMemberDetailsPage({personalDetails, policy, route}: WorkspaceM
                                 copyable
                             />
                             <MenuItemWithTopDescription
-                                disabled={isSelectedMemberOwner || isSelectedMemberCurrentUser || !canManageSelectedMemberRole}
+                                disabled={isSelectedMemberOwner || isSelectedMemberCurrentUser}
                                 title={translate(`workspace.common.roleName`, member?.role)}
                                 interactive={!isReimburser && canManageSelectedMemberRole}
                                 description={translate('common.role')}


### PR DESCRIPTION
### Details  The read-only Role selector in the Member details panel displays at 50 percent opacity. The caret is already hidden for read-only roles, but the field should display at full opacity matching other read-only fields.  ### Explanation of Change  The disabled prop included !canManageSelectedMemberRole, which applied disabled styling when permissions prevent role changes. The interactive equals false prop already blocks interaction, so the disabled styling was redundant.  Fix: remove !canManageSelectedMemberRole from the disabled condition.  ### Fixed Issues  DOLLAR https://github.com/Expensify/App/issues/96791  PROPOSAL: https://github.com/Expensify/App/issues/96791#issuecomment-5086421949