### PR TITLE
Handle edge case for chore: replace deprecated importsnotuse

### DIFF
--- a/modules/group-ib-fp/tsconfig.json
+++ b/modules/group-ib-fp/tsconfig.json
@@ -7,7 +7,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "lib": ["esnext"],


### PR DESCRIPTION
Replaced the deprecated `importsNotUsedAsValues` compiler option in the group-ib-fp module's tsconfig.json with `verbatimModuleSyntax` to resolve compilation errors in modern TypeScript versions (5.5+ / 6.x).