### PR TITLE
Revert useConfirmModal to use ConfirmModal for DeleteWorkspaceFlow

### DIFF
--- a/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
+++ b/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
@@ -23,6 +23,7 @@ import {isSubscriptionTypeOfInvoicing} from '@libs/SubscriptionUtils';
 import {getIsTravelInvoicingEnabled, getTravelInvoicingCardSettingsKey} from '@libs/TravelInvoicingUtils';
 
 import CONST from '@src/CONST';
+import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import {canDowngradeSelector} from '@src/selectors/Account';
@@ -122,7 +123,9 @@ function DeleteWorkspaceFlow({policyID, onDismiss, onDeleteComplete}: DeleteWork
     // TODO: temporary fix for https://github.com/Expensify/App/issues/96369 - the error modal is kept as a locally controlled ConfirmModal
     // instead of the global useConfirmModal one, because closing the loading delete confirmation modal and immediately pushing another
     // global modal leaves the flow latched on iOS, so a second delete attempt never restarts the flow.
-    const [deleteWorkspaceErrorMessage, setDeleteWorkspaceErrorMessage] = useState<string>();
+    // Only the translation key is latched (not the translated copy) so the modal follows the current locale, the raw message is kept
+    // as-is because it comes from the backend and is cleared from Onyx as soon as the error is dismissed.
+    const [deleteWorkspaceError, setDeleteWorkspaceError] = useState<{translationKey?: TranslationPaths; message?: string}>();
 
     const hideDeleteWorkspaceErrorModal = useCallback(() => {
         dismissWorkspaceError(policyID, policy?.pendingAction);
@@ -134,7 +137,7 @@ function DeleteWorkspaceFlow({policyID, onDismiss, onDeleteComplete}: DeleteWork
     }, [hideDeleteWorkspaceErrorModal, onDismiss]);
 
     const closeDeleteWorkspaceErrorModal = useCallback(() => {
-        setDeleteWorkspaceErrorMessage(undefined);
+        setDeleteWorkspaceError(undefined);
         dismissDeleteWorkspaceFlow();
     }, [dismissDeleteWorkspaceFlow]);
 
@@ -145,19 +148,21 @@ function DeleteWorkspaceFlow({policyID, onDismiss, onDeleteComplete}: DeleteWork
         }
 
         // When both Expensify Cards and Consolidated Travel Billing are enabled, prioritize the Expensify Cards copy.
-        setDeleteWorkspaceErrorMessage(translate(hasExpensifyCardsEnabledOnWorkspace ? 'workspace.common.deleteOpenExpensifyCardsError' : 'workspace.common.deleteTravelInvoicingError'));
-    }, [dismissDeleteWorkspaceFlow, hasExpensifyCardsEnabledOnWorkspace, isFocused, translate]);
+        setDeleteWorkspaceError({translationKey: hasExpensifyCardsEnabledOnWorkspace ? 'workspace.common.deleteOpenExpensifyCardsError' : 'workspace.common.deleteTravelInvoicingError'});
+    }, [dismissDeleteWorkspaceFlow, hasExpensifyCardsEnabledOnWorkspace, isFocused]);
 
     const didCompletePendingDelete = !isOffline && prevIsPendingDelete && !isPendingDelete;
     const shouldLatchDeleteWorkspaceErrorModal = didCompletePendingDelete && !!policyLatestErrorMessage && isFocused;
 
-    if (shouldLatchDeleteWorkspaceErrorModal && !deleteWorkspaceErrorMessage) {
-        setDeleteWorkspaceErrorMessage(
+    if (shouldLatchDeleteWorkspaceErrorModal && !deleteWorkspaceError) {
+        setDeleteWorkspaceError(
             hasExpensifyCardsEnabledOnWorkspace || hasTravelInvoicingEnabledOnWorkspace
-                ? translate(hasExpensifyCardsEnabledOnWorkspace ? 'workspace.common.deleteOpenExpensifyCardsError' : 'workspace.common.deleteTravelInvoicingError')
-                : policyLatestErrorMessage,
+                ? {translationKey: hasExpensifyCardsEnabledOnWorkspace ? 'workspace.common.deleteOpenExpensifyCardsError' : 'workspace.common.deleteTravelInvoicingError'}
+                : {message: policyLatestErrorMessage},
         );
     }
+
+    const deleteWorkspaceErrorMessage = deleteWorkspaceError?.translationKey ? translate(deleteWorkspaceError.translationKey) : deleteWorkspaceError?.message;
 
     const deleteWorkspaceErrorPrompt =
         !!deleteWorkspaceErrorMessage && CONST.HTML_TAG_REGEX.test(deleteWorkspaceErrorMessage) ? (

--- a/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
+++ b/src/pages/workspace/deleteWorkspace/DeleteWorkspaceFlow.tsx
@@ -1,3 +1,4 @@
+import ConfirmModal from '@components/ConfirmModal';
 import {ModalActions} from '@components/Modal/Global/ModalContext';
 import RenderHTML from '@components/RenderHTML';
 
@@ -32,7 +33,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
 import {useIsFocused} from '@react-navigation/native';
-import React, {useCallback, useEffect, useRef} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 
 type DeleteWorkspaceFlowProps = {
@@ -118,6 +119,11 @@ function DeleteWorkspaceFlow({policyID, onDismiss, onDeleteComplete}: DeleteWork
     const shouldCalculateBillNewDot = !!canDowngrade && ownedPaidPoliciesCounts?.total === 1;
     const {shouldBlockDeletion, outstandingBalanceModal} = useOutstandingBalanceGuard(ownedPaidPoliciesCounts?.active ?? 0, onDismiss);
 
+    // TODO: temporary fix for https://github.com/Expensify/App/issues/96369 - the error modal is kept as a locally controlled ConfirmModal
+    // instead of the global useConfirmModal one, because closing the loading delete confirmation modal and immediately pushing another
+    // global modal leaves the flow latched on iOS, so a second delete attempt never restarts the flow.
+    const [deleteWorkspaceErrorMessage, setDeleteWorkspaceErrorMessage] = useState<string>();
+
     const hideDeleteWorkspaceErrorModal = useCallback(() => {
         dismissWorkspaceError(policyID, policy?.pendingAction);
     }, [policyID, policy?.pendingAction]);
@@ -127,69 +133,43 @@ function DeleteWorkspaceFlow({policyID, onDismiss, onDeleteComplete}: DeleteWork
         onDismiss();
     }, [hideDeleteWorkspaceErrorModal, onDismiss]);
 
+    const closeDeleteWorkspaceErrorModal = useCallback(() => {
+        setDeleteWorkspaceErrorMessage(undefined);
+        dismissDeleteWorkspaceFlow();
+    }, [dismissDeleteWorkspaceFlow]);
+
     const showDeleteWorkspaceErrorModal = useCallback(() => {
         if (!isFocused) {
             dismissDeleteWorkspaceFlow();
             return;
         }
 
-        showConfirmModal({
-            title: translate('workspace.common.delete'),
-            prompt: (
-                <View style={[styles.renderHTML, styles.flexRow]}>
-                    <RenderHTML
-                        // When both Expensify Cards and Consolidated Travel Billing are enabled, prioritize the Expensify Cards copy.
-                        html={translate(hasExpensifyCardsEnabledOnWorkspace ? 'workspace.common.deleteOpenExpensifyCardsError' : 'workspace.common.deleteTravelInvoicingError')}
-                        onConciergeLinkPress={() => {
-                            closeModal();
-                            dismissDeleteWorkspaceFlow();
-                        }}
-                    />
-                </View>
-            ),
-            confirmText: translate('common.buttonConfirm'),
-            shouldShowCancelButton: false,
-            success: false,
-            shouldHandleNavigationBack: false,
-        }).then(() => {
-            dismissDeleteWorkspaceFlow();
-        });
-    }, [closeModal, dismissDeleteWorkspaceFlow, hasExpensifyCardsEnabledOnWorkspace, isFocused, showConfirmModal, styles.flexRow, styles.renderHTML, translate]);
+        // When both Expensify Cards and Consolidated Travel Billing are enabled, prioritize the Expensify Cards copy.
+        setDeleteWorkspaceErrorMessage(translate(hasExpensifyCardsEnabledOnWorkspace ? 'workspace.common.deleteOpenExpensifyCardsError' : 'workspace.common.deleteTravelInvoicingError'));
+    }, [dismissDeleteWorkspaceFlow, hasExpensifyCardsEnabledOnWorkspace, isFocused, translate]);
 
-    const showGenericDeleteWorkspaceErrorModal = useCallback(
-        (errorMessage: string) => {
-            if (!isFocused) {
-                dismissDeleteWorkspaceFlow();
-                return;
-            }
+    const didCompletePendingDelete = !isOffline && prevIsPendingDelete && !isPendingDelete;
+    const shouldLatchDeleteWorkspaceErrorModal = didCompletePendingDelete && !!policyLatestErrorMessage && isFocused;
 
-            const prompt = CONST.HTML_TAG_REGEX.test(errorMessage) ? (
-                <View style={[styles.renderHTML, styles.flexRow]}>
-                    <RenderHTML
-                        html={errorMessage}
-                        onConciergeLinkPress={() => {
-                            closeModal();
-                            dismissDeleteWorkspaceFlow();
-                        }}
-                    />
-                </View>
-            ) : (
-                errorMessage
-            );
+    if (shouldLatchDeleteWorkspaceErrorModal && !deleteWorkspaceErrorMessage) {
+        setDeleteWorkspaceErrorMessage(
+            hasExpensifyCardsEnabledOnWorkspace || hasTravelInvoicingEnabledOnWorkspace
+                ? translate(hasExpensifyCardsEnabledOnWorkspace ? 'workspace.common.deleteOpenExpensifyCardsError' : 'workspace.common.deleteTravelInvoicingError')
+                : policyLatestErrorMessage,
+        );
+    }
 
-            showConfirmModal({
-                title: translate('workspace.common.delete'),
-                prompt,
-                confirmText: translate('common.buttonConfirm'),
-                shouldShowCancelButton: false,
-                success: false,
-                shouldHandleNavigationBack: false,
-            }).then(() => {
-                dismissDeleteWorkspaceFlow();
-            });
-        },
-        [closeModal, dismissDeleteWorkspaceFlow, isFocused, showConfirmModal, styles.flexRow, styles.renderHTML, translate],
-    );
+    const deleteWorkspaceErrorPrompt =
+        !!deleteWorkspaceErrorMessage && CONST.HTML_TAG_REGEX.test(deleteWorkspaceErrorMessage) ? (
+            <View style={[styles.renderHTML, styles.flexRow]}>
+                <RenderHTML
+                    html={deleteWorkspaceErrorMessage}
+                    onConciergeLinkPress={closeDeleteWorkspaceErrorModal}
+                />
+            </View>
+        ) : (
+            deleteWorkspaceErrorMessage
+        );
 
     // Always invoked after a re-render (from the start effect below for normal deletes, or from usePayAndDowngrade for billed deletes),
     // so the workspace being deleted and its derived data are read from the latest state.
@@ -280,33 +260,34 @@ function DeleteWorkspaceFlow({policyID, onDismiss, onDeleteComplete}: DeleteWork
 
         closeModal();
 
-        if (policyLatestErrorMessage && (hasExpensifyCardsEnabledOnWorkspace || hasTravelInvoicingEnabledOnWorkspace)) {
-            showDeleteWorkspaceErrorModal();
-            return;
-        }
-
         if (policyLatestErrorMessage) {
-            showGenericDeleteWorkspaceErrorModal(policyLatestErrorMessage);
+            if (!isFocused) {
+                dismissDeleteWorkspaceFlow();
+            }
             return;
         }
 
         onDeleteComplete?.();
         onDismiss();
-    }, [
-        isOffline,
-        isPendingDelete,
-        prevIsPendingDelete,
-        policyLatestErrorMessage,
-        hasExpensifyCardsEnabledOnWorkspace,
-        hasTravelInvoicingEnabledOnWorkspace,
-        closeModal,
-        onDeleteComplete,
-        onDismiss,
-        showDeleteWorkspaceErrorModal,
-        showGenericDeleteWorkspaceErrorModal,
-    ]);
+    }, [isOffline, isPendingDelete, prevIsPendingDelete, policyLatestErrorMessage, isFocused, closeModal, dismissDeleteWorkspaceFlow, onDeleteComplete, onDismiss]);
 
-    return outstandingBalanceModal;
+    return (
+        <>
+            {outstandingBalanceModal}
+            {/* eslint-disable-next-line @typescript-eslint/no-deprecated -- Local modal avoids stacking issues with the global delete confirmation modal on mobile. */}
+            <ConfirmModal
+                title={translate('workspace.common.delete')}
+                isVisible={!!deleteWorkspaceErrorMessage && isFocused}
+                onConfirm={closeDeleteWorkspaceErrorModal}
+                onCancel={closeDeleteWorkspaceErrorModal}
+                prompt={deleteWorkspaceErrorPrompt}
+                confirmText={translate('common.buttonConfirm')}
+                shouldShowCancelButton={false}
+                success={false}
+                shouldHandleNavigationBack={false}
+            />
+        </>
+    );
 }
 
 export default DeleteWorkspaceFlow;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/96369
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Precondition:

- Login with new expensifail account
- Create new workspace
- Set Expensify card to Enable
- Add Expensify card

Steps:

1. Open Expensify App on iOS
2. Login with account from Precondition
3. Go to Account > Troubleshoot > Clear cache and restart > Reset and refresh.
4. Go to Workspaces tab.
5. Click 3-dot menu on the workspace with Expensify Card > Delete workspace > Delete.
6. Verify that the error modal shows "Your company still has Expensify Cards. Please reach out to Concierge to remove them."
7. Open workspace settings > Expensify Cards.
8. Go to Workspaces tab again
9. Click 3-dot menu on the workspace with Expensify Card > Delete workspace > Delete.
10. Verify that "Delete" button works correctly if pressed again after a workspace deletion error occurs.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/e5d23400-d7a1-48e1-9af7-20910db7c8fe

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/e5d23400-d7a1-48e1-9af7-20910db7c8fe



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/9e869354-7c95-4065-9fd7-f2ca90260e3d



</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/f537c9b2-a66d-4d79-9ab3-b34a2f508041




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/7b2d4d7a-6e53-499b-a3e9-1254221bfc22



</details>
