### PR TITLE
[No QA] Update iOS build workflows to Xcode 26.6

### DIFF
--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -50,7 +50,7 @@ jobs:
     name: Build iOS HybridApp
     runs-on: blacksmith-12vcpu-macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
       PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
     outputs:
       IOS_VERSION: ${{ steps.getIOSVersion.outputs.IOS_VERSION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -442,7 +442,7 @@ jobs:
     runs-on: blacksmith-12vcpu-macos-latest
     if: ${{ fromJSON(needs.prep.outputs.SHOULD_BUILD_NATIVE) }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
     steps:
       - name: Checkout
         # Upstream checkout on macOS - Blacksmith's git-mirror cache can't work there (see workflows/README.md)
@@ -523,7 +523,7 @@ jobs:
     runs-on: blacksmith-12vcpu-macos-latest
     if: ${{ always() && !cancelled() && needs.prep.outputs.DEPLOY_ENV == 'production' && needs.iosBuild.result != 'failure' && needs.iosUploadTestflight.result != 'failure' }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
     steps:
       - name: Checkout
         # Upstream checkout on macOS - Blacksmith's git-mirror cache can't work there (see workflows/README.md)

--- a/.github/workflows/publishReactNativeiOSArtifacts.yml
+++ b/.github/workflows/publishReactNativeiOSArtifacts.yml
@@ -26,7 +26,7 @@ on:
         required: true
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
 
 jobs:
   buildSlice:

--- a/.github/workflows/remote-build-ios.yml
+++ b/.github/workflows/remote-build-ios.yml
@@ -47,7 +47,7 @@ jobs:
     needs: [prep, resolveRefs]
     runs-on: ${{ github.repository_owner == 'Expensify' && 'blacksmith-12vcpu-macos-latest' || 'macos-latest' }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Explanation of Change

All iOS build jobs in this repo select Xcode by pinning the `DEVELOPER_DIR` environment variable to `/Applications/Xcode_26.2.app/Contents/Developer`. That pin was set in [Update Xcode version to 26.2 in Rock iOS build workflows](https://github.com/Expensify/App/pull/80797) in January 2026.

Since then the macOS jobs moved to Blacksmith `macos-latest` runners, which [track the macOS 26 image](https://docs.blacksmith.sh/blacksmith-runners/overview) and mirror the [GitHub-hosted macOS 26 runner image](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md). That image now ships Xcode 26.0.1, 26.1.1, 26.2, 26.3, 26.4.1, 26.5 (default) and 26.6 (build 17F113) — so the builds run three releases behind the image default, compiling against an older toolchain and older simulator runtimes than the runner otherwise provides. The four macOS jobs that don't set `DEVELOPER_DIR` are already on the image default, so the build jobs and the rest of CI disagree about which Xcode they use.

This PR bumps all five pins to `/Applications/Xcode_26.6.app/Contents/Developer`:

| File | Job(s) |
| --- | --- |
| `.github/workflows/buildIOS.yml` | `build` — the reusable iOS build, called from `deploy.yml`, `verifyHybridApp.yml`, `buildAdHoc.yml` |
| `.github/workflows/deploy.yml` | `iosUploadTestflight` and `iosSubmit` (Fastlane) |
| `.github/workflows/remote-build-ios.yml` | `build` (Rock remote build matrix) |
| `.github/workflows/publishReactNativeiOSArtifacts.yml` | workflow-level `env`, covers `Build iOS Slice` and `Compose XCFramework` |

There is no single source of truth for the version — no `.xcode-version` file, no `setup-xcode` action, and `workflow_call` does not inherit `env` from the caller — so all five occurrences change together in one commit. Worth noting for reviewers: the previous two bumps each needed a follow-up commit because `deploy.yml` was missed, and that broke the staging deploy.

Two follow-ups are tracked in the linked issue and deliberately not done here: `Mobile-Expensify/.github/workflows/lint-swift.yml` is still on Xcode 16.2.0 but lives in the submodule (separate PR), and a `getXcodeVersion` composite action would stop this drifting again.

### Fixed Issues
$ https://github.com/Expensify/App/issues/97450

### Tests

Because this PR only touches `.github/**`, no iOS build is triggered automatically — `remote-build-ios.yml` has `paths-ignore: ['.github/**', ...]` on its push trigger, and `verifyHybridApp.yml` only fires on native-source / `package.json` / `Podfile.lock` paths. The builds below must be dispatched manually against this branch.

1. Dispatch `remote-build-ios.yml` against this branch with `reviewed_code=true`.
2. Verify the workflow does not fail with `xcode-select: error: invalid developer directory` or `xcrun: error: unable to find utility`, which would mean Xcode 26.6 is not present on the Blacksmith image.
3. Verify every entry in the build matrix (`New Expensify Dev`, `Expensify Dev`, and the remaining schemes) compiles successfully.
4. Verify the Rock build log shows a genuine compile rather than an S3 remote-cache hit. A build finishing in seconds has not exercised the toolchain — in the 26.0 breakage the failures were masked by cache hits that completed in ~5 seconds.
5. Dispatch `testBuild.yml` against this branch with `IOS=true` and `REVIEWED_CODE=true` to exercise the HybridApp path through `buildIOS.yml`.
6. Verify the iOS ad-hoc build completes and produces an installable IPA.
7. Install the resulting IPA on a device and verify the app launches and reaches the sign-in screen.

- [ ] Verify that no errors appear in the JS console

Two jobs cannot be verified before merge and need watching afterwards:

- `deploy.yml` (`iosUploadTestflight`, `iosSubmit`) only runs on `staging` / `production` deploys, so the first staging deploy after merge must be watched. This is the exact job that regressed on the previous two bumps.
- `publishReactNativeiOSArtifacts.yml` is `workflow_call`-only and runs via `publishReactNativeArtifacts.yml`; confirm the next artifact-publish run on `main` produces the XCFramework.

### Offline tests

N/A — this changes CI workflow configuration only and has no runtime or network behavior.

### QA Steps

[No QA] — this is a CI infrastructure change with no user-facing behavior.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not yet tested — needs manual QA.

</details>
