### PR TITLE
Advance lastUpdateID for WRITE requests only after the deferred flush applies

### DIFF
--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -14,7 +14,7 @@ import type {Merge} from 'type-fest';
 
 import Onyx from 'react-native-onyx';
 
-import {queueOnyxUpdates} from './QueuedOnyxUpdates';
+import {getCurrentFlushPromise, queueOnyxUpdates} from './QueuedOnyxUpdates';
 
 // This key needs to be separate from ONYXKEYS.ONYX_UPDATES_FROM_SERVER so that it can be updated without triggering the callback when the server IDs are updated. If that
 // callback were triggered it would lead to duplicate processing of server updates.
@@ -194,7 +194,16 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
             });
 
     if (type === CONST.ONYX_UPDATE_TYPES.HTTPS && request && response) {
-        return advanceLastUpdateIDAfterApply(applyHTTPSOnyxUpdates(request, response, Number(lastUpdateID)));
+        const applyPromise = applyHTTPSOnyxUpdates(request, response, Number(lastUpdateID));
+
+        // WRITE requests only stage their updates in memory here — the real Onyx write happens later in
+        // QueuedOnyxUpdates.flushQueue(). Gate the watermark on that flush, but detached from the returned promise:
+        // SequentialQueue only flushes after this promise settles, so awaiting the flush here would deadlock.
+        if (request.data?.apiRequestType === CONST.API_REQUEST_TYPE.WRITE) {
+            advanceLastUpdateIDAfterApply(applyPromise.then(() => getCurrentFlushPromise())).catch(() => {});
+            return applyPromise;
+        }
+        return advanceLastUpdateIDAfterApply(applyPromise);
     }
     if (type === CONST.ONYX_UPDATE_TYPES.PUSHER && updates) {
         return advanceLastUpdateIDAfterApply(applyPusherOnyxUpdates(updates, Number(lastUpdateID)));

--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -20,6 +20,10 @@ import {getCurrentFlushPromise, queueOnyxUpdates} from './QueuedOnyxUpdates';
 // callback were triggered it would lead to duplicate processing of server updates.
 let lastUpdateIDAppliedToClient: number | undefined = 0;
 
+// Highest update ID staged for the deferred WRITE flush but not yet persisted. Gap detection treats these as
+// applied so queued WRITE responses don't look like gaps; reset if the flush fails so recovery can kick in.
+let lastUpdateIDPendingFlush = 0;
+
 // We have used `connectWithoutView` here because OnyxUpdates is not connected to any UI
 Onyx.connectWithoutView({
     key: ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT,
@@ -133,7 +137,10 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
 function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, updates}: OnyxUpdatesFromServer<TKey>): Promise<void | Response<TKey>> | undefined {
     Log.info(`[OnyxUpdateManager] Applying update type: ${type} with lastUpdateID: ${lastUpdateID}`, false, {command: request?.command});
 
-    const isUpdateOld = lastUpdateID && lastUpdateIDAppliedToClient && Number(lastUpdateID) <= lastUpdateIDAppliedToClient;
+    // Updates staged for the deferred WRITE flush count as applied for ordering purposes, otherwise they would
+    // get re-staged (and reapplied on flush) if the same update ID arrives again while the flush is pending.
+    const effectiveLastUpdateID = Math.max(lastUpdateIDAppliedToClient ?? 0, lastUpdateIDPendingFlush);
+    const isUpdateOld = lastUpdateID && effectiveLastUpdateID && Number(lastUpdateID) <= effectiveLastUpdateID;
     const isOpenAppRequest = request?.command === WRITE_COMMANDS.OPEN_APP;
     const isFullReconnectRequest = request?.command === SIDE_EFFECT_REQUEST_COMMANDS.RECONNECT_APP && !request?.data?.updateIDFrom;
 
@@ -178,6 +185,10 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
                     lastUpdateIDAppliedToClient = Number(lastUpdateID);
                     Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, Number(lastUpdateID));
                 }
+                // The persisted watermark now covers the staged WRITE updates, so the pending marker is no longer needed
+                if (lastUpdateIDPendingFlush && lastUpdateIDPendingFlush <= Number(lastUpdateID)) {
+                    lastUpdateIDPendingFlush = 0;
+                }
                 return result;
             })
             .catch((error) => {
@@ -200,7 +211,14 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
         // QueuedOnyxUpdates.flushQueue(). Gate the watermark on that flush, but detached from the returned promise:
         // SequentialQueue only flushes after this promise settles, so awaiting the flush here would deadlock.
         if (request.data?.apiRequestType === CONST.API_REQUEST_TYPE.WRITE) {
-            advanceLastUpdateIDAfterApply(applyPromise.then(() => getCurrentFlushPromise())).catch(() => {});
+            if (shouldAdvanceLastUpdateID) {
+                lastUpdateIDPendingFlush = Math.max(lastUpdateIDPendingFlush, Number(lastUpdateID));
+            }
+            advanceLastUpdateIDAfterApply(applyPromise.then(() => getCurrentFlushPromise())).catch(() => {
+                // The staged updates never applied, so stop counting them as pending — the next gap check
+                // then sees the missing range against the persisted watermark and triggers recovery.
+                lastUpdateIDPendingFlush = 0;
+            });
             return applyPromise;
         }
         return advanceLastUpdateIDAfterApply(applyPromise);
@@ -247,7 +265,9 @@ function doesClientNeedToBeUpdated({previousUpdateID, clientLastUpdateID}: DoesC
         return false;
     }
 
-    const lastUpdateIDFromClient = clientLastUpdateID ?? lastUpdateIDAppliedToClient;
+    // Updates staged for the deferred WRITE flush count as applied here, otherwise the responses of queued
+    // WRITE requests would look like gaps until the flush runs and needlessly pause the queue to refetch.
+    const lastUpdateIDFromClient = Math.max(clientLastUpdateID ?? lastUpdateIDAppliedToClient ?? 0, lastUpdateIDPendingFlush);
 
     // If we don't have any value in lastUpdateIDFromClient, this is the first time we're receiving anything, so we need to do a last reconnectApp
     if (!lastUpdateIDFromClient) {

--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -27,7 +27,15 @@ let lastUpdateIDPendingFlush = 0;
 // We have used `connectWithoutView` here because OnyxUpdates is not connected to any UI
 Onyx.connectWithoutView({
     key: ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT,
-    callback: (val) => (lastUpdateIDAppliedToClient = val),
+    callback: (val) => {
+        lastUpdateIDAppliedToClient = val;
+
+        // The persisted watermark is only ever cleared by Onyx.clear (sign-out), so drop the pending marker
+        // too — a stale value from the previous session would mask real gaps after signing back in.
+        if (val === undefined) {
+            lastUpdateIDPendingFlush = 0;
+        }
+    },
 });
 
 // This promise is used to ensure pusher events are always processed in the order they are received,

--- a/src/libs/actions/QueuedOnyxUpdates.ts
+++ b/src/libs/actions/QueuedOnyxUpdates.ts
@@ -13,6 +13,12 @@ import Onyx from 'react-native-onyx';
 let queuedOnyxUpdates: AnyOnyxUpdate[] = [];
 let currentAccountID: number | undefined;
 
+// Queued WRITE updates only land in Onyx when flushQueue() runs, so we track a promise that settles with that
+// flush. OnyxUpdates.apply uses it to hold the lastUpdateID watermark back until the data is actually applied.
+let flushPromise: Promise<void> | null = null;
+let resolveFlushPromise: (() => void) | undefined;
+let rejectFlushPromise: ((error: unknown) => void) | undefined;
+
 // We use `connectWithoutView` because it is not connected to any UI component.
 Onyx.connectWithoutView({
     key: ONYXKEYS.SESSION,
@@ -27,14 +33,36 @@ Onyx.connectWithoutView({
 function queueOnyxUpdates<TKey extends OnyxKey>(updates: Array<OnyxUpdate<TKey>>): Promise<void> {
     queuedOnyxUpdates = queuedOnyxUpdates.concat(updates);
 
+    if (!flushPromise) {
+        flushPromise = new Promise<void>((resolve, reject) => {
+            resolveFlushPromise = resolve;
+            rejectFlushPromise = reject;
+        });
+        // Not every queued batch has a watermark waiting on it, so keep a no-op handler to avoid unhandled rejections.
+        flushPromise.catch(() => {});
+    }
+
     return Promise.resolve();
+}
+
+/**
+ * Returns a promise that settles when the currently queued updates are flushed to Onyx, or an already-resolved
+ * promise when nothing is queued.
+ */
+function getCurrentFlushPromise(): Promise<void> {
+    return flushPromise ?? Promise.resolve();
 }
 
 function flushQueue(): Promise<void> {
     let copyUpdates = [...queuedOnyxUpdates];
+    const resolveCurrentFlush = resolveFlushPromise;
+    const rejectCurrentFlush = rejectFlushPromise;
 
     // Clear queue immediately to prevent race conditions with new updates during Onyx processing
     queuedOnyxUpdates = [];
+    flushPromise = null;
+    resolveFlushPromise = undefined;
+    rejectFlushPromise = undefined;
 
     if (!currentAccountID && !CONFIG.IS_TEST_ENV) {
         const preservedKeys = new Set<OnyxKey>([
@@ -57,18 +85,21 @@ function flushQueue(): Promise<void> {
 
         copyUpdates = copyUpdates.filter((update) => preservedKeys.has(update.key as OnyxKey));
     }
-    // WRITE requests queue their updates here and advance the lastUpdateID watermark before this deferred flush runs.
-    // If the flush fails the updates are lost while the client already claims to be caught up, so surface it in Sentry.
-    return Onyx.update(copyUpdates).catch((error: unknown) => {
-        Log.alert('[OnyxUpdateManagerError] Deferred WRITE Onyx update failed to apply after the watermark advanced, the updates may be lost', {
-            error: error instanceof Error ? error.message : String(error),
+    // WRITE requests gate their lastUpdateID watermark advance on this flush (see OnyxUpdates.apply), so a
+    // failure here keeps the watermark back and the next reconnect refetches and reapplies the missed updates.
+    return Onyx.update(copyUpdates)
+        .then(() => resolveCurrentFlush?.())
+        .catch((error: unknown) => {
+            Log.alert('[OnyxUpdateManagerError] Deferred WRITE Onyx update failed to apply, not advancing lastUpdateID so the client can recover on the next reconnect', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+            rejectCurrentFlush?.(error);
+            throw error;
         });
-        throw error;
-    });
 }
 
 function isEmpty() {
     return queuedOnyxUpdates.length === 0;
 }
 
-export {queueOnyxUpdates, flushQueue, isEmpty};
+export {queueOnyxUpdates, flushQueue, getCurrentFlushPromise, isEmpty};

--- a/src/libs/actions/QueuedOnyxUpdates.ts
+++ b/src/libs/actions/QueuedOnyxUpdates.ts
@@ -86,7 +86,7 @@ function flushQueue(): Promise<void> {
         copyUpdates = copyUpdates.filter((update) => preservedKeys.has(update.key as OnyxKey));
     }
     // WRITE requests gate their lastUpdateID watermark advance on this flush (see OnyxUpdates.apply), so a
-    // failure here keeps the watermark back and the next reconnect refetches and reapplies the missed updates.
+    // failure here keeps the watermark back and the next reconnect can refetch and reapply the missed updates.
     return Onyx.update(copyUpdates)
         .then(() => resolveCurrentFlush?.())
         .catch((error: unknown) => {

--- a/tests/unit/OnyxUpdatesTest.ts
+++ b/tests/unit/OnyxUpdatesTest.ts
@@ -229,6 +229,64 @@ describe('OnyxUpdatesTest', () => {
         updateSpy.mockRestore();
     });
 
+    it('does not report a gap for updates staged for the deferred WRITE flush', async () => {
+        // Given the client is caught up to update 10
+        await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);
+        await waitForBatchedUpdates();
+
+        // When we apply a WRITE update (lastUpdateID 20) whose updates are only staged for the deferred flush
+        await OnyxUpdates.apply({
+            type: CONST.ONYX_UPDATE_TYPES.HTTPS,
+            previousUpdateID: 10,
+            lastUpdateID: 20,
+            request: {command: 'AddComment', data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE}},
+            response: {
+                jsonCode: 200,
+                onyxData: [{onyxMethod: 'merge', key: `${ONYXKEYS.COLLECTION.REPORT}${NumberUtils.rand64()}`, value: {}}],
+            },
+        });
+        await waitForBatchedUpdates();
+
+        // Then a following response chained on update 20 is not treated as a gap, even though the
+        // persisted watermark is still at 10 — otherwise every queued WRITE would pause the queue
+        expect(OnyxUpdates.doesClientNeedToBeUpdated({previousUpdateID: 20})).toBe(false);
+
+        // And once the flush applies the staged updates, the persisted watermark catches up
+        await flushQueue();
+        await waitForBatchedUpdates();
+        const lastUpdateID = await getOnyxValue(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT);
+        expect(lastUpdateID).toBe(20);
+    });
+
+    it('resumes gap detection when the deferred WRITE flush fails', async () => {
+        // Given the client is caught up to update 10
+        await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);
+        await waitForBatchedUpdates();
+
+        // And a WRITE update (lastUpdateID 20) whose updates are staged for the deferred flush
+        await OnyxUpdates.apply({
+            type: CONST.ONYX_UPDATE_TYPES.HTTPS,
+            previousUpdateID: 10,
+            lastUpdateID: 20,
+            request: {command: 'AddComment', data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE}},
+            response: {
+                jsonCode: 200,
+                onyxData: [{onyxMethod: 'merge', key: `${ONYXKEYS.COLLECTION.REPORT}${NumberUtils.rand64()}`, value: {}}],
+            },
+        });
+        await waitForBatchedUpdates();
+
+        // When the deferred flush fails to apply the staged updates
+        const updateSpy = jest.spyOn(Onyx, 'update').mockRejectedValueOnce(new Error('storage write failed'));
+        await expect(flushQueue()).rejects.toThrow('storage write failed');
+        await waitForBatchedUpdates();
+
+        // Then the staged updates no longer count as applied, so the gap is detected and recovery can refetch them
+        expect(OnyxUpdates.doesClientNeedToBeUpdated({previousUpdateID: 20})).toBe(true);
+
+        updateSpy.mockRestore();
+    });
+
     it('does not move the watermark backwards when a slower older update settles after a newer one', async () => {
         // Given the client is caught up to update 10
         await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);

--- a/tests/unit/OnyxUpdatesTest.ts
+++ b/tests/unit/OnyxUpdatesTest.ts
@@ -2,6 +2,7 @@ import {SIDE_EFFECT_REQUEST_COMMANDS} from '@libs/API/types';
 
 import CONST from '@src/CONST';
 import * as OnyxUpdates from '@src/libs/actions/OnyxUpdates';
+import {flushQueue} from '@src/libs/actions/QueuedOnyxUpdates';
 import DateUtils from '@src/libs/DateUtils';
 import * as NumberUtils from '@src/libs/NumberUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -153,6 +154,72 @@ describe('OnyxUpdatesTest', () => {
                 },
             }),
         ).rejects.toThrow('storage write failed');
+        await waitForBatchedUpdates();
+
+        // Then the watermark is not advanced, so the next reconnect can refetch and reapply the missed updates
+        const lastUpdateID = await getOnyxValue(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT);
+        expect(lastUpdateID).toBe(10);
+
+        updateSpy.mockRestore();
+    });
+
+    it('advances lastUpdateID for WRITE requests only after the queued updates are flushed', async () => {
+        // Given the client is caught up to update 10
+        await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);
+        await waitForBatchedUpdates();
+
+        const reportID = NumberUtils.rand64();
+        const reportValue = {reportID};
+
+        // When we apply a newer WRITE update (lastUpdateID 20), which only queues the updates in memory
+        await OnyxUpdates.apply({
+            type: CONST.ONYX_UPDATE_TYPES.HTTPS,
+            previousUpdateID: 10,
+            lastUpdateID: 20,
+            request: {command: 'AddComment', data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE}},
+            response: {
+                jsonCode: 200,
+                onyxData: [{onyxMethod: 'merge', key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`, value: reportValue}],
+            },
+        });
+        await waitForBatchedUpdates();
+
+        // Then the watermark does not advance yet — the updates are only queued, not applied
+        let lastUpdateID = await getOnyxValue(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT);
+        expect(lastUpdateID).toBe(10);
+
+        // When the sequential queue flushes the queued updates
+        await flushQueue();
+        await waitForBatchedUpdates();
+
+        // Then the updates are applied and the watermark advances to 20
+        const report = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+        lastUpdateID = await getOnyxValue(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT);
+        expect(report).toStrictEqual(reportValue);
+        expect(lastUpdateID).toBe(20);
+    });
+
+    it('does not advance lastUpdateID for WRITE requests when the deferred flush fails', async () => {
+        // Given the client is caught up to update 10
+        await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);
+        await waitForBatchedUpdates();
+
+        // When we apply a newer WRITE update (lastUpdateID 20), which only queues the updates in memory
+        await OnyxUpdates.apply({
+            type: CONST.ONYX_UPDATE_TYPES.HTTPS,
+            previousUpdateID: 10,
+            lastUpdateID: 20,
+            request: {command: 'AddComment', data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE}},
+            response: {
+                jsonCode: 200,
+                onyxData: [{onyxMethod: 'merge', key: `${ONYXKEYS.COLLECTION.REPORT}${NumberUtils.rand64()}`, value: {}}],
+            },
+        });
+        await waitForBatchedUpdates();
+
+        // And the deferred flush fails to apply the queued updates (e.g. a storage write error)
+        const updateSpy = jest.spyOn(Onyx, 'update').mockRejectedValueOnce(new Error('storage write failed'));
+        await expect(flushQueue()).rejects.toThrow('storage write failed');
         await waitForBatchedUpdates();
 
         // Then the watermark is not advanced, so the next reconnect can refetch and reapply the missed updates

--- a/tests/unit/OnyxUpdatesTest.ts
+++ b/tests/unit/OnyxUpdatesTest.ts
@@ -287,6 +287,34 @@ describe('OnyxUpdatesTest', () => {
         updateSpy.mockRestore();
     });
 
+    it('clears the pending flush watermark on sign-out', async () => {
+        // Given the client is caught up to update 10 and a WRITE update (lastUpdateID 20) is staged for the deferred flush
+        await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);
+        await waitForBatchedUpdates();
+        await OnyxUpdates.apply({
+            type: CONST.ONYX_UPDATE_TYPES.HTTPS,
+            previousUpdateID: 10,
+            lastUpdateID: 20,
+            request: {command: 'AddComment', data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE}},
+            response: {
+                jsonCode: 200,
+                onyxData: [{onyxMethod: 'merge', key: `${ONYXKEYS.COLLECTION.REPORT}${NumberUtils.rand64()}`, value: {}}],
+            },
+        });
+        await waitForBatchedUpdates();
+        expect(OnyxUpdates.doesClientNeedToBeUpdated({previousUpdateID: 20})).toBe(false);
+
+        // When the user signs out, which clears Onyx storage
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+
+        // Then the pending watermark from the previous session no longer masks gaps in the new session
+        expect(OnyxUpdates.doesClientNeedToBeUpdated({clientLastUpdateID: 5, previousUpdateID: 15})).toBe(true);
+
+        // Drain the staged updates so they don't leak into other tests
+        await flushQueue();
+    });
+
     it('does not move the watermark backwards when a slower older update settles after a newer one', async () => {
         // Given the client is caught up to update 10
         await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);


### PR DESCRIPTION
### Explanation of Change

Follow-up to https://github.com/Expensify/App/pull/96039, which made the `ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT` watermark advance only after the Onyx updates are successfully applied. That fix covered the Pusher, Airship, and READ request paths — but not WRITE requests.

**The gap:** for WRITE requests, `applyHTTPSOnyxUpdates` routes the updates through `queueOnyxUpdates`, which only stages them in an in-memory array and resolves immediately. The real `Onyx.update` happens later, in `QueuedOnyxUpdates.flushQueue()`, after the SequentialQueue drains. Since the watermark was keyed off the queueing promise, it advanced before the data was actually written — and if the deferred flush then failed (e.g. a transient IndexedDB error), the updates were silently lost while the client already claimed to be caught up, so no reconnect would ever refetch them.

The logging-only precursor (https://github.com/Expensify/App/pull/96290) confirmed this happens in production: 172 events over 4 days, ~79% of them transient IndexedDB open/transaction failures that a refetch would recover from (see https://github.com/Expensify/App/pull/96290#issuecomment-5070365357).

**The fix** extends #96039's gating to the deferred WRITE path:

- `QueuedOnyxUpdates` now tracks a flush promise per queued batch, settled by `flushQueue()`'s real `Onyx.update` — resolved on success, rejected on failure. It is exposed via `getCurrentFlushPromise()`.
- `OnyxUpdates.apply()` gates the watermark advance for WRITE requests on that flush promise instead of the immediate queueing promise.
- The gating chain is deliberately detached from `apply()`'s returned promise: `SequentialQueue` only calls `flushQueue()` after the request's middleware promise settles, so awaiting the flush inside `apply()` would deadlock the queue. The returned promise is unchanged for all callers.

Result: if the deferred flush fails, the watermark stays put and the next reconnect refetches and reapplies the missed updates — same recovery semantics #96039 established for the other paths. READ/Pusher/Airship behavior is untouched.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96376
PROPOSAL: https://github.com/Expensify/App/pull/96290#issuecomment-5070365357

### Automated Tests

Two new tests in `tests/unit/OnyxUpdatesTest.ts`:

1. `advances lastUpdateID for WRITE requests only after the queued updates are flushed` — applies a WRITE update, asserts the watermark does **not** advance while the updates are only queued, then asserts it advances to the new ID after `flushQueue()` applies them.
2. `does not advance lastUpdateID for WRITE requests when the deferred flush fails` — applies a WRITE update, makes the deferred `Onyx.update` reject (simulated storage write error), and asserts the watermark stays at its previous value so the next reconnect can recover.

### Tests

1. Sign in and send a message in any chat (a WRITE request).
2. Verify the message appears in the chat normally.
3. Reload the app (refresh the page / reopen the app) and verify the sent message is still there and the chat is up to date.
4. Perform another write action (e.g. add a reaction or edit the message) and verify it applies and persists after another reload.
5. Verify new incoming updates (e.g. a reply from another account) keep arriving as expected afterwards.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline and send a few messages in a chat.
2. Go back online and verify the queued messages send successfully.
3. Reload the app and verify the messages are still there and the chat is up to date.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/103850cd-a8fc-4e04-b44f-5bf6e2421673



</details>
