### PR TITLE
Fix stuck SAML reauthentication blocking token renewal and SequentialQueue dropping 407'd writes

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2536,6 +2536,9 @@ const CONST = {
         MAX_RETRY_WAIT_TIME_MS: 10 * 1000,
         PROCESS_REQUEST_DELAY_MS: 1000,
         MAX_PENDING_TIME_MS: 10 * 1000,
+        // The longest an authentication attempt may be considered in-flight. Past this, the "is authenticating" state is
+        // treated as stuck (e.g. an interrupted SAML sign-in) and reset so subsequent 407s can trigger a fresh token renewal.
+        MAX_AUTHENTICATION_PENDING_TIME_MS: 60 * 1000,
         MAX_REQUEST_RETRIES: 10,
         MAX_OPEN_APP_REQUEST_RETRIES: 2,
         SUSTAINED_FAILURE_THRESHOLD_COUNT: 3,

--- a/src/libs/Middleware/Reauthentication.ts
+++ b/src/libs/Middleware/Reauthentication.ts
@@ -1,5 +1,5 @@
 import {reconnect} from '@libs/actions/Reconnect';
-import redirectToSignIn from '@libs/actions/SignInRedirect';
+import redirectToSignIn, {getLastRedirectToSignInTime} from '@libs/actions/SignInRedirect';
 import HttpsError from '@libs/Errors/HttpsError';
 import Log from '@libs/Log';
 import {replay as replayMainQueue} from '@libs/Network/MainQueue';
@@ -21,27 +21,63 @@ import type Middleware from './types';
 
 // We store a reference to the active authentication request so that we are only ever making one request to authenticate at a time.
 let isAuthenticating: Promise<boolean> | null = null;
+let authenticationStartTime = 0;
+
+// Bumped whenever a stuck authentication chain is discarded so the discarded chain can notice it no longer owns the
+// shared state (throttle, flags) and stop retrying.
+let authenticationGeneration = 0;
 
 const reauthThrottle = new RequestThrottle('Re-authentication');
 
 function reauthenticate(commandName?: string): Promise<boolean> {
     if (isAuthenticating) {
-        return isAuthenticating;
+        if (Date.now() - authenticationStartTime <= CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS) {
+            return isAuthenticating;
+        }
+
+        // The in-flight authentication attempt never settled (e.g. a SAML/short-lived-token login that hung mid-flow).
+        // If we kept returning the stuck promise, every subsequent 407 would chain onto it and token renewal would be
+        // blocked forever. Discard it and start fresh so the session can recover without a page refresh.
+        Log.hmmm('[Reauthenticate] Discarding an authentication attempt that has been pending for too long and starting a fresh one', {
+            commandName,
+            elapsedTime: Date.now() - authenticationStartTime,
+        });
+        isAuthenticating = null;
+        // The stuck attempt may have left the network paused (see NetworkStore.isAuthenticating)
+        setIsAuthenticating(false);
+        // The stuck chain and the fresh one share this throttle: reclaim the full retry budget for the fresh chain and
+        // cancel the stuck chain's pending backoff timer (parking that chain for good).
+        reauthThrottle.clear();
     }
 
-    isAuthenticating = retryReauthenticate(commandName).finally(() => {
-        // Reset the isAuthenticating state to allow new reauthentication flows to start fresh
+    authenticationGeneration += 1;
+    const authenticationPromise = retryReauthenticate(commandName, authenticationGeneration).finally(() => {
+        // Reset the isAuthenticating state to allow new reauthentication flows to start fresh. The identity check keeps a
+        // discarded (stuck) attempt that settles late from clobbering a newer in-flight one.
+        if (isAuthenticating !== authenticationPromise) {
+            return;
+        }
         isAuthenticating = null;
     });
+    isAuthenticating = authenticationPromise;
 
-    return isAuthenticating;
+    return authenticationPromise;
 }
 
-function retryReauthenticate(commandName?: string): Promise<boolean> {
+function retryReauthenticate(commandName?: string, generation: number = authenticationGeneration): Promise<boolean> {
+    // Stamp each attempt rather than only the chain start: an actively retrying chain keeps refreshing this and is
+    // never misclassified as stuck, while a chain whose current attempt itself hangs goes stale and gets discarded
+    // by the next reauthenticate() call.
+    authenticationStartTime = Date.now();
     return reauthenticateLibs(commandName).catch((error: RequestError) => {
+        // A discarded (stuck) chain must not keep retrying: a newer chain owns the shared throttle and flags now.
+        if (generation !== authenticationGeneration) {
+            Log.hmmm('[Reauthenticate] Abandoning a discarded authentication attempt because a newer one is in flight', {commandName});
+            return false;
+        }
         return reauthThrottle
             .sleep(error, 'Authenticate')
-            .then(() => retryReauthenticate(commandName))
+            .then(() => retryReauthenticate(commandName, generation))
             .catch(() => {
                 setIsAuthenticating(false);
                 Log.hmmm('[Reauthenticate] Redirecting to Sign In because we failed to reauthenticate after multiple attempts', {error});
@@ -55,6 +91,8 @@ function retryReauthenticate(commandName?: string): Promise<boolean> {
 function resetReauthentication(): void {
     // Resets the authentication state flag to allow new reauthentication flows to start fresh
     isAuthenticating = null;
+    authenticationStartTime = 0;
+    authenticationGeneration += 1;
 
     // Clears any pending reauth timeouts set by reauthThrottle.sleep()
     reauthThrottle.clear();
@@ -103,8 +141,11 @@ function handleExpiredSession<TKey extends OnyxKey>(
         return Promise.resolve(data);
     }
 
-    // We are already authenticating and using the DeprecatedAPI so we will replay the request
-    if (!apiRequestType && isAuthenticatingNetworkStore()) {
+    // We are already authenticating and using the DeprecatedAPI so we will replay the request to the main queue.
+    // Sequential queue requests must never take this path: resolving with the 407 data would read as success to the
+    // SequentialQueue, which would delete the persisted request and silently lose the user's write. They fall through
+    // to reauthenticate() below, which chains them onto the in-flight authentication and retries them once it settles.
+    if (!apiRequestType && !isFromSequentialQueue && isAuthenticatingNetworkStore()) {
         replayMainQueue(request);
         return Promise.resolve(data);
     }
@@ -112,6 +153,16 @@ function handleExpiredSession<TKey extends OnyxKey>(
     return reauthenticate(request?.commandName)
         .then((wasSuccessful) => {
             if (!wasSuccessful) {
+                // When the failed reauthentication triggered a sign-out redirect, the whole store (including the
+                // persisted request queue) is about to be cleared — resolve with the original response like before so
+                // the queue deletes the request instead of rolling it back into storage mid-clear, which would orphan
+                // it on disk for a future session. Without a redirect the session can still recover (e.g. a stuck SAML
+                // login), so throw to keep the write queued for retry instead of silently dropping it.
+                const didRedirectToSignIn = Date.now() - getLastRedirectToSignInTime() < CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS;
+                if (isFromSequentialQueue && !didRedirectToSignIn) {
+                    throw new Error('Failed to reauthenticate');
+                }
+
                 // Reauth already handled the sign-in redirect, so do not briefly show the failed request UI before sign-in.
                 request.failureData = undefined;
                 request.finallyData = undefined;

--- a/src/libs/Network/NetworkStore.ts
+++ b/src/libs/Network/NetworkStore.ts
@@ -15,6 +15,7 @@ let authToken: string | null | undefined;
 let authTokenType: ValueOf<typeof CONST.AUTH_TOKEN_TYPES> | null;
 let accountID: number | null | undefined;
 let authenticating = false;
+let authenticatingStartTime = 0;
 
 let resolveIsReadyPromise: (args?: unknown[]) => void;
 let isReadyPromise = new Promise((resolve) => {
@@ -94,10 +95,23 @@ function hasReadRequiredDataFromStorage(): Promise<unknown> {
 }
 
 function isAuthenticating(): boolean {
+    // Self-heal a stuck flag: an authentication that never settles (e.g. an interrupted SAML sign-in) would otherwise
+    // leave this true forever, freezing the main queue (see MainQueue.canMakeRequest) and short-circuiting the 407
+    // reauthentication path so the session never recovers without a page refresh.
+    if (authenticating && Date.now() - authenticatingStartTime > CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS) {
+        Log.hmmm('[NetworkStore] Authentication has been pending for too long. Clearing the isAuthenticating flag so requests can flow and reauthentication can restart.', {
+            elapsedTime: Date.now() - authenticatingStartTime,
+        });
+        authenticating = false;
+    }
     return authenticating;
 }
 
 function setIsAuthenticating(val: boolean) {
+    if (val) {
+        // Stamp each new authentication attempt so a hung one can be detected as stale in isAuthenticating().
+        authenticatingStartTime = Date.now();
+    }
     authenticating = val;
 }
 

--- a/src/libs/Reauthentication.ts
+++ b/src/libs/Reauthentication.ts
@@ -255,6 +255,11 @@ function reauthenticate(command = ''): Promise<boolean> {
         })
             .then((response) => {
                 if (!response) {
+                    // Authenticate can resolve without a response when it bails out early (e.g. requireParameters fails
+                    // because credentials were wiped mid-flow during a short-lived-token transition). Every other terminal
+                    // path resets the flag — missing it here left the network permanently paused and blocked all future
+                    // reauthentication until a page refresh.
+                    setIsAuthenticating(false);
                     return false;
                 }
 

--- a/src/libs/actions/SignInRedirect.ts
+++ b/src/libs/actions/SignInRedirect.ts
@@ -12,6 +12,7 @@ import Onyx from 'react-native-onyx';
 
 import {resetSignInFlow} from './HybridApp';
 
+let lastRedirectToSignInTime = 0;
 let currentShouldForceOffline: boolean | undefined;
 let currentIsUsingImportedState: boolean | undefined;
 let currentSessionAuthToken: string | undefined;
@@ -128,9 +129,19 @@ function clearStorageAndRedirect(errorMessage?: string, isSAMLReauthentication?:
  * @param isSAMLReauthentication Whether the redirection was triggered by reauthentication for SAML required account
  */
 function redirectToSignIn(errorMessage?: string, isSAMLReauthentication?: boolean): Promise<void> {
+    lastRedirectToSignInTime = Date.now();
     return clearStorageAndRedirect(errorMessage, isSAMLReauthentication).then(() => {
         clearSessionStorage();
     });
 }
 
+/**
+ * When the last sign-out redirect started. The reauthentication middleware uses this to tell a session that is being
+ * torn down (redirected to sign-in, storage clearing) apart from one that can still recover.
+ */
+function getLastRedirectToSignInTime(): number {
+    return lastRedirectToSignInTime;
+}
+
 export default redirectToSignIn;
+export {getLastRedirectToSignInTime};

--- a/tests/unit/NetworkStoreTest.ts
+++ b/tests/unit/NetworkStoreTest.ts
@@ -1,0 +1,47 @@
+import CONST from '@src/CONST';
+import * as NetworkStore from '@src/libs/Network/NetworkStore';
+
+describe('NetworkStore', () => {
+    afterEach(() => {
+        NetworkStore.setIsAuthenticating(false);
+        jest.restoreAllMocks();
+    });
+
+    describe('isAuthenticating', () => {
+        test('stays true within the allowed authentication window', () => {
+            const dateNowSpy = jest.spyOn(Date, 'now');
+            const startTime = 1000000000000;
+            dateNowSpy.mockReturnValue(startTime);
+            NetworkStore.setIsAuthenticating(true);
+
+            dateNowSpy.mockReturnValue(startTime + CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS);
+            expect(NetworkStore.isAuthenticating()).toBe(true);
+        });
+
+        test('self-clears once an authentication attempt has been pending for too long', () => {
+            const dateNowSpy = jest.spyOn(Date, 'now');
+            const startTime = 1000000000000;
+            dateNowSpy.mockReturnValue(startTime);
+            NetworkStore.setIsAuthenticating(true);
+
+            // A stuck authentication (e.g. an interrupted SAML sign-in) must not block the network forever
+            dateNowSpy.mockReturnValue(startTime + CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS + 1);
+            expect(NetworkStore.isAuthenticating()).toBe(false);
+
+            // And it stays cleared on subsequent reads
+            expect(NetworkStore.isAuthenticating()).toBe(false);
+        });
+
+        test('a fresh authentication attempt restarts the stuck-detection window', () => {
+            const dateNowSpy = jest.spyOn(Date, 'now');
+            const startTime = 1000000000000;
+            dateNowSpy.mockReturnValue(startTime);
+            NetworkStore.setIsAuthenticating(true);
+
+            // A new attempt re-stamps the window, so it is not treated as stale even though the first one would be
+            dateNowSpy.mockReturnValue(startTime + CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS + 1);
+            NetworkStore.setIsAuthenticating(true);
+            expect(NetworkStore.isAuthenticating()).toBe(true);
+        });
+    });
+});

--- a/tests/unit/ReauthenticationMiddlewareTest.ts
+++ b/tests/unit/ReauthenticationMiddlewareTest.ts
@@ -1,4 +1,5 @@
-import Reauthentication from '@libs/Middleware/Reauthentication';
+import {getLastRedirectToSignInTime} from '@libs/actions/SignInRedirect';
+import Reauthentication, {resetReauthentication} from '@libs/Middleware/Reauthentication';
 import SaveResponseInOnyx from '@libs/Middleware/SaveResponseInOnyx';
 import reauthenticate from '@libs/Reauthentication';
 
@@ -22,6 +23,11 @@ import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import waitForNetworkPromises from '../utils/waitForNetworkPromises';
 
 jest.mock('@libs/Reauthentication');
+jest.mock('@libs/actions/SignInRedirect', () => ({
+    __esModule: true,
+    default: jest.fn(),
+    getLastRedirectToSignInTime: jest.fn(() => 0),
+}));
 
 Onyx.init({
     keys: ONYXKEYS,
@@ -34,6 +40,8 @@ beforeEach(() => {
     MainQueue.clear();
     HttpUtils.cancelPendingRequests();
     NetworkStore.checkRequiredData();
+    NetworkStore.setIsAuthenticating(false);
+    resetReauthentication();
     global.fetch = TestHelper.getGlobalFetchMock();
     setHasRadio(true);
     jest.clearAllMocks();
@@ -152,6 +160,179 @@ describe('Reauthentication middleware', () => {
                 title: '',
             });
         });
+    });
+
+    test('rejects for a sequential queue write when reauthentication is unsuccessful so the request is not dropped', () => {
+        jest.mocked(reauthenticate).mockResolvedValueOnce(false);
+
+        const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+            command: 'RenameReport',
+            data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE, shouldRetry: true},
+            failureData: [
+                {
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: ONYXKEYS.NETWORK,
+                    value: {shouldFailAllRequests: true},
+                },
+            ],
+            finallyData: [
+                {
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: ONYXKEYS.NETWORK,
+                    value: {shouldForceOffline: true},
+                },
+            ],
+        };
+
+        return Reauthentication(
+            Promise.resolve({
+                jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+            }),
+            request,
+            true,
+        )
+            .then(() => {
+                throw new Error('Expected the middleware to reject so the SequentialQueue keeps the request');
+            })
+            .catch((error: Error) => {
+                expect(error.message).toBe('Failed to reauthenticate');
+
+                // The SequentialQueue applies failureData when it finally gives up retrying, so it must stay intact here
+                expect(request.failureData).not.toBeUndefined();
+                expect(request.finallyData).not.toBeUndefined();
+            });
+    });
+
+    test('resolves with the original response for a sequential queue write when reauthentication failed with a sign-out redirect', () => {
+        jest.mocked(reauthenticate).mockResolvedValueOnce(false);
+        // The failed reauthentication redirected to sign-in, so the store (incl. the persisted queue) is being cleared
+        jest.mocked(getLastRedirectToSignInTime).mockReturnValueOnce(Date.now());
+
+        const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+            command: 'RenameReport',
+            data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE, shouldRetry: true},
+            failureData: [
+                {
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: ONYXKEYS.NETWORK,
+                    value: {shouldFailAllRequests: true},
+                },
+            ],
+        };
+
+        return Reauthentication(
+            Promise.resolve({
+                jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+            }),
+            request,
+            true,
+        ).then((response) => {
+            // Resolving (not throwing) lets the queue delete the request instead of rolling it back into a store that
+            // is being wiped, which would orphan it on disk for a future session.
+            expect(response?.jsonCode).toBe(CONST.JSON_CODE.NOT_AUTHENTICATED);
+            expect(request.failureData).toBeUndefined();
+        });
+    });
+
+    test('reauthenticates a sequential queue request without apiRequestType instead of resolving it with the 407 while the authenticating flag is set', () => {
+        jest.mocked(reauthenticate).mockResolvedValueOnce(false);
+        NetworkStore.setIsAuthenticating(true);
+
+        const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+            command: 'TestCommand',
+            data: {shouldRetry: true},
+        };
+
+        return Reauthentication(
+            Promise.resolve({
+                jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+            }),
+            request,
+            true,
+        )
+            .then(() => {
+                throw new Error('Expected the middleware to reject so the SequentialQueue keeps the request');
+            })
+            .catch((error: Error) => {
+                expect(error.message).toBe('Failed to reauthenticate');
+                expect(reauthenticate).toHaveBeenCalled();
+            })
+            .finally(() => NetworkStore.setIsAuthenticating(false));
+    });
+
+    test('still replays a main queue request and resolves with the original response while the authenticating flag is set', () => {
+        NetworkStore.setIsAuthenticating(true);
+
+        const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+            command: 'TestCommand',
+            data: {shouldRetry: true},
+        };
+
+        return Reauthentication(
+            Promise.resolve({
+                jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+            }),
+            request,
+            false,
+        )
+            .then((response) => {
+                expect(response?.jsonCode).toBe(CONST.JSON_CODE.NOT_AUTHENTICATED);
+                expect(reauthenticate).not.toHaveBeenCalled();
+            })
+            .finally(() => NetworkStore.setIsAuthenticating(false));
+    });
+
+    test('starts a fresh authentication when the in-flight one has been pending for too long', () => {
+        const dateNowSpy = jest.spyOn(Date, 'now');
+        const startTime = 1000000000000;
+        dateNowSpy.mockReturnValue(startTime);
+
+        // The first 407 starts an authentication that never settles (e.g. an interrupted SAML sign-in)
+        jest.mocked(reauthenticate).mockReturnValueOnce(new Promise<boolean>(() => {}));
+
+        const stuckRequest: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+            command: 'TestCommand',
+            data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE, shouldRetry: true},
+        };
+
+        // Intentionally not returned/awaited — this promise stays pending while the authentication hangs
+        Reauthentication(
+            Promise.resolve({
+                jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+            }),
+            stuckRequest,
+            true,
+        );
+
+        return waitForBatchedUpdates()
+            .then(() => {
+                expect(reauthenticate).toHaveBeenCalledTimes(1);
+
+                // Advance past the stuck-authentication window and let the next attempt succeed
+                dateNowSpy.mockReturnValue(startTime + CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS + 1);
+                jest.mocked(reauthenticate).mockResolvedValueOnce(true);
+
+                const retriedRequest: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+                    command: 'TestCommand',
+                    data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE, shouldRetry: true},
+                };
+
+                return Reauthentication(
+                    Promise.resolve({
+                        jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+                    }),
+                    retriedRequest,
+                    true,
+                );
+            })
+            .then(() => {
+                // The stale attempt was discarded and a fresh authentication ran instead of chaining onto the stuck one
+                expect(reauthenticate).toHaveBeenCalledTimes(2);
+            })
+            .finally(() => {
+                dateNowSpy.mockRestore();
+                resetReauthentication();
+            });
     });
 
     test('does not reauthenticate HTTP 407 while offline', () => {


### PR DESCRIPTION
### Explanation of Change

Fixes two bugs that combined to silently drop a SAML user's writes (approve/rename/edit) for ~40 minutes: every write returned a 407 (expired authToken), re-authentication never fired, and the SequentialQueue deleted each persisted write as if it had succeeded. Observed in a real user session; internal logs available on request.

**Bug 1 - a stuck "is authenticating" state permanently blocked token renewal.** When a SAML/short-lived-token login never completes, the authenticating flag stays `true` in memory forever. Every path that could clear it sits behind the very check the stuck flag short-circuits, and `MainQueue.canMakeRequest` stays frozen. Fix (3 layers):
- `NetworkStore.isAuthenticating()` now self-heals when an attempt has been pending longer than the new `CONST.NETWORK.MAX_AUTHENTICATION_PENDING_TIME_MS` (60s).
- The Reauthentication middleware discards an in-flight authentication gate whose current attempt has hung past the window and starts a fresh one - with per-attempt staleness stamping (an actively retrying chain is never misclassified as stuck), an identity-guarded reset, throttle reclaim, and a generation guard so a discarded chain stops retrying.
- `Reauthentication.reauthenticate()` now resets the flag on the early no-response bail-out path - the one terminal path that leaked it (the `SignInWithShortLivedAuthToken` -> `requireParameters` scenario already described in the middleware comments).

**Bug 2 - a 407'd sequential-queue write resolved as success, so the queue deleted the user's write.** `handleExpiredSession` resolved with the 407 response when reauthentication was unsuccessful; `SequentialQueue.process()` treats any resolution as success, removed the persisted request, and the wiped `failureData` meant no optimistic rollback either. Fix:
- When reauthentication is unsuccessful and **no sign-out redirect fired** (the session can still recover, e.g. the stuck-SAML case), the middleware now throws - the queue keeps the request, rolls back, retries with backoff, and applies `failureData` honestly if retries exhaust.
- When a sign-out redirect **did** fire, the previous resolve semantics are kept deliberately: throwing there would make the queue's rollback race the sign-out `Onyx.clear` and orphan the request on disk for a future session. A new `SignInRedirect.getLastRedirectToSignInTime()` distinguishes the two modes.
- The already-authenticating replay branch now excludes sequential-queue requests (resolving there deleted them too); they chain onto the in-flight authentication and retry once it settles.

### Fixed Issues
$
PROPOSAL:

<!-- No dedicated issue exists yet for this incident; related but distinct:
- https://github.com/Expensify/App/issues/96848 (non-SAML short-lived-token transition 407 loop)
- https://github.com/Expensify/App/issues/86705 (mobile Okta SSO double login)
This PR addresses the SAML stuck-flag path plus the failure-treated-as-success queue drop. -->

### Tests

1. Run `npx jest tests/unit/ReauthenticationMiddlewareTest.ts tests/unit/NetworkStoreTest.ts`
2. Verify all tests pass, including the new cases:
   - a sequential-queue write whose reauthentication fails (no sign-out) rejects and keeps `failureData`/`finallyData` intact
   - a sequential-queue write whose reauthentication fails **with** a sign-out redirect resolves with the original 407 (request deleted before the store clear)
   - a sequential-queue request without `apiRequestType` triggers reauthentication instead of being resolved-and-dropped while the authenticating flag is set
   - a main-queue DeprecatedAPI request still replays and resolves while authenticating (unchanged behavior)
   - an authentication pending longer than 60s is discarded and a fresh one starts on the next 407
   - `NetworkStore.isAuthenticating()` stays `true` within the 60s window, self-clears past it, and re-stamps on each new attempt
3. Sign in with a SAML-required account, let the session token expire (or force a 407 via the API), then approve/rename a report. Verify the write is either completed after automatic re-authentication or visibly fails - it must not show success while the server never receives it.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, make a write (e.g. rename a report), come back online with an expired token. Verify the queued write survives the 407 -> reauthentication cycle and reaches the server after a fresh token is issued (the offline early-return in `handleExpiredSession` is unchanged).

### QA Steps

1. On staging, sign in with a SAML-required account (e.g. Okta).
2. Invalidate/expire the session's authToken server-side (or wait for expiry).
3. Approve a report, rename a report, and edit a report field.
4. Verify each change either completes after the app re-authenticates, or visibly fails with an error state - no silent phantom success.
5. Verify the app recovers without a page refresh (main queue unfreezes within ~60s even if a login attempt hung).

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>