### PR TITLE
Extract syncVersions workflow shell into a script

### DIFF
--- a/.github/scripts/syncVersions.sh
+++ b/.github/scripts/syncVersions.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# Syncs E/App and Mobile-Expensify versions and the Mobile-Expensify submodule pointer on App main.
+#
+# Only ever invoked by .github/workflows/syncVersions.yml, which is a manual workflow_dispatch
+# restricted to mobile deployers and run as OSBotify. It is not meant to be run locally.
+#
+# Usage: ./.github/scripts/syncVersions.sh <check|sync|version-components>
+#
+#   check              Records the current submodule gitlink, updates Mobile-Expensify to its latest
+#                      main, and decides what kind of sync (if any) is needed.
+#   sync               Performs the sync decided by `check` and verifies the result.
+#   version-components Prints the native version components derived from a version string. Pure
+#                      helper, exposed so it can be unit tested.
+#
+# Inputs:
+#   - Run from the App repo root, after checkout with submodules initialized and git configured
+#     with push access to App main.
+#   - GITHUB_OUTPUT: written by `check` and `sync` (defaults to /dev/null outside GitHub Actions).
+#   - TARGET_VERSION (sync, optional): version to sync to. Must equal the Mobile-Expensify version,
+#     since only the App side is rewritten and the final verification compares the two. Empty means
+#     "use the Mobile-Expensify version".
+#   - NEED_FULL_VERSION_SYNC (sync): 'true' to rewrite versions, anything else to only bump the
+#     submodule pointer. Threaded from `check` so exactly one decision exists across both steps.
+#   - EXPECTED_SUBMODULE_SHA (sync): Mobile-Expensify SHA `check` updated to. The submodule-only
+#     path asserts against it so a checkout that moved in between is caught.
+#
+# Outputs (via GITHUB_OUTPUT):
+#   - check: IN_SYNC, NEED_FULL_VERSION_SYNC, ACTUAL_SHA
+#   - sync:  POST_SYNC_APP_VERSION
+#
+# Side effects:
+#   - `check` is not read-only: it runs `git submodule update --remote`.
+#   - `sync` commits and pushes to App main.
+#   - `sync` never re-runs `git submodule update --remote`, because Mobile-Expensify main can
+#     advance while Node is being set up between the two steps.
+#   - Never stage with `git add -A`: setupNode leaves an untracked normalized-package-lock.json
+#     in the working tree.
+#
+# Requirements: macOS (BSD sed, PlistBuddy), bash 3.2, git, jq, and npm for the full sync path.
+# The version math mirrors generateAndroidVersionCode in scripts/bumpVersion.ts.
+
+set -euo pipefail
+
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+TARGET_VERSION="${TARGET_VERSION:-}"
+NEED_FULL_VERSION_SYNC="${NEED_FULL_VERSION_SYNC:-}"
+EXPECTED_SUBMODULE_SHA="${EXPECTED_SUBMODULE_SHA:-}"
+
+# Writes a step output. Centralized so consecutive outputs don't need individual redirects.
+function set_output {
+    echo "$1=$2" >> "$GITHUB_OUTPUT"
+}
+
+function get_app_version {
+    jq -r .version package.json
+}
+
+function get_mobile_expensify_version {
+    jq -r .meta.version Mobile-Expensify/app/config/config.json
+}
+
+# Derives the native version components from an npm version such as 9.3.11-48, and sets:
+#   SHORT_VERSION       9.3.11
+#   BUILD_NUMBER        48
+#   CF_VERSION          9.3.11.48
+#   ANDROID_VERSION_CODE 1009031148 (prefix 10 for E/App, then two digits each for major/minor/patch/build)
+function compute_version_components {
+    local version="$1"
+
+    SHORT_VERSION="${version%-*}"
+    BUILD_NUMBER="${version#*-}"
+    CF_VERSION="${SHORT_VERSION}.${BUILD_NUMBER}"
+
+    local major
+    local minor
+    local patch
+    IFS='.' read -r major minor patch <<< "$SHORT_VERSION"
+
+    ANDROID_VERSION_CODE="10$(printf '%02d' "$major")$(printf '%02d' "$minor")$(printf '%02d' "$patch")$(printf '%02d' "$BUILD_NUMBER")"
+}
+
+function update_android_version {
+    local target="$1"
+
+    echo "Updating Android build.gradle with versionName=$target, versionCode=$ANDROID_VERSION_CODE"
+    sed -i '' "s/versionName \"[0-9.-]*\"/versionName \"$target\"/" android/app/build.gradle
+    sed -i '' "s/versionCode [0-9]*/versionCode $ANDROID_VERSION_CODE/" android/app/build.gradle
+}
+
+function update_ios_versions {
+    echo "Updating iOS plists with CFBundleShortVersionString=$SHORT_VERSION, CFBundleVersion=$CF_VERSION"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios/NewExpensify/Info.plist
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_VERSION" ios/NewExpensify/Info.plist
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios/NotificationServiceExtension/Info.plist
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_VERSION" ios/NotificationServiceExtension/Info.plist
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios/ShareViewController/Info.plist
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_VERSION" ios/ShareViewController/Info.plist
+}
+
+function resolve_target_version {
+    if [[ -n "$TARGET_VERSION" ]]; then
+        echo "Using provided target version: $TARGET_VERSION" >&2
+        echo "$TARGET_VERSION"
+        return
+    fi
+
+    # Use Mobile-Expensify version as source of truth since it was pushed first
+    local me_version
+    me_version="$(get_mobile_expensify_version)"
+    echo "Using Mobile-Expensify version as target: $me_version" >&2
+    echo "$me_version"
+}
+
+function cmd_check {
+    local recorded_sha
+    recorded_sha=$(git rev-parse HEAD:Mobile-Expensify)
+    echo "Submodule commit recorded on App: $recorded_sha"
+
+    git submodule update --remote
+
+    local actual_sha
+    actual_sha=$(git -C Mobile-Expensify rev-parse HEAD)
+    echo "Mobile-Expensify after remote update: $actual_sha"
+    set_output ACTUAL_SHA "$actual_sha"
+
+    local app_version
+    local me_version
+    app_version="$(get_app_version)"
+    me_version="$(get_mobile_expensify_version)"
+
+    echo "E/App version: $app_version"
+    echo "Mobile-Expensify version: $me_version"
+
+    if [[ "$recorded_sha" != "$actual_sha" ]]; then
+        echo "::warning::⚠️ Submodule pointer is behind Mobile-Expensify main (recorded $recorded_sha, latest $actual_sha)"
+    fi
+
+    if [[ "$app_version" == "$me_version" && "$recorded_sha" == "$actual_sha" ]]; then
+        echo "::notice::✅ Versions and submodule are in sync ($app_version @ $actual_sha)"
+        set_output IN_SYNC true
+        set_output NEED_FULL_VERSION_SYNC false
+        return
+    fi
+
+    set_output IN_SYNC false
+    if [[ "$app_version" != "$me_version" ]]; then
+        echo "::warning::⚠️ Versions are out of sync - E/App: $app_version, Mobile-Expensify: $me_version"
+        set_output NEED_FULL_VERSION_SYNC true
+    else
+        echo "::notice::Versions match ($app_version) but App must record the latest submodule commit"
+        set_output NEED_FULL_VERSION_SYNC false
+    fi
+}
+
+function sync_full_version {
+    local target
+    target="$(resolve_target_version)"
+    echo "::notice::Syncing E/App to version $target"
+
+    # Update version using npm (this updates package.json and package-lock.json)
+    npm --no-git-tag-version version "$target"
+
+    compute_version_components "$target"
+    update_android_version "$target"
+    update_ios_versions
+
+    # Commit version changes
+    git add package.json package-lock.json android/app/build.gradle ios/*/Info.plist
+    git commit -m "Update version to $target (sync recovery)"
+
+    # Update submodule reference
+    git add Mobile-Expensify
+    git commit -m "Update Mobile-Expensify submodule version to $target (sync recovery)"
+
+    # Push changes
+    if ! git push origin main; then
+        echo "::warning::Push failed, attempting rebase..."
+        git fetch origin main
+        git rebase origin/main
+        git push origin main
+    fi
+
+    echo "::notice::✅ Successfully synced E/App to version $target"
+}
+
+function sync_submodule_only {
+    local current_sha
+    current_sha=$(git -C Mobile-Expensify rev-parse HEAD)
+    if [[ "$current_sha" != "$EXPECTED_SUBMODULE_SHA" ]]; then
+        echo "::error::Mobile-Expensify checkout ($current_sha) does not match expected main ($EXPECTED_SUBMODULE_SHA)"
+        exit 1
+    fi
+
+    echo "::notice::Recording Mobile-Expensify submodule at $current_sha (versions already matched $(get_app_version))"
+    git add Mobile-Expensify
+    git commit -m "Bump Mobile-Expensify submodule to latest main ($current_sha)"
+
+    if ! git push origin main; then
+        echo "::warning::Push failed, attempting rebase..."
+        git fetch origin main
+        git rebase origin/main
+        git submodule update --remote
+        git add Mobile-Expensify
+        if ! git diff --staged --quiet; then
+            git commit -m "Bump Mobile-Expensify submodule to latest main after rebase ($(git -C Mobile-Expensify rev-parse HEAD))"
+        fi
+        git push origin main
+    fi
+
+    echo "::notice::✅ Submodule pointer updated on App main"
+}
+
+function verify_sync {
+    local app_version
+    local me_version
+    app_version="$(get_app_version)"
+    me_version="$(get_mobile_expensify_version)"
+
+    if [[ "$app_version" != "$me_version" ]]; then
+        echo "::error::Sync failed! Versions still don't match"
+        echo "::error::E/App: $app_version, Mobile-Expensify: $me_version"
+        exit 1
+    fi
+
+    git -C Mobile-Expensify fetch origin
+
+    local recorded
+    local remote_sha
+    recorded=$(git rev-parse HEAD:Mobile-Expensify)
+    remote_sha=$(git -C Mobile-Expensify rev-parse origin/main)
+    if [[ "$recorded" != "$remote_sha" ]]; then
+        echo "::error::Submodule on App main ($recorded) still differs from Mobile-Expensify origin/main ($remote_sha)"
+        exit 1
+    fi
+
+    set_output POST_SYNC_APP_VERSION "$app_version"
+    echo "::notice::✅ Verified versions ($app_version) and submodule match Mobile-Expensify main ($recorded)"
+}
+
+function cmd_sync {
+    if [[ "$NEED_FULL_VERSION_SYNC" == 'true' ]]; then
+        sync_full_version
+    else
+        sync_submodule_only
+    fi
+
+    verify_sync
+}
+
+function cmd_version_components {
+    if [[ -z "${1:-}" ]]; then
+        echo "::error::version-components requires a version argument"
+        exit 1
+    fi
+
+    compute_version_components "$1"
+    echo "SHORT_VERSION=$SHORT_VERSION"
+    echo "BUILD_NUMBER=$BUILD_NUMBER"
+    echo "CF_VERSION=$CF_VERSION"
+    echo "ANDROID_VERSION_CODE=$ANDROID_VERSION_CODE"
+}
+
+function usage {
+    echo "::error::Usage: $0 <check|sync|version-components>"
+    exit 1
+}
+
+case "${1:-}" in
+    check) cmd_check ;;
+    sync) cmd_sync ;;
+    version-components) cmd_version_components "${2:-}" ;;
+    *) usage ;;
+esac

--- a/.github/workflows/syncVersions.yml
+++ b/.github/workflows/syncVersions.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       TARGET_VERSION:
-        description: 'Version to sync to (leave empty to auto-detect from Mobile-Expensify)'
+        description: 'Version to sync to (must match the Mobile-Expensify version, leave empty to auto-detect from Mobile-Expensify)'
         required: false
         type: string
 
@@ -36,171 +36,25 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SETUP_AS_APP: false
 
-      - name: Record submodule gitlink and update Mobile-Expensify to latest main
-        id: submoduleRemote
-        run: |
-          RECORDED_SHA=$(git rev-parse HEAD:Mobile-Expensify)
-          echo "Submodule commit recorded on App: $RECORDED_SHA"
-          echo "RECORDED_SHA=$RECORDED_SHA" >> "$GITHUB_OUTPUT"
-
-          git submodule update --remote
-
-          ACTUAL_SHA=$(git -C Mobile-Expensify rev-parse HEAD)
-          echo "Mobile-Expensify after remote update: $ACTUAL_SHA"
-          echo "ACTUAL_SHA=$ACTUAL_SHA" >> "$GITHUB_OUTPUT"
-
       - name: Check sync state (versions + submodule pointer)
-        id: checkVersions
-        run: |
-          APP_VERSION=$(jq -r .version package.json)
-          ME_VERSION=$(jq -r .meta.version Mobile-Expensify/app/config/config.json)
-          RECORDED_SHA="${{ steps.submoduleRemote.outputs.RECORDED_SHA }}"
-          ACTUAL_SHA="${{ steps.submoduleRemote.outputs.ACTUAL_SHA }}"
-
-          echo "E/App version: $APP_VERSION"
-          echo "Mobile-Expensify version: $ME_VERSION"
-          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "ME_VERSION=$ME_VERSION" >> "$GITHUB_OUTPUT"
-
-          if [[ "$RECORDED_SHA" != "$ACTUAL_SHA" ]]; then
-            echo "::warning::⚠️ Submodule pointer is behind Mobile-Expensify main (recorded $RECORDED_SHA, latest $ACTUAL_SHA)"
-          fi
-
-          if [[ "$APP_VERSION" == "$ME_VERSION" && "$RECORDED_SHA" == "$ACTUAL_SHA" ]]; then
-            echo "::notice::✅ Versions and submodule are in sync ($APP_VERSION @ $ACTUAL_SHA)"
-            echo "IN_SYNC=true" >> "$GITHUB_OUTPUT"
-            echo "NEED_FULL_VERSION_SYNC=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "IN_SYNC=false" >> "$GITHUB_OUTPUT"
-            if [[ "$APP_VERSION" != "$ME_VERSION" ]]; then
-              echo "::warning::⚠️ Versions are out of sync - E/App: $APP_VERSION, Mobile-Expensify: $ME_VERSION"
-              echo "NEED_FULL_VERSION_SYNC=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "::notice::Versions match ($APP_VERSION) but App must record the latest submodule commit"
-              echo "NEED_FULL_VERSION_SYNC=false" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
-      - name: Determine target version
-        if: steps.checkVersions.outputs.IN_SYNC != 'true' && steps.checkVersions.outputs.NEED_FULL_VERSION_SYNC == 'true'
-        id: targetVersion
-        run: |
-          if [[ -n "${{ inputs.TARGET_VERSION }}" ]]; then
-            echo "Using provided target version: ${{ inputs.TARGET_VERSION }}"
-            echo "VERSION=${{ inputs.TARGET_VERSION }}" >> "$GITHUB_OUTPUT"
-          else
-            # Use Mobile-Expensify version as source of truth since it was pushed first
-            echo "Using Mobile-Expensify version as target: ${{ steps.checkVersions.outputs.ME_VERSION }}"
-            echo "VERSION=${{ steps.checkVersions.outputs.ME_VERSION }}" >> "$GITHUB_OUTPUT"
-          fi
+        id: checkSync
+        run: ./.github/scripts/syncVersions.sh check
 
       - name: Setup Node
-        if: steps.checkVersions.outputs.IN_SYNC != 'true' && steps.checkVersions.outputs.NEED_FULL_VERSION_SYNC == 'true'
+        if: steps.checkSync.outputs.NEED_FULL_VERSION_SYNC == 'true'
         uses: ./.github/actions/composite/setupNode
 
-      - name: Sync E/App to target version
-        if: steps.checkVersions.outputs.IN_SYNC != 'true' && steps.checkVersions.outputs.NEED_FULL_VERSION_SYNC == 'true'
-        run: |
-          TARGET="${{ steps.targetVersion.outputs.VERSION }}"
-          echo "::notice::Syncing E/App to version $TARGET"
-
-          # Update version using npm (this updates package.json and package-lock.json)
-          npm --no-git-tag-version version "$TARGET"
-
-          # Extract version components for native file updates
-          SHORT_VERSION="${TARGET%-*}"  # e.g., "9.3.11" from "9.3.11-48"
-          BUILD_NUMBER="${TARGET#*-}"   # e.g., "48" from "9.3.11-48"
-          CF_VERSION="${SHORT_VERSION}.${BUILD_NUMBER}"  # e.g., "9.3.11.48"
-
-          # Pad build number components for Android version code (prefix 10 for E/App)
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$SHORT_VERSION"
-          ANDROID_VERSION_CODE="10$(printf '%02d' "$MAJOR")$(printf '%02d' "$MINOR")$(printf '%02d' "$PATCH")$(printf '%02d' "$BUILD_NUMBER")"
-
-          echo "Updating Android build.gradle with versionName=$TARGET, versionCode=$ANDROID_VERSION_CODE"
-          sed -i '' "s/versionName \"[0-9.-]*\"/versionName \"$TARGET\"/" android/app/build.gradle
-          sed -i '' "s/versionCode [0-9]*/versionCode $ANDROID_VERSION_CODE/" android/app/build.gradle
-
-          echo "Updating iOS plists with CFBundleShortVersionString=$SHORT_VERSION, CFBundleVersion=$CF_VERSION"
-          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios/NewExpensify/Info.plist
-          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_VERSION" ios/NewExpensify/Info.plist
-          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios/NotificationServiceExtension/Info.plist
-          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_VERSION" ios/NotificationServiceExtension/Info.plist
-          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios/ShareViewController/Info.plist
-          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_VERSION" ios/ShareViewController/Info.plist
-
-          # Commit version changes
-          git add package.json package-lock.json android/app/build.gradle ios/*/Info.plist
-          git commit -m "Update version to $TARGET (sync recovery)"
-
-          # Update submodule reference
-          git add Mobile-Expensify
-          git commit -m "Update Mobile-Expensify submodule version to $TARGET (sync recovery)"
-
-          # Push changes
-          if ! git push origin main; then
-            echo "::warning::Push failed, attempting rebase..."
-            git fetch origin main
-            git rebase origin/main
-            git push origin main
-          fi
-
-          echo "::notice::✅ Successfully synced E/App to version $TARGET"
-
-      - name: Bump Mobile-Expensify submodule only
-        if: steps.checkVersions.outputs.IN_SYNC != 'true' && steps.checkVersions.outputs.NEED_FULL_VERSION_SYNC != 'true'
-        run: |
-          EXPECTED_SHA="${{ steps.submoduleRemote.outputs.ACTUAL_SHA }}"
-          CURRENT_SHA=$(git -C Mobile-Expensify rev-parse HEAD)
-          if [[ "$CURRENT_SHA" != "$EXPECTED_SHA" ]]; then
-            echo "::error::Mobile-Expensify checkout ($CURRENT_SHA) does not match expected main ($EXPECTED_SHA)"
-            exit 1
-          fi
-
-          echo "::notice::Recording Mobile-Expensify submodule at $CURRENT_SHA (versions already matched ${{ steps.checkVersions.outputs.APP_VERSION }})"
-          git add Mobile-Expensify
-          git commit -m "Bump Mobile-Expensify submodule to latest main ($CURRENT_SHA)"
-
-          if ! git push origin main; then
-            echo "::warning::Push failed, attempting rebase..."
-            git fetch origin main
-            git rebase origin/main
-            git submodule update --remote
-            git add Mobile-Expensify
-            if ! git diff --staged --quiet; then
-              git commit -m "Bump Mobile-Expensify submodule to latest main after rebase ($(git -C Mobile-Expensify rev-parse HEAD))"
-            fi
-            git push origin main
-          fi
-
-          echo "::notice::✅ Submodule pointer updated on App main"
-
-      - name: Verify sync completed
-        id: verifySync
-        if: steps.checkVersions.outputs.IN_SYNC != 'true'
-        run: |
-          APP_VERSION=$(jq -r .version package.json)
-          ME_VERSION=$(jq -r .meta.version Mobile-Expensify/app/config/config.json)
-
-          if [[ "$APP_VERSION" != "$ME_VERSION" ]]; then
-            echo "::error::Sync failed! Versions still don't match"
-            echo "::error::E/App: $APP_VERSION, Mobile-Expensify: $ME_VERSION"
-            exit 1
-          fi
-
-          git -C Mobile-Expensify fetch origin
-
-          RECORDED=$(git rev-parse HEAD:Mobile-Expensify)
-          REMOTE_SHA=$(git -C Mobile-Expensify rev-parse origin/main)
-          if [[ "$RECORDED" != "$REMOTE_SHA" ]]; then
-            echo "::error::Submodule on App main ($RECORDED) still differs from Mobile-Expensify origin/main ($REMOTE_SHA)"
-            exit 1
-          fi
-
-          echo "POST_SYNC_APP_VERSION=$APP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "::notice::✅ Verified versions ($APP_VERSION) and submodule match Mobile-Expensify main ($RECORDED)"
+      - name: Sync versions and verify
+        id: performSync
+        if: steps.checkSync.outputs.IN_SYNC != 'true'
+        env:
+          TARGET_VERSION: ${{ inputs.TARGET_VERSION }}
+          NEED_FULL_VERSION_SYNC: ${{ steps.checkSync.outputs.NEED_FULL_VERSION_SYNC }}
+          EXPECTED_SUBMODULE_SHA: ${{ steps.checkSync.outputs.ACTUAL_SHA }}
+        run: ./.github/scripts/syncVersions.sh sync
 
       - name: Announce sync in Slack
-        if: steps.checkVersions.outputs.IN_SYNC != 'true'
+        if: steps.checkSync.outputs.IN_SYNC != 'true'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK }}
@@ -210,7 +64,7 @@ jobs:
               "channel": "#deployer",
               "attachments": [{
                 "color": "good",
-                "text": "✅ Version sync completed. E/App and Mobile-Expensify are at ${{ steps.verifySync.outputs.POST_SYNC_APP_VERSION }}; submodule matches Mobile-Expensify main."
+                "text": "✅ Version sync completed. E/App and Mobile-Expensify are at ${{ steps.performSync.outputs.POST_SYNC_APP_VERSION }}; submodule matches Mobile-Expensify main."
               }]
             }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]
-    paths: ['**.js', '**.ts', '**.tsx', 'package.json', 'package-lock.json']
+    paths: ['**.js', '**.ts', '**.tsx', '**.sh', 'package.json', 'package-lock.json']
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-jest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]
-    paths: ['**.js', '**.ts', '**.tsx', '**.sh', 'package.json', 'package-lock.json']
+    paths: ['**.js', '**.ts', '**.tsx', 'package.json', 'package-lock.json']
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-jest

--- a/.github/workflows/testSyncVersions.yml
+++ b/.github/workflows/testSyncVersions.yml
@@ -1,0 +1,28 @@
+name: Test syncVersions script
+
+# The syncVersions workflow runs on macOS, and its full version sync path depends on PlistBuddy and
+# BSD `sed -i ''`. Those tests skip themselves on the Ubuntu runners the main Jest job uses, so this
+# runs the same suite on macOS whenever the script or its tests change.
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
+    paths: ['.github/scripts/syncVersions.sh', 'tests/unit/SyncVersionsTest.ts', '.github/workflows/testSyncVersions.yml']
+
+concurrency:
+  group: ${{ github.ref }}-testSyncVersions
+  cancel-in-progress: true
+
+jobs:
+  testSyncVersions:
+    runs-on: blacksmith-6vcpu-macos-latest
+    steps:
+      - name: Check out
+        # Upstream checkout on macOS - Blacksmith's git-mirror cache can't work there (see workflows/README.md)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Jest tests
+        run: npm test -- --silent tests/unit/SyncVersionsTest.ts

--- a/tests/unit/SyncVersionsTest.ts
+++ b/tests/unit/SyncVersionsTest.ts
@@ -33,6 +33,14 @@ function git(cwd: string, ...args: string[]): string {
     return execFileSync('git', args, {cwd, encoding: 'utf-8', env: {...process.env, ...GIT_ALLOW_FILE_TRANSPORT}}).trim();
 }
 
+function readVersion(filePath: string): unknown {
+    const parsed: unknown = JSON.parse(fs.readFileSync(filePath, {encoding: 'utf-8'}));
+    if (typeof parsed !== 'object' || parsed === null || !('version' in parsed)) {
+        throw new Error(`Expected ${filePath} to contain a version field`);
+    }
+    return parsed.version;
+}
+
 function writeJSON(filePath: string, contents: Record<string, unknown>) {
     fs.mkdirSync(path.dirname(filePath), {recursive: true});
     fs.writeFileSync(filePath, `${JSON.stringify(contents, null, 4)}\n`);
@@ -116,12 +124,13 @@ function setUpFixture(appVersion: string, mobileExpensifyVersion: string, fullSy
             return;
         }
 
+        // `npm version` refuses to update a lockfile that isn't there, and rewrites the root package entry itself
         writeJSON(path.join(workingDir, 'package-lock.json'), {
             name: 'new.expensify',
             version: appVersion,
             lockfileVersion: 3,
             requires: true,
-            packages: {'': {name: 'new.expensify', version: appVersion}},
+            packages: Object.fromEntries([['', {name: 'new.expensify', version: appVersion}]]),
         });
         fs.mkdirSync(path.join(workingDir, 'android/app'), {recursive: true});
         fs.writeFileSync(
@@ -275,7 +284,7 @@ describeMacOS('syncVersions.sh sync (full version)', () => {
         expect(result.status).toBe(0);
         expect(result.outputs.POST_SYNC_APP_VERSION).toBe('9.3.11-48');
 
-        expect((JSON.parse(fs.readFileSync(path.join(appDir, 'package.json'), {encoding: 'utf-8'})) as {version: string}).version).toBe('9.3.11-48');
+        expect(readVersion(path.join(appDir, 'package.json'))).toBe('9.3.11-48');
 
         const buildGradle = fs.readFileSync(path.join(appDir, 'android/app/build.gradle'), {encoding: 'utf-8'});
         expect(buildGradle).toContain('versionName "9.3.11-48"');

--- a/tests/unit/SyncVersionsTest.ts
+++ b/tests/unit/SyncVersionsTest.ts
@@ -1,0 +1,320 @@
+/**
+ * @jest-environment node
+ */
+import type {SpawnSyncReturns} from 'child_process';
+
+import {execFileSync, spawnSync} from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const SCRIPT_PATH = path.resolve(__dirname, '../../.github/scripts/syncVersions.sh');
+
+/**
+ * These fixtures use local paths as git remotes, and the file transport has been blocked for submodules
+ * since CVE-2022-39253. This re-enables it for every git process the script spawns, including the fetch
+ * that `git submodule update --remote` runs inside the submodule.
+ */
+const GIT_ALLOW_FILE_TRANSPORT = {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'protocol.file.allow',
+    GIT_CONFIG_VALUE_0: 'always',
+};
+
+// PlistBuddy and BSD `sed -i ''` only exist on macOS, which is what the workflow runs on.
+const describeMacOS = process.platform === 'darwin' ? describe : describe.skip;
+
+type ScriptResult = SpawnSyncReturns<string> & {outputs: Record<string, string>};
+
+let tmpRoot: string;
+let appDir: string;
+
+function git(cwd: string, ...args: string[]): string {
+    return execFileSync('git', args, {cwd, encoding: 'utf-8', env: {...process.env, ...GIT_ALLOW_FILE_TRANSPORT}}).trim();
+}
+
+function writeJSON(filePath: string, contents: Record<string, unknown>) {
+    fs.mkdirSync(path.dirname(filePath), {recursive: true});
+    fs.writeFileSync(filePath, `${JSON.stringify(contents, null, 4)}\n`);
+}
+
+/** Runs the script and parses whatever it wrote to GITHUB_OUTPUT back into a map. */
+function runScript(command: string, options: {cwd?: string; env?: Record<string, string>; args?: string[]} = {}): ScriptResult {
+    const outputFile = path.join(tmpRoot, `github-output-${Math.random().toString(36).slice(2)}`);
+    fs.writeFileSync(outputFile, '');
+
+    const result = spawnSync(SCRIPT_PATH, [command, ...(options.args ?? [])], {
+        cwd: options.cwd ?? appDir,
+        encoding: 'utf-8',
+        env: {
+            ...process.env,
+            ...GIT_ALLOW_FILE_TRANSPORT,
+            GITHUB_OUTPUT: outputFile,
+            ...options.env,
+        },
+    });
+
+    const outputs: Record<string, string> = {};
+    for (const line of fs.readFileSync(outputFile, {encoding: 'utf-8'}).split('\n')) {
+        if (line) {
+            const separatorIndex = line.indexOf('=');
+            outputs[line.slice(0, separatorIndex)] = line.slice(separatorIndex + 1);
+        }
+    }
+
+    return {...result, outputs};
+}
+
+/** Creates a bare remote plus a working clone with an initial commit on main. */
+function createRepoWithRemote(name: string, populate: (workingDir: string) => void): {remote: string; workingDir: string} {
+    const remote = path.join(tmpRoot, `${name}.git`);
+    const workingDir = path.join(tmpRoot, name);
+
+    execFileSync('git', ['init', '--bare', '--initial-branch=main', remote]);
+    execFileSync('git', ['init', '--initial-branch=main', workingDir]);
+    git(workingDir, 'config', 'user.name', 'test');
+    git(workingDir, 'config', 'user.email', 'test@test.com');
+
+    populate(workingDir);
+
+    git(workingDir, 'add', '-A');
+    git(workingDir, 'commit', '-m', `Initial ${name} commit`);
+    git(workingDir, 'remote', 'add', 'origin', remote);
+    git(workingDir, 'push', '-u', 'origin', 'main');
+
+    return {remote, workingDir};
+}
+
+/** Adds a commit to Mobile-Expensify main, optionally changing its version, and returns the new SHA. */
+function advanceMobileExpensify(version?: string): string {
+    const workingDir = path.join(tmpRoot, 'Mobile-Expensify');
+    if (version) {
+        writeJSON(path.join(workingDir, 'app/config/config.json'), {meta: {version}});
+    } else {
+        fs.appendFileSync(path.join(workingDir, 'README.md'), 'more\n');
+    }
+    git(workingDir, 'add', '-A');
+    git(workingDir, 'commit', '-m', version ? `Bump to ${version}` : 'Unrelated change');
+    git(workingDir, 'push', 'origin', 'main');
+    return git(workingDir, 'rev-parse', 'HEAD');
+}
+
+/**
+ * Builds an App repo whose Mobile-Expensify submodule points at a real (local) Mobile-Expensify remote.
+ * `fullSyncFixtures` adds the native files the full version sync path rewrites.
+ */
+function setUpFixture(appVersion: string, mobileExpensifyVersion: string, fullSyncFixtures = false) {
+    const mobileExpensifyRemote = createRepoWithRemote('Mobile-Expensify', (workingDir) => {
+        writeJSON(path.join(workingDir, 'app/config/config.json'), {meta: {version: mobileExpensifyVersion}});
+        fs.writeFileSync(path.join(workingDir, 'README.md'), 'Mobile-Expensify\n');
+    }).remote;
+
+    const app = createRepoWithRemote('App', (workingDir) => {
+        writeJSON(path.join(workingDir, 'package.json'), {name: 'new.expensify', version: appVersion});
+
+        if (!fullSyncFixtures) {
+            return;
+        }
+
+        writeJSON(path.join(workingDir, 'package-lock.json'), {
+            name: 'new.expensify',
+            version: appVersion,
+            lockfileVersion: 3,
+            requires: true,
+            packages: {'': {name: 'new.expensify', version: appVersion}},
+        });
+        fs.mkdirSync(path.join(workingDir, 'android/app'), {recursive: true});
+        fs.writeFileSync(
+            path.join(workingDir, 'android/app/build.gradle'),
+            ['android {', '    defaultConfig {', `        versionCode 1009031000`, `        versionName "${appVersion}"`, '    }', '}', ''].join('\n'),
+        );
+        for (const target of ['NewExpensify', 'NotificationServiceExtension', 'ShareViewController']) {
+            fs.mkdirSync(path.join(workingDir, 'ios', target), {recursive: true});
+            fs.writeFileSync(
+                path.join(workingDir, 'ios', target, 'Info.plist'),
+                [
+                    '<?xml version="1.0" encoding="UTF-8"?>',
+                    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+                    '<plist version="1.0">',
+                    '<dict>',
+                    '\t<key>CFBundleShortVersionString</key>',
+                    '\t<string>0.0.0</string>',
+                    '\t<key>CFBundleVersion</key>',
+                    '\t<string>0.0.0.0</string>',
+                    '</dict>',
+                    '</plist>',
+                    '',
+                ].join('\n'),
+            );
+        }
+    });
+
+    appDir = app.workingDir;
+
+    git(appDir, 'submodule', 'add', mobileExpensifyRemote, 'Mobile-Expensify');
+    git(appDir, 'commit', '-m', 'Add Mobile-Expensify submodule');
+    git(appDir, 'push', 'origin', 'main');
+}
+
+beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'syncVersions-'));
+});
+
+afterEach(() => {
+    fs.rmSync(tmpRoot, {recursive: true, force: true});
+});
+
+describe('syncVersions.sh version-components', () => {
+    // Mirrors generateAndroidVersionCode in scripts/bumpVersion.ts: prefix 10, then two digits each for major/minor/patch/build
+    it.each([
+        ['9.3.11-48', {SHORT_VERSION: '9.3.11', BUILD_NUMBER: '48', CF_VERSION: '9.3.11.48', ANDROID_VERSION_CODE: '1009031148'}],
+        ['1.2.3-4', {SHORT_VERSION: '1.2.3', BUILD_NUMBER: '4', CF_VERSION: '1.2.3.4', ANDROID_VERSION_CODE: '1001020304'}],
+        ['10.20.30-40', {SHORT_VERSION: '10.20.30', BUILD_NUMBER: '40', CF_VERSION: '10.20.30.40', ANDROID_VERSION_CODE: '1010203040'}],
+    ])('derives the native version components of %s', (version, expected) => {
+        const result = runScript('version-components', {cwd: tmpRoot, args: [version]});
+
+        expect(result.status).toBe(0);
+        expect(
+            Object.fromEntries(
+                result.stdout
+                    .trim()
+                    .split('\n')
+                    .map((line) => line.split('=')),
+            ),
+        ).toEqual(expected);
+    });
+
+    it('fails without a version argument', () => {
+        const result = runScript('version-components', {cwd: tmpRoot});
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain('::error::');
+    });
+
+    it('fails on an unknown subcommand', () => {
+        const result = runScript('not-a-command', {cwd: tmpRoot});
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain('::error::Usage:');
+    });
+});
+
+describe('syncVersions.sh check', () => {
+    it('reports in sync when versions and the submodule pointer match', () => {
+        setUpFixture('9.3.11-48', '9.3.11-48');
+
+        const result = runScript('check');
+
+        expect(result.status).toBe(0);
+        expect(result.outputs.IN_SYNC).toBe('true');
+        expect(result.outputs.NEED_FULL_VERSION_SYNC).toBe('false');
+        expect(result.stdout).toContain('::notice::✅ Versions and submodule are in sync');
+    });
+
+    it('requests a full version sync when the versions differ', () => {
+        setUpFixture('9.3.10-1', '9.3.11-48');
+
+        const result = runScript('check');
+
+        expect(result.status).toBe(0);
+        expect(result.outputs.IN_SYNC).toBe('false');
+        expect(result.outputs.NEED_FULL_VERSION_SYNC).toBe('true');
+        expect(result.stdout).toContain('::warning::⚠️ Versions are out of sync');
+    });
+
+    it('requests a submodule-only bump when the versions match but the pointer is behind', () => {
+        setUpFixture('9.3.11-48', '9.3.11-48');
+        const newSubmoduleSha = advanceMobileExpensify();
+
+        const result = runScript('check');
+
+        expect(result.status).toBe(0);
+        expect(result.outputs.IN_SYNC).toBe('false');
+        expect(result.outputs.NEED_FULL_VERSION_SYNC).toBe('false');
+        expect(result.outputs.ACTUAL_SHA).toBe(newSubmoduleSha);
+        expect(result.stdout).toContain('::warning::⚠️ Submodule pointer is behind Mobile-Expensify main');
+    });
+});
+
+describe('syncVersions.sh sync (submodule only)', () => {
+    it('commits and pushes the new submodule pointer, then verifies', () => {
+        setUpFixture('9.3.11-48', '9.3.11-48');
+        const newSubmoduleSha = advanceMobileExpensify();
+        runScript('check');
+
+        const result = runScript('sync', {env: {NEED_FULL_VERSION_SYNC: 'false', EXPECTED_SUBMODULE_SHA: newSubmoduleSha}});
+
+        expect(result.status).toBe(0);
+        expect(result.outputs.POST_SYNC_APP_VERSION).toBe('9.3.11-48');
+        expect(git(appDir, 'ls-tree', 'origin/main', 'Mobile-Expensify')).toContain(newSubmoduleSha);
+        expect(git(appDir, 'log', '-1', '--format=%s', 'origin/main')).toBe(`Bump Mobile-Expensify submodule to latest main (${newSubmoduleSha})`);
+    });
+
+    it('fails when the submodule checkout moved since the check step', () => {
+        setUpFixture('9.3.11-48', '9.3.11-48');
+        advanceMobileExpensify();
+        runScript('check');
+
+        const result = runScript('sync', {env: {NEED_FULL_VERSION_SYNC: 'false', EXPECTED_SUBMODULE_SHA: '0'.repeat(40)}});
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain('::error::Mobile-Expensify checkout');
+        expect(git(appDir, 'log', '-1', '--format=%s', 'origin/main')).toBe('Add Mobile-Expensify submodule');
+    });
+});
+
+describeMacOS('syncVersions.sh sync (full version)', () => {
+    it('rewrites the App version across package.json, Android and iOS, then pushes and verifies', () => {
+        setUpFixture('9.3.10-1', '9.3.11-48', true);
+        // A real version drift always comes with the submodule pointer being behind, since Mobile-Expensify is bumped first
+        advanceMobileExpensify();
+        runScript('check');
+
+        const result = runScript('sync', {env: {NEED_FULL_VERSION_SYNC: 'true'}});
+
+        expect(result.status).toBe(0);
+        expect(result.outputs.POST_SYNC_APP_VERSION).toBe('9.3.11-48');
+
+        expect((JSON.parse(fs.readFileSync(path.join(appDir, 'package.json'), {encoding: 'utf-8'})) as {version: string}).version).toBe('9.3.11-48');
+
+        const buildGradle = fs.readFileSync(path.join(appDir, 'android/app/build.gradle'), {encoding: 'utf-8'});
+        expect(buildGradle).toContain('versionName "9.3.11-48"');
+        expect(buildGradle).toContain('versionCode 1009031148');
+
+        for (const target of ['NewExpensify', 'NotificationServiceExtension', 'ShareViewController']) {
+            const plist = path.join(appDir, 'ios', target, 'Info.plist');
+            expect(execFileSync('/usr/libexec/PlistBuddy', ['-c', 'Print :CFBundleShortVersionString', plist], {encoding: 'utf-8'}).trim()).toBe('9.3.11');
+            expect(execFileSync('/usr/libexec/PlistBuddy', ['-c', 'Print :CFBundleVersion', plist], {encoding: 'utf-8'}).trim()).toBe('9.3.11.48');
+        }
+
+        expect(git(appDir, 'log', '-2', '--format=%s', 'origin/main').split('\n')).toEqual([
+            'Update Mobile-Expensify submodule version to 9.3.11-48 (sync recovery)',
+            'Update version to 9.3.11-48 (sync recovery)',
+        ]);
+    }, 120000);
+
+    it('uses TARGET_VERSION when it is provided', () => {
+        setUpFixture('9.3.10-1', '9.3.11-48', true);
+        // A real version drift always comes with the submodule pointer being behind, since Mobile-Expensify is bumped first
+        advanceMobileExpensify();
+        runScript('check');
+
+        const result = runScript('sync', {env: {NEED_FULL_VERSION_SYNC: 'true', TARGET_VERSION: '9.3.11-48'}});
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain('Using provided target version: 9.3.11-48');
+        expect(result.outputs.POST_SYNC_APP_VERSION).toBe('9.3.11-48');
+    }, 120000);
+
+    it('fails verification when the target version does not match Mobile-Expensify', () => {
+        setUpFixture('9.3.10-1', '9.3.11-48', true);
+        // A real version drift always comes with the submodule pointer being behind, since Mobile-Expensify is bumped first
+        advanceMobileExpensify();
+        runScript('check');
+
+        const result = runScript('sync', {env: {NEED_FULL_VERSION_SYNC: 'true', TARGET_VERSION: '9.9.9-9'}});
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain("::error::Sync failed! Versions still don't match");
+    }, 120000);
+});

--- a/tests/unit/SyncVersionsTest.ts
+++ b/tests/unit/SyncVersionsTest.ts
@@ -30,7 +30,8 @@ let tmpRoot: string;
 let appDir: string;
 
 function git(cwd: string, ...args: string[]): string {
-    return execFileSync('git', args, {cwd, encoding: 'utf-8', env: {...process.env, ...GIT_ALLOW_FILE_TRANSPORT}}).trim();
+    // Pipe stderr rather than letting it reach the parent, so fixture setup doesn't spam the CI log
+    return execFileSync('git', args, {cwd, encoding: 'utf-8', stdio: 'pipe', env: {...process.env, ...GIT_ALLOW_FILE_TRANSPORT}}).trim();
 }
 
 function readVersion(filePath: string): unknown {
@@ -78,8 +79,8 @@ function createRepoWithRemote(name: string, populate: (workingDir: string) => vo
     const remote = path.join(tmpRoot, `${name}.git`);
     const workingDir = path.join(tmpRoot, name);
 
-    execFileSync('git', ['init', '--bare', '--initial-branch=main', remote]);
-    execFileSync('git', ['init', '--initial-branch=main', workingDir]);
+    execFileSync('git', ['init', '--bare', '--initial-branch=main', remote], {stdio: 'pipe'});
+    execFileSync('git', ['init', '--initial-branch=main', workingDir], {stdio: 'pipe'});
     git(workingDir, 'config', 'user.name', 'test');
     git(workingDir, 'config', 'user.email', 'test@test.com');
 


### PR DESCRIPTION
### Explanation of Change

Follow-up to the review feedback on [Fix version sync between E/App and Mobile-Expensify](https://github.com/Expensify/App/pull/88170): the main shell logic is moved out of `.github/workflows/syncVersions.yml` and into `.github/scripts/syncVersions.sh`, leaving the workflow responsible only for `workflow_dispatch`, checkout, `validateActor`, `setupGitForOSBotify`, `setupNode`, and thin `run:` invocations.

**This is a behavior-preserving refactor.** Every annotation string, commit message and git invocation is carried over unchanged.

Six `run:`-bearing steps collapse into two:

| Before | After |
| --- | --- |
| `submoduleRemote`, `checkVersions` | `./.github/scripts/syncVersions.sh check` |
| `targetVersion`, full version sync, submodule-only bump, `verifySync` | `./.github/scripts/syncVersions.sh sync` |

The script uses two subcommands rather than a single always-run step so that `setupNode` can stay conditional — it is only needed for the full version sync path, and on macOS it runs `npm ci` (which also runs `npm i` inside `Mobile-Expensify` via `scripts/postInstall.sh`, dirtying the submodule working tree). Forcing it on the submodule-only path would be both slow and a new failure mode.

Notes on the details that matter for parity:

- `ACTUAL_SHA` and `NEED_FULL_VERSION_SYNC` are threaded from `check` to `sync` through step outputs rather than recomputed. Recomputing `ACTUAL_SHA` would turn the "did the submodule checkout move since we updated it?" guard into a comparison of a value with itself.
- `sync` deliberately never re-runs `git submodule update --remote` — Mobile-Expensify `main` can advance while Node is being set up between the two steps.
- The two rebase-retry paths are kept separate rather than factored into a shared helper, because they genuinely differ (the submodule-only path re-updates the submodule, re-stages, and guards with `git diff --staged --quiet`; the full-sync path does none of that).
- No `${{ }}` expression is interpolated into a shell body any more. `TARGET_VERSION` now reaches the script via `env:`, which removes a script-injection vector on a runner that holds `OS_BOTIFY_COMMIT_TOKEN` and 1Password credentials.

The script gains one extra subcommand, `version-components`, purely so the Android/iOS version math can be unit tested without a repo fixture.

Two follow-ups intentionally left out of this PR so it stays a pure refactor:

1. The full-sync path runs `git add Mobile-Expensify; git commit` unconditionally. When the versions differ but the App gitlink already points at Mobile-Expensify `main`, nothing is staged, `git commit` exits 1, and the job dies after the local version commit and before any push. The submodule-only path already guards this with `git diff --staged --quiet`. Fixed in a follow-up PR stacked on this one.
2. The `TARGET_VERSION` dispatch input is only usable when it equals the Mobile-Expensify version, since only the App side is rewritten and verification then compares the two. The input `description:` is clarified here; the behavior is unchanged.

### Fixed Issues

$ https://github.com/Expensify/App/issues/88233
PROPOSAL: N/A

### Tests

This is a CI-only workflow change; there is no app-facing behavior to exercise. It is covered by new unit tests plus ShellCheck.

1. Run `npm run shellcheck` and verify it passes for all files, including the new `.github/scripts/syncVersions.sh`.
2. Run `npx jest tests/unit/SyncVersionsTest.ts` on macOS and verify all 13 tests pass. The suite builds throwaway git repos (a bare Mobile-Expensify remote, a bare App remote, and a working clone wiring them together as a submodule) under `os.tmpdir()` and runs the real script against them:
    - `version-components` derives the correct `SHORT_VERSION` / `BUILD_NUMBER` / `CF_VERSION` / `ANDROID_VERSION_CODE`, including zero-padding, matching `generateAndroidVersionCode` in `scripts/bumpVersion.ts`.
    - `check` reports in-sync, full-version-sync-needed, and submodule-bump-needed for the three real-world states.
    - `sync` in submodule-only mode commits and pushes the new pointer and verifies it, and fails with `::error::` (without pushing) when the submodule checkout moved since `check`.
    - `sync` in full-version mode rewrites `package.json`, `android/app/build.gradle` and all three `Info.plist` files, pushes both commits, and fails verification when the target version does not match Mobile-Expensify.
3. Verify that the three full-version-sync tests are skipped on Linux (they depend on `PlistBuddy` and BSD `sed -i ''`) and run on macOS. The main Jest job runs on Ubuntu, so those three would otherwise never run in CI — `.github/workflows/testSyncVersions.yml` runs the same suite on a macOS runner instead. It is path-gated to `.github/scripts/syncVersions.sh` and `tests/unit/SyncVersionsTest.ts`, so it only spends a macOS runner when this script or its tests change. Verify that job is green on this PR and that its log shows all 13 tests running with none skipped.
4. Confirm the rendered workflow file still contains the same step order: checkout → `validateActor` → `setupGitForOSBotify` → `check` → conditional `setupNode` → `sync` → Slack announce → Slack failure.
5. Deployer validation: trigger the `Sync E/App and Mobile-Expensify versions` workflow manually while App and Mobile-Expensify are already in sync, and verify the run exits early with `::notice::✅ Versions and submodule are in sync` and makes no commits, no pushes and no Slack post.
- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable — this changes a GitHub Actions workflow and its supporting script. There is no client-side behavior and no network state to vary.

### QA Steps

Not applicable — no user-facing behavior changes. The workflow is a manual `workflow_dispatch` restricted to mobile deployers and is validated by triggering it directly (see step 5 in `Tests`), not on staging or production.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not yet tested — needs manual QA.

</details>
