### PR TITLE
fix: scale Search Router Spend context with system font size

### DIFF
--- a/src/components/Search/SearchList/ListItem/TextWithIconCell.tsx
+++ b/src/components/Search/SearchList/ListItem/TextWithIconCell.tsx
@@ -13,13 +13,14 @@ import {View} from 'react-native';
 
 type TextWithIconCellProps = {
     icon: IconAsset;
+    iconSize?: number;
     text?: string;
     showTooltip: boolean;
     textStyle?: StyleProp<TextStyle>;
     numberOfLines?: number;
 };
 
-export default function TextWithIconCell({icon, text, showTooltip, textStyle, numberOfLines = 1}: TextWithIconCellProps) {
+export default function TextWithIconCell({icon, iconSize = 12, text, showTooltip, textStyle, numberOfLines = 1}: TextWithIconCellProps) {
     const styles = useThemeStyles();
     const theme = useTheme();
 
@@ -32,8 +33,8 @@ export default function TextWithIconCell({icon, text, showTooltip, textStyle, nu
             <Icon
                 src={icon}
                 fill={theme.icon}
-                height={12}
-                width={12}
+                height={iconSize}
+                width={iconSize}
             />
             <TextWithTooltip
                 text={text}

--- a/src/components/Search/SearchRouter/useNavigationSuggestions.tsx
+++ b/src/components/Search/SearchRouter/useNavigationSuggestions.tsx
@@ -19,6 +19,8 @@ import type {SearchTypeMenuItem, SearchTypeMenuSection} from '@libs/SearchUIUtil
 
 import navigationRef from '@navigation/navigationRef';
 
+import variables from '@styles/variables';
+
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
@@ -149,8 +151,9 @@ function useNavigationSuggestions(query: string, shouldWatchForApprovals = true)
             <TextWithIconCell
                 text={translate('common.spend')}
                 icon={icons.ReceiptMultiple}
+                iconSize={variables.fontSizeLabel}
                 showTooltip={false}
-                textStyle={styles.textLabelSupporting}
+                textStyle={[styles.textLabelSupporting, styles.label]}
             />
         ),
         getItemText: (item) => translate(item.translationPath),

--- a/tests/unit/SearchRouterNavigationTest.ts
+++ b/tests/unit/SearchRouterNavigationTest.ts
@@ -15,6 +15,8 @@ import Navigation from '@libs/Navigation/Navigation';
 import navigateToCannedSpendSearch from '@libs/SearchNavigationUtils';
 import type {SearchTypeMenuItem, SearchTypeMenuSection} from '@libs/SearchUIUtils';
 
+import variables from '@styles/variables';
+
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type IconAsset from '@src/types/utils/IconAsset';
@@ -416,11 +418,11 @@ describe('Spend Search Router navigation source', () => {
         expect(result.current.some((item) => item.keyForList === `spend_${CONST.SEARCH.SAVED_SEARCH_PREFIX}1`)).toBe(false);
 
         const rightElement = result.current.at(0)?.rightElement;
-        expect(isValidElement<{label: string; icon: IconAsset}>(rightElement)).toBe(true);
-        if (!isValidElement<{label: string; icon: IconAsset}>(rightElement)) {
+        expect(isValidElement<{text: string; icon: IconAsset; iconSize: number; showTooltip: boolean}>(rightElement)).toBe(true);
+        if (!isValidElement<{text: string; icon: IconAsset; iconSize: number; showTooltip: boolean}>(rightElement)) {
             throw new Error('Expected Spend navigation context to be a React element');
         }
-        expect(rightElement.props).toMatchObject({text: 'Spend', icon: spendContextIcon, showTooltip: false});
+        expect(rightElement.props).toMatchObject({text: 'Spend', icon: spendContextIcon, iconSize: variables.fontSizeLabel, showTooltip: false});
 
         rerender({shouldWatchForApprovals: true});
         expect(mockUseSearchTypeMenuSections).toHaveBeenLastCalledWith(undefined, true);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Updates the Search Router’s right-side Spend context so its icon and text scale correctly with the system font size.

`TextWithIconCell` now accepts an optional icon size while retaining the existing `12px` default for other callers. The Spend context uses the label font and matching icon size, preventing “Spend” from being clipped at maximum font size.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97248
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
**Maximum font size**

Precondition: Set the device font size to maximum and use an account with at least one workspace.

1. Open Search.
2. Enter `go to`.
3. Locate a Spend destination such as Expenses, Reports, or Drafts.
4. Verify the Spend icon scales with the text.
5. Verify “Spend” is fully visible and not clipped.
6. Verify the icon and text are vertically aligned.

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests.
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Same as Tests.
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


<img width="1080" height="2340" alt="clip-fix" src="https://github.com/user-attachments/assets/b9268e78-11b3-4c96-9796-88b43c50b538" />


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="1080" height="2340" alt="android-web-clip-fix" src="https://github.com/user-attachments/assets/c069638f-0efa-41d4-89c4-b30a5ec6436c" />


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
>
<img width="630" height="1206" alt="Screenshot 2026-07-29 at 1 49 52 AM" src="https://github.com/user-attachments/assets/2f4d42bb-a179-4eb3-83fb-107177261e06" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
>
<img width="630" height="1206" alt="Screenshot 2026-07-29 at 1 50 53 AM" src="https://github.com/user-attachments/assets/4be85b69-ff5a-4cd4-b44d-d50d4f51593b" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="576" height="531" alt="macos-clip-fix" src="https://github.com/user-attachments/assets/7e1ed566-5f23-4f7e-9774-1f8476c46a3c" />

</details>
