### PR TITLE
Do not seed My expenses saved search for approve-only accounts

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1517,27 +1517,31 @@ function arePaymentsEnabled(policy: OnyxEntry<Policy>): boolean {
     return policy?.reimbursementChoice !== CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO;
 }
 
+/** Whether the user is an admin or auditor of a group workspace. */
+function isPolicyManager(policy: OnyxEntry<Policy>): boolean {
+    return isGroupPolicy(policy) && (policy?.role === CONST.POLICY.ROLE.ADMIN || policy?.role === CONST.POLICY.ROLE.AUDITOR);
+}
+
 /**
- * Returns true when the user is both a submitter and an approver, mirroring the Submit/Approve suggested-search eligibility in
- * `getSuggestedSearchesVisibility` (SearchUIUtils): a submitter is a member of any group workspace, and an approver is a member of a
- * group workspace with a non-optional approval flow whom `isPolicyApprover` recognizes (named approver or someone reports submit/forward to).
+ * Whether the user both submits and approves expenses. Any member of a group workspace can submit, so the submit half is
+ * covered by managing one; the two roles need not be held on the same workspace.
  */
 function isSubmitterAndApprover(policies: OnyxCollection<Policy> | null | undefined, currentUserEmail: string | undefined): boolean {
     if (!policies || !currentUserEmail) {
         return false;
     }
-    let isSubmitter = false;
+    let isManager = false;
     let isApprover = false;
     for (const policy of Object.values(policies)) {
         if (!policy) {
             continue;
         }
-        isSubmitter = isSubmitter || isGroupPolicy(policy);
+        isManager = isManager || isPolicyManager(policy);
         if (!isApprover) {
             const hasApprovalFlow = isGroupPolicy(policy) && !!policy.approvalMode && policy.approvalMode !== CONST.POLICY.APPROVAL_MODE.OPTIONAL;
             isApprover = hasApprovalFlow && isPolicyApprover(policy, currentUserEmail);
         }
-        if (isSubmitter && isApprover) {
+        if (isManager && isApprover) {
             return true;
         }
     }

--- a/tests/unit/Search/seedMyExpensesSearchTest.ts
+++ b/tests/unit/Search/seedMyExpensesSearchTest.ts
@@ -6,6 +6,8 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy} from '@src/types/onyx';
 
+import type {ValueOf} from 'type-fest';
+
 import Onyx from 'react-native-onyx';
 
 import getOnyxValue from '../../utils/getOnyxValue';
@@ -55,40 +57,53 @@ describe('isSubmitterAndApprover', () => {
         expect(isSubmitterAndApprover(policies, '')).toBe(false);
     });
 
-    it('returns true for a user who submits on one policy and approves on another', () => {
-        // submitter: role=user on a free policy
-        const submitPolicy = makeFreePolicy({
-            id: 'submitPolicy',
-            employeeList: {
-                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER_EMAIL},
-            },
+    it('returns true for a manager who manages one policy and approves on another', () => {
+        // manager: admin role on a free (Submit-type) policy
+        const managePolicy = makeFreePolicy({
+            id: 'managePolicy',
+            role: CONST.POLICY.ROLE.ADMIN,
         });
-        // approver: paid+basic policy where user receives submissions
+        // approver: paid+basic policy where a peer submits to the user
         const approvePolicy = makePaidPolicy({
             id: 'approvePolicy',
+            role: CONST.POLICY.ROLE.USER,
             approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
             employeeList: {
                 [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: USER_EMAIL},
             },
         });
-        expect(isSubmitterAndApprover({submitPolicy, approvePolicy}, USER_EMAIL)).toBe(true);
+        expect(isSubmitterAndApprover({managePolicy, approvePolicy}, USER_EMAIL)).toBe(true);
     });
 
-    it('returns true when the user is both submitter and approver on the same paid policy', () => {
+    it('returns true when the user is both manager and approver on the same paid policy', () => {
         const policy = makePaidPolicy({
             id: 'dualPolicy',
+            role: CONST.POLICY.ROLE.ADMIN,
             approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
             employeeList: {
-                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER_EMAIL},
+                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.ADMIN, submitsTo: APPROVER_EMAIL},
                 [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: USER_EMAIL},
             },
         });
         expect(isSubmitterAndApprover({dualPolicy: policy}, USER_EMAIL)).toBe(true);
     });
 
-    it('returns false for a submit-only user (no one submits to them)', () => {
+    it('returns true for an auditor who approves, not only admins', () => {
+        const policy = makePaidPolicy({
+            id: 'auditorApprover',
+            role: CONST.POLICY.ROLE.AUDITOR,
+            approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
+            employeeList: {
+                [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: USER_EMAIL},
+            },
+        });
+        expect(isSubmitterAndApprover({auditorApprover: policy}, USER_EMAIL)).toBe(true);
+    });
+
+    it('returns false for a plain member who manages nothing, even though they submit', () => {
         const policy = makePaidPolicy({
             id: 'submitOnly',
+            role: CONST.POLICY.ROLE.USER,
             approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
             employeeList: {
                 [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER_EMAIL},
@@ -97,34 +112,54 @@ describe('isSubmitterAndApprover', () => {
         expect(isSubmitterAndApprover({submitOnly: policy}, USER_EMAIL)).toBe(false);
     });
 
-    it('returns true for an admin who approves on a group policy (any member is a submitter, not just role=user)', () => {
+    // The default workflow gives every member a `submitsTo` target, so role is the only thing separating an
+    // approve-only member from a manager.
+    it('returns false for an approve-only plain member who is another member’s approver', () => {
         const policy = makePaidPolicy({
-            id: 'adminApprover',
+            id: 'approveOnly',
+            role: CONST.POLICY.ROLE.USER,
             approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
             employeeList: {
-                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.ADMIN, submitsTo: ''},
+                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER_EMAIL},
                 [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: USER_EMAIL},
             },
         });
-        expect(isSubmitterAndApprover({adminApprover: policy}, USER_EMAIL)).toBe(true);
+        expect(isSubmitterAndApprover({approveOnly: policy}, USER_EMAIL)).toBe(false);
     });
 
-    it('returns true for an approver on a free (Submit-type) group policy, not only paid group policies', () => {
-        const policy = makeFreePolicy({
-            id: 'freeApprover',
+    it('returns false for a manager who approves nothing (no approval flow reaches them)', () => {
+        const policy = makePaidPolicy({
+            id: 'adminOnly',
+            role: CONST.POLICY.ROLE.ADMIN,
             approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
             employeeList: {
-                [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: USER_EMAIL},
+                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.ADMIN, submitsTo: APPROVER_EMAIL},
+                [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER_EMAIL},
             },
         });
-        expect(isSubmitterAndApprover({freeApprover: policy}, USER_EMAIL)).toBe(true);
+        expect(isSubmitterAndApprover({adminOnly: policy}, USER_EMAIL)).toBe(false);
+    });
+
+    it('treats the named policy approver as an approver', () => {
+        const policy = makePaidPolicy({
+            id: 'namedApprover',
+            role: CONST.POLICY.ROLE.ADMIN,
+            approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
+            approver: USER_EMAIL,
+            employeeList: {
+                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.ADMIN, submitsTo: USER_EMAIL},
+            },
+        });
+        expect(isSubmitterAndApprover({namedApprover: policy}, USER_EMAIL)).toBe(true);
     });
 
     it('treats an over-limit forwards-to target as an approver', () => {
         const policy = makePaidPolicy({
             id: 'overLimitApprover',
+            role: CONST.POLICY.ROLE.ADMIN,
             approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
             employeeList: {
+                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.ADMIN, submitsTo: APPROVER_EMAIL},
                 [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER_EMAIL, overLimitForwardsTo: USER_EMAIL},
             },
         });
@@ -132,20 +167,66 @@ describe('isSubmitterAndApprover', () => {
     });
 
     it('returns false when the approver policy has OPTIONAL approval mode (no approval flow)', () => {
-        const submitPolicy = makeFreePolicy({
-            id: 'submitPolicy',
-            employeeList: {
-                [USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER_EMAIL},
-            },
+        const managePolicy = makeFreePolicy({
+            id: 'managePolicy',
+            role: CONST.POLICY.ROLE.ADMIN,
         });
         const optionalApprovePolicy = makePaidPolicy({
             id: 'optionalApprove',
+            role: CONST.POLICY.ROLE.ADMIN,
             approvalMode: CONST.POLICY.APPROVAL_MODE.OPTIONAL,
             employeeList: {
                 [PEER_EMAIL]: {email: PEER_EMAIL, role: CONST.POLICY.ROLE.USER, submitsTo: USER_EMAIL},
             },
         });
-        expect(isSubmitterAndApprover({submitPolicy, optionalApprovePolicy}, USER_EMAIL)).toBe(false);
+        expect(isSubmitterAndApprover({managePolicy, optionalApprovePolicy}, USER_EMAIL)).toBe(false);
+    });
+
+    // An owner who invited a submitter and an approver, with a workflow routing the submitter to the approver.
+    describe('a workspace with an owner, a submitter and an approver', () => {
+        const OWNER = 'owner@expensifail.com';
+        const SUBMITTER = 'submitter@gmail.com';
+        const APPROVER = 'approver@expensifail.com';
+        const employeeList: Record<string, NonNullable<Policy['employeeList']>[string]> = {
+            [APPROVER]: {email: APPROVER, role: CONST.POLICY.ROLE.USER, submitsTo: OWNER, forwardsTo: '', overLimitForwardsTo: ''},
+            [OWNER]: {email: OWNER, role: CONST.POLICY.ROLE.ADMIN, submitsTo: OWNER, forwardsTo: ''},
+            [SUBMITTER]: {email: SUBMITTER, role: CONST.POLICY.ROLE.USER, submitsTo: APPROVER},
+        };
+        // `policy.role` holds the viewing user's own role, so build a per-viewer copy.
+        const asViewedBy = (role: ValueOf<typeof CONST.POLICY.ROLE>) =>
+            makePaidPolicy({
+                id: 'reported',
+                approvalMode: CONST.POLICY.APPROVAL_MODE.ADVANCED,
+                approver: OWNER,
+                owner: OWNER,
+                employeeList,
+                role,
+            });
+
+        it('does not seed the approve-only member', () => {
+            expect(isSubmitterAndApprover({reported: asViewedBy(CONST.POLICY.ROLE.USER)}, APPROVER)).toBe(false);
+        });
+
+        it('does not seed the submit-only member', () => {
+            expect(isSubmitterAndApprover({reported: asViewedBy(CONST.POLICY.ROLE.USER)}, SUBMITTER)).toBe(false);
+        });
+
+        it('seeds the owner/admin who also approves', () => {
+            expect(isSubmitterAndApprover({reported: asViewedBy(CONST.POLICY.ROLE.ADMIN)}, OWNER)).toBe(true);
+        });
+    });
+
+    it('returns false for a personal policy even when the user is its admin', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        const personal = {
+            id: 'personal',
+            type: CONST.POLICY.TYPE.PERSONAL,
+            role: CONST.POLICY.ROLE.ADMIN,
+            approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
+            approver: USER_EMAIL,
+            employeeList: {[USER_EMAIL]: {email: USER_EMAIL, role: CONST.POLICY.ROLE.ADMIN}},
+        } as unknown as Policy;
+        expect(isSubmitterAndApprover({personal}, USER_EMAIL)).toBe(false);
     });
 
     it('returns false for an empty policy collection', () => {


### PR DESCRIPTION
### Explanation of Change

Follow-up to #93541, which seeded the "My expenses" saved search on approve-only accounts.

The submitter half of `isSubmitterAndApprover` was derived from `isGroupPolicy(policy)` — a check on `policy.type` that never looks at the current user:

```ts
isSubmitter = isSubmitter || isGroupPolicy(policy);
```

The `POLICY` Onyx collection only holds policies the user belongs to, so this was true for anyone in any group workspace. Eligibility therefore collapsed to "is an approver somewhere", and the approve-only account in the linked issue satisfied it: member of the workspace ⇒ `isSubmitter`, set as the submitter's approver in workflow ⇒ `isApprover`.

This also explains why the submit-only case in #93541's test steps passed — only the approve-only half of the condition was broken, so manual testing did not surface it.

This PR gates the first half on the admin/auditor role instead, matching the `isAdmin || isAuditor` check the admin-facing suggested searches already use in `getSuggestedSearchesVisibility`. Any member of a group workspace can file their own expenses, so managing a workspace covers the "submits" half of the audience #92780 describes.

Notes for reviewers on why `role` is the signal used, since two more obvious candidates do not work:

1. **Approval-chain position cannot distinguish these accounts.** Being an approver is not recorded on the approver's own `employeeList` entry — it is an inbound reference from whoever submits to them. The default workflow also gives _every_ member a `submitsTo` target (members route to the owner, the owner to themselves), so requiring one does not exclude the reported account.
2. **Neither can membership or expense-creation capability.** An approve-only account is a full member with its own policy expense chat, so `isPolicyExpenseChatEnabled` + membership is also true for it. Gating on whether the user _has_ expenses was rejected separately: a newly-added manager with no expenses yet should still be seeded.

Three existing unit tests asserted the old behaviour (including one named "any member is a submitter, not just role=user") and have been corrected.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97213
PROPOSAL:

### Tests

Preconditions: 3 accounts (1 workspace owner, 1 submitter, 1 approver).

1. As the owner, create a workspace with Workflows enabled and invite the submitter and the approver as Members.
2. Go to Workspace settings > Workflows, enable Approvals, and add an approval workflow: expenses from the **submitter** are approved by the **approver**.
3. Log in as the **approver** and navigate to Search.
4. Verify **no** "My expenses" entry appears in the Saved section of the left-hand nav, and no Saved section is shown at all if they have no other saved searches.
5. Log in as the **submitter** and navigate to Search. Verify no "My expenses" entry appears.
6. Log in as the **owner** (workspace admin, and the default approver) and navigate to Search. Verify a "My expenses" entry **does** appear in the Saved section, and that opening it filters to `from:<owner account ID>`.
7. As the owner, delete the "My expenses" saved search. Sign out, clear site storage, sign back in, and navigate to Search. Verify it does not reappear.

Failure scenario: with the network throttled or offline at step 6, the entry appears optimistically and rolls back if the `SaveSearch` write fails, matching the existing manual save-search behaviour.

- [x] Verify that no errors appear in the JS console

### Offline tests

Unchanged from #93541. The seed uses the existing `saveSearch` write path, which has optimistic data plus failure rollback, so offline behaviour is identical to saving a search manually while offline: the entry appears optimistically and syncs when back online. This PR only narrows which accounts are eligible and adds no new network calls.

### QA Steps

Same as tests. The key assertion is step 4 — the approve-only account must not receive the seeded search — and step 6, which confirms the eligible dual-role account still does.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Verified on a real 3-account workspace against the dev backend (owner + submitter + approver, with a workflow routing the submitter to the approver):

| Account                         | Workspace role | Recognized as approver | "My expenses" seeded                      |
| ------------------------------- | -------------- | ---------------------- | ----------------------------------------- |
| Approver (the reported account) | `user`         | yes                    | **no**                                    |
| Owner / admin                   | `admin`        | yes                    | **yes** — `type:expense from:<accountID>` |

For the approver, `nvp_hasSeededMyExpensesSearch` and `nvp_savedSearches` both remained unset and no Saved section rendered. For the owner, the NVP was set and the entry appeared in the Saved section.

</details>
