### PR TITLE
[No QA] Show reconciled integrations messages without export-error text

### DIFF
--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -66,6 +66,7 @@ type IntegrationsMessageParams = {
         code?: number;
         messages?: string[];
         title?: string;
+        reconciled?: boolean;
         link?: {
             url: string;
             text: string;

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -2179,6 +2179,11 @@ function getMessageOfOldDotReportAction(translate: LocalizedTranslate, oldDotAct
         case CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE: {
             const {result, label} = originalMessage;
             const errorMessage = result?.messages?.join(', ') ?? '';
+
+            // Reconciled results are informational (the payment already exists in the integration), so show the message without the "failed to export" framing
+            if (result?.reconciled) {
+                return errorMessage;
+            }
             const linkText = result?.link?.text ?? '';
             const linkURL = result?.link?.url ?? '';
             if (errorMessage.includes(CONST.ERROR.INTEGRATION_MESSAGE_INVALID_CREDENTIALS)) {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -12954,16 +12954,17 @@ function hasExportError(reportActions: OnyxEntry<ReportActions> | ReportAction[]
         return true;
     }
 
-    // Fallback to checking actions for backward compatibility
+    // Fallback to checking actions for backward compatibility. Reconciled integration messages are informational
+    // (the export was already recorded in the integration), not errors.
     if (!reportActions) {
         return false;
     }
 
     if (Array.isArray(reportActions)) {
-        return reportActions.some((action) => isIntegrationMessageAction(action));
+        return reportActions.some((action) => isIntegrationMessageAction(action) && !getOriginalMessage(action)?.result?.reconciled);
     }
 
-    return Object.values(reportActions).some((action) => isIntegrationMessageAction(action));
+    return Object.values(reportActions).some((action) => isIntegrationMessageAction(action) && !getOriginalMessage(action)?.result?.reconciled);
 }
 
 function doesReportContainRequestsFromMultipleUsers(iouReport: OnyxEntry<Report>, shouldExcludeDeletedTransactions = false): boolean {

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -1575,6 +1575,9 @@ type OriginalMessageIntegrationMessage = {
     result: {
         /** Wether action was successful */
         success: boolean;
+
+        /** Whether the message is informational (the export was reconciled as already recorded in the integration) rather than an error */
+        reconciled?: boolean;
     };
 };
 

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -1557,6 +1557,45 @@ describe('ReportActionsUtils', () => {
 
             expect(message).toBe(translateLocal('report.actions.type.reimbursementACHBounceDefault'));
         });
+
+        it('should return a reconciled integrations message as-is, without the export error framing', () => {
+            const reconciledMessage = "A payment for this report already exists in NetSuite and the report is fully paid there, so there's nothing left to sync.";
+            const action: Parameters<typeof ReportActionsUtils.getMessageOfOldDotReportAction>[1] = {
+                reportActionID: '1',
+                created: '2024-01-01 00:00:00.000',
+                actionName: CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE,
+                originalMessage: {
+                    label: 'NetSuite',
+                    result: {
+                        messages: [reconciledMessage],
+                        reconciled: true,
+                    },
+                },
+            };
+
+            const message = ReportActionsUtils.getMessageOfOldDotReportAction(translateLocal, action);
+
+            expect(message).toBe(reconciledMessage);
+        });
+
+        it('should return an integrations error message with the export error framing when not reconciled', () => {
+            const errorMessage = 'NS0196 Sync Error: Could not mark expense reports as paid. This record already exists';
+            const action: Parameters<typeof ReportActionsUtils.getMessageOfOldDotReportAction>[1] = {
+                reportActionID: '1',
+                created: '2024-01-01 00:00:00.000',
+                actionName: CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE,
+                originalMessage: {
+                    label: 'NetSuite',
+                    result: {
+                        messages: [errorMessage],
+                    },
+                },
+            };
+
+            const message = ReportActionsUtils.getMessageOfOldDotReportAction(translateLocal, action);
+
+            expect(message).toBe(translateLocal('report.actions.type.integrationsMessage', errorMessage, 'NetSuite', '', ''));
+        });
     });
 
     describe('getSendMoneyFlowAction', () => {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -20796,6 +20796,24 @@ describe('ReportUtils', () => {
             ]);
             expect(hasExportError(reportActions, report)).toBe(true);
         });
+
+        it('returns false when the only integration message action is reconciled', () => {
+            const report = createMock<Report>({hasExportError: false});
+            const reportActions = createMock<ReportAction[]>([
+                {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE,
+                    reportActionID: '1',
+                    created: '2024-01-01',
+                    originalMessage: {
+                        result: {
+                            success: true,
+                            reconciled: true,
+                        },
+                    },
+                },
+            ]);
+            expect(hasExportError(reportActions, report)).toBe(false);
+        });
     });
 
     describe('getReportFieldsByPolicyID', () => {


### PR DESCRIPTION
@NikkiWines please review

### Explanation of Change
Companion to the NetSuite mark-as-paid "This record already exists" loop fix. When the sync finds the payment already recorded and the report fully paid in NetSuite, the backend now posts an informational `INTEGRATIONSMESSAGE` with `result.reconciled: true` instead of an error. Without this change, NewDot wraps that message in `failed to export this report to NetSuite ("…")`, which contradicts it — reconciled messages now render as plain text. Regular integrations error messages are unchanged.

Companion PRs (deploy order Auth → Web-Expensify → Integration-Server; this PR just needs to land before the Integration-Server one):
- Auth: https://github.com/Expensify/Auth/pull/23262
- Web-Expensify: https://github.com/Expensify/Web-Expensify/pull/54896
- Integration-Server: https://github.com/Expensify/Integration-Server/pull/9145

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/647842
PROPOSAL:

### Tests
1. Run `npx jest tests/unit/ReportActionsUtilsTest.ts -t getMessageOfOldDotReportAction`.
2. Verify all tests pass, including the two new cases: a `reconciled` integrations message renders as its plain message text, and a regular integrations error message keeps the `failed to export this report to NetSuite ("…")` framing.

- [x] Verify that no errors appear in the JS console

### Offline tests
None — this only changes how an existing report action's text is formatted; there is no network behavior.

### QA Steps
None — covered by unit tests. The `reconciled` flag is only produced by the Integration-Server companion PR, and triggering it requires a NetSuite policy whose mark-as-paid sync hits a pre-existing, fully-paid payment record.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Text-formatting change with no UI reachable without the backend companion PRs; behavior is pinned by unit tests (see Tests).

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Text-formatting change with no UI reachable without the backend companion PRs; behavior is pinned by unit tests (see Tests).

</details>

<details>
<summary>iOS: Native</summary>

Text-formatting change with no UI reachable without the backend companion PRs; behavior is pinned by unit tests (see Tests).

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Text-formatting change with no UI reachable without the backend companion PRs; behavior is pinned by unit tests (see Tests).

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

```
PASS tests/unit/ReportActionsUtilsTest.ts (26.9 s)
  getMessageOfOldDotReportAction
    ✓ should return the ACH bounce message with return reason when provided
    ✓ should return the default ACH bounce message when return reason is missing
    ✓ should return a reconciled integrations message as-is, without the export error framing
    ✓ should return an integrations error message with the export error framing when not reconciled
Tests: 353 skipped, 4 passed, 357 total
```

</details>

<details>
<summary>MacOS: Desktop</summary>

Text-formatting change with no UI reachable without the backend companion PRs; behavior is pinned by unit tests (see Tests).

</details>
