### PR TITLE
Fix company cards import crash by transposing spreadsheet data densely

### DIFF
--- a/src/libs/actions/ImportSpreadsheet.ts
+++ b/src/libs/actions/ImportSpreadsheet.ts
@@ -37,7 +37,7 @@ function setSpreadsheetData(
     const numColumns = firstRow.length;
 
     // Transpose data from row-major to column-major format
-    const transposedData: string[][] = firstRow.map((_, colIndex) => data.map((row) => String(row.at(colIndex) ?? '')));
+    const transposedData: string[][] = Array.from({length: numColumns}, (_, colIndex) => data.map((row) => String(row.at(colIndex) ?? '')));
 
     const columnNames: Record<number, string> = {};
     for (let colIndex = 0; colIndex < numColumns; colIndex++) {

--- a/tests/unit/ImportSpreadsheetTest.ts
+++ b/tests/unit/ImportSpreadsheetTest.ts
@@ -1,0 +1,130 @@
+import {setSpreadsheetData} from '@libs/actions/ImportSpreadsheet';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type ImportedSpreadsheet from '@src/types/onyx/ImportedSpreadsheet';
+
+import Onyx from 'react-native-onyx';
+
+/**
+ * Builds a sparse row, mirroring what `XLSX.utils.sheet_to_json(worksheet, {header: 1})` returns for a sheet with a
+ * blank column: the missing cell is left as an array *hole*, not as `undefined`.
+ */
+function buildSparseRow(cells: string[], holeIndexes: number[]): string[] {
+    const row = new Array<string>(cells.length);
+    for (const [index, cell] of cells.entries()) {
+        if (holeIndexes.includes(index)) {
+            continue;
+        }
+        row[index] = cell;
+    }
+    return row;
+}
+
+function isImportedSpreadsheet(value: unknown): value is ImportedSpreadsheet {
+    return typeof value === 'object' && !!value && 'data' in value;
+}
+
+/** Replays the column-major to row-major transpose the company cards import runs when Import is pressed. */
+function transposeBackToRows(columns: string[][]): string[][] {
+    const rows: string[][] = [];
+    for (let rowIndex = 0; rowIndex < (columns.at(0)?.length ?? 0); rowIndex++) {
+        const row: string[] = [];
+        for (const column of columns) {
+            row.push(column.at(rowIndex) ?? '');
+        }
+        rows.push(row);
+    }
+    return rows;
+}
+
+describe('ImportSpreadsheet', () => {
+    describe('setSpreadsheetData', () => {
+        let storedSpreadsheet: ImportedSpreadsheet | undefined;
+
+        beforeEach(() => {
+            storedSpreadsheet = undefined;
+            jest.spyOn(Onyx, 'set').mockImplementation((key, value) => {
+                if (key === ONYXKEYS.IMPORTED_SPREADSHEET && isImportedSpreadsheet(value)) {
+                    storedSpreadsheet = value;
+                }
+                return Promise.resolve();
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        async function importData(data: string[][]) {
+            await setSpreadsheetData(data, 'file://spreadsheet.csv', 'text/csv', 'spreadsheet.csv', false);
+            expect(storedSpreadsheet).toBeDefined();
+            return storedSpreadsheet;
+        }
+
+        it('transposes dense data to column-major format', async () => {
+            const spreadsheet = await importData([
+                ['Date', 'Merchant', 'Amount'],
+                ['2026-07-21', 'Starbucks', '10'],
+                ['2026-07-22', 'Amazon', '20'],
+            ]);
+
+            expect(spreadsheet?.data).toEqual([
+                ['Date', '2026-07-21', '2026-07-22'],
+                ['Merchant', 'Starbucks', 'Amazon'],
+                ['Amount', '10', '20'],
+            ]);
+            expect(Object.values(spreadsheet?.columns ?? {})).toEqual([CONST.CSV_IMPORT_COLUMNS.IGNORE, CONST.CSV_IMPORT_COLUMNS.IGNORE, CONST.CSV_IMPORT_COLUMNS.IGNORE]);
+        });
+
+        it('produces a dense column for a blank column in the header row', async () => {
+            const spreadsheet = await importData([buildSparseRow(['Date', '', 'Amount'], [1]), buildSparseRow(['2026-07-21', '', '10'], [1])]);
+
+            expect(spreadsheet?.data).toEqual([
+                ['Date', '2026-07-21'],
+                ['', ''],
+                ['Amount', '10'],
+            ]);
+            // Object.keys skips array holes, so this only matches the length when every index holds a real column
+            expect(Object.keys(spreadsheet?.data ?? []).length).toBe(spreadsheet?.data?.length);
+        });
+
+        it('keeps the column count in sync with the generated column roles', async () => {
+            const spreadsheet = await importData([buildSparseRow(['Date', '', '', 'Amount'], [1, 2]), buildSparseRow(['2026-07-21', '', '', '10'], [1, 2])]);
+
+            expect(spreadsheet?.data?.length).toBe(4);
+            expect(Object.keys(spreadsheet?.data ?? []).length).toBe(4);
+            expect(Object.keys(spreadsheet?.columns ?? {}).length).toBe(4);
+        });
+
+        it('lets the company cards import transpose the data back without throwing', async () => {
+            const spreadsheet = await importData([buildSparseRow(['Date', '', 'Amount'], [1]), buildSparseRow(['2026-07-21', '', '10'], [1]), buildSparseRow(['2026-07-22', '', '20'], [1])]);
+
+            expect(transposeBackToRows(spreadsheet?.data ?? [])).toEqual([
+                ['Date', '', 'Amount'],
+                ['2026-07-21', '', '10'],
+                ['2026-07-22', '', '20'],
+            ]);
+        });
+
+        it('pads ragged rows so every column has one cell per row', async () => {
+            const spreadsheet = await importData([
+                ['Date', 'Merchant', 'Amount'],
+                ['2026-07-21', 'Starbucks'],
+            ]);
+
+            expect(spreadsheet?.data).toEqual([
+                ['Date', '2026-07-21'],
+                ['Merchant', 'Starbucks'],
+                ['Amount', ''],
+            ]);
+        });
+
+        it('rejects data that does not have at least a header and one row', async () => {
+            await expect(setSpreadsheetData([['Date', 'Amount']], 'file://spreadsheet.csv', 'text/csv', 'spreadsheet.csv', false)).rejects.toThrow(
+                'Invalid data format: file must contain at least 2 rows',
+            );
+            expect(storedSpreadsheet).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
### Explanation of Change

`setSpreadsheetData` transposed the uploaded spreadsheet with `firstRow.map(...)`. `XLSX.utils.sheet_to_json(worksheet, {header: 1})` returns rows as **sparse arrays** — a blank column is left as an array *hole*, not `undefined` — and `Array.prototype.map` skips holes and re-emits them. So a blank column in the header row produced a hole in `IMPORTED_SPREADSHEET.data`.

The company cards import iterates every column with `for...of`, which **yields `undefined` for a hole** (unlike `map`), then calls `column.at(rowIndex)`. The existing `?? ''` guards the *result* of `.at()`, not the receiver, so it threw `TypeError: Cannot read properties of undefined (reading 'at')`. Since `importTransactions` is `async` and passed straight to `onPress`, it surfaced as the reported unhandled rejection.

Fixed at the single producer by building the transpose densely with `Array.from({length: numColumns}, ...)`, so `IMPORTED_SPREADSHEET.data` always honors its declared rectangular `string[][]` type. `numColumns` is `firstRow.length`, which already counts holes, so for any dense (normal) file the output is identical — only the previously-missing column changes, becoming a real column of empty strings.

This also fixes a second symptom: the mapping UI renders columns with `spreadsheetColumns.map(...)`, which skipped the hole, so users saw `N-1` columns while `columnNames` was generated from `data.length` (`N`) — the UI and the column role map were out of sync. Every import flow (company cards, tags, categories, per diem, members) reads this same `data`, so fixing the producer removes the latent hole risk from all of them without touching any consumer.

Added `tests/unit/ImportSpreadsheetTest.ts` as a regression test — 3 of its 6 cases fail without this change.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97101
PROPOSAL: https://github.com/Expensify/App/issues/97101#issuecomment-5092371975

### Tests

1. Create a CSV file named `blank-column.csv` with a **blank second column** (note the two commas):
   ```
   Card number,,Date,Merchant,Amount,Currency
   4111111111111111,,2026-07-21,Starbucks,10.00,USD
   4111111111111111,,2026-07-22,Amazon,24.50,USD
   ```
2. Open a Control workspace → **Company cards** → **Add cards**
3. Select a country → **Next** → choose **Import transactions from file** → **Next**
4. Enter any card feed layout name → **Next** → **Choose file** → upload `blank-column.csv`
5. On the mapping screen, verify **6 columns** are listed — the blank one appears with no header and the `Ignore` role (before this fix only 5 were shown and the blank one was silently dropped)
6. Verify the other columns are auto-mapped to Card number / Date / Merchant / Amount / Currency
7. Press **Import**
8. Verify the **"Import successful"** modal appears and no error is logged in the JS console (before this fix, pressing Import threw `TypeError: Cannot read properties of undefined (reading 'at')` and nothing was imported)
9. Regression: repeat steps 2–7 with a normal CSV that has **no** blank column and verify the mapping screen and import behave exactly as before
10. Regression: go to **Tags** (or **Categories**) → **Import spreadsheet**, upload a normal CSV and verify mapping and import still work

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline
2. Follow steps 1–6 of the **Tests** section — the file is parsed locally, so verify the mapping screen still renders all columns including the blank one
3. Verify the **Import** button is disabled while offline
4. Go back online and verify the **Import** button becomes enabled and completes successfully

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

After fix:

https://github.com/user-attachments/assets/8cc45a9a-e24d-41f7-962c-3e6fb6baad1a





</details>