### PR TITLE
Prevent composer autofocus from draft comment on mobile web

### DIFF
--- a/src/libs/Browser/index.ts
+++ b/src/libs/Browser/index.ts
@@ -1,8 +1,10 @@
-import type {GetBrowser, IsMobile, IsMobileChrome, IsMobileIOS, IsMobileSafari, IsMobileSafariOnIos26, IsMobileWebKit, IsSafari} from './types';
+import type {GetBrowser, IsIPadInDesktopMode, IsMobile, IsMobileChrome, IsMobileIOS, IsMobileSafari, IsMobileSafariOnIos26, IsMobileWebKit, IsSafari} from './types';
 
 const getBrowser: GetBrowser = () => '';
 
 const isMobile: IsMobile = () => false;
+
+const isIPadInDesktopMode: IsIPadInDesktopMode = () => false;
 
 const isMobileIOS: IsMobileIOS = () => false;
 
@@ -16,4 +18,4 @@ const isSafari: IsSafari = () => false;
 
 const isMobileSafariOnIos26: IsMobileSafariOnIos26 = () => false;
 
-export {getBrowser, isMobile, isMobileIOS, isMobileSafari, isMobileWebKit, isSafari, isMobileSafariOnIos26, isMobileChrome};
+export {getBrowser, isMobile, isIPadInDesktopMode, isMobileIOS, isMobileSafari, isMobileWebKit, isSafari, isMobileSafariOnIos26, isMobileChrome};

--- a/src/libs/Browser/index.web.ts
+++ b/src/libs/Browser/index.web.ts
@@ -2,7 +2,7 @@ import getOSAndName from '@libs/actions/Device/getDeviceInfo/getOSAndName';
 
 import CONST from '@src/CONST';
 
-import type {GetBrowser, IsMobile, IsMobileChrome, IsMobileIOS, IsMobileSafari, IsMobileSafariOnIos26, IsMobileWebKit, IsSafari} from './types';
+import type {GetBrowser, IsIPadInDesktopMode, IsMobile, IsMobileChrome, IsMobileIOS, IsMobileSafari, IsMobileSafariOnIos26, IsMobileWebKit, IsSafari} from './types';
 
 /**
  * Fetch browser name from UA string
@@ -41,6 +41,12 @@ const getBrowser: GetBrowser = () => {
  */
 const isMobile: IsMobile = () => /Android|webOS|iPhone|iPad|iPod|BlackBerry|BB|PlayBook|IEMobile|Windows Phone|Silk|Opera Mini/i.test(navigator.userAgent);
 
+/**
+ * iPadOS Safari in "Request Desktop Website" mode (the default) reports a Macintosh user agent that
+ * isMobile() can't recognize; real Macs report zero touch points.
+ */
+const isIPadInDesktopMode: IsIPadInDesktopMode = () => /Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1;
+
 const isMobileIOS: IsMobileIOS = () => {
     const userAgent = navigator.userAgent;
     return /iP(ad|od|hone)/i.test(userAgent);
@@ -78,4 +84,4 @@ const isMobileSafariOnIos26: IsMobileSafariOnIos26 = (): boolean => {
     return isMobileSafari() && getOSAndName().osVersion === '26';
 };
 
-export {getBrowser, isMobile, isMobileIOS, isMobileSafari, isMobileWebKit, isSafari, isMobileChrome, isMobileSafariOnIos26};
+export {getBrowser, isMobile, isIPadInDesktopMode, isMobileIOS, isMobileSafari, isMobileWebKit, isSafari, isMobileChrome, isMobileSafariOnIos26};

--- a/src/libs/Browser/types.ts
+++ b/src/libs/Browser/types.ts
@@ -2,6 +2,8 @@ type GetBrowser = () => string;
 
 type IsMobile = () => boolean;
 
+type IsIPadInDesktopMode = () => boolean;
+
 type IsMobileIOS = () => boolean;
 
 type IsMobileSafari = () => boolean;
@@ -14,4 +16,4 @@ type IsSafari = () => boolean;
 
 type IsMobileSafariOnIos26 = () => boolean;
 
-export type {GetBrowser, IsMobile, IsMobileIOS, IsMobileSafari, IsMobileChrome, IsMobileWebKit, IsSafari, IsMobileSafariOnIos26};
+export type {GetBrowser, IsMobile, IsIPadInDesktopMode, IsMobileIOS, IsMobileSafari, IsMobileChrome, IsMobileWebKit, IsSafari, IsMobileSafariOnIos26};

--- a/src/libs/snapshotPickedFile/index.ts
+++ b/src/libs/snapshotPickedFile/index.ts
@@ -1,10 +1,4 @@
-import {isMobile} from '@libs/Browser';
-
-// iPadOS Safari in "Request Desktop Website" mode (the default) reports a Macintosh user agent that
-// isMobile() can't recognize; real Macs report zero touch points.
-function isIPadInDesktopMode(): boolean {
-    return /Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1;
-}
+import {isIPadInDesktopMode, isMobile} from '@libs/Browser';
 
 /**
  * Copies a picked file's bytes into a memory-backed File. A picked File only references its OS

--- a/src/pages/inbox/report/ReportActionCompose/ComposerProvider.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerProvider.tsx
@@ -2,6 +2,7 @@ import useOnyx from '@hooks/useOnyx';
 import useOriginalReportID from '@hooks/useOriginalReportID';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 
+import {isMobile} from '@libs/Browser';
 import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import Log from '@libs/Log';
 import {chatIncludesConcierge} from '@libs/ReportUtils';
@@ -51,7 +52,7 @@ function ComposerProvider({children, reportID}: ComposerProviderProps) {
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [isComposerFullSize = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${reportID}`);
 
-    const shouldFocusComposerOnScreenFocus = shouldFocusInputOnScreenFocus || !!draftComment;
+    const shouldFocusComposerOnScreenFocus = shouldFocusInputOnScreenFocus || (!!draftComment && !isMobile());
     const initialFocused = shouldFocusComposerOnScreenFocus && !initialModalState?.isVisible && !initialModalState?.willAlertModalBecomeVisible;
 
     const includesConcierge = chatIncludesConcierge({participants: report?.participants});

--- a/src/pages/inbox/report/ReportActionCompose/ComposerProvider.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerProvider.tsx
@@ -2,7 +2,7 @@ import useOnyx from '@hooks/useOnyx';
 import useOriginalReportID from '@hooks/useOriginalReportID';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 
-import {isMobile} from '@libs/Browser';
+import {isIPadInDesktopMode, isMobile} from '@libs/Browser';
 import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import Log from '@libs/Log';
 import {chatIncludesConcierge} from '@libs/ReportUtils';
@@ -37,6 +37,7 @@ import useDebouncedCommentMaxLengthValidation from './useDebouncedCommentMaxLeng
 import useEditMessage from './useEditMessage';
 
 const shouldFocusInputOnScreenFocus = canFocusInputOnScreenFocus();
+const isMobileBrowser = isMobile() || isIPadInDesktopMode();
 
 type ComposerProviderProps = {
     reportID: string;
@@ -52,7 +53,7 @@ function ComposerProvider({children, reportID}: ComposerProviderProps) {
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [isComposerFullSize = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_IS_COMPOSER_FULL_SIZE}${reportID}`);
 
-    const shouldFocusComposerOnScreenFocus = shouldFocusInputOnScreenFocus || (!!draftComment && !isMobile());
+    const shouldFocusComposerOnScreenFocus = shouldFocusInputOnScreenFocus || (!!draftComment && !isMobileBrowser);
     const initialFocused = shouldFocusComposerOnScreenFocus && !initialModalState?.isVisible && !initialModalState?.willAlertModalBecomeVisible;
 
     const includesConcierge = chatIncludesConcierge({participants: report?.participants});

--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
@@ -17,7 +17,7 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {isMobileSafari} from '@libs/Browser';
+import {isMobile, isMobileSafari} from '@libs/Browser';
 import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import {forceClearInput} from '@libs/ComponentUtils';
 import {canSkipTriggerHotkeys, findCommonSuffixLength, insertText, insertWhiteSpaceAtIndex} from '@libs/ComposerUtils';
@@ -387,7 +387,7 @@ function ComposerWithSuggestions({
     }, [text]);
 
     const maxComposerLines = shouldUseNarrowLayout ? CONST.COMPOSER.MAX_LINES_SMALL_SCREEN : CONST.COMPOSER.MAX_LINES;
-    const shouldAutoFocus = (shouldFocusInputOnScreenFocus || !!text) && areAllModalsHidden() && isFocused;
+    const shouldAutoFocus = (shouldFocusInputOnScreenFocus || (!!text && !isMobile())) && areAllModalsHidden() && isFocused;
     const delayedAutoFocusRouteKeyRef = useRef<string | null>(null);
 
     const valueRef = useRef(initialText);

--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
@@ -17,7 +17,7 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {isMobile, isMobileSafari} from '@libs/Browser';
+import {isIPadInDesktopMode, isMobile, isMobileSafari} from '@libs/Browser';
 import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import {forceClearInput} from '@libs/ComponentUtils';
 import {canSkipTriggerHotkeys, findCommonSuffixLength, insertText, insertWhiteSpaceAtIndex} from '@libs/ComposerUtils';
@@ -207,6 +207,8 @@ const willBlurTextInputOnTapOutside = willBlurTextInputOnTapOutsideFunc();
 // prevent auto focus for mobile device
 const shouldFocusInputOnScreenFocus = canFocusInputOnScreenFocus();
 
+const isMobileBrowser = isMobile() || isIPadInDesktopMode();
+
 /**
  * This component holds the value and selection state.
  * If a component really needs access to these state values it should be put here.
@@ -387,7 +389,7 @@ function ComposerWithSuggestions({
     }, [text]);
 
     const maxComposerLines = shouldUseNarrowLayout ? CONST.COMPOSER.MAX_LINES_SMALL_SCREEN : CONST.COMPOSER.MAX_LINES;
-    const shouldAutoFocus = (shouldFocusInputOnScreenFocus || (!!text && !isMobile())) && areAllModalsHidden() && isFocused;
+    const shouldAutoFocus = (shouldFocusInputOnScreenFocus || (!!text && !isMobileBrowser)) && areAllModalsHidden() && isFocused;
     const delayedAutoFocusRouteKeyRef = useRef<string | null>(null);
 
     const valueRef = useRef(initialText);

--- a/tests/unit/ValidateAttachmentFileSnapshotTest.ts
+++ b/tests/unit/ValidateAttachmentFileSnapshotTest.ts
@@ -11,8 +11,9 @@ import * as FileUtils from '../../src/libs/fileDownload/FileUtils';
 jest.mock('@src/libs/snapshotPickedFile', () => jest.requireActual<{default: (file: File, name: string) => Promise<File>}>('@src/libs/snapshotPickedFile/index.ts'));
 
 // The web snapshot only copies bytes on desktop browsers; make the browser type controllable per test.
+// Force the web implementation here too, so the user-agent based checks under test are the real ones.
 jest.mock('@src/libs/Browser', () => ({
-    ...jest.requireActual<Record<string, unknown>>('@src/libs/Browser'),
+    ...jest.requireActual<Record<string, unknown>>('@src/libs/Browser/index.web.ts'),
     isMobile: jest.fn(() => false),
 }));
 


### PR DESCRIPTION
### Explanation of Change

On mobile web, opening a chat that already has a draft comment auto-focused the composer, which opened the keyboard and pushed the composer over the bottom navigation bar. This PR stops the draft comment from triggering autofocus on mobile browsers (`isMobile()`), so the composer only auto-focuses when the platform actually supports it. Desktop/web behavior is unchanged.

### Fixed Issues

$ https://github.com/Expensify/App/issues/90789
PROPOSAL: https://github.com/Expensify/App/issues/90789#issuecomment-5005800804

### Tests

1. Open the app on mWeb (Chrome/Safari) or a narrow browser window in mobile emulation.
2. Open any chat and type some text in the composer, but do not send it (leave a draft).
3. Navigate back to the LHN, then open the same chat again.
4. Verify the keyboard does NOT open automatically and the composer does NOT overlap the bottom navigation bar.
5. Tap the composer and verify it focuses normally and the draft text is still there.
6. Repeat on desktop web: open a chat with a draft and verify the composer is still auto-focused as before.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests — the change is UI-only and behaves identically offline.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e.`StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>