### PR TITLE
Show only Custom range (not Custom date) in Consolidated Travel Billing export

### DIFF
--- a/src/components/Search/FilterComponents/DateFilterBase.tsx
+++ b/src/components/Search/FilterComponents/DateFilterBase.tsx
@@ -39,6 +39,8 @@ type DateFilterBaseProps = {
     defaultDateValues: SearchDateValues;
     /** The date presets to display (e.g. "This month", "Last month") */
     presets: SearchDatePreset[];
+    /** Whether to show the "Custom date" (On/After/Before) option. Defaults to true. */
+    shouldShowCustomDate?: boolean;
     /** Whether the search advanced filters form Onyx data is loading or not */
     isSearchAdvancedFiltersFormLoading?: boolean;
     /** Callback when the back button is pressed. Required when shouldShowHeader is true. */
@@ -70,6 +72,7 @@ function DateFilterBase({
     title,
     defaultDateValues,
     presets,
+    shouldShowCustomDate,
     isSearchAdvancedFiltersFormLoading,
     onBackButtonPress,
     onSubmit,
@@ -234,6 +237,7 @@ function DateFilterBase({
                     selectedDateModifier={selectedDateModifier}
                     onSelectDateModifier={handleSelectDateModifier}
                     presets={presets}
+                    shouldShowCustomDate={shouldShowCustomDate}
                     isSearchAdvancedFiltersFormLoading={isSearchAdvancedFiltersFormLoading}
                     onDateValuesChange={handleDateValuesChange}
                     onRangeValidationErrorChange={setShouldShowRangeError}

--- a/src/components/Search/FilterComponents/DatePresetFilterBase.tsx
+++ b/src/components/Search/FilterComponents/DatePresetFilterBase.tsx
@@ -97,6 +97,9 @@ type DatePresetFilterBaseProps = {
     /** The date presets */
     presets?: SearchDatePreset[];
 
+    /** Whether to show the "Custom date" (On/After/Before) option. Defaults to true. */
+    shouldShowCustomDate?: boolean;
+
     /** Whether the search advanced filters form Onyx data is loading or not */
     isSearchAdvancedFiltersFormLoading?: boolean;
 
@@ -125,6 +128,7 @@ function DatePresetFilterBase({
     selectedDateModifier,
     onSelectDateModifier,
     presets,
+    shouldShowCustomDate = true,
     isSearchAdvancedFiltersFormLoading,
     onDateValuesChange,
     onRangeValidationErrorChange,
@@ -430,13 +434,15 @@ function DatePresetFilterBase({
                         style={[StyleUtils.getBorderColorStyle(theme.border), styles.mh3]}
                     />
                 )}
-                <MenuItem
-                    shouldShowRightIcon
-                    viewMode={CONST.OPTION_MODE.COMPACT}
-                    title={customDateTitle}
-                    description={customDateDescription}
-                    onPress={selectCustomDateMode}
-                />
+                {shouldShowCustomDate && (
+                    <MenuItem
+                        shouldShowRightIcon
+                        viewMode={CONST.OPTION_MODE.COMPACT}
+                        title={customDateTitle}
+                        description={customDateDescription}
+                        onPress={selectCustomDateMode}
+                    />
+                )}
                 <MenuItem
                     shouldShowRightIcon
                     viewMode={CONST.OPTION_MODE.COMPACT}

--- a/src/pages/workspace/travel/WorkspaceTravelInvoicingExportPage.tsx
+++ b/src/pages/workspace/travel/WorkspaceTravelInvoicingExportPage.tsx
@@ -68,9 +68,7 @@ function WorkspaceTravelInvoicingExportPage({route}: WorkspaceTravelInvoicingExp
     /**
      * Checks whether the user has a complete date selection.
      * A selection is complete when either ON is set (preset or specific date),
-     * or both AFTER and BEFORE are set. A single After or Before alone is
-     * incomplete — we don't silently fill in today's date for the missing value
-     * because that can produce invalid ranges the backend rejects.
+     * or both range boundaries are set.
      */
     const hasDateSelected = (valuesToValidate?: SearchDateValues): boolean => {
         const values = valuesToValidate ?? dateFilterBaseRef.current?.getDateValues();
@@ -83,13 +81,7 @@ function WorkspaceTravelInvoicingExportPage({route}: WorkspaceTravelInvoicingExp
         }
 
         const {from: rangeStart, to: rangeEnd} = getSelectedRangeBoundaries(values);
-        if (rangeStart && rangeEnd) {
-            return true;
-        }
-
-        // Both after and before must be set for a complete range
-
-        return !!(values[CONST.SEARCH.DATE_MODIFIERS.AFTER] && values[CONST.SEARCH.DATE_MODIFIERS.BEFORE]);
+        return !!(rangeStart && rangeEnd);
     };
 
     /**
@@ -97,18 +89,9 @@ function WorkspaceTravelInvoicingExportPage({route}: WorkspaceTravelInvoicingExp
      */
     const isDateRangeInvalid = (valuesToValidate?: SearchDateValues): boolean => {
         const values = valuesToValidate ?? dateFilterBaseRef.current?.getDateValues();
-        const dateAfter = values?.[CONST.SEARCH.DATE_MODIFIERS.AFTER];
-        const dateBefore = values?.[CONST.SEARCH.DATE_MODIFIERS.BEFORE];
         const {from: rangeStart, to: rangeEnd} = getSelectedRangeBoundaries(values);
 
-        if (rangeStart && rangeEnd && rangeStart > rangeEnd) {
-            return true;
-        }
-
-        if (dateAfter && dateBefore && dateAfter > dateBefore) {
-            return true;
-        }
-        return false;
+        return !!(rangeStart && rangeEnd && rangeStart > rangeEnd);
     };
 
     /**
@@ -129,13 +112,11 @@ function WorkspaceTravelInvoicingExportPage({route}: WorkspaceTravelInvoicingExp
     /**
      * Computes startDate and endDate in YYYY-MM-DD format from the current date selection.
      * Callers must validate via hasDateSelected() before calling — this function
-     * assumes the selection is complete (ON is set, or both AFTER and BEFORE are set).
+     * assumes the selection is complete (ON is set, or both range boundaries are set).
      */
     const getDateRange = (): {startDate: string; endDate: string} => {
         const values = dateFilterBaseRef.current?.getDateValues();
         const dateOn = values?.[CONST.SEARCH.DATE_MODIFIERS.ON];
-        const dateAfter = values?.[CONST.SEARCH.DATE_MODIFIERS.AFTER];
-        const dateBefore = values?.[CONST.SEARCH.DATE_MODIFIERS.BEFORE];
         const {from: rangeStart, to: rangeEnd} = getSelectedRangeBoundaries(values);
 
         if (dateOn) {
@@ -149,13 +130,6 @@ function WorkspaceTravelInvoicingExportPage({route}: WorkspaceTravelInvoicingExp
 
         if (rangeStart && rangeEnd) {
             return {startDate: rangeStart, endDate: rangeEnd};
-        }
-
-        if (dateAfter && dateBefore) {
-            return {
-                startDate: dateAfter,
-                endDate: dateBefore,
-            };
         }
 
         // Default: this month (only reached on initial mount before any interaction)
@@ -252,6 +226,7 @@ function WorkspaceTravelInvoicingExportPage({route}: WorkspaceTravelInvoicingExp
                     style={styles.flex1}
                     defaultDateValues={defaultDateValues}
                     presets={presets}
+                    shouldShowCustomDate={false}
                     onSubmit={onSubmit}
                     onDateValuesChange={handleDateValuesChange}
                     onDateModifierChange={setIsDateModifierOpen}


### PR DESCRIPTION
### Explanation of Change

The Consolidated Travel Billing export requires a closed date range (a concrete start and end date the backend can bound the statement to). The date picker, however, offered a single-select **Custom date** option (On / After / Before), where After and Before are mutually exclusive. 

This changed recently when we added the "Custom range" option, so this PR adds a flag that hides the "Custom date"

### Fixed Issues

$
PROPOSAL:

### Tests

1. Open a workspace with travel invoicing enabled.
2. Navigate to the Consolidated Travel Billing export page.
3. Verify the date options shown are only: `This month`, `Last month`, and `Custom range` — there is no `Custom date` option.
4. Tap `Custom range`, pick a `from` and a `to` date, and save.
5. Tap `Export to PDF` and verify the export succeeds with no `Please select a date range to export` error.
6. Repeat step 5 with `Export to CSV`.
7. Select a preset (e.g. `This month`) instead of a custom range and verify export still succeeds.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests.

### QA Steps

Same as Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<img width="2672" height="1522" alt="Screenshot 2026-07-30 at 09 16 34" src="https://github.com/user-attachments/assets/70bbab9e-c51f-43a9-b8dc-f46deba51e91" />
<img width="2672" height="1522" alt="Screenshot 2026-07-30 at 09 16 42" src="https://github.com/user-attachments/assets/e79e77c7-5855-4404-b9df-958fbeec2f79" />
