### PR TITLE
Enable live markdown for agent prompts

### DIFF
--- a/src/pages/settings/Agents/AddAgentPage.tsx
+++ b/src/pages/settings/Agents/AddAgentPage.tsx
@@ -167,6 +167,7 @@ function AddAgentPage({route}: AddAgentPageProps) {
                             role={CONST.ROLE.PRESENTATION}
                             defaultValue={defaultPrompt}
                             multiline
+                            type="markdown"
                             containerStyles={[styles.flex1]}
                             touchableInputWrapperStyle={[styles.flex1]}
                             textInputContainerStyles={[styles.flex1]}

--- a/src/pages/settings/Agents/Fields/EditPromptPage.tsx
+++ b/src/pages/settings/Agents/Fields/EditPromptPage.tsx
@@ -100,6 +100,7 @@ function EditPromptPage({route}: EditPromptPageProps) {
                         role={CONST.ROLE.PRESENTATION}
                         defaultValue={Str.htmlDecode(agentPrompt?.prompt ?? '')}
                         multiline
+                        type="markdown"
                         containerStyles={[styles.flex1]}
                         touchableInputWrapperStyle={[styles.flex1]}
                         textInputContainerStyles={[styles.flex1]}

--- a/src/pages/workspace/rules/AgentRules/AddAgentRuleWriteTab.tsx
+++ b/src/pages/workspace/rules/AgentRules/AddAgentRuleWriteTab.tsx
@@ -91,6 +91,7 @@ function AddAgentRuleWriteTab({onSave}: AddAgentRuleWriteTabProps) {
                         role={CONST.ROLE.PRESENTATION}
                         onKeyPress={submitFormOnModEnter}
                         multiline
+                        type="markdown"
                         shouldSaveDraft
                         shouldLabelStayOnSingleLine
                         containerStyles={[styles.flex1]}


### PR DESCRIPTION
## Summary

* Enabled the existing markdown-backed TextInput mode for agent prompt editing.
* Applied it to agent creation, agent prompt editing, and workspace agent rule prompt authoring.

## Test plan

* Not run locally: sparse checkout has no installed dependencies.
* Manual verification target:
  1. Go to Account > Agents > Create agent.
  2. Type Markdown syntax such as `*bold*`, `# heading`, and `- list item`.
  3. Verify formatting renders live in the input.
  4. Repeat for editing an existing agent prompt and Workspace > Rules > Add agent rule > Write your own.

$ Expensify/App#96902