### PR TITLE
fix: keep createWorkspace getting-started task responsive after opening a connection task

### DIFF
--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -132,7 +132,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         label: translate('homePage.gettingStartedSection.createWorkspace'),
         subText: translate('homePage.gettingStartedSection.createWorkspaceSubText'),
         isComplete: true,
-        route: shouldUseNarrowLayout ? ROUTES.WORKSPACE_INITIAL.getRoute(activePolicyID, Navigation.getActiveRoute()) : ROUTES.WORKSPACE_OVERVIEW.getRoute(activePolicyID),
+        route: shouldUseNarrowLayout ? ROUTES.WORKSPACE_INITIAL.getRoute(activePolicyID, ROUTES.HOME) : ROUTES.WORKSPACE_OVERVIEW.getRoute(activePolicyID),
     });
 
     if (intent === CONST.ONBOARDING_CHOICES.TRACK_PERSONAL) {

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention -- test fixtures use backend-shaped object keys that don't follow camelCase: email addresses for PolicyEmployeeList entries and human-readable names / 'GL Code' for PolicyCategories */
 import {renderHook, waitFor} from '@testing-library/react-native';
 
+import Navigation from '@libs/Navigation/Navigation';
+
 import useGettingStartedItems from '@pages/home/GettingStartedSection/hooks/useGettingStartedItems';
 
 import CONST from '@src/CONST';
@@ -1395,6 +1397,27 @@ describe('useGettingStartedItems', () => {
 
                 const createWorkspaceItem = result.current.items.find((item) => item.key === 'createWorkspace');
                 expect(createWorkspaceItem?.route).toContain(ROUTES.WORKSPACE_INITIAL.getRoute(POLICY_ID).split('?').at(0) ?? '');
+            });
+
+            it('should pin the createWorkspace backTo to Home on narrow layout even when the active route has drifted to the workspace page', async () => {
+                // Regression guard for #96172: opening the Connect-to-accounting task re-renders this section while a
+                // workspaces/{id} route is active, so Navigation.getActiveRoute() returns that route. Baking it into backTo
+                // made the createWorkspace route self-referential (workspaces/{id}?backTo=workspaces/{id}), which the linkTo
+                // arePathAndBackToEqual guard swallows, so the tap did nothing. backTo must stay Home regardless of the live route.
+                const getActiveRouteSpy = jest.spyOn(Navigation, 'getActiveRoute').mockReturnValue(ROUTES.WORKSPACE_INITIAL.getRoute(POLICY_ID));
+                // renderHook re-renders as Onyx settles, so pin narrow across every render (mockReturnValueOnce gets consumed by an early render).
+                useResponsiveLayoutMock.mockReturnValue({shouldUseNarrowLayout: true});
+                try {
+                    await setupTrackWorkspaceScenario();
+
+                    const {result} = renderHook(() => useGettingStartedItems());
+
+                    const createWorkspaceItem = result.current.items.find((item) => item.key === 'createWorkspace');
+                    expect(createWorkspaceItem?.route).toBe(ROUTES.WORKSPACE_INITIAL.getRoute(POLICY_ID, ROUTES.HOME));
+                } finally {
+                    useResponsiveLayoutMock.mockReturnValue({shouldUseNarrowLayout: false});
+                    getActiveRouteSpy.mockRestore();
+                }
             });
 
             it('should resolve customizeCategories route to WORKSPACE_CATEGORIES', async () => {


### PR DESCRIPTION
### Explanation of Change

On narrow layout the "Create a workspace" task in the Home "Getting started" section could go dead after you opened the "Connect to accounting" task and came back. Tapping it did nothing.

The route for the createWorkspace item is built at render time and baked `Navigation.getActiveRoute()` into its `backTo`:

```ts
route: shouldUseNarrowLayout ? ROUTES.WORKSPACE_INITIAL.getRoute(activePolicyID, Navigation.getActiveRoute()) : ROUTES.WORKSPACE_OVERVIEW.getRoute(activePolicyID),
```

Opening the "Connect to QBO" task hits `PolicyAccountingPage`, which writes `policy.connections` / connection sync progress / imported categories over the next few seconds. Those writes re-render the Getting started section while a `workspaces/{activePolicyID}` route is the active route, so `getActiveRoute()` now returns `workspaces/{activePolicyID}` and gets stored as the backTo. The createWorkspace route becomes self-referential: `workspaces/{id}?backTo=workspaces/{id}`. When it's tapped, `arePathAndBackToEqual` in `linkTo` sees the focused path equal to its own backTo and returns early, so no navigation happens. It's narrow-only because the wide branch uses `WORKSPACE_OVERVIEW` with no backTo, so there is nothing to self-reference.

The Getting started section only ever renders on Home, so the workspace page's back target is always Home. I pass `ROUTES.HOME` as the backTo instead of the live route. `ROUTES.HOME` is `'home'`, which is exactly what `getActiveRoute()` already returns when the row is tapped legitimately from Home, so the happy-path route (`workspaces/{id}?backTo=home`) is unchanged. It just can no longer drift to a self-reference during the connection flow's re-renders. `Navigation` is still used elsewhere in the file (the fallback `onPress`), so the import stays.

I also added a regression test that pins the narrow-layout createWorkspace `backTo` to Home even when `getActiveRoute()` has drifted to the workspace page.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96172
PROPOSAL: https://github.com/Expensify/App/issues/96172#issuecomment-5006026881

### Tests

1. Onboard as "Manage my team's expenses" so a paid workspace exists and the Home "Getting started" section is shown.
2. On a narrow layout (iOS, or resize web to mobile width), open Home and confirm the "Getting started" section is visible.
3. Tap the "Connect to [accounting]" task (e.g. Connect to QuickBooks Online), wait a few seconds for the accounting page to load its connection state, then go back to Home.
4. Tap "Create a workspace".
5. Verify it navigates to the workspace page (before this change, the tap did nothing).

- [x] Verify that no errors appear in the JS console

Unit test: `tests/unit/hooks/useGettingStartedItems.test.ts`. The added case forces `Navigation.getActiveRoute()` to return the drifted `workspaces/{id}` route and asserts the narrow createWorkspace route stays `workspaces/{id}?backTo=home`. It fails on `main` (route comes out `workspaces/{id}?backTo=workspaces%2F1`) and passes with this change. Run: `TZ=UTC npx jest tests/unit/hooks/useGettingStartedItems.test.ts`

### Offline tests

Same as Tests. The change only affects which `backTo` value is stored on a client-side route, so behavior is identical offline.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

