### PR TITLE
Fix typecheck break left by the incomplete #96963 revert

### DIFF
--- a/src/pages/iou/request/step/DynamicIOURequestStepDestination.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepDestination.tsx
@@ -21,6 +21,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {fetchPerDiemRates} from '@libs/actions/Policy/PerDiem';
 import {setTransactionReport} from '@libs/actions/Transaction';
 import {getInitialPerDiemTargetReport} from '@libs/IOUUtils';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import {getPerDiemCustomUnit, getPolicyByCustomUnitID, isPolicyAdmin} from '@libs/PolicyUtils';
 import {findSelfDMReportID, getPolicyExpenseChat} from '@libs/ReportUtils';

--- a/src/pages/iou/request/step/IOURequestStepTime.tsx
+++ b/src/pages/iou/request/step/IOURequestStepTime.tsx
@@ -16,7 +16,7 @@ import {addErrorMessage} from '@libs/ErrorUtils';
 import {isValidMoneyRequestType} from '@libs/IOUUtils';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
-import {getActivePoliciesWithExpenseChatAndPerDiemEnabledAndHasRates} from '@libs/PolicyUtils';
+import {getActivePoliciesWithExpenseChatAndPerDiemEnabled} from '@libs/PolicyUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 
 import {getIOURequestPolicyID, setMoneyRequestDateAttribute} from '@userActions/IOU/MoneyRequest';
@@ -79,7 +79,7 @@ function IOURequestStepTime({
 
     const shouldShowNotFound = !isValidMoneyRequestType(iouType) || isEmptyObject(policy) || (isEditPage && isEmptyObject(transaction?.comment?.customUnit));
     const {login: currentUserLogin} = useCurrentUserPersonalDetails();
-    const policiesWithPerDiemEnabled = useMemo(() => getActivePoliciesWithExpenseChatAndPerDiemEnabledAndHasRates(allPolicies, currentUserLogin), [allPolicies, currentUserLogin]);
+    const policiesWithPerDiemEnabled = useMemo(() => getActivePoliciesWithExpenseChatAndPerDiemEnabled(allPolicies, currentUserLogin), [allPolicies, currentUserLogin]);
     const hasMoreThanOnePolicyWithPerDiemEnabled = policiesWithPerDiemEnabled.length > 1;
 
     const navigateBack = () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

[`main`'s typecheck check is currently red](https://github.com/Expensify/App/actions/runs/30671347102/job/91289534124) because [`64d08f13d6f`](https://github.com/Expensify/App/commit/64d08f13d6f), a revert of [PR 96963](https://github.com/Expensify/App/pull/96963) ("Migrate money request time step to dynamic routes"), restored a version of `IOURequestStepTime.tsx` that imports `getActivePoliciesWithExpenseChatAndPerDiemEnabledAndHasRates` from `PolicyUtils.ts`. That helper no longer exists.

This PR points `IOURequestStepTime.tsx` at `getActivePoliciesWithExpenseChatAndPerDiemEnabled` and restores the `createDynamicRoute` import that the same revert dropped from `DynamicIOURequestStepDestination.tsx`. The revert removed only the one [PR 96963](https://github.com/Expensify/App/pull/96963) added and missed the pre-existing one used by the "Add rates" empty-state button.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ N/A
PROPOSAL: 


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Open the money request flow for a user with per diem enabled on more than one policy, and verify the Time step's back navigation still lands on the correct step.
2. From a per diem policy with no rates configured, open the destination step's empty state as a workspace admin and verify the "Add rates" button still navigates to the workspace per diem settings and back correctly.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A. Both changes are compile-time fixes with no network dependency.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x]  I linked the correct issue in the `### Fixed Issues` section above
- [x]  I wrote clear testing steps that cover the changes made in this PR
    - [x]  I added steps for local testing in the `Tests` section
    - [x]  I added steps for the expected offline behavior in the `Offline steps` section
    - [x]  I added steps for Staging and/or Production testing in the `QA steps` section
    - [x]  I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x]  I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x]  I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x]  I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x]  I ran the tests on **all platforms** & verified they passed on:
    - [x]  Android: Native
    - [x]  Android: mWeb Chrome
    - [x]  iOS: Native
    - [x]  iOS: mWeb Safari
    - [x]  MacOS: Chrome / Safari
- [x]  I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x]  I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x]  I verified that comments were added to code that is not self explanatory
    - [x]  I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x]  I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x]  If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x]  I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x]  I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x]  If a new CSS style is added I verified that:
    - [x]  A similar style doesn't already exist
    - [x]  The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x]  If new assets were added or existing ones were modified, I verified that:
    - [x]  The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x]  The assets load correctly across all supported platforms.
- [x]  If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x]  If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x]  If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x]  If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x]  If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x]  I verified that all the inputs inside a form are aligned with each other.
    - [x]  I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x]  I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x]  If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/6e3e94a8-26dc-4953-b67a-1e07e5117edb




</details>
