### PR TITLE
[CP Staging] Preserve self-closing tags and entities when tokenizing comment HTML

### DIFF
--- a/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
+++ b/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
@@ -102,7 +102,7 @@ function tokenizeForReveal(html: string): string[] {
     // `recognizeSelfClosing` defaults to false in HTML mode, which makes the parser ignore the trailing slash on
     // custom tags like `<victorypie … />` and nest each following sibling inside the previous one. `decodeEntities`
     // keeps `&amp;`, `&lt;` and `&gt;` escaped on the way back out, so escaped markup in a comment stays text
-    // instead of being re-serialised as live markup.
+    // instead of being re-serialized as live markup.
     const doc = parseDocument(html, {recognizeSelfClosing: true});
     const anchors = collectAnchors(doc);
     const stages: string[] = [''];

--- a/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
+++ b/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
@@ -99,11 +99,15 @@ function tokenizeForReveal(html: string): string[] {
     if (!html) {
         return [''];
     }
-    const doc = parseDocument(html);
+    // `recognizeSelfClosing` defaults to false in HTML mode, which makes the parser ignore the trailing slash on
+    // custom tags like `<victorypie … />` and nest each following sibling inside the previous one. `decodeEntities`
+    // keeps `&amp;`, `&lt;` and `&gt;` escaped on the way back out, so escaped markup in a comment stays text
+    // instead of being re-serialised as live markup.
+    const doc = parseDocument(html, {recognizeSelfClosing: true});
     const anchors = collectAnchors(doc);
     const stages: string[] = [''];
     for (const anchor of anchors) {
-        stages.push(render(buildClippedNodes(doc, anchor)));
+        stages.push(render(buildClippedNodes(doc, anchor), {decodeEntities: true}));
     }
     return stages;
 }

--- a/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
+++ b/tests/unit/libs/ReportActionFollowupUtils/tokenizeForRevealTest.ts
@@ -1,6 +1,16 @@
 // cspell:ignore dani
 import tokenizeForReveal from '@libs/ReportActionFollowupUtils/tokenizeForReveal';
 
+import {isTag} from 'domhandler';
+import {parseDocument} from 'htmlparser2';
+
+/** Tag names of the chart element's direct element children, as a renderer walking the tree would see them. */
+function getChartChildTags(html: string): string[] {
+    const chart = parseDocument(html, {recognizeSelfClosing: true}).children.find(isTag);
+
+    return (chart?.children ?? []).filter(isTag).map((child) => child.tagName);
+}
+
 describe('tokenizeForReveal', () => {
     it('returns just the empty stage for an empty input', () => {
         expect(tokenizeForReveal('')).toEqual(['']);
@@ -93,6 +103,21 @@ describe('tokenizeForReveal', () => {
         for (let i = 1; i < lengths.length; i++) {
             expect(lengths.at(i) ?? 0).toBeGreaterThanOrEqual(lengths.at(i - 1) ?? 0);
         }
+    });
+
+    it('keeps self-closing chart tags as siblings rather than nesting them', () => {
+        const html =
+            '<victorychart width="680"><victoryaxis style="{axis: {stroke: \'transparent\'}}" /><victorypie data="[{x: \'Equipment\', y: 40}]" /><victorylabel text="Total" /></victorychart>';
+        const stages = tokenizeForReveal(html);
+
+        expect(getChartChildTags(html)).toEqual(['victoryaxis', 'victorypie', 'victorylabel']);
+        expect(getChartChildTags(stages.at(-1) ?? '')).toEqual(['victoryaxis', 'victorypie', 'victorylabel']);
+    });
+
+    it('leaves escaped markup escaped instead of turning it into live markup', () => {
+        const html = '<p>Type &lt;strong&gt;bold&lt;/strong&gt; to embolden, Jack &amp; Jill.</p>';
+
+        expect(tokenizeForReveal(html).at(-1)).toBe(html);
     });
 
     it('produces enough anchors that a typical multi-paragraph response trickles smoothly', () => {


### PR DESCRIPTION
### Explanation of Change

`tokenizeForReveal` builds streamed Concierge responses by parsing the comment HTML with `htmlparser2` and re-serialising it with `dom-serializer`. Both calls used default options, which corrupts the markup in two ways:

1. `recognizeSelfClosing` defaults to `false` in HTML mode, so the parser ignores the trailing slash on custom tags. `<victoryaxis … /><victorypie … />` is parsed as `victoryaxis` containing `victorypie`, nesting every following sibling inside the previous element. `processVictoryChartTree` walks the tree recursively so it still finds the pie and populates the chart data, but `VictoryChartPolar` reads chart elements from `tnode.children` only — so the pie is never rendered and the chart shows its background, title and centre total with no donut.
2. Without `decodeEntities`, `dom-serializer` writes attribute values and text with only `"` escaped, leaving `&`, `<` and `>` raw. Escaped markup in a comment is re-serialised as live markup.

Passing `recognizeSelfClosing: true` to `parseDocument` and `decodeEntities: true` to `render` fixes both. The reveal now emits `<victoryaxis …></victoryaxis>` rather than `<victoryaxis … />`, which is not byte-identical to the input but parses to the same tree.

The input to the tokenizer is the persisted `message.html`, which is well formed — `usePusherDraftPacing` reads it via `getReportActionHtml` and every reveal stage, including the final one, is serialiser output. This is why the chart renders correctly after a reload or after navigating away and back: those read the stored HTML directly and never pass through the tokenizer.

Note `decodeEntities: true` also encodes non-ASCII characters as numeric references, so an emoji is serialised as `&#x1F600;`. It re-parses to the same character, and reveal pacing is unaffected because anchors are computed from the DOM rather than the serialised string.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96699
PROPOSAL:

### Tests

1. Create two expenses with different categories.
1. Open the concierge chat and ask it "What are my top spend categories this month?". Don't click away or reload the page.
1. Verify that the response contains a correct donut chart.

- [x] Verify that no errors appear in the JS console

### Offline tests
n/a - original bug happens only during streaming (online).

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/e5e92cc7-6ef1-4229-bf69-4f2c55fd384d

</details>
