### PR TITLE
[cp stag] Fix Not Here page when opening card spend rules on a Collect workspace

### DIFF
--- a/src/hooks/useControlOnlyRuleUpgradeRedirect.ts
+++ b/src/hooks/useControlOnlyRuleUpgradeRedirect.ts
@@ -1,0 +1,49 @@
+import useOnyx from '@hooks/useOnyx';
+import usePermissions from '@hooks/usePermissions';
+import usePolicy from '@hooks/usePolicy';
+
+import {arePolicyRulesEnabled, isCollectPolicy, tryNavigateToControlPolicyUpgrade} from '@libs/PolicyUtils';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Route} from '@src/ROUTES';
+import ROUTES from '@src/ROUTES';
+
+import {useEffect, useRef} from 'react';
+
+/**
+ * Sends a Collect admin who lands on a Control-only Rules page to the Control upgrade page.
+ *
+ * The Rules page gates its own Control-only features on press, but these pages are also reachable in ways that
+ * skip it: direct deep links to the page and its child pickers, and Wallet > Expensify card > Edit spend rules.
+ * An `accessVariants` CONTROL check can't be used for that, because AccessOrNotFoundWrapper only ever renders
+ * Not Found, never an upgrade path.
+ *
+ * @param policyID - The policy the page belongs to.
+ * @param backTo - Where the upgrade page should return to. Defaults to the workspace Rules page.
+ */
+function useControlOnlyRuleUpgradeRedirect(policyID: string, backTo?: Route) {
+    const policy = usePolicy(policyID);
+    const {isBetaEnabled} = usePermissions();
+    const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`);
+
+    const isCollect = isCollectPolicy(policy);
+    // Mirrors the feature check in AccessOrNotFoundWrapper. When Rules itself is disabled, that wrapper already
+    // redirects to More features, so redirecting to the upgrade page too would flash it on the way there.
+    const isRulesFeatureEnabled = arePolicyRulesEnabled(policy, policyCategories, isBetaEnabled(CONST.BETAS.RULES_REVAMP));
+    const hasRedirectedToUpgrade = useRef(false);
+    const upgradeBackTo = backTo ?? ROUTES.WORKSPACE_RULES.getRoute(policyID);
+
+    useEffect(() => {
+        if (!isCollect || !isRulesFeatureEnabled || hasRedirectedToUpgrade.current) {
+            return;
+        }
+
+        // Replace rather than push: Back from the upgrade page must not land on a page Collect can't use.
+        hasRedirectedToUpgrade.current = tryNavigateToControlPolicyUpgrade(policy, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, upgradeBackTo, true);
+        // `policy` changes identity on unrelated writes, so gate on the derived flags instead.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isCollect, isRulesFeatureEnabled, upgradeBackTo]);
+}
+
+export default useControlOnlyRuleUpgradeRedirect;

--- a/src/hooks/useControlOnlyRuleUpgradeRedirect.ts
+++ b/src/hooks/useControlOnlyRuleUpgradeRedirect.ts
@@ -1,7 +1,3 @@
-import useOnyx from '@hooks/useOnyx';
-import usePermissions from '@hooks/usePermissions';
-import usePolicy from '@hooks/usePolicy';
-
 import {arePolicyRulesEnabled, isCollectPolicy, tryNavigateToControlPolicyUpgrade} from '@libs/PolicyUtils';
 
 import CONST from '@src/CONST';
@@ -10,6 +6,10 @@ import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 
 import {useEffect, useRef} from 'react';
+
+import useOnyx from './useOnyx';
+import usePermissions from './usePermissions';
+import usePolicy from './usePolicy';
 
 /**
  * Sends a Collect admin who lands on a Control-only Rules page to the Control upgrade page.

--- a/src/hooks/useControlOnlyRuleUpgradeRedirect.ts
+++ b/src/hooks/useControlOnlyRuleUpgradeRedirect.ts
@@ -41,9 +41,7 @@ function useControlOnlyRuleUpgradeRedirect(policyID: string, backTo?: Route) {
 
         // Replace rather than push: Back from the upgrade page must not land on a page Collect can't use.
         hasRedirectedToUpgrade.current = tryNavigateToControlPolicyUpgrade(policy, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, upgradeBackTo, true);
-        // `policy` changes identity on unrelated writes, so gate on the derived flags instead.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isCollect, isRulesFeatureEnabled, upgradeBackTo]);
+    }, [isCollect, isRulesFeatureEnabled, policy, upgradeBackTo]);
 }
 
 export default useControlOnlyRuleUpgradeRedirect;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1446,13 +1446,17 @@ function isCollectPolicy(policy: OnyxEntry<Policy>): boolean {
 /**
  * Collect workspaces can access a limited subset of Rules features. When a Collect admin tries to
  * access a Control-only Rules feature, navigate to the upgrade flow and return true.
+ *
+ * @param shouldReplace - Replace the current screen instead of pushing the upgrade page on top of it. Use this when
+ * the redirect happens from the Control-only page itself, so pressing Back doesn't land back on a page Collect
+ * can't use. Press handlers on a page Collect *can* use should keep the default push.
  */
-function tryNavigateToControlPolicyUpgrade(policy: OnyxEntry<Policy>, upgradeFeatureAlias: string, backTo?: string): boolean {
+function tryNavigateToControlPolicyUpgrade(policy: OnyxEntry<Policy>, upgradeFeatureAlias: string, backTo?: string, shouldReplace = false): boolean {
     if (!policy?.id || isControlPolicy(policy) || !isCollectPolicy(policy)) {
         return false;
     }
 
-    Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(policy.id, upgradeFeatureAlias, backTo ?? ROUTES.WORKSPACE_RULES.getRoute(policy.id)));
+    Navigation.navigate(ROUTES.WORKSPACE_UPGRADE.getRoute(policy.id, upgradeFeatureAlias, backTo ?? ROUTES.WORKSPACE_RULES.getRoute(policy.id)), {forceReplace: shouldReplace});
     return true;
 }
 

--- a/src/pages/settings/Wallet/WalletExpensifyCardSpendRulesPage.tsx
+++ b/src/pages/settings/Wallet/WalletExpensifyCardSpendRulesPage.tsx
@@ -20,6 +20,9 @@ function WalletExpensifyCardSpendRulesPage({route}: WalletExpensifyCardSpendRule
             ruleID={isNewRule ? undefined : ruleID}
             titleKey={isNewRule ? 'workspace.rules.merchantRules.addRuleTitle' : 'workspace.rules.spendRules.editRuleTitle'}
             testID="WalletExpensifyCardSpendRulesPage"
+            // Come back here after upgrading rather than dropping the user on the workspace Rules page,
+            // since this flow starts from the Wallet.
+            upgradeBackTo={ROUTES.SETTINGS_WALLET_EXPENSIFY_CARD_SPEND_RULES.getRoute(policyID, isNewRule ? undefined : ruleID)}
         />
     );
 }

--- a/src/pages/workspace/rules/SpendRules/SpendRuleCardPage.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRuleCardPage.tsx
@@ -209,7 +209,7 @@ function SpendRuleCardPage({route}: SpendRuleCardPageProps) {
         <AccessOrNotFoundWrapper
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED}
-            accessVariants={[CONST.POLICY.ACCESS_VARIANTS.PAID, CONST.POLICY.ACCESS_VARIANTS.CONTROL]}
+            accessVariants={[CONST.POLICY.ACCESS_VARIANTS.PAID]}
             shouldBeBlocked={!canWriteCardSpendRules}
         >
             {isCardSettingsLoading ? (

--- a/src/pages/workspace/rules/SpendRules/SpendRuleCardPage.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRuleCardPage.tsx
@@ -11,6 +11,7 @@ import type {ListItem} from '@components/SelectionList/types';
 
 import useCanWriteCardSpendRules from '@hooks/useCanWriteCardSpendRules';
 import {useCompanyCardFeedIcons} from '@hooks/useCompanyCardIcons';
+import useControlOnlyRuleUpgradeRedirect from '@hooks/useControlOnlyRuleUpgradeRedirect';
 import useDefaultFundID from '@hooks/useDefaultFundID';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
@@ -104,6 +105,7 @@ function SpendRuleCardPage({route}: SpendRuleCardPageProps) {
 
     const [selectedCardIDs, setSelectedCardIDs] = useState<string[]>([]);
     const {isLoading, startWithLoading} = usePressLoading();
+    useControlOnlyRuleUpgradeRedirect(policyID);
 
     useFocusEffect(
         useCallback(() => {

--- a/src/pages/workspace/rules/SpendRules/SpendRuleCategoryPage.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRuleCategoryPage.tsx
@@ -1,6 +1,7 @@
 import SpendRuleCategoryBase from '@components/SpendRules/configuration/SpendRuleCategoryBase';
 
 import useCanWriteCardSpendRules from '@hooks/useCanWriteCardSpendRules';
+import useControlOnlyRuleUpgradeRedirect from '@hooks/useControlOnlyRuleUpgradeRedirect';
 import useOnyx from '@hooks/useOnyx';
 
 import {updateDraftSpendRule} from '@libs/actions/User';
@@ -22,6 +23,7 @@ function SpendRuleCategoryPage({route}: SpendRuleCategoryPageProps) {
     const {policyID} = route.params;
     const canWriteCardSpendRules = useCanWriteCardSpendRules(policyID);
     const [spendRuleForm] = useOnyx(ONYXKEYS.FORMS.SPEND_RULE_FORM);
+    useControlOnlyRuleUpgradeRedirect(policyID);
 
     const onCategoriesChange = (categories: SpendRuleCategory[]) => {
         updateDraftSpendRule({categories});

--- a/src/pages/workspace/rules/SpendRules/SpendRuleCategoryPage.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRuleCategoryPage.tsx
@@ -31,7 +31,7 @@ function SpendRuleCategoryPage({route}: SpendRuleCategoryPageProps) {
         <AccessOrNotFoundWrapper
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED}
-            accessVariants={[CONST.POLICY.ACCESS_VARIANTS.PAID, CONST.POLICY.ACCESS_VARIANTS.CONTROL]}
+            accessVariants={[CONST.POLICY.ACCESS_VARIANTS.PAID]}
             shouldBeBlocked={!canWriteCardSpendRules}
         >
             <SpendRuleCategoryBase

--- a/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
@@ -30,6 +30,7 @@ import {convertToBackendAmount} from '@libs/CurrencyUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {rand64} from '@libs/NumberUtils';
 import {temporaryGetDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
+import {isCollectPolicy, tryNavigateToControlPolicyUpgrade} from '@libs/PolicyUtils';
 import {getSpendRuleFormValuesFromCardRule, getTruncatedSpendRuleSummary} from '@libs/SpendRulesUtils';
 
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
@@ -40,13 +41,14 @@ import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import type {SpendRuleCategory} from '@src/types/form/SpendRuleForm';
 import type IconAsset from '@src/types/utils/IconAsset';
 
 import type {ValueOf} from 'type-fest';
 
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 
 type SpendRulePageBaseProps = {
@@ -54,6 +56,9 @@ type SpendRulePageBaseProps = {
     ruleID?: string;
     titleKey: TranslationPaths;
     testID: string;
+
+    /** Where the Control upgrade page should return to. Defaults to the workspace Rules page. */
+    upgradeBackTo?: Route;
 };
 
 function getErrorMessage(hasSelectedCards: boolean, hasAnyRuleApplied: boolean, translate: (path: TranslationPaths) => string) {
@@ -69,7 +74,7 @@ function getErrorMessage(hasSelectedCards: boolean, hasAnyRuleApplied: boolean, 
     return '';
 }
 
-function SpendRulePageBase({policyID, ruleID, titleKey, testID}: SpendRulePageBaseProps) {
+function SpendRulePageBase({policyID, ruleID, titleKey, testID, upgradeBackTo}: SpendRulePageBaseProps) {
     const {convertToDisplayString} = useCurrencyListActions();
     const styles = useThemeStyles();
     const {translate} = useLocalize();
@@ -99,6 +104,25 @@ function SpendRulePageBase({policyID, ruleID, titleKey, testID}: SpendRulePageBa
         const hasNoMerchantRestrictions = !existingFormValues?.merchantNames.length && !existingFormValues?.categories?.length;
         return isNewRule || hasNoMerchantRestrictions;
     });
+
+    // Card restrictions are Control-only, so Collect admins get the upgrade page rather than a Not Found page.
+    // This runs here rather than as an `accessVariants` CONTROL check because AccessOrNotFoundWrapper can only
+    // render Not Found, and because deep links (Wallet > card > Edit spend rules) skip the Rules page's own
+    // upgrade gating entirely.
+    const isCollect = isCollectPolicy(policy);
+    const hasRedirectedToUpgrade = useRef(false);
+    const rulesUpgradeBackTo = upgradeBackTo ?? ROUTES.WORKSPACE_RULES.getRoute(policyID);
+
+    useEffect(() => {
+        if (!isCollect || hasRedirectedToUpgrade.current) {
+            return;
+        }
+
+        // Replace rather than push: Back from the upgrade page must not land on this page, which Collect can't use.
+        hasRedirectedToUpgrade.current = tryNavigateToControlPolicyUpgrade(policy, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, rulesUpgradeBackTo, true);
+        // `policy` changes identity on unrelated writes, so gate on the plan type to avoid re-navigating.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isCollect, rulesUpgradeBackTo]);
 
     useEffect(() => () => clearDraftSpendRule(), []);
 
@@ -491,7 +515,7 @@ function SpendRulePageBase({policyID, ruleID, titleKey, testID}: SpendRulePageBa
         <AccessOrNotFoundWrapper
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED}
-            accessVariants={[CONST.POLICY.ACCESS_VARIANTS.PAID, CONST.POLICY.ACCESS_VARIANTS.CONTROL]}
+            accessVariants={[CONST.POLICY.ACCESS_VARIANTS.PAID]}
             shouldBeBlocked={!!policy?.id && !canWriteSpendRules}
         >
             <ScreenWrapper

--- a/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
@@ -11,6 +11,7 @@ import Text from '@components/Text';
 
 import useCanWriteCardSpendRules from '@hooks/useCanWriteCardSpendRules';
 import useConfirmModal from '@hooks/useConfirmModal';
+import useControlOnlyRuleUpgradeRedirect from '@hooks/useControlOnlyRuleUpgradeRedirect';
 import {useCurrencyListActions} from '@hooks/useCurrencyList';
 import useDefaultFundID from '@hooks/useDefaultFundID';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
@@ -30,7 +31,6 @@ import {convertToBackendAmount} from '@libs/CurrencyUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {rand64} from '@libs/NumberUtils';
 import {temporaryGetDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
-import {isCollectPolicy, tryNavigateToControlPolicyUpgrade} from '@libs/PolicyUtils';
 import {getSpendRuleFormValuesFromCardRule, getTruncatedSpendRuleSummary} from '@libs/SpendRulesUtils';
 
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
@@ -48,7 +48,7 @@ import type IconAsset from '@src/types/utils/IconAsset';
 
 import type {ValueOf} from 'type-fest';
 
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
 
 type SpendRulePageBaseProps = {
@@ -83,6 +83,7 @@ function SpendRulePageBase({policyID, ruleID, titleKey, testID, upgradeBackTo}: 
 
     const {showReadOnlyModal} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.RULES);
     const canWriteSpendRules = useCanWriteCardSpendRules(policyID);
+    useControlOnlyRuleUpgradeRedirect(policyID, upgradeBackTo);
     const {isBetaEnabled} = usePermissions();
     const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
     const icons = useMemoizedLazyExpensifyIcons(['CreditCardHourglass', 'MoneyCircle', 'CoinsButton', 'Basket']);
@@ -104,25 +105,6 @@ function SpendRulePageBase({policyID, ruleID, titleKey, testID, upgradeBackTo}: 
         const hasNoMerchantRestrictions = !existingFormValues?.merchantNames.length && !existingFormValues?.categories?.length;
         return isNewRule || hasNoMerchantRestrictions;
     });
-
-    // Card restrictions are Control-only, so Collect admins get the upgrade page rather than a Not Found page.
-    // This runs here rather than as an `accessVariants` CONTROL check because AccessOrNotFoundWrapper can only
-    // render Not Found, and because deep links (Wallet > card > Edit spend rules) skip the Rules page's own
-    // upgrade gating entirely.
-    const isCollect = isCollectPolicy(policy);
-    const hasRedirectedToUpgrade = useRef(false);
-    const rulesUpgradeBackTo = upgradeBackTo ?? ROUTES.WORKSPACE_RULES.getRoute(policyID);
-
-    useEffect(() => {
-        if (!isCollect || hasRedirectedToUpgrade.current) {
-            return;
-        }
-
-        // Replace rather than push: Back from the upgrade page must not land on this page, which Collect can't use.
-        hasRedirectedToUpgrade.current = tryNavigateToControlPolicyUpgrade(policy, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, rulesUpgradeBackTo, true);
-        // `policy` changes identity on unrelated writes, so gate on the plan type to avoid re-navigating.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isCollect, rulesUpgradeBackTo]);
 
     useEffect(() => () => clearDraftSpendRule(), []);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

#95310 added the `CONTROL` access variant to the spend rule pages to keep **Card restrictions** Control-only. However, access variants in `AccessOrNotFoundWrapper` are **ANDed**, so they can only render **Not Found** when any required variant is missing. As a result, Collect workspaces were hard-blocked from these pages.

This also bypassed the existing **feature disabled → More features** upgrade flow that these pages previously used.

The main entry point affected is **Wallet → Card details → Edit spend rules**. That action is available to any workspace admin and doesn't perform any plan or feature checks, so it bypasses the upgrade gating already implemented by the Rules pages.

## Fix

- Remove the `CONTROL` access variant from the three spend rule pages.
- Redirect Collect admins to the **Control upgrade** page instead, matching the behavior of the Rules page for other Control-only features.
- Use `Navigation.dismissModalAndReplace` so pressing **Back** from the upgrade flow doesn't return to a page Collect workspaces can't access.
- Preserve the Wallet flow by passing the current route as `backTo`, so after upgrading the user is returned to where they started.



### Fixed Issues
$ https://github.com/Expensify/App/issues/97632
PROPOSAL:



### Tests

1. **Collect workspace + card issued + Rules feature disabled**
   * Go to **Wallet → Card → Edit spend rules**.
   * **Verify:** You are redirected to the **More features** upgrade page.
2. **Collect workspace + card issued + Rules feature enabled**
   * Go to **Wallet → Card → Edit spend rules**.
   * **Verify:** The **upgrade page** is shown (previously this was the "Not Here" page).
   * Complete the upgrade.
   * **Verify:** You are redirected back to the **Spend rules** page and can use it normally.
3. **Control workspace + Rules feature enabled**
   * Go to **Wallet → Card → Edit spend rules**.
   * **Verify:** The page opens normally and changes can be saved.
4. **Control workspace + Rules feature disabled**
   * Go to **Wallet → Card → Edit spend rules**.
   * **Verify:** You are redirected to the **More features** page (same behavior as before this PR).
5. **Control workspace**
   * Go to **Rules → Card restrictions**.
   * Add and edit a rule.
   * **Verify:** The card and category pickers work correctly.

- [x] Verify that no errors appear in the JS console

### Offline tests
- Same as test

### QA Steps
- Same as test

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


https://github.com/user-attachments/assets/dc7ac875-fa61-4cb4-a747-9e22fca993ea


https://github.com/user-attachments/assets/ddea9dbe-ab73-4d42-9355-86e490959e3c


