### PR TITLE
[No QA] Seed the AdHoc build cache from main so PR test builds hit it warm

### DIFF
--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -27,6 +27,14 @@ on:
         description: Force a full native build, bypassing Rock remote cache
         type: string
         default: 'false'
+      seed-cache-only:
+        description: Build only to warm the Rock remote cache. Skips re-signing and ad-hoc distribution, so a cached fingerprint costs nothing but the lookup.
+        type: string
+        default: 'false'
+      expected-fingerprint:
+        description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
+        type: string
+        default: ''
 
     outputs:
       VERSION_CODE:
@@ -160,6 +168,25 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      # A caller that skips this build on a cache hit is only as good as its fingerprint matching the one used
+      # here. Warn rather than fail: a mismatch costs the savings, never correctness, because the build below
+      # repeats the lookup itself and stops early when it does hit.
+      - name: Compare fingerprint against the one the caller looked up
+        if: ${{ inputs.seed-cache-only == 'true' && inputs.expected-fingerprint != '' }}
+        env:
+          IS_HYBRID_APP: 'true'
+          EXPECTED_FINGERPRINT: ${{ inputs.expected-fingerprint }}
+        run: |
+          ACTUAL_FINGERPRINT=$(npx rock fingerprint -p android --raw 2>/dev/null) || ACTUAL_FINGERPRINT=''
+          if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then
+            echo "::warning::The caller looked up $EXPECTED_FINGERPRINT but this build computed ${ACTUAL_FINGERPRINT:-nothing}, so its cache check is guarding a different fingerprint and can never skip this build."
+            echo "### Fingerprint mismatch" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Caller looked up \`$EXPECTED_FINGERPRINT\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- This build computed \`${ACTUAL_FINGERPRINT:-nothing}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Fingerprint matches the caller's lookup: $ACTUAL_FINGERPRINT"
+          fi
+
       - name: Rock Remote Build - Android
         uses: callstackincubator/android@4cedf4d9b5c167452c96fe67233577e0fde9a025
         env:
@@ -171,8 +198,10 @@ jobs:
           variant: ${{ inputs.variant }}
           aab: ${{ inputs.variant == 'Release' }}
           sign: true
-          re-sign: true
-          ad-hoc: ${{ inputs.variant == 'Adhoc' }}
+          # A seed build only needs to upload the base artifact it just compiled, which happens on a cache miss
+          # regardless of these two. Leaving them off means a cache hit stops right after the lookup.
+          re-sign: ${{ inputs.seed-cache-only != 'true' }}
+          ad-hoc: ${{ inputs.variant == 'Adhoc' && inputs.seed-cache-only != 'true' }}
           # We don't need Rock to setup java, because we already ran the setup-java action above
           setup-java: false
           keystore-file: './upload-key.keystore'

--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -28,9 +28,12 @@ on:
         type: string
         default: 'false'
       seed-cache-only:
+        # Typed boolean rather than a string like `force-native-build` above, which has to stay a string because it is
+        # threaded through from a dispatch input. This one is only ever set to a literal, and actionlint rejects a
+        # quoted 'true' passed to a string input, so a real boolean is both truthful and lintable.
         description: Build only to warm the Rock remote cache. Skips re-signing and ad-hoc distribution, so a cached fingerprint costs nothing but the lookup.
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
       expected-fingerprint:
         description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
         type: string
@@ -172,7 +175,7 @@ jobs:
       # here. Warn rather than fail: a mismatch costs the savings, never correctness, because the build below
       # repeats the lookup itself and stops early when it does hit.
       - name: Compare fingerprint against the one the caller looked up
-        if: ${{ inputs.seed-cache-only == 'true' && inputs.expected-fingerprint != '' }}
+        if: ${{ inputs.seed-cache-only && inputs.expected-fingerprint != '' }}
         env:
           IS_HYBRID_APP: 'true'
           EXPECTED_FINGERPRINT: ${{ inputs.expected-fingerprint }}
@@ -180,9 +183,11 @@ jobs:
           ACTUAL_FINGERPRINT=$(npx rock fingerprint -p android --raw 2>/dev/null) || ACTUAL_FINGERPRINT=''
           if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then
             echo "::warning::The caller looked up $EXPECTED_FINGERPRINT but this build computed ${ACTUAL_FINGERPRINT:-nothing}, so its cache check is guarding a different fingerprint and can never skip this build."
-            echo "### Fingerprint mismatch" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Caller looked up \`$EXPECTED_FINGERPRINT\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- This build computed \`${ACTUAL_FINGERPRINT:-nothing}\`" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "### Fingerprint mismatch"
+              echo "- Caller looked up \`$EXPECTED_FINGERPRINT\`"
+              echo "- This build computed \`${ACTUAL_FINGERPRINT:-nothing}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "Fingerprint matches the caller's lookup: $ACTUAL_FINGERPRINT"
           fi
@@ -200,8 +205,8 @@ jobs:
           sign: true
           # A seed build only needs to upload the base artifact it just compiled, which happens on a cache miss
           # regardless of these two. Leaving them off means a cache hit stops right after the lookup.
-          re-sign: ${{ inputs.seed-cache-only != 'true' }}
-          ad-hoc: ${{ inputs.variant == 'Adhoc' && inputs.seed-cache-only != 'true' }}
+          re-sign: ${{ !inputs.seed-cache-only }}
+          ad-hoc: ${{ inputs.variant == 'Adhoc' && !inputs.seed-cache-only }}
           # We don't need Rock to setup java, because we already ran the setup-java action above
           setup-java: false
           keystore-file: './upload-key.keystore'

--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -38,6 +38,13 @@ on:
         description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
         type: string
         default: ''
+      cache-traits:
+        # Taken from the caller rather than derived here so that the traits its gate looked up and the traits this
+        # build verifies afterwards cannot drift apart. Required whenever `seed-cache-only` is set - the verification
+        # errors out without it rather than skipping, so forgetting it cannot silently disable the check.
+        description: Rock traits naming the base cache artifact a seed build should have written, e.g. 'Adhoc'. Required when seed-cache-only is set.
+        type: string
+        default: ''
 
     outputs:
       VERSION_CODE:
@@ -329,3 +336,48 @@ jobs:
         with:
           name: ${{ inputs.artifact-prefix }}android-apk-artifact
           path: Expensify.apk
+
+      # A seed build that finishes without uploading anything looks exactly like a working one, and nothing notices:
+      # PR builds simply compile their own native code again, which reads as slow CI rather than as a failure. So ask
+      # the bucket the same question a PR build's lookup asks. Asking the bucket rather than reading the build
+      # action's own `ARTIFACT_URL` is the point - one action bump could move the gate on its upload step and break
+      # the upload and its self-report together. Last in the job so a failure here costs none of the uploads above.
+      - name: Verify the seed landed in the remote cache
+        if: ${{ inputs.seed-cache-only }}
+        env:
+          IS_HYBRID_APP: 'true'
+          TRAITS: ${{ inputs.cache-traits }}
+        run: |
+          # Erroring rather than skipping: a seed that quietly stops verifying is the failure this step exists to
+          # catch, so it must not be possible to turn it off by leaving an input out.
+          if [ -z "$TRAITS" ]; then
+            echo "::error::seed-cache-only builds need cache-traits set, naming the artifact this seed should have written. Without it there is nothing to verify against."
+            exit 1
+          fi
+
+          # Unlike the lookup that gates this build, this needs no separate check that the cache provider is usable:
+          # a broken one makes `list` print nothing, which fails here. That is the safe direction to guess wrong in.
+          # On a gate the same silence reads as "nothing cached" and quietly turns it into a rubber stamp.
+          for attempt in 1 2 3; do
+            if OUTPUT=$(npx rock remote-cache list -p android --traits "$TRAITS" --json); then
+              if [ -n "$OUTPUT" ]; then
+                # Only for the log line. The verdict is `$OUTPUT` being non-empty, so a formatting call must not
+                # be able to fail the step.
+                ARTIFACT_NAME=$(echo "$OUTPUT" | jq -r '.name') || ARTIFACT_NAME='unknown'
+                echo "Seed landed as $ARTIFACT_NAME"
+                echo "- Seed landed in the remote cache as \`$ARTIFACT_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+              echo "::error::This seed build ran, but nothing is cached for traits '$TRAITS'. Seeding has stopped working: check whether the build still reaches its upload step."
+              echo "- **A seed just ran and the cache is still empty.** Seeding has stopped working." >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+            echo "Lookup attempt $attempt failed"
+            sleep 5
+          done
+
+          # Nothing downstream re-checks this, so guessing would report a success that was never verified - the exact
+          # silent pass this step exists to catch.
+          echo "::error::Could not query the remote cache after 3 attempts, so whether the seed landed is unknown. Failing rather than reporting an unverified success."
+          echo "- **Lookup failed, so the seed could not be verified.**" >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -38,13 +38,6 @@ on:
         description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
         type: string
         default: ''
-      cache-traits:
-        # Taken from the caller rather than derived here so that the traits its gate looked up and the traits this
-        # build verifies afterwards cannot drift apart. Required whenever `seed-cache-only` is set - the verification
-        # errors out without it rather than skipping, so forgetting it cannot silently disable the check.
-        description: Rock traits naming the base cache artifact a seed build should have written, e.g. 'Adhoc'. Required when seed-cache-only is set.
-        type: string
-        default: ''
 
     outputs:
       VERSION_CODE:
@@ -181,6 +174,9 @@ jobs:
       # A caller that skips this build on a cache hit is only as good as its fingerprint matching the one used
       # here. Warn rather than fail: a mismatch costs the savings, never correctness, because the build below
       # repeats the lookup itself and stops early when it does hit.
+      #
+      # Kept in step with the iOS workflow, where the lookup and the build run on different hosts and so this is
+      # answering a real question. Here both run on Linux, which makes it a cheap canary rather than a check.
       - name: Compare fingerprint against the one the caller looked up
         if: ${{ inputs.seed-cache-only && inputs.expected-fingerprint != '' }}
         env:
@@ -337,47 +333,28 @@ jobs:
           name: ${{ inputs.artifact-prefix }}android-apk-artifact
           path: Expensify.apk
 
-      # A seed build that finishes without uploading anything looks exactly like a working one, and nothing notices:
-      # PR builds simply compile their own native code again, which reads as slow CI rather than as a failure. So ask
-      # the bucket the same question a PR build's lookup asks. Asking the bucket rather than reading the build
-      # action's own `ARTIFACT_URL` is the point - one action bump could move the gate on its upload step and break
-      # the upload and its self-report together. Last in the job so a failure here costs none of the uploads above.
+      # A seed build that finishes without caching anything looks exactly like a working one, and nothing downstream
+      # notices: PR builds just compile their own native code again, which reads as slow CI rather than as a failure.
+      # So ask the bucket the same question a PR build's lookup asks, rather than trusting the build action's own
+      # report - an action bump could move the gate on its upload step and break the upload and its self-report
+      # together. Last in the job so a failure here costs none of the uploads above.
       - name: Verify the seed landed in the remote cache
         if: ${{ inputs.seed-cache-only }}
         env:
           IS_HYBRID_APP: 'true'
-          TRAITS: ${{ inputs.cache-traits }}
+          # The same `variant` handed to the build above, which is what the action keys its traits on, so the
+          # namespace checked here is the one just built. A single query, unretried: nothing depends on this
+          # workflow, so a transient S3 blip failing a seed run is cheaper than a retry loop.
+          TRAITS: ${{ inputs.variant }}
         run: |
-          # Erroring rather than skipping: a seed that quietly stops verifying is the failure this step exists to
-          # catch, so it must not be possible to turn it off by leaving an input out.
-          if [ -z "$TRAITS" ]; then
-            echo "::error::seed-cache-only builds need cache-traits set, naming the artifact this seed should have written. Without it there is nothing to verify against."
+          if ! OUTPUT=$(npx rock remote-cache list -p android --traits "$TRAITS" --json); then
+            echo "::error::Could not query the remote cache, so whether the seed landed is unknown. Failing rather than reporting an unverified success."
+            echo '- **Lookup failed, so the seed could not be verified.**' >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-
-          # Unlike the lookup that gates this build, this needs no separate check that the cache provider is usable:
-          # a broken one makes `list` print nothing, which fails here. That is the safe direction to guess wrong in.
-          # On a gate the same silence reads as "nothing cached" and quietly turns it into a rubber stamp.
-          for attempt in 1 2 3; do
-            if OUTPUT=$(npx rock remote-cache list -p android --traits "$TRAITS" --json); then
-              if [ -n "$OUTPUT" ]; then
-                # Only for the log line. The verdict is `$OUTPUT` being non-empty, so a formatting call must not
-                # be able to fail the step.
-                ARTIFACT_NAME=$(echo "$OUTPUT" | jq -r '.name') || ARTIFACT_NAME='unknown'
-                echo "Seed landed as $ARTIFACT_NAME"
-                echo "- Seed landed in the remote cache as \`$ARTIFACT_NAME\`" >> "$GITHUB_STEP_SUMMARY"
-                exit 0
-              fi
-              echo "::error::This seed build ran, but nothing is cached for traits '$TRAITS'. Seeding has stopped working: check whether the build still reaches its upload step."
-              echo "- **A seed just ran and the cache is still empty.** Seeding has stopped working." >> "$GITHUB_STEP_SUMMARY"
-              exit 1
-            fi
-            echo "Lookup attempt $attempt failed"
-            sleep 5
-          done
-
-          # Nothing downstream re-checks this, so guessing would report a success that was never verified - the exact
-          # silent pass this step exists to catch.
-          echo "::error::Could not query the remote cache after 3 attempts, so whether the seed landed is unknown. Failing rather than reporting an unverified success."
-          echo "- **Lookup failed, so the seed could not be verified.**" >> "$GITHUB_STEP_SUMMARY"
-          exit 1
+          if [ -z "$OUTPUT" ]; then
+            echo "::error::This seed build ran, but nothing is cached for traits '$TRAITS'. Check whether the build still reaches 'Upload ZIP Artifact for caching'."
+            echo '- **A seed just ran and the cache is still empty.** Seeding has stopped working.' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Seed landed for traits '$TRAITS'"

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -27,6 +27,14 @@ on:
         description: Force a full native build, bypassing Rock remote cache
         type: string
         default: 'false'
+      seed-cache-only:
+        description: Build only to warm the Rock remote cache. Skips re-signing and ad-hoc distribution, so a cached fingerprint costs nothing but the lookup.
+        type: string
+        default: 'false'
+      expected-fingerprint:
+        description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
+        type: string
+        default: ''
 
     outputs:
       IOS_VERSION:
@@ -222,6 +230,25 @@ jobs:
             echo 'PROFILES=[{"name":"(OldApp) AdHoc","file":"./OldApp_AdHoc.mobileprovision"},{"name":"(OldApp) AdHoc: Share Extension","file":"./OldApp_AdHoc_Share_Extension.mobileprovision"},{"name":"(OldApp) AdHoc: Notification Service","file":"./OldApp_AdHoc_Notification_Service.mobileprovision"},{"name":"(OldApp) AdHoc: LiveActivityExtension","file":"./OldApp_AdHoc_LiveActivityExtension.mobileprovision"}]' >> "$GITHUB_OUTPUT"
           fi
 
+      # A caller that skips this build on a cache hit is only as good as its fingerprint matching the one used
+      # here. Warn rather than fail: a mismatch costs the savings, never correctness, because the build below
+      # repeats the lookup itself and stops early when it does hit.
+      - name: Compare fingerprint against the one the caller looked up
+        if: ${{ inputs.seed-cache-only == 'true' && inputs.expected-fingerprint != '' }}
+        env:
+          IS_HYBRID_APP: 'true'
+          EXPECTED_FINGERPRINT: ${{ inputs.expected-fingerprint }}
+        run: |
+          ACTUAL_FINGERPRINT=$(npx rock fingerprint -p ios --raw 2>/dev/null) || ACTUAL_FINGERPRINT=''
+          if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then
+            echo "::warning::The caller looked up $EXPECTED_FINGERPRINT but this build computed ${ACTUAL_FINGERPRINT:-nothing}, so its cache check is guarding a different fingerprint and can never skip this build."
+            echo "### Fingerprint mismatch" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Caller looked up \`$EXPECTED_FINGERPRINT\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- This build computed \`${ACTUAL_FINGERPRINT:-nothing}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Fingerprint matches the caller's lookup: $ACTUAL_FINGERPRINT"
+          fi
+
       - name: Rock Remote Build - iOS
         id: rock-remote-build-ios
         uses: callstackincubator/ios@dd30f7e53eee2ea6a59509793d0a30fbb5c91216
@@ -232,8 +259,10 @@ jobs:
           FORCE_NATIVE_BUILD: ${{ inputs.force-native-build == 'true' && github.run_id || '' }}
         with:
           destination: device
-          re-sign: true
-          ad-hoc: ${{ inputs.variant == 'Adhoc' }}
+          # A seed build only needs to upload the base artifact it just compiled, which happens on a cache miss
+          # regardless of these two. Leaving them off means a cache hit stops right after the lookup.
+          re-sign: ${{ inputs.seed-cache-only != 'true' }}
+          ad-hoc: ${{ inputs.variant == 'Adhoc' && inputs.seed-cache-only != 'true' }}
           scheme: ${{ inputs.variant == 'Release' && 'Expensify' || 'Expensify AdHoc' }}
           configuration: ${{ inputs.variant == 'Release' && 'Release' || 'AdHoc' }}
           certificate-file: './Certificates.p12'

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -28,9 +28,12 @@ on:
         type: string
         default: 'false'
       seed-cache-only:
+        # Typed boolean rather than a string like `force-native-build` above, which has to stay a string because it is
+        # threaded through from a dispatch input. This one is only ever set to a literal, and actionlint rejects a
+        # quoted 'true' passed to a string input, so a real boolean is both truthful and lintable.
         description: Build only to warm the Rock remote cache. Skips re-signing and ad-hoc distribution, so a cached fingerprint costs nothing but the lookup.
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
       expected-fingerprint:
         description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
         type: string
@@ -234,7 +237,7 @@ jobs:
       # here. Warn rather than fail: a mismatch costs the savings, never correctness, because the build below
       # repeats the lookup itself and stops early when it does hit.
       - name: Compare fingerprint against the one the caller looked up
-        if: ${{ inputs.seed-cache-only == 'true' && inputs.expected-fingerprint != '' }}
+        if: ${{ inputs.seed-cache-only && inputs.expected-fingerprint != '' }}
         env:
           IS_HYBRID_APP: 'true'
           EXPECTED_FINGERPRINT: ${{ inputs.expected-fingerprint }}
@@ -242,9 +245,11 @@ jobs:
           ACTUAL_FINGERPRINT=$(npx rock fingerprint -p ios --raw 2>/dev/null) || ACTUAL_FINGERPRINT=''
           if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then
             echo "::warning::The caller looked up $EXPECTED_FINGERPRINT but this build computed ${ACTUAL_FINGERPRINT:-nothing}, so its cache check is guarding a different fingerprint and can never skip this build."
-            echo "### Fingerprint mismatch" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Caller looked up \`$EXPECTED_FINGERPRINT\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- This build computed \`${ACTUAL_FINGERPRINT:-nothing}\`" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "### Fingerprint mismatch"
+              echo "- Caller looked up \`$EXPECTED_FINGERPRINT\`"
+              echo "- This build computed \`${ACTUAL_FINGERPRINT:-nothing}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "Fingerprint matches the caller's lookup: $ACTUAL_FINGERPRINT"
           fi
@@ -261,8 +266,8 @@ jobs:
           destination: device
           # A seed build only needs to upload the base artifact it just compiled, which happens on a cache miss
           # regardless of these two. Leaving them off means a cache hit stops right after the lookup.
-          re-sign: ${{ inputs.seed-cache-only != 'true' }}
-          ad-hoc: ${{ inputs.variant == 'Adhoc' && inputs.seed-cache-only != 'true' }}
+          re-sign: ${{ !inputs.seed-cache-only }}
+          ad-hoc: ${{ inputs.variant == 'Adhoc' && !inputs.seed-cache-only }}
           scheme: ${{ inputs.variant == 'Release' && 'Expensify' || 'Expensify AdHoc' }}
           configuration: ${{ inputs.variant == 'Release' && 'Release' || 'AdHoc' }}
           certificate-file: './Certificates.p12'

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -38,6 +38,13 @@ on:
         description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
         type: string
         default: ''
+      cache-traits:
+        # Taken from the caller rather than derived here so that the traits its gate looked up and the traits this
+        # build verifies afterwards cannot drift apart. Required whenever `seed-cache-only` is set - the verification
+        # errors out without it rather than skipping, so forgetting it cannot silently disable the check.
+        description: Rock traits naming the base cache artifact a seed build should have written, e.g. 'device,AdHoc'. Required when seed-cache-only is set.
+        type: string
+        default: ''
 
     outputs:
       IOS_VERSION:
@@ -338,3 +345,48 @@ jobs:
         with:
           name: ${{ inputs.artifact-prefix }}ios-sourcemap-artifact
           path: Mobile-Expensify/main.jsbundle.map
+
+      # A seed build that finishes without uploading anything looks exactly like a working one, and nothing notices:
+      # PR builds simply compile their own native code again, which reads as slow CI rather than as a failure. So ask
+      # the bucket the same question a PR build's lookup asks. Asking the bucket rather than reading the build
+      # action's own `ARTIFACT_URL` is the point - one action bump could move the gate on its upload step and break
+      # the upload and its self-report together. Last in the job so a failure here costs none of the uploads above.
+      - name: Verify the seed landed in the remote cache
+        if: ${{ inputs.seed-cache-only }}
+        env:
+          IS_HYBRID_APP: 'true'
+          TRAITS: ${{ inputs.cache-traits }}
+        run: |
+          # Erroring rather than skipping: a seed that quietly stops verifying is the failure this step exists to
+          # catch, so it must not be possible to turn it off by leaving an input out.
+          if [ -z "$TRAITS" ]; then
+            echo "::error::seed-cache-only builds need cache-traits set, naming the artifact this seed should have written. Without it there is nothing to verify against."
+            exit 1
+          fi
+
+          # Unlike the lookup that gates this build, this needs no separate check that the cache provider is usable:
+          # a broken one makes `list` print nothing, which fails here. That is the safe direction to guess wrong in.
+          # On a gate the same silence reads as "nothing cached" and quietly turns it into a rubber stamp.
+          for attempt in 1 2 3; do
+            if OUTPUT=$(npx rock remote-cache list -p ios --traits "$TRAITS" --json); then
+              if [ -n "$OUTPUT" ]; then
+                # Only for the log line. The verdict is `$OUTPUT` being non-empty, so a formatting call must not
+                # be able to fail the step.
+                ARTIFACT_NAME=$(echo "$OUTPUT" | jq -r '.name') || ARTIFACT_NAME='unknown'
+                echo "Seed landed as $ARTIFACT_NAME"
+                echo "- Seed landed in the remote cache as \`$ARTIFACT_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+              echo "::error::This seed build ran, but nothing is cached for traits '$TRAITS'. Seeding has stopped working: check whether the build still reaches its upload step."
+              echo "- **A seed just ran and the cache is still empty.** Seeding has stopped working." >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+            echo "Lookup attempt $attempt failed"
+            sleep 5
+          done
+
+          # Nothing downstream re-checks this, so guessing would report a success that was never verified - the exact
+          # silent pass this step exists to catch.
+          echo "::error::Could not query the remote cache after 3 attempts, so whether the seed landed is unknown. Failing rather than reporting an unverified success."
+          echo "- **Lookup failed, so the seed could not be verified.**" >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -38,13 +38,6 @@ on:
         description: Fingerprint a caller already computed elsewhere. Seed builds warn when theirs differs, which means the caller's cache lookup was answering for a different build.
         type: string
         default: ''
-      cache-traits:
-        # Taken from the caller rather than derived here so that the traits its gate looked up and the traits this
-        # build verifies afterwards cannot drift apart. Required whenever `seed-cache-only` is set - the verification
-        # errors out without it rather than skipping, so forgetting it cannot silently disable the check.
-        description: Rock traits naming the base cache artifact a seed build should have written, e.g. 'device,AdHoc'. Required when seed-cache-only is set.
-        type: string
-        default: ''
 
     outputs:
       IOS_VERSION:
@@ -243,6 +236,9 @@ jobs:
       # A caller that skips this build on a cache hit is only as good as its fingerprint matching the one used
       # here. Warn rather than fail: a mismatch costs the savings, never correctness, because the build below
       # repeats the lookup itself and stops early when it does hit.
+      #
+      # This exists to answer one open question - whether the Linux host the iOS lookup runs on computes the same
+      # fingerprint as this macOS runner. Once a real run confirms that, it can go; keeping it is a cheap canary.
       - name: Compare fingerprint against the one the caller looked up
         if: ${{ inputs.seed-cache-only && inputs.expected-fingerprint != '' }}
         env:
@@ -346,47 +342,28 @@ jobs:
           name: ${{ inputs.artifact-prefix }}ios-sourcemap-artifact
           path: Mobile-Expensify/main.jsbundle.map
 
-      # A seed build that finishes without uploading anything looks exactly like a working one, and nothing notices:
-      # PR builds simply compile their own native code again, which reads as slow CI rather than as a failure. So ask
-      # the bucket the same question a PR build's lookup asks. Asking the bucket rather than reading the build
-      # action's own `ARTIFACT_URL` is the point - one action bump could move the gate on its upload step and break
-      # the upload and its self-report together. Last in the job so a failure here costs none of the uploads above.
+      # A seed build that finishes without caching anything looks exactly like a working one, and nothing downstream
+      # notices: PR builds just compile their own native code again, which reads as slow CI rather than as a failure.
+      # So ask the bucket the same question a PR build's lookup asks, rather than trusting the build action's own
+      # report - an action bump could move the gate on its upload step and break the upload and its self-report
+      # together. Last in the job so a failure here costs none of the uploads above.
       - name: Verify the seed landed in the remote cache
         if: ${{ inputs.seed-cache-only }}
         env:
           IS_HYBRID_APP: 'true'
-          TRAITS: ${{ inputs.cache-traits }}
+          # Same expression that sets `configuration` on the build above, so the namespace checked here is the one
+          # just built. A single query, unretried: nothing depends on this workflow, so a transient S3 blip failing
+          # a seed run is cheaper than a retry loop, and failing loud is the safe direction to guess wrong in.
+          TRAITS: device,${{ inputs.variant == 'Release' && 'Release' || 'AdHoc' }}
         run: |
-          # Erroring rather than skipping: a seed that quietly stops verifying is the failure this step exists to
-          # catch, so it must not be possible to turn it off by leaving an input out.
-          if [ -z "$TRAITS" ]; then
-            echo "::error::seed-cache-only builds need cache-traits set, naming the artifact this seed should have written. Without it there is nothing to verify against."
+          if ! OUTPUT=$(npx rock remote-cache list -p ios --traits "$TRAITS" --json); then
+            echo "::error::Could not query the remote cache, so whether the seed landed is unknown. Failing rather than reporting an unverified success."
+            echo '- **Lookup failed, so the seed could not be verified.**' >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-
-          # Unlike the lookup that gates this build, this needs no separate check that the cache provider is usable:
-          # a broken one makes `list` print nothing, which fails here. That is the safe direction to guess wrong in.
-          # On a gate the same silence reads as "nothing cached" and quietly turns it into a rubber stamp.
-          for attempt in 1 2 3; do
-            if OUTPUT=$(npx rock remote-cache list -p ios --traits "$TRAITS" --json); then
-              if [ -n "$OUTPUT" ]; then
-                # Only for the log line. The verdict is `$OUTPUT` being non-empty, so a formatting call must not
-                # be able to fail the step.
-                ARTIFACT_NAME=$(echo "$OUTPUT" | jq -r '.name') || ARTIFACT_NAME='unknown'
-                echo "Seed landed as $ARTIFACT_NAME"
-                echo "- Seed landed in the remote cache as \`$ARTIFACT_NAME\`" >> "$GITHUB_STEP_SUMMARY"
-                exit 0
-              fi
-              echo "::error::This seed build ran, but nothing is cached for traits '$TRAITS'. Seeding has stopped working: check whether the build still reaches its upload step."
-              echo "- **A seed just ran and the cache is still empty.** Seeding has stopped working." >> "$GITHUB_STEP_SUMMARY"
-              exit 1
-            fi
-            echo "Lookup attempt $attempt failed"
-            sleep 5
-          done
-
-          # Nothing downstream re-checks this, so guessing would report a success that was never verified - the exact
-          # silent pass this step exists to catch.
-          echo "::error::Could not query the remote cache after 3 attempts, so whether the seed landed is unknown. Failing rather than reporting an unverified success."
-          echo "- **Lookup failed, so the seed could not be verified.**" >> "$GITHUB_STEP_SUMMARY"
-          exit 1
+          if [ -z "$OUTPUT" ]; then
+            echo "::error::This seed build ran, but nothing is cached for traits '$TRAITS'. Check whether the build still reaches 'Upload ZIP Artifact for caching'."
+            echo '- **A seed just ran and the cache is still empty.** Seeding has stopped working.' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Seed landed for traits '$TRAITS'"

--- a/.github/workflows/checkRockCache.yml
+++ b/.github/workflows/checkRockCache.yml
@@ -1,0 +1,131 @@
+name: Check Rock remote cache
+
+# Reusable workflow that reports whether Rock's remote cache already holds an artifact for the current native
+# `fingerprint` and the given traits. A build whose only purpose is to seed that cache has nothing to do when it
+# does, so its caller can skip it.
+#
+# Rock computes the answer, so there is nothing here to keep in sync with `rock.config.mjs`. If the lookup is
+# wrong or fails, this reports that a build is needed and the build repeats the same lookup itself and stops
+# early, so the worst case is one cheap job that did not need to run, never a cache that silently stops being
+# seeded.
+#
+# With `expect-cached`, the same lookup becomes an assertion instead of a question: run it after a seed build to
+# prove the seed actually wrote something. Without it, a seed that stops uploading - because an action bump moved
+# the gate its upload step sits behind, say - keeps reporting success while the cache quietly goes cold.
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: "'ios' or 'android'"
+        type: string
+        required: true
+      traits:
+        description: "Comma separated Rock traits identifying the variant, e.g. 'device,AdHoc' on iOS or 'Adhoc' on Android"
+        type: string
+        required: true
+      expect-cached:
+        description: Fail when the cache holds nothing, instead of reporting that a build is needed. Use after a seed build to verify it landed.
+        type: string
+        default: 'false'
+    # Named rather than inherited: a lookup needs the submodule and the bucket, and nothing else. Callers of the
+    # build workflows have to inherit, because a build needs most of the vault.
+    secrets:
+      OS_BOTIFY_TOKEN:
+        description: Token used to check out the Mobile-Expensify submodule, whose native sources the fingerprint covers.
+        required: true
+      AWS_ACCESS_KEY_ID:
+        description: Key for the bucket backing Rock's remote cache.
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        description: Secret for the bucket backing Rock's remote cache.
+        required: true
+    outputs:
+      NEEDS_BUILD:
+        description: Whether the cache holds no artifact for this fingerprint, so a build would do real work.
+        value: ${{ jobs.check.outputs.NEEDS_BUILD }}
+      FINGERPRINT:
+        description: The fingerprint this lookup used, so a build can confirm it computed the same one on its own host.
+        value: ${{ jobs.check.outputs.FINGERPRINT }}
+
+jobs:
+  check:
+    name: Check Rock remote cache
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Nothing here should take more than a couple of minutes. Without a bound, a hung install or S3 call would
+    # hold a runner for the default six hours on every push to main.
+    timeout-minutes: 15
+    outputs:
+      NEEDS_BUILD: ${{ steps.check.outputs.NEEDS_BUILD }}
+      FINGERPRINT: ${{ steps.check.outputs.FINGERPRINT }}
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
+        with:
+          ref: ${{ github.sha }}
+          # The fingerprint covers the HybridApp native sources, which live in the submodule.
+          submodules: true
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+        with:
+          IS_HYBRID_BUILD: 'true'
+
+      - name: Configure AWS Credentials
+        # v6
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Look up an artifact for this fingerprint
+        id: check
+        env:
+          # Seeds are HybridApp builds, so the fingerprint has to be computed over the same sources they use.
+          IS_HYBRID_APP: 'true'
+          PLATFORM: ${{ inputs.platform }}
+          TRAITS: ${{ inputs.traits }}
+          EXPECT_CACHED: ${{ inputs.expect-cached }}
+        run: |
+          # With no cache provider configured at all, Rock's lookup prints nothing and exits 0, which reads here as
+          # "not cached" and would quietly turn this from a gate into a rubber stamp that seeds on every push. That
+          # can only mean `rock.config.mjs` is broken, never a transient fault, so fail rather than guess. Missing
+          # credentials are a different story and need no check: the bucket refuses anonymous ListObjects, so the
+          # lookup below fails loudly and takes the warn-and-seed path instead of answering wrongly.
+          PROVIDER=$(npx rock remote-cache get-provider-name) || PROVIDER=''
+          if [ "$PROVIDER" != 'S3' ]; then
+            echo "::error::Expected the S3 remote cache provider, got '${PROVIDER:-none}'. This lookup cannot answer without it."
+            exit 1
+          fi
+
+          # Exported so a seed build can confirm it computed the same fingerprint on its own host. `--raw` puts the
+          # hash on stdout and the full source list on stderr, which stays in the log for comparisons.
+          FINGERPRINT=$(npx rock fingerprint -p "$PLATFORM" --raw) || FINGERPRINT=''
+          echo "FINGERPRINT=$FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "### Rock remote cache: \`$PLATFORM\` \`$TRAITS\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Fingerprint: \`${FINGERPRINT:-unknown}\`" >> "$GITHUB_STEP_SUMMARY"
+
+          # A lookup that errors out may just be a bad minute for S3, so warn and let the build decide for itself.
+          if ! OUTPUT=$(npx rock remote-cache list -p "$PLATFORM" --traits "$TRAITS" --json); then
+            echo "::warning::Could not query the remote cache, so assuming a build is needed"
+            echo "- Lookup failed, assuming a build is needed" >> "$GITHUB_STEP_SUMMARY"
+            echo "NEEDS_BUILD=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$OUTPUT" ]; then
+            ARTIFACT_NAME=$(echo "$OUTPUT" | jq -r '.name')
+            echo "Already cached: $ARTIFACT_NAME"
+            echo "- Cached as \`$ARTIFACT_NAME\`, no build needed" >> "$GITHUB_STEP_SUMMARY"
+            echo "NEEDS_BUILD=false" >> "$GITHUB_OUTPUT"
+          elif [ "$EXPECT_CACHED" == 'true' ]; then
+            echo "::error::A seed build for traits '$TRAITS' just ran, but nothing is cached at fingerprint ${FINGERPRINT:-unknown}. Seeding has stopped working: check whether the build still reaches its upload step."
+            echo "- **A seed just ran and the cache is still empty.** Seeding has stopped working." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          else
+            echo "Nothing cached for traits '$TRAITS' at this fingerprint"
+            echo "- Nothing cached, a build would do real work" >> "$GITHUB_STEP_SUMMARY"
+            echo "NEEDS_BUILD=true" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/checkRockCache.yml
+++ b/.github/workflows/checkRockCache.yml
@@ -107,8 +107,28 @@ jobs:
           echo "### Rock remote cache: \`$PLATFORM\` \`$TRAITS\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Fingerprint: \`${FINGERPRINT:-unknown}\`" >> "$GITHUB_STEP_SUMMARY"
 
-          # A lookup that errors out may just be a bad minute for S3, so warn and let the build decide for itself.
-          if ! OUTPUT=$(npx rock remote-cache list -p "$PLATFORM" --traits "$TRAITS" --json); then
+          # A lookup that errors out may just be a bad minute for S3, so give it a few tries before deciding.
+          LOOKUP_OK=false
+          for attempt in 1 2 3; do
+            if OUTPUT=$(npx rock remote-cache list -p "$PLATFORM" --traits "$TRAITS" --json); then
+              LOOKUP_OK=true
+              break
+            fi
+            echo "Lookup attempt $attempt failed"
+            sleep 5
+          done
+
+          if [ "$LOOKUP_OK" != 'true' ]; then
+            # Which way to fail depends on who is asking. A gate can afford to guess "build needed", because the
+            # build repeats this lookup and stops early if it was wrong. A verification has nothing downstream to
+            # correct it, so guessing there would report that a seed landed without having checked - the exact
+            # silent success this job exists to catch.
+            if [ "$EXPECT_CACHED" == 'true' ]; then
+              echo "::error::Could not query the remote cache after 3 attempts, so whether the seed landed is unknown. Nothing downstream re-checks this, so failing rather than reporting an unverified success."
+              echo "- **Lookup failed, so the seed could not be verified.**" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+
             echo "::warning::Could not query the remote cache, so assuming a build is needed"
             echo "- Lookup failed, assuming a build is needed" >> "$GITHUB_STEP_SUMMARY"
             echo "NEEDS_BUILD=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/checkRockCache.yml
+++ b/.github/workflows/checkRockCache.yml
@@ -26,8 +26,8 @@ on:
         required: true
       expect-cached:
         description: Fail when the cache holds nothing, instead of reporting that a build is needed. Use after a seed build to verify it landed.
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
     # Named rather than inherited: a lookup needs the submodule and the bucket, and nothing else. Callers of the
     # build workflows have to inherit, because a build needs most of the vault.
     secrets:

--- a/.github/workflows/checkRockCache.yml
+++ b/.github/workflows/checkRockCache.yml
@@ -9,9 +9,9 @@ name: Check Rock remote cache
 # early, so the worst case is one cheap job that did not need to run, never a cache that silently stops being
 # seeded.
 #
-# With `expect-cached`, the same lookup becomes an assertion instead of a question: run it after a seed build to
-# prove the seed actually wrote something. Without it, a seed that stops uploading - because an action bump moved
-# the gate its upload step sits behind, say - keeps reporting success while the cache quietly goes cold.
+# This only ever answers the question before a build. The mirror-image assertion afterwards - proving a seed build
+# actually wrote something - lives as a step at the end of the build workflows, where the repo is already checked
+# out and the fingerprint is the one that host really built.
 
 on:
   workflow_call:
@@ -24,10 +24,6 @@ on:
         description: "Comma separated Rock traits identifying the variant, e.g. 'device,AdHoc' on iOS or 'Adhoc' on Android"
         type: string
         required: true
-      expect-cached:
-        description: Fail when the cache holds nothing, instead of reporting that a build is needed. Use after a seed build to verify it landed.
-        type: boolean
-        default: false
     # Named rather than inherited: a lookup needs the submodule and the bucket, and nothing else. Callers of the
     # build workflows have to inherit, because a build needs most of the vault.
     secrets:
@@ -47,6 +43,12 @@ on:
       FINGERPRINT:
         description: The fingerprint this lookup used, so a build can confirm it computed the same one on its own host.
         value: ${{ jobs.check.outputs.FINGERPRINT }}
+      TRAITS:
+        # An echo of the input, on purpose. A seed build verifies afterwards that it wrote what this gate looked for,
+        # and handing it these traits rather than restating them is what stops the two from ever naming different
+        # artifacts.
+        description: The traits this lookup was given, so a seed build can verify against exactly what was looked up.
+        value: ${{ inputs.traits }}
 
 jobs:
   check:
@@ -87,7 +89,6 @@ jobs:
           IS_HYBRID_APP: 'true'
           PLATFORM: ${{ inputs.platform }}
           TRAITS: ${{ inputs.traits }}
-          EXPECT_CACHED: ${{ inputs.expect-cached }}
         run: |
           # With no cache provider configured at all, Rock's lookup prints nothing and exits 0, which reads here as
           # "not cached" and would quietly turn this from a gate into a rubber stamp that seeds on every push. That
@@ -119,16 +120,7 @@ jobs:
           done
 
           if [ "$LOOKUP_OK" != 'true' ]; then
-            # Which way to fail depends on who is asking. A gate can afford to guess "build needed", because the
-            # build repeats this lookup and stops early if it was wrong. A verification has nothing downstream to
-            # correct it, so guessing there would report that a seed landed without having checked - the exact
-            # silent success this job exists to catch.
-            if [ "$EXPECT_CACHED" == 'true' ]; then
-              echo "::error::Could not query the remote cache after 3 attempts, so whether the seed landed is unknown. Nothing downstream re-checks this, so failing rather than reporting an unverified success."
-              echo "- **Lookup failed, so the seed could not be verified.**" >> "$GITHUB_STEP_SUMMARY"
-              exit 1
-            fi
-
+            # Safe to guess "build needed" here: the build repeats this lookup and stops early if the guess was wrong.
             echo "::warning::Could not query the remote cache, so assuming a build is needed"
             echo "- Lookup failed, assuming a build is needed" >> "$GITHUB_STEP_SUMMARY"
             echo "NEEDS_BUILD=true" >> "$GITHUB_OUTPUT"
@@ -140,10 +132,6 @@ jobs:
             echo "Already cached: $ARTIFACT_NAME"
             echo "- Cached as \`$ARTIFACT_NAME\`, no build needed" >> "$GITHUB_STEP_SUMMARY"
             echo "NEEDS_BUILD=false" >> "$GITHUB_OUTPUT"
-          elif [ "$EXPECT_CACHED" == 'true' ]; then
-            echo "::error::A seed build for traits '$TRAITS' just ran, but nothing is cached at fingerprint ${FINGERPRINT:-unknown}. Seeding has stopped working: check whether the build still reaches its upload step."
-            echo "- **A seed just ran and the cache is still empty.** Seeding has stopped working." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
           else
             echo "Nothing cached for traits '$TRAITS' at this fingerprint"
             echo "- Nothing cached, a build would do real work" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/checkRockCache.yml
+++ b/.github/workflows/checkRockCache.yml
@@ -43,12 +43,6 @@ on:
       FINGERPRINT:
         description: The fingerprint this lookup used, so a build can confirm it computed the same one on its own host.
         value: ${{ jobs.check.outputs.FINGERPRINT }}
-      TRAITS:
-        # An echo of the input, on purpose. A seed build verifies afterwards that it wrote what this gate looked for,
-        # and handing it these traits rather than restating them is what stops the two from ever naming different
-        # artifacts.
-        description: The traits this lookup was given, so a seed build can verify against exactly what was looked up.
-        value: ${{ inputs.traits }}
 
 jobs:
   check:

--- a/.github/workflows/seedAdHocCache.yml
+++ b/.github/workflows/seedAdHocCache.yml
@@ -67,7 +67,7 @@ jobs:
     with:
       ref: ${{ github.sha }}
       variant: Adhoc
-      seed-cache-only: 'true'
+      seed-cache-only: true
       artifact-prefix: adhoc-seed-
       # The lookup ran on Linux and this build runs on macOS. Passing the hash lets the build say so when the two
       # hosts disagree, which would mean the lookup above is guarding nothing.
@@ -83,7 +83,7 @@ jobs:
     with:
       platform: ios
       traits: device,AdHoc
-      expect-cached: 'true'
+      expect-cached: true
     secrets:
       OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -109,7 +109,7 @@ jobs:
     with:
       ref: ${{ github.sha }}
       variant: Adhoc
-      seed-cache-only: 'true'
+      seed-cache-only: true
       artifact-prefix: adhoc-seed-
       # Both the lookup and this build run on Linux, so the two fingerprints should always agree. Passing the hash
       # keeps that an assertion rather than an assumption.
@@ -123,7 +123,7 @@ jobs:
     with:
       platform: android
       traits: Adhoc
-      expect-cached: 'true'
+      expect-cached: true
     secrets:
       OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/seedAdHocCache.yml
+++ b/.github/workflows/seedAdHocCache.yml
@@ -1,0 +1,130 @@
+name: Seed AdHoc build cache
+
+# Rock keys its remote cache by variant/traits plus the native `fingerprint`, and pushes to main only ever build
+# the simulator/Debug variant on iOS and developmentDebug/Debug on Android. Nothing warms the AdHoc namespaces
+# that PR test builds read from, so the first PR on any new native fingerprint pays a full ~8 minute compile.
+# Running the same AdHoc builds PR test builds run means that first compile happens here instead of on a PR's
+# critical path, and every later PR on the same fingerprint downloads it in seconds.
+#
+# This is deliberately its own workflow rather than more jobs inside the remote-build workflows. There, an
+# 8 minute compile would extend every run in main's serialized concurrency group, and a seed failure would redden
+# `Remote Build iOS` / `Remote Build Android`, which `failureNotifier.yml` watches and files against whoever
+# merged the unrelated PR that happened to trigger the run.
+#
+# Nothing depends on this workflow. When it fails, PR test builds simply compile their own native code again -
+# slower, never wrong - so failures are intentionally not filed against anyone. Watch the Actions tab.
+
+on:
+  push:
+    branches: [main]
+    # Mirrors the remote-build workflows. Note `scripts/**` is a pre-existing gap: `compute-patches-hash.sh` is a
+    # fingerprint input, so changing it alone moves the fingerprint without triggering any build, seed or otherwise.
+    paths-ignore: ['docs/**', 'contributingGuides/**', 'help/**', '.github/**', 'scripts/**', 'tests/**']
+  workflow_dispatch:
+    inputs:
+      reviewed_code:
+        description: I reviewed the code at the ref I am building and verified that it does not contain any malicious code.
+        type: boolean
+        required: true
+        default: false
+
+concurrency:
+  # Seeding one fingerprint twice is wasted work, but cancelling a compile that is nearly finished is worse, so let
+  # runs queue instead. GitHub drops the older pending run, and the newer one's fingerprint already covers it.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # A dispatch builds whatever ref it names and exposes the build secrets to it, exactly as the remote-build
+  # workflows do, so it gets the same gate: the actor must be an Expensify employee with write access and must
+  # confirm they reviewed the code at that ref. Pushes to main are already trusted, and the gate no-ops for them.
+  prep:
+    uses: ./.github/workflows/validateBuildRequest.yml
+    with:
+      REVIEWED_CODE: ${{ inputs.reviewed_code || false }}
+    secrets:
+      OS_BOTIFY_COMMIT_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
+
+  # The cache is keyed by fingerprint alone, not by branch, so seeding from wherever this runs is always correct and
+  # can never overwrite an existing entry. That is what makes a dispatch from a branch a safe way to test this.
+  checkIOSCache:
+    name: Check iOS AdHoc cache
+    needs: [prep]
+    uses: ./.github/workflows/checkRockCache.yml
+    with:
+      platform: ios
+      traits: device,AdHoc
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  seedIOS:
+    name: Seed iOS AdHoc cache
+    needs: [checkIOSCache]
+    if: ${{ needs.checkIOSCache.outputs.NEEDS_BUILD == 'true' }}
+    uses: ./.github/workflows/buildIOS.yml
+    with:
+      ref: ${{ github.sha }}
+      variant: Adhoc
+      seed-cache-only: 'true'
+      artifact-prefix: adhoc-seed-
+      # The lookup ran on Linux and this build runs on macOS. Passing the hash lets the build say so when the two
+      # hosts disagree, which would mean the lookup above is guarding nothing.
+      expected-fingerprint: ${{ needs.checkIOSCache.outputs.FINGERPRINT }}
+    secrets: inherit
+
+  # A seed that goes green without uploading anything looks exactly like a working one, so ask again afterwards.
+  # Skipped automatically when the seed itself failed, since a failed `needs` skips its dependents.
+  verifyIOSSeedLanded:
+    name: Verify iOS AdHoc seed landed
+    needs: [seedIOS]
+    uses: ./.github/workflows/checkRockCache.yml
+    with:
+      platform: ios
+      traits: device,AdHoc
+      expect-cached: 'true'
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  checkAndroidCache:
+    name: Check Android AdHoc cache
+    needs: [prep]
+    uses: ./.github/workflows/checkRockCache.yml
+    with:
+      platform: android
+      traits: Adhoc
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  seedAndroid:
+    name: Seed Android AdHoc cache
+    needs: [checkAndroidCache]
+    if: ${{ needs.checkAndroidCache.outputs.NEEDS_BUILD == 'true' }}
+    uses: ./.github/workflows/buildAndroid.yml
+    with:
+      ref: ${{ github.sha }}
+      variant: Adhoc
+      seed-cache-only: 'true'
+      artifact-prefix: adhoc-seed-
+      # Both the lookup and this build run on Linux, so the two fingerprints should always agree. Passing the hash
+      # keeps that an assertion rather than an assumption.
+      expected-fingerprint: ${{ needs.checkAndroidCache.outputs.FINGERPRINT }}
+    secrets: inherit
+
+  verifyAndroidSeedLanded:
+    name: Verify Android AdHoc seed landed
+    needs: [seedAndroid]
+    uses: ./.github/workflows/checkRockCache.yml
+    with:
+      platform: android
+      traits: Adhoc
+      expect-cached: 'true'
+    secrets:
+      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/seedAdHocCache.yml
+++ b/.github/workflows/seedAdHocCache.yml
@@ -72,22 +72,10 @@ jobs:
       # The lookup ran on Linux and this build runs on macOS. Passing the hash lets the build say so when the two
       # hosts disagree, which would mean the lookup above is guarding nothing.
       expected-fingerprint: ${{ needs.checkIOSCache.outputs.FINGERPRINT }}
+      # Taken from the lookup rather than written out again, so the artifact the build verifies it wrote is by
+      # construction the one the lookup above went looking for.
+      cache-traits: ${{ needs.checkIOSCache.outputs.TRAITS }}
     secrets: inherit
-
-  # A seed that goes green without uploading anything looks exactly like a working one, so ask again afterwards.
-  # Skipped automatically when the seed itself failed, since a failed `needs` skips its dependents.
-  verifyIOSSeedLanded:
-    name: Verify iOS AdHoc seed landed
-    needs: [seedIOS]
-    uses: ./.github/workflows/checkRockCache.yml
-    with:
-      platform: ios
-      traits: device,AdHoc
-      expect-cached: true
-    secrets:
-      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   checkAndroidCache:
     name: Check Android AdHoc cache
@@ -114,17 +102,7 @@ jobs:
       # Both the lookup and this build run on Linux, so the two fingerprints should always agree. Passing the hash
       # keeps that an assertion rather than an assumption.
       expected-fingerprint: ${{ needs.checkAndroidCache.outputs.FINGERPRINT }}
+      # Taken from the lookup rather than written out again, so the artifact the build verifies it wrote is by
+      # construction the one the lookup above went looking for.
+      cache-traits: ${{ needs.checkAndroidCache.outputs.TRAITS }}
     secrets: inherit
-
-  verifyAndroidSeedLanded:
-    name: Verify Android AdHoc seed landed
-    needs: [seedAndroid]
-    uses: ./.github/workflows/checkRockCache.yml
-    with:
-      platform: android
-      traits: Adhoc
-      expect-cached: true
-    secrets:
-      OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/seedAdHocCache.yml
+++ b/.github/workflows/seedAdHocCache.yml
@@ -72,9 +72,6 @@ jobs:
       # The lookup ran on Linux and this build runs on macOS. Passing the hash lets the build say so when the two
       # hosts disagree, which would mean the lookup above is guarding nothing.
       expected-fingerprint: ${{ needs.checkIOSCache.outputs.FINGERPRINT }}
-      # Taken from the lookup rather than written out again, so the artifact the build verifies it wrote is by
-      # construction the one the lookup above went looking for.
-      cache-traits: ${{ needs.checkIOSCache.outputs.TRAITS }}
     secrets: inherit
 
   checkAndroidCache:
@@ -102,7 +99,4 @@ jobs:
       # Both the lookup and this build run on Linux, so the two fingerprints should always agree. Passing the hash
       # keeps that an assertion rather than an assumption.
       expected-fingerprint: ${{ needs.checkAndroidCache.outputs.FINGERPRINT }}
-      # Taken from the lookup rather than written out again, so the artifact the build verifies it wrote is by
-      # construction the one the lookup above went looking for.
-      cache-traits: ${{ needs.checkAndroidCache.outputs.TRAITS }}
     secrets: inherit


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Rock keys its remote cache by `traits + configuration + fingerprint`, and on both platforms pushes to `main` build a different variant than PR test builds do - `simulator`/`Debug` vs `device`/`AdHoc` on iOS, `developmentDebug`/`Debug` vs `Adhoc` on Android. Different keys, different S3 namespaces, so nothing warms the one PR test builds read from and the first PR on any new native fingerprint always compiles for ~8 minutes.

This adds a `Seed AdHoc build cache` workflow that runs the same AdHoc builds PR test builds run, on pushes to `main`. Per platform: ask Rock whether the cache already holds an artifact for the current fingerprint, build only if it doesn't, and have that build confirm before it finishes that it actually uploaded something.

**Why it calls the shared build workflows rather than adding a matrix entry.** Trait parity by construction - destination, configuration, scheme, signing material and the pinned Rock action version all come from the workflow PR test builds already use, so the cache key cannot drift. A matrix entry wouldn't have worked anyway: the Rock action SHA pinned in the remote-build workflows predates the `provisioning-profiles` array our AdHoc signing needs.

**Why it's a separate workflow.** The remote-build workflows use a serialized concurrency group on `main` (`cancel-in-progress: false`), so an 8-minute compile inside one widens the window in which pushes queue and older pending runs get dropped - the simulator build's own signal would get slower in order to warm a cache it doesn't read. And `failureNotifier.yml` watches both by name, so a seed failure (an expired AdHoc provisioning profile, say) would file an issue assigned to whoever merged the unrelated PR that happened to trigger that run. On its own trigger it costs those workflows nothing: both are byte-identical to `main` in this PR.

**Failures here are deliberately not routed to anyone.** Nothing depends on this workflow. When it fails, PR test builds just compile their own native code again - slower, never wrong.

**Honest framing.** This is a latency shift, not a compute saving. A fingerprint that one PR would have compiled gets compiled on `main` instead. It wins when several PRs want the same new fingerprint - the common case, since most PRs are JS-only - and loses when a seeded fingerprint is never requested. What it buys is that nobody waits 13 minutes for a test build unless their own PR changed native code. On a sample of 14 recent iOS test builds, ~3 (~20%) convert from ~13 minutes to ~5.

| File | Change |
|---|---|
| `seedAdHocCache.yml` | new. check -> seed, per platform, on pushes to `main` and on dispatch. The seed verifies itself before it finishes |
| `checkRockCache.yml` | new. Reusable lookup: asserts the S3 provider, computes the fingerprint, and reports whether an artifact exists |
| `buildIOS.yml`, `buildAndroid.yml` | `seed-cache-only` makes a cache hit stop right after the lookup, and makes the build ask the bucket at the end whether the artifact it was meant to write is actually there. The traits it verifies come from the same `variant` expression that configures the build, so they cannot name a different namespace than the one just built. `expected-fingerprint` covers the other half of the cache key. Both inert unless passed |

<details>
<summary>Why existing builds and deploys can't be affected</summary>

**All four pre-existing callers resolve to the literals they had.** `deploy.yml` and `verifyHybridApp.yml` pass `variant: Release`, `buildAdHoc.yml` passes `Adhoc`, none passes `seed-cache-only`, so `re-sign: ${{ !inputs.seed-cache-only }}` is `true` and `ad-hoc` is unchanged. They also fail safe: `seed-cache-only` is a typed boolean defaulting to `false`, so re-signing can't be switched off for an existing caller by accident. The step that verifies a seed landed is gated on the same input, so it never runs for them either. Release builds key on `device,Release` while seeds write `device,AdHoc`, so a seed can't contaminate what a deploy downloads.

**The cache can't be poisoned.** Upload is gated on `!ARTIFACT_URL` plus a re-check immediately before uploading, so a seed can only fill an empty slot, never overwrite. The artifact it writes is the same kind PR builds already write, because on a miss the re-sign path never executes.

**PR test builds keep their own JS.** The cache-hit path runs `rock sign:ios --build-jsbundle` / `rock sign:android --build-jsbundle`, which rebuilds the bundle from the PR checkout, so a cached artifact contributes native code only. `inject-ci-data.sh` only rewrites `src/CONST/CI.ts`, which is part of that rebuilt bundle.

**Secrets.** The lookup workflow takes three named secrets rather than `inherit`, since it only needs the submodule and the bucket. A dispatch passes the same gate the remote-build workflows apply (`validateBuildRequest.yml`: Expensify employee with write access, plus a confirmation they reviewed the code at that ref), because like them it builds whatever ref it names with the build secrets in scope.

</details>

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/96950
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**⚠️ These need an Expensify internal - I have `pull` access only, so I can neither dispatch a workflow nor push a branch to `Expensify/App`.** Nothing in this PR has executed yet, and tests 1 and 2 can be run *before* merge, which I'd strongly prefer: test 1 needs push access for one throwaway branch plus two dispatches, test 2 needs a test build on any JS-only PR.

**1. Dry run, before merge**

**Nothing in this PR is exercised by CI.** `verifyHybridApp.yml` is the only workflow that would run `buildIOS.yml` / `buildAndroid.yml` before merge, and it is excluded twice over: its `paths` filter doesn't list `.github/**`, and its jobs are gated on `!github.event.pull_request.head.repo.fork`. So this dry run is the only pre-merge signal available.

`workflow_dispatch` resolves its `ref` only against branches in the repo hosting the workflow, so neither this PR's head nor anything on my fork is dispatchable, and `Seed AdHoc build cache` isn't dispatchable either until it's on `main`. What *is* reachable: the remote-build workflows are already on `main`, a dispatch runs the workflow file from whichever ref it names, and everything worth validating here lives in the reusable workflows those can call. So branch `korytko/seed-dry-run` on my fork carries this PR's logic with the check and seed jobs borrowed back into the remote-build workflows and the `main`-only guard dropped. The verification needs no borrowing - it lives inside the build workflows those jobs already call. It needs to be placed on `Expensify/App` by someone with push access - I don't have it:

```
git fetch https://github.com/software-mansion-labs/expensify-app-fork.git korytko/seed-dry-run
git push origin FETCH_HEAD:refs/heads/korytko/seed-dry-run
```

Pointing this at a branch is safe and isn't wasted work: the cache is keyed by fingerprint rather than branch, that branch's only diff from `main` is under `.github/**` (not a fingerprint input, so its fingerprint *is* `main`'s), and an upload can only fill an empty slot. A successful dry run seeds the real cache. It also runs each workflow's own simulator matrix, which is the cost of borrowing them. Delete the branch afterwards - `git push origin --delete korytko/seed-dry-run` - it is not meant to be merged.

1. Dispatch both, selecting ref `korytko/seed-dry-run` and ticking `reviewed_code`. (The push itself may already have triggered them, since all the branch's commits touch only `.github/**` and so may or may not be filtered out by `paths-ignore` - if it did, just read those runs instead.)
   - `gh workflow run 'Remote Build iOS' --ref korytko/seed-dry-run -f reviewed_code=true`
   - `gh workflow run 'Remote Build Android' --ref korytko/seed-dry-run -f reviewed_code=true`
2. Open `Check Rock remote cache` and verify it asserts the provider is `S3`, logs a fingerprint, and reports `NEEDS_BUILD=true` on a cold namespace
3. Open the seed job's `Compare fingerprint against the one the caller looked up` step and verify it reports a match. The iOS lookup runs on Linux while the build runs on macOS, and if the two disagree the iOS gate is guarding nothing - harmless, but then it should be dropped for iOS. I checked the inputs locally and expect a match: of the fingerprint's 2270 inputs, 2266 are content hashes and the four JSON ones (`autolinkingSources`, `env`, `reactNativeVersion`, `scripts`) contain no absolute host paths, no `darwin`/`macos`/`arm64` strings and no host-specific packages among the 52 autolinked dependencies. This step is the confirmation rather than the open question
4. Verify the `Rock Remote Build` step is a real ~8 minute compile ending in `Upload ZIP Artifact for caching`, and that no `Download and Unpack IPA`, `Re-sign IPA` or `Upload for Ad-hoc distribution` steps ran
5. Verify the artifact name is `rock-ios-device-AdHoc-<fingerprint>` / `rock-android-Adhoc-<fingerprint>`, with no PR number or commit SHA in it, since that is the namespace PR test builds read
6. Verify the seed job's last step, `Verify the seed landed in the remote cache`, logs `Seed landed for traits '...'`, and that those traits are the ones the lookup in step 2 was given - the same namespace step 5 just confirmed the artifact was named for
7. Dispatch the same thing a second time and verify the lookup now logs `Already cached: ...`, reports `NEEDS_BUILD=false`, and that the seed job is *skipped* rather than failed, taking its verification step with it
8. Verify the two pre-existing `build (...)` matrix jobs ran exactly as before in both runs

**2. PR test builds get the warm cache and keep their own JS**

1. With a fingerprint seeded by test 1, open a PR that changes only JS
2. Trigger `Build and deploy apps for testing` for that PR
3. Open the `Build iOS` job and time the `Rock Remote Build - iOS` step
4. Verify it hits the cache at roughly 100s instead of cold compiling for roughly 510s
5. Install the ad-hoc build from the link posted on the PR
6. Verify the app runs and reports this PR's number, confirming the JS bundle was rebuilt during re-sign and the cached native binary did not leak `main`'s CI data
7. Verify the PR comment and build summary still contain working iOS and Android download links, so ad-hoc distribution is unchanged for PR builds

**3. After merge: the push trigger**

This is the only part a dry run can't cover, since `.github/**` is in `paths-ignore` and this branch's own pushes never fire it.

1. Dispatch `Seed AdHoc build cache` from `main` once, ticking `reviewed_code`
2. On an already-warm fingerprint, verify the whole run is two cheap lookups and two skipped builds - which is itself confirmation the trigger and the gate are wired up
3. Watch the next push to `main` that changes native inputs (a `Mobile-Expensify` submodule bump, or a file added under `patches/`) and verify the seed runs and lands

Reverting is deleting `seedAdHocCache.yml`. The inputs added to the shared build workflows are inert unless passed, and `checkRockCache.yml` has no other callers.

**Known limitations, follow-ups rather than blockers**

- **Native code under `modules/` isn't in the fingerprint.** `calculateFingerprint` reads only `sourceDir` plus `extraSources`, and the autolinking input records dependency roots rather than file contents, so editing `modules/hybrid-app/{android,ios}/**` doesn't move the hash and Rock serves a stale binary. Pre-existing, but it only bites when the fingerprint is already cached - and making fingerprints cached is what this PR does. ~18 commits touched native code under `modules/` in the last 6 months. Fix is adding those directories to `extraSources`, which invalidates every cache namespace once and so deserves its own PR; until then, PRs touching `modules/` should use `FORCE_NATIVE_BUILD`.
- **`scripts/**` is in `paths-ignore`,** so a change to `scripts/compute-patches-hash.sh` alone moves the fingerprint without triggering any build, seed or otherwise. Pre-existing; also affects the simulator seeding that already happens today.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A. This PR only changes GitHub Actions workflows.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

N/A. This PR only changes GitHub Actions workflows.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

