### PR TITLE
Fix device back from Submit to my employer confirmation landing on the workspace chat

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -586,8 +586,19 @@ function IOURequestStepConfirmation({
                 iouType,
                 isCreatingTrackExpense,
                 isSelfDMDestination,
+                isMovingTransactionFromTrackExpense,
             }),
-        [isTransactionReady, destinationReportID, destinationReport, isFromGlobalCreate, canPreInsertSearch, iouType, isCreatingTrackExpense, isSelfDMDestination],
+        [
+            isTransactionReady,
+            destinationReportID,
+            destinationReport,
+            isFromGlobalCreate,
+            canPreInsertSearch,
+            iouType,
+            isCreatingTrackExpense,
+            isSelfDMDestination,
+            isMovingTransactionFromTrackExpense,
+        ],
     );
 
     const {reveal: revealPreMountDestination, cleanupPreMount} = usePreMountDestination(preMountDestinationRoute, {

--- a/src/pages/iou/request/step/confirmation/getSubmitExpensePreMountDestinationRoute.ts
+++ b/src/pages/iou/request/step/confirmation/getSubmitExpensePreMountDestinationRoute.ts
@@ -23,6 +23,8 @@ type GetSubmitExpensePreMountDestinationRouteParams = {
     iouType: IOUType;
     isCreatingTrackExpense: boolean;
     isSelfDMDestination: boolean;
+    /** Whether the flow relocates an already-tracked expense (SUBMIT/SHARE/CATEGORIZE) rather than creating one in place. */
+    isMovingTransactionFromTrackExpense: boolean;
 };
 
 /**
@@ -38,6 +40,7 @@ function getSubmitExpensePreMountDestinationRoute({
     iouType,
     isCreatingTrackExpense,
     isSelfDMDestination,
+    isMovingTransactionFromTrackExpense,
 }: GetSubmitExpensePreMountDestinationRouteParams): Route | undefined {
     // Unlike getSkipConfirmationPreMountDestinationRoute (which lets usePreMountDestination own the narrow gate), this builder
     // returns undefined on wide up front - it avoids the nav reads below, and reveal() would never consume a wide result anyway.
@@ -71,13 +74,19 @@ function getSubmitExpensePreMountDestinationRoute({
     const isOutsideRHP = !isReportOpenInRHP(navigationRef.getRootState());
     // Don't pre-insert if the report is already the topmost fullscreen - it would push a duplicate route (extra back press).
     const hasValidDestination = !!destinationReportID && (hasPreInsertedFullscreen || Navigation.getTopmostReportId() !== destinationReportID);
+    // A report destination while a *different* report is topmost has no tab to switch to, so the pre-insert overwrites the
+    // visible report and cancelling must rebuild it from a state snapshot - a restore the root router's guards can silently
+    // swallow (#97437). Relocating a tracked expense is where that bites: it is rebound to its destination chat before this
+    // screen opens, so the destination is a report the user has never been on. Skipping it costs only the pre-mount.
+    const isReplacingVisibleReport =
+        !hasPreInsertedFullscreen && isMovingTransactionFromTrackExpense && isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() !== destinationReportID;
     // The report must be in the REPORT collection so the pre-inserted screen can render immediately. A draft-only report
     // (e.g. the expense chat of a freshly created draft workspace in the zero-workspace "Submit to my employer" flow) can't
     // render - the report screen only reads COLLECTION.REPORT - so pre-inserting one would strand the user on an infinite
     // skeleton if they back out before submitting. Passing an empty draft to getReportOrDraftReport skips its REPORT_DRAFT
     // fallback while keeping the module-cache fallback for real reports that useOnyx hasn't hydrated yet.
     const isDestinationReportLoaded = !!destinationReportID && !!getReportOrDraftReport(destinationReportID, undefined, undefined, {}, destinationReport)?.reportID;
-    const shouldPreInsertReport = canUseReportPreInsert && isOutsideRHP && hasValidDestination && isDestinationReportLoaded;
+    const shouldPreInsertReport = canUseReportPreInsert && isOutsideRHP && hasValidDestination && isDestinationReportLoaded && !isReplacingVisibleReport;
 
     if (!shouldPreInsertSearch && !shouldPreInsertReport) {
         return undefined;

--- a/tests/unit/getSubmitExpensePreMountDestinationRouteTest.ts
+++ b/tests/unit/getSubmitExpensePreMountDestinationRouteTest.ts
@@ -54,6 +54,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
                 iouType: CONST.IOU.TYPE.SUBMIT,
                 isCreatingTrackExpense: false,
                 isSelfDMDestination: false,
+                isMovingTransactionFromTrackExpense: false,
             }),
         ).toBeUndefined();
     });
@@ -69,6 +70,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
                 iouType: CONST.IOU.TYPE.SUBMIT,
                 isCreatingTrackExpense: false,
                 isSelfDMDestination: false,
+                isMovingTransactionFromTrackExpense: false,
             }),
         ).toBeUndefined();
     });
@@ -83,13 +85,55 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.SUBMIT,
             isCreatingTrackExpense: false,
             isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
         });
 
         expect(route).toEqual(ROUTES.SEARCH_ROOT.getRoute({query: 'type:expense'}));
     });
 
-    it('returns report route when report pre-insert is eligible', () => {
+    it('returns report route when the destination is not the report the user is looking at', () => {
+        const route = getSubmitExpensePreMountDestinationRoute({
+            isTransactionReady: true,
+            destinationReportID: '123',
+            destinationReport: {reportID: '123'},
+            isFromGlobalCreate: false,
+            canPreInsertSearch: false,
+            iouType: CONST.IOU.TYPE.SUBMIT,
+            isCreatingTrackExpense: false,
+            isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
+        });
+
+        expect(route).toEqual(ROUTES.REPORT_WITH_ID.getRoute('123'));
+    });
+
+    it('returns undefined when relocating a tracked expense over a different visible report', () => {
+        // The single-workspace "Submit to my employer" shape: the user is reading their self-DM while the expense is
+        // bound to the workspace chat. Both are reports, so there is no tab to switch to and the pre-insert would
+        // replace the report on screen - leaving the cancel path to rebuild it from a snapshot (#97437).
         mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+        jest.mocked(Navigation.getTopmostReportId).mockReturnValue('456');
+
+        expect(
+            getSubmitExpensePreMountDestinationRoute({
+                isTransactionReady: true,
+                destinationReportID: '123',
+                destinationReport: {reportID: '123'},
+                isFromGlobalCreate: false,
+                canPreInsertSearch: false,
+                iouType: CONST.IOU.TYPE.SUBMIT,
+                isCreatingTrackExpense: false,
+                isSelfDMDestination: false,
+                isMovingTransactionFromTrackExpense: true,
+            }),
+        ).toBeUndefined();
+    });
+
+    it('keeps the pre-insert for an in-place expense whose destination is a different visible report', () => {
+        // Same navigation topology as the case above, but the expense is created in place rather than relocated (e.g. the
+        // per-diem chat-report destination), so it keeps the pre-mount instead of being caught by the track-expense guard.
+        mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+        jest.mocked(Navigation.getTopmostReportId).mockReturnValue('456');
 
         const route = getSubmitExpensePreMountDestinationRoute({
             isTransactionReady: true,
@@ -100,6 +144,29 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.SUBMIT,
             isCreatingTrackExpense: false,
             isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
+        });
+
+        expect(route).toEqual(ROUTES.REPORT_WITH_ID.getRoute('123'));
+    });
+
+    it('stays eligible once it has pre-inserted, so the hook does not tear down its own insert', () => {
+        // After the pre-insert the visible report *is* the destination, so the same-tab check reads as safe on its own.
+        // Assert it through the explicit pre-inserted flag too, since that is what keeps the result stable.
+        mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+        jest.mocked(Navigation.getTopmostReportId).mockReturnValue('456');
+        jest.mocked(Navigation.getIsFullscreenPreInsertedUnderRHP).mockReturnValue(true);
+
+        const route = getSubmitExpensePreMountDestinationRoute({
+            isTransactionReady: true,
+            destinationReportID: '123',
+            destinationReport: {reportID: '123'},
+            isFromGlobalCreate: false,
+            canPreInsertSearch: false,
+            iouType: CONST.IOU.TYPE.SUBMIT,
+            isCreatingTrackExpense: false,
+            isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: true,
         });
 
         expect(route).toEqual(ROUTES.REPORT_WITH_ID.getRoute('123'));
@@ -115,6 +182,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.TRACK,
             isCreatingTrackExpense: true,
             isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
         });
 
         expect(route).toEqual(ROUTES.REPORT_WITH_ID.getRoute('123'));
@@ -130,6 +198,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.CREATE,
             isCreatingTrackExpense: false,
             isSelfDMDestination: true,
+            isMovingTransactionFromTrackExpense: false,
         });
 
         expect(route).toEqual(ROUTES.REPORT_WITH_ID.getRoute('123'));
@@ -145,6 +214,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.PAY,
             isCreatingTrackExpense: false,
             isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
         });
 
         expect(route).toEqual(ROUTES.REPORT_WITH_ID.getRoute('123'));
@@ -163,6 +233,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
                 iouType: CONST.IOU.TYPE.SUBMIT,
                 isCreatingTrackExpense: false,
                 isSelfDMDestination: false,
+                isMovingTransactionFromTrackExpense: false,
             }),
         ).toBeUndefined();
     });
@@ -181,6 +252,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
                 iouType: CONST.IOU.TYPE.SUBMIT,
                 isCreatingTrackExpense: false,
                 isSelfDMDestination: false,
+                isMovingTransactionFromTrackExpense: false,
             }),
         ).toBeUndefined();
     });
@@ -202,6 +274,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.SUBMIT,
             isCreatingTrackExpense: false,
             isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
         });
 
         expect(route).toEqual(ROUTES.REPORT_WITH_ID.getRoute('123'));
@@ -221,6 +294,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
                 iouType: CONST.IOU.TYPE.SUBMIT,
                 isCreatingTrackExpense: false,
                 isSelfDMDestination: false,
+                isMovingTransactionFromTrackExpense: false,
             }),
         ).toBeUndefined();
     });
@@ -240,6 +314,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.SUBMIT,
             isCreatingTrackExpense: false,
             isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
         });
 
         expect(route).toEqual(ROUTES.SEARCH_ROOT.getRoute({query: 'type:expense'}));
@@ -264,6 +339,7 @@ describe('getSubmitExpensePreMountDestinationRoute', () => {
             iouType: CONST.IOU.TYPE.SUBMIT,
             isCreatingTrackExpense: false,
             isSelfDMDestination: false,
+            isMovingTransactionFromTrackExpense: false,
         });
 
         expect(route).toEqual(ROUTES.SEARCH_ROOT.getRoute({query: 'type:expense'}));


### PR DESCRIPTION
### Explanation of Change

**Problem:** pressing the device back button on the "Submit it to my employer" confirmation page leaves you on the workspace chat instead of the self DM you started from.

**Cause:** the confirmation RHP pre-mounts its destination report underneath itself, so submitting reveals an already-rendered screen. This flow rebinds the draft to the workspace chat before the confirmation opens, so the destination is a chat the user has never visited while they are still looking at their self DM. Both are reports, so there is no tab to switch to and the pre-mount overwrites the visible report in place. Back pops the RHP and reveals that overwritten screen.

Cleaning it up afterwards doesn't work. The pop happens before the cleanup runs, so the workspace chat is already on screen for the whole dismiss animation, and any restore that follows shows the wrong screen first and then jumps.

**Fix:** don't pre-mount in this case. Skip it when a tracked expense is being relocated (submit/share/categorize) to a report other than the one currently on screen. Backing out is then a true no-op, and submitting falls through to the existing dismiss-and-navigate path already used whenever the pre-mount isn't eligible.

**Unaffected:** in-place expense creation, Search pre-mounts, cross-tab pre-mounts, and skip-confirmation flows.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97437
PROPOSAL:

### Tests

With the `submit2026` beta enabled, on an account with a self DM and **exactly one** paid workspace, on Android (or any narrow layout):

1. Open the self DM and create a manual expense.
2. On the expense whisper, tap **Submit it to my employer** — the confirmation page opens directly (no destination picker).
3. Press the device back button.
4. Verify you land back on the self DM, with no flash of the workspace chat on the way.
5. Repeat steps 1–2, then tap **Submit** instead of backing out, and verify you still land on the workspace chat.

Regression checks for flows that keep the pre-mount:

6. From the Inbox tab, create and submit an expense in a chat you are already viewing, and verify it behaves as before.
7. From the global create (FAB) on the Inbox tab, submit an expense and verify you still land on Search.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests while offline — the flow is navigation-only, so behavior is identical.

### QA Steps

1. On an account with the `submit2026` beta, a self DM and exactly one paid workspace, create a manual expense in the self DM on Android.
2. Tap **Submit it to my employer**, then press the device back button on the confirmation page.
3. Verify you return to the self DM instead of the workspace chat.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/9abe5d42-857d-4ac8-a036-74f5f665680b

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b3d03bc7-e5df-47d2-8e5a-d5ec9ec2d1b1



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/26286dcd-13c3-42a0-9b19-597261de600d



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/399b49b5-9026-454a-a76b-9a4c03b1dd91



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->





https://github.com/user-attachments/assets/94f04f5a-cebb-433a-ae39-0dcfd486c4b5



</details>
