### PR TITLE
Add Travel setup task to Getting Started section

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1090,6 +1090,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: 'Sprechen Sie mit Ihrer Kundenbetreuung',
             forGuidedSetup: 'für die geführte Einrichtung.',
             configureApprovalsSubText: 'Berichtsfreigaben festlegen',
+            setupTravel: 'Reisen einrichten',
+            setupTravelSubText: 'Reisespezifische Regeln konfigurieren',
         },
         freeTrialSection: {
             title: ({days}: {days: number}) => `Kostenlose Testversion: Noch ${days} ${days === 1 ? 'Tag' : 'Tage'}!`,

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1153,6 +1153,8 @@ const translations = {
             linkCompanyCardsSubText: 'Import expenses automatically',
             issueExpensifyCards: 'Issue Expensify cards',
             issueExpensifyCardsSubtitle: 'Customize controls and streamline spending',
+            setupTravel: 'Setup travel',
+            setupTravelSubText: 'Configure travel specific rules',
             configureApprovals: 'Configure approval workflow',
             configureApprovalsSubText: 'Define report approvals',
             setupRules: 'Set up spend rules',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1060,6 +1060,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToConcierge: 'Habla con Concierge',
             forGuidedSetup: 'para la configuración guiada.',
             configureApprovalsSubText: 'Definir aprobaciones de informes',
+            setupTravel: 'Configurar viajes',
+            setupTravelSubText: 'Configura reglas específicas de viaje',
         },
         upcomingTravel: 'Próximos viajes',
         upcomingTravelSection: {

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1106,6 +1106,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: 'Parlez à votre chargé de compte',
             forGuidedSetup: 'pour la configuration guidée.',
             configureApprovalsSubText: 'Définir les approbations de notes de frais',
+            setupTravel: 'Configurer les déplacements',
+            setupTravelSubText: 'Configurer des règles spécifiques aux déplacements',
         },
         yourSpend: {
             title: 'Vos dépenses',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1104,6 +1104,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: 'Parla con il tuo account executive',
             forGuidedSetup: 'per la configurazione guidata.',
             configureApprovalsSubText: 'Definisci le approvazioni dei report',
+            setupTravel: 'Configura viaggi',
+            setupTravelSubText: 'Configura regole specifiche per i viaggi',
         },
         yourSpend: {
             title: 'Le tue spese',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1086,6 +1086,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: 'アカウントエグゼクティブに相談する',
             forGuidedSetup: 'ガイド付きセットアップ用です。',
             configureApprovalsSubText: 'レポート承認を定義する',
+            setupTravel: '出張を設定',
+            setupTravelSubText: '出張用のルールを設定する',
         },
         yourSpend: {
             title: 'あなたの支出',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1102,6 +1102,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: 'Praat met je accountmanager',
             forGuidedSetup: 'voor begeleide installatie.',
             configureApprovalsSubText: 'Definieer rapportgoedkeuringen',
+            setupTravel: 'Reizen instellen',
+            setupTravelSubText: 'Reisspecifieke regels instellen',
         },
         yourSpend: {
             title: 'Je uitgaven',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1100,6 +1100,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: 'Porozmawiaj ze swoim opiekunem klienta',
             forGuidedSetup: 'z prowadzeniem konfiguracji.',
             configureApprovalsSubText: 'Zdefiniuj zatwierdzanie raportów',
+            setupTravel: 'Skonfiguruj podróże',
+            setupTravelSubText: 'Skonfiguruj zasady dotyczące podróży',
         },
         yourSpend: {
             title: 'Twoje wydatki',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1102,6 +1102,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: 'Fale com seu executivo de contas',
             forGuidedSetup: 'para configuração guiada.',
             configureApprovalsSubText: 'Definir aprovações de relatórios',
+            setupTravel: 'Configurar viagem',
+            setupTravelSubText: 'Configurar regras específicas de viagem',
         },
         yourSpend: {
             title: 'Seus gastos',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1069,6 +1069,8 @@ const translations: TranslationDeepObject<typeof en> = {
             talkToAccountExecutive: '联系您的客户经理',
             forGuidedSetup: '以获取引导式设置。',
             configureApprovalsSubText: '定义报表审批',
+            setupTravel: '设置差旅',
+            setupTravelSubText: '配置差旅专用规则',
         },
         yourSpend: {title: '您的支出', awaitingApproval: '等待审批', repaidLast30Days: '过去30天内已偿还', recentTransactions: ({lastFour}: {lastFour: string}) => `最近交易 • ${lastFour}`},
         seeMore: ({count}: {count: number}) => `再查看 ${count} 个`,

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -188,6 +188,16 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             });
         }
 
+        if (policy.isTravelEnabled) {
+            items.push({
+                key: 'setupTravel',
+                label: translate('homePage.gettingStartedSection.setupTravel'),
+                subText: translate('homePage.gettingStartedSection.setupTravelSubText'),
+                isComplete: !!policy.travelSettings?.spotnanaCompanyID,
+                route: ROUTES.WORKSPACE_TRAVEL.getRoute(activePolicyID),
+            });
+        }
+
         const activeMemberCount = Object.values(policy.employeeList ?? {}).filter((member) => member?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE).length;
         items.push({
             key: 'inviteAccountant',
@@ -245,6 +255,16 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             subText: translate('homePage.gettingStartedSection.issueExpensifyCardsSubtitle'),
             isComplete: hasIssuedExpensifyCard,
             route: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(activePolicyID),
+        });
+    }
+
+    if (policy.isTravelEnabled) {
+        items.push({
+            key: 'setupTravel',
+            label: translate('homePage.gettingStartedSection.setupTravel'),
+            subText: translate('homePage.gettingStartedSection.setupTravelSubText'),
+            isComplete: !!policy.travelSettings?.spotnanaCompanyID,
+            route: ROUTES.WORKSPACE_TRAVEL.getRoute(activePolicyID),
         });
     }
 

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -20,6 +20,7 @@ import {
     isPaidGroupPolicy,
     isPendingDeletePolicy,
     isPolicyAdmin,
+    isWorkspaceProvisionedForTravel,
 } from '@libs/PolicyUtils';
 import {generateReportID} from '@libs/ReportUtils';
 import {isDeletedTransaction, isTransactionPendingDelete} from '@libs/TransactionUtils';
@@ -193,7 +194,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
                 key: 'setupTravel',
                 label: translate('homePage.gettingStartedSection.setupTravel'),
                 subText: translate('homePage.gettingStartedSection.setupTravelSubText'),
-                isComplete: !!policy.travelSettings?.spotnanaCompanyID,
+                isComplete: isWorkspaceProvisionedForTravel(policy.travelSettings),
                 route: ROUTES.WORKSPACE_TRAVEL.getRoute(activePolicyID),
             });
         }
@@ -263,7 +264,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             key: 'setupTravel',
             label: translate('homePage.gettingStartedSection.setupTravel'),
             subText: translate('homePage.gettingStartedSection.setupTravelSubText'),
-            isComplete: !!policy.travelSettings?.spotnanaCompanyID,
+            isComplete: isWorkspaceProvisionedForTravel(policy.travelSettings),
             route: ROUTES.WORKSPACE_TRAVEL.getRoute(activePolicyID),
         });
     }

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -1563,13 +1563,13 @@ describe('useGettingStartedItems', () => {
         });
 
         describe('setup travel step', () => {
-            it('should insert setupTravel between customizeCategories and linkCompanyCards when travel is enabled', async () => {
+            it('should insert setupTravel after linkCompanyCards when both travel and company cards are enabled', async () => {
                 await setupTrackWorkspaceScenario({policy: {isTravelEnabled: true, areCompanyCardsEnabled: true}});
 
                 const {result} = renderHook(() => useGettingStartedItems());
 
                 const keys = result.current.items.map((item) => item.key);
-                expect(keys).toEqual(['createWorkspace', 'customizeCategories', 'setupTravel', 'linkCompanyCards', 'inviteAccountant']);
+                expect(keys).toEqual(['createWorkspace', 'customizeCategories', 'linkCompanyCards', 'setupTravel', 'inviteAccountant']);
             });
 
             it('should not show setupTravel when travel is not enabled', async () => {

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -826,6 +826,21 @@ describe('useGettingStartedItems', () => {
             const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
             expect(travelItem?.isComplete).toBe(true);
         });
+
+        it('should be completed once the workspace is provisioned with an associated Spotnana travel domain account (no Spotnana company ID)', async () => {
+            // Real-world Spotnana entity-based provisioning populates associatedTravelDomainAccountID rather
+            // than spotnanaCompanyID, so isComplete must not rely on spotnanaCompanyID alone.
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {isTravelEnabled: true, travelSettings: {associatedTravelDomainAccountID: '12345', hasAcceptedTerms: true}},
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+            expect(travelItem?.isComplete).toBe(true);
+        });
     });
 
     describe('row 4 - Set up spend rules', () => {
@@ -1592,6 +1607,15 @@ describe('useGettingStartedItems', () => {
 
             it('should be completed once the workspace is provisioned with a Spotnana company ID', async () => {
                 await setupTrackWorkspaceScenario({policy: {isTravelEnabled: true, travelSettings: {spotnanaCompanyID: 'spotnana-company-1'}}});
+
+                const {result} = renderHook(() => useGettingStartedItems());
+
+                const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+                expect(travelItem?.isComplete).toBe(true);
+            });
+
+            it('should be completed once the workspace is provisioned with an associated Spotnana travel domain account (no Spotnana company ID)', async () => {
+                await setupTrackWorkspaceScenario({policy: {isTravelEnabled: true, travelSettings: {associatedTravelDomainAccountID: '12345', hasAcceptedTerms: true}}});
 
                 const {result} = renderHook(() => useGettingStartedItems());
 

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -761,6 +761,73 @@ describe('useGettingStartedItems', () => {
         });
     });
 
+    describe('row - Setup travel', () => {
+        it('should be shown when the travel feature is enabled', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {isTravelEnabled: true},
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+            expect(travelItem).toBeDefined();
+        });
+
+        it('should not be shown when the travel feature is not enabled', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {isTravelEnabled: false},
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+            expect(travelItem).toBeUndefined();
+        });
+
+        it('should navigate to the workspace travel route', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {isTravelEnabled: true},
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+            expect(travelItem?.route).toBe(ROUTES.WORKSPACE_TRAVEL.getRoute(POLICY_ID));
+        });
+
+        it('should be not completed when the workspace has not been provisioned with Spotnana', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {isTravelEnabled: true, travelSettings: undefined},
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+            expect(travelItem?.isComplete).toBe(false);
+        });
+
+        it('should be completed once the workspace is provisioned with a Spotnana company ID', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {isTravelEnabled: true, travelSettings: {spotnanaCompanyID: 'spotnana-company-1'}},
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+            await waitForBatchedUpdates();
+
+            const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+            expect(travelItem?.isComplete).toBe(true);
+        });
+    });
+
     describe('row 4 - Set up spend rules', () => {
         it('should be shown when areRulesEnabled is true', async () => {
             await setupManageTeamScenario({
@@ -1492,6 +1559,44 @@ describe('useGettingStartedItems', () => {
 
                 const {result} = renderHook(() => useGettingStartedItems());
                 await waitFor(() => expect(result.current.items.find((item) => item.key === 'linkCompanyCards')?.isComplete).toBe(true));
+            });
+        });
+
+        describe('setup travel step', () => {
+            it('should insert setupTravel between customizeCategories and linkCompanyCards when travel is enabled', async () => {
+                await setupTrackWorkspaceScenario({policy: {isTravelEnabled: true, areCompanyCardsEnabled: true}});
+
+                const {result} = renderHook(() => useGettingStartedItems());
+
+                const keys = result.current.items.map((item) => item.key);
+                expect(keys).toEqual(['createWorkspace', 'customizeCategories', 'setupTravel', 'linkCompanyCards', 'inviteAccountant']);
+            });
+
+            it('should not show setupTravel when travel is not enabled', async () => {
+                await setupTrackWorkspaceScenario({policy: {isTravelEnabled: false}});
+
+                const {result} = renderHook(() => useGettingStartedItems());
+
+                const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+                expect(travelItem).toBeUndefined();
+            });
+
+            it('should navigate to the workspace travel route', async () => {
+                await setupTrackWorkspaceScenario({policy: {isTravelEnabled: true}});
+
+                const {result} = renderHook(() => useGettingStartedItems());
+
+                const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+                expect(travelItem?.route).toBe(ROUTES.WORKSPACE_TRAVEL.getRoute(POLICY_ID));
+            });
+
+            it('should be completed once the workspace is provisioned with a Spotnana company ID', async () => {
+                await setupTrackWorkspaceScenario({policy: {isTravelEnabled: true, travelSettings: {spotnanaCompanyID: 'spotnana-company-1'}}});
+
+                const {result} = renderHook(() => useGettingStartedItems());
+
+                const travelItem = result.current.items.find((item) => item.key === 'setupTravel');
+                expect(travelItem?.isComplete).toBe(true);
             });
         });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Coming from [this slack thread](https://expensify.slack.com/archives/C05S5EV2JTX/p1784939902822259). Admins who turn on the Travel workspace feature (via onboarding or Workspace Settings) but never complete the one-time Spotnana provisioning process are left with Travel "enabled" but never actually usable by their employees, with no reminder to finish setup. This adds a "Setup travel" task to the home screen's Getting Started section, following the same pattern as the existing "Issue Expensify cards" / "Link company cards" rows: it appears once Travel is enabled on the policy, and clears once the workspace is provisioned (`travelSettings.spotnanaCompanyID` set).

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/664889
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

- [ ] Verify that no errors appear in the JS console

### Offline tests


### QA Steps
1. Log in to staging.new.expensify.com as the admin of a workspace that is within its Getting Started window (created less than 60 days ago) and does not have Travel enabled.
2. Go to Settings > Workspaces > [workspace] > More features and enable the Travel toggle.
3. Return to the Home screen.
   - Verify a "Setup travel" task appears in the Getting Started section.
4. Click the "Setup travel" task.
   - Verify it navigates to staging.new.expensify.com/workspaces/[policyID]/travel.
5. Complete the Travel provisioning flow (accept the Spotnana terms) for the workspace.
6. Return to the Home screen.
   - Verify the "Setup travel" task is now marked as complete.
7. Go to Settings > Workspaces > [workspace] > More features and disable the Travel toggle, then re-enable it.
8. Return to the Home screen.
   - Verify the "Setup travel" task reappears in the Getting Started section (same behavior as the existing "Issue Expensify cards" / "Link company cards" tasks). It should be marked as already completed.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<img width="1316" height="956" alt="Screenshot 2026-07-27 at 12 03 18 PM" src="https://github.com/user-attachments/assets/938fd1af-ec56-48cc-bf5c-c4cdcc8b3832" />
<img width="1378" height="957" alt="Screenshot 2026-07-27 at 12 30 23 PM" src="https://github.com/user-attachments/assets/b6ebc319-0012-4aa0-801a-2fcf7787563e" />


