### PR TITLE
[NoQA] Skip the submodule commit during a full version sync when the pointer is already current

### DIFF
--- a/.github/scripts/syncVersions.sh
+++ b/.github/scripts/syncVersions.sh
@@ -168,9 +168,12 @@ function sync_full_version {
     git add package.json package-lock.json android/app/build.gradle ios/*/Info.plist
     git commit -m "Update version to $target (sync recovery)"
 
-    # Update submodule reference
+    # Update submodule reference. It can already be current when a previous sync only got half way,
+    # in which case there is nothing to commit.
     git add Mobile-Expensify
-    git commit -m "Update Mobile-Expensify submodule version to $target (sync recovery)"
+    if ! git diff --staged --quiet; then
+        git commit -m "Update Mobile-Expensify submodule version to $target (sync recovery)"
+    fi
 
     # Push changes
     if ! git push origin main; then

--- a/tests/unit/SyncVersionsTest.ts
+++ b/tests/unit/SyncVersionsTest.ts
@@ -326,4 +326,17 @@ describeMacOS('syncVersions.sh sync (full version)', () => {
         expect(result.status).toBe(1);
         expect(result.stdout).toContain("::error::Sync failed! Versions still don't match");
     }, 120000);
+
+    it('still syncs when the submodule pointer is already current', () => {
+        // Reachable after a previous sync got as far as bumping the submodule pointer but not the versions
+        setUpFixture('9.3.10-1', '9.3.11-48', true);
+        runScript('check');
+
+        const result = runScript('sync', {env: {NEED_FULL_VERSION_SYNC: 'true'}});
+
+        expect(result.status).toBe(0);
+        expect(result.outputs.POST_SYNC_APP_VERSION).toBe('9.3.11-48');
+        expect(readVersion(path.join(appDir, 'package.json'))).toBe('9.3.11-48');
+        expect(git(appDir, 'log', '-1', '--format=%s', 'origin/main')).toBe('Update version to 9.3.11-48 (sync recovery)');
+    }, 120000);
 });


### PR DESCRIPTION
### Explanation of Change

> [!NOTE]
> Stacked on [Extract syncVersions workflow shell into a script](https://github.com/Expensify/App/pull/97598) — please review and merge that one first. This PR's diff is only the two hunks described below.

The full version sync path in `.github/scripts/syncVersions.sh` records the Mobile-Expensify submodule pointer unconditionally:

```bash
git add Mobile-Expensify
git commit -m "Update Mobile-Expensify submodule version to $TARGET (sync recovery)"
```

When the versions differ but the App gitlink already points at Mobile-Expensify `main`, nothing is staged, so `git commit` exits 1. Under `set -e` (and under GitHub's default `bash -e {0}` before the extraction) that kills the job **after** the local version commit and **before** any push — so the sync silently accomplishes nothing and has to be re-run.

That state is reachable in practice: it is exactly what a previously half-completed sync leaves behind, where the submodule pointer got bumped but the versions did not.

The fix applies the same guard the submodule-only path already uses:

```bash
git add Mobile-Expensify
if ! git diff --staged --quiet; then
    git commit -m "Update Mobile-Expensify submodule version to $target (sync recovery)"
fi
```

This was deliberately left out of [#97598](https://github.com/Expensify/App/pull/97598) so that PR stays a provably behavior-neutral refactor.

### Fixed Issues

$ https://github.com/Expensify/App/issues/88233
PROPOSAL: N/A

### Tests

1. Check out this branch and run `npx jest tests/unit/SyncVersionsTest.ts` on macOS. Verify all 14 tests pass, including the new `still syncs when the submodule pointer is already current`.
2. Verify the new test is a genuine regression test: `git stash push .github/scripts/syncVersions.sh`, re-run `npx jest tests/unit/SyncVersionsTest.ts -t "still syncs when the submodule pointer is already current"`, and confirm it fails; then `git stash pop` and confirm it passes again.
3. Verify the failure it guards against, in the failing state: with the fix reverted, the test output shows `nothing to commit, working tree clean` and a non-zero exit, with `origin/main` left without the version commit. With the fix, `origin/main` ends on `Update version to 9.3.11-48 (sync recovery)` and `POST_SYNC_APP_VERSION` is set.
4. Run `npm run shellcheck` and verify it passes.
5. Deployer validation: trigger the `Sync E/App and Mobile-Expensify versions` workflow manually and verify a normal sync (versions differ *and* the submodule pointer is behind) still produces both commits — `Update version to <version> (sync recovery)` followed by `Update Mobile-Expensify submodule version to <version> (sync recovery)`.
- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable — this changes a GitHub Actions workflow script. There is no client-side behavior and no network state to vary.

### QA Steps

Not applicable — no user-facing behavior changes. The workflow is a manual `workflow_dispatch` restricted to mobile deployers and is validated by triggering it directly (see step 5 in `Tests`), not on staging or production.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>iOS: Native</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — CI workflow change only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — CI workflow change only.

</details>
