### PR TITLE
Extract authToken from gap-deferred sign-in while OpenApp is in-flight

### DIFF
--- a/src/libs/actions/OnyxUpdateManager/index.ts
+++ b/src/libs/actions/OnyxUpdateManager/index.ts
@@ -157,6 +157,10 @@ function handleMissingOnyxUpdates<TKey extends OnyxKey>(onyxUpdatesFromServer: O
         // If one of these onyx updates is for the authToken, update it now because our current authToken is probably invalid.
         updateAuthTokenIfNecessary(onyxUpdatesFromServer);
 
+        // Nothing reads this key again once we return, but it is persisted, so a restart would replay it and
+        // could write a now-stale authToken over a newer session. Drop the consumed copy.
+        Onyx.set(ONYXKEYS.ONYX_UPDATES_FROM_SERVER, null);
+
         // When ONYX_UPDATES_FROM_SERVER is set, we pause the queue. Let's unpause
         // it so the app is not stuck forever without processing requests.
         unpauseSequentialQueue();

--- a/src/libs/actions/OnyxUpdateManager/index.ts
+++ b/src/libs/actions/OnyxUpdateManager/index.ts
@@ -154,6 +154,9 @@ function handleMissingOnyxUpdates<TKey extends OnyxKey>(onyxUpdatesFromServer: O
     // we don't have base state of the app (reports, policies, etc.) setup. If we apply this update,
     // we'll only have them overwritten by the openApp response. So let's skip it and return.
     if (isLoadingApp) {
+        // If one of these onyx updates is for the authToken, update it now because our current authToken is probably invalid.
+        updateAuthTokenIfNecessary(onyxUpdatesFromServer);
+
         // When ONYX_UPDATES_FROM_SERVER is set, we pause the queue. Let's unpause
         // it so the app is not stuck forever without processing requests.
         unpauseSequentialQueue();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

When a stale, gap-behind client returns to NewDot via an OldDot→NewDot `/transition?...&shortLivedAuthToken=...` link, the app can get stuck on an endless loading spinner with every request returning 407, and the user is never logged out.

Root cause is a single branch in `handleMissingOnyxUpdates` (`src/libs/actions/OnyxUpdateManager/index.ts`):

If user:
- has expired session locally AND
- has gap in data (missing onyx updates) AND
- has `session.signedInWithShortLivedAuthToken` set as true

1. On transition the app calls `OpenApp` with the **expired** persisted authToken, which sets `isLoadingApp: true`.
2. `SignInWithShortLivedAuthToken` returns `200` with the **fresh authToken**, but because the client is behind on updates, that response is **gap-deferred** into `ONYX_UPDATES_FROM_SERVER` instead of applied inline.
3. The deferred response reaches `handleMissingOnyxUpdates` **while `OpenApp` is still in-flight** (`isLoadingApp === true`), so it hits the `if (isLoadingApp)` early-return **before** `updateAuthTokenIfNecessary` ever runs. The fresh authToken is skipped, and this pass runs only once — nothing retries it.
4. `OpenApp` then 407s (expired token) and its `isLoadingApp: false` clear is discarded on the failed-reauth path, so the loader stays up. Every subsequent read / Pusher connection 407s and is aborted by the short-lived-token reauth guard → endless loading, no logout.

The deadlock: `OpenApp` needs a valid token to finish and clear `isLoadingApp`, but the fresh token can't be applied while `isLoadingApp` is true.


https://github.com/user-attachments/assets/a0d7e18f-e91f-4428-bf4a-d9d675ffd4b4


**Fix:** extract the authToken even when the deferred update body is skipped. In the `if (isLoadingApp)` branch, call `updateAuthTokenIfNecessary(onyxUpdatesFromServer)` before the early-return. This still skips applying the update body while `OpenApp` is in-flight (base state isn't ready yet — the original reason for the branch), but it lets a gap-deferred `SignInWithShortLivedAuthToken` response hand over its fresh authToken.
 Once the token lands, the app's OpenApp retry succeeds and loading completes normally.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/96848
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

**Pre-condition:**
Login to the same account:
- in Browser 1 - new dot
- in Browser 2 - new dot
- in Browser 1 - old dot

1. Open the app from browser 1 (ND)
2. Open troubleshoot menu
3. In console, run `Onyx.merge('session', {signedInWithShortLivedAuthToken: true})`
4. In troubleshoot menu Authentication status -> tap `Invalidate` and close the app right away
5. Open app in Browser 2. Do some activity, send some messages.
6. Go back to Browser 1,  from OldDot, transition to NewDot via a `/transition?...&shortLivedAuthToken=...` link.
7. Verify the app loads instead of getting stuck on an endless loading spinner. In logs you should see `[OnyxUpdateManager] Found an authToken update while handling an Onyx update gap. Updating the authToken.`

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same, as in the **Tests** section

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

Same, as in the **Tests** section

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/b61bf3ac-bf1a-4d7d-8914-93e9fcc40941



</details>
