### PR TITLE
perf: defer central report list on Inbox tab navigation

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2272,6 +2272,7 @@ const CONST = {
             REPORT_ACTIONS_APP_LOAD: 'report_actions_app_load',
             SKELETON_GUARD_LOADING: 'skeleton_guard_loading',
             SKELETON_GUARD_DERIVED_TIMING: 'skeleton_guard_derived_timing',
+            INBOX_TAB_DEFER: 'inbox_tab_defer',
         },
         /** Follow-up action after expense submit (action-based; used as submit_follow_up_action in span). */
         SUBMIT_FOLLOW_UP_ACTION: {

--- a/src/components/Navigation/NavigationTabBar/InboxTabButton.tsx
+++ b/src/components/Navigation/NavigationTabBar/InboxTabButton.tsx
@@ -8,7 +8,7 @@ import {useSidebarOrderedReportsState} from '@hooks/useSidebarOrderedReports';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import Navigation from '@libs/Navigation/Navigation';
+import Navigation, {startOpenReportSpan} from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
 import {isDeletedAction} from '@libs/ReportActionsUtils';
 import {startSpan} from '@libs/telemetry/activeSpans';
@@ -23,23 +23,14 @@ import type {Report, ReportActions} from '@src/types/onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 
-import React from 'react';
+import {TabActions} from '@react-navigation/native';
+import React, {useEffect, useRef} from 'react';
 
 import getLastRoute from './getLastRoute';
+import getReusableReportsTabStateKey, {getTabNavigatorStateKey} from './getReusableReportsTabStateKey';
+import getStringParam from './getStringParam';
 import NAVIGATION_TABS from './NAVIGATION_TABS';
 import TabBarItem from './TabBarItem';
-
-function getStringParam(params: unknown, key: string): string | undefined {
-    if (!params || typeof params !== 'object') {
-        return undefined;
-    }
-    for (const [k, v] of Object.entries(params)) {
-        if (k === key && typeof v === 'string') {
-            return v;
-        }
-    }
-    return undefined;
-}
 
 function startNavigateToInboxTabSpan({isWideLayout}: {isWideLayout: boolean}) {
     startSpan(CONST.TELEMETRY.SPAN_NAVIGATE_TO_INBOX_TAB, {
@@ -78,6 +69,14 @@ function WideInboxTabButton({selectedTab, statusIndicatorColor, accessibilityLab
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Inbox']);
+    const hasVisitedInboxTab = useRef(selectedTab === NAVIGATION_TABS.INBOX);
+
+    useEffect(() => {
+        if (selectedTab !== NAVIGATION_TABS.INBOX) {
+            return;
+        }
+        hasVisitedInboxTab.current = true;
+    }, [selectedTab]);
 
     const lastReportRouteReportID = useRootNavigationState((rootState) => {
         if (!rootState) {
@@ -117,9 +116,56 @@ function WideInboxTabButton({selectedTab, statusIndicatorColor, accessibilityLab
                 const reportActionID = getStringParam(lastRoute.params, 'reportActionID');
                 const referrer = getStringParam(lastRoute.params, 'referrer');
                 const backTo = getStringParam(lastRoute.params, 'backTo');
-                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(reportID, doesLastReportActionExist ? reportActionID : undefined, referrer, backTo));
+                const tabNavigatorStateKey = getTabNavigatorStateKey(rootState);
+                const reusableReportsTabStateKey = getReusableReportsTabStateKey(rootState, reportID, reportActionID, doesLastReportActionExist);
+                const shouldDeferReportActions = !hasVisitedInboxTab.current;
+                const reportRoute = ROUTES.REPORT_WITH_ID.getRoute(reportID, doesLastReportActionExist ? reportActionID : undefined, referrer, backTo);
+
+                if (reusableReportsTabStateKey && !shouldDeferReportActions) {
+                    // Focusing the existing tab without nested params preserves the mounted ReportScreen and
+                    // avoids rebuilding its cached report list as part of the tab navigation commit.
+                    navigationRef.dispatch({
+                        ...TabActions.jumpTo(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR),
+                        target: reusableReportsTabStateKey,
+                    });
+                    return;
+                }
+                if (tabNavigatorStateKey && reportID) {
+                    startOpenReportSpan(reportRoute);
+                    navigationRef.dispatch({
+                        ...TabActions.jumpTo(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR, {
+                            screen: SCREENS.REPORT,
+                            ...(shouldDeferReportActions ? {shouldDeferInitialReportActions: true} : {}),
+                            params: {
+                                reportID,
+                                reportActionID: doesLastReportActionExist ? reportActionID : undefined,
+                                referrer,
+                                backTo,
+                            },
+                        }),
+                        target: tabNavigatorStateKey,
+                    });
+                    return;
+                }
+                Navigation.navigate(reportRoute);
                 return;
             }
+        }
+
+        if (lastReportRouteReportID) {
+            Navigation.navigate(ROUTES.INBOX);
+            return;
+        }
+
+        const tabNavigatorStateKey = getTabNavigatorStateKey(navigationRef.getRootState());
+        if (tabNavigatorStateKey) {
+            navigationRef.dispatch({
+                ...TabActions.jumpTo(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR, {
+                    shouldDeferInitialReportActions: true,
+                }),
+                target: tabNavigatorStateKey,
+            });
+            return;
         }
 
         Navigation.navigate(ROUTES.INBOX);

--- a/src/components/Navigation/NavigationTabBar/getReusableReportsTabStateKey.ts
+++ b/src/components/Navigation/NavigationTabBar/getReusableReportsTabStateKey.ts
@@ -1,0 +1,47 @@
+/**
+ * Locates Reports tab state so Inbox navigation can reuse a mounted ReportScreen instead of rebuilding its route.
+ */
+import {getTabState} from '@libs/Navigation/helpers/tabNavigatorUtils';
+
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+
+import type {NavigationState, PartialState} from '@react-navigation/native';
+
+import getStringParam from './getStringParam';
+
+type RootNavigationState = NavigationState | PartialState<NavigationState> | undefined;
+
+function getTabNavigatorRoute(rootState: RootNavigationState) {
+    return rootState?.routes.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
+}
+
+function getTabNavigatorStateKey(rootState: RootNavigationState): string | undefined {
+    return getTabNavigatorRoute(rootState)?.state?.key;
+}
+
+function getReusableReportsTabStateKey(
+    rootState: RootNavigationState,
+    reportID: string | undefined,
+    reportActionID: string | undefined,
+    doesReportActionExist: boolean | undefined,
+): string | undefined {
+    if (!rootState || !reportID || (reportActionID && !doesReportActionExist)) {
+        return undefined;
+    }
+
+    const tabNavigatorRoute = getTabNavigatorRoute(rootState);
+    const tabState = getTabState(tabNavigatorRoute);
+    const reportsSplitRoute = tabState?.routes.findLast((route) => route.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR);
+    const preservedReportRoute = reportsSplitRoute?.state?.routes.findLast((route) => route.name === SCREENS.REPORT);
+    const preservedReportID = getStringParam(preservedReportRoute?.params, 'reportID');
+
+    if (!reportsSplitRoute?.state || preservedReportID !== reportID) {
+        return undefined;
+    }
+
+    return tabNavigatorRoute?.state?.key;
+}
+
+export {getTabNavigatorStateKey};
+export default getReusableReportsTabStateKey;

--- a/src/components/Navigation/NavigationTabBar/getStringParam.ts
+++ b/src/components/Navigation/NavigationTabBar/getStringParam.ts
@@ -1,0 +1,11 @@
+import {isRecord} from '@libs/ObjectUtils';
+
+function getStringParam(params: unknown, key: string): string | undefined {
+    if (!isRecord(params)) {
+        return undefined;
+    }
+    const value = params[key];
+    return typeof value === 'string' ? value : undefined;
+}
+
+export default getStringParam;

--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -307,14 +307,18 @@ function useSearchHighlightAndScroll({
         });
 
         // Early return if the new item is not found in the data array
-        if (indexOfNewItem <= 0) {
+        if (indexOfNewItem < 0) {
+            return;
+        }
+
+        // Reset the trigger even when the item is already first so a later render cannot scroll or highlight it again.
+        triggeredByHookRef.current = false;
+        if (indexOfNewItem === 0) {
             return;
         }
 
         // Perform the scrolling action
         ref.scrollToIndex(indexOfNewItem);
-        // Reset the trigger flag to prevent unintended future scrolls and highlights
-        triggeredByHookRef.current = false;
     };
 
     const hasQueuedHighlights = newSearchResultKeys !== null && newSearchResultKeys.size > 0;

--- a/src/libs/Navigation/AppNavigator/Navigators/ReportsSplitNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/ReportsSplitNavigator.tsx
@@ -7,8 +7,10 @@ import useSplitNavigatorScreenOptions from '@libs/Navigation/AppNavigator/useSpl
 import getCurrentUrl from '@libs/Navigation/currentUrl';
 import shouldOpenOnAdminRoom from '@libs/Navigation/helpers/shouldOpenOnAdminRoom';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {ReportsSplitNavigatorParamList, TabNavigatorParamList} from '@libs/Navigation/types';
+import type {NavigationStateRoute, ReportsSplitNavigatorParamList, TabNavigatorParamList} from '@libs/Navigation/types';
 import * as ReportUtils from '@libs/ReportUtils';
+
+import type {ReportScreenProps} from '@pages/inbox/ReportScreen';
 
 import CONST from '@src/CONST';
 import type NAVIGATORS from '@src/NAVIGATORS';
@@ -17,9 +19,9 @@ import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
-const loadReportScreen = () => require<ReactComponentModule>('@pages/inbox/ReportScreen').default;
+const loadReportScreen = () => require<{default: React.ComponentType<ReportScreenProps>}>('@pages/inbox/ReportScreen').default;
 const loadSidebarScreen = () => require<ReactComponentModule>('@pages/inbox/sidebar/BaseSidebarScreen').default;
 const Split = createSplitNavigator<ReportsSplitNavigatorParamList>();
 
@@ -27,16 +29,18 @@ const Split = createSplitNavigator<ReportsSplitNavigatorParamList>();
  * This SplitNavigator includes the HOME screen (<BaseSidebarScreen /> component) with a list of reports as a sidebar screen and the REPORT screen displayed as a central one.
  * There can be multiple report screens in the stack with different report IDs.
  */
-function ReportsSplitNavigator({route}: PlatformStackScreenProps<TabNavigatorParamList, typeof NAVIGATORS.REPORTS_SPLIT_NAVIGATOR>) {
+function ReportsSplitNavigator({navigation, route}: PlatformStackScreenProps<TabNavigatorParamList, typeof NAVIGATORS.REPORTS_SPLIT_NAVIGATOR>) {
     const {isBetaEnabled} = usePermissions();
     const splitNavigatorScreenOptions = useSplitNavigatorScreenOptions();
     const [reportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS);
     const isOpenOnAdminRoom = shouldOpenOnAdminRoom();
+    const shouldClearInitialReportActionsDefer = !!route.params && 'shouldDeferInitialReportActions' in route.params && route.params.shouldDeferInitialReportActions === true;
+    const [shouldDeferInitialReportActions] = useState(() => shouldClearInitialReportActionsDefer);
 
     const [initialReportID] = useState(() => {
         // Deep links and REPORT_WITH_ID navigation pass the reportID in nested params,
         // which lets us skip the O(n) findLastAccessedReport scan over all reports.
-        if (route.params?.screen === SCREENS.REPORT && route.params.params?.reportID) {
+        if (route.params && 'screen' in route.params && route.params.screen === SCREENS.REPORT && route.params.params?.reportID) {
             return route.params.params.reportID;
         }
 
@@ -58,6 +62,13 @@ function ReportsSplitNavigator({route}: PlatformStackScreenProps<TabNavigatorPar
         // eslint-disable-next-line rulesdir/no-default-id-values
         return initialReport?.reportID ?? '';
     });
+
+    useEffect(() => {
+        if (!shouldClearInitialReportActionsDefer) {
+            return;
+        }
+        navigation.setParams({shouldDeferInitialReportActions: undefined});
+    }, [navigation, shouldClearInitialReportActionsDefer]);
 
     const reportScreenInitialParams = {
         reportID: initialReportID,
@@ -81,8 +92,19 @@ function ReportsSplitNavigator({route}: PlatformStackScreenProps<TabNavigatorPar
                 <Split.Screen
                     name={SCREENS.REPORT}
                     initialParams={reportScreenInitialParams}
-                    getComponent={loadReportScreen}
-                />
+                >
+                    {(screenProps: ReportScreenProps) => {
+                        const ReportScreen = loadReportScreen();
+                        // A split navigator can contain multiple report routes, but the Inbox defer should only apply to the route that mounted with the navigator.
+                        const initialReportRouteKey = screenProps.navigation.getState().routes.find((navigatorRoute: NavigationStateRoute) => navigatorRoute.name === SCREENS.REPORT)?.key;
+                        return (
+                            <ReportScreen
+                                {...screenProps}
+                                shouldDeferReportActions={shouldDeferInitialReportActions && initialReportRouteKey === screenProps.route.key}
+                            />
+                        );
+                    }}
+                </Split.Screen>
             </Split.Navigator>
         </FreezeWrapper>
     );

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -288,6 +288,36 @@ function isActiveRoute(routePath: Route): boolean {
     return cleanRoutePath(activeRoute) === cleanRoutePath(routePath);
 }
 
+function startOpenReportSpan(route: Route) {
+    // Start a Sentry span for report navigation — only for exact report-open routes, not sub-pages.
+    // Matches: r/<id>, search/r/<id>, search/view/<id>, e/<id>
+    const reportOpenMatch = Str.cutAfter(route, '?').match(/^(search\/(?:r|view)|r|e)\/(\w+)$/);
+    if (!reportOpenMatch) {
+        return;
+    }
+
+    const routePrefix = reportOpenMatch.at(1);
+    const reportID = reportOpenMatch.at(2);
+    if (!reportID) {
+        return;
+    }
+
+    const spanId = `${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`;
+    let span = getSpan(spanId);
+    if (!span) {
+        const spanName = `/${routePrefix}/*`;
+        span = startSpan(spanId, {
+            name: spanName,
+            op: CONST.TELEMETRY.SPAN_OPEN_REPORT,
+        });
+    }
+    span?.setAttributes({
+        [CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID,
+        [CONST.TELEMETRY.ATTRIBUTE_ROUTE_FROM]: getActiveRouteWithoutParams(),
+        [CONST.TELEMETRY.ATTRIBUTE_ROUTE_TO]: Str.cutAfter(route, '?'),
+    });
+}
+
 /**
  * Navigates to a specified route.
  * Main navigation method for redirecting to a route.
@@ -310,30 +340,7 @@ function navigate(route: Route, options?: LinkToOptions) {
         return;
     }
 
-    // Start a Sentry span for report navigation — only for exact report-open routes, not sub-pages.
-    // Matches: r/<id>, search/r/<id>, search/view/<id>, e/<id>
-    const reportOpenMatch = Str.cutAfter(route, '?').match(/^(search\/(?:r|view)|r|e)\/(\w+)$/);
-    if (reportOpenMatch) {
-        const routePrefix = reportOpenMatch.at(1);
-        const reportID = reportOpenMatch.at(2);
-        if (reportID) {
-            const spanId = `${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`;
-            let span = getSpan(spanId);
-            if (!span) {
-                const spanName = `/${routePrefix}/*`;
-                span = startSpan(spanId, {
-                    name: spanName,
-                    op: CONST.TELEMETRY.SPAN_OPEN_REPORT,
-                });
-            }
-            span?.setAttributes({
-                [CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID,
-                [CONST.TELEMETRY.ATTRIBUTE_ROUTE_FROM]: getActiveRouteWithoutParams(),
-                [CONST.TELEMETRY.ATTRIBUTE_ROUTE_TO]: Str.cutAfter(route, '?'),
-            });
-        }
-    }
-
+    startOpenReportSpan(route);
     const runImmediately = !options?.waitForTransition;
     TransitionTracker.runAfterTransitions({
         callback: () => {
@@ -459,11 +466,11 @@ function goUp(backToRoute: Route, options?: GoBackOptions): boolean {
     }
 
     // Arms the one-shot inline with each dispatch — no window between "set flag" and dispatch for an early-return to leak it.
-    const dispatch = (dispatchable: NavigationAction) => {
+    const dispatch = (actionToDispatch: NavigationAction) => {
         if (options?.shouldSkipFocusRestore) {
             skipNextFocusRestore();
         }
-        navigationRef.current?.dispatch(dispatchable);
+        navigationRef.current?.dispatch(actionToDispatch);
     };
 
     // TabRouter does not handle POP or REPLACE (BaseRouter returns null). Switch tabs with jumpTo.
@@ -1351,4 +1358,4 @@ export default {
     navigateBackToLastSuperWideRHPScreen,
 };
 
-export {navigationRef, getDeepestFocusedScreen, isTwoFactorSetupScreen, isMFAFlowScreen};
+export {navigationRef, getDeepestFocusedScreen, isTwoFactorSetupScreen, isMFAFlowScreen, startOpenReportSpan};

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -3046,7 +3046,14 @@ type WorkspaceNavigatorParamList = {
 
 type TabNavigatorParamList = {
     [SCREENS.HOME]: undefined;
-    [NAVIGATORS.REPORTS_SPLIT_NAVIGATOR]: NavigatorScreenParams<ReportsSplitNavigatorParamList>;
+    [NAVIGATORS.REPORTS_SPLIT_NAVIGATOR]:
+        | (NavigatorScreenParams<ReportsSplitNavigatorParamList> & {
+              shouldDeferInitialReportActions?: true;
+          })
+        | {
+              shouldDeferInitialReportActions?: true;
+          }
+        | undefined;
     [NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR]: NavigatorScreenParams<SearchFullscreenNavigatorParamList>;
     [NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR]: NavigatorScreenParams<SettingsSplitNavigatorParamList>;
     [NAVIGATORS.WORKSPACE_NAVIGATOR]: NavigatorScreenParams<WorkspaceNavigatorParamList>;

--- a/src/pages/inbox/ReportActions.tsx
+++ b/src/pages/inbox/ReportActions.tsx
@@ -1,4 +1,5 @@
 import MoneyRequestReportActionsList from '@components/MoneyRequestReportView/MoneyRequestReportActionsList';
+import NavigationDeferredMount from '@components/NavigationDeferredMount';
 
 import {useIsAppLoadPending} from '@hooks/useInFlightRequests';
 import useMarkOpenReportEndOnSkeleton from '@hooks/useMarkOpenReportEndOnSkeleton';
@@ -103,4 +104,33 @@ function ReportActions() {
     );
 }
 
+type ReportActionsWithInboxTabDeferredMountProps = {
+    /** The report ID used by the deferred loading skeleton */
+    reportID: string | undefined;
+
+    /** Whether to defer mounting report actions during the initial Inbox tab navigation */
+    shouldDefer: boolean;
+};
+
+function ReportActionsWithInboxTabDeferredMount({reportID, shouldDefer}: ReportActionsWithInboxTabDeferredMountProps) {
+    if (!shouldDefer) {
+        return <ReportActions />;
+    }
+
+    return (
+        <NavigationDeferredMount
+            waitForUpcomingTransition={false}
+            placeholder={
+                <ReportActionsLoadingSkeleton
+                    reportID={reportID}
+                    skeletonName={CONST.TELEMETRY.CANCELED_BY_SKELETON.INBOX_TAB_DEFER}
+                />
+            }
+        >
+            <ReportActions />
+        </NavigationDeferredMount>
+    );
+}
+
+export {ReportActionsWithInboxTabDeferredMount};
 export default ReportActions;

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -40,7 +40,7 @@ import ReportActionCompose from './report/ReportActionCompose/ReportActionCompos
 import {ReportActionEditMessageContextProvider, ReportScreenEditMessageProviderWithTransactionThread} from './report/ReportActionEditMessageContext';
 import ReportFooter from './report/ReportFooter';
 import useClearReportActionDraftsOnReportChange from './report/useClearReportActionDraftsOnReportChange';
-import ReportActions from './ReportActions';
+import {ReportActionsWithInboxTabDeferredMount} from './ReportActions';
 import ReportDragAndDropProvider from './ReportDragAndDropProvider';
 import ReportFetchHandler from './ReportFetchHandler';
 import ReportHeader from './ReportHeader';
@@ -50,7 +50,10 @@ import ReportNotFoundGuard from './ReportNotFoundGuard';
 import ReportRouteParamHandler from './ReportRouteParamHandler';
 import WideRHPReceiptPanel from './WideRHPReceiptPanel';
 
-type ReportScreenProps = ReportScreenNavigationProps;
+type ReportScreenProps = ReportScreenNavigationProps & {
+    /** Whether to defer mounting report actions during the initial Inbox tab navigation */
+    shouldDeferReportActions?: boolean;
+};
 
 type ReportScreenEditMessageProviderProps = {
     /** The report ID */
@@ -72,7 +75,7 @@ function ReportScreenEditMessageProvider({reportID, children}: ReportScreenEditM
     return <ReportScreenEditMessageProviderWithTransactionThread reportID={reportID}>{children}</ReportScreenEditMessageProviderWithTransactionThread>;
 }
 
-function ReportScreen({route, navigation}: ReportScreenProps) {
+function ReportScreen({route, navigation, shouldDeferReportActions = false}: ReportScreenProps) {
     const styles = useThemeStyles();
     const reportIDFromRoute = getNonEmptyStringOnyxID(route.params?.reportID);
     const {isInNarrowPaneModal} = useResponsiveLayout();
@@ -151,7 +154,10 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                                                             style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden]}
                                                             testID="report-actions-view-wrapper"
                                                         >
-                                                            <ReportActions />
+                                                            <ReportActionsWithInboxTabDeferredMount
+                                                                reportID={reportIDFromRoute}
+                                                                shouldDefer={shouldDeferReportActions}
+                                                            />
                                                             {shouldDeferNonEssentials ? <ReportActionCompose.Placeholder /> : <ReportFooter />}
                                                         </View>
                                                     </ConciergeDraftProvider>
@@ -171,3 +177,4 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 }
 
 export default ReportScreen;
+export type {ReportScreenProps};

--- a/tests/unit/InboxTabButtonTest.tsx
+++ b/tests/unit/InboxTabButtonTest.tsx
@@ -1,0 +1,262 @@
+import {fireEvent, render, screen} from '@testing-library/react-native';
+
+import InboxTabButton from '@components/Navigation/NavigationTabBar/InboxTabButton';
+import NAVIGATION_TABS from '@components/Navigation/NavigationTabBar/NAVIGATION_TABS';
+
+import NAVIGATORS from '@src/NAVIGATORS';
+import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
+
+import type {ComponentType, ReactNode} from 'react';
+
+import React from 'react';
+
+const mockDispatch = jest.fn();
+const mockNavigate = jest.fn();
+const mockStartOpenReportSpan = jest.fn();
+const mockStartSpan = jest.fn();
+
+let mockOnyxEntry: {reportID: string} | undefined = {reportID: '123'};
+let mockRootState: unknown;
+let mockLastRoute: {params: {reportID: string}} | undefined = {params: {reportID: '123'}};
+
+type PressableProps = {
+    accessibilityLabel: string;
+    children: ReactNode | ((state: {hovered: boolean}) => ReactNode);
+    onPress: () => void;
+};
+
+type ReactActual = {
+    createElement: typeof React.createElement;
+};
+
+type ReactNativeActual = {
+    View: ComponentType<{accessibilityLabel: string; onPress: () => void; testID: string}>;
+};
+
+jest.mock('@components/Pressable', () => {
+    const {createElement} = jest.requireActual<ReactActual>('react');
+    const {View} = jest.requireActual<ReactNativeActual>('react-native');
+
+    return {
+        PressableWithFeedback: ({accessibilityLabel, onPress}: PressableProps) =>
+            createElement(View, {
+                accessibilityLabel,
+                onPress,
+                testID: 'inbox-tab-button',
+            }),
+    };
+});
+
+jest.mock('@components/Navigation/NavigationTabBar/TabBarItem', () => () => null);
+jest.mock('@components/Navigation/NavigationTabBar/getLastRoute', () => () => mockLastRoute);
+jest.mock('@hooks/useLazyAsset', () => ({useMemoizedLazyExpensifyIcons: () => ({Inbox: 'inbox-icon'})}));
+jest.mock('@hooks/useLocalize', () => () => ({translate: (key: string) => key}));
+jest.mock('@hooks/useSidebarOrderedReports', () => ({useSidebarOrderedReportsState: () => ({chatTabBrickRoad: undefined})}));
+jest.mock('@hooks/useTheme', () => () => ({danger: 'danger', iconSuccessFill: 'success'}));
+jest.mock('@hooks/useThemeStyles', () => () => ({
+    flex1: {},
+    leftNavigationTabBarItem: {},
+    navigationTabBarItem: {},
+    navigationTabBarItemHovered: {},
+}));
+
+jest.mock('@hooks/useRootNavigationState', () => (selector: (state: unknown) => unknown) => selector(mockRootState));
+
+jest.mock('@hooks/useOnyx', () => (_key: string, options?: {selector?: (entry: {reportID: string} | undefined) => unknown}) => {
+    return [options?.selector ? options.selector(mockOnyxEntry) : mockOnyxEntry];
+});
+
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    __esModule: true,
+    default: {
+        dispatch: (action: unknown) => {
+            mockDispatch(action);
+        },
+        getRootState: () => mockRootState,
+    },
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    default: {
+        navigate: (route: string) => {
+            mockNavigate(route);
+        },
+    },
+    startOpenReportSpan: (route: string) => {
+        mockStartOpenReportSpan(route);
+    },
+}));
+
+jest.mock('@libs/telemetry/activeSpans', () => ({
+    startSpan: (...args: unknown[]) => {
+        mockStartSpan(...args);
+        return undefined;
+    },
+}));
+
+function buildRootState() {
+    return {
+        key: 'root-state',
+        index: 0,
+        routes: [
+            {
+                key: 'tab-route',
+                name: NAVIGATORS.TAB_NAVIGATOR,
+                state: {
+                    key: 'tab-state',
+                    index: 0,
+                    routes: [
+                        {
+                            key: 'reports-route',
+                            name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+                            state: {
+                                key: 'reports-state',
+                                index: 1,
+                                routes: [
+                                    {key: 'inbox-route', name: SCREENS.INBOX},
+                                    {key: 'report-route', name: SCREENS.REPORT, params: {reportID: '123'}},
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    };
+}
+
+describe('InboxTabButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockOnyxEntry = {reportID: '123'};
+        mockRootState = buildRootState();
+        mockLastRoute = {params: {reportID: '123'}};
+    });
+
+    it('starts ManualOpenReport and requests defer on the first report jump', () => {
+        render(
+            <InboxTabButton
+                selectedTab={NAVIGATION_TABS.HOME}
+                isWideLayout
+            />,
+        );
+
+        fireEvent.press(screen.getByTestId('inbox-tab-button'));
+
+        expect(mockStartOpenReportSpan).toHaveBeenCalledWith(ROUTES.REPORT_WITH_ID.getRoute('123'));
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                target: 'tab-state',
+                payload: expect.objectContaining({
+                    params: expect.objectContaining({
+                        shouldDeferInitialReportActions: true,
+                        params: expect.objectContaining({
+                            reportID: '123',
+                        }),
+                        screen: SCREENS.REPORT,
+                    }),
+                }),
+            }),
+        );
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('reuses the report without a span or nested params after Inbox was visited', () => {
+        const {rerender} = render(
+            <InboxTabButton
+                selectedTab={NAVIGATION_TABS.HOME}
+                isWideLayout
+            />,
+        );
+        rerender(
+            <InboxTabButton
+                selectedTab={NAVIGATION_TABS.INBOX}
+                isWideLayout
+            />,
+        );
+        rerender(
+            <InboxTabButton
+                selectedTab={NAVIGATION_TABS.HOME}
+                isWideLayout
+            />,
+        );
+
+        fireEvent.press(screen.getByTestId('inbox-tab-button'));
+
+        expect(mockStartOpenReportSpan).not.toHaveBeenCalled();
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                target: 'tab-state',
+                payload: {
+                    name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+                },
+            }),
+        );
+    });
+
+    it('requests initial report actions defer when no previous report route exists', () => {
+        mockOnyxEntry = undefined;
+        mockLastRoute = undefined;
+
+        render(
+            <InboxTabButton
+                selectedTab={NAVIGATION_TABS.HOME}
+                isWideLayout
+            />,
+        );
+
+        fireEvent.press(screen.getByTestId('inbox-tab-button'));
+
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                target: 'tab-state',
+                payload: expect.objectContaining({
+                    name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+                    params: {
+                        shouldDeferInitialReportActions: true,
+                    },
+                }),
+            }),
+        );
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockStartOpenReportSpan).not.toHaveBeenCalled();
+    });
+
+    it('navigates to Inbox when the previous report no longer exists', () => {
+        mockOnyxEntry = undefined;
+
+        render(
+            <InboxTabButton
+                selectedTab={NAVIGATION_TABS.HOME}
+                isWideLayout
+            />,
+        );
+
+        fireEvent.press(screen.getByTestId('inbox-tab-button'));
+
+        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.INBOX);
+        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(mockStartOpenReportSpan).not.toHaveBeenCalled();
+    });
+
+    it('navigates to Inbox when the tab navigator is not ready', () => {
+        mockOnyxEntry = undefined;
+        mockRootState = undefined;
+        mockLastRoute = undefined;
+
+        render(
+            <InboxTabButton
+                selectedTab={NAVIGATION_TABS.HOME}
+                isWideLayout
+            />,
+        );
+
+        fireEvent.press(screen.getByTestId('inbox-tab-button'));
+
+        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.INBOX);
+        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(mockStartOpenReportSpan).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/ReportActionsWithInboxTabDeferredMountTest.tsx
+++ b/tests/unit/ReportActionsWithInboxTabDeferredMountTest.tsx
@@ -1,0 +1,75 @@
+import {render, screen} from '@testing-library/react-native';
+
+import {ReportActionsWithInboxTabDeferredMount} from '@pages/inbox/ReportActions';
+
+import type {ComponentType} from 'react';
+
+import React from 'react';
+
+type ReactActual = {
+    createElement: typeof React.createElement;
+};
+
+type ReactNativeActual = {
+    View: ComponentType<{testID: string}>;
+};
+
+jest.mock(
+    '@components/NavigationDeferredMount',
+    () =>
+        function NavigationDeferredMountMock() {
+            const {createElement} = jest.requireActual<ReactActual>('react');
+            const {View} = jest.requireActual<ReactNativeActual>('react-native');
+            return createElement(View, {testID: 'navigation-deferred-mount'});
+        },
+);
+
+jest.mock('@hooks/useMarkOpenReportEndOnSkeleton', () => () => undefined);
+jest.mock('@hooks/useNetwork', () => () => ({isOffline: false}));
+jest.mock('@hooks/useOnyx', () => () => [undefined]);
+jest.mock('@hooks/usePaginatedReportActions', () => () => ({reportActions: {}}));
+jest.mock('@hooks/useReportTransactionsCollection', () => () => ({}));
+
+jest.mock('@react-navigation/native', () => {
+    const navigation = jest.requireActual<Record<string, unknown>>('@react-navigation/native');
+    return {
+        ...navigation,
+        useRoute: () => ({params: {reportID: '123'}}),
+    };
+});
+
+jest.mock(
+    '@pages/inbox/report/ReportActionsLoadingSkeleton',
+    () =>
+        function ReportActionsLoadingSkeletonMock() {
+            const {createElement} = jest.requireActual<ReactActual>('react');
+            const {View} = jest.requireActual<ReactNativeActual>('react-native');
+            return createElement(View, {testID: 'report-actions'});
+        },
+);
+
+describe('ReportActionsWithInboxTabDeferredMount', () => {
+    it('renders report actions immediately without an explicit defer request', () => {
+        render(
+            <ReportActionsWithInboxTabDeferredMount
+                reportID="123"
+                shouldDefer={false}
+            />,
+        );
+
+        expect(screen.getByTestId('report-actions')).toBeOnTheScreen();
+        expect(screen.queryByTestId('navigation-deferred-mount')).not.toBeOnTheScreen();
+    });
+
+    it('defers report actions when the Inbox navigation requests it', () => {
+        render(
+            <ReportActionsWithInboxTabDeferredMount
+                reportID="123"
+                shouldDefer
+            />,
+        );
+
+        expect(screen.getByTestId('navigation-deferred-mount')).toBeOnTheScreen();
+        expect(screen.queryByTestId('report-actions')).not.toBeOnTheScreen();
+    });
+});

--- a/tests/unit/getReusableReportsTabStateKeyTest.ts
+++ b/tests/unit/getReusableReportsTabStateKeyTest.ts
@@ -1,0 +1,86 @@
+import getReusableReportsTabStateKey from '@components/Navigation/NavigationTabBar/getReusableReportsTabStateKey';
+
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+
+import type {NavigationState, PartialState} from '@react-navigation/native';
+
+type BuildRootStateOptions = {
+    tabStateKey?: string;
+    reportID?: string;
+    reportActionID?: string;
+    includeReportsState?: boolean;
+    olderTabStateKey?: string;
+};
+
+function buildRootState({
+    tabStateKey = 'tab-state',
+    reportID = '123',
+    reportActionID,
+    includeReportsState = true,
+    olderTabStateKey,
+}: BuildRootStateOptions = {}): PartialState<NavigationState> {
+    const reportsRoute = {
+        key: 'reports-route',
+        name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+        ...(includeReportsState
+            ? {
+                  state: {
+                      key: 'reports-state',
+                      index: 1,
+                      routes: [
+                          {key: 'inbox-route', name: SCREENS.INBOX},
+                          {key: 'report-route', name: SCREENS.REPORT, params: {reportID, ...(reportActionID ? {reportActionID} : {})}},
+                      ],
+                  },
+              }
+            : {}),
+    };
+    const tabRoute = {
+        key: `${tabStateKey}-route`,
+        name: NAVIGATORS.TAB_NAVIGATOR,
+        state: {
+            key: tabStateKey,
+            index: 1,
+            routes: [{key: 'home-route', name: SCREENS.HOME}, reportsRoute],
+        },
+    };
+    const routes = olderTabStateKey
+        ? [
+              {
+                  key: `${olderTabStateKey}-route`,
+                  name: NAVIGATORS.TAB_NAVIGATOR,
+                  state: {key: olderTabStateKey, index: 0, routes: [{key: 'older-home-route', name: SCREENS.HOME}]},
+              },
+              tabRoute,
+          ]
+        : [tabRoute];
+
+    return {key: 'root-state', index: routes.length - 1, routes} satisfies PartialState<NavigationState>;
+}
+
+describe('getReusableReportsTabStateKey', () => {
+    it('returns the active tab state key for the preserved report', () => {
+        expect(getReusableReportsTabStateKey(buildRootState(), '123', undefined, false)).toBe('tab-state');
+    });
+
+    it('uses the newest tab navigator instance', () => {
+        expect(getReusableReportsTabStateKey(buildRootState({olderTabStateKey: 'older-tab'}), '123', undefined, false)).toBe('tab-state');
+    });
+
+    it('returns the tab state key when the report action still exists', () => {
+        expect(getReusableReportsTabStateKey(buildRootState({reportActionID: '456'}), '123', '456', true)).toBe('tab-state');
+    });
+
+    it('does not reuse the tab when the report action was removed', () => {
+        expect(getReusableReportsTabStateKey(buildRootState({reportActionID: '456'}), '123', '456', false)).toBeUndefined();
+    });
+
+    it('does not reuse a different report', () => {
+        expect(getReusableReportsTabStateKey(buildRootState({reportID: '999'}), '123', undefined, false)).toBeUndefined();
+    });
+
+    it('does not reuse an uninitialized reports navigator', () => {
+        expect(getReusableReportsTabStateKey(buildRootState({includeReportsState: false}), '123', undefined, false)).toBeUndefined();
+    });
+});

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -237,7 +237,7 @@ describe('useSearchHighlightAndScroll', () => {
         expect(search).not.toHaveBeenCalled();
     });
 
-    it('should return multiple new search result keys when there are multiple new expenses', () => {
+    it('should clear the scroll trigger when the first new expense is already first', () => {
         const {rerender, result} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
             initialProps: baseProps,
         });
@@ -267,6 +267,24 @@ describe('useSearchHighlightAndScroll', () => {
         // @ts-expect-error
         rerender(updatedProps);
         expect(result.current.newSearchResultKeys?.size).toBe(2);
+
+        const scrollToIndex = jest.fn();
+        const ref: NonNullable<Parameters<typeof result.current.handleSelectionListScroll>[1]> = {
+            scrollAndHighlightItem: jest.fn(),
+            scrollToIndex,
+            updateFocusedIndex: jest.fn(),
+            scrollToFocusedInput: jest.fn(),
+            focusTextInput: jest.fn(),
+        };
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        result.current.handleSelectionListScroll([{transactionID: '1'}, {transactionID: '2'}], ref);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        result.current.handleSelectionListScroll([{transactionID: '2'}, {transactionID: '1'}], ref);
+
+        expect(scrollToIndex).not.toHaveBeenCalled();
     });
 
     it('should return new search result keys for manually highlighted expenses', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
On wide layouts, opening Inbox rebuilds the nested report route and mounts the report actions list in the same render as the left navigation. This delays the first paint.

This change focuses an existing Reports tab when possible and defers the report actions list on the first warm Inbox mount. Later visits reuse the mounted report screen and preserve its route, report parameters, and URL. Cold navigation and missing report data keep the existing URL based fallback.

This reapplies the reverted change while the Spend row flicker reported in https://github.com/Expensify/App/issues/97154 is addressed.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/96398
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Test:
Deploy blocker: https://github.com/Expensify/App/issues/97154

Previous tests confirm works:
1. Open the app on a wide screen and navigate to Home.
2. Refresh, then tap Inbox. Verify the central report shows a loading skeleton once, followed by the cached report content.
3. Navigate to Home and tap Inbox again. Verify the same report appears immediately without another skeleton and the URL remains `/r/:reportID`.
4. Repeat Home to Inbox navigation, then use browser back and forward. Verify Home and the same Inbox report are restored.
5. Open another report from the LHN and through a deep link. Verify both render without the Inbox defer skeleton.
6. Verify no console errors appear.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
