### PR TITLE
fix: show floating action badge for errored expense not above viewpor…

### DIFF
--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -441,14 +441,21 @@ function ReportActionsListContent({reportID, onLayout}: ReportActionsListProps) 
         return <ReportActionsSkeletonView />;
     }
 
+    // The FIX badge points at the errored child (the just-failed expense), which is the newest action at the
+    // bottom of the chat — never above the viewport — so it must surface regardless of scroll position, but only
+    // when it has a resolved, rendered target (actionBadgeTargetIndex >= 0) so pressing the pill scrolls to it
+    // instead of being a no-op (some RBR sources leave actionTargetReportActionID undefined). Green badges stay a
+    // "scroll up to your queue" affordance and remain gated to the above-viewport case.
+    const shouldShowActionBadge = !isProduction && (isActionBadgeAboveViewport || (reportAttributes?.actionBadge === CONST.REPORT.ACTION_BADGE.FIX && actionBadgeTargetIndex >= 0));
+
     return (
         <>
             <FloatingMessageCounter
                 hasNewMessages={!!unreadMarkerReportActionID}
                 isActive={isFloatingMessageCounterVisible}
                 onClick={scrollToBottomAndMarkReportAsRead}
-                actionBadge={!isProduction && isActionBadgeAboveViewport ? reportAttributes?.actionBadge : undefined}
-                actionBadgeBrickRoadStatus={!isProduction && isActionBadgeAboveViewport ? reportAttributes?.brickRoadStatus : undefined}
+                actionBadge={shouldShowActionBadge ? reportAttributes?.actionBadge : undefined}
+                actionBadgeBrickRoadStatus={shouldShowActionBadge ? reportAttributes?.brickRoadStatus : undefined}
                 onActionBadgePress={scrollToActionBadgeTarget}
                 isMarkAsDone={shouldUseMarkAsDoneCopy}
             />


### PR DESCRIPTION
### Explanation of Change

The floating action badge (`FloatingMessageCounter`) is only rendered when its target report action is **above** the viewport (`isActionBadgeAboveViewport`). PR #94762 retargeted the FIX badge's `actionTargetReportActionID` to the oldest errored child's report-preview action — the just-failed expense, which is the **newest** action at the **bottom** of the chat. That target is never above the viewport, so after a failed submission the badge stopped appearing instead of changing to "Fix".

This gates the badge on the error status too, so the red **FIX** badge surfaces regardless of scroll position. The green SUBMIT/APPROVE/PAY badges keep their existing above-viewport ("scroll up to your queue") behavior.

```tsx
const shouldShowActionBadge = !isProduction && (isActionBadgeAboveViewport || reportAttributes?.actionBadge === CONST.REPORT.ACTION_BADGE.FIX);
```

### Fixed Issues

$ https://github.com/Expensify/App/issues/96132
PROPOSAL: https://github.com/Expensify/App/issues/96132#issuecomment-4973867429

### Tests

Prerequisite: a workspace chat.

1. Open the workspace chat and scroll to the bottom.
2. Press Ctrl + D (native) / Account → Troubleshoot (web) and enable **Simulate failing network requests**.
3. Create an expense.
4. Wait for the expense to fail — it shows "Unexpected error submitting this expense".
5. Verify the floating action badge appears as a red **Fix** pill at the top of the chat.
6. Click the **Fix** badge and verify the app scrolls to the failed expense.

- [x] Verify that no errors appear in the JS console

### Offline tests

With failing network simulated, the failed expense shows its error state and the floating **Fix** badge appears; clicking it scrolls to the failed expense.

### QA Steps

Prerequisite: a workspace chat.

1. Open the workspace chat and scroll to the bottom.
2. Enable **Simulate failing network requests**.
3. Create an expense and wait for it to fail.
4. Verify the floating action badge appears as **Fix** and clicking it scrolls to the failed expense.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/b2b18e1b-ef1d-435a-9ea1-6db737b5d5ba



</details>
