### PR TITLE
Apply the sign-in response on arrival

### DIFF
--- a/src/libs/Middleware/SaveResponseInOnyx.ts
+++ b/src/libs/Middleware/SaveResponseInOnyx.ts
@@ -21,6 +21,13 @@ const requestsToIgnoreLastUpdateID = new Set<string>([
     SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES,
 ]);
 
+// These requests carry the state that unblocks authentication itself: a new session, plus the finallyData that clears
+// `isAuthenticatingWithShortLivedToken`. They run while the previous session's watermark is still in Onyx, so a gap parks them,
+// and a parked payload leaves that flag set, which makes `reauthenticate()` give up and every later command 407.
+// `updateAuthTokenIfNecessary` only rescues a session authToken out of `response.onyxData`, never successData/finallyData,
+// so a command whose client-side data gates authentication has to be applied on arrival and belongs here.
+const requestsToApplyWithoutAdvancingLastUpdateID = new Set<string>([READ_COMMANDS.SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN, READ_COMMANDS.SIGN_IN_WITH_SUPPORT_AUTH_TOKEN]);
+
 const SaveResponseInOnyx: Middleware = <TKey extends OnyxKey>(requestResponse: Promise<Response<TKey> | void>, request: OnyxRequest<TKey>) =>
     requestResponse.then((response = {}) => {
         const onyxUpdates = response?.onyxData ?? [];
@@ -39,17 +46,16 @@ const SaveResponseInOnyx: Middleware = <TKey extends OnyxKey>(requestResponse: P
             response: response ?? {},
         };
 
-        // Apply a sign-in response on arrival, without advancing the watermark. A zero lastUpdateID does both: the payload applies now,
-        // so the new session and the finallyData that clears `isAuthenticatingWithShortLivedToken` land immediately and later commands
-        // do not 407, and the watermark stays put, so the gap is still fetched by the next response that carries a previousUpdateID.
-        const isSignInCommand = request.command === READ_COMMANDS.SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN || request.command === READ_COMMANDS.SIGN_IN_WITH_SUPPORT_AUTH_TOKEN;
+        // Zeroing lastUpdateID does both jobs: the payload applies now, so the new session and the flags land immediately,
+        // and the watermark stays put, so the gap is still fetched by the next response that carries a previousUpdateID.
+        const shouldApplyWithoutAdvancingLastUpdateID = requestsToApplyWithoutAdvancingLastUpdateID.has(request.command);
 
         if (
-            isSignInCommand ||
+            shouldApplyWithoutAdvancingLastUpdateID ||
             requestsToIgnoreLastUpdateID.has(request.command) ||
             !OnyxUpdates.doesClientNeedToBeUpdated({previousUpdateID: Number(response?.previousUpdateID ?? CONST.DEFAULT_NUMBER_ID)})
         ) {
-            return OnyxUpdates.apply(isSignInCommand ? {...responseToApply, lastUpdateID: CONST.DEFAULT_NUMBER_ID} : responseToApply);
+            return OnyxUpdates.apply(shouldApplyWithoutAdvancingLastUpdateID ? {...responseToApply, lastUpdateID: CONST.DEFAULT_NUMBER_ID} : responseToApply);
         }
 
         // Save the update IDs to Onyx so they can be used to fetch incremental updates if the client gets out of sync from the server

--- a/src/libs/Middleware/SaveResponseInOnyx.ts
+++ b/src/libs/Middleware/SaveResponseInOnyx.ts
@@ -19,10 +19,6 @@ const requestsToIgnoreLastUpdateID = new Set<string>([
     WRITE_COMMANDS.CLOSE_ACCOUNT,
     WRITE_COMMANDS.DELETE_MONEY_REQUEST,
     SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES,
-    // A sign-in response carries the finallyData that clears `isAuthenticatingWithShortLivedToken` and `account.isLoading`.
-    // A parked response applies only after the gap fill ends. A gap fill that fails or aborts blocks reauthentication for the life of the tab.
-    READ_COMMANDS.SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN,
-    READ_COMMANDS.SIGN_IN_WITH_SUPPORT_AUTH_TOKEN,
 ]);
 
 const SaveResponseInOnyx: Middleware = <TKey extends OnyxKey>(requestResponse: Promise<Response<TKey> | void>, request: OnyxRequest<TKey>) =>
@@ -43,8 +39,17 @@ const SaveResponseInOnyx: Middleware = <TKey extends OnyxKey>(requestResponse: P
             response: response ?? {},
         };
 
-        if (requestsToIgnoreLastUpdateID.has(request.command) || !OnyxUpdates.doesClientNeedToBeUpdated({previousUpdateID: Number(response?.previousUpdateID ?? CONST.DEFAULT_NUMBER_ID)})) {
-            return OnyxUpdates.apply(responseToApply);
+        // Apply a sign-in response on arrival, without advancing the watermark. A zero lastUpdateID does both: the payload applies now,
+        // so the new session and the finallyData that clears `isAuthenticatingWithShortLivedToken` land immediately and later commands
+        // do not 407, and the watermark stays put, so the gap is still fetched by the next response that carries a previousUpdateID.
+        const isSignInCommand = request.command === READ_COMMANDS.SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN || request.command === READ_COMMANDS.SIGN_IN_WITH_SUPPORT_AUTH_TOKEN;
+
+        if (
+            isSignInCommand ||
+            requestsToIgnoreLastUpdateID.has(request.command) ||
+            !OnyxUpdates.doesClientNeedToBeUpdated({previousUpdateID: Number(response?.previousUpdateID ?? CONST.DEFAULT_NUMBER_ID)})
+        ) {
+            return OnyxUpdates.apply(isSignInCommand ? {...responseToApply, lastUpdateID: CONST.DEFAULT_NUMBER_ID} : responseToApply);
         }
 
         // Save the update IDs to Onyx so they can be used to fetch incremental updates if the client gets out of sync from the server

--- a/src/libs/Middleware/SaveResponseInOnyx.ts
+++ b/src/libs/Middleware/SaveResponseInOnyx.ts
@@ -21,11 +21,7 @@ const requestsToIgnoreLastUpdateID = new Set<string>([
     SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES,
 ]);
 
-// These requests carry the state that unblocks authentication itself: a new session, plus the finallyData that clears
-// `isAuthenticatingWithShortLivedToken`. They run while the previous session's watermark is still in Onyx, so a gap parks them,
-// and a parked payload leaves that flag set, which makes `reauthenticate()` give up and every later command 407.
-// `updateAuthTokenIfNecessary` only rescues a session authToken out of `response.onyxData`, never successData/finallyData,
-// so a command whose client-side data gates authentication has to be applied on arrival and belongs here.
+// A request belongs here when its successData/finallyData is what unblocks authentication, because parking that leaves the client unable to reauthenticate.
 const requestsToApplyWithoutAdvancingLastUpdateID = new Set<string>([READ_COMMANDS.SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN, READ_COMMANDS.SIGN_IN_WITH_SUPPORT_AUTH_TOKEN]);
 
 const SaveResponseInOnyx: Middleware = <TKey extends OnyxKey>(requestResponse: Promise<Response<TKey> | void>, request: OnyxRequest<TKey>) =>
@@ -46,8 +42,6 @@ const SaveResponseInOnyx: Middleware = <TKey extends OnyxKey>(requestResponse: P
             response: response ?? {},
         };
 
-        // Zeroing lastUpdateID does both jobs: the payload applies now, so the new session and the flags land immediately,
-        // and the watermark stays put, so the gap is still fetched by the next response that carries a previousUpdateID.
         const shouldApplyWithoutAdvancingLastUpdateID = requestsToApplyWithoutAdvancingLastUpdateID.has(request.command);
 
         if (

--- a/src/libs/Middleware/SaveResponseInOnyx.ts
+++ b/src/libs/Middleware/SaveResponseInOnyx.ts
@@ -1,4 +1,4 @@
-import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
+import {READ_COMMANDS, SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 
 import * as OnyxUpdates from '@userActions/OnyxUpdates';
 
@@ -19,6 +19,10 @@ const requestsToIgnoreLastUpdateID = new Set<string>([
     WRITE_COMMANDS.CLOSE_ACCOUNT,
     WRITE_COMMANDS.DELETE_MONEY_REQUEST,
     SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES,
+    // A sign-in response carries the finallyData that clears `isAuthenticatingWithShortLivedToken` and `account.isLoading`.
+    // A parked response applies only after the gap fill ends. A gap fill that fails or aborts blocks reauthentication for the life of the tab.
+    READ_COMMANDS.SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN,
+    READ_COMMANDS.SIGN_IN_WITH_SUPPORT_AUTH_TOKEN,
 ]);
 
 const SaveResponseInOnyx: Middleware = <TKey extends OnyxKey>(requestResponse: Promise<Response<TKey> | void>, request: OnyxRequest<TKey>) =>

--- a/tests/unit/MiddlewareTest.ts
+++ b/tests/unit/MiddlewareTest.ts
@@ -1,10 +1,12 @@
+import {READ_COMMANDS} from '@libs/API/types';
 import SaveResponseInOnyx from '@libs/Middleware/SaveResponseInOnyx';
 
+import CONST from '@src/CONST';
 import * as PersistedRequests from '@src/libs/actions/PersistedRequests';
 import HttpUtils from '@src/libs/HttpUtils';
-import handleUnusedOptimisticID from '@src/libs/Middleware/HandleUnusedOptimisticID';
 // This import is needed to initialize the Onyx connections that call replaceOptimisticReportWithActualReport
 import '@src/libs/actions/replaceOptimisticReportWithActualReport';
+import handleUnusedOptimisticID from '@src/libs/Middleware/HandleUnusedOptimisticID';
 import * as Network from '@src/libs/Network';
 import * as MainQueue from '@src/libs/Network/MainQueue';
 import * as NetworkStore from '@src/libs/Network/NetworkStore';
@@ -17,6 +19,7 @@ import type {OnyxEntry} from 'react-native-onyx';
 
 import Onyx from 'react-native-onyx';
 
+import getOnyxValue from '../utils/getOnyxValue';
 import * as TestHelper from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import waitForNetworkPromises from '../utils/waitForNetworkPromises';
@@ -82,6 +85,36 @@ describe('Middleware', () => {
             // Then the response should not be undefined — the caller may need the raw response for side effects
             expect(result).toBeDefined();
             expect(result?.jsonCode).toBe(200);
+        });
+
+        test.each([
+            ['the client watermark is behind the response', 1],
+            ['the client has no watermark yet', undefined],
+        ])('applies a sign-in response on arrival when %s', async (_case, clientLastUpdateID) => {
+            if (clientLastUpdateID) {
+                await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, clientLastUpdateID);
+            }
+            await Onyx.set(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN, true);
+            await waitForBatchedUpdates();
+
+            Request.addMiddleware(SaveResponseInOnyx);
+            jest.spyOn(HttpUtils, 'xhr').mockResolvedValueOnce({jsonCode: 200, lastUpdateID: 501, previousUpdateID: 500});
+
+            await Request.processWithMiddleware({
+                command: READ_COMMANDS.SIGN_IN_WITH_SHORT_LIVED_AUTH_TOKEN,
+                data: {apiRequestType: CONST.API_REQUEST_TYPE.READ},
+                finallyData: [
+                    {
+                        onyxMethod: Onyx.METHOD.SET,
+                        key: ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN,
+                        value: false,
+                    },
+                ],
+            });
+            await waitForBatchedUpdates();
+
+            expect(await getOnyxValue(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN)).toBe(false);
+            expect(await getOnyxValue(ONYXKEYS.ONYX_UPDATES_FROM_SERVER)).toBeUndefined();
         });
     });
 

--- a/tests/unit/MiddlewareTest.ts
+++ b/tests/unit/MiddlewareTest.ts
@@ -115,6 +115,7 @@ describe('Middleware', () => {
 
             expect(await getOnyxValue(ONYXKEYS.RAM_ONLY_IS_AUTHENTICATING_WITH_SHORT_LIVED_TOKEN)).toBe(false);
             expect(await getOnyxValue(ONYXKEYS.ONYX_UPDATES_FROM_SERVER)).toBeUndefined();
+            expect(await getOnyxValue(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT)).toBe(clientLastUpdateID);
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
**Case**
A user signs in with SAML and the client is behind on Onyx updates. The client had applied update `14868706738`. The sign-in response came back with `previousUpdateID: 14886370217`. That is a gap of about 17 million updates.

Before the change, `SaveResponseInOnyx` saw the gap and parked the whole sign-in response in `ONYX_UPDATES_FROM_SERVER`. The parked payload held the `finallyData` that clears `isAuthenticatingWithShortLivedToken` and `account.isLoading`. The app then ran a gap fill to catch up. That gap fill failed and later aborted. The two flags stayed set. `reauthenticate()` checks those flags and gives up, so every write returned 407 for the next 8 hours. The user saw approvals and renames succeed on screen. The server got none of them.

After the change, `SaveResponseInOnyx` applies a sign-in response on arrival with `lastUpdateID` zeroed. A zero does both jobs. The payload applies now, so the new session and the two flags land immediately and later commands do not 407. The watermark stays where it was, so the gap is still fetched by the next response that carries a `previousUpdateID`, this time with a live token.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97480
PROPOSAL: n/a


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Run `npx jest tests/unit/MiddlewareTest.ts`.
2. Verify all 14 tests pass, including the two new cases: a sign-in response applies on arrival when the client watermark is behind the response, and when the client has no watermark yet. Both cases fail without the change.
3. Sign in on web.
4. Set `ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT` in Onyx far below the current server update ID, for example to 1.
5. Open `/transition` with a fresh short-lived auth token.
6. Read the console. Verify the line `Applying update type: https ... command: 'SignInWithShortLivedAuthToken'` appears and no `Re-authentication aborted` line follows.
7. Read `ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT` in Onyx. Verify it is still 1 and did not jump to the `lastUpdateID` of the sign-in response.
8. Approve a report. Verify the approval reaches the server.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Go offline and make a write, for example rename a report.
2. Come back online with an expired token. Verify the queued write reaches the server after the token renews. The sign-in change does not touch the offline path.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

1. On staging, sign in with a SAML-required account, for example Okta.
2. Set `ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT` in Onyx to 1 so the client looks behind on updates.
3. Open `/transition` with a fresh short-lived auth token.
4. Approve a report, rename a report, and edit a report field.
5. Verify each change reaches the server. Verify the app does not need a page refresh.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>

