### PR TITLE
Migrate Button to ButtonComposed (batch 6) text-only styled — rest

### DIFF
--- a/src/components/MoneyRequestConfirmationList/ConfirmationFooterContent.tsx
+++ b/src/components/MoneyRequestConfirmationList/ConfirmationFooterContent.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import ButtonWithDropdownMenu from '@components/ButtonWithDropdownMenu';
 import type {DropdownOption} from '@components/ButtonWithDropdownMenu/types';
 import FormHelpMessage from '@components/FormHelpMessage';
@@ -110,12 +110,13 @@ function ConfirmationFooterContent({
         <>
             {expensesNumber > 1 && (
                 <Button
-                    large
-                    text={translate('iou.removeThisExpense')}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     onPress={showRemoveExpenseConfirmModal}
                     style={styles.mb3}
                     sentryLabel={CONST.SENTRY_LABEL.MONEY_REQUEST.CONFIRMATION_REMOVE_EXPENSE_BUTTON}
-                />
+                >
+                    <Button.Text>{translate('iou.removeThisExpense')}</Button.Text>
+                </Button>
             )}
             <EducationalTooltip
                 shouldRender={shouldShowProductTrainingTooltip}

--- a/src/components/MultifactorAuthentication/components/OutcomeScreen/OutcomeScreenBase.tsx
+++ b/src/components/MultifactorAuthentication/components/OutcomeScreen/OutcomeScreenBase.tsx
@@ -1,5 +1,5 @@
 import BlockingView from '@components/BlockingViews/BlockingView';
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {loadIllustration} from '@components/Icon/IllustrationLoader';
 import type {IllustrationName} from '@components/Icon/IllustrationLoader';
@@ -14,6 +14,8 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import Parser from '@libs/Parser';
+
+import CONST from '@src/CONST';
 
 import type {StyleProp, TextStyle, ViewStyle} from 'react-native';
 
@@ -116,12 +118,13 @@ function OutcomeScreenBaseContent({
                 </ScrollView>
                 <View style={[styles.flexRow, styles.m5, styles.mt0]}>
                     <Button
-                        large
-                        success
+                        size={CONST.BUTTON_SIZE.LARGE}
+                        variant={CONST.BUTTON_VARIANT.SUCCESS}
                         style={styles.flex1}
                         onPress={onClose}
-                        text={translate('common.buttonConfirm')}
-                    />
+                    >
+                        <Button.Text>{translate('common.buttonConfirm')}</Button.Text>
+                    </Button>
                 </View>
             </View>
         </ScreenWrapper>

--- a/src/components/OpenAppFailureModal/BaseOpenAppFailureModal.tsx
+++ b/src/components/OpenAppFailureModal/BaseOpenAppFailureModal.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import Header from '@components/Header';
 import Modal from '@components/Modal';
 import Text from '@components/Text';
@@ -52,17 +52,19 @@ function BaseOpenAppFailureModal({onRefreshAndTryAgainButtonPress}: BaseOpenAppF
                     </TextLink>
                 </Text>
                 <Button
-                    large
-                    success
+                    size={CONST.BUTTON_SIZE.LARGE}
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
                     style={[styles.mb3]}
-                    text={translate('openAppFailureModal.refreshAndTryAgain')}
                     onPress={onRefreshAndTryAgainButtonPress}
-                />
+                >
+                    <Button.Text>{translate('openAppFailureModal.refreshAndTryAgain')}</Button.Text>
+                </Button>
                 <Button
-                    large
-                    text={translate('common.close')}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     onPress={() => setIsOpenAppFailureModalOpen(false)}
-                />
+                >
+                    <Button.Text>{translate('common.close')}</Button.Text>
+                </Button>
             </View>
         </Modal>
     );

--- a/src/components/SelectionList/components/Footer.tsx
+++ b/src/components/SelectionList/components/Footer.tsx
@@ -49,7 +49,7 @@ function Footer<TItem extends ListItem>({footerContent, confirmButtonOptions, ad
                     isDisabled={isConfirmButtonDisabled}
                 >
                     <Button.KeyboardShortcut enterKeyEventListenerPriority={1} />
-                    {confirmButtonText && <Button.Text>{confirmButtonText}</Button.Text>}
+                    {!!confirmButtonText && <Button.Text>{confirmButtonText}</Button.Text>}
                 </Button>
             </FixedFooter>
         );

--- a/src/components/SelectionList/components/Footer.tsx
+++ b/src/components/SelectionList/components/Footer.tsx
@@ -49,7 +49,7 @@ function Footer<TItem extends ListItem>({footerContent, confirmButtonOptions, ad
                     isDisabled={isConfirmButtonDisabled}
                 >
                     <Button.KeyboardShortcut enterKeyEventListenerPriority={1} />
-                    <Button.Text>{confirmButtonText}</Button.Text>
+                    {confirmButtonText && <Button.Text>{confirmButtonText}</Button.Text>}
                 </Button>
             </FixedFooter>
         );

--- a/src/components/SelectionList/components/Footer.tsx
+++ b/src/components/SelectionList/components/Footer.tsx
@@ -1,8 +1,10 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FixedFooter from '@components/FixedFooter';
 import type {ConfirmButtonOptions, ListItem} from '@components/SelectionList/types';
 
 import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
 
 import React from 'react';
 
@@ -40,17 +42,15 @@ function Footer<TItem extends ListItem>({footerContent, confirmButtonOptions, ad
                 addBottomSafeAreaPadding={addBottomSafeAreaPadding}
             >
                 <Button
-                    success
-                    large={confirmButtonSize === 'large'}
-                    medium={confirmButtonSize === 'medium'}
-                    small={confirmButtonSize === 'small'}
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={confirmButtonSize}
                     style={[styles.w100, confirmButtonStyle]}
-                    text={confirmButtonText}
                     onPress={onConfirm}
-                    pressOnEnter
-                    enterKeyEventListenerPriority={1}
                     isDisabled={isConfirmButtonDisabled}
-                />
+                >
+                    <Button.KeyboardShortcut enterKeyEventListenerPriority={1} />
+                    <Button.Text>{confirmButtonText}</Button.Text>
+                </Button>
             </FixedFooter>
         );
     }

--- a/src/components/SubStepForms/ConfirmationStep.tsx
+++ b/src/components/SubStepForms/ConfirmationStep.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import RenderHTML from '@components/RenderHTML';
@@ -13,6 +13,8 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import type {ForwardedFSClassProps} from '@libs/Fullstory/types';
 import type {BrickRoad} from '@libs/WorkspacesSettingsUtils';
+
+import CONST from '@src/CONST';
 
 import React from 'react';
 import {View} from 'react-native';
@@ -105,13 +107,14 @@ function ConfirmationStep({
                 )}
                 <Button
                     isDisabled={isOffline}
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     isLoading={isLoading}
                     style={[styles.w100]}
                     onPress={onNext}
-                    text={translate('common.confirm')}
-                />
+                >
+                    <Button.Text>{translate('common.confirm')}</Button.Text>
+                </Button>
             </View>
         </ScrollView>
     );

--- a/src/components/SubStepForms/DocusignFullStep.tsx
+++ b/src/components/SubStepForms/DocusignFullStep.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
 import type {FormInputErrors, FormOnyxKeys, FormOnyxValues, FormRef} from '@components/Form/types';
@@ -131,14 +131,15 @@ function DocusignFullStepImpl({defaultValue, formID, inputID, isLoading, onBackB
                     </>
                 )}
                 <Button
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     style={[styles.w100, styles.mb15]}
                     onPress={() => {
                         openLink(CONST.DOCUSIGN_POWERFORM_LINK[country as 'CA' | 'AU' | 'US'], environmentURL);
                     }}
-                    text={translate('docusignStep.takeMeTo')}
-                />
+                >
+                    <Button.Text>{translate('docusignStep.takeMeTo')}</Button.Text>
+                </Button>
                 {(country === CONST.COUNTRY.CA || country === CONST.COUNTRY.US) && (
                     <Text style={[styles.textHeadlineLineHeightXXL, styles.mb5]}>{translate('docusignStep.uploadAdditional')}</Text>
                 )}

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -1,6 +1,6 @@
 import AmountTextInput from '@components/AmountTextInput';
 import BigNumberPad from '@components/BigNumberPad';
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FormHelpMessage from '@components/FormHelpMessage';
 import Text from '@components/Text';
 
@@ -741,29 +741,31 @@ function TimePicker({defaultValue = '', onSubmit, onInputChange = () => {}, shou
         () => (
             <View style={styles.timePickerSwitcherContainer}>
                 <Button
-                    shouldEnableHapticFeedback
+                    enableHapticFeedback
                     innerStyles={styleForAM}
-                    small
-                    text={translate('common.am')}
+                    size={CONST.BUTTON_SIZE.SMALL}
                     onLongPress={() => {}}
                     onPress={() => {
                         setAmPmValue(CONST.TIME_PERIOD.AM);
                     }}
                     onPressOut={() => {}}
                     onMouseDown={(e) => e.preventDefault()}
-                />
+                >
+                    <Button.Text>{translate('common.am')}</Button.Text>
+                </Button>
                 <Button
-                    shouldEnableHapticFeedback
+                    enableHapticFeedback
                     innerStyles={[styleForPM, styles.ml1]}
-                    small
-                    text={translate('common.pm')}
+                    size={CONST.BUTTON_SIZE.SMALL}
                     onLongPress={() => {}}
                     onPress={() => {
                         setAmPmValue(CONST.TIME_PERIOD.PM);
                     }}
                     onPressOut={() => {}}
                     onMouseDown={(e) => e.preventDefault()}
-                />
+                >
+                    <Button.Text>{translate('common.pm')}</Button.Text>
+                </Button>
             </View>
         ),
         [styles, styleForAM, styleForPM, translate, setAmPmValue],
@@ -888,14 +890,14 @@ function TimePicker({defaultValue = '', onSubmit, onInputChange = () => {}, shou
                 {numberPad()}
             </View>
             <Button
-                success
-                medium={isExtraSmallScreenHeight}
-                large={!isExtraSmallScreenHeight}
+                variant={CONST.BUTTON_VARIANT.SUCCESS}
+                size={isExtraSmallScreenHeight ? CONST.BUTTON_SIZE.MEDIUM : CONST.BUTTON_SIZE.LARGE}
                 style={[styles.mb5, styles.mh5]}
                 onPress={handleSubmit}
-                pressOnEnter
-                text={translate('common.save')}
-            />
+            >
+                <Button.KeyboardShortcut />
+                <Button.Text>{translate('common.save')}</Button.Text>
+            </Button>
         </View>
     );
 }

--- a/src/pages/Debug/Report/DebugReportActions.tsx
+++ b/src/pages/Debug/Report/DebugReportActions.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import ScrollView from '@components/ScrollView';
 import SelectionList from '@components/SelectionList';
 import SingleSelectListItem from '@components/SelectionList/ListItem/SingleSelectListItem';
@@ -17,6 +17,7 @@ import {getOriginalMessage, getReportActionMessage, getReportActionMessageText, 
 import {canUserPerformWriteAction, formatReportLastMessageText, getInvoiceReceiverPolicyID, getParticipantsAccountIDsForDisplay} from '@libs/ReportUtils';
 import SidebarUtils from '@libs/SidebarUtils';
 
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {ReportAction, ReportActions} from '@src/types/onyx';
@@ -115,12 +116,13 @@ function DebugReportActions({reportID}: DebugReportActionsProps) {
     return (
         <ScrollView style={styles.mv3}>
             <Button
-                success
-                large
-                text={translate('common.create')}
+                variant={CONST.BUTTON_VARIANT.SUCCESS}
+                size={CONST.BUTTON_SIZE.LARGE}
                 onPress={() => Navigation.navigate(ROUTES.DEBUG_REPORT_ACTION_CREATE.getRoute(reportID))}
                 style={[styles.pb3, styles.ph3]}
-            />
+            >
+                <Button.Text>{translate('common.create')}</Button.Text>
+            </Button>
             <SelectionList
                 data={searchedReportActions}
                 style={{listItemTitleStyles: styles.fontWeightNormal}}

--- a/src/pages/Debug/Transaction/DebugTransactionViolations.tsx
+++ b/src/pages/Debug/Transaction/DebugTransactionViolations.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
@@ -9,6 +9,7 @@ import useTransactionViolations from '@hooks/useTransactionViolations';
 
 import Navigation from '@libs/Navigation/Navigation';
 
+import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type {TransactionViolation} from '@src/types/onyx';
 
@@ -40,12 +41,13 @@ function DebugTransactionViolations({transactionID}: DebugTransactionViolationsP
     return (
         <ScrollView style={styles.mv5}>
             <Button
-                success
-                large
-                text={translate('common.create')}
+                variant={CONST.BUTTON_VARIANT.SUCCESS}
+                size={CONST.BUTTON_SIZE.LARGE}
                 onPress={() => Navigation.navigate(ROUTES.DEBUG_TRANSACTION_VIOLATION_CREATE.getRoute(transactionID))}
                 style={[styles.pb5, styles.ph3]}
-            />
+            >
+                <Button.Text>{translate('common.create')}</Button.Text>
+            </Button>
             {/* This list was previously rendered as a FlatList, but it turned out that it caused the component to flash in some cases,
             so it was replaced by this solution. */}
             {transactionViolations?.map((item, index) => renderItem(item, index))}

--- a/src/pages/EnablePayments/Wallet/AddBankAccount/substeps/ConfirmationStep.tsx
+++ b/src/pages/EnablePayments/Wallet/AddBankAccount/substeps/ConfirmationStep.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import ScrollView from '@components/ScrollView';
@@ -70,12 +70,13 @@ function ConfirmationStep({onNext, onMove}: ConfirmationStepProps) {
                 <Button
                     isLoading={isLoading}
                     isDisabled={isLoading || isOffline}
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     style={[styles.w100]}
                     onPress={onNext}
-                    text={translate('common.confirm')}
-                />
+                >
+                    <Button.Text>{translate('common.confirm')}</Button.Text>
+                </Button>
             </View>
         </ScrollView>
     );

--- a/src/pages/EnablePayments/Wallet/FeesAndTerms/substeps/FeesStep.tsx
+++ b/src/pages/EnablePayments/Wallet/FeesAndTerms/substeps/FeesStep.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 
@@ -10,6 +10,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import LongTermsForm from '@pages/EnablePayments/shared/TermsForms/LongTermsForm';
 import ShortTermsForm from '@pages/EnablePayments/shared/TermsForms/ShortTermsForm';
 
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 import React from 'react';
@@ -27,12 +28,13 @@ function FeesStep({onNext}: SubPageProps) {
                 <ShortTermsForm userWallet={userWallet} />
                 <LongTermsForm />
                 <Button
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     style={[styles.w100, styles.mv5]}
                     onPress={onNext}
-                    text={translate('common.next')}
-                />
+                >
+                    <Button.Text>{translate('common.next')}</Button.Text>
+                </Button>
             </View>
         </ScrollView>
     );

--- a/src/pages/ErrorPage/GenericErrorPage.tsx
+++ b/src/pages/ErrorPage/GenericErrorPage.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import Icon from '@components/Icon';
 import ImageSVG from '@components/ImageSVG';
 import SafeAreaConsumer from '@components/SafeAreaConsumer';
@@ -68,19 +68,21 @@ function GenericErrorPage({error}: {error?: Error}) {
                             <View style={[styles.flexRow]}>
                                 <View style={[styles.flex1, styles.flexRow]}>
                                     <Button
-                                        success
-                                        text={translate('genericErrorPage.refresh')}
+                                        variant={CONST.BUTTON_VARIANT.SUCCESS}
                                         style={styles.mr3}
                                         onPress={() => refreshPage(chunkLoadError)}
-                                    />
+                                    >
+                                        <Button.Text>{translate('genericErrorPage.refresh')}</Button.Text>
+                                    </Button>
                                     {isAuthenticated && (
                                         <Button
-                                            text={translate('initialSettingsPage.signOut')}
                                             onPress={() => {
                                                 signOutAndRedirectToSignIn();
                                                 refreshPage();
                                             }}
-                                        />
+                                        >
+                                            <Button.Text>{translate('initialSettingsPage.signOut')}</Button.Text>
+                                        </Button>
                                     )}
                                 </View>
                             </View>

--- a/src/pages/ErrorPage/UpdateRequiredView.tsx
+++ b/src/pages/ErrorPage/UpdateRequiredView.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import Header from '@components/Header';
 import ImageSVG from '@components/ImageSVG';
 import Lottie from '@components/Lottie';
@@ -20,6 +20,7 @@ import variables from '@styles/variables';
 import {updateApp} from '@userActions/AppUpdate';
 
 import CONFIG from '@src/CONFIG';
+import CONST from '@src/CONST';
 
 import React from 'react';
 import {View} from 'react-native';
@@ -73,12 +74,13 @@ function UpdateRequiredView() {
                     </View>
                 </View>
                 <Button
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     onPress={() => updateApp(isProduction)}
-                    text={translate('common.update')}
                     style={styles.updateRequiredViewTextContainer}
-                />
+                >
+                    <Button.Text>{translate('common.update')}</Button.Text>
+                </Button>
             </View>
         </View>
     );

--- a/src/pages/MultifactorAuthentication/AuthorizeTransactionPage/AuthorizeTransactionActions.tsx
+++ b/src/pages/MultifactorAuthentication/AuthorizeTransactionPage/AuthorizeTransactionActions.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FixedFooter from '@components/FixedFooter';
 import LoadingIndicator from '@components/LoadingIndicator';
 
@@ -6,6 +6,8 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import variables from '@styles/variables';
+
+import CONST from '@src/CONST';
 
 import React from 'react';
 import {View} from 'react-native';
@@ -29,19 +31,21 @@ function MultifactorAuthenticationAuthorizeTransactionActions({onAuthorize, onDe
             ) : (
                 <>
                     <Button
-                        danger
-                        large
+                        variant={CONST.BUTTON_VARIANT.DANGER}
+                        size={CONST.BUTTON_SIZE.LARGE}
                         style={styles.flex1}
                         onPress={onDeny}
-                        text={translate('multifactorAuthentication.reviewTransaction.deny')}
-                    />
+                    >
+                        <Button.Text>{translate('multifactorAuthentication.reviewTransaction.deny')}</Button.Text>
+                    </Button>
                     <Button
-                        success
-                        large
+                        variant={CONST.BUTTON_VARIANT.SUCCESS}
+                        size={CONST.BUTTON_SIZE.LARGE}
                         style={styles.flex1}
                         onPress={onAuthorize}
-                        text={translate('multifactorAuthentication.reviewTransaction.approve')}
-                    />
+                    >
+                        <Button.Text>{translate('multifactorAuthentication.reviewTransaction.approve')}</Button.Text>
+                    </Button>
                 </>
             )}
         </FixedFooter>

--- a/src/pages/MultifactorAuthentication/RevokePage.tsx
+++ b/src/pages/MultifactorAuthentication/RevokePage.tsx
@@ -1,5 +1,5 @@
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import ConfirmModal from '@components/ConfirmModal';
 import FormHelpMessage from '@components/FormHelpMessage';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -16,6 +16,8 @@ import {revokeMultifactorAuthenticationCredentials} from '@libs/actions/Multifac
 import Navigation from '@libs/Navigation/Navigation';
 
 import {openMultifactorAuthenticationRevokePage} from '@userActions/User';
+
+import CONST from '@src/CONST';
 
 import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
@@ -193,17 +195,18 @@ function MultifactorAuthenticationRevokePage() {
                                     rightComponent={
                                         <View style={styles.justifyContentCenter}>
                                             <Button
-                                                danger
-                                                small
+                                                variant={CONST.BUTTON_VARIANT.DANGER}
+                                                size={CONST.BUTTON_SIZE.SMALL}
                                                 isLoading={isThisDeviceLoading}
-                                                text={translate('multifactorAuthentication.revoke.revoke')}
                                                 onPress={() => {
                                                     if (!localCredentialID) {
                                                         return;
                                                     }
                                                     showConfirmModal('thisDevice');
                                                 }}
-                                            />
+                                            >
+                                                <Button.Text>{translate('multifactorAuthentication.revoke.revoke')}</Button.Text>
+                                            </Button>
                                         </View>
                                     }
                                 />
@@ -216,14 +219,15 @@ function MultifactorAuthenticationRevokePage() {
                                     rightComponent={
                                         <View style={styles.justifyContentCenter}>
                                             <Button
-                                                danger
-                                                small
+                                                variant={CONST.BUTTON_VARIANT.DANGER}
+                                                size={CONST.BUTTON_SIZE.SMALL}
                                                 isLoading={isOtherDevicesLoading}
-                                                text={translate('multifactorAuthentication.revoke.revoke')}
                                                 onPress={() => {
                                                     showConfirmModal(otherDevicesConfirmMode());
                                                 }}
-                                            />
+                                            >
+                                                <Button.Text>{translate('multifactorAuthentication.revoke.revoke')}</Button.Text>
+                                            </Button>
                                         </View>
                                     }
                                 />
@@ -240,21 +244,23 @@ function MultifactorAuthenticationRevokePage() {
                 <View style={[styles.flexRow, styles.m5, styles.mt0]}>
                     {hasDevices ? (
                         <Button
-                            large
-                            danger
+                            size={CONST.BUTTON_SIZE.LARGE}
+                            variant={CONST.BUTTON_VARIANT.DANGER}
                             style={styles.flex1}
                             isLoading={isThisDeviceLoading && isOtherDevicesLoading}
                             onPress={() => showConfirmModal(revokeAllConfirmMode())}
-                            text={translate(hasMultipleKeys ? 'multifactorAuthentication.revoke.ctaAll' : 'multifactorAuthentication.revoke.cta')}
-                        />
+                        >
+                            <Button.Text>{translate(hasMultipleKeys ? 'multifactorAuthentication.revoke.ctaAll' : 'multifactorAuthentication.revoke.cta')}</Button.Text>
+                        </Button>
                     ) : (
                         <Button
-                            large
-                            success
+                            size={CONST.BUTTON_SIZE.LARGE}
+                            variant={CONST.BUTTON_VARIANT.SUCCESS}
                             style={styles.flex1}
                             onPress={onGoBackPress}
-                            text={translate('multifactorAuthentication.revoke.dismiss')}
-                        />
+                        >
+                            <Button.Text>{translate('multifactorAuthentication.revoke.dismiss')}</Button.Text>
+                        </Button>
                     )}
                 </View>
             </FullPageOfflineBlockingView>

--- a/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
+++ b/src/pages/MultifactorAuthentication/ValidateCodePage.tsx
@@ -1,5 +1,5 @@
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FormHelpMessage from '@components/FormHelpMessage';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {useMultifactorAuthentication, useMultifactorAuthenticationActions, useMultifactorAuthenticationState} from '@components/MultifactorAuthentication/Context';
@@ -254,14 +254,15 @@ function MultifactorAuthenticationValidateCodePage() {
                         />
                     )}
                     <Button
-                        success
-                        large
+                        variant={CONST.BUTTON_VARIANT.SUCCESS}
+                        size={CONST.BUTTON_SIZE.LARGE}
                         style={[styles.w100, styles.ph5, styles.pb5, styles.mt4]}
                         onPress={validateAndSubmitForm}
-                        text={translate('common.verify')}
                         isLoading={isValidateCodeFormSubmitting}
                         isDisabled={isOffline}
-                    />
+                    >
+                        <Button.Text>{translate('common.verify')}</Button.Text>
+                    </Button>
                 </View>
             </FullPageOfflineBlockingView>
         </ScreenWrapper>

--- a/src/pages/NewChatPage/index.tsx
+++ b/src/pages/NewChatPage/index.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import ReferralProgramCTA from '@components/ReferralProgramCTA';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -433,11 +433,12 @@ function NewChatPage({ref}: NewChatPageProps) {
             <Button
                 onPress={() => toggleOption(item)}
                 style={[styles.pl2]}
-                text={translate('newChatPage.addToGroup')}
                 accessibilityLabel={item.text ? translate('newChatPage.addUserToGroup', item.text) : ''}
                 innerStyles={buttonInnerStyles}
-                small
-            />
+                size={CONST.BUTTON_SIZE.SMALL}
+            >
+                <Button.Text>{translate('newChatPage.addToGroup')}</Button.Text>
+            </Button>
         );
     };
 
@@ -465,12 +466,13 @@ function NewChatPage({ref}: NewChatPageProps) {
 
             {!!selectedOptions.length && (
                 <Button
-                    success
-                    large
-                    text={translate('common.next')}
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     onPress={createGroup}
-                    pressOnEnter
-                />
+                >
+                    <Button.KeyboardShortcut />
+                    <Button.Text>{translate('common.next')}</Button.Text>
+                </Button>
             )}
         </>
     );

--- a/src/pages/ReimbursementAccount/NonUSD/BeneficialOwnerInfo/BeneficialOwnersList.tsx
+++ b/src/pages/ReimbursementAccount/NonUSD/BeneficialOwnerInfo/BeneficialOwnersList.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItem from '@components/MenuItem';
 import ScrollView from '@components/ScrollView';
@@ -92,16 +92,17 @@ function BeneficialOwnersList({handleConfirmation, ownerKeys, handleOwnerEdit}: 
                     />
                 )}
                 <Button
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     isLoading={reimbursementAccount?.isSavingCorpayOnboardingBeneficialOwnersFields}
                     isDisabled={isOffline}
                     style={styles.w100}
                     onPress={() => {
                         handleConfirmation({anyIndividualOwn25PercentOrMore: true});
                     }}
-                    text={translate('common.confirm')}
-                />
+                >
+                    <Button.Text>{translate('common.confirm')}</Button.Text>
+                </Button>
             </View>
         </ScrollView>
     );

--- a/src/pages/ReimbursementAccount/USD/BeneficialOwnerInfo/subSteps/CompanyOwnersListUBO.tsx
+++ b/src/pages/ReimbursementAccount/USD/BeneficialOwnerInfo/subSteps/CompanyOwnersListUBO.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItem from '@components/MenuItem';
 import ScrollView from '@components/ScrollView';
@@ -117,14 +117,15 @@ function CompanyOwnersListUBO({isAnyoneElseUBO, isUserUBO, handleUBOsConfirmatio
                     />
                 )}
                 <Button
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     isLoading={isLoading}
                     isDisabled={isOffline}
                     style={[styles.w100]}
                     onPress={handleUBOsConfirmation}
-                    text={translate('common.confirm')}
-                />
+                >
+                    <Button.Text>{translate('common.confirm')}</Button.Text>
+                </Button>
             </View>
         </ScrollView>
     );

--- a/src/pages/ReimbursementAccount/USD/KYBDocuments/index.tsx
+++ b/src/pages/ReimbursementAccount/USD/KYBDocuments/index.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
 import type {FormInputErrors, FormOnyxValues} from '@components/Form/types';
@@ -169,12 +169,13 @@ function KYBDocuments({onBackButtonPress, onSubmit}: KYBDocumentsProps) {
 
     const footer = (
         <Button
-            large
+            size={CONST.BUTTON_SIZE.LARGE}
             style={[styles.mv3]}
-            text={translate('documentsStep.finishViaChat')}
             onPress={handleNavigateToConciergeChat}
             isDisabled={isLoading}
-        />
+        >
+            <Button.Text>{translate('documentsStep.finishViaChat')}</Button.Text>
+        </Button>
     );
 
     return (

--- a/src/pages/Share/ShareButton.tsx
+++ b/src/pages/Share/ShareButton.tsx
@@ -1,8 +1,10 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FixedFooter from '@components/FixedFooter';
 
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
 
 import React from 'react';
 
@@ -17,12 +19,13 @@ function ShareButton({onPress}: ShareButtonProps) {
     return (
         <FixedFooter style={[styles.pt4]}>
             <Button
-                success
-                large
-                text={translate('common.share')}
+                variant={CONST.BUTTON_VARIANT.SUCCESS}
+                size={CONST.BUTTON_SIZE.LARGE}
                 style={styles.w100}
                 onPress={onPress}
-            />
+            >
+                <Button.Text>{translate('common.share')}</Button.Text>
+            </Button>
         </FixedFooter>
     );
 }

--- a/src/pages/domain/Saml/ScimTokenContent.tsx
+++ b/src/pages/domain/Saml/ScimTokenContent.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import CopyableTextField from '@components/Domain/CopyableTextField';
 import FormHelpMessageRowWithRetryButton from '@components/Domain/FormHelpMessageRowWithRetryButton';
 
@@ -35,12 +35,13 @@ function ScimTokenContent({domainName}: ScimTokenContentProps) {
     if (!oktaScimToken || oktaScimToken.state === ScimTokenState.LOADING) {
         return (
             <Button
-                text={translate('domain.samlConfigurationDetails.revealToken')}
                 style={styles.alignSelfStart}
                 onPress={fetchOktaScimToken}
                 isLoading={oktaScimToken?.state === ScimTokenState.LOADING}
                 isDisabled={isOffline}
-            />
+            >
+                <Button.Text>{translate('domain.samlConfigurationDetails.revealToken')}</Button.Text>
+            </Button>
         );
     }
 

--- a/src/pages/home/FreeTrialSection/index.tsx
+++ b/src/pages/home/FreeTrialSection/index.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import Icon from '@components/Icon';
 import {PressableWithoutFeedback} from '@components/Pressable';
 import Text from '@components/Text';
@@ -95,12 +95,13 @@ function FreeTrialSection() {
                         {!!countdownSubtitle && <Text style={[styles.widgetItemSubtitle, {color: theme.trialTimer}]}>{countdownSubtitle}</Text>}
                     </View>
                     <Button
-                        text={ctaText}
                         onPress={onCtaPress}
-                        small
+                        size={CONST.BUTTON_SIZE.SMALL}
                         style={styles.widgetItemButton}
-                        success
-                    />
+                        variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    >
+                        <Button.Text>{ctaText}</Button.Text>
+                    </Button>
                 </View>
             </PressableWithoutFeedback>
         </WidgetContainer>

--- a/src/pages/inbox/report/EnableNotificationsBanner.tsx
+++ b/src/pages/inbox/report/EnableNotificationsBanner.tsx
@@ -1,5 +1,5 @@
 import Banner from '@components/Banner';
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -46,17 +46,19 @@ function EnableNotificationsBanner() {
                 containerStyles={[styles.pt3, styles.pr3, styles.pl4, containerOverrideStyle]}
             >
                 <Button
-                    success
-                    small
-                    text={translate('concierge.enableNotifications.cta')}
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.SMALL}
                     onPress={requestAndDismiss}
-                />
+                >
+                    <Button.Text>{translate('concierge.enableNotifications.cta')}</Button.Text>
+                </Button>
                 <Button
-                    small
+                    size={CONST.BUTTON_SIZE.SMALL}
                     style={[styles.ml2]}
-                    text={translate('common.notNow')}
                     onPress={dismissForSession}
-                />
+                >
+                    <Button.Text>{translate('common.notNow')}</Button.Text>
+                </Button>
             </Banner>
         </View>
     );

--- a/src/pages/inbox/report/ReportActionItemMessage.tsx
+++ b/src/pages/inbox/report/ReportActionItemMessage.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import Text from '@components/Text';
 
 import useLocalize from '@hooks/useLocalize';
@@ -84,12 +84,13 @@ function ReportActionItemMessage({action, displayAsGroup, reportID, style, isHid
                 <Text>{translate('signerInfoStep.isConnecting', bankAccountLastFour, currency)}</Text>
                 <Button
                     style={[styles.mt2, styles.alignSelfStart]}
-                    success
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
                     isDisabled={completed}
-                    text={translate(completed ? 'signerInfoStep.thisStep' : 'signerInfoStep.enterSignerInfo')}
                     onPress={() => handleEnterSignerInfoPress(policyID, bankAccountID, !!completed)}
                     sentryLabel={CONST.SENTRY_LABEL.REPORT.REPORT_ACTION_ITEM_MESSAGE_ENTER_SIGNER_INFO}
-                />
+                >
+                    <Button.Text>{translate(completed ? 'signerInfoStep.thisStep' : 'signerInfoStep.enterSignerInfo')}</Button.Text>
+                </Button>
             </View>
         );
     }

--- a/src/pages/signin/SMSDeliveryFailurePage.tsx
+++ b/src/pages/signin/SMSDeliveryFailurePage.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import FormAlertWithSubmitButton from '@components/FormAlertWithSubmitButton';
 import Text from '@components/Text';
 
@@ -73,14 +73,15 @@ function SMSDeliveryFailurePage() {
                 </View>
                 <View style={[styles.mv4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsEnd]}>
                     <Button
-                        success
-                        large
-                        text={translate('common.buttonConfirm')}
+                        variant={CONST.BUTTON_VARIANT.SUCCESS}
+                        size={CONST.BUTTON_SIZE.LARGE}
                         onPress={() => clearSignInData()}
-                        pressOnEnter
                         style={styles.w100}
                         sentryLabel={CONST.SENTRY_LABEL.SIGN_IN.CONFIRM}
-                    />
+                    >
+                        <Button.KeyboardShortcut />
+                        <Button.Text>{translate('common.buttonConfirm')}</Button.Text>
+                    </Button>
                 </View>
                 <View style={[styles.mt3, styles.mb2]}>
                     <ChangeExpensifyLoginLink onPress={() => clearSignInData()} />

--- a/src/pages/signin/SignUpWelcomeForm.tsx
+++ b/src/pages/signin/SignUpWelcomeForm.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import CheckboxWithLabel from '@components/CheckboxWithLabel';
 import FormHelpMessage from '@components/FormHelpMessage';
 
@@ -49,18 +49,19 @@ function SignUpWelcomeForm() {
             <View style={[styles.mt3, styles.mb2]}>
                 <Button
                     isDisabled={network.isOffline || !!account?.message}
-                    success
-                    large
-                    text={translate('welcomeSignUpForm.join')}
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     isLoading={account?.isLoading}
                     onPress={() => {
                         signUpUser(preferredLocale, isPhoneSignup ? hasSMSMarketingConsent : undefined);
                         setReadyToShowAuthScreens(true);
                     }}
-                    pressOnEnter
                     style={[styles.mb2]}
                     sentryLabel={CONST.SENTRY_LABEL.SIGN_IN.JOIN}
-                />
+                >
+                    <Button.KeyboardShortcut />
+                    <Button.Text>{translate('welcomeSignUpForm.join')}</Button.Text>
+                </Button>
                 {!!serverErrorText && (
                     <FormHelpMessage
                         isError

--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.tsx
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button';
+import Button from '@components/ButtonComposed';
 import SafariFormWrapper from '@components/Form/SafariFormWrapper';
 import FormHelpMessage from '@components/FormHelpMessage';
 import Icon from '@components/Icon';
@@ -434,14 +434,15 @@ function BaseValidateCodeForm({autoComplete, isUsingRecoveryCode, setIsUsingReco
             <View>
                 <Button
                     isDisabled={isOffline}
-                    success
-                    large
+                    variant={CONST.BUTTON_VARIANT.SUCCESS}
+                    size={CONST.BUTTON_SIZE.LARGE}
                     style={[styles.mv3]}
-                    text={translate('common.signIn')}
                     isLoading={isValidateCodeFormSubmitting}
                     onPress={validateAndSubmitForm}
                     sentryLabel={CONST.SENTRY_LABEL.SIGN_IN.SIGN_IN_BUTTON}
-                />
+                >
+                    <Button.Text>{translate('common.signIn')}</Button.Text>
+                </Button>
                 <ChangeExpensifyLoginLink onPress={clearSignInData} />
             </View>
             <View style={[styles.mt5, styles.signInPageWelcomeTextContainer]}>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This is batch 6 (PR6 of 9) of the ongoing effort to migrate every direct `<Button>` usage (`import Button from '@components/Button'`) over to the composed `ButtonComposed`, so the old `Button` can eventually be deprecated. This batch is the **"text-only · styled · rest"** shape: **28 files / 38 button instances**.

The migration issue lists 29 files / 40 usages, but `src/pages/signin/ChooseSSOOrMagicCode.tsx` (listed with ×2) was deleted upstream after the issue was written — so the real batch is 29 − 1 = **28 files** and 40 − 2 = **38 usages**, which matches this diff exactly.

No visual change is expected anywhere in this batch.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95175
PROPOSAL: https://github.com/Expensify/App/issues/83762#issuecomment-4836927575



<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

For every migrated button, verify that behaviour is unchanged from before the migration:

1. **Label** renders correctly and is not clipped or truncated.
2. **Variant/color** is correct — `success` = green, `danger` = red, default = grey.
3. **Size** is correct — SMALL vs MEDIUM vs LARGE height/padding matches the previous look.
4. **Disabled state** — the button greys out and is non-interactive when its precondition isn't met.
5. **Loading state** — the spinner replaces the label and the button is non-interactive while a request is in flight.
6. **Enter key** — where the button was submittable with Enter before, it still is, it fires exactly once, and it does nothing while the button is disabled.
7. **Press action** — pressing fires the same action as before.

The migrated buttons fall into a few categories by the styling or behaviour applied to them. Steps for one representative of each:

<details>
<summary>Toggle whose selected state comes entirely from the screen using it (AM/PM), plus a size that changes with screen height</summary>

##### Preconditions

None.

##### Test steps

1. Open **Account menu** (your avatar) > **Profile** > **Status** > **Clear after**.
2. Choose **Custom** in the list — a **Date** and a **Time** row appear at the bottom.
3. Click **Time**. You're on a screen with a large hour:minute display, an **AM** / **PM** pair next to it, a number pad, and a green **Save** button at the bottom.
4. Click **AM**, then **PM**, then **AM** again.

##### Expected behavior

- Each AM/PM click visibly moves the highlighted background to the clicked half and leaves the other one plain — identical to production.

</details>

---

<details>
<summary>Button submitted with the Enter key, and a button tinted by keyboard focus</summary>

##### Preconditions

None.

##### Test steps

1. In the **Inbox**, press the green **+** button at the bottom right, then **Start chat**. (There's a **Start chat** / **Room** tab pair at the top — stay on the first one.)
2. Use the **arrow keys** to move down the contact list, and watch the small **Add to group** button on the row that has focus.
3. Click **Add to group** on one row — the row becomes a checked selection and a green **Next** button appears at the bottom.
4. Press **Enter** on the keyboard instead of clicking **Next**.

##### Expected behavior

- The focused row's **Add to group** button picks up a tinted background and loses it as focus moves to the next row — same tint as production.
- Pressing **Enter** advances to the group-confirmation screen **exactly once** — not twice, and without skipping past it.
- If **Next** doesn't appear, nothing is selected yet — it only renders once at least one participant is picked. If a row has no **Add to group** button, that row is your own chat, is already selected (it shows a checkbox instead), or is otherwise excluded — all three are by design.

</details>

---

<details>
<summary>Button that greys out when offline and shows a spinner while a request is in flight</summary>

##### Preconditions

An existing account you can sign in to.

##### Test steps

1. Sign out: **Account menu** (your avatar) > **Sign out**.
2. On the sign-in page enter the email of an existing account and continue. You land on the magic-code screen — a code input, a "didn't get the code?" link, and a green **Sign in** button at the bottom.
3. Compare the button against production at rest.
4. Go offline. (Troubleshoot isn't reachable while signed out, so use your browser devtools > **Network** > **Offline**.) Try to click **Sign in**.
5. Go back online, type the magic code and press **Sign in**. Watch the button while the request runs — throttle to **Slow 3G** first if it completes too fast to see.

##### Expected behavior

- At rest: green, full width, same height/padding/label size as production.
- Offline: greyed out and unclickable.
- In flight: the label disappears and a spinner shows **centred inside the button** — not off to one side, not invisible — and the button does not change height. Worth repeating on **iOS**, which is where a mis-positioned spinner would show up first.

</details>

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/57e73148-3aa2-40ff-9176-a9c6f9769660

<img width="552" height="1122" alt="button_add_to_group_android" src="https://github.com/user-attachments/assets/a7504fbb-5ddd-4ef6-9fb3-2b0bef327cec" />

https://github.com/user-attachments/assets/d6604b9f-6ac8-4bf9-ae83-04395bf4b66f


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/c91da792-09bd-47d0-8492-ae746c7b4d7e

<img width="552" height="1122" alt="button_add_to_group_android_web" src="https://github.com/user-attachments/assets/9fd304e2-5f22-4409-b4a4-0bc7d715d6fb" />

https://github.com/user-attachments/assets/d4105a20-3bfe-4085-a178-82645e6ca1f9



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/fbdfa886-5ee8-4c0d-bbc7-51276b0193aa

<img width="586" height="1122" alt="button_add_to_group_ios" src="https://github.com/user-attachments/assets/f7bb4f98-313f-4ccb-9b6c-5445a0188ad8" />

https://github.com/user-attachments/assets/d20d0dfb-eb15-4f8c-82d7-d5852551c133




</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/4ee08667-b9da-417e-b423-e2b65e15cbb8

<img width="586" height="1122" alt="button_add_to_group_ios_web" src="https://github.com/user-attachments/assets/8c903b3a-93ea-4270-95c1-ca830f47692a" />

https://github.com/user-attachments/assets/02ccdab5-8bd9-47ec-855e-a77419e2f6ea



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/696b13cb-ebf0-426b-ae09-5e4294dd2984

<img width="1029" height="955" alt="button_add_to_group_web" src="https://github.com/user-attachments/assets/193ef12b-b3ea-4474-b41b-153e646cfc2e" />

https://github.com/user-attachments/assets/c6e0519e-4a9f-4a00-95a6-eaf37324c8dd




</details>
