### PR TITLE
[No QA] Keep the queued write when re-authentication gives up

### DIFF
--- a/src/libs/Middleware/Reauthentication.ts
+++ b/src/libs/Middleware/Reauthentication.ts
@@ -112,6 +112,12 @@ function handleExpiredSession<TKey extends OnyxKey>(
     return reauthenticate(request?.commandName)
         .then((wasSuccessful) => {
             if (!wasSuccessful) {
+                if (isFromSequentialQueue) {
+                    // A resolved 407 reads as success to SequentialQueue, which deletes the persisted write.
+                    // reauthenticate() returns false even when the session is still alive, so retry instead.
+                    throw new Error('Failed to reauthenticate');
+                }
+
                 // Reauth already handled the sign-in redirect, so do not briefly show the failed request UI before sign-in.
                 request.failureData = undefined;
                 request.finallyData = undefined;

--- a/src/libs/Middleware/Reauthentication.ts
+++ b/src/libs/Middleware/Reauthentication.ts
@@ -114,7 +114,8 @@ function handleExpiredSession<TKey extends OnyxKey>(
             if (!wasSuccessful) {
                 if (isFromSequentialQueue) {
                     // A resolved 407 reads as success to SequentialQueue, which deletes the persisted write.
-                    // reauthenticate() returns false even when the session is still alive, so retry instead.
+                    // Throw on every give-up: the latched short-lived-token abort and the delegate restore return
+                    // false with the session alive. One that did sign out costs nothing, its Onyx.clear empties the queue first.
                     throw new Error('Failed to reauthenticate');
                 }
 

--- a/tests/unit/ReauthenticationMiddlewareTest.ts
+++ b/tests/unit/ReauthenticationMiddlewareTest.ts
@@ -128,6 +128,25 @@ describe('Reauthentication middleware', () => {
             });
     });
 
+    test('rejects a queued write when reauthentication gives up so the queue keeps it', () => {
+        jest.mocked(reauthenticate).mockResolvedValueOnce(false);
+
+        const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+            command: 'TestCommand',
+            data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE},
+        };
+
+        return expect(
+            Reauthentication(
+                Promise.resolve({
+                    jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+                }),
+                request,
+                true,
+            ),
+        ).rejects.toThrow('Failed to reauthenticate');
+    });
+
     test('resolves Authenticate HTTP failures as auth responses instead of retryable errors', () => {
         const resolve = jest.fn();
         const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {

--- a/tests/unit/ReauthenticationMiddlewareTest.ts
+++ b/tests/unit/ReauthenticationMiddlewareTest.ts
@@ -147,6 +147,45 @@ describe('Reauthentication middleware', () => {
         ).rejects.toThrow('Failed to reauthenticate');
     });
 
+    test('keeps the failure updates of a queued write when reauthentication gives up and signs out', () => {
+        // Same mock as the abort case on purpose: the middleware cannot tell the two apart.
+        jest.mocked(reauthenticate).mockResolvedValueOnce(false);
+
+        const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {
+            command: 'TestCommand',
+            data: {apiRequestType: CONST.API_REQUEST_TYPE.WRITE},
+            failureData: [
+                {
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: ONYXKEYS.NETWORK,
+                    value: {shouldFailAllRequests: true},
+                },
+            ],
+            finallyData: [
+                {
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: ONYXKEYS.NETWORK,
+                    value: {shouldForceOffline: true},
+                },
+            ],
+        };
+
+        return expect(
+            Reauthentication(
+                Promise.resolve({
+                    jsonCode: CONST.JSON_CODE.NOT_AUTHENTICATED,
+                }),
+                request,
+                true,
+            ),
+        )
+            .rejects.toThrow('Failed to reauthenticate')
+            .then(() => {
+                expect(request.failureData).toBeDefined();
+                expect(request.finallyData).toBeDefined();
+            });
+    });
+
     test('resolves Authenticate HTTP failures as auth responses instead of retryable errors', () => {
         const resolve = jest.fn();
         const request: OnyxRequest<typeof ONYXKEYS.NETWORK> = {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The app queues unsent changes: approve a report, rename a report, set a report field. Each change appears on screen at once, then goes to the server.

An expired auth token makes the server reject a queued change with `jsonCode` 407 (AuthTokenExpired) inside an HTTP 200. The app tries to renew the token. When the renewal gives up, `handleExpiredSession` in `src/libs/Middleware/Reauthentication.ts` returned the 407 as a resolved promise. `SequentialQueue.process()` reads any resolved promise as success, so the queue deleted the saved request. Nothing retried. Nothing reverted on screen.

From the reported session: a user approved report 5506795830517958 at 15:34:18 UTC. The client logged `Request processed successfully`. The server logged `AuthTokenExpired` for the same request 97ms later.

This pull request throws in that branch when the request came from the queue. The `catch` twelve lines below already turns a throw into a queue retry, so this adds no branch and no error string. The queue keeps the request, retries up to `MAX_REQUEST_RETRIES` (10) times, then applies `failureData`.

The throw is limited to `isFromSequentialQueue`. A queued write is the only request where a resolved promise deletes a saved record. Other requests hand the value to a caller and still resolve.

Notes for reviewers:
- The `skipReauthentication` early return also resolves a 407 for a queued request. Only `LOG_OUT` and `SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN` set that flag, and neither one is a queued write. The first `API.write` that sets the flag reopens this bug.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97480
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Automated: `npx jest tests/unit/ReauthenticationMiddlewareTest.ts`

New test: `rejects a queued write when reauthentication gives up so the queue keeps it`. The test mocks `reauthenticate` to resolve `false`, feeds a 407 with `isFromSequentialQueue: true`, and asserts that the promise rejects. The test fails without the fix. The four earlier tests pass unchanged.

Regression over `SequentialQueueTest.ts`, `APITest.ts`, `NetworkTest.tsx`, and `ReauthenticationMiddlewareTest.ts`: 65 tests, all passing.

Manual QA:
1. Sign in on web.
2. Force a 407 on a write. Overwrite `session.authToken` in Onyx with a garbage value, or return `{jsonCode: 407}` for a write command.
3. Approve a report.
4. Expect a retry. After the last retry the change reverts on screen and an error appears. Before this fix the change stayed on screen and the server received nothing.
5. Sign out while a write is in flight. Expect no error UI before the sign-in page.

No platform-specific paths. Verified on web.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>