### PR TITLE
Test ad-hoc build cache for #97110

### DIFF
--- a/.github/workflows/buildAdHoc.yml
+++ b/.github/workflows/buildAdHoc.yml
@@ -131,7 +131,21 @@ jobs:
           aws-region: us-east-1
 
       - name: Deploy to S3
-        run: aws s3 cp --recursive --acl public-read dist s3://ad-hoc-expensify-cash/web/${{ inputs.APP_PR_NUMBER }}
+        run: |
+          BUCKET="s3://ad-hoc-expensify-cash/web/${{ inputs.APP_PR_NUMBER }}"
+
+          aws s3 sync dist "$BUCKET" --delete --acl public-read \
+            --exclude "index.html" \
+            --exclude "service-worker.js" \
+            --exclude "workbox-*.js" \
+            --cache-control "public,max-age=31536000,immutable"
+
+          aws s3 sync dist "$BUCKET" --acl public-read \
+            --exclude "*" \
+            --include "index.html" \
+            --include "service-worker.js" \
+            --include "workbox-*.js" \
+            --cache-control "no-cache,no-store,must-revalidate"
 
   postGithubComment:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/src/styles/theme/themes/light.ts
+++ b/src/styles/theme/themes/light.ts
@@ -39,7 +39,7 @@ const lightTheme = {
     dangerHover: colors.redHover,
     dangerPressed: colors.redHover,
     warning: colors.yellow400,
-    success: colors.blue400,
+    success: colors.pink400,
     successHover: colors.greenHover,
     successPressed: colors.greenPressed,
     transparent: colors.transparent,

--- a/src/styles/theme/themes/light.ts
+++ b/src/styles/theme/themes/light.ts
@@ -39,7 +39,7 @@ const lightTheme = {
     dangerHover: colors.redHover,
     dangerPressed: colors.redHover,
     warning: colors.yellow400,
-    success: colors.green400,
+    success: colors.blue400,
     successHover: colors.greenHover,
     successPressed: colors.greenPressed,
     transparent: colors.transparent,


### PR DESCRIPTION
## Purpose
Testing PR for [#97110](https://github.com/Expensify/App/issues/97110) — Web ad-hoc builds serve stale code (v2 shows v1's changes).

Trivial, visible UI change (success/green color swapped to blue) so a build change is easy to eyeball. Plan: trigger an ad-hoc build, push another commit changing the color again, trigger a second ad-hoc build, and confirm it reflects the new commit instead of serving the previous build's output.

Not intended to merge.

## Test plan
- [x] Trigger ad-hoc build (v1), confirm blue success color shows
- [x] Push follow-up commit changing color again
- [x] Trigger ad-hoc build (v2), confirm it shows the new color, not v1's