### PR TITLE
reset the shared request throttle when the queue stops

### DIFF
--- a/contributingGuides/SEQUENTIAL_QUEUE.md
+++ b/contributingGuides/SEQUENTIAL_QUEUE.md
@@ -234,11 +234,13 @@ async push()  (online · idle · no conflict)
 **How it works today.**
 - **`getRequestWaitTime`** seeds the first wait with a random jitter in `[MIN_RETRY_WAIT_TIME_MS, MAX_RANDOM_RETRY_WAIT_TIME_MS]` = `[10, 100]` ms, then **doubles** the prior wait on each retry, capped at `MAX_RETRY_WAIT_TIME_MS` (10 s).
 - **`sleep`** increments the retry count and picks the cap: `MAX_OPEN_APP_REQUEST_RETRIES` (2) for the `OPEN_APP` command, else `MAX_REQUEST_RETRIES` (10). Within the cap it resolves after the wait; once exceeded it **rejects with no argument**. This argument-less rejection is the give-up signal that `process()`'s catch consumes.
-- **`clear`** resets the wait, the retry count, and any pending timeout. It is called on success and on any non-retryable outcome.
+- **`clear`** resets the wait, the retry count, and any pending timeout. It is called on success, on any non-retryable outcome, and on the `isQueuePaused` and `isOfflineNetwork()` early returns in `process()`. A sleeping retry always wakes up back into `process()`, so those two guards are where a retry chain stops and where its state would otherwise be left behind.
 - The queue uses a single shared instance, `sequentialQueueRequestThrottle`.
 
 **Sharp edges.**
 - After the retry cap, a request is **permanently dropped** (see the [give-up row](#error-handling)), for non-`OPEN_APP` commands with no user-facing modal.
+- The instance is shared, so state earned by one command is charged to whichever command runs next. The two `clear()` calls above stop that state from crossing an offline gap or a gap sync, but it still crosses between two commands that fail back to back while online.
+- `clear()` is deliberately called only from inside the retry chain's own flow. `clear()` does `clearTimeout` on the pending `sleep` timeout, which is the `resolve` the chain is awaiting, so calling it from outside (a `NetworkState` edge, `Reconnect.ts`) during a fast flap would leave `currentRequestPromise` unsettled and wedge the queue.
 - `clear()` fires on every success, so a burst that interleaves successes with failures keeps resetting backoff to the floor, weakening the intended exponential spacing against a degraded backend.
 
 ## QueuedOnyxUpdates and queueFlushedData
@@ -317,7 +319,7 @@ The blocks above describe what the queue does; this is the inbound surface: who 
 | `isReadyPromisePending` | Idempotency guard for `setIsReadyPromisePending()` (prevents orphaning READs parked on a prior pending promise) | `true` when a pending promise is armed | `false` inside `resolveIsReadyPromise` | At most one pending `isReadyPromise` is armed at a time |
 | `shouldFailAllRequests` | Sticky `NETWORK`-key flag → erroring requests are failed and dropped | `NETWORK` Onyx callback | `NETWORK` Onyx callback | Test/debug only |
 | `queueFlushedDataToStore` | In-memory mirror of `QUEUE_FLUSHED_DATA` | the `QUEUE_FLUSHED_DATA` connect-callback echo of `saveQueueFlushedData`'s `Onyx.set` | `clearQueueFlushedData` | Applied only on full drain |
-| `sequentialQueueRequestThrottle` | Shared backoff state (wait time, retry count, pending timeout) | `sleep()` on each generic-error retry | `clear()` on success and every non-retryable outcome | Backoff state never survives a settled request |
+| `sequentialQueueRequestThrottle` | Shared backoff state (wait time, retry count, pending timeout) | `sleep()` on each generic-error retry | `clear()` on success, every non-retryable outcome, and the paused and offline early returns in `process()` | Backoff state never survives a settled request, an offline gap, or a gap sync |
 
 ### Why `isReadyPromise` resolves on offline, not on paused
 

--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -142,15 +142,21 @@ function getQueueFlushedData() {
  * requests to our backend is evenly distributed and it gradually decreases with time, which helps the servers catch up.
  */
 function process(): Promise<void> {
+    // A sleeping retry always wakes up back into process(), so these two guards are where the throttle
+    // stops. One throttle serves every command, so shed this run's retry count and backoff here rather
+    // than charging them to whichever command runs next.
+
     // When the queue is paused, return early. This prevents any new requests from happening.
     // The queue will be flushed again when the queue is unpaused.
     if (isQueuePaused) {
         Log.info('[SequentialQueue] Unable to process. Queue is paused.');
+        sequentialQueueRequestThrottle.clear();
         return Promise.resolve();
     }
 
     if (isOfflineNetwork()) {
         Log.info('[SequentialQueue] Unable to process. We are offline.');
+        sequentialQueueRequestThrottle.clear();
         return Promise.resolve();
     }
 

--- a/tests/unit/SequentialQueueTest.ts
+++ b/tests/unit/SequentialQueueTest.ts
@@ -422,7 +422,9 @@ describe('SequentialQueue', () => {
 
             // Go offline while the retry is still sleeping. When it wakes, process() stops on its offline guard.
             offlineSpy.mockReturnValue(true);
-            await new Promise((resolve) => setTimeout(resolve, scheduledWait + 10));
+            await new Promise((resolve) => {
+                setTimeout(resolve, scheduledWait + 10);
+            });
 
             // The next command must start from a fresh count and a floor-range wait rather than inherit this one.
             expect(SequentialQueue.sequentialQueueRequestThrottle.getLastRequestWaitTime()).toBe(0);

--- a/tests/unit/SequentialQueueTest.ts
+++ b/tests/unit/SequentialQueueTest.ts
@@ -407,6 +407,29 @@ describe('SequentialQueue', () => {
             onyxUpdateSpy.mockRestore();
         }
     });
+
+    it('should reset the shared throttle when the queue stops because the app went offline', async () => {
+        const offlineSpy = jest.spyOn(NetworkState, 'getIsOffline').mockReturnValue(false);
+        mockFetch.mockRejectedValue(new Error(CONST.ERROR.FAILED_TO_FETCH));
+
+        try {
+            await SequentialQueue.push(request);
+            await waitForBatchedUpdates();
+
+            // The request failed once, so the throttle is now carrying a retry count and a wait time.
+            const scheduledWait = SequentialQueue.sequentialQueueRequestThrottle.getLastRequestWaitTime();
+            expect(scheduledWait).toBeGreaterThan(0);
+
+            // Go offline while the retry is still sleeping. When it wakes, process() stops on its offline guard.
+            offlineSpy.mockReturnValue(true);
+            await new Promise((resolve) => setTimeout(resolve, scheduledWait + 10));
+
+            // The next command must start from a fresh count and a floor-range wait rather than inherit this one.
+            expect(SequentialQueue.sequentialQueueRequestThrottle.getLastRequestWaitTime()).toBe(0);
+        } finally {
+            offlineSpy.mockRestore();
+        }
+    });
 });
 
 describe('SequentialQueue - reconnect coverage collapse', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

<!-- Explain what your change does and how it addresses the linked issue -->


The SequentialQueue shares one `RequestThrottle`, which holds the retry wait time and the retry count that decides when a request is dropped. `clear()` ran on success and on non-retryable outcomes. It did not run when a retry chain stopped.

A sleeping retry wakes back into `process()` and stops on one of two guards: offline, or paused for a gap sync. Neither cleared the throttle, so the next command inherited the state. A fresh `PayMoneyRequest` could start on a 10 second backoff and be dropped after one real failure, with no modal. Over 7 days the give-up branch dropped 690 such writes across 286 users.

This clears the throttle on both guards. The paused guard runs first, so covering only offline would be bypassed when a flap and a gap sync overlap.

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/Expensify/App/issues/97715
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


New unit test in `tests/unit/SequentialQueueTest.ts`: fail a request so the throttle holds a wait time and a retry count, go offline while the retry sleeps, then assert the throttle is back to zero. Verified it fails without the fix.

`tests/unit/APITest.ts`, `tests/unit/NetworkTest.tsx` and `tests/unit/RequestTest.ts` still pass.

- [x] Verify that no errors appear in the JS console

### Offline tests

<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>