### PR TITLE
Concierge HTML tables: make the whole row clickable and align styling with other tables

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8430,6 +8430,7 @@ const CONST = {
             IMAGE: 'HTMLRenderer-Image',
             PRE: 'HTMLRenderer-Pre',
             VICTORY_CHART_EXPAND_BUTTON: 'HTMLRenderer-VictoryChartExpandButton',
+            TABLE_ROW: 'HTMLRenderer-TableRow',
         },
         RECEIPT: {
             IMAGE: 'Receipt-Image',

--- a/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.tsx
@@ -19,8 +19,11 @@ import type {StyleProp, TextStyle} from 'react-native';
 import type {CustomRendererProps, TPhrasing, TText} from 'react-native-render-html';
 
 import {Str} from 'expensify-common';
-import React, {useMemo} from 'react';
+import React, {useContext, useMemo} from 'react';
 import {TNodeChildrenRenderer} from 'react-native-render-html';
+
+import TableLinkColumnContext from './TableLinkColumnContext';
+import {getTextContent, isLinkColumnAnchor} from './TableRowLink';
 
 type AnchorRendererProps = CustomRendererProps<TText | TPhrasing> & {
     /** Key of the element */
@@ -47,6 +50,7 @@ function AnchorRenderer({tnode, style, key}: AnchorRendererProps) {
 
     const isDeleted = HTMLEngineUtils.isDeletedNode(tnode);
     const isChildOfTaskTitle = HTMLEngineUtils.isChildOfTaskTitle(tnode);
+    const linkColumnIndex = useContext(TableLinkColumnContext);
 
     const textDecorationLineStyle = isDeleted ? styles.lineThrough : {};
 
@@ -61,6 +65,12 @@ function AnchorRenderer({tnode, style, key}: AnchorRendererProps) {
 
         return undefined;
     }, [internalNewExpensifyPath, internalExpensifyPath, attrHref, environmentURL, isAttachment]);
+
+    // The table row already navigates to this link's destination, so the cell shows the link text as plain content
+    // rather than a second target styled as a link.
+    if (isLinkColumnAnchor(tnode, linkColumnIndex)) {
+        return <Text>{getTextContent(tnode)}</Text>;
+    }
 
     if (!HTMLEngineUtils.isChildOfComment(tnode) && !isChildOfTaskTitle) {
         // This is not a comment from a chat, the AnchorForCommentsOnly uses a Pressable to create a context menu on right click.

--- a/src/components/HTMLEngineProvider/HTMLRenderers/TableLinkColumnContext.ts
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/TableLinkColumnContext.ts
@@ -1,0 +1,10 @@
+import {createContext} from 'react';
+
+/**
+ * The column index whose links make each body row of the table currently being rendered navigable, or undefined when
+ * the table has no such column. `TableRenderer` derives it and shares it so the row renderer can navigate and the cell
+ * renderer can drop the now-redundant per-cell anchor.
+ */
+const TableLinkColumnContext = createContext<number | undefined>(undefined);
+
+export default TableLinkColumnContext;

--- a/src/components/HTMLEngineProvider/HTMLRenderers/TableRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/TableRenderer.tsx
@@ -11,6 +11,8 @@ import HTMLTableScroll from './HTMLTableScroll';
 import TableChildrenRenderer, {getElementChildren} from './TableChildrenRenderer';
 import TableColumnAlignmentContext from './TableColumnAlignmentContext';
 import TableContentWidthContext from './TableContentWidthContext';
+import TableLinkColumnContext from './TableLinkColumnContext';
+import {getLinkColumnIndex} from './TableRowLink';
 
 /**
  * Derives the horizontal alignment for each column from the table body. Concierge expense tables put the amount in
@@ -31,23 +33,27 @@ function getColumnAlignments(tableNode: TNode): CellHorizontalAlignment[] {
 
 function TableRenderer({tnode}: CustomRendererProps<TBlock>) {
     const columnAlignments = useMemo(() => getColumnAlignments(tnode), [tnode]);
+    const linkColumnIndex = useMemo(() => getLinkColumnIndex(tnode), [tnode]);
 
     // The comment-level width fills the message exactly; fall back to the HTML content width when the table is rendered
     // outside a comment. A concrete number is required because the scroller needs a fixed viewport and content width.
     const measuredContentWidth = useContext(TableContentWidthContext);
     const fallbackContentWidth = useContentWidth();
     const viewportWidth = measuredContentWidth || fallbackContentWidth;
-    const columnsWidth = columnAlignments.length * variables.htmlTableColumnMaxWidth + 2 * variables.tableRowPaddingHorizontal;
+    const chevronWidth = linkColumnIndex === undefined ? 0 : variables.htmlTableChevronColumnWidth;
+    const columnsWidth = columnAlignments.length * variables.htmlTableColumnMaxWidth + 2 * variables.tableRowPaddingHorizontal + chevronWidth;
     const contentWidth = Math.max(viewportWidth, columnsWidth);
 
     return (
         <TableColumnAlignmentContext.Provider value={columnAlignments}>
-            <HTMLTableScroll
-                viewportWidth={viewportWidth}
-                contentWidth={contentWidth}
-            >
-                <TableChildrenRenderer tnode={tnode} />
-            </HTMLTableScroll>
+            <TableLinkColumnContext.Provider value={linkColumnIndex}>
+                <HTMLTableScroll
+                    viewportWidth={viewportWidth}
+                    contentWidth={contentWidth}
+                >
+                    <TableChildrenRenderer tnode={tnode} />
+                </HTMLTableScroll>
+            </TableLinkColumnContext.Provider>
         </TableColumnAlignmentContext.Provider>
     );
 }

--- a/src/components/HTMLEngineProvider/HTMLRenderers/TableRowLink.ts
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/TableRowLink.ts
@@ -1,0 +1,82 @@
+import type {TNode} from 'react-native-render-html';
+
+import {getElementChildren} from './TableChildrenRenderer';
+
+function getBodyRows(tableTnode: TNode): TNode[] {
+    return getElementChildren(tableTnode)
+        .filter((section) => section.tagName === 'tbody')
+        .flatMap((section) => getElementChildren(section));
+}
+
+function findAnchor(node: TNode): TNode | undefined {
+    if (node.tagName === 'a') {
+        return node;
+    }
+    return (node.children ?? []).reduce<TNode | undefined>((found, child) => found ?? findAnchor(child), undefined);
+}
+
+/**
+ * The single column whose cells hold links, or undefined when the table has no such column.
+ *
+ * Concierge expense tables link one cell per row — the merchant — and that link points at the row's transaction, so
+ * the row as a whole can navigate there. Requiring the links to sit in exactly one column leaves any other table
+ * (no links, or links spread across columns) rendering as a plain table with its own per-cell anchors.
+ */
+function getLinkColumnIndex(tableTnode: TNode): number | undefined {
+    const columnsWithLinks = new Set<number>();
+    for (const row of getBodyRows(tableTnode)) {
+        for (const [columnIndex, cell] of getElementChildren(row).entries()) {
+            if (findAnchor(cell)) {
+                columnsWithLinks.add(columnIndex);
+            }
+        }
+    }
+
+    return columnsWithLinks.size === 1 ? columnsWithLinks.values().next().value : undefined;
+}
+
+/**
+ * Whether an anchor sits in the column whose links make the row navigable, in which case it renders as plain text
+ * instead of a link. The anchor can be nested any number of levels below its cell.
+ */
+function isLinkColumnAnchor(anchorTnode: TNode, linkColumnIndex: number | undefined): boolean {
+    if (linkColumnIndex === undefined) {
+        return false;
+    }
+
+    let cell = anchorTnode.parent;
+    while (cell && cell.tagName !== 'td') {
+        // A cell is never nested in another row, so reaching one means this anchor is not inside a body cell.
+        if (cell.tagName === 'tr') {
+            return false;
+        }
+        cell = cell.parent;
+    }
+
+    const row = cell?.parent;
+    if (!cell || row?.parent?.tagName !== 'tbody') {
+        return false;
+    }
+
+    return getElementChildren(row).indexOf(cell) === linkColumnIndex;
+}
+
+/** The plain text of a node, used to render a link column's cell without any of the anchor's own styling. */
+function getTextContent(node: TNode): string {
+    if ('data' in node && typeof node.data === 'string') {
+        return node.data;
+    }
+    return (node.children ?? []).map(getTextContent).join('');
+}
+
+/** The URL a row navigates to: the href of the link in the table's link column. */
+function getRowLinkURL(rowTnode: TNode, linkColumnIndex: number | undefined): string | undefined {
+    if (linkColumnIndex === undefined || rowTnode.parent?.tagName !== 'tbody') {
+        return undefined;
+    }
+
+    const linkCell = getElementChildren(rowTnode).at(linkColumnIndex);
+    return linkCell ? findAnchor(linkCell)?.attributes?.href : undefined;
+}
+
+export {getLinkColumnIndex, getRowLinkURL, getTextContent, isLinkColumnAnchor};

--- a/src/components/HTMLEngineProvider/HTMLRenderers/TableRowLink.ts
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/TableRowLink.ts
@@ -1,3 +1,7 @@
+/**
+ * Helpers for treating a table's link column as the link of each row: finding the single column whose cells hold
+ * links, resolving each row's destination, and spotting the anchor that renders as plain text because of it.
+ */
 import type {TNode} from 'react-native-render-html';
 
 import {getElementChildren} from './TableChildrenRenderer';
@@ -8,31 +12,49 @@ function getBodyRows(tableTnode: TNode): TNode[] {
         .flatMap((section) => getElementChildren(section));
 }
 
-function findAnchor(node: TNode): TNode | undefined {
+function getAnchors(node: TNode): TNode[] {
     if (node.tagName === 'a') {
-        return node;
+        return [node];
     }
-    return (node.children ?? []).reduce<TNode | undefined>((found, child) => found ?? findAnchor(child), undefined);
+    return (node.children ?? []).flatMap(getAnchors);
+}
+
+/** The destination of a cell, defined only when the cell holds exactly one link and that link has an href. */
+function getCellLinkURL(cell: TNode): string | undefined {
+    const anchors = getAnchors(cell);
+    if (anchors.length !== 1) {
+        return undefined;
+    }
+
+    return anchors.at(0)?.attributes?.href || undefined;
 }
 
 /**
  * The single column whose cells hold links, or undefined when the table has no such column.
  *
  * Concierge expense tables link one cell per row — the merchant — and that link points at the row's transaction, so
- * the row as a whole can navigate there. Requiring the links to sit in exactly one column leaves any other table
- * (no links, or links spread across columns) rendering as a plain table with its own per-cell anchors.
+ * the row as a whole can navigate there. Requiring the links to sit in exactly one column, each cell holding a single
+ * link with an href, leaves every other table (no links, links spread across columns, or a cell whose several links
+ * one row destination could not stand in for) rendering as a plain table with its own per-cell anchors.
  */
 function getLinkColumnIndex(tableTnode: TNode): number | undefined {
     const columnsWithLinks = new Set<number>();
+    let hasCellWithoutSingleLink = false;
     for (const row of getBodyRows(tableTnode)) {
         for (const [columnIndex, cell] of getElementChildren(row).entries()) {
-            if (findAnchor(cell)) {
-                columnsWithLinks.add(columnIndex);
+            if (getAnchors(cell).length === 0) {
+                continue;
             }
+            columnsWithLinks.add(columnIndex);
+            hasCellWithoutSingleLink = hasCellWithoutSingleLink || !getCellLinkURL(cell);
         }
     }
 
-    return columnsWithLinks.size === 1 ? columnsWithLinks.values().next().value : undefined;
+    if (hasCellWithoutSingleLink || columnsWithLinks.size !== 1) {
+        return undefined;
+    }
+
+    return columnsWithLinks.values().next().value;
 }
 
 /**
@@ -76,7 +98,7 @@ function getRowLinkURL(rowTnode: TNode, linkColumnIndex: number | undefined): st
     }
 
     const linkCell = getElementChildren(rowTnode).at(linkColumnIndex);
-    return linkCell ? findAnchor(linkCell)?.attributes?.href : undefined;
+    return linkCell ? getCellLinkURL(linkCell) : undefined;
 }
 
 export {getLinkColumnIndex, getRowLinkURL, getTextContent, isLinkColumnAnchor};

--- a/src/components/HTMLEngineProvider/HTMLRenderers/TableRowLink.ts
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/TableRowLink.ts
@@ -26,7 +26,8 @@ function getCellLinkURL(cell: TNode): string | undefined {
         return undefined;
     }
 
-    return anchors.at(0)?.attributes?.href || undefined;
+    const href = anchors.at(0)?.attributes?.href ?? '';
+    return href.length > 0 ? href : undefined;
 }
 
 /**

--- a/src/components/HTMLEngineProvider/HTMLRenderers/TableRowRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/TableRowRenderer.tsx
@@ -1,10 +1,25 @@
+import Icon from '@components/Icon';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
+import {showContextMenuForReport, useShowContextMenuActions, useShowContextMenuState} from '@components/ShowContextMenuContext';
+
+import useEnvironment from '@hooks/useEnvironment';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+
+import {openLink} from '@libs/actions/Link';
+
+import CONST from '@src/CONST';
 
 import type {CustomRendererProps, TBlock, TNode} from 'react-native-render-html';
 
+import {useContext} from 'react';
 import {View} from 'react-native';
 
 import TableChildrenRenderer, {getElementChildren} from './TableChildrenRenderer';
+import TableLinkColumnContext from './TableLinkColumnContext';
+import {getRowLinkURL} from './TableRowLink';
 
 function isLastRowOfTable(tnode: TNode): boolean {
     const section = tnode.parent;
@@ -19,14 +34,59 @@ function isLastRowOfTable(tnode: TNode): boolean {
 
 function TableRowRenderer({tnode}: CustomRendererProps<TBlock>) {
     const styles = useThemeStyles();
+    const theme = useTheme();
+    const {translate} = useLocalize();
+    const {environmentURL} = useEnvironment();
+    const icons = useMemoizedLazyExpensifyIcons(['ArrowRight']);
+    const {anchor, report, action, originalReportID} = useShowContextMenuState();
+    const {onShowContextMenu, checkIfContextMenuActive} = useShowContextMenuActions();
 
     // Header rows (inside <thead>) use header padding; body rows use the compact min-height.
     const isHeaderRow = tnode.parent?.tagName === 'thead';
+    const linkColumnIndex = useContext(TableLinkColumnContext);
+    const rowLinkURL = getRowLinkURL(tnode, linkColumnIndex);
+
+    const rowStyle = [isHeaderRow ? styles.htmlTableHeaderRow : styles.htmlTableRow, isLastRowOfTable(tnode) && styles.htmlTableLastRow];
+
+    // Every row of a table with a link column reserves the chevron width so the columns stay aligned, but only a row
+    // that actually navigates shows the chevron.
+    const chevron =
+        linkColumnIndex === undefined ? null : (
+            <View style={styles.htmlTableChevronCell}>
+                {!!rowLinkURL && (
+                    <Icon
+                        src={icons.ArrowRight}
+                        fill={theme.icon}
+                        size={CONST.ICON_SIZE.SMALL}
+                    />
+                )}
+            </View>
+        );
+
+    if (!rowLinkURL) {
+        return (
+            <View style={rowStyle}>
+                <TableChildrenRenderer tnode={tnode} />
+                {chevron}
+            </View>
+        );
+    }
 
     return (
-        <View style={[isHeaderRow ? styles.htmlTableHeaderRow : styles.htmlTableRow, isLastRowOfTable(tnode) && styles.htmlTableLastRow]}>
+        <PressableWithoutFeedback
+            style={rowStyle}
+            hoverStyle={styles.htmlTableRowHovered}
+            onPress={() => openLink(rowLinkURL, environmentURL)}
+            onLongPress={(event) => onShowContextMenu(() => showContextMenuForReport(event, anchor, report?.reportID, action, checkIfContextMenuActive, originalReportID))}
+            role={CONST.ROLE.BUTTON}
+            accessibilityLabel={translate('iou.viewDetails')}
+            sentryLabel={CONST.SENTRY_LABEL.HTML_RENDERER.TABLE_ROW}
+            shouldUseHapticsOnLongPress
+            isNested
+        >
             <TableChildrenRenderer tnode={tnode} />
-        </View>
+            {chevron}
+        </PressableWithoutFeedback>
     );
 }
 

--- a/src/components/HTMLEngineProvider/HTMLRenderers/TableRowRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/TableRowRenderer.tsx
@@ -3,12 +3,15 @@ import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeed
 import {showContextMenuForReport, useShowContextMenuActions, useShowContextMenuState} from '@components/ShowContextMenuContext';
 
 import useEnvironment from '@hooks/useEnvironment';
+import useHover from '@hooks/useHover';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {openLink} from '@libs/actions/Link';
+
+import variables from '@styles/variables';
 
 import CONST from '@src/CONST';
 
@@ -19,7 +22,7 @@ import {View} from 'react-native';
 
 import TableChildrenRenderer, {getElementChildren} from './TableChildrenRenderer';
 import TableLinkColumnContext from './TableLinkColumnContext';
-import {getRowLinkURL} from './TableRowLink';
+import {getRowLinkURL, getTextContent} from './TableRowLink';
 
 function isLastRowOfTable(tnode: TNode): boolean {
     const section = tnode.parent;
@@ -32,12 +35,21 @@ function isLastRowOfTable(tnode: TNode): boolean {
     return sectionRows.at(-1) === tnode && tableSections.at(-1) === section;
 }
 
+/** The row read out as its cells, e.g. `Airbnb, 2026-06-02, £404.60`. */
+function getRowCellsText(rowTnode: TNode): string {
+    return getElementChildren(rowTnode)
+        .map((cell) => getTextContent(cell).trim())
+        .filter((cellText) => cellText.length > 0)
+        .join(', ');
+}
+
 function TableRowRenderer({tnode}: CustomRendererProps<TBlock>) {
     const styles = useThemeStyles();
     const theme = useTheme();
     const {translate} = useLocalize();
     const {environmentURL} = useEnvironment();
     const icons = useMemoizedLazyExpensifyIcons(['ArrowRight']);
+    const {hovered, bind} = useHover();
     const {anchor, report, action, originalReportID} = useShowContextMenuState();
     const {onShowContextMenu, checkIfContextMenuActive} = useShowContextMenuActions();
 
@@ -57,7 +69,9 @@ function TableRowRenderer({tnode}: CustomRendererProps<TBlock>) {
                     <Icon
                         src={icons.ArrowRight}
                         fill={theme.icon}
-                        size={CONST.ICON_SIZE.SMALL}
+                        additionalStyles={!hovered && styles.opacitySemiTransparent}
+                        width={variables.iconSizeNormal}
+                        height={variables.iconSizeNormal}
                     />
                 )}
             </View>
@@ -79,10 +93,12 @@ function TableRowRenderer({tnode}: CustomRendererProps<TBlock>) {
             onPress={() => openLink(rowLinkURL, environmentURL)}
             onLongPress={(event) => onShowContextMenu(() => showContextMenuForReport(event, anchor, report?.reportID, action, checkIfContextMenuActive, originalReportID))}
             role={CONST.ROLE.BUTTON}
-            accessibilityLabel={translate('iou.viewDetails')}
+            accessibilityLabel={getRowCellsText(tnode) || translate('iou.viewDetails')}
+            accessibilityHint={translate('iou.viewDetails')}
             sentryLabel={CONST.SENTRY_LABEL.HTML_RENDERER.TABLE_ROW}
             shouldUseHapticsOnLongPress
             isNested
+            {...bind}
         >
             <TableChildrenRenderer tnode={tnode} />
             {chevron}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -2724,6 +2724,17 @@ const staticStyles = (theme: ThemeColors) =>
             borderBottomWidth: 0,
         },
 
+        // A step past the hover background the surrounding comment uses, so a hovered row stays distinguishable
+        // while the whole comment is also highlighted.
+        htmlTableRowHovered: {
+            backgroundColor: theme.activeComponentBG,
+        },
+
+        htmlTableChevronCell: {
+            width: variables.htmlTableChevronColumnWidth,
+            alignItems: 'flex-end',
+        },
+
         htmlTableCell: {
             // A definite flexBasis with flexShrink: 0 gives every column a fixed width so a wide table keeps its size
             // and can be scrolled horizontally, and columns stay aligned across rows; flexGrow: 1 still lets columns

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -141,6 +141,7 @@ export default {
     htmlTableHeaderRowMinHeight: 30,
     htmlTableColumnMinWidth: 120,
     htmlTableColumnMaxWidth: 240,
+    htmlTableChevronColumnWidth: 20,
     tableGroupRowPaddingVertical: 4,
     tableGroupRowHeight: 36,
     tableCheckboxColumnWidth: 20,

--- a/tests/unit/TableRowLinkTest.ts
+++ b/tests/unit/TableRowLinkTest.ts
@@ -1,0 +1,153 @@
+import {getLinkColumnIndex, getRowLinkURL, getTextContent, isLinkColumnAnchor} from '@components/HTMLEngineProvider/HTMLRenderers/TableRowLink';
+
+import type {TNode} from 'react-native-render-html';
+
+type FakeNode = {
+    tagName?: string;
+    data?: string;
+    children: FakeNode[];
+    parent?: FakeNode;
+    attributes?: Record<string, string>;
+};
+
+function node(tagName: string, children: FakeNode[] = [], attributes: Record<string, string> = {}): FakeNode {
+    const created: FakeNode = {tagName, children, attributes};
+    children.forEach((child) => {
+        // eslint-disable-next-line no-param-reassign
+        child.parent = created;
+    });
+    return created;
+}
+
+function text(data: string): FakeNode {
+    return {data, children: []};
+}
+
+function link(label: string, href: string): FakeNode {
+    return node('a', [text(label)], {href});
+}
+
+/** A table whose rows hold the given cells, e.g. `table([[link('Airbnb', url), text('£10')]])`. */
+function table(rows: FakeNode[][]): FakeNode {
+    const bodyRows = rows.map((cells) =>
+        node(
+            'tr',
+            cells.map((cell) => node('td', [cell])),
+        ),
+    );
+    return node('table', [node('thead', [node('tr', [node('th', [text('Merchant')]), node('th', [text('Amount')])])]), node('tbody', bodyRows)]);
+}
+
+function bodyRowAt(tableNode: FakeNode, index: number): TNode {
+    const body = tableNode.children.find((child) => child.tagName === 'tbody');
+    return body?.children.at(index) as unknown as TNode;
+}
+
+const AIRBNB_URL = 'https://new.expensify.com/r/8412';
+const UBER_URL = 'https://new.expensify.com/r/8413';
+
+describe('getLinkColumnIndex', () => {
+    it('returns the column holding the links when every link sits in one column', () => {
+        const expenseTable = table([
+            [link('Airbnb', AIRBNB_URL), text('£404.60')],
+            [link('Uber', UBER_URL), text('£15.93')],
+        ]);
+
+        expect(getLinkColumnIndex(expenseTable as unknown as TNode)).toBe(0);
+    });
+
+    it('returns the column even when only some rows carry a link', () => {
+        const expenseTable = table([
+            [link('Airbnb', AIRBNB_URL), text('£404.60')],
+            [text('Uber'), text('£15.93')],
+        ]);
+
+        expect(getLinkColumnIndex(expenseTable as unknown as TNode)).toBe(0);
+    });
+
+    it('returns undefined for a table with no links', () => {
+        const plainTable = table([[text('Airbnb'), text('£404.60')]]);
+
+        expect(getLinkColumnIndex(plainTable as unknown as TNode)).toBeUndefined();
+    });
+
+    it('returns undefined when links are spread across columns', () => {
+        const mixedTable = table([[link('Airbnb', AIRBNB_URL), link('£404.60', UBER_URL)]]);
+
+        expect(getLinkColumnIndex(mixedTable as unknown as TNode)).toBeUndefined();
+    });
+});
+
+describe('getRowLinkURL', () => {
+    it('returns the href of the link column cell', () => {
+        const expenseTable = table([
+            [link('Airbnb', AIRBNB_URL), text('£404.60')],
+            [link('Uber', UBER_URL), text('£15.93')],
+        ]);
+
+        expect(getRowLinkURL(bodyRowAt(expenseTable, 0), 0)).toBe(AIRBNB_URL);
+        expect(getRowLinkURL(bodyRowAt(expenseTable, 1), 0)).toBe(UBER_URL);
+    });
+
+    it('returns undefined for a row with no link in that column', () => {
+        const expenseTable = table([
+            [link('Airbnb', AIRBNB_URL), text('£404.60')],
+            [text('Uber'), text('£15.93')],
+        ]);
+
+        expect(getRowLinkURL(bodyRowAt(expenseTable, 1), 0)).toBeUndefined();
+    });
+
+    it('returns undefined when the table has no link column', () => {
+        const expenseTable = table([[link('Airbnb', AIRBNB_URL), text('£404.60')]]);
+
+        expect(getRowLinkURL(bodyRowAt(expenseTable, 0), undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for a header row', () => {
+        const expenseTable = table([[link('Airbnb', AIRBNB_URL), text('£404.60')]]);
+        const headerRow = expenseTable.children.find((child) => child.tagName === 'thead')?.children.at(0);
+
+        expect(getRowLinkURL(headerRow as unknown as TNode, 0)).toBeUndefined();
+    });
+});
+
+describe('isLinkColumnAnchor', () => {
+    it('recognizes an anchor nested below its cell, as the render tree wraps inline content', () => {
+        const anchor = link('Airbnb', AIRBNB_URL);
+        const wrapped = node('td', [node('span', [anchor])]);
+        const row = node('tr', [wrapped, node('td', [text('£404.60')])]);
+        node('table', [node('tbody', [row])]);
+
+        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(true);
+    });
+
+    it('leaves an anchor in another column alone', () => {
+        const anchor = link('£404.60', UBER_URL);
+        const row = node('tr', [node('td', [text('Airbnb')]), node('td', [anchor])]);
+        node('table', [node('tbody', [row])]);
+
+        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(false);
+    });
+
+    it('leaves an anchor outside a table alone', () => {
+        const anchor = link('Insight', 'https://new.expensify.com/search?q=');
+        node('div', [anchor]);
+
+        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(false);
+    });
+
+    it('leaves a header anchor alone', () => {
+        const anchor = link('Merchant', AIRBNB_URL);
+        const headerRow = node('tr', [node('th', [anchor]), node('th', [text('Amount')])]);
+        node('table', [node('thead', [headerRow])]);
+
+        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(false);
+    });
+});
+
+describe('getTextContent', () => {
+    it('joins the text of every descendant', () => {
+        expect(getTextContent(node('td', [node('strong', [text('Amazon ')]), text('web services')]) as unknown as TNode)).toBe('Amazon web services');
+    });
+});

--- a/tests/unit/TableRowLinkTest.ts
+++ b/tests/unit/TableRowLinkTest.ts
@@ -76,6 +76,18 @@ describe('getLinkColumnIndex', () => {
 
         expect(getLinkColumnIndex(mixedTable as unknown as TNode)).toBeUndefined();
     });
+
+    it('returns undefined when a cell holds more than one link, since one row destination cannot stand in for both', () => {
+        const twoLinkCellTable = table([[node('span', [link('Airbnb', AIRBNB_URL), link('Uber', UBER_URL)]), text('£404.60')]]);
+
+        expect(getLinkColumnIndex(twoLinkCellTable as unknown as TNode)).toBeUndefined();
+    });
+
+    it('returns undefined when the linked cell has an anchor without an href', () => {
+        const hreflessTable = table([[node('a', [text('Airbnb')]), text('£404.60')]]);
+
+        expect(getLinkColumnIndex(hreflessTable as unknown as TNode)).toBeUndefined();
+    });
 });
 
 describe('getRowLinkURL', () => {

--- a/tests/unit/TableRowLinkTest.ts
+++ b/tests/unit/TableRowLinkTest.ts
@@ -10,12 +10,17 @@ type FakeNode = {
     attributes?: Record<string, string>;
 };
 
+/** Hands a fake to the code under test, which reads only tagName, data, children, parent and attributes. */
+function asTNode(fakeNode: FakeNode | undefined): TNode {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- minimal mock that only exposes the fields the helpers read
+    return fakeNode as unknown as TNode;
+}
+
 function node(tagName: string, children: FakeNode[] = [], attributes: Record<string, string> = {}): FakeNode {
     const created: FakeNode = {tagName, children, attributes};
-    children.forEach((child) => {
-        // eslint-disable-next-line no-param-reassign
+    for (const child of children) {
         child.parent = created;
-    });
+    }
     return created;
 }
 
@@ -27,7 +32,7 @@ function link(label: string, href: string): FakeNode {
     return node('a', [text(label)], {href});
 }
 
-/** A table whose rows hold the given cells, e.g. `table([[link('Airbnb', url), text('£10')]])`. */
+/** A table whose body rows hold the given cells, e.g. `table([[link('Airbnb', url), text('£10')]])`. */
 function table(rows: FakeNode[][]): FakeNode {
     const bodyRows = rows.map((cells) =>
         node(
@@ -38,9 +43,12 @@ function table(rows: FakeNode[][]): FakeNode {
     return node('table', [node('thead', [node('tr', [node('th', [text('Merchant')]), node('th', [text('Amount')])])]), node('tbody', bodyRows)]);
 }
 
-function bodyRowAt(tableNode: FakeNode, index: number): TNode {
-    const body = tableNode.children.find((child) => child.tagName === 'tbody');
-    return body?.children.at(index) as unknown as TNode;
+function sectionOf(tableNode: FakeNode, tagName: string): FakeNode | undefined {
+    return tableNode.children.find((child) => child.tagName === tagName);
+}
+
+function bodyRowAt(tableNode: FakeNode, index: number): FakeNode | undefined {
+    return sectionOf(tableNode, 'tbody')?.children.at(index);
 }
 
 const AIRBNB_URL = 'https://new.expensify.com/r/8412';
@@ -53,7 +61,7 @@ describe('getLinkColumnIndex', () => {
             [link('Uber', UBER_URL), text('£15.93')],
         ]);
 
-        expect(getLinkColumnIndex(expenseTable as unknown as TNode)).toBe(0);
+        expect(getLinkColumnIndex(asTNode(expenseTable))).toBe(0);
     });
 
     it('returns the column even when only some rows carry a link', () => {
@@ -62,31 +70,31 @@ describe('getLinkColumnIndex', () => {
             [text('Uber'), text('£15.93')],
         ]);
 
-        expect(getLinkColumnIndex(expenseTable as unknown as TNode)).toBe(0);
+        expect(getLinkColumnIndex(asTNode(expenseTable))).toBe(0);
     });
 
     it('returns undefined for a table with no links', () => {
         const plainTable = table([[text('Airbnb'), text('£404.60')]]);
 
-        expect(getLinkColumnIndex(plainTable as unknown as TNode)).toBeUndefined();
+        expect(getLinkColumnIndex(asTNode(plainTable))).toBeUndefined();
     });
 
     it('returns undefined when links are spread across columns', () => {
         const mixedTable = table([[link('Airbnb', AIRBNB_URL), link('£404.60', UBER_URL)]]);
 
-        expect(getLinkColumnIndex(mixedTable as unknown as TNode)).toBeUndefined();
+        expect(getLinkColumnIndex(asTNode(mixedTable))).toBeUndefined();
     });
 
     it('returns undefined when a cell holds more than one link, since one row destination cannot stand in for both', () => {
         const twoLinkCellTable = table([[node('span', [link('Airbnb', AIRBNB_URL), link('Uber', UBER_URL)]), text('£404.60')]]);
 
-        expect(getLinkColumnIndex(twoLinkCellTable as unknown as TNode)).toBeUndefined();
+        expect(getLinkColumnIndex(asTNode(twoLinkCellTable))).toBeUndefined();
     });
 
-    it('returns undefined when the linked cell has an anchor without an href', () => {
-        const hreflessTable = table([[node('a', [text('Airbnb')]), text('£404.60')]]);
+    it('returns undefined when the linked cell holds an anchor with no href', () => {
+        const anchorWithoutURLTable = table([[node('a', [text('Airbnb')]), text('£404.60')]]);
 
-        expect(getLinkColumnIndex(hreflessTable as unknown as TNode)).toBeUndefined();
+        expect(getLinkColumnIndex(asTNode(anchorWithoutURLTable))).toBeUndefined();
     });
 });
 
@@ -97,8 +105,8 @@ describe('getRowLinkURL', () => {
             [link('Uber', UBER_URL), text('£15.93')],
         ]);
 
-        expect(getRowLinkURL(bodyRowAt(expenseTable, 0), 0)).toBe(AIRBNB_URL);
-        expect(getRowLinkURL(bodyRowAt(expenseTable, 1), 0)).toBe(UBER_URL);
+        expect(getRowLinkURL(asTNode(bodyRowAt(expenseTable, 0)), 0)).toBe(AIRBNB_URL);
+        expect(getRowLinkURL(asTNode(bodyRowAt(expenseTable, 1)), 0)).toBe(UBER_URL);
     });
 
     it('returns undefined for a row with no link in that column', () => {
@@ -107,31 +115,30 @@ describe('getRowLinkURL', () => {
             [text('Uber'), text('£15.93')],
         ]);
 
-        expect(getRowLinkURL(bodyRowAt(expenseTable, 1), 0)).toBeUndefined();
+        expect(getRowLinkURL(asTNode(bodyRowAt(expenseTable, 1)), 0)).toBeUndefined();
     });
 
     it('returns undefined when the table has no link column', () => {
         const expenseTable = table([[link('Airbnb', AIRBNB_URL), text('£404.60')]]);
 
-        expect(getRowLinkURL(bodyRowAt(expenseTable, 0), undefined)).toBeUndefined();
+        expect(getRowLinkURL(asTNode(bodyRowAt(expenseTable, 0)), undefined)).toBeUndefined();
     });
 
     it('returns undefined for a header row', () => {
         const expenseTable = table([[link('Airbnb', AIRBNB_URL), text('£404.60')]]);
-        const headerRow = expenseTable.children.find((child) => child.tagName === 'thead')?.children.at(0);
+        const headerRow = sectionOf(expenseTable, 'thead')?.children.at(0);
 
-        expect(getRowLinkURL(headerRow as unknown as TNode, 0)).toBeUndefined();
+        expect(getRowLinkURL(asTNode(headerRow), 0)).toBeUndefined();
     });
 });
 
 describe('isLinkColumnAnchor', () => {
     it('recognizes an anchor nested below its cell, as the render tree wraps inline content', () => {
         const anchor = link('Airbnb', AIRBNB_URL);
-        const wrapped = node('td', [node('span', [anchor])]);
-        const row = node('tr', [wrapped, node('td', [text('£404.60')])]);
+        const row = node('tr', [node('td', [node('span', [anchor])]), node('td', [text('£404.60')])]);
         node('table', [node('tbody', [row])]);
 
-        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(true);
+        expect(isLinkColumnAnchor(asTNode(anchor), 0)).toBe(true);
     });
 
     it('leaves an anchor in another column alone', () => {
@@ -139,14 +146,14 @@ describe('isLinkColumnAnchor', () => {
         const row = node('tr', [node('td', [text('Airbnb')]), node('td', [anchor])]);
         node('table', [node('tbody', [row])]);
 
-        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(false);
+        expect(isLinkColumnAnchor(asTNode(anchor), 0)).toBe(false);
     });
 
     it('leaves an anchor outside a table alone', () => {
         const anchor = link('Insight', 'https://new.expensify.com/search?q=');
         node('div', [anchor]);
 
-        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(false);
+        expect(isLinkColumnAnchor(asTNode(anchor), 0)).toBe(false);
     });
 
     it('leaves a header anchor alone', () => {
@@ -154,12 +161,12 @@ describe('isLinkColumnAnchor', () => {
         const headerRow = node('tr', [node('th', [anchor]), node('th', [text('Amount')])]);
         node('table', [node('thead', [headerRow])]);
 
-        expect(isLinkColumnAnchor(anchor as unknown as TNode, 0)).toBe(false);
+        expect(isLinkColumnAnchor(asTNode(anchor), 0)).toBe(false);
     });
 });
 
 describe('getTextContent', () => {
     it('joins the text of every descendant', () => {
-        expect(getTextContent(node('td', [node('strong', [text('Amazon ')]), text('web services')]) as unknown as TNode)).toBe('Amazon web services');
+        expect(getTextContent(asTNode(node('td', [node('strong', [text('Amazon ')]), text('web services')])))).toBe('Amazon web services');
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

If a table's links all sit in one column, that column's link becomes the row's link:

1. TableRenderer scans the table body once. If every link lives in a single column, that column index becomes the table's link column. No links, or links spread across columns → no link column, and the table renders exactly as before.
2. Each body row in such a table takes its link column cell's href as the row's destination, and renders as a pressable: press opens the link, hover highlights the row, and a chevron sits at the row end. Long press still opens the comment context menu.
3. The link column's anchor renders as plain text, since the row is now the thing that navigates — no link color, no second target inside the row.
4. Rows in that table with no link stay static, but still reserve the chevron width so columns line up.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97247
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to Concierge chat
2. Ask the question Show my June 2026 expenses sorted by amount
3. Wait until the concierge responds
4. Verify the table is shown in this response
6. Verify that the row is clickable and we don't show the link in the merchant column

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
9. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f2f1bcec-04f9-42b9-b9b1-357f3905af29



</details>
