### PR TITLE
Revert "Fix CollapsibleHeaderOnKeyboard not restoring header height after rotation" (#97214)

### DIFF
--- a/src/components/CollapsibleHeaderOnKeyboard/index.native.tsx
+++ b/src/components/CollapsibleHeaderOnKeyboard/index.native.tsx
@@ -86,9 +86,9 @@ function CollapsibleHeaderOnKeyboard({children, collapsibleHeaderOffset = 0, alw
             return;
         }
 
-        // First measurement, or content changed while keyboard is fully open
+        // First measurement, or content changed while header is fully open
         // (to skip onLayout calls triggered by our own height animation collapsing the view to 0)
-        if (naturalHeightRef.current === -1 || (animatedHeight.get() >= naturalHeightRef.current && height !== naturalHeightRef.current)) {
+        if (naturalHeightRef.current === -1 || animatedHeight.get() >= naturalHeightRef.current) {
             naturalHeightRef.current = height;
             naturalHeight.set(height);
             animatedHeight.set(height);
@@ -147,16 +147,15 @@ function CollapsibleHeaderOnKeyboard({children, collapsibleHeaderOffset = 0, alw
 
             // If the keyboard is closing, bail out
             const prevKeyboardProgress = previous?.keyboardProgress ?? 0;
-            if (prevKeyboardProgress > keyboardProgress) {
+            if (prevKeyboardProgress >= keyboardProgress) {
                 return;
             }
 
-            // Only act when the keyboard is starting to open, reaching a threshold or fully open, not on every intermediate frame.
+            // Only act when the keyboard is starting to open or reaching a threshold, not on every intermediate frame.
             const isKeyboardStartingOpening = prevKeyboardProgress === 0 && keyboardProgress > 0;
             const isKeyboardOpeningAndReachingThreshold = isKeyboardOpeningAtGivenProgress(keyboardProgress, prevKeyboardProgress, KEYBOARD_OPENING_PROGRESS_THRESHOLDS);
-            const isKeyboardFullyOpen = keyboardProgress === 1;
 
-            if (!isKeyboardStartingOpening && !isKeyboardOpeningAndReachingThreshold && !isKeyboardFullyOpen) {
+            if (!isKeyboardStartingOpening && !isKeyboardOpeningAndReachingThreshold) {
                 return;
             }
 
@@ -191,11 +190,11 @@ function CollapsibleHeaderOnKeyboard({children, collapsibleHeaderOffset = 0, alw
     // Inner wrapper slides the content upward during landscape keyboard collapse only.
     const innerStyle = useAnimatedStyle(() => {
         if (animatedHeight.get() >= naturalHeight.get()) {
-            return {transform: [{translateY: 0}]};
+            return {};
         }
 
         if (!isInLandscapeModeSV.get()) {
-            return {transform: [{translateY: 0}]};
+            return {};
         }
 
         return {transform: [{translateY: animatedHeight.get() - naturalHeight.get()}]};


### PR DESCRIPTION
### Explanation of Change

Reverts https://github.com/Expensify/App/pull/97214 (Fix `CollapsibleHeaderOnKeyboard` not restoring header height after rotation).

This is a clean revert of the merge commit `d51fb3663d7` on top of current `main`; it only touches `src/components/CollapsibleHeaderOnKeyboard/index.native.tsx`.

### Fixed Issues

For https://github.com/Expensify/App/issues/97196
PROPOSAL: N/A

### Tests

1. On a native device, open a screen that uses `CollapsibleHeaderOnKeyboard` (e.g. the split expense page).
2. Focus an input so the keyboard opens and the header collapses.
3. Dismiss the keyboard and verify the header is restored.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Same as tests.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
