### PR TITLE
fix: stop Table lists scrolling with the keyboard while an RHP is open

### DIFF
--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -1,6 +1,7 @@
 import useBottomSafeSafeAreaPaddingStyle from '@hooks/useBottomSafeSafeAreaPaddingStyle';
 import useDebouncedAccessibilityAnnouncement from '@hooks/useDebouncedAccessibilityAnnouncement';
 import useLocalize from '@hooks/useLocalize';
+import useScrollEnabled from '@hooks/useScrollEnabled';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import type {StyleProp, ViewProps, ViewStyle} from 'react-native';
@@ -52,6 +53,7 @@ type TableBodyProps = ViewProps & {
 function TableBody<DataType extends TableData>({contentContainerStyle, style, ...props}: TableBodyProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
+    const scrollEnabled = useScrollEnabled();
     const {
         processedData: filteredAndSortedData,
         activeSearchString,
@@ -116,6 +118,7 @@ function TableBody<DataType extends TableData>({contentContainerStyle, style, ..
                 ListHeaderComponent={ListHeaderComponent}
                 ListEmptyComponent={ListEmptyComponent}
                 {...restListProps}
+                scrollEnabled={scrollEnabled}
             />
         </View>
     );


### PR DESCRIPTION
### Explanation of Change

The Categories list (and every other workspace list) renders through the shared `Table` component, whose body is a plain `FlashList`. Nothing tied that list's scrollability to whether its screen is focused, so it stayed a live scroll target while an RHP was open on top of it.

When a category setting opens in the RHP, `FocusTrapForScreen` blurs the clicked row and focuses nothing (`initialFocus: false`), so `document.activeElement` becomes `<body>`. Chromium then falls back to the last mouse-press node for keyboard scrolling — the category row that was just clicked — and arrow keys scroll its nearest scrollable ancestor, the categories `FlashList` behind the RHP. That is why the repro says "do not click on the RHP": clicking inside the RHP moves that anchor and the bug disappears.

This applies the existing `useScrollEnabled` hook to `Table.Body`, the same pattern `BaseSelectionList` has used since #56435. On web the hook returns `useIsFocused()`, so `scrollEnabled` is `false` exactly while another screen covers this one; `react-native-web` then sets `overflow: hidden` on the scroller and the browser can no longer scroll it. When the RHP closes, the screen regains focus, scrolling is restored and the scroll offset is preserved. On native the hook returns `undefined`, so native behavior is unchanged.

Fixing it in `TableBody` covers every `Table`-backed screen at once — Categories, Taxes, Tags, Members, Distance rates, Report fields, Cards, Rooms, Vendors, the Workspaces list and the Domain tables — instead of patching the Categories page alone.

Note on Taxes: the two pages share the same code path. A default workspace just has too few tax rates for the list to overflow, so there is nothing to scroll. With enough tax rates, Taxes reproduces the same bug and is fixed by this same change.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96867
PROPOSAL: https://github.com/Expensify/App/issues/96867#issuecomment-5062332745

### Tests

1. Sign in and open a Collect workspace that has enough categories for the list to overflow (a default workspace's ~19 categories are enough on a laptop-sized window).
2. Go to Workspace > Categories.
3. Click a category row to open its settings in the RHP. Do not click anywhere inside the RHP afterwards.
4. Press the up and down arrow keys several times.
5. Verify the categories list behind the RHP does not move.
6. Close the RHP (Escape or the back arrow) - focus returns to the category row you opened in step 3.
7. Press the up and down arrow keys again, and scroll with the mouse wheel over the list.
8. Verify the list scrolls normally again, from the same position it was left at.
9. Go to Workspace > Taxes, add tax rates until the list overflows, and repeat steps 3-8. Verify the same behavior.
10. Repeat steps 3-8 on Workspace > Tags and Workspace > Members to confirm the other `Table`-based lists behave the same.

> [!NOTE]
> Arrow keys only scroll the list when the keyboard focus (or the last mouse press) is inside it. On a fresh page load, before any row has been clicked, `document.activeElement` is `<body>` and the arrow keys do nothing - that is existing behavior on `main` and is not changed by this PR. Use the mouse wheel, or click a row first, if you are testing without going through steps 3-6.

- [x] Verify that no errors appear in the JS console

### Offline tests

The change is purely a client-side scroll lock and makes no API calls. Same steps as above with the network disconnected: the categories list still does not scroll while the RHP is open, and scrolls again once it is closed.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/491db203-98b3-429d-b149-f4b0f0950ca1

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/7f4994ae-a4e2-464c-919c-e01bf705b77c

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/f8402430-e65d-4cb2-a279-cf426465b52e

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/0d7df68d-1f81-4d18-a81b-762c1850cea2

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/e68bd35f-5f25-4773-b8db-148c48b57108

</details>
