### PR TITLE
fix: number commercial card feed default names

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1011,6 +1011,7 @@
         "usernotifications",
         "utilise",
         "vcfanzfav",
+        "vcfcitibank",
         "vcpu",
         "verticalanchor",
         "victoryaxis",

--- a/cspell.json
+++ b/cspell.json
@@ -1010,6 +1010,7 @@
         "useblacksmith",
         "usernotifications",
         "utilise",
+        "vcfanzfav",
         "vcpu",
         "verticalanchor",
         "victoryaxis",

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -824,6 +824,28 @@ function getBankName(feedType: CardFeedWithNumber | CardFeedWithDomainID): strin
     return result;
 }
 
+const COMMERCIAL_FEED_DISPLAY_BASES = [
+    {base: 'vcfanzfav', displayName: 'ANZ NZ', shouldHideOne: false},
+    {base: CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX, displayName: getBankName(CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX), shouldHideOne: true},
+    {base: CONST.COMPANY_CARD.FEED_BANK_NAME.VISA, displayName: getBankName(CONST.COMPANY_CARD.FEED_BANK_NAME.VISA), shouldHideOne: true},
+    {base: CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD, displayName: getBankName(CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD), shouldHideOne: true},
+] as const;
+
+function getDefaultCommercialFeedDisplayName(feed: string | undefined): string | undefined {
+    const [feedName = ''] = feed?.split(CONST.COMPANY_CARD.FEED_KEY_SEPARATOR) ?? [];
+    const displayBase = COMMERCIAL_FEED_DISPLAY_BASES.find(({base}) => feedName.startsWith(base));
+    if (!displayBase) {
+        return;
+    }
+
+    const suffix = feedName.slice(displayBase.base.length);
+    if (!suffix || !/^\d+$/.test(suffix) || (displayBase.shouldHideOne && suffix === '1')) {
+        return displayBase.displayName;
+    }
+
+    return `${displayBase.displayName} ${suffix}`;
+}
+
 const getBankCardDetailsImage = (bank: BankName, illustrations: IllustrationsType, companyCardIllustrations: CompanyCardBankIcons): IconAsset => {
     const iconMap: Record<BankName, IconAsset> = {
         [CONST.COMPANY_CARDS.BANKS.AMEX]: companyCardIllustrations.AmexCardCompanyCardDetail,
@@ -855,7 +877,7 @@ function getCustomOrFormattedFeedName(
         return '';
     }
 
-    const feedName = getBankName(feed);
+    const feedName = getDefaultCommercialFeedDisplayName(feed) ?? getBankName(feed);
     const formattedFeedName = feedName && shouldAddCardsSuffix ? translate('workspace.companyCards.feedName', feedName) : feedName;
 
     // Custom feed name can be empty. Fallback to default feed name
@@ -2033,6 +2055,7 @@ export {
     isCurrencySupportedForECards,
     getCardFeedIcon,
     getBankName,
+    getDefaultCommercialFeedDisplayName,
     isSelectedFeedExpired,
     isTravelCard,
     isTravelCardTransaction,

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -831,8 +831,8 @@ const COMMERCIAL_FEED_DISPLAY_BASES = [
     {base: CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD, displayName: getBankName(CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD), shouldHideOne: true},
 ] as const;
 
-function getDefaultCommercialFeedDisplayName(feed: string | undefined): string | undefined {
-    const [feedName = ''] = feed?.split(CONST.COMPANY_CARD.FEED_KEY_SEPARATOR) ?? [];
+function getDefaultCommercialFeedDisplayName(feed: CardFeedWithNumber | CardFeedWithDomainID | undefined): string | undefined {
+    const feedName = getCompanyCardFeed(feed);
     const displayBase = COMMERCIAL_FEED_DISPLAY_BASES.find(({base}) => feedName.startsWith(base));
     if (!displayBase) {
         return;

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -824,8 +824,11 @@ function getBankName(feedType: CardFeedWithNumber | CardFeedWithDomainID): strin
     return result;
 }
 
+const ANZ_NZ_COMMERCIAL_FEED_BASE = 'vcfanzfav';
+const ANZ_NZ_COMMERCIAL_FEED_DISPLAY_NAME = 'ANZ NZ';
+
 const COMMERCIAL_FEED_DISPLAY_BASES = [
-    {base: 'vcfanzfav', displayName: 'ANZ NZ', shouldHideOne: false},
+    {base: ANZ_NZ_COMMERCIAL_FEED_BASE, displayName: ANZ_NZ_COMMERCIAL_FEED_DISPLAY_NAME, shouldHideOne: false},
     {base: CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX, displayName: getBankName(CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX), shouldHideOne: true},
     {base: CONST.COMPANY_CARD.FEED_BANK_NAME.VISA, displayName: getBankName(CONST.COMPANY_CARD.FEED_BANK_NAME.VISA), shouldHideOne: true},
     {base: CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD, displayName: getBankName(CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD), shouldHideOne: true},

--- a/tests/unit/CardFeedUtilsTest.ts
+++ b/tests/unit/CardFeedUtilsTest.ts
@@ -3,11 +3,12 @@ import {getCardFeedsForDisplay, getCardFeedsForDisplayPerPolicy, getExpensifyCar
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import type {Card, CardFeeds, CardList, CompanyCardFeed, Domain, Policy} from '@src/types/onyx';
-import type {CardFeedWithNumber} from '@src/types/onyx/CardFeeds';
+import type {CardFeedWithNumber, CustomCardFeedData} from '@src/types/onyx/CardFeeds';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 import type {OnyxCollection} from 'react-native-onyx';
 
+import createMock from '../utils/createMock';
 import {translateLocal} from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
@@ -36,6 +37,14 @@ function createTestPolicy(overrides: Partial<Policy> & Pick<Policy, 'id'>): Poli
         isPolicyExpenseChatEnabled: false,
         ...overrides,
     };
+}
+
+function createCompanyCardFeedsWithRawKeys(feedNames: string[]): Record<string, CustomCardFeedData> {
+    const companyCards: Record<string, CustomCardFeedData> = {};
+    for (const feedName of feedNames) {
+        companyCards[feedName] = createMock<CustomCardFeedData>({});
+    }
+    return companyCards;
 }
 
 const cardFeedAmericaExpressMock: CardFeedWithNumber = `${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX_DIRECT} 1001`;
@@ -96,13 +105,12 @@ describe('Card Feed Utils', () => {
     });
 
     it('returns numbered commercial card feed names for search display', () => {
+        const companyCards = createCompanyCardFeedsWithRawKeys([`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`, 'vcfanzfav1', 'cdfbmo', 'vcfcitibank2']);
         const cardFeedsWithNumberedCommercialFeeds: OnyxCollection<CardFeeds> = {
             sharedNVP_private_domain_member_1234: {
                 settings: {
                     companyCardNicknames: {},
-                    companyCards: {
-                        [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`]: {},
-                    },
+                    companyCards,
                 },
             },
         };
@@ -110,6 +118,9 @@ describe('Card Feed Utils', () => {
         const cardFeedsForDisplay = getCardFeedsForDisplay(cardFeedsWithNumberedCommercialFeeds, {}, translateLocal);
         expect(cardFeedsForDisplay).toEqual({
             '1234_vcf2': {id: '1234_vcf2', fundID: '1234', feed: 'vcf2', name: 'Visa 2'},
+            '1234_vcfanzfav1': {id: '1234_vcfanzfav1', fundID: '1234', feed: 'vcfanzfav1', name: 'ANZ NZ 1'},
+            '1234_cdfbmo': {id: '1234_cdfbmo', fundID: '1234', feed: 'cdfbmo', name: 'Mastercard'},
+            '1234_vcfcitibank2': {id: '1234_vcfcitibank2', fundID: '1234', feed: 'vcfcitibank2', name: 'Visa'},
         });
     });
 

--- a/tests/unit/CardFeedUtilsTest.ts
+++ b/tests/unit/CardFeedUtilsTest.ts
@@ -95,6 +95,24 @@ describe('Card Feed Utils', () => {
         });
     });
 
+    it('returns numbered commercial card feed names for search display', () => {
+        const cardFeedsWithNumberedCommercialFeeds: OnyxCollection<CardFeeds> = {
+            sharedNVP_private_domain_member_1234: {
+                settings: {
+                    companyCardNicknames: {},
+                    companyCards: {
+                        [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`]: {},
+                    },
+                },
+            },
+        };
+
+        const cardFeedsForDisplay = getCardFeedsForDisplay(cardFeedsWithNumberedCommercialFeeds, {}, translateLocal);
+        expect(cardFeedsForDisplay).toEqual({
+            '1234_vcf2': {id: '1234_vcf2', fundID: '1234', feed: 'vcf2', name: 'Visa 2'},
+        });
+    });
+
     it('returns card feeds grouped per policy', () => {
         const cardFeedsForDisplayPerPolicy = getCardFeedsForDisplayPerPolicy(cardFeedsMock, translateLocal, undefined, undefined);
         expect(cardFeedsForDisplayPerPolicy).toEqual({

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -37,6 +37,7 @@ import {
     getCSVFeedType,
     getCustomFeedNameFromFeeds,
     getCustomOrFormattedFeedName,
+    getDefaultCommercialFeedDisplayName,
     getDefaultExpensifyCardLimitType,
     getDisplayableExpensifyCards,
     getDisplayableThirdPartyCards,
@@ -1438,6 +1439,58 @@ describe('CardUtils', () => {
             );
             expect(feedName).toBe(unknownFeed);
         });
+
+        const commercialFeedCases: Array<[Parameters<typeof getCustomOrFormattedFeedName>[1], string]> = [
+            [CONST.COMPANY_CARD.FEED_BANK_NAME.VISA, 'Visa cards'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}1`, 'Visa cards'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`, 'Visa 2 cards'],
+            [CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD, 'Mastercard cards'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}1`, 'Mastercard cards'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}2`, 'Mastercard 2 cards'],
+            [CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX, 'American Express cards'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX}1`, 'American Express cards'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX}2`, 'American Express 2 cards'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2${CONST.COMPANY_CARD.FEED_KEY_SEPARATOR}12345`, 'Visa 2 cards'],
+        ];
+
+        it.each(commercialFeedCases)('Should format commercial feed %s as %s', (feed, expectedFeedName) => {
+            const feedName = getCustomOrFormattedFeedName(translateLocal, feed);
+            expect(feedName).toBe(expectedFeedName);
+        });
+
+        const commercialFeedWithoutSuffixCases: Array<[Parameters<typeof getCustomOrFormattedFeedName>[1], string]> = [[`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`, 'Visa 2']];
+
+        it.each(commercialFeedWithoutSuffixCases)('Should format commercial feed %s without cards suffix as %s', (feed, expectedFeedName) => {
+            const feedName = getCustomOrFormattedFeedName(translateLocal, feed, undefined, false);
+            expect(feedName).toBe(expectedFeedName);
+        });
+
+        it('Should return custom name for numbered feed if custom name exists', () => {
+            const numberedVisaFeedForCustomName: Parameters<typeof getCustomOrFormattedFeedName>[1] = `${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`;
+            const feedName = getCustomOrFormattedFeedName(translateLocal, numberedVisaFeedForCustomName, customFeedName);
+            expect(feedName).toBe(customFeedName);
+        });
+    });
+
+    describe('getDefaultCommercialFeedDisplayName', () => {
+        it.each([
+            [CONST.COMPANY_CARD.FEED_BANK_NAME.VISA, 'Visa'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}1`, 'Visa'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`, 'Visa 2'],
+            ['vcfanzfav1', 'ANZ NZ 1'],
+            [CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD, 'Mastercard'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}1`, 'Mastercard'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}2`, 'Mastercard 2'],
+            [CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX, 'American Express'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX}1`, 'American Express'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX}2`, 'American Express 2'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}bmo`, 'Mastercard'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}citibank2`, 'Visa'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2${CONST.COMPANY_CARD.FEED_KEY_SEPARATOR}12345`, 'Visa 2'],
+        ])('Should derive default display name for commercial feed %s as %s', (feed, expectedFeedName) => {
+            const feedName = getDefaultCommercialFeedDisplayName(feed);
+            expect(feedName).toBe(expectedFeedName);
+        });
     });
 
     describe('doesCardFeedExist', () => {
@@ -1677,6 +1730,16 @@ describe('CardUtils', () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Runtime feed suffixes are accepted but are not modeled by the production parameter type.
             const feedName = getBankName(feedWithAmex1205Prefix as Parameters<typeof getBankName>[0]);
             expect(feedName).toBe('American Express');
+        });
+
+        const canonicalDisplayFeedCases: Array<[Parameters<typeof getBankName>[0], string]> = [
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`, 'Visa'],
+            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX}2`, 'American Express'],
+        ];
+
+        it.each(canonicalDisplayFeedCases)('Should keep canonical bank name for display feed variant %s', (feed, expectedFeedName) => {
+            const feedName = getBankName(feed);
+            expect(feedName).toBe(expectedFeedName);
         });
     });
 

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -1473,21 +1473,20 @@ describe('CardUtils', () => {
     });
 
     describe('getDefaultCommercialFeedDisplayName', () => {
-        it.each([
+        const defaultCommercialFeedCases: Array<[Parameters<typeof getDefaultCommercialFeedDisplayName>[0], string]> = [
             [CONST.COMPANY_CARD.FEED_BANK_NAME.VISA, 'Visa'],
             [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}1`, 'Visa'],
             [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2`, 'Visa 2'],
-            ['vcfanzfav1', 'ANZ NZ 1'],
             [CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD, 'Mastercard'],
             [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}1`, 'Mastercard'],
             [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}2`, 'Mastercard 2'],
             [CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX, 'American Express'],
             [`${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX}1`, 'American Express'],
             [`${CONST.COMPANY_CARD.FEED_BANK_NAME.AMEX}2`, 'American Express 2'],
-            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD}bmo`, 'Mastercard'],
-            [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}citibank2`, 'Visa'],
             [`${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}2${CONST.COMPANY_CARD.FEED_KEY_SEPARATOR}12345`, 'Visa 2'],
-        ])('Should derive default display name for commercial feed %s as %s', (feed, expectedFeedName) => {
+        ];
+
+        it.each(defaultCommercialFeedCases)('Should derive default display name for commercial feed %s as %s', (feed, expectedFeedName) => {
             const feedName = getDefaultCommercialFeedDisplayName(feed);
             expect(feedName).toBe(expectedFeedName);
         });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
NewDot previously derived commercial card feed labels through `getBankName()`. Because that function resolves feeds by matching their bank-family prefix, distinct feed keys such as `vcf`, `vcf1`, and `vcf2` all resolved to the same canonical bank name and displayed as Visa cards.

This PR keeps `getBankName()` unchanged as the canonical bank-name resolver and adds display-only formatting for the commercial feed families covered by the accepted proposal.

The new display-name logic:

- Uses the existing `getCompanyCardFeed()` helper to normalize domain-suffixed feed keys such as `vcf2#12345`.
- Matches a scoped list of supported commercial feed bases in longest-prefix order, ensuring `vcfanzfav1` is matched before the generic `vcf` family.
- Hides the `1` suffix for the standard Visa, Mastercard, and American Express feed families.
- Preserves visible numeric suffixes such as `2`.
- Displays `vcfanzfav1` as `ANZ NZ 1`.
- Preserves the existing visible output for non-numeric and out-of-scope variants such as `cdfbmo` and `vcfcitibank2`, without interpreting their trailing text as numeric feed suffixes.
- Keeps custom feed nicknames as the highest-priority display value.
- Leaves `getBankName()` unchanged for callers that require a stable canonical bank identity.

`getCustomOrFormattedFeedName()` applies the generated display name before the existing cards translation. The same formatter is used by the Company Cards feed selector and search card-feed filter, keeping the visible names consistent across both surfaces.

Automated coverage was added for:

- Visa, Mastercard, and American Express numbered feed variants.
- The `vcfanzfav1` legacy feed key.
- Domain-suffixed feed keys.
- Non-numeric and out-of-scope feed variants.
- Custom nickname precedence.
- Display names with and without the `cards` suffix.
- The `getCardFeedsForDisplay()` consumer path.
- Continued canonical behavior of `getBankName()`.

The valid `vcfanzfav` and `vcfcitibank` commercial feed identifiers were also added to the repository’s central CSpell dictionary.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95206
PROPOSAL: https://github.com/Expensify/App/issues/95206#issuecomment-4867091359

### Tests
**Manual product verification status**

Manual UI verification of the commercial-feed scenarios was not completed locally because the available test workspace does not contain seeded Visa VCF, Mastercard CDF, or American Express commercial feeds.

The behavior was verified through focused unit tests, consumer-path coverage for `getCardFeedsForDisplay()`, typechecking, linting, formatting, spellchecking, and repository code inspection.

I am not claiming live UI verification for scenarios that require a workspace with seeded commercial card feeds.

**Manual test steps**

1. Sign in to a domain/workspace containing the relevant commercial card feeds.
2. Navigate to **Workspace > Company cards**.
3. Open the card-feed selector.
4. Verify `vcf` displays as `Visa cards`.
5. Verify `vcf1` displays as `Visa cards`.
6. Verify `vcf2` displays as `Visa 2 cards`.
7. Verify `vcfanzfav1` displays as `ANZ NZ 1 cards`.
8. Verify `cdf` displays as `Mastercard cards`.
9. Verify `cdf2` displays as `Mastercard 2 cards`.
10. Verify `gl1025` displays as `American Express cards`, not `American Express 1025 cards`.
11. Verify `gl10252` displays as `American Express 2 cards`.
12. Verify `cdfbmo` does not display `bmo` as a numeric suffix.
13. Verify `vcfcitibank2` is not converted to `Visa 2 cards`.
14. Open the card-feed filter from Search.
15. Verify the same numbered names appear in the Search card-feed filter.
16. Configure a custom nickname for a numbered commercial feed.
17. Verify the custom nickname is displayed instead of the generated default name.
18. Verify that no errors appear in the JavaScript console.

- [x] Verify that no errors appear in the JS console

### Offline tests
The change formats feed keys already available on the client and does not introduce a network request or change offline synchronization behavior.

The following steps require a workspace containing seeded commercial card feeds and were not completed locally:

1. Sign in to a workspace containing at least `vcf` and `vcf2`.
2. Navigate to **Workspace > Company cards** and allow the feeds to load.
3. Turn off the network connection.
4. Open the card-feed selector.
5. Verify `vcf` displays as `Visa cards`.
6. Verify `vcf2` displays as `Visa 2 cards`.
7. Open the Search card-feed filter.
8. Verify the same feed names remain visible while offline.
9. Verify a configured custom nickname still takes precedence.
10. Verify that no errors appear in the JavaScript console.

### QA Steps
Repeat the following steps on every supported platform:

1. Sign in to staging using a domain/workspace containing the relevant commercial card feeds.
2. Navigate to **Workspace > Company cards**.
3. Open the card-feed selector.
4. Verify `vcf `and `vcf1` display as `Visa cards`.
5. Verify `vcf2` displays as `Visa 2 cards`.
6. Verify `vcfanzfav1` displays as `ANZ NZ 1 cards`.
7. Verify `cdf` displays as `Mastercard cards`.
8. Verify `cdf2` displays as `Mastercard 2 cards`.
9. Verify `gl1025` displays as `American Express cards`, not `American Express 1025 cards`.
10. Verify `gl10252` displays as `American Express 2 cards`.
11. Verify `cdfbmo` does not display `bmo` as a numeric suffix.
12. Verify `vcfcitibank2` is not converted to `Visa 2 cards`.
13. Open the card-feed filter from Search.
14. Verify the same numbered names appear in the Search card-feed filter.
15. Configure a custom nickname for a numbered commercial feed.
16. Verify the custom nickname overrides the generated default name.
17. Verify that no errors appear in the JavaScript console.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Manual screenshots and videos are pending because the available test workspace does not contain seeded commercial card feeds.

Do not mark the platform testing or screenshot checklist complete until the required platform evidence has been captured.
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
Not tested yet; requires access to a workspace with seeded commercial card feeds.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
Not tested yet; requires access to a workspace with seeded commercial card feeds.

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
Not tested yet; requires access to a workspace with seeded commercial card feeds

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
Not tested yet; requires access to a workspace with seeded commercial card feeds.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
Not tested yet; requires access to a workspace with seeded commercial card feeds.

</details>
