### PR TITLE
Keep the KYC continuation route when the bank account flow is left mid-setup

### DIFF
--- a/src/pages/AddPersonalBankAccountPage.tsx
+++ b/src/pages/AddPersonalBankAccountPage.tsx
@@ -18,8 +18,9 @@ import {continueSetup} from '@userActions/PaymentMethods';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
+import type PersonalBankAccount from '@src/types/onyx/PersonalBankAccount';
 
-import React, {useContext, useEffect} from 'react';
+import React, {useContext, useEffect, useRef} from 'react';
 
 import PersonalInfoPage from './settings/Wallet/InternationalDepositAccount/PersonalInfo/PersonalInfo';
 
@@ -30,6 +31,8 @@ function AddPersonalBankAccountPage() {
     const shouldShowSuccess = personalBankAccount?.shouldShowSuccess ?? false;
     const topmostFullScreenRoute = navigationRef.current?.getRootState()?.routes.findLast((route) => isFullScreenName(route.name));
     const kycWallRef = useContext(KYCWallContext);
+    const flowRoutingDataRef = useRef<Partial<PersonalBankAccount> | undefined>(undefined);
+    const hasExitedFlowRef = useRef(false);
 
     const goBack = () => {
         switch (topmostFullScreenRoute?.name) {
@@ -54,12 +57,24 @@ function AddPersonalBankAccountPage() {
         } else if (shouldContinue && onSuccessFallbackRoute) {
             continueSetup(kycWallRef, onSuccessFallbackRoute);
         } else {
+            hasExitedFlowRef.current = true;
+            flowRoutingDataRef.current = undefined;
             goBack();
             clearPersonalBankAccount();
         }
     };
 
-    useEffect(() => clearPersonalBankAccount, []);
+    useEffect(() => {
+        if (hasExitedFlowRef.current) {
+            return;
+        }
+        const {onSuccessFallbackRoute, exitReportID} = personalBankAccount ?? {};
+        flowRoutingDataRef.current = !onSuccessFallbackRoute && !exitReportID ? undefined : {onSuccessFallbackRoute, exitReportID};
+    });
+
+    // Where the flow continues once an account is added is seeded by its entry point (e.g. Pay > KYC), not by this form,
+    // so tearing the form down when the user leaves mid-setup must keep it for when they come back and finish.
+    useEffect(() => () => clearPersonalBankAccount(flowRoutingDataRef.current), []);
 
     if (shouldShowSuccess) {
         return (

--- a/src/pages/AddPersonalBankAccountPage.tsx
+++ b/src/pages/AddPersonalBankAccountPage.tsx
@@ -52,13 +52,15 @@ function AddPersonalBankAccountPage() {
         const exitReportID = personalBankAccount?.exitReportID;
         const onSuccessFallbackRoute = personalBankAccount?.onSuccessFallbackRoute ?? '';
 
+        // Reaching this handler always means leaving on purpose, so the next flow must not inherit where this one was headed.
+        hasExitedFlowRef.current = true;
+        flowRoutingDataRef.current = undefined;
+
         if (exitReportID) {
             Navigation.dismissModalWithReport({reportID: exitReportID});
         } else if (shouldContinue && onSuccessFallbackRoute) {
             continueSetup(kycWallRef, onSuccessFallbackRoute);
         } else {
-            hasExitedFlowRef.current = true;
-            flowRoutingDataRef.current = undefined;
             goBack();
             clearPersonalBankAccount();
         }
@@ -70,7 +72,7 @@ function AddPersonalBankAccountPage() {
         }
         const {onSuccessFallbackRoute, exitReportID} = personalBankAccount ?? {};
         flowRoutingDataRef.current = !onSuccessFallbackRoute && !exitReportID ? undefined : {onSuccessFallbackRoute, exitReportID};
-    });
+    }, [personalBankAccount]);
 
     // Where the flow continues once an account is added is seeded by its entry point (e.g. Pay > KYC), not by this form,
     // so tearing the form down when the user leaves mid-setup must keep it for when they come back and finish.

--- a/tests/ui/AddPersonalBankAccountPageTest.tsx
+++ b/tests/ui/AddPersonalBankAccountPageTest.tsx
@@ -1,0 +1,92 @@
+import {act, render} from '@testing-library/react-native';
+
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+
+import AddPersonalBankAccountPage from '@pages/AddPersonalBankAccountPage';
+
+import {clearPersonalBankAccount} from '@userActions/BankAccounts';
+
+import ROUTES from '@src/ROUTES';
+import type PersonalBankAccount from '@src/types/onyx/PersonalBankAccount';
+
+import React from 'react';
+
+let mockPersonalBankAccount: PersonalBankAccount | undefined;
+
+jest.mock('@pages/settings/Wallet/InternationalDepositAccount/PersonalInfo/PersonalInfo', () => jest.fn(() => null));
+jest.mock('@components/ScreenWrapper', () => jest.fn(({children}: {children: React.ReactNode}) => children));
+jest.mock('@components/BlockingViews/FullPageNotFoundView', () => jest.fn(({children}: {children: React.ReactNode}) => children));
+jest.mock('@components/ScrollView', () => jest.fn(({children}: {children: React.ReactNode}) => children));
+jest.mock('@components/ConfirmationPage', () => jest.fn(() => null));
+jest.mock('@components/HeaderWithBackButton', () => jest.fn(() => null));
+jest.mock('@hooks/useOnyx', () => jest.fn(() => [mockPersonalBankAccount, jest.fn()]));
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: (key: string) => key,
+    })),
+);
+jest.mock('@hooks/useThemeStyles', () => jest.fn(() => ({})));
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    default: {
+        goBack: jest.fn(),
+        closeRHPFlow: jest.fn(),
+        dismissModalWithReport: jest.fn(),
+    },
+    navigationRef: {current: null},
+}));
+jest.mock('@userActions/BankAccounts', () => ({
+    clearPersonalBankAccount: jest.fn(),
+}));
+jest.mock('@userActions/PaymentMethods', () => ({
+    continueSetup: jest.fn(),
+}));
+
+describe('AddPersonalBankAccountPage', () => {
+    const mockedClearPersonalBankAccount = jest.mocked(clearPersonalBankAccount);
+
+    beforeEach(() => {
+        mockPersonalBankAccount = undefined;
+        mockedClearPersonalBankAccount.mockClear();
+    });
+
+    it('keeps the KYC continuation route when the user leaves the flow mid-setup', () => {
+        mockPersonalBankAccount = {onSuccessFallbackRoute: ROUTES.ENABLE_PAYMENTS};
+        const {unmount} = render(<AddPersonalBankAccountPage />);
+
+        unmount();
+
+        expect(mockedClearPersonalBankAccount).toHaveBeenCalledWith({onSuccessFallbackRoute: ROUTES.ENABLE_PAYMENTS, exitReportID: undefined});
+    });
+
+    it('keeps the report to return to when the user leaves the flow mid-setup', () => {
+        mockPersonalBankAccount = {exitReportID: '1234'};
+        const {unmount} = render(<AddPersonalBankAccountPage />);
+
+        unmount();
+
+        expect(mockedClearPersonalBankAccount).toHaveBeenCalledWith({onSuccessFallbackRoute: undefined, exitReportID: '1234'});
+    });
+
+    it('drops the KYC continuation route once the user deliberately leaves the success screen', () => {
+        mockPersonalBankAccount = {onSuccessFallbackRoute: ROUTES.ENABLE_PAYMENTS, shouldShowSuccess: true};
+        const {rerender, unmount} = render(<AddPersonalBankAccountPage />);
+
+        act(() => {
+            jest.mocked(HeaderWithBackButton).mock.calls.at(-1)?.at(0)?.onBackButtonPress?.();
+        });
+        rerender(<AddPersonalBankAccountPage />);
+        unmount();
+
+        expect(mockedClearPersonalBankAccount.mock.calls.at(-1)?.at(0)).toBeUndefined();
+    });
+
+    it('clears everything when there is no flow to continue', () => {
+        mockPersonalBankAccount = {bankAccountID: 1234};
+        const {unmount} = render(<AddPersonalBankAccountPage />);
+
+        unmount();
+
+        expect(mockedClearPersonalBankAccount.mock.calls.at(0)?.at(0)).toBeUndefined();
+    });
+});

--- a/tests/ui/AddPersonalBankAccountPageTest.tsx
+++ b/tests/ui/AddPersonalBankAccountPageTest.tsx
@@ -81,6 +81,19 @@ describe('AddPersonalBankAccountPage', () => {
         expect(mockedClearPersonalBankAccount.mock.calls.at(-1)?.at(0)).toBeUndefined();
     });
 
+    it('drops the report to return to once the user has been sent back to it', () => {
+        mockPersonalBankAccount = {exitReportID: '1234', shouldShowSuccess: true};
+        const {rerender, unmount} = render(<AddPersonalBankAccountPage />);
+
+        act(() => {
+            jest.mocked(HeaderWithBackButton).mock.calls.at(-1)?.at(0)?.onBackButtonPress?.();
+        });
+        rerender(<AddPersonalBankAccountPage />);
+        unmount();
+
+        expect(mockedClearPersonalBankAccount.mock.calls.at(-1)?.at(0)).toBeUndefined();
+    });
+
     it('clears everything when there is no flow to continue', () => {
         mockPersonalBankAccount = {bankAccountID: 1234};
         const {unmount} = render(<AddPersonalBankAccountPage />);


### PR DESCRIPTION
### Explanation of Change

When you pay someone from a 1:1 chat and pick "Pay with personal account", the KYC wall seeds `PERSONAL_BANK_ACCOUNT` with an `onSuccessFallbackRoute` (and `exitReportID` where relevant) so the app knows where to continue once a bank account exists.

`AddPersonalBankAccountPage` cleared that whole Onyx key on unmount:

```js
useEffect(() => clearPersonalBankAccount, []);
```

Backing out of the Plaid step calls `Navigation.goBack`, which unmounts the page and wipes the key along with the continuation route. Re-entering through `AccountFlowEntryPoint` just navigates, it never re-seeds it, so on the second, successful attempt `exitFlow(true)` can no longer satisfy `shouldContinue && onSuccessFallbackRoute` and falls through to `goBack()`. That drops you back on the Add bank account entry point instead of starting KYC.

The fix keeps the routing data across an unmount that isn't a deliberate exit. A ref tracks the latest `onSuccessFallbackRoute` / `exitReportID` and hands it to `clearPersonalBankAccount(preservedData)` in the cleanup, and a second ref makes sure a deliberate exit still clears everything, so a stale route can't leak into the next flow regardless of render ordering.

`clearPersonalBankAccount` already accepts `preservedData`, so nothing in the action layer changes. `AccountFlowEntryPoint` does the same preservation on entry, so this is consistent with the existing pattern.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94659
PROPOSAL: https://github.com/Expensify/App/issues/94659#issuecomment-5006699514

### Tests

1. Sign in with a validated account that has no personal bank account added
2. Start a 1:1 conversation with another user
3. Press the + button and select "Pay [User]"
4. On the amount screen tap the currency selector, choose USD, enter any amount and continue
5. Click "Pay with personal account"
6. Start the bank account flow and exit/cancel it before entering credentials
7. Start the bank account flow again and complete the setup
8. Click Continue on the "Bank account added" page
9. Verify the KYC verification flow is triggered, and you are not sent back to the Add bank account entry point

Check that a deliberate exit still clears the flow:

10. Go to Settings > Wallet > Add bank account and complete the setup
11. Click Continue on the "Bank account added" page
12. Verify you land back on the Wallet page and no KYC flow is triggered

- [x] Verify that no errors appear in the JS console

### Offline tests

Adding a bank account needs the API (Plaid and `AddPersonalBankAccount`), so there is no offline path through this flow. This change only touches in-memory routing state kept across an unmount, so offline behavior is unchanged.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/3a2bd9c2-66d1-4d1f-8a0a-b9ddeb75f2a9


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/82609de6-d7b6-4790-8c0e-cc6ff44943bb


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/069f93cf-3ad9-4fe5-9417-131a09adc69b


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/a1e04fb1-d073-4600-9bf5-25e4dfde74d5


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/0cbb6c38-7356-4704-9a1a-52a4ae29c170


<!-- add screenshots or videos here -->

</details>
