### PR TITLE
[No QA] move PusherPing off the durable write queue

### DIFF
--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -140,7 +140,6 @@ const WRITE_COMMANDS = {
     ADD_EMOJI_REACTION: 'AddEmojiReaction',
     REMOVE_EMOJI_REACTION: 'RemoveEmojiReaction',
     LEAVE_ROOM: 'LeaveRoom',
-    PUSHER_PING: 'PusherPing',
     LEAVE_GROUP_CHAT: 'LeaveGroupChat',
     INVITE_TO_ROOM: 'InviteToRoom',
     INVITE_TO_GROUP_CHAT: 'InviteToGroupChat',
@@ -789,7 +788,6 @@ type WriteCommandParameters = {
     [WRITE_COMMANDS.INVITE_TO_GROUP_CHAT]: Parameters.InviteToGroupChatParams;
     [WRITE_COMMANDS.UPDATE_GROUP_CHAT_AVATAR]: Parameters.UpdateGroupChatAvatarParams;
     [WRITE_COMMANDS.UPDATE_ROOM_AVATAR]: Parameters.UpdateRoomAvatarParams;
-    [WRITE_COMMANDS.PUSHER_PING]: Parameters.PusherPingParams;
     [WRITE_COMMANDS.LEAVE_GROUP_CHAT]: Parameters.LeaveGroupChatParams;
     [WRITE_COMMANDS.REMOVE_FROM_GROUP_CHAT]: Parameters.RemoveFromGroupChatParams;
     [WRITE_COMMANDS.UPDATE_GROUP_CHAT_MEMBER_ROLES]: Parameters.UpdateGroupChatMemberRolesParams;
@@ -1569,6 +1567,7 @@ const SIDE_EFFECT_REQUEST_COMMANDS = {
     IMPORT_PER_DIEM_RATES: 'ImportPerDiemRates',
     IMPORT_TAGS_SPREADSHEET: 'ImportTagsSpreadsheet',
     OPEN_OLD_DOT_LINK: 'OpenOldDotLink',
+    PUSHER_PING: 'PusherPing',
     RECONNECT_APP: 'ReconnectApp',
     REVEAL_EXPENSIFY_TRAVEL_CARD_DETAILS: 'RevealExpensifyTravelCardDetails',
     TWO_FACTOR_AUTH_VALIDATE: 'TwoFactorAuth_Validate',
@@ -1616,6 +1615,7 @@ type SideEffectRequestCommandParameters = {
     [SIDE_EFFECT_REQUEST_COMMANDS.IMPORT_PER_DIEM_RATES]: Parameters.ImportPerDiemRatesParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.IMPORT_TAGS_SPREADSHEET]: Parameters.ImportTagsSpreadsheetParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.OPEN_OLD_DOT_LINK]: Parameters.OpenOldDotLinkParams;
+    [SIDE_EFFECT_REQUEST_COMMANDS.PUSHER_PING]: Parameters.PusherPingParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.REVEAL_EXPENSIFY_TRAVEL_CARD_DETAILS]: Parameters.RevealExpensifyCardDetailsParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES]: Parameters.GetMissingOnyxMessagesParams;
     [SIDE_EFFECT_REQUEST_COMMANDS.RECONNECT_APP]: Parameters.ReconnectAppParams;

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -846,7 +846,11 @@ function pingPusher() {
     lastPingSentTimestamp = pingTimestamp;
 
     const parameters: PusherPingParams = {pingID, pingTimestamp};
-    API.writeWithNoDuplicatesConflictAction(WRITE_COMMANDS.PUSHER_PING, parameters);
+
+    // The heartbeat is a probe, not a user's write, so it must not be persisted to disk, retried, or hold the
+    // head of the queue while a real write waits behind it. The Logging middleware already logs any failure.
+    // eslint-disable-next-line rulesdir/no-api-side-effects-method
+    API.makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.PUSHER_PING, parameters).catch(() => {});
     Log.info(`[Pusher PINGPONG] Sending a PING to the server: ${pingID} timestamp: ${pingTimestamp}`);
 }
 

--- a/tests/unit/PusherPingPongTest.ts
+++ b/tests/unit/PusherPingPongTest.ts
@@ -26,6 +26,8 @@ jest.mock('@libs/NetworkState', () => ({
 // The watchdog checks every 60s; each reconnect skips the following check, so while PONGs stay missing it fires on every second check tick (~2 minutes)
 const CHECK_INTERVAL_MS = 60_000;
 
+const PING_INTERVAL_MS = 30_000;
+
 describe('Pusher PINGPONG watchdog', () => {
     let reconnectSpy: jest.SpyInstance;
     let pongCallback: Parameters<typeof PusherUtils.subscribeToPrivateUserChannelEvent>[2];
@@ -86,7 +88,10 @@ describe('Pusher PINGPONG watchdog', () => {
         expect(reconnectSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('sends the PING off the durable write queue', () => {
+    it('sends the PING off the durable write queue', async () => {
+        mockAPI.makeRequestWithSideEffects.mockClear();
+        await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS);
+
         expect(mockAPI.makeRequestWithSideEffects).toHaveBeenCalledWith(SIDE_EFFECT_REQUEST_COMMANDS.PUSHER_PING, expect.anything());
         expect(mockAPI.writeWithNoDuplicatesConflictAction).not.toHaveBeenCalled();
     });

--- a/tests/unit/PusherPingPongTest.ts
+++ b/tests/unit/PusherPingPongTest.ts
@@ -10,6 +10,8 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import Onyx from 'react-native-onyx';
 
 jest.mock('@libs/API');
+const mockAPI = jest.mocked(API);
+
 jest.mock('@libs/PusherUtils');
 jest.mock('@libs/ActiveClientManager', () => ({
     isClientTheLeader: jest.fn(() => true),
@@ -36,7 +38,7 @@ describe('Pusher PINGPONG watchdog', () => {
         reconnectSpy = jest.spyOn(Pusher, 'reconnect').mockImplementation(() => {});
 
         // The automock returns undefined, and pingPusher chains a .catch on the returned promise
-        jest.mocked(API.makeRequestWithSideEffects).mockResolvedValue(undefined);
+        mockAPI.makeRequestWithSideEffects.mockResolvedValue(undefined);
 
         subscribeToUserEvents(123, 'test@example.com', () => undefined);
 
@@ -85,7 +87,7 @@ describe('Pusher PINGPONG watchdog', () => {
     });
 
     it('sends the PING off the durable write queue', () => {
-        expect(API.makeRequestWithSideEffects).toHaveBeenCalledWith(SIDE_EFFECT_REQUEST_COMMANDS.PUSHER_PING, expect.objectContaining({pingID: expect.any(String)}));
-        expect(API.writeWithNoDuplicatesConflictAction).not.toHaveBeenCalled();
+        expect(mockAPI.makeRequestWithSideEffects).toHaveBeenCalledWith(SIDE_EFFECT_REQUEST_COMMANDS.PUSHER_PING, expect.anything());
+        expect(mockAPI.writeWithNoDuplicatesConflictAction).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/PusherPingPongTest.ts
+++ b/tests/unit/PusherPingPongTest.ts
@@ -1,4 +1,6 @@
 import {subscribeToUserEvents} from '@libs/actions/User';
+import * as API from '@libs/API';
+import {SIDE_EFFECT_REQUEST_COMMANDS} from '@libs/API/types';
 import type * as NetworkStateModule from '@libs/NetworkState';
 import Pusher from '@libs/Pusher';
 import PusherUtils from '@libs/PusherUtils';
@@ -32,6 +34,9 @@ describe('Pusher PINGPONG watchdog', () => {
         jest.useFakeTimers();
         Onyx.init({keys: ONYXKEYS});
         reconnectSpy = jest.spyOn(Pusher, 'reconnect').mockImplementation(() => {});
+
+        // The automock returns undefined, and pingPusher chains a .catch on the returned promise
+        jest.mocked(API.makeRequestWithSideEffects).mockResolvedValue(undefined);
 
         subscribeToUserEvents(123, 'test@example.com', () => undefined);
 
@@ -77,5 +82,10 @@ describe('Pusher PINGPONG watchdog', () => {
 
         await jest.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
         expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends the PING off the durable write queue', () => {
+        expect(API.makeRequestWithSideEffects).toHaveBeenCalledWith(SIDE_EFFECT_REQUEST_COMMANDS.PUSHER_PING, expect.objectContaining({pingID: expect.any(String)}));
+        expect(API.writeWithNoDuplicatesConflictAction).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change


`PusherPing` is a 30 second heartbeat that checks the Pusher event path. The client posts a ping over HTTP and the server answers with a `PONG` over the websocket.

It was sent with `API.write`, so it was written to disk every 30 seconds, retried up to 10 times with doubling backoff, and could hold the head of the single-flight queue while a real write waited behind it. In a 4 hour window it was the most retried command in the app: 5,075 attempts across 2,924 users, against 1,135 for the next command.

This moves `PUSHER_PING` to `SIDE_EFFECT_REQUEST_COMMANDS` and sends it with `API.makeRequestWithSideEffects`. That path is not persisted, not retried, and does not touch the queue. `API.read` waits for the write queue to drain first, which is the coupling being removed.

The probe stays. `checkForLatePongReplies` calls `Pusher.reconnect()` when a `PONG` goes missing, which shipped in #96883.

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/Expensify/App/issues/97712
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

`tests/unit/PusherPingPongTest.ts`: the existing watchdog tests needed a mock fix, because the automocked `@libs/API` returns `undefined` and `pingPusher` now chains a `.catch` on the returned promise. Added one assertion that the ping goes out through `makeRequestWithSideEffects` with `PusherPing` and that the old write path is not called. Verified it fails against the old call and passes against the new one.

Also ran `tests/unit/APITest.ts`, `tests/unit/SequentialQueueTest.ts`, `tests/unit/NetworkTest.tsx` and `tests/unit/RequestTest.ts`. All pass.

Manual check for a reviewer: sign in, wait a minute, and confirm the `[Pusher PINGPONG] Received a PONG event from the server` log still arrives and that `PusherPing` no longer appears in `PERSISTED_REQUESTS`.

### Offline tests

<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>