### PR TITLE
Fix: land onboarding Track-business users on Home instead of Inbox

### DIFF
--- a/src/components/SidePanel/RHPVariantTest/index.ts
+++ b/src/components/SidePanel/RHPVariantTest/index.ts
@@ -1,5 +1,5 @@
 import SidePanelActions from '@libs/actions/SidePanel';
-import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
+import isReportRevealedInTopmostSplitNavigator from '@libs/Navigation/helpers/isReportRevealedInTopmostSplitNavigator';
 import Navigation from '@libs/Navigation/Navigation';
 
 import CONST from '@src/CONST';
@@ -67,7 +67,7 @@ const shouldOpenRHPVariant: ShouldOpenRHPVariant = (variantOverride) => {
 const handleRHPVariantNavigation: HandleRHPVariantNavigation = (onboardingPolicyID, variantOverride, navigationOptions) => {
     const variant = variantOverride ?? onboardingRHPVariant;
     if (variant === CONST.ONBOARDING_RHP_VARIANT.TRACK_EXPENSES_WITH_CONCIERGE) {
-        const shouldPreserveRevealedReport = isReportTopmostSplitNavigator();
+        const shouldPreserveRevealedReport = isReportRevealedInTopmostSplitNavigator();
         if (!shouldPreserveRevealedReport) {
             Navigation.navigate(ROUTES.HOME, navigationOptions);
         }
@@ -78,7 +78,7 @@ const handleRHPVariantNavigation: HandleRHPVariantNavigation = (onboardingPolicy
     const isRHPHomePage = variant === CONST.ONBOARDING_RHP_VARIANT.RHP_HOME_PAGE;
 
     if (isRHPHomePage) {
-        const shouldPreserveRevealedReport = isReportTopmostSplitNavigator();
+        const shouldPreserveRevealedReport = isReportRevealedInTopmostSplitNavigator();
         if (!shouldPreserveRevealedReport) {
             Navigation.navigate(ROUTES.HOME, navigationOptions);
         }

--- a/src/libs/Navigation/helpers/isReportRevealedInTopmostSplitNavigator.ts
+++ b/src/libs/Navigation/helpers/isReportRevealedInTopmostSplitNavigator.ts
@@ -22,8 +22,6 @@ function isReportRevealedInTopmostSplitNavigator(): boolean {
         return false;
     }
 
-    // Read the split's live inner routes first, then fall back to the preserved state keyed on the split
-    // route's key.
     const innerRoutes: ReadonlyArray<{name: string}> | undefined =
         topmostFullScreenRoute.state?.routes ?? (topmostFullScreenRoute.key ? getPreservedNavigatorState(topmostFullScreenRoute.key)?.routes : undefined);
 

--- a/src/libs/Navigation/helpers/isReportRevealedInTopmostSplitNavigator.ts
+++ b/src/libs/Navigation/helpers/isReportRevealedInTopmostSplitNavigator.ts
@@ -1,0 +1,34 @@
+import {getPreservedNavigatorState} from '@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState';
+
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+
+import getTopmostFullScreenRoute from './getTopmostFullScreenRoute';
+
+/**
+ * Returns true only when a report is revealed in the topmost Reports split navigator. Returns false when
+ * the Reports tab is topmost but shows only the empty Inbox sidebar.
+ *
+ * The read falls back to the preserved navigator state because the split's live state can be stripped to
+ * preserved-only inside the onboarding microtask. Without that fallback a deep-linked report is missed and
+ * the user gets sent to Home.
+ */
+function isReportRevealedInTopmostSplitNavigator(): boolean {
+    const topmostFullScreenRoute = getTopmostFullScreenRoute();
+
+    // getTopmostFullScreenRoute applies the tab-level preserved-state fallback, so this stays correct when
+    // the live tab state has been stripped.
+    if (topmostFullScreenRoute?.name !== NAVIGATORS.REPORTS_SPLIT_NAVIGATOR) {
+        return false;
+    }
+
+    // Read the split's live inner routes first, then fall back to the preserved state keyed on the split
+    // route's key.
+    const innerRoutes: ReadonlyArray<{name: string}> | undefined =
+        topmostFullScreenRoute.state?.routes ?? (topmostFullScreenRoute.key ? getPreservedNavigatorState(topmostFullScreenRoute.key)?.routes : undefined);
+
+    // Only a report counts as revealed. The Inbox sidebar on its own does not.
+    return !!innerRoutes?.some((route) => route.name === SCREENS.REPORT);
+}
+
+export default isReportRevealedInTopmostSplitNavigator;

--- a/src/libs/navigateAfterOnboarding.ts
+++ b/src/libs/navigateAfterOnboarding.ts
@@ -13,7 +13,7 @@ import Onyx from 'react-native-onyx';
 import {setDisableDismissOnEscape} from './actions/Modal';
 import SidePanelActions from './actions/SidePanel';
 import {setOnboardingRHPVariant} from './actions/Welcome';
-import isReportTopmostSplitNavigator from './Navigation/helpers/isReportTopmostSplitNavigator';
+import isReportRevealedInTopmostSplitNavigator from './Navigation/helpers/isReportRevealedInTopmostSplitNavigator';
 import {dismissOnboardingModalBeforeExit} from './Navigation/helpers/OnboardingNavigationUtils';
 import shouldOpenOnAdminRoom from './Navigation/helpers/shouldOpenOnAdminRoom';
 import Navigation from './Navigation/Navigation';
@@ -108,7 +108,7 @@ function navigateAfterOnboarding(
     );
     if (reportID) {
         Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(reportID), navigationOptions);
-    } else if (!isReportTopmostSplitNavigator()) {
+    } else if (!isReportRevealedInTopmostSplitNavigator()) {
         // Navigate to home to trigger guard evaluation
         Navigation.navigate(ROUTES.HOME, navigationOptions);
     }

--- a/tests/unit/components/SidePanel/RHPVariantTest.test.ts
+++ b/tests/unit/components/SidePanel/RHPVariantTest.test.ts
@@ -6,7 +6,7 @@ import ROUTES from '@src/ROUTES';
 
 import type * as RHPVariantTest from '../../../../src/components/SidePanel/RHPVariantTest/index';
 
-const mockIsReportTopmostSplitNavigator = jest.fn(() => false);
+const mockIsReportRevealedInTopmostSplitNavigator = jest.fn<boolean, []>(() => false);
 
 jest.mock('@expensify/react-native-hybrid-app', () => ({
     __esModule: true,
@@ -35,9 +35,9 @@ jest.mock('react-native-onyx', () => ({
     },
 }));
 
-jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator', () => ({
+jest.mock('@libs/Navigation/helpers/isReportRevealedInTopmostSplitNavigator', () => ({
     __esModule: true,
-    default: () => mockIsReportTopmostSplitNavigator(),
+    default: () => mockIsReportRevealedInTopmostSplitNavigator(),
 }));
 
 jest.mock('@libs/Navigation/Navigation', () => ({
@@ -59,11 +59,11 @@ const {handleRHPVariantNavigation} = jest.requireActual<typeof RHPVariantTest>('
 describe('handleRHPVariantNavigation', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        mockIsReportTopmostSplitNavigator.mockReturnValue(false);
+        mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(false);
     });
 
-    it('preserves the topmost report for the rhpHomePage variant', () => {
-        mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+    it('preserves the revealed report for the rhpHomePage variant', () => {
+        mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(true);
 
         handleRHPVariantNavigation('policyID', CONST.ONBOARDING_RHP_VARIANT.RHP_HOME_PAGE);
 
@@ -71,15 +71,15 @@ describe('handleRHPVariantNavigation', () => {
         expect(SidePanelActions.openSidePanel).toHaveBeenCalledWith(true);
     });
 
-    it('navigates home for the rhpHomePage variant when no report is topmost', () => {
+    it('navigates home for the rhpHomePage variant when no report is revealed', () => {
         handleRHPVariantNavigation('policyID', CONST.ONBOARDING_RHP_VARIANT.RHP_HOME_PAGE);
 
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.HOME, undefined);
         expect(SidePanelActions.openSidePanel).toHaveBeenCalledWith(true);
     });
 
-    it('preserves the topmost report for the trackExpensesWithConcierge variant and opens the side panel on top of it', () => {
-        mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+    it('preserves the revealed report for the trackExpensesWithConcierge variant and opens the side panel on top of it', () => {
+        mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(true);
 
         handleRHPVariantNavigation('policyID', CONST.ONBOARDING_RHP_VARIANT.TRACK_EXPENSES_WITH_CONCIERGE);
 
@@ -87,7 +87,9 @@ describe('handleRHPVariantNavigation', () => {
         expect(SidePanelActions.openSidePanel).toHaveBeenCalledWith(true);
     });
 
-    it('navigates home for the trackExpensesWithConcierge variant when no report is topmost', () => {
+    it('navigates home for the trackExpensesWithConcierge variant when the Inbox tab is topmost but no report is revealed', () => {
+        // Reproduces the reported bug. The Reports split navigator is topmost but shows only the empty Inbox
+        // sidebar, so onboarding must still land the user on Home.
         handleRHPVariantNavigation('policyID', CONST.ONBOARDING_RHP_VARIANT.TRACK_EXPENSES_WITH_CONCIERGE);
 
         expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.HOME, undefined);

--- a/tests/unit/navigateAfterOnboardingTest.ts
+++ b/tests/unit/navigateAfterOnboardingTest.ts
@@ -111,7 +111,6 @@ describe('navigateAfterOnboarding', () => {
 
     it('should preserve the revealed report if onboardingAdminsChatReportID is not provided on larger screens', () => {
         const navigate = jest.spyOn(Navigation, 'navigate');
-        // A report is revealed in the topmost split navigator, so the user should stay on it.
         mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(true);
 
         navigateAfterOnboarding(false, true, '', {}, undefined, undefined);
@@ -120,8 +119,6 @@ describe('navigateAfterOnboarding', () => {
 
     it('should navigate to home when the Inbox tab is topmost but no report is revealed on larger screens', () => {
         const navigate = jest.spyOn(Navigation, 'navigate');
-        // The Reports split navigator is topmost but shows only the empty Inbox sidebar, so the onboarding
-        // user must still land on Home.
         mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(false);
 
         navigateAfterOnboarding(false, true, '', {}, undefined, undefined);

--- a/tests/unit/navigateAfterOnboardingTest.ts
+++ b/tests/unit/navigateAfterOnboardingTest.ts
@@ -21,7 +21,7 @@ const REPORT_ID = '3';
 const USER_ID = '4';
 const mockFindLastAccessedReport = jest.fn<OnyxEntry<Report>, Parameters<typeof ReportUtils.findLastAccessedReport>>();
 const mockShouldOpenOnAdminRoom = jest.fn();
-const mockIsReportTopmostSplitNavigator = jest.fn(() => false);
+const mockIsReportRevealedInTopmostSplitNavigator = jest.fn<boolean, []>(() => false);
 
 jest.mock('@expensify/react-native-hybrid-app', () => ({
     __esModule: true,
@@ -74,9 +74,9 @@ jest.mock('@libs/Navigation/helpers/shouldOpenOnAdminRoom', () => ({
     default: () => mockShouldOpenOnAdminRoom() as boolean,
 }));
 
-jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator', () => ({
+jest.mock('@libs/Navigation/helpers/isReportRevealedInTopmostSplitNavigator', () => ({
     __esModule: true,
-    default: () => mockIsReportTopmostSplitNavigator(),
+    default: () => mockIsReportRevealedInTopmostSplitNavigator(),
 }));
 
 describe('navigateAfterOnboarding', () => {
@@ -88,7 +88,7 @@ describe('navigateAfterOnboarding', () => {
 
     beforeEach(async () => {
         jest.clearAllMocks();
-        mockIsReportTopmostSplitNavigator.mockReturnValue(false);
+        mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(false);
         return Onyx.clear();
     });
 
@@ -109,12 +109,23 @@ describe('navigateAfterOnboarding', () => {
         expect(navigate).toHaveBeenCalledWith(ROUTES.HOME, undefined);
     });
 
-    it('should preserve the topmost report if onboardingAdminsChatReportID is not provided on larger screens', () => {
+    it('should preserve the revealed report if onboardingAdminsChatReportID is not provided on larger screens', () => {
         const navigate = jest.spyOn(Navigation, 'navigate');
-        mockIsReportTopmostSplitNavigator.mockReturnValue(true);
+        // A report is revealed in the topmost split navigator, so the user should stay on it.
+        mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(true);
 
         navigateAfterOnboarding(false, true, '', {}, undefined, undefined);
         expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('should navigate to home when the Inbox tab is topmost but no report is revealed on larger screens', () => {
+        const navigate = jest.spyOn(Navigation, 'navigate');
+        // The Reports split navigator is topmost but shows only the empty Inbox sidebar, so the onboarding
+        // user must still land on Home.
+        mockIsReportRevealedInTopmostSplitNavigator.mockReturnValue(false);
+
+        navigateAfterOnboarding(false, true, '', {}, undefined, undefined);
+        expect(navigate).toHaveBeenCalledWith(ROUTES.HOME, undefined);
     });
 
     it('should not navigate to last accessed report if it is a concierge chat on small screens', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
After onboarding with "Track expenses for my business", some users landed on the empty Inbox instead of Home. The guard at the onboarding call sites used `isReportTopmostSplitNavigator()`, which only checks whether the Reports tab is topmost, not whether it actually shows a report. When a fresh onboarding user's base tab happened to be the empty Inbox, the guard treated that as a report worth preserving, skipped `Navigation.navigate(ROUTES.HOME)`, and left the user stranded on Inbox. The outcome was intermittent because it depended on which tab was the base of the tab navigator when onboarding started.

This PR adds `isReportRevealedInTopmostSplitNavigator()` in `src/libs/Navigation/helpers/`, which also requires a `SCREENS.REPORT` route in the split's inner routes before treating it as revealed. It replaces the guard at both call sites in `RHPVariantTest/index.ts` and at the fallback gate in `navigateAfterOnboarding.ts`. `isReportTopmostSplitNavigator` is left untouched, since the IOU flows and `SignInModal` still call it directly for unrelated checks.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/663126
PROPOSAL: https://github.com/Expensify/Expensify/issues/663126#issuecomment-5074382682

### Tests
1. Sign in as a new user and start onboarding.
2. Select "Track expenses for my business" and complete onboarding.
3. Verify you land on Home, not the empty Inbox. Repeat a few times, since the original bug was intermittent and depended on which tab was the base of the split navigator when onboarding started.
4. Deep-link into an existing report before starting onboarding, complete the same onboarding flow, and verify that report is still shown instead of being replaced by Home. Repeat on both a small and a large screen.

New automated regression tests cover the same two scenarios: `tests/unit/components/SidePanel/RHPVariantTest.test.ts` and `tests/unit/navigateAfterOnboardingTest.ts` each gained a case asserting that an onboarding user whose Reports tab shows only the empty Inbox sidebar still lands on Home, alongside the existing cases that a genuinely revealed report is preserved.

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A. This change only affects which route onboarding navigates to, and it reads navigation state that is already local.

### QA Steps
1. On staging, create a new account and go through onboarding.
2. Select "Track expenses for my business" and complete onboarding.
3. Verify you land on the Home tab, not an empty Inbox. Repeat a few times, since the original bug appeared intermittently.
4. Open an existing report via a deep link, then start a new onboarding flow and complete it. Verify the deep-linked report stays open instead of being replaced by Home.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
