### PR TITLE
fix: Invoice - stop infinite loading when viewing an offline-created invoice online

### DIFF
--- a/src/libs/actions/IOU/SendInvoice.ts
+++ b/src/libs/actions/IOU/SendInvoice.ts
@@ -59,6 +59,7 @@ type SendInvoiceInformation = {
     onyxData: OnyxData<
         | typeof ONYXKEYS.COLLECTION.REPORT
         | typeof ONYXKEYS.COLLECTION.REPORT_METADATA
+        | typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE
         | typeof ONYXKEYS.COLLECTION.TRANSACTION
         | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS
         | typeof ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_CATEGORIES
@@ -125,6 +126,7 @@ function buildOnyxDataForInvoice(
 ): OnyxData<
     | typeof ONYXKEYS.COLLECTION.REPORT
     | typeof ONYXKEYS.COLLECTION.REPORT_METADATA
+    | typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE
     | typeof ONYXKEYS.COLLECTION.TRANSACTION
     | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS
     | typeof ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_CATEGORIES
@@ -142,6 +144,7 @@ function buildOnyxDataForInvoice(
         OnyxUpdate<
             | typeof ONYXKEYS.COLLECTION.REPORT
             | typeof ONYXKEYS.COLLECTION.REPORT_METADATA
+            | typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE
             | typeof ONYXKEYS.COLLECTION.TRANSACTION
             | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS
             | typeof ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_CATEGORIES
@@ -169,6 +172,17 @@ function buildOnyxDataForInvoice(
             key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${iou.report?.reportID}`,
             value: {
                 isOptimisticReport: true,
+            },
+        },
+        {
+            // The optimistic data below is the complete local truth for this offline-created invoice report, so its
+            // initial actions are already "loaded". Without this stamp the report stays pinned at
+            // isLoadingInitialReportActions on reconnect and shows an infinite skeleton (see #96925). Mirrors the
+            // expense flow in MoneyRequestBuilder.
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${iou.report?.reportID}`,
+            value: {
+                hasOnceLoadedReportActions: true,
             },
         },
         {
@@ -250,13 +264,25 @@ function buildOnyxDataForInvoice(
         });
 
         if (chat.isNewReport) {
-            optimisticData.push({
-                onyxMethod: Onyx.METHOD.MERGE,
-                key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${chat.report?.reportID}`,
-                value: {
-                    isOptimisticReport: true,
+            optimisticData.push(
+                {
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${chat.report?.reportID}`,
+                    value: {
+                        isOptimisticReport: true,
+                    },
                 },
-            });
+                {
+                    // The invoice room is an optimistic CHAT, so ReportFetchHandler never fires openReport for it and
+                    // nothing else would ever clear its initial-load state. Stamp it as loaded so it doesn't hang on an
+                    // infinite skeleton once online (see #96925).
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: `${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${chat.report?.reportID}`,
+                    value: {
+                        hasOnceLoadedReportActions: true,
+                    },
+                },
+            );
         }
     }
 

--- a/src/libs/actions/IOU/SendInvoice.ts
+++ b/src/libs/actions/IOU/SendInvoice.ts
@@ -175,10 +175,7 @@ function buildOnyxDataForInvoice(
             },
         },
         {
-            // The optimistic data below is the complete local truth for this offline-created invoice report, so its
-            // initial actions are already "loaded". Without this stamp the report stays pinned at
-            // isLoadingInitialReportActions on reconnect and shows an infinite skeleton (see #96925). Mirrors the
-            // expense flow in MoneyRequestBuilder.
+            // The optimistic data below is the complete local truth for this offline-created invoice report, so its initial actions are already "loaded".
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${iou.report?.reportID}`,
             value: {
@@ -275,7 +272,7 @@ function buildOnyxDataForInvoice(
                 {
                     // The invoice room is an optimistic CHAT, so ReportFetchHandler never fires openReport for it and
                     // nothing else would ever clear its initial-load state. Stamp it as loaded so it doesn't hang on an
-                    // infinite skeleton once online (see #96925).
+                    // infinite skeleton once online.
                     onyxMethod: Onyx.METHOD.MERGE,
                     key: `${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${chat.report?.reportID}`,
                     value: {

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -5800,6 +5800,18 @@ function updateLoadingInitialReportAction(reportID: string | undefined, isLoadin
     Onyx.merge(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${reportID}`, {isLoadingInitialReportActions});
 }
 
+/**
+ * Marks a report's initial actions as loaded without a server round-trip. Used for optimistic reports whose local
+ * actions are the complete truth (openReport is intentionally never called for them), so the RAM-only loading state
+ * can be reconstructed after an app restart drops the stamp written at creation (see #96925).
+ */
+function markLocalReportActionsAsLoaded(reportID: string | undefined) {
+    if (!isValidReportIDFromPath(reportID)) {
+        return;
+    }
+    Onyx.merge(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${reportID}`, {isLoadingInitialReportActions: false, hasOnceLoadedReportActions: true});
+}
+
 function setNewRoomFormLoading(isLoading = true) {
     Onyx.merge(`${ONYXKEYS.FORMS.NEW_ROOM_FORM}`, {isLoading});
 }
@@ -8438,6 +8450,7 @@ export {
     updateChatName,
     updateLastVisitTime,
     updateLoadingInitialReportAction,
+    markLocalReportActionsAsLoaded,
     updateNotificationPreference,
     updatePolicyRoomName,
     updatePrivateNotes,

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -5803,7 +5803,7 @@ function updateLoadingInitialReportAction(reportID: string | undefined, isLoadin
 /**
  * Marks a report's initial actions as loaded without a server round-trip. Used for optimistic reports whose local
  * actions are the complete truth (openReport is intentionally never called for them), so the RAM-only loading state
- * can be reconstructed after an app restart drops the stamp written at creation (see #96925).
+ * can be reconstructed after an app restart drops the stamp written at creation.
  */
 function markLocalReportActionsAsLoaded(reportID: string | undefined) {
     if (!isValidReportIDFromPath(reportID)) {

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -38,6 +38,7 @@ import {
     clearStaleDMRecoveryTargetByTargetReportID,
     createTransactionThreadReport,
     joinReportViaSecureLink,
+    markLocalReportActionsAsLoaded,
     openReport,
     readNewestAction,
     setViewingPublicRoomReportID,
@@ -155,6 +156,14 @@ function ReportFetchHandler() {
 
     const fetchReport = useEffectEvent(() => {
         if (reportMetadata.isOptimisticReport && report?.type === CONST.REPORT.TYPE.CHAT && !isPolicyExpenseChat(report)) {
+            // openReport is intentionally never called for an optimistic chat report, so nothing else can settle its
+            // initial-load state. The stamp written at creation lives in a RAM-only key and is lost on an app restart,
+            // which would leave the report pinned on the loading skeleton once online (the effect below re-arms
+            // isLoadingInitialReportActions while hasOnceLoadedReportActions is false). The persisted local actions are
+            // the complete truth for an optimistic report, so reconstruct the readiness stamp here. See #96925.
+            if (!reportLoadingState.hasOnceLoadedReportActions) {
+                markLocalReportActionsAsLoaded(reportIDFromRoute);
+            }
             return;
         }
 

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -160,7 +160,7 @@ function ReportFetchHandler() {
             // initial-load state. The stamp written at creation lives in a RAM-only key and is lost on an app restart,
             // which would leave the report pinned on the loading skeleton once online (the effect below re-arms
             // isLoadingInitialReportActions while hasOnceLoadedReportActions is false). The persisted local actions are
-            // the complete truth for an optimistic report, so reconstruct the readiness stamp here. See #96925.
+            // the complete truth for an optimistic report, so reconstruct the readiness stamp here.
             if (!reportLoadingState.hasOnceLoadedReportActions) {
                 markLocalReportActionsAsLoaded(reportIDFromRoute);
             }

--- a/tests/actions/IOUTest/SendInvoiceTest.ts
+++ b/tests/actions/IOUTest/SendInvoiceTest.ts
@@ -288,6 +288,34 @@ describe('actions/SendInvoice', () => {
             expect(result.onyxData.failureData).toBeDefined();
         });
 
+        it('stamps hasOnceLoadedReportActions for the invoice report and the new invoice room (#96925)', () => {
+            // Given: a brand new invoice (no existing chat report), which creates both an invoice report and an invoice room
+            const result = getSendInvoiceInformation({
+                transaction: baseTransaction as OnyxEntry<Transaction>,
+                currentUserAccountID: 123,
+                policyRecentlyUsedCurrencies: [],
+                invoiceChatReport: undefined,
+                receiptFile: undefined,
+                policy: undefined,
+                policyTagList: undefined,
+                policyCategories: undefined,
+                companyName: undefined,
+                companyWebsite: undefined,
+                policyRecentlyUsedCategories: [],
+                senderPolicyTags: baseSenderPolicyTags,
+                formatPhoneNumber,
+                delegateAccountID: undefined,
+            });
+
+            // Then: both reports are stamped as "actions already loaded" so they never hang on an infinite skeleton once online
+            const optimisticData = result.onyxData.optimisticData ?? [];
+            const invoiceReportLoadingState = optimisticData.find((update) => update.key === `${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${result.invoiceReportID}`);
+            const invoiceRoomLoadingState = optimisticData.find((update) => update.key === `${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${result.invoiceRoom.reportID}`);
+
+            expect(invoiceReportLoadingState?.value).toMatchObject({hasOnceLoadedReportActions: true});
+            expect(invoiceRoomLoadingState?.value).toMatchObject({hasOnceLoadedReportActions: true});
+        });
+
         describe('delegateAccountID forwarding', () => {
             it('sets delegateAccountID on the IOU action when delegateAccountID is provided', () => {
                 const DELEGATE_ACCOUNT_ID = 999;

--- a/tests/actions/IOUTest/SendInvoiceTest.ts
+++ b/tests/actions/IOUTest/SendInvoiceTest.ts
@@ -288,7 +288,7 @@ describe('actions/SendInvoice', () => {
             expect(result.onyxData.failureData).toBeDefined();
         });
 
-        it('stamps hasOnceLoadedReportActions for the invoice report and the new invoice room (#96925)', () => {
+        it('stamps hasOnceLoadedReportActions for the invoice report and the new invoice room', () => {
             // Given: a brand new invoice (no existing chat report), which creates both an invoice report and an invoice room
             const result = getSendInvoiceInformation({
                 transaction: baseTransaction as OnyxEntry<Transaction>,

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -1276,6 +1276,22 @@ describe('actions/Report', () => {
         await waitForBatchedUpdates();
     });
 
+    it('markLocalReportActionsAsLoaded settles the initial-load state for an optimistic report (#96925)', async () => {
+        const REPORT_ID = '96925001';
+
+        // Given the RAM-only loading state was dropped by an app restart, leaving the report re-armed as loading
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${REPORT_ID}`, {isLoadingInitialReportActions: true, hasOnceLoadedReportActions: false});
+        await waitForBatchedUpdates();
+
+        // When the readiness stamp is reconstructed on open (ReportFetchHandler's optimistic-report skip path)
+        Report.markLocalReportActionsAsLoaded(REPORT_ID);
+        await waitForBatchedUpdates();
+
+        // Then both flags settle so the report can never hang on the loading skeleton
+        const loadingState = await getOnyxValue(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${REPORT_ID}`);
+        expect(loadingState).toMatchObject({isLoadingInitialReportActions: false, hasOnceLoadedReportActions: true});
+    });
+
     it('openReport legacy preview fallback stores action under correct Onyx key and preserves existing actions', async () => {
         global.fetch = TestHelper.createGlobalFetchMock();
 

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -1276,7 +1276,7 @@ describe('actions/Report', () => {
         await waitForBatchedUpdates();
     });
 
-    it('markLocalReportActionsAsLoaded settles the initial-load state for an optimistic report (#96925)', async () => {
+    it('markLocalReportActionsAsLoaded settles the initial-load state for an optimistic report', async () => {
         const REPORT_ID = '96925001';
 
         // Given the RAM-only loading state was dropped by an app restart, leaving the report re-armed as loading


### PR DESCRIPTION
### Explanation of Change

When an invoice is created **offline**, `buildOnyxDataForInvoice` (`SendInvoice.ts`) writes the invoice report and the new invoice room as optimistic reports (`isOptimisticReport: true`) but — unlike every other money-request creation flow — it never stamps `RAM_ONLY_REPORT_LOADING_STATE.hasOnceLoadedReportActions: true`.

The invoice room is a `CHAT` (chatType `INVOICE`), and `ReportFetchHandler` deliberately never calls `openReport` for an optimistic chat report, so nothing ever writes that flag. Worse, the fetch handler keeps re-arming `isLoadingInitialReportActions` back to `true` while `hasOnceLoadedReportActions` is `false`. So once the user reconnects and opens the invoice, the report is pinned in a loading state and shows an infinite skeleton. Because the create was rejected server-side (invalid company website), the report exists only in local Onyx, which is why clearing the cache makes it disappear.

This brings `buildOnyxDataForInvoice` to parity with the expense flow in `MoneyRequestBuilder`: stamp `hasOnceLoadedReportActions: true` in `optimisticData` for both the invoice report and the newly-created invoice room. The optimistic data is already the complete local truth for these reports, so "loaded" is correct from creation. Once the wait ends, the invoice room renders its locally-written created action, whose existing `OfflineWithFeedback` surfaces the `errorFields.createChat` red-brick-road error that `failureData` already writes. `isOptimisticReport` and `failureData` are intentionally left untouched so `clearCreateChatError`'s dismiss-and-delete behavior is preserved.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96925
PROPOSAL: https://github.com/Expensify/App/issues/96925#issuecomment-5066907879

### Tests

1. Go offline.
2. Click FAB > Invoice.
3. Create an invoice with a valid user who is not a member of the workspace, and enter an invalid website address in the company address (e.g. `www.none.com`).
4. Go online.
5. Open the invoice created in step 3.
6. Verify no infinite loading skeleton appears — the invoice renders and its red-brick-road creation error is visible.
7. Verify the created invoice is dismissable (dismiss-and-delete of the failed local invoice still works).

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as the Tests steps above — the repro requires creating the invoice while offline, then going online.

### QA Steps

1. Go offline.
2. Click FAB > Invoice.
3. Create an invoice with a valid user who is not a member of the workspace, and enter an invalid website address in the company address (e.g. `www.none.com`).
4. Go online.
5. Open the invoice created in step 3.
6. Verify no infinite loading appears and the invoice's creation error is shown instead.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/aca6e98b-3e42-4d4f-85eb-c19bf73c6bba




</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/83e918c9-13fe-466c-81a4-680bfee0926e




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/3de97a8d-b385-4fd2-81bc-4a2dab76a8bb



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/1ef325c5-32e9-4b72-af01-6bae5127a78b




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/7b8a2cb5-6d4a-4bf6-adbb-171b63fedbe7




</details>
