### PR TITLE
Add tag GL code display in tag picker

### DIFF
--- a/src/components/Search/SearchList/ListItem/TransactionListItem/TransactionListItemWide.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/TransactionListItemWide.tsx
@@ -45,6 +45,7 @@ function TransactionListItemWide<TItem extends ListItem>({
     exportedReportActions,
     policyCategories,
     policyTagLists,
+    rowPolicy,
     nonPersonalAndWorkspaceCards,
     isAttendeesEnabledForMovingPolicy,
     currentSearchHash,
@@ -180,7 +181,7 @@ function TransactionListItemWide<TItem extends ListItem>({
                         transactionItem={transactionItem}
                         report={transactionItem.report}
                         chatReport={chatReport}
-                        policy={transactionItem.policy}
+                        policy={rowPolicy ?? transactionItem.policy}
                         policyCategories={policyCategories}
                         policyTagLists={policyTagLists}
                         shouldShowTooltip={showTooltip}

--- a/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
@@ -170,6 +170,7 @@ function TransactionListItemInner<TItem extends ListItem>({
     // Use snapshotReport/snapshotPolicy as fallbacks to fix offline issues where
     // newly created reports aren't in the search snapshot yet
     const policyForViolations = parentPolicy ?? snapshotPolicy;
+    const rowPolicy = parentPolicy || snapshotPolicy.id || transactionItem.policy ? {...transactionItem.policy, ...snapshotPolicy, ...parentPolicy} : undefined;
     const reportForViolations = parentReport ?? snapshotReport;
 
     const onyxViolations = (transactionViolationsForRow ?? []).filter(
@@ -262,6 +263,7 @@ function TransactionListItemInner<TItem extends ListItem>({
         exportedReportActions,
         policyCategories,
         policyTagLists,
+        rowPolicy,
         nonPersonalAndWorkspaceCards,
         isAttendeesEnabledForMovingPolicy,
         chatReport,

--- a/src/components/Search/SearchList/ListItem/TransactionListItem/types.ts
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/types.ts
@@ -30,7 +30,6 @@ type TransactionListItemSharedProps<TItem extends ListItem> = {
     exportedReportActions: ReportAction[];
     policyCategories?: PolicyCategories;
     policyTagLists?: PolicyTagLists;
-    /** Policy fields merged from the row snapshot and live Onyx data. */
     rowPolicy?: Policy;
     nonPersonalAndWorkspaceCards?: CardList;
     isAttendeesEnabledForMovingPolicy?: boolean;

--- a/src/components/Search/SearchList/ListItem/TransactionListItem/types.ts
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/types.ts
@@ -5,7 +5,7 @@ import type {ListItem} from '@components/SelectionList/types';
 import type {TransactionPreviewData} from '@libs/actions/Search';
 import type {ModifiedMouseEvent} from '@libs/Navigation/helpers/openInternalRouteInNewTab';
 
-import type {CardList, PolicyCategories, PolicyTagLists, Report, ReportAction, TransactionViolation} from '@src/types/onyx';
+import type {CardList, Policy, PolicyCategories, PolicyTagLists, Report, ReportAction, TransactionViolation} from '@src/types/onyx';
 
 type TransactionListItemSharedProps<TItem extends ListItem> = {
     item: TItem;
@@ -30,6 +30,8 @@ type TransactionListItemSharedProps<TItem extends ListItem> = {
     exportedReportActions: ReportAction[];
     policyCategories?: PolicyCategories;
     policyTagLists?: PolicyTagLists;
+    /** Policy fields merged from the row snapshot and live Onyx data. */
+    rowPolicy?: Policy;
     nonPersonalAndWorkspaceCards?: CardList;
     isAttendeesEnabledForMovingPolicy?: boolean;
     chatReport?: Report;

--- a/src/components/TagPicker/TagPickerModal.tsx
+++ b/src/components/TagPicker/TagPickerModal.tsx
@@ -42,6 +42,9 @@ type TagPickerModalProps = {
     /** Whether the policy has dependent tags */
     hasDependentTags?: boolean;
 
+    /** Optional override for whether to show GL codes under each tag */
+    shouldShowGLCode?: boolean;
+
     /** Called when the user confirms a tag selection */
     onSelected?: (tag: string) => void;
 } & Omit<PopoverWithMeasuredContentProps, 'anchorRef' | 'children' | 'onClose'>;
@@ -54,6 +57,7 @@ function TagPickerModal({
     selectedTag = '',
     transactionTag,
     hasDependentTags,
+    shouldShowGLCode,
     onSelected,
     anchorAlignment = DEFAULT_ANCHOR_ALIGNMENT,
     shouldMeasureAnchorPositionFromTop = false,
@@ -100,6 +104,7 @@ function TagPickerModal({
                     selectedTag={selectedTag}
                     transactionTag={transactionTag}
                     hasDependentTags={hasDependentTags}
+                    shouldShowGLCode={shouldShowGLCode}
                     onSubmit={handleTagSelected}
                 />
             </View>

--- a/src/components/TagPicker/index.tsx
+++ b/src/components/TagPicker/index.tsx
@@ -54,6 +54,12 @@ type TagPickerProps = {
      * split-edit where the active workspace no longer carries the original tag value.
      */
     additionalTagsToInclude?: string[];
+
+    /**
+     * Optional override for whether to show GL codes. When omitted, TagPicker reads
+     * `showTagGLCodes && glCodes` from the policy in Onyx.
+     */
+    shouldShowGLCode?: boolean;
 };
 
 const getSelectedOptions = (selectedTag: string): SelectedTagOption[] => {
@@ -80,11 +86,13 @@ function TagPicker({
     shouldOrderListByTagName = false,
     onSubmit,
     additionalTagsToInclude,
+    shouldShowGLCode: shouldShowGLCodeProp,
 }: TagPickerProps) {
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
-    const [shouldShowGLCode] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {
+    const [shouldShowGLCodeFromPolicy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {
         selector: (policy) => !!policy?.showTagGLCodes && !!policy?.glCodes,
     });
+    const shouldShowGLCode = shouldShowGLCodeProp ?? shouldShowGLCodeFromPolicy;
     const [policyRecentlyUsedTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_TAGS}${policyID}`);
     const styles = useThemeStyles();
     const {inputCallbackRef} = useAutoFocusInput();
@@ -157,7 +165,6 @@ function TagPicker({
               data: option.data.sort((a, b) => localeCompare(a.text ?? '', b.text ?? '')),
           }))
         : tagSections;
-
     const selectedOptionKey = sections.at(0)?.data?.find((policyTag) => policyTag.searchText === selectedTag)?.keyForList;
 
     const textInputOptions = {

--- a/src/components/TagPicker/index.tsx
+++ b/src/components/TagPicker/index.tsx
@@ -82,6 +82,9 @@ function TagPicker({
     additionalTagsToInclude,
 }: TagPickerProps) {
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
+    const [shouldShowGLCode] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {
+        selector: (policy) => !!policy?.showTagGLCodes && !!policy?.glCodes,
+    });
     const [policyRecentlyUsedTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_TAGS}${policyID}`);
     const styles = useThemeStyles();
     const {inputCallbackRef} = useAutoFocusInput();
@@ -146,6 +149,7 @@ function TagPicker({
         recentlyUsedTags: policyRecentlyUsedTagsList,
         localeCompare,
         translate,
+        shouldShowGLCode,
     });
     const sections = shouldOrderListByTagName
         ? tagSections.map((option) => ({

--- a/src/components/TagPicker/index.tsx
+++ b/src/components/TagPicker/index.tsx
@@ -165,6 +165,7 @@ function TagPicker({
               data: option.data.sort((a, b) => localeCompare(a.text ?? '', b.text ?? '')),
           }))
         : tagSections;
+
     const selectedOptionKey = sections.at(0)?.data?.find((policyTag) => policyTag.searchText === selectedTag)?.keyForList;
 
     const textInputOptions = {

--- a/src/components/TransactionItemRow/DataCells/TagCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/TagCell.tsx
@@ -31,8 +31,6 @@ function TagCell({canEdit, onSave, shouldUseNarrowLayout, shouldShowTooltip, tra
 
     const [livePolicy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
-    // Search rows can have policy fields that are absent from the live Onyx policy entry. Preserve those
-    // snapshot fields while allowing newer live values (including optimistic toggle updates) to win.
     const policy = livePolicy ? {...policyProp, ...livePolicy} : policyProp;
 
     const policyHasDependentTags = hasDependentTags(policy, policyTags);

--- a/src/components/TransactionItemRow/DataCells/TagCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/TagCell.tsx
@@ -13,6 +13,7 @@ import {getDecodedTagName} from '@libs/TagUtils';
 import {getTagForDisplay} from '@libs/TransactionUtils';
 
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {Policy} from '@src/types/onyx';
 
 import React from 'react';
 
@@ -21,16 +22,21 @@ import type TransactionDataCellProps from './TransactionDataCellProps';
 type TagCellProps = TransactionDataCellProps &
     EditableProps<string> & {
         policyID?: string;
+        policy?: Policy;
     };
 
-function TagCell({canEdit, onSave, shouldUseNarrowLayout, shouldShowTooltip, transactionItem, policyID}: TagCellProps) {
+function TagCell({canEdit, onSave, shouldUseNarrowLayout, shouldShowTooltip, transactionItem, policyID, policy: policyProp}: TagCellProps) {
     const icons = useMemoizedLazyExpensifyIcons(['Tag']);
     const styles = useThemeStyles();
 
-    const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
+    const [livePolicy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
+    // Search rows can have policy fields that are absent from the live Onyx policy entry. Preserve those
+    // snapshot fields while allowing newer live values (including optimistic toggle updates) to win.
+    const policy = livePolicy ? {...policyProp, ...livePolicy} : policyProp;
 
     const policyHasDependentTags = hasDependentTags(policy, policyTags);
+    const shouldShowGLCode = !!policy?.showTagGLCodes && !!policy?.glCodes;
 
     const {isEditing, anchorRef, isPopoverVisible, popoverPosition, isInverted, startEditing, cancelEditing, handleSave} = usePopoverEditState({
         canEdit,
@@ -69,6 +75,7 @@ function TagCell({canEdit, onSave, shouldUseNarrowLayout, shouldShowTooltip, tra
                     selectedTag={transactionItem?.tag ?? ''}
                     transactionTag={transactionItem?.tag}
                     hasDependentTags={policyHasDependentTags}
+                    shouldShowGLCode={shouldShowGLCode}
                     isVisible={isPopoverVisible}
                     onClose={cancelEditing}
                     anchorPosition={popoverPosition}

--- a/src/components/TransactionItemRow/TransactionItemRowWide.tsx
+++ b/src/components/TransactionItemRow/TransactionItemRowWide.tsx
@@ -202,6 +202,7 @@ function TransactionItemRowWide({
                             canEdit={canEditTag}
                             onSave={onEditTag}
                             policyID={effectivePolicyID}
+                            policy={policy}
                         />
                     </View>
                 );

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -6459,7 +6459,7 @@ _Für ausführlichere Anweisungen [besuchen Sie unsere Hilfeseite](${CONST.NETSU
                 one: '1 Tag',
                 other: (count: number) => `${count} Tags`,
             }),
-            showTagGLCodes: '[de] Show GL codes when selecting a tag',
+            showTagGLCodes: 'Kontenplan-Codes beim Auswählen eines Tags anzeigen',
         },
         taxes: {
             subtitle: 'Steuernamen und -sätze hinzufügen und Standardwerte festlegen.',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -6459,6 +6459,7 @@ _Für ausführlichere Anweisungen [besuchen Sie unsere Hilfeseite](${CONST.NETSU
                 one: '1 Tag',
                 other: (count: number) => `${count} Tags`,
             }),
+            showTagGLCodes: '[de] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Steuernamen und -sätze hinzufügen und Standardwerte festlegen.',

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -6595,6 +6595,7 @@ _Για πιο αναλυτικές οδηγίες, [επισκεφθείτε τ
                 one: '1 ετικέτα',
                 other: (count: number) => `${count} ετικέτες`,
             }),
+            showTagGLCodes: '[el] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Προσθέστε ονόματα φόρων, συντελεστές και ορίστε προεπιλογές.',
@@ -7457,8 +7458,10 @@ _Για πιο αναλυτικές οδηγίες, [επισκεφθείτε τ
         },
         exportAgainModal: {
             title: 'Προσοχή!',
-            description: (reportName, connectionName) =>
-                `Οι παρακάτω αναφορές έχουν ήδη εξαχθεί στο ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName]}. Είστε βέβαιοι ότι θέλετε να τις εξαγάγετε ξανά;
+            description: (
+                reportName,
+                connectionName,
+            ) => `Οι παρακάτω αναφορές έχουν ήδη εξαχθεί στο ${CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName]}. Είστε βέβαιοι ότι θέλετε να τις εξαγάγετε ξανά;
 
 ${reportName}`,
             confirmText: 'Ναι, εξαγωγή ξανά',

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -6595,7 +6595,7 @@ _Για πιο αναλυτικές οδηγίες, [επισκεφθείτε τ
                 one: '1 ετικέτα',
                 other: (count: number) => `${count} ετικέτες`,
             }),
-            showTagGLCodes: '[el] Show GL codes when selecting a tag',
+            showTagGLCodes: 'Εμφάνιση κωδικών Γ.Λ. κατά την επιλογή ετικέτας',
         },
         taxes: {
             subtitle: 'Προσθέστε ονόματα φόρων, συντελεστές και ορίστε προεπιλογές.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6468,6 +6468,7 @@ const translations = {
         tags: {
             tagName: 'Tag name',
             requiresTag: 'Members must tag all expenses',
+            showTagGLCodes: 'Show GL codes when selecting a tag',
             trackBillable: 'Track billable expenses',
             customTagName: 'Custom tag name',
             enableTag: 'Enable tag',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -6333,7 +6333,7 @@ ${amount} para ${merchant} - ${date}`,
                 one: '1 etiqueta',
                 other: (count: number) => `${count} etiquetas`,
             }),
-            showTagGLCodes: '[es] Show GL codes when selecting a tag',
+            showTagGLCodes: 'Mostrar códigos del libro mayor al seleccionar una etiqueta',
         },
         taxes: {
             subtitle: 'Añade nombres, tasas y establezca valores por defecto para los impuestos.',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -6333,6 +6333,7 @@ ${amount} para ${merchant} - ${date}`,
                 one: '1 etiqueta',
                 other: (count: number) => `${count} etiquetas`,
             }),
+            showTagGLCodes: '[es] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Añade nombres, tasas y establezca valores por defecto para los impuestos.',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -6483,7 +6483,7 @@ _Pour des instructions plus détaillées, [visitez notre site d’aide](${CONST.
                 one: '1 tag',
                 other: (count: number) => `${count} tags`,
             }),
-            showTagGLCodes: '[fr] Show GL codes when selecting a tag',
+            showTagGLCodes: 'Afficher les codes GL lors de la sélection d’un tag',
         },
         taxes: {
             subtitle: 'Ajoutez des noms de taxes, des taux et définissez des valeurs par défaut.',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -6483,6 +6483,7 @@ _Pour des instructions plus détaillées, [visitez notre site d’aide](${CONST.
                 one: '1 tag',
                 other: (count: number) => `${count} tags`,
             }),
+            showTagGLCodes: '[fr] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Ajoutez des noms de taxes, des taux et définissez des valeurs par défaut.',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -6434,7 +6434,7 @@ _Per istruzioni più dettagliate, [visita il nostro sito di assistenza](${CONST.
                 one: '1 giorno',
                 other: (count: number) => `${count} tag`,
             }),
-            showTagGLCodes: '[it] Show GL codes when selecting a tag',
+            showTagGLCodes: 'Mostra i codici GL quando selezioni un tag',
         },
         taxes: {
             subtitle: 'Aggiungi nomi e aliquote delle imposte e imposta i valori predefiniti.',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -6434,6 +6434,7 @@ _Per istruzioni più dettagliate, [visita il nostro sito di assistenza](${CONST.
                 one: '1 giorno',
                 other: (count: number) => `${count} tag`,
             }),
+            showTagGLCodes: '[it] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Aggiungi nomi e aliquote delle imposte e imposta i valori predefiniti.',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -6356,7 +6356,7 @@ _詳しい手順については、[ヘルプサイトをご覧ください](${CO
                 one: '1日タグ',
                 other: (count: number) => `${count} 件のタグ`,
             }),
-            showTagGLCodes: '[ja] Show GL codes when selecting a tag',
+            showTagGLCodes: 'タグ選択時にGLコードを表示する',
         },
         taxes: {
             subtitle: '税名と税率を追加し、デフォルトを設定します。',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -6356,6 +6356,7 @@ _詳しい手順については、[ヘルプサイトをご覧ください](${CO
                 one: '1日タグ',
                 other: (count: number) => `${count} 件のタグ`,
             }),
+            showTagGLCodes: '[ja] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: '税名と税率を追加し、デフォルトを設定します。',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -6421,6 +6421,7 @@ _Voor meer gedetailleerde instructies, [bezoek onze help-site](${CONST.NETSUITE_
                 one: '1 label',
                 other: (count: number) => `${count} tags`,
             }),
+            showTagGLCodes: '[nl] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Belastingnamen en -tarieven toevoegen en standaarden instellen.',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -6421,7 +6421,7 @@ _Voor meer gedetailleerde instructies, [bezoek onze help-site](${CONST.NETSUITE_
                 one: '1 label',
                 other: (count: number) => `${count} tags`,
             }),
-            showTagGLCodes: '[nl] Show GL codes when selecting a tag',
+            showTagGLCodes: 'GL-codes tonen bij het selecteren van een tag',
         },
         taxes: {
             subtitle: 'Belastingnamen en -tarieven toevoegen en standaarden instellen.',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6401,7 +6401,7 @@ _Aby uzyskać bardziej szczegółowe instrukcje, [odwiedź naszą stronę pomocy
                 one: '1 dzień',
                 other: (count: number) => `${count} tagi`,
             }),
-            showTagGLCodes: '[pl] Show GL codes when selecting a tag',
+            showTagGLCodes: 'Pokaż kody GL przy wybieraniu tagu',
         },
         taxes: {
             subtitle: 'Dodaj nazwy podatków, stawki i ustaw domyślne.',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6401,6 +6401,7 @@ _Aby uzyskać bardziej szczegółowe instrukcje, [odwiedź naszą stronę pomocy
                 one: '1 dzień',
                 other: (count: number) => `${count} tagi`,
             }),
+            showTagGLCodes: '[pl] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Dodaj nazwy podatków, stawki i ustaw domyślne.',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -6419,7 +6419,7 @@ _Para instruções mais detalhadas, [visite nossa central de ajuda](${CONST.NETS
                 one: '1 etiqueta',
                 other: (count: number) => `${count} Tags`,
             }),
-            showTagGLCodes: '[pt-BR] Show GL codes when selecting a tag',
+            showTagGLCodes: 'Mostrar códigos GL ao selecionar uma tag',
         },
         taxes: {
             subtitle: 'Adicione nomes de impostos, taxas e defina padrões.',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -6419,6 +6419,7 @@ _Para instruções mais detalhadas, [visite nossa central de ajuda](${CONST.NETS
                 one: '1 etiqueta',
                 other: (count: number) => `${count} Tags`,
             }),
+            showTagGLCodes: '[pt-BR] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: 'Adicione nomes de impostos, taxas e defina padrões.',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -6204,6 +6204,7 @@ _如需更详细的说明，请[访问我们的帮助网站](${CONST.NETSUITE_IM
                 one: '1 天',
                 other: (count: number) => `${count} 个标签`,
             }),
+            showTagGLCodes: '[zh-hans] Show GL codes when selecting a tag',
         },
         taxes: {
             subtitle: '添加税种名称、税率，并设置默认值。',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -6204,7 +6204,7 @@ _如需更详细的说明，请[访问我们的帮助网站](${CONST.NETSUITE_IM
                 one: '1 天',
                 other: (count: number) => `${count} 个标签`,
             }),
-            showTagGLCodes: '[zh-hans] Show GL codes when selecting a tag',
+            showTagGLCodes: '在选择标签时显示总账科目代码',
         },
         taxes: {
             subtitle: '添加税种名称、税率，并设置默认值。',

--- a/src/libs/API/parameters/SetPolicyShowTagGLCodesParams.ts
+++ b/src/libs/API/parameters/SetPolicyShowTagGLCodesParams.ts
@@ -1,0 +1,6 @@
+type SetPolicyShowTagGLCodesParams = {
+    policyID: string;
+    enabled: boolean;
+};
+
+export default SetPolicyShowTagGLCodesParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -261,6 +261,7 @@ export type {default as SetWorkspacePayerParams} from './SetWorkspacePayerParams
 export type {default as SetWorkspaceReimbursementParams} from './SetWorkspaceReimbursementParams';
 export type {default as SetWorkspaceDefaultSpendCategoryParams} from './SetWorkspaceDefaultSpendCategoryParams';
 export type {default as SetPolicyRequiresTag} from './SetPolicyRequiresTag';
+export type {default as SetPolicyShowTagGLCodesParams} from './SetPolicyShowTagGLCodesParams';
 export type {default as SetPolicyTagsRequired} from './SetPolicyTagsRequired';
 export type {default as SetPolicyTagListsRequired} from './SetPolicyTagListsRequired';
 export type {default as RenamePolicyTagListParams} from './RenamePolicyTagListParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -196,6 +196,7 @@ const WRITE_COMMANDS = {
     SET_POLICY_TAGS_REQUIRED: 'SetPolicyTagsRequired',
     SET_POLICY_TAG_LISTS_REQUIRED: 'SetPolicyTagListsRequired',
     SET_POLICY_REQUIRES_TAG: 'SetPolicyRequiresTag',
+    SET_POLICY_SHOW_TAG_GL_CODES: 'SetPolicyShowTagGLCodes',
     // cspell:disable-next-line
     RENAME_POLICY_TAG_LIST: 'RenamePolicyTaglist',
     DELETE_POLICY_TAGS: 'DeletePolicyTags',
@@ -835,6 +836,7 @@ type WriteCommandParameters = {
     [WRITE_COMMANDS.UPDATE_POLICY_CATEGORY_GL_CODE]: Parameters.UpdatePolicyCategoryGLCodeParams;
     [WRITE_COMMANDS.DELETE_POLICY_REPORT_FIELD]: Parameters.DeletePolicyReportField;
     [WRITE_COMMANDS.SET_POLICY_REQUIRES_TAG]: Parameters.SetPolicyRequiresTag;
+    [WRITE_COMMANDS.SET_POLICY_SHOW_TAG_GL_CODES]: Parameters.SetPolicyShowTagGLCodesParams;
     [WRITE_COMMANDS.SET_POLICY_TAGS_REQUIRED]: Parameters.SetPolicyTagsRequired;
     [WRITE_COMMANDS.SET_POLICY_TAG_LISTS_REQUIRED]: Parameters.SetPolicyTagListsRequired;
     [WRITE_COMMANDS.RENAME_POLICY_TAG_LIST]: Parameters.RenamePolicyTagListParams;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1292,17 +1292,6 @@ function getGLCodeFromPolicyTag(tag: {['GL Code']?: string | number} | undefined
 }
 
 /**
- * Resolves the GL code for a tag name within a single tag list.
- */
-function getPolicyTagGLCode(tags: PolicyTags | undefined, tagName: string | undefined): string {
-    if (!tags || !tagName) {
-        return '';
-    }
-    const matchingTag = tags[tagName] ?? Object.values(tags).find((tag) => tag.name === tagName);
-    return getGLCodeFromPolicyTag(matchingTag);
-}
-
-/**
  * Escape colon from tag name
  */
 function escapeTagName(tag: string) {
@@ -3210,7 +3199,6 @@ export {
     getLengthOfTag,
     getTagGLCode,
     getGLCodeFromPolicyTag,
-    getPolicyTagGLCode,
     isPolicyMemberWithoutPendingDelete,
     hasDynamicExternalWorkflow,
     getActivePoliciesWithExpenseChatAndPerDiemEnabled,

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1284,6 +1284,26 @@ function getTagGLCode(policyTagLists: OnyxEntry<PolicyTagLists>, transactionTag:
 }
 
 /**
+ * Resolves the GL code for a single policy tag object, stripping wrapping quotes from the backend.
+ */
+function getGLCodeFromPolicyTag(tag: {['GL Code']?: string | number} | undefined): string {
+    const glCode = tag?.['GL Code'];
+    return glCode != null ? String(glCode).replaceAll('"', '') : '';
+}
+
+/**
+ * Resolves the GL code for a tag name within a single tag list.
+ */
+function getPolicyTagGLCode(tags: PolicyTags | undefined, tagName: string | undefined): string {
+    if (!tags || !tagName) {
+        return '';
+    }
+    const directMatch = tags[tagName];
+    const glCode = directMatch?.['GL Code'] ?? Object.values(tags).find((tag) => tag.name === tagName)?.['GL Code'];
+    return glCode != null ? String(glCode).replaceAll('"', '') : '';
+}
+
+/**
  * Escape colon from tag name
  */
 function escapeTagName(tag: string) {
@@ -3190,6 +3210,8 @@ export {
     hasIndependentTags,
     getLengthOfTag,
     getTagGLCode,
+    getGLCodeFromPolicyTag,
+    getPolicyTagGLCode,
     isPolicyMemberWithoutPendingDelete,
     hasDynamicExternalWorkflow,
     getActivePoliciesWithExpenseChatAndPerDiemEnabled,

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1298,9 +1298,8 @@ function getPolicyTagGLCode(tags: PolicyTags | undefined, tagName: string | unde
     if (!tags || !tagName) {
         return '';
     }
-    const directMatch = tags[tagName];
-    const glCode = directMatch?.['GL Code'] ?? Object.values(tags).find((tag) => tag.name === tagName)?.['GL Code'];
-    return glCode != null ? String(glCode).replaceAll('"', '') : '';
+    const matchingTag = tags[tagName] ?? Object.values(tags).find((tag) => tag.name === tagName);
+    return getGLCodeFromPolicyTag(matchingTag);
 }
 
 /**

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1276,8 +1276,7 @@ function getTagGLCode(policyTagLists: OnyxEntry<PolicyTagLists>, transactionTag:
 
             const directMatch = levelTags[tagName];
             const matchingTag = matchesTagAtLevel(directMatch) ? directMatch : Object.values(levelTags).find(matchesTagAtLevel);
-            const glCode = matchingTag?.['GL Code'];
-            return glCode != null ? String(glCode).replaceAll('"', '') : '';
+            return getGLCodeFromPolicyTag(matchingTag);
         })
         .filter(Boolean)
         .join(', ');

--- a/src/libs/TagsOptionsListUtils.ts
+++ b/src/libs/TagsOptionsListUtils.ts
@@ -102,11 +102,13 @@ function getTagListSections({
 }) {
     const tagSections = [];
     const sortedTags = sortTags(tags, localeCompare);
+    // O(1) lookup for selected/recent shims that lack the PolicyTag GL Code field.
+    const tagByName = new Map(sortedTags.map((tag) => [tag.name, tag]));
     const withGLCode = (tag: SelectedTagOption | PolicyTag): TagOptionInput => {
         if (!shouldShowGLCode) {
             return tag;
         }
-        const fullTag = 'GL Code' in tag && tag['GL Code'] ? tag : sortedTags.find((sortedTag) => sortedTag.name === tag.name);
+        const fullTag = 'GL Code' in tag ? tag : tagByName.get(tag.name);
         return {...tag, glCode: getGLCodeFromPolicyTag(fullTag)};
     };
 
@@ -166,11 +168,11 @@ function getTagListSections({
 
     const filteredRecentlyUsedTags = recentlyUsedTags
         .filter((recentlyUsedTag) => {
-            const tagObject = sortedTags.find((tag) => tag.name === recentlyUsedTag);
+            const tagObject = tagByName.get(recentlyUsedTag);
             return !!tagObject?.enabled && !selectedOptionNames.has(recentlyUsedTag) && tagObject?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
         })
         .map((tagName) => {
-            const tagObject = sortedTags.find((tag) => tag.name === tagName);
+            const tagObject = tagByName.get(tagName);
             return withGLCode(tagObject ?? {name: tagName, enabled: true});
         });
 

--- a/src/libs/TagsOptionsListUtils.ts
+++ b/src/libs/TagsOptionsListUtils.ts
@@ -102,7 +102,6 @@ function getTagListSections({
 }) {
     const tagSections = [];
     const sortedTags = sortTags(tags, localeCompare);
-    // O(1) lookup for selected/recent shims that lack the PolicyTag GL Code field.
     const tagByName = new Map(sortedTags.map((tag) => [tag.name, tag]));
     const withGLCode = (tag: SelectedTagOption | PolicyTag): TagOptionInput => {
         if (!shouldShowGLCode) {

--- a/src/libs/TagsOptionsListUtils.ts
+++ b/src/libs/TagsOptionsListUtils.ts
@@ -10,7 +10,14 @@ import type {Option} from './OptionsListUtils';
 
 import {insertTagIntoTransactionTagsString} from './IOUUtils';
 import {hasEnabledOptions} from './OptionsListUtils';
-import {getCleanedTagName, getTagList, getTagLists, hasDependentTags as hasDependentTagsPolicyUtils, isMultiLevelTags as isMultiLevelTagsPolicyUtils} from './PolicyUtils';
+import {
+    getCleanedTagName,
+    getGLCodeFromPolicyTag,
+    getTagList,
+    getTagLists,
+    hasDependentTags as hasDependentTagsPolicyUtils,
+    isMultiLevelTags as isMultiLevelTagsPolicyUtils,
+} from './PolicyUtils';
 import tokenizedSearch from './tokenizedSearch';
 import {getTagArrayFromName, getTagForDisplay} from './TransactionUtils';
 
@@ -20,6 +27,10 @@ type SelectedTagOption = {
     isSelected?: boolean;
     accountID: number | undefined;
     pendingAction?: PendingAction;
+};
+
+type TagOptionInput = Pick<PolicyTag, 'name' | 'enabled' | 'pendingAction'> & {
+    glCode?: string;
 };
 
 type TagOption = Option & {
@@ -49,12 +60,14 @@ type UpdatedTransactionTagParams = {
  *
  * @param tags - an initial tag array
  */
-function getTagsOptions(tags: Array<Pick<PolicyTag, 'name' | 'enabled' | 'pendingAction'>>, selectedOptions?: SelectedTagOption[]): TagOption[] {
+function getTagsOptions(tags: TagOptionInput[], selectedOptions?: SelectedTagOption[], shouldShowGLCode = false): TagOption[] {
     return tags.map((tag) => {
         // This is to remove unnecessary escaping backslash in tag name sent from backend.
         const cleanedName = getCleanedTagName(tag.name);
+        const glCode = tag.glCode ?? '';
         return {
             text: cleanedName,
+            ...(shouldShowGLCode && glCode ? {alternateText: glCode} : {}),
             keyForList: tag.name,
             searchText: tag.name,
             tooltipText: cleanedName,
@@ -76,6 +89,7 @@ function getTagListSections({
     searchValue = '',
     maxRecentReportsToShow = CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
     translate,
+    shouldShowGLCode = false,
 }: {
     tags: PolicyTags | Array<SelectedTagOption | PolicyTag>;
     localeCompare: LocaleContextProps['localeCompare'];
@@ -84,23 +98,31 @@ function getTagListSections({
     searchValue?: string;
     maxRecentReportsToShow?: number;
     translate: LocalizedTranslate;
+    shouldShowGLCode?: boolean;
 }) {
     const tagSections = [];
     const sortedTags = sortTags(tags, localeCompare);
+    const withGLCode = (tag: SelectedTagOption | PolicyTag): TagOptionInput => {
+        if (!shouldShowGLCode) {
+            return tag;
+        }
+        const fullTag = 'GL Code' in tag && tag['GL Code'] ? tag : sortedTags.find((sortedTag) => sortedTag.name === tag.name);
+        return {...tag, glCode: getGLCodeFromPolicyTag(fullTag)};
+    };
 
     const selectedOptionNames = new Set(selectedOptions.map((selectedOption) => selectedOption.name));
-    const enabledTags = sortedTags.filter((tag) => tag.enabled);
+    const enabledTags = sortedTags.filter((tag) => tag.enabled).map(withGLCode);
     const enabledTagsNames = new Set(enabledTags.map((tag) => tag.name));
     const enabledTagsWithoutSelectedOptions = enabledTags.filter((tag) => !selectedOptionNames.has(tag.name));
-    const selectedTagsWithDisabledState: SelectedTagOption[] = [];
+    const selectedTagsWithDisabledState: TagOptionInput[] = [];
     const numberOfTags = enabledTags.length;
 
     for (const tag of selectedOptions) {
         if (enabledTagsNames.has(tag.name)) {
-            selectedTagsWithDisabledState.push({...tag, enabled: true});
+            selectedTagsWithDisabledState.push(withGLCode({...tag, enabled: true}));
             continue;
         }
-        selectedTagsWithDisabledState.push({...tag, enabled: false});
+        selectedTagsWithDisabledState.push(withGLCode({...tag, enabled: false}));
     }
 
     // If all tags are disabled but there's a previously selected tag, show only the selected tag
@@ -109,7 +131,7 @@ function getTagListSections({
             // "Selected" section
             title: '',
             sectionIndex: 0,
-            data: getTagsOptions(selectedTagsWithDisabledState, selectedOptions),
+            data: getTagsOptions(selectedTagsWithDisabledState, selectedOptions, shouldShowGLCode),
         });
 
         return tagSections;
@@ -117,15 +139,15 @@ function getTagListSections({
 
     if (searchValue) {
         const tagsForSearch = [
-            ...tokenizedSearch(selectedTagsWithDisabledState, searchValue, (tag) => [getCleanedTagName(tag.name)]),
-            ...tokenizedSearch(enabledTagsWithoutSelectedOptions, searchValue, (tag) => [getCleanedTagName(tag.name)]),
+            ...tokenizedSearch(selectedTagsWithDisabledState, searchValue, (tag) => (shouldShowGLCode ? [getCleanedTagName(tag.name), tag.glCode ?? ''] : [getCleanedTagName(tag.name)])),
+            ...tokenizedSearch(enabledTagsWithoutSelectedOptions, searchValue, (tag) => (shouldShowGLCode ? [getCleanedTagName(tag.name), tag.glCode ?? ''] : [getCleanedTagName(tag.name)])),
         ];
 
         tagSections.push({
             // "Search" section
             title: '',
             sectionIndex: 1,
-            data: getTagsOptions(tagsForSearch, selectedOptions),
+            data: getTagsOptions(tagsForSearch, selectedOptions, shouldShowGLCode),
         });
 
         return tagSections;
@@ -136,7 +158,7 @@ function getTagListSections({
             // "All" section when items amount less than the threshold
             title: '',
             sectionIndex: 2,
-            data: getTagsOptions([...selectedTagsWithDisabledState, ...enabledTagsWithoutSelectedOptions], selectedOptions),
+            data: getTagsOptions([...selectedTagsWithDisabledState, ...enabledTagsWithoutSelectedOptions], selectedOptions, shouldShowGLCode),
         });
 
         return tagSections;
@@ -147,14 +169,17 @@ function getTagListSections({
             const tagObject = sortedTags.find((tag) => tag.name === recentlyUsedTag);
             return !!tagObject?.enabled && !selectedOptionNames.has(recentlyUsedTag) && tagObject?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
         })
-        .map((tag) => ({name: tag, enabled: true}));
+        .map((tagName) => {
+            const tagObject = sortedTags.find((tag) => tag.name === tagName);
+            return withGLCode(tagObject ?? {name: tagName, enabled: true});
+        });
 
     if (selectedOptions.length) {
         tagSections.push({
             // "Selected" section
             title: '',
             sectionIndex: 3,
-            data: getTagsOptions(selectedTagsWithDisabledState, selectedOptions),
+            data: getTagsOptions(selectedTagsWithDisabledState, selectedOptions, shouldShowGLCode),
         });
     }
 
@@ -165,7 +190,7 @@ function getTagListSections({
             // "Recent" section
             title: translate('common.recent'),
             sectionIndex: 4,
-            data: getTagsOptions(cutRecentlyUsedTags, selectedOptions),
+            data: getTagsOptions(cutRecentlyUsedTags, selectedOptions, shouldShowGLCode),
         });
     }
 
@@ -173,7 +198,7 @@ function getTagListSections({
         // "All" section when items amount more than the threshold
         title: translate('common.all'),
         sectionIndex: 5,
-        data: getTagsOptions(enabledTagsWithoutSelectedOptions, selectedOptions),
+        data: getTagsOptions(enabledTagsWithoutSelectedOptions, selectedOptions, shouldShowGLCode),
     });
 
     return tagSections;

--- a/src/libs/actions/Policy/CopyPolicySettings.ts
+++ b/src/libs/actions/Policy/CopyPolicySettings.ts
@@ -58,6 +58,7 @@ const PARTS_TO_POLICY_FIELDS = {
         'preventSelfApproval',
         'disabledFields',
         'glCodes',
+        'showTagGLCodes',
         'shouldShowAutoApprovalOptions',
         'shouldShowAutoReimbursementLimitOption',
         'customRules',

--- a/src/libs/actions/Policy/Tag.ts
+++ b/src/libs/actions/Policy/Tag.ts
@@ -14,6 +14,7 @@ import type {
     SetPolicyTagListsRequired,
     SetPolicyTagsEnabled,
     SetPolicyTagsRequired,
+    SetPolicyShowTagGLCodesParams,
     UpdatePolicyTagGLCodeParams,
 } from '@libs/API/parameters';
 import {READ_COMMANDS, SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
@@ -1136,6 +1137,66 @@ function setPolicyRequiresTag(policyData: PolicyData, requiresTag: boolean) {
     API.write(WRITE_COMMANDS.SET_POLICY_REQUIRES_TAG, parameters, onyxData);
 }
 
+function setPolicyShowTagGLCodes(policyID: string | undefined, showTagGLCodes: boolean) {
+    if (!policyID) {
+        return;
+    }
+
+    const onyxData: OnyxData<typeof ONYXKEYS.COLLECTION.POLICY> = {
+        optimisticData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                value: {
+                    showTagGLCodes,
+                    errorFields: {
+                        showTagGLCodes: null,
+                    },
+                    pendingFields: {
+                        showTagGLCodes: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                    },
+                },
+            },
+        ],
+        successData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                value: {
+                    errorFields: {
+                        showTagGLCodes: null,
+                    },
+                    pendingFields: {
+                        showTagGLCodes: null,
+                    },
+                },
+            },
+        ],
+        failureData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                value: {
+                    showTagGLCodes: !showTagGLCodes,
+                    errorFields: {
+                        showTagGLCodes: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workspace.tags.genericFailureMessage'),
+                    },
+                    pendingFields: {
+                        showTagGLCodes: null,
+                    },
+                },
+            },
+        ],
+    };
+
+    const parameters: SetPolicyShowTagGLCodesParams = {
+        policyID,
+        enabled: showTagGLCodes,
+    };
+
+    API.write(WRITE_COMMANDS.SET_POLICY_SHOW_TAG_GL_CODES, parameters, onyxData);
+}
+
 function setPolicyTagsRequired(policyData: PolicyData, requiresTag: boolean, tagListIndex: number) {
     const policyTag = PolicyUtils.getTagLists(policyData.tags)?.at(tagListIndex);
     if (!policyTag?.name) {
@@ -1385,6 +1446,7 @@ function downloadMultiLevelTagsCSV(policyID: string, onDownloadFailed: () => voi
 export {
     buildOptimisticPolicyRecentlyUsedTags,
     setPolicyRequiresTag,
+    setPolicyShowTagGLCodes,
     setPolicyTagsRequired,
     createPolicyTag,
     clearPolicyTagErrors,

--- a/src/libs/actions/Policy/Tag.ts
+++ b/src/libs/actions/Policy/Tag.ts
@@ -1137,7 +1137,7 @@ function setPolicyRequiresTag(policyData: PolicyData, requiresTag: boolean) {
     API.write(WRITE_COMMANDS.SET_POLICY_REQUIRES_TAG, parameters, onyxData);
 }
 
-function setPolicyShowTagGLCodes(policyID: string | undefined, showTagGLCodes: boolean) {
+function setPolicyShowTagGLCodes(policyID: string | undefined, showTagGLCodes: boolean, currentShowTagGLCodes: boolean | undefined) {
     if (!policyID) {
         return;
     }
@@ -1177,7 +1177,7 @@ function setPolicyShowTagGLCodes(policyID: string | undefined, showTagGLCodes: b
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    showTagGLCodes: !showTagGLCodes,
+                    showTagGLCodes: currentShowTagGLCodes,
                     errorFields: {
                         showTagGLCodes: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workspace.tags.genericFailureMessage'),
                     },

--- a/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
@@ -13,8 +13,8 @@ import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {getBillableExpensesPendingAction, toggleBillableExpenses} from '@libs/actions/Policy/Policy';
-import {clearPolicyTagListErrors, setPolicyRequiresTag} from '@libs/actions/Policy/Tag';
+import {clearPolicyErrorField, getBillableExpensesPendingAction, toggleBillableExpenses} from '@libs/actions/Policy/Policy';
+import {clearPolicyTagListErrors, setPolicyRequiresTag, setPolicyShowTagGLCodes} from '@libs/actions/Policy/Tag';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -62,6 +62,9 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
     const shouldBlockEmptySettings = isRulesRevampEnabled && isMultiLevelTags && !isLoading;
 
     const getTagsSettings = (policy: OnyxEntry<Policy>) => {
+        const updateShowTagGLCodes = (value: boolean) => {
+            setPolicyShowTagGLCodes(policyID, value, policy?.showTagGLCodes);
+        };
         const hasDependentTags = hasDependentTagsUtil(policy, policyTags);
         return (
             <View style={styles.flexGrow1}>
@@ -135,6 +138,30 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
                             </View>
                         </OfflineWithFeedback>
                     </>
+                )}
+                {!!policy?.glCodes && (
+                    <OfflineWithFeedback
+                        errors={policy?.errorFields?.showTagGLCodes}
+                        pendingAction={policy?.pendingFields?.showTagGLCodes}
+                        errorRowStyles={styles.mh5}
+                        onClose={() => clearPolicyErrorField(policyID, 'showTagGLCodes')}
+                    >
+                        <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
+                            <Text
+                                style={[styles.textNormal, styles.flex1, styles.mr2]}
+                                accessible={false}
+                                aria-hidden
+                            >
+                                {translate('workspace.tags.showTagGLCodes')}
+                            </Text>
+                            <Switch
+                                isOn={policy?.showTagGLCodes ?? false}
+                                accessibilityLabel={translate('workspace.tags.showTagGLCodes')}
+                                onToggle={updateShowTagGLCodes}
+                                disabled={!policy?.areTagsEnabled}
+                            />
+                        </View>
+                    </OfflineWithFeedback>
                 )}
             </View>
         );

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -2632,6 +2632,9 @@ type Policy = OnyxCommon.OnyxValueWithOfflineFeedback<
         /** Whether new transactions need to be tagged */
         requiresTag?: boolean;
 
+        /** Whether to show tag GL codes when selecting a tag */
+        showTagGLCodes?: boolean;
+
         /** Client-only marker used to restore required tags after switching tag levels clears all tags */
         pendingRequiresTagRestore?: boolean | null;
 

--- a/tests/actions/CopyPolicySettingsTest.ts
+++ b/tests/actions/CopyPolicySettingsTest.ts
@@ -202,6 +202,19 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(policy?.employeeList).toEqual(targetPolicy.employeeList);
             });
 
+            it('copies showTagGLCodes with rules so tag pickers match the source workspace', () => {
+                const sourcePolicy = makeSourcePolicy({glCodes: true, showTagGLCodes: true});
+                const targetPolicy = makeTargetPolicy({glCodes: false, showTagGLCodes: false});
+
+                const {optimisticData} = buildCopyPolicySettingsData(sourcePolicy, [targetPolicy], ['rules'], {}, {});
+                const policy = getOptimisticPolicy(optimisticData);
+
+                expect(policy?.glCodes).toBe(true);
+                expect(policy?.showTagGLCodes).toBe(true);
+                expect(policy?.pendingFields?.glCodes).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
+                expect(policy?.pendingFields?.showTagGLCodes).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
+            });
+
             it('copies only autoAddTripName from travelSettings, never the Spotnana identity fields or terms acceptance', () => {
                 const sourcePolicy = makeSourcePolicy({
                     travelSettings: {

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -18,6 +18,7 @@ import {
     renamePolicyTag,
     renamePolicyTagList,
     setPolicyRequiresTag,
+    setPolicyShowTagGLCodes,
     setPolicyTagApprover,
     setPolicyTagGLCode,
     setPolicyTagsRequired,
@@ -201,6 +202,83 @@ describe('actions/Policy', () => {
             });
 
             expect(updatePolicyTags?.[tagListName]?.required).toBeTruthy();
+        });
+    });
+
+    describe('SetPolicyShowTagGLCodes', () => {
+        it('enable show tag GL codes', () => {
+            const fakePolicy = createRandomPolicy(0);
+            fakePolicy.showTagGLCodes = false;
+
+            mockFetch?.pause?.();
+
+            return Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy)
+                .then(() => {
+                    setPolicyShowTagGLCodes(fakePolicy.id, true);
+                    return waitForBatchedUpdates();
+                })
+                .then(
+                    () =>
+                        new Promise<void>((resolve) => {
+                            const connection = Onyx.connect({
+                                key: `${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`,
+                                callback: (policy) => {
+                                    Onyx.disconnect(connection);
+
+                                    expect(policy?.showTagGLCodes).toBeTruthy();
+                                    expect(policy?.pendingFields?.showTagGLCodes).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
+
+                                    resolve();
+                                },
+                            });
+                        }),
+                )
+                .then(mockFetch?.resume)
+                .then(waitForBatchedUpdates)
+                .then(
+                    () =>
+                        new Promise<void>((resolve) => {
+                            const connection = Onyx.connect({
+                                key: `${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`,
+                                callback: (policy) => {
+                                    Onyx.disconnect(connection);
+                                    expect(policy?.pendingFields?.showTagGLCodes).toBeFalsy();
+                                    resolve();
+                                },
+                            });
+                        }),
+                );
+        });
+
+        it('reset show tag GL codes when api returns an error', () => {
+            const fakePolicy = createRandomPolicy(0);
+            fakePolicy.showTagGLCodes = true;
+
+            mockFetch?.pause?.();
+
+            return Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy)
+                .then(() => {
+                    mockFetch?.fail?.();
+                    setPolicyShowTagGLCodes(fakePolicy.id, false);
+                    return waitForBatchedUpdates();
+                })
+                .then(mockFetch?.resume)
+                .then(waitForBatchedUpdates)
+                .then(
+                    () =>
+                        new Promise<void>((resolve) => {
+                            const connection = Onyx.connect({
+                                key: `${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`,
+                                callback: (policy) => {
+                                    Onyx.disconnect(connection);
+                                    expect(policy?.pendingFields?.showTagGLCodes).toBeFalsy();
+                                    expect(policy?.errorFields?.showTagGLCodes).toBeTruthy();
+                                    expect(policy?.showTagGLCodes).toBeTruthy();
+                                    resolve();
+                                },
+                            });
+                        }),
+                );
         });
     });
 

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -214,7 +214,7 @@ describe('actions/Policy', () => {
 
             return Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy)
                 .then(() => {
-                    setPolicyShowTagGLCodes(fakePolicy.id, true);
+                    setPolicyShowTagGLCodes(fakePolicy.id, true, false);
                     return waitForBatchedUpdates();
                 })
                 .then(
@@ -259,7 +259,7 @@ describe('actions/Policy', () => {
             return Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy)
                 .then(() => {
                     mockFetch?.fail?.();
-                    setPolicyShowTagGLCodes(fakePolicy.id, false);
+                    setPolicyShowTagGLCodes(fakePolicy.id, false, true);
                     return waitForBatchedUpdates();
                 })
                 .then(mockFetch?.resume)

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -40,6 +40,8 @@ import {
     getSubmitToEmail,
     getTagApproverRule,
     getTagGLCode,
+    getGLCodeFromPolicyTag,
+    getPolicyTagGLCode,
     getTagList,
     getTagListByOrderWeight,
     getUberConnectionErrorDirectlyFromPolicy,
@@ -73,7 +75,7 @@ import {isWorkspaceEligibleForReportChange} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {PersonalDetailsList, Policy, PolicyEmployeeList, PolicyTagLists, Report, Transaction} from '@src/types/onyx';
+import type {PersonalDetailsList, Policy, PolicyEmployeeList, PolicyTagLists, PolicyTags, Report, Transaction} from '@src/types/onyx';
 import type {Connections, QBONonReimbursableExportAccountType, SageIntacctExportConfig} from '@src/types/onyx/Policy';
 
 import type {OnyxCollection, OnyxEntry, OnyxMultiSetInput} from 'react-native-onyx';
@@ -1444,6 +1446,48 @@ describe('PolicyUtils', () => {
             expect(getTagGLCode(tagListsWithNumberGLCode, 'Engineering')).toBe('1234');
         });
     });
+
+    describe('getGLCodeFromPolicyTag', () => {
+        it('returns empty string when tag is undefined', () => {
+            expect(getGLCodeFromPolicyTag(undefined)).toBe('');
+        });
+
+        it('returns empty string when tag has no GL code', () => {
+            expect(getGLCodeFromPolicyTag({})).toBe('');
+        });
+
+        it('returns stripped GL code from tag', () => {
+            expect(getGLCodeFromPolicyTag({'GL Code': '"1234"'})).toBe('1234');
+        });
+    });
+
+    describe('getPolicyTagGLCode', () => {
+        const tags: PolicyTags = {
+            Engineering: {name: 'Engineering', enabled: true, 'GL Code': '1234'},
+            Marketing: {name: 'Marketing', enabled: true},
+        };
+
+        it('returns empty string when tags or tag name is missing', () => {
+            expect(getPolicyTagGLCode(undefined, 'Engineering')).toBe('');
+            expect(getPolicyTagGLCode(tags, undefined)).toBe('');
+        });
+
+        it('returns GL code for matching tag', () => {
+            expect(getPolicyTagGLCode(tags, 'Engineering')).toBe('1234');
+        });
+
+        it('returns empty string when tag has no GL code', () => {
+            expect(getPolicyTagGLCode(tags, 'Marketing')).toBe('');
+        });
+
+        it('strips wrapping quotes from GL code', () => {
+            const quotedTags: PolicyTags = {
+                Engineering: {name: 'Engineering', enabled: true, 'GL Code': '"5678"'},
+            };
+            expect(getPolicyTagGLCode(quotedTags, 'Engineering')).toBe('5678');
+        });
+    });
+
     describe('sortWorkspacesBySelected', () => {
         it('should order workspaces with selected workspace first', () => {
             const workspace1 = {policyID: '1', name: 'Workspace 1'};

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -41,7 +41,6 @@ import {
     getTagApproverRule,
     getTagGLCode,
     getGLCodeFromPolicyTag,
-    getPolicyTagGLCode,
     getTagList,
     getTagListByOrderWeight,
     getUberConnectionErrorDirectlyFromPolicy,
@@ -75,7 +74,7 @@ import {isWorkspaceEligibleForReportChange} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {PersonalDetailsList, Policy, PolicyEmployeeList, PolicyTagLists, PolicyTags, Report, Transaction} from '@src/types/onyx';
+import type {PersonalDetailsList, Policy, PolicyEmployeeList, PolicyTagLists, Report, Transaction} from '@src/types/onyx';
 import type {Connections, QBONonReimbursableExportAccountType, SageIntacctExportConfig} from '@src/types/onyx/Policy';
 
 import type {OnyxCollection, OnyxEntry, OnyxMultiSetInput} from 'react-native-onyx';
@@ -1458,33 +1457,6 @@ describe('PolicyUtils', () => {
 
         it('returns stripped GL code from tag', () => {
             expect(getGLCodeFromPolicyTag({'GL Code': '"1234"'})).toBe('1234');
-        });
-    });
-
-    describe('getPolicyTagGLCode', () => {
-        const tags: PolicyTags = {
-            Engineering: {name: 'Engineering', enabled: true, 'GL Code': '1234'},
-            Marketing: {name: 'Marketing', enabled: true},
-        };
-
-        it('returns empty string when tags or tag name is missing', () => {
-            expect(getPolicyTagGLCode(undefined, 'Engineering')).toBe('');
-            expect(getPolicyTagGLCode(tags, undefined)).toBe('');
-        });
-
-        it('returns GL code for matching tag', () => {
-            expect(getPolicyTagGLCode(tags, 'Engineering')).toBe('1234');
-        });
-
-        it('returns empty string when tag has no GL code', () => {
-            expect(getPolicyTagGLCode(tags, 'Marketing')).toBe('');
-        });
-
-        it('strips wrapping quotes from GL code', () => {
-            const quotedTags: PolicyTags = {
-                Engineering: {name: 'Engineering', enabled: true, 'GL Code': '"5678"'},
-            };
-            expect(getPolicyTagGLCode(quotedTags, 'Engineering')).toBe('5678');
         });
     });
 

--- a/tests/unit/TagsOptionsListUtilsTest.ts
+++ b/tests/unit/TagsOptionsListUtilsTest.ts
@@ -959,12 +959,11 @@ describe('TagsOptionsListUtils', () => {
     });
 
     describe('getTagListSections GL code display', () => {
-        /* eslint-disable @typescript-eslint/naming-convention -- PolicyTag GL Code field uses backend naming */
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- PolicyTag GL Code field uses backend naming
         const tagsWithGLCode: Record<string, {name: string; enabled: boolean; 'GL Code'?: string}> = {
-            ProjectA: {name: 'Project A', enabled: true, 'GL Code': 'SP4100'},
+            ProjectA: {name: 'Project A', enabled: true, 'GL Code': 'SP4100'}, // eslint-disable-line @typescript-eslint/naming-convention
             ProjectB: {name: 'Project B', enabled: true},
         };
-        /* eslint-enable @typescript-eslint/naming-convention */
 
         it('sets alternateText when shouldShowGLCode is true and tag has a GL code', () => {
             const result = getTagListSections({

--- a/tests/unit/TagsOptionsListUtilsTest.ts
+++ b/tests/unit/TagsOptionsListUtilsTest.ts
@@ -957,4 +957,69 @@ describe('TagsOptionsListUtils', () => {
             expect(result).toEqual([]);
         });
     });
+
+    describe('getTagListSections GL code display', () => {
+        /* eslint-disable @typescript-eslint/naming-convention -- PolicyTag GL Code field uses backend naming */
+        const tagsWithGLCode: Record<string, {name: string; enabled: boolean; 'GL Code'?: string}> = {
+            ProjectA: {name: 'Project A', enabled: true, 'GL Code': 'SP4100'},
+            ProjectB: {name: 'Project B', enabled: true},
+        };
+        /* eslint-enable @typescript-eslint/naming-convention */
+
+        it('sets alternateText when shouldShowGLCode is true and tag has a GL code', () => {
+            const result = getTagListSections({
+                searchValue: '',
+                tags: tagsWithGLCode,
+                localeCompare,
+                translate: translateLocal,
+                shouldShowGLCode: true,
+            });
+
+            const projectA = result.at(0)?.data.find((option) => option.keyForList === 'Project A');
+            const projectB = result.at(0)?.data.find((option) => option.keyForList === 'Project B');
+
+            expect(projectA?.alternateText).toBe('SP4100');
+            expect(projectA?.text).toBe('Project A');
+            expect(projectA?.searchText).toBe('Project A');
+            expect(projectB?.alternateText).toBeUndefined();
+        });
+
+        it('does not set alternateText when shouldShowGLCode is false', () => {
+            const result = getTagListSections({
+                searchValue: '',
+                tags: tagsWithGLCode,
+                localeCompare,
+                translate: translateLocal,
+                shouldShowGLCode: false,
+            });
+
+            const projectA = result.at(0)?.data.find((option) => option.keyForList === 'Project A');
+            expect(projectA?.alternateText).toBeUndefined();
+        });
+
+        it('finds tags by GL code when shouldShowGLCode is true', () => {
+            const result = getTagListSections({
+                searchValue: 'SP4100',
+                tags: tagsWithGLCode,
+                localeCompare,
+                translate: translateLocal,
+                shouldShowGLCode: true,
+            });
+
+            expect(result.at(0)?.data).toHaveLength(1);
+            expect(result.at(0)?.data.at(0)?.keyForList).toBe('Project A');
+        });
+
+        it('does not find tags by GL code when shouldShowGLCode is false', () => {
+            const result = getTagListSections({
+                searchValue: 'SP4100',
+                tags: tagsWithGLCode,
+                localeCompare,
+                translate: translateLocal,
+                shouldShowGLCode: false,
+            });
+
+            expect(result.at(0)?.data).toHaveLength(0);
+        });
+    });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR adds the ability for admins to display tag GL codes when selecting a tag in the tag picker

Changes include:
- Added `showTagGLCodes` policy flag and `SetPolicyShowTagGLCodes` API action with optimistic update / failure rollback
- Added `getGLCodeFromPolicyTag` and `getPolicyTagGLCode` helpers in `PolicyUtils.ts`
- Updated `TagsOptionsListUtils` to render GL codes as `alternateText` (muted second line) and include GL codes in `tokenizedSearch`
- Updated `TagPicker` to read `!!policy?.showTagGLCodes && !!policy?.glCodes` and pass `shouldShowGLCode` down
- Added "Show GL codes when selecting a tag" toggle in `WorkspaceTagsSettingsPage`, gated on `policy.glCodes`
- Added unit tests in `PolicyTagTest`, `PolicyUtilsTest`, and `TagsOptionsListUtilsTest`

**Backend dependency:** This PR requires a backend `SetPolicyShowTagGLCodes` command (same pattern as category GL codes). Until the backend is deployed, toggling the setting on will optimistically show GL codes briefly, then roll back with an error when the API call fails.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/96390
PROPOSAL: https://github.com/Expensify/App/issues/96390#issuecomment-5008506432

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open a workspace that has GL codes enabled and tags with GL codes configured (e.g. a project tag like "Sunshine Project" with GL code "SP4100")
2. Go to **Workspace > Tags > Settings**
3. Verify the **Show GL codes when selecting a tag** toggle is visible (only when `policy.glCodes` is enabled)
4. Turn the toggle **ON** (note: will roll back with error until backend `SetPolicyShowTagGLCodes` is deployed; GL codes still appear optimistically for a few seconds)
5. Create or edit an expense and open the tag picker
6. Verify each tag shows its GL code as a muted second line below the tag name (e.g. "Sunshine Project" / "SP4100")
7. Search for a GL code (e.g. "SP4100") and verify matching tags appear
8. Select a tag and confirm the expense saves with the correct tag name
9. Turn the toggle **OFF** and verify GL codes no longer appear in the tag picker
10. Verify tag picker behavior is unchanged when the toggle is off or when the workspace has no GL codes enabled

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Go offline
2. Toggle **Show GL codes when selecting a tag** ON in workspace tag settings
3. Verify the toggle updates optimistically while offline
4. Open the tag picker and verify GL codes display from local policy data
5. Go back online and verify the pending state clears (or shows error if backend endpoint is not yet deployed)

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
1. Log in as a workspace admin on a Control workspace with GL codes and tags configured
2. Navigate to **Workspace > Tags > Settings**
3. Confirm **Show GL codes when selecting a tag** toggle appears when GL codes are enabled for the workspace
4. Enable the toggle and create/edit an expense
5. Open the tag picker and confirm GL codes appear as a second muted line under each tag name
6. Search by GL code and confirm matching tags are returned
7. Select a tag and confirm the expense is tagged correctly
8. Disable the toggle and confirm GL codes no longer appear in the picker
9. Verify no regressions in tag selection for workspaces without GL codes or with the toggle disabled

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/73c19003-5ef0-48c6-a090-8c8d29646307


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/619d0fd5-39e7-41bb-b19f-05ef86165822

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/ee57ea6d-1158-4667-ad30-077aa1c90a7e


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/82db7a4f-5fef-462d-af54-c5642c598aeb



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

GL codes toggle and alt text preview

https://github.com/user-attachments/assets/9184d492-b957-4239-8327-5557485382dd

Gl codes in spend inline edit popover as well

<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/9874f082-e101-4d63-aedd-ae680dda4bb7" />

</details>