### PR TITLE
Fix: URL descriptions render as raw Markdown in modified expense system message

### DIFF
--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -18,7 +18,6 @@ import DateUtils from './DateUtils';
 import {getEnvironmentURL} from './Environment/Environment';
 import {formatList} from './Localize';
 import Log from './Log';
-import Parser from './Parser';
 import {getPersonalDetailByEmail} from './PersonalDetailsUtils';
 import {
     arePolicyRulesEnabled,
@@ -248,7 +247,7 @@ function getRulesModifiedMessage(
         }
         // The backend saves the description field as `comment` key, but we need to display it as `description` key.
         if (key === 'comment') {
-            return translate('iou.rulesModifiedFields.common', 'description', Parser.htmlToMarkdown(updatedValue), isFirst);
+            return translate('iou.rulesModifiedFields.common', 'description', updatedValue, isFirst);
         }
 
         return translate('iou.rulesModifiedFields.common', key, updatedValue, isFirst);
@@ -362,8 +361,8 @@ function getForReportAction({
 
         buildMessageFragmentForValue(
             translate,
-            Parser.htmlToMarkdown(reportActionOriginalMessage?.newComment ?? ''),
-            Parser.htmlToMarkdown(reportActionOriginalMessage?.oldComment ?? ''),
+            reportActionOriginalMessage?.newComment ?? '',
+            reportActionOriginalMessage?.oldComment ?? '',
             descriptionLabel,
             true,
             setFragments,

--- a/tests/unit/ModifiedExpenseMessageTest.ts
+++ b/tests/unit/ModifiedExpenseMessageTest.ts
@@ -1031,6 +1031,33 @@ describe('ModifiedExpenseMessage', () => {
             });
         });
 
+        describe('when the description is changed to a URL', () => {
+            const reportAction = {
+                ...createRandomReportAction(1),
+                actionName: CONST.REPORT.ACTIONS.TYPE.MODIFIED_EXPENSE,
+                originalMessage: {
+                    oldComment: '<a href="https://old.example.com" target="_blank">https://old.example.com</a>',
+                    newComment: '<a href="https://new.example.com" target="_blank">https://new.example.com</a>',
+                },
+            };
+
+            it('keeps the stored HTML link instead of converting it to Markdown', () => {
+                const expectedResult =
+                    'changed the description to "<a href="https://new.example.com" target="_blank">https://new.example.com</a>" (previously "<a href="https://old.example.com" target="_blank">https://old.example.com</a>")';
+
+                const result = getForReportAction({
+                    convertToDisplayString,
+                    translate: translateLocal,
+                    reportAction,
+                    policy: undefined,
+                    policyTags: undefined,
+                    currentUserLogin: CURRENT_USER_LOGIN,
+                });
+
+                expect(result).toEqual(expectedResult);
+            });
+        });
+
         describe('when the category is changed with AI attribution', () => {
             const reportAction = {
                 ...createRandomReportAction(1),


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
When an expense description containing a URL is added or updated, the "changed the description to …" system message showed the link as raw Markdown (`[text](url)`) instead of a clickable hyperlink.

Root cause: `ModifiedExpenseMessage.ts` builds an HTML message, but the description fragment was the one field that converted the stored HTML description to Markdown via `Parser.htmlToMarkdown` before building the fragment. Every consumer of this message (chat `RenderHTML`, LHN last-message preview, report/thread preview name, browser notifications, copy-to-clipboard) already treats the return value as HTML, so the stray Markdown conversion corrupted the description field specifically.

Fix: stop converting the stored HTML to Markdown at both call sites in `ModifiedExpenseMessage.ts` (`getForReportAction` and `getRulesModifiedMessage`), and pass the HTML through directly. Each consumer's existing HTML-to-X conversion then produces correct output.

### Fixed Issues
$ https://github.com/Expensify/App/issues/96687
PROPOSAL: https://github.com/Expensify/App/issues/96687#issuecomment-5057617966

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. Create an expense (e.g. Track/Submit an expense to yourself).
2. Set the description to a URL, e.g. `https://old.example.com`.
3. Edit the description again to a different URL, e.g. `https://new.example.com`.
4. Verify the resulting "changed the description to …" system message renders both the old and new descriptions as clickable hyperlinks, not raw `[text](url)` Markdown text.
5. Verify the LHN last-message preview and thread name show clean plain text (no visible Markdown syntax).

- [x] Verify that no errors appear in the JS console

### Offline tests
Description edits are queued optimistically offline and the message is rendered client-side from Onyx data, so behavior is unaffected by network state. Repeat the Tests steps above with the network throttled/offline in dev tools; the system message renders identically once the edit is applied optimistically.

### QA Steps
1. Create an expense.
2. Set its description to a URL.
3. Edit the description to a different URL.
4. Verify the "changed the description" message in the chat renders both URLs as clickable links (not raw Markdown).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
<img width="324" height="720" alt="2-android-native-FIXED" src="https://github.com/user-attachments/assets/d1dabc44-3765-4ce6-a7bd-69167e6e1229" />

Verified on Android emulator (native app, Metro dev build): the system message renders both URLs as clickable links instead of raw Markdown.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="324" height="720" alt="4-android-mweb-chrome-FIXED" src="https://github.com/user-attachments/assets/2fcf0fbb-2fb8-4048-bd45-137c2fa472c6" />

</details>

<details>
<summary>iOS: Native</summary>
<img width="362" height="787" alt="1-ios-native-FIXED" src="https://github.com/user-attachments/assets/10a76663-5336-4d97-b913-fd04d1b54987" />


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="362" height="787" alt="3-ios-mweb-safari-FIXED" src="https://github.com/user-attachments/assets/427f5444-5c6c-4fa4-81ec-d200d1d1954e" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="800" height="1219" alt="Screenshot 2026-08-05 at 3 56 48 AM" src="https://github.com/user-attachments/assets/96436bce-8a42-4c9c-8857-633c7c6d186e" />


</details>

