### PR TITLE
Fix saved search selection in Spend

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -1259,7 +1259,8 @@ const ROUTES = {
         route: 'search',
         getRoute: ({query, rawQuery, name}: {query: SearchQueryString; rawQuery?: SearchQueryString; name?: string}) => {
             const rawQuerySegment = rawQuery ? `&rawQuery=${encodeURIComponent(rawQuery)}` : '';
-            return `search?q=${encodeURIComponent(query)}${name ? `&name=${name}` : ''}${rawQuerySegment}` as const;
+            const nameSegment = name ? `&name=${encodeURIComponent(name)}` : '';
+            return `search?q=${encodeURIComponent(query)}${nameSegment}${rawQuerySegment}` as const;
         },
     },
     SEARCH_SAVE: 'search/save',

--- a/src/components/Navigation/SearchSidebar.tsx
+++ b/src/components/Navigation/SearchSidebar.tsx
@@ -56,6 +56,7 @@ function SearchSidebar({state}: SearchSidebarProps) {
     const toggleButtonAnimatedStyle = useSearchSidebarToggleButtonStyle();
 
     const route = state.routes.at(-1);
+    const searchRouteParams = route?.name === SCREENS.SEARCH.ROOT ? (route.params as {q?: string; name?: string} | undefined) : undefined;
     const {lastSearchType, currentSearchResults} = useSearchResultsContext();
     const {currentSearchQueryJSON} = useSearchQueryContext();
     const {setLastSearchType} = useSearchResultsActions();
@@ -122,7 +123,10 @@ function SearchSidebar({state}: SearchSidebarProps) {
                         </TopBar>
                         <Hoverable onHoverIn={startPeek}>
                             <View style={styles.flex1}>
-                                <SearchTypeMenuWide queryJSON={currentSearchQueryJSON} />
+                                <SearchTypeMenuWide
+                                    queryJSON={currentSearchQueryJSON}
+                                    name={searchRouteParams?.name}
+                                />
                             </View>
                         </Hoverable>
                     </View>

--- a/src/components/Navigation/SearchSidebar.tsx
+++ b/src/components/Navigation/SearchSidebar.tsx
@@ -15,6 +15,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import type {PlatformStackNavigationState} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {SearchFullscreenNavigatorParamList} from '@libs/Navigation/types';
 
 import SearchTypeMenuWide from '@pages/Search/SearchTypeMenuWide';
 
@@ -42,6 +43,8 @@ type SearchSidebarProps = {
     state: PlatformStackNavigationState<ParamListBase>;
 };
 
+type SearchRootParams = SearchFullscreenNavigatorParamList[typeof SCREENS.SEARCH.ROOT];
+
 function SearchSidebar({state}: SearchSidebarProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
@@ -56,7 +59,7 @@ function SearchSidebar({state}: SearchSidebarProps) {
     const toggleButtonAnimatedStyle = useSearchSidebarToggleButtonStyle();
 
     const route = state.routes.at(-1);
-    const searchRouteParams = route?.name === SCREENS.SEARCH.ROOT ? (route.params as {q?: string; name?: string} | undefined) : undefined;
+    const searchRouteParams = route?.name === SCREENS.SEARCH.ROOT ? (route.params as SearchRootParams | undefined) : undefined;
     const {lastSearchType, currentSearchResults} = useSearchResultsContext();
     const {currentSearchQueryJSON} = useSearchQueryContext();
     const {setLastSearchType} = useSearchResultsActions();

--- a/src/components/Navigation/SearchSidebar.tsx
+++ b/src/components/Navigation/SearchSidebar.tsx
@@ -15,7 +15,6 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import type {PlatformStackNavigationState} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {SearchFullscreenNavigatorParamList} from '@libs/Navigation/types';
 
 import SearchTypeMenuWide from '@pages/Search/SearchTypeMenuWide';
 
@@ -43,8 +42,6 @@ type SearchSidebarProps = {
     state: PlatformStackNavigationState<ParamListBase>;
 };
 
-type SearchRootParams = SearchFullscreenNavigatorParamList[typeof SCREENS.SEARCH.ROOT];
-
 function SearchSidebar({state}: SearchSidebarProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
@@ -59,7 +56,7 @@ function SearchSidebar({state}: SearchSidebarProps) {
     const toggleButtonAnimatedStyle = useSearchSidebarToggleButtonStyle();
 
     const route = state.routes.at(-1);
-    const searchRouteParams = route?.name === SCREENS.SEARCH.ROOT ? (route.params as SearchRootParams | undefined) : undefined;
+    const searchName = route?.name === SCREENS.SEARCH.ROOT && route.params && 'name' in route.params && typeof route.params.name === 'string' ? route.params.name : undefined;
     const {lastSearchType, currentSearchResults} = useSearchResultsContext();
     const {currentSearchQueryJSON} = useSearchQueryContext();
     const {setLastSearchType} = useSearchResultsActions();
@@ -128,7 +125,7 @@ function SearchSidebar({state}: SearchSidebarProps) {
                             <View style={styles.flex1}>
                                 <SearchTypeMenuWide
                                     queryJSON={currentSearchQueryJSON}
-                                    name={searchRouteParams?.name}
+                                    name={searchName}
                                 />
                             </View>
                         </Hoverable>

--- a/src/components/Search/SearchPageHeader/SearchPageHeaderWide.tsx
+++ b/src/components/Search/SearchPageHeader/SearchPageHeaderWide.tsx
@@ -10,11 +10,12 @@ import React from 'react';
 
 type SearchPageHeaderWideProps = {
     queryJSON: SearchQueryJSON;
+    name?: string;
 };
 
-function SearchPageHeaderWide({queryJSON}: SearchPageHeaderWideProps) {
+function SearchPageHeaderWide({queryJSON, name}: SearchPageHeaderWideProps) {
     const {translate} = useLocalize();
-    const {typeMenuSections, activeItemIndex} = useSearchTypeMenuSections(queryJSON);
+    const {typeMenuSections, activeItemIndex} = useSearchTypeMenuSections({...queryJSON, name});
     const selectedItem = typeMenuSections.flatMap((section) => section.menuItems).at(activeItemIndex);
 
     let title = translate('common.spend');

--- a/src/hooks/useSearchTypeMenuSections.ts
+++ b/src/hooks/useSearchTypeMenuSections.ts
@@ -55,6 +55,7 @@ type UseSearchTypeMenuSectionsParams = {
     sortBy?: string;
     sortOrder?: string;
     type?: string;
+    name?: string;
 };
 
 /**
@@ -66,7 +67,7 @@ type UseSearchTypeMenuSectionsParams = {
  * reliably, so this hook never depends on a navigation context itself.
  */
 const useSearchTypeMenuSections = (queryParams?: UseSearchTypeMenuSectionsParams, isScreenFocused = true) => {
-    const {hash, similarSearchHash, sortBy, sortOrder, type} = queryParams ?? {};
+    const {hash, similarSearchHash, sortBy, sortOrder, type, name} = queryParams ?? {};
     const [defaultExpensifyCard] = useOnyx(ONYXKEYS.DERIVED.NON_PERSONAL_AND_WORKSPACE_CARD_LIST, {selector: defaultExpensifyCardSelector});
 
     const {defaultCardFeed, cardFeedsByPolicy} = useCardFeedsForDisplay();
@@ -142,7 +143,7 @@ const useSearchTypeMenuSections = (queryParams?: UseSearchTypeMenuSectionsParams
     );
 
     const activeItemIndex = useMemo(() => {
-        const isSavedSearchActive = hash !== undefined && !!savedSearches && Object.keys(savedSearches).some((key) => Number(key) === hash);
+        const isSavedSearchActive = !!name && hash !== undefined && savedSearches?.[hash]?.name === name;
 
         if (isSavedSearchActive) {
             return -1;
@@ -180,7 +181,7 @@ const useSearchTypeMenuSections = (queryParams?: UseSearchTypeMenuSectionsParams
         }
 
         return -1;
-    }, [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type]);
+    }, [typeMenuSections, savedSearches, hash, similarSearchHash, sortBy, sortOrder, type, name]);
 
     const activeKey = activeItemIndex < 0 ? undefined : typeMenuSections.flatMap((section) => section.menuItems).at(activeItemIndex)?.key;
 

--- a/src/pages/Search/SavedSearchList.tsx
+++ b/src/pages/Search/SavedSearchList.tsx
@@ -35,6 +35,7 @@ import SearchTypeMenuItem from './SearchTypeMenuItem';
 
 type SavedSearchListProps = {
     hash: number | undefined;
+    name?: string;
 };
 
 type SavedSearchMenuItemBuilderParams = {
@@ -42,14 +43,15 @@ type SavedSearchMenuItemBuilderParams = {
     key: string;
     index: number;
     hash: number | undefined;
+    name?: string;
     title: string;
     getOverflowMenu: (itemName: string, itemHash: number, itemQuery: string) => ReturnType<typeof getOverflowMenuUtil>;
     itemStyle: SavedSearchMenuItem['style'];
     isCopied: boolean;
 };
 
-function buildSavedSearchMenuItem({item, key, index, hash, title, getOverflowMenu, itemStyle, isCopied}: SavedSearchMenuItemBuilderParams): SavedSearchMenuItem {
-    const isItemFocused = Number(key) === hash;
+function buildSavedSearchMenuItem({item, key, index, hash, name, title, getOverflowMenu, itemStyle, isCopied}: SavedSearchMenuItemBuilderParams): SavedSearchMenuItem {
+    const isItemFocused = !!name && Number(key) === hash && item.name === name;
     const baseMenuItem: SavedSearchMenuItem = createBaseSavedSearchMenuItem(item, key, index, title, isItemFocused);
 
     return {
@@ -71,7 +73,7 @@ function buildSavedSearchMenuItem({item, key, index, hash, title, getOverflowMen
     };
 }
 
-function SavedSearchList({hash}: SavedSearchListProps) {
+function SavedSearchList({hash, name}: SavedSearchListProps) {
     const styles = useThemeStyles();
     const {translate, localeCompare} = useLocalize();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
@@ -128,6 +130,7 @@ function SavedSearchList({hash}: SavedSearchListProps) {
                       key,
                       index,
                       hash,
+                      name,
                       title: item.name === item.query ? (savedSearchTitles.get(item.query) ?? item.name) : item.name,
                       getOverflowMenu,
                       itemStyle,

--- a/src/pages/Search/SearchPageWide.tsx
+++ b/src/pages/Search/SearchPageWide.tsx
@@ -120,7 +120,10 @@ function SearchPageWide({
                 >
                     {!!queryJSON && (
                         <>
-                            <SearchPageHeaderWide queryJSON={queryJSON} />
+                            <SearchPageHeaderWide
+                                queryJSON={queryJSON}
+                                name={route.params.name}
+                            />
                             <SearchActionsBarWide
                                 queryJSON={queryJSON}
                                 searchResults={searchResults}

--- a/src/pages/Search/SearchSavePage.tsx
+++ b/src/pages/Search/SearchSavePage.tsx
@@ -28,6 +28,7 @@ import type {SearchFilter} from '@libs/SearchUIUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import type {SearchAdvancedFiltersForm} from '@src/types/form';
 import INPUT_IDS from '@src/types/form/SearchSaveForm';
 import {getEmptyObject} from '@src/types/utils/EmptyObject';
@@ -166,7 +167,15 @@ function SearchSavePage() {
 
         const newName = name.trim() || currentSearchQueryJSON?.inputQuery;
         saveSearch({queryJSON: currentSearchQueryJSON, newName});
-        Navigation.goBack();
+        Navigation.dismissModal();
+        Navigation.isNavigationReady().then(() => {
+            Navigation.navigate(
+                ROUTES.SEARCH_ROOT.getRoute({
+                    query: currentSearchQueryJSON.inputQuery,
+                    name: newName,
+                }),
+            );
+        });
     };
 
     const appliedFilters = mapFiltersFormToLabelValueList(searchAdvancedFiltersForm, undefined, translate, localeCompare, convertToDisplayStringWithoutCurrency);

--- a/src/pages/Search/SearchTypeMenuNarrow.tsx
+++ b/src/pages/Search/SearchTypeMenuNarrow.tsx
@@ -21,11 +21,14 @@ import useTodoCounts from '@hooks/useTodoCounts';
 
 import {setSearchContext} from '@libs/actions/Search';
 import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
+import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {SearchFullscreenNavigatorParamList} from '@libs/Navigation/types';
 import {getAllTaxRates} from '@libs/PolicyUtils';
 import {getItemBadgeText, getOverflowMenu, SEARCH_TYPE_MENU_ICON_NAMES} from '@libs/SearchUIUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type SCREENS from '@src/SCREENS';
 import {accountIDSelector} from '@src/selectors/Session';
 
 // NOTE: This component has a static twin in SearchPageNarrow/StaticSearchTypeMenu.tsx
@@ -79,9 +82,8 @@ function SearchTypeMenuNarrowContent({tabs, activeTabKey, onActiveTabPress, onTa
 function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps) {
     const {isOffline} = useNetwork();
     const navigation = useNavigation();
-    const route = useRoute();
-    const routeParams = route.params as {q?: string; name?: string} | undefined;
-    const searchName = routeParams?.name;
+    const route = useRoute<PlatformStackRouteProp<SearchFullscreenNavigatorParamList, typeof SCREENS.SEARCH.ROOT>>();
+    const searchName = route.params?.name;
     const {translate, localeCompare} = useLocalize();
     const styles = useThemeStyles();
     const isFocused = useIsFocused();

--- a/src/pages/Search/SearchTypeMenuNarrow.tsx
+++ b/src/pages/Search/SearchTypeMenuNarrow.tsx
@@ -31,7 +31,7 @@ import {accountIDSelector} from '@src/selectors/Session';
 // NOTE: This component has a static twin in SearchPageNarrow/StaticSearchTypeMenu.tsx
 // used for fast perceived performance. If you change the UI here, verify the
 // static version still looks visually identical.
-import {useIsFocused, useNavigation} from '@react-navigation/native';
+import {useIsFocused, useNavigation, useRoute} from '@react-navigation/native';
 import React, {useRef, useState} from 'react';
 import {View} from 'react-native';
 
@@ -79,6 +79,9 @@ function SearchTypeMenuNarrowContent({tabs, activeTabKey, onActiveTabPress, onTa
 function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps) {
     const {isOffline} = useNetwork();
     const navigation = useNavigation();
+    const route = useRoute();
+    const routeParams = route.params as {q?: string; name?: string} | undefined;
+    const searchName = routeParams?.name;
     const {translate, localeCompare} = useLocalize();
     const styles = useThemeStyles();
     const isFocused = useIsFocused();
@@ -89,6 +92,7 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
             sortBy: queryJSON?.sortBy,
             sortOrder: queryJSON?.sortOrder,
             type: queryJSON?.type,
+            name: searchName,
         },
         isFocused,
     );
@@ -157,7 +161,7 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
                       isCopied: copiedHash === itemHash,
                   });
 
-                  if (Number(key) === queryJSON?.hash) {
+                  if (!!searchName && Number(key) === queryJSON?.hash && item.name === searchName) {
                       activeKey = key;
                   }
 

--- a/src/pages/Search/SearchTypeMenuWide.tsx
+++ b/src/pages/Search/SearchTypeMenuWide.tsx
@@ -35,18 +35,20 @@ import SuggestedSearchSkeleton from './SuggestedSearchSkeleton';
 
 type SearchTypeMenuProps = {
     queryJSON: SearchQueryJSON | undefined;
+    name?: string;
 };
 
 type SectionParams = {
     section: SearchTypeMenuSection;
     hash: number | undefined;
+    name?: string;
     activeItemIndex: number;
     sectionStartIndex: number;
     reportCounts: TodoCounts;
     onItemPress: (query: string) => void;
 };
 
-function Section({section, hash, activeItemIndex, sectionStartIndex, reportCounts, onItemPress}: SectionParams) {
+function Section({section, hash, name, activeItemIndex, sectionStartIndex, reportCounts, onItemPress}: SectionParams) {
     const {translate} = useLocalize();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(SEARCH_TYPE_MENU_ICON_NAMES);
 
@@ -63,7 +65,12 @@ function Section({section, hash, activeItemIndex, sectionStartIndex, reportCount
             title={translate(section.translationPath)}
             badgeText={getSectionBadgeText(section.translationPath, reportCounts)}
         >
-            {isSavedSearchesSection && <SavedSearchList hash={hash} />}
+            {isSavedSearchesSection && (
+                <SavedSearchList
+                    hash={hash}
+                    name={name}
+                />
+            )}
             {!isSavedSearchesSection &&
                 section.menuItems.map((item, itemIndex) => {
                     const flattenedIndex = sectionStartIndex + itemIndex;
@@ -85,14 +92,14 @@ function Section({section, hash, activeItemIndex, sectionStartIndex, reportCount
     );
 }
 
-function SearchTypeMenuWide({queryJSON}: SearchTypeMenuProps) {
+function SearchTypeMenuWide({queryJSON, name}: SearchTypeMenuProps) {
     const {hash, similarSearchHash, sortBy, sortOrder, type} = queryJSON ?? {};
 
     const styles = useThemeStyles();
     const {isOffline} = useNetwork();
     const {singleExecution} = useSingleExecution();
     const {clearSelectedTransactions} = useSearchSelectionActions();
-    const {typeMenuSections, activeItemIndex} = useSearchTypeMenuSections({hash, similarSearchHash, sortBy, sortOrder, type});
+    const {typeMenuSections, activeItemIndex} = useSearchTypeMenuSections({hash, similarSearchHash, sortBy, sortOrder, type, name});
     const {isVisuallyCollapsed} = useSearchSidebarCollapse();
     const [isSearchDataLoaded, isSearchDataLoadedResult] = useOnyx(ONYXKEYS.IS_SEARCH_PAGE_DATA_LOADED);
     // Intentionally left enabled (no focus freeze): the wide menu renders in the search navigator's ExtraContent
@@ -142,6 +149,7 @@ function SearchTypeMenuWide({queryJSON}: SearchTypeMenuProps) {
                         section={expenseReportsSection}
                         onItemPress={handleTypeMenuItemPress}
                         hash={hash}
+                        name={name}
                         sectionStartIndex={0}
                         activeItemIndex={activeItemIndex}
                         reportCounts={reportCounts}
@@ -160,6 +168,7 @@ function SearchTypeMenuWide({queryJSON}: SearchTypeMenuProps) {
                             section={section}
                             onItemPress={handleTypeMenuItemPress}
                             hash={hash}
+                            name={name}
                             sectionStartIndex={sectionStartIndices.at(index + (expenseReportsSection ? 1 : 0)) ?? 0}
                             activeItemIndex={activeItemIndex}
                             reportCounts={reportCounts}

--- a/tests/unit/RoutesTest.ts
+++ b/tests/unit/RoutesTest.ts
@@ -6,7 +6,8 @@ describe('ROUTES', () => {
             ['plain name', 'test-97161', 'test-97161'],
             ['name with URL metacharacters', 'R&D Q1#draft 100%', 'R%26D%20Q1%23draft%20100%25'],
         ])('encodes %s', (_, name, encodedName) => {
-            expect(ROUTES.SEARCH_ROOT.getRoute({query: 'type:expense', name})).toBe(`search?q=type%3Aexpense&name=${encodedName}`);
+            const query = 'type:expense';
+            expect(ROUTES.SEARCH_ROOT.getRoute({query, name})).toBe(`search?q=${encodeURIComponent(query)}&name=${encodedName}`);
         });
     });
 });

--- a/tests/unit/RoutesTest.ts
+++ b/tests/unit/RoutesTest.ts
@@ -1,0 +1,12 @@
+import ROUTES from '@src/ROUTES';
+
+describe('ROUTES', () => {
+    describe('SEARCH_ROOT', () => {
+        it.each([
+            ['plain name', 'test-97161', 'test-97161'],
+            ['name with URL metacharacters', 'R&D Q1#draft 100%', 'R%26D%20Q1%23draft%20100%25'],
+        ])('encodes %s', (_, name, encodedName) => {
+            expect(ROUTES.SEARCH_ROOT.getRoute({query: 'type:expense', name})).toBe(`search?q=type%3Aexpense&name=${encodedName}`);
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR fixes incorrect Spend menu selection when a saved search has the same query as a canned tab such as Expenses.

After saving a view, the app now navigates to the named saved-search route. Saved-search selection also requires both the query hash and the route name to match. This allows Expenses and the saved view to share the same query while remaining distinct menu destinations across wide and narrow layouts.



### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ #97161
PROPOSAL: [#97161 (comment)](https://github.com/Expensify/App/issues/97161#issuecomment-5114607017)


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests




<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Sign in and navigate to **Spend > Expenses**.
2. Select **Save**, enter `test-97161`, and select **Save View**.
3. Verify the saved search is selected and the URL contains `name=test-97161`.
4. Select **Reports** and verify Reports is selected.
5. Select **Expenses**.
6. Verify Expenses is selected, the saved search is not selected, and the URL does not contain `name`.
7. Select the `test-97161` saved search.
8. Verify it is selected and the URL contains `name=test-97161`.
9. Select **Expenses** again and verify Expenses is selected.
10. Repeat the steps on wide and narrow layouts.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Sign in and navigate to **Spend > Expenses**.
2. Disable the network connection.
3. Save the view as `test-97161`.
4. Verify the saved search appears and is selected.
5. Navigate between **Reports**, **Expenses**, and `test-97161`.
6. Verify the correct item is selected each time.
7. Restore the network connection.
8. Verify the saved search syncs and the selection behavior remains correct.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
>


https://github.com/user-attachments/assets/6d2be9a8-ef0a-4680-b694-7cd953303f2b



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
>

https://github.com/user-attachments/assets/ca13ad0a-69d0-4b6e-a0be-10eae4261ab3




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
>


https://github.com/user-attachments/assets/b2d838e6-cf72-4766-a926-1a2309e7ec7e



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
>


https://github.com/user-attachments/assets/58e77cb8-39f3-4a52-9a08-b77b30e5bd06



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
>

https://github.com/user-attachments/assets/c3913ace-48d9-495d-ba82-2282d8dcaef9




</details>
