### PR TITLE
Fix Workflows off submission fallback

### DIFF
--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -5230,6 +5230,7 @@ function enablePolicyWorkflows(
     enabled: boolean,
     currentApprovalMode: Policy['approvalMode'],
     currentAutoReporting: Policy['autoReporting'],
+    currentAutoReportingFrequency: Policy['autoReportingFrequency'],
     currentHarvesting: Policy['harvesting'],
     currentReimbursementChoice: Policy['reimbursementChoice'],
 ) {
@@ -5243,9 +5244,10 @@ function enablePolicyWorkflows(
                     ...(!enabled
                         ? {
                               approvalMode: CONST.POLICY.APPROVAL_MODE.OPTIONAL,
-                              autoReporting: false,
+                              autoReporting: true,
+                              autoReportingFrequency: CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT,
                               harvesting: {
-                                  enabled: false,
+                                  enabled: true,
                               },
                               reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO,
                           }
@@ -5256,6 +5258,7 @@ function enablePolicyWorkflows(
                             ? {
                                   approvalMode: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                                   autoReporting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                                  autoReportingFrequency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                                   harvesting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                                   reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                               }
@@ -5275,6 +5278,7 @@ function enablePolicyWorkflows(
                             ? {
                                   approvalMode: null,
                                   autoReporting: null,
+                                  autoReportingFrequency: null,
                                   harvesting: null,
                                   reimbursementChoice: null,
                               }
@@ -5293,6 +5297,7 @@ function enablePolicyWorkflows(
                         ? {
                               approvalMode: currentApprovalMode,
                               autoReporting: currentAutoReporting,
+                              autoReportingFrequency: currentAutoReportingFrequency ?? null,
                               harvesting: currentHarvesting,
                               reimbursementChoice: currentReimbursementChoice,
                           }
@@ -5303,6 +5308,7 @@ function enablePolicyWorkflows(
                             ? {
                                   approvalMode: null,
                                   autoReporting: null,
+                                  autoReportingFrequency: null,
                                   harvesting: null,
                                   reimbursementChoice: null,
                               }

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -495,7 +495,15 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
                                 if (!policyID) {
                                     return;
                                 }
-                                enablePolicyWorkflows(policyID, isEnabled, policy?.approvalMode, policy?.autoReporting, policy?.harvesting, policy?.reimbursementChoice);
+                                enablePolicyWorkflows(
+                                    policyID,
+                                    isEnabled,
+                                    policy?.approvalMode,
+                                    policy?.autoReporting,
+                                    policy?.autoReportingFrequency,
+                                    policy?.harvesting,
+                                    policy?.reimbursementChoice,
+                                );
                             }}
                             onPress={() => {
                                 if (!policyID) {

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -5263,7 +5263,7 @@ describe('actions/Policy', () => {
 
             // When enablePolicyWorkflows is called to enable workflows
             mockFetch.pause();
-            Policy.enablePolicyWorkflows(policyID, true, undefined, undefined, undefined, undefined);
+            Policy.enablePolicyWorkflows(policyID, true, undefined, undefined, undefined, undefined, undefined);
             await waitForBatchedUpdates();
 
             // Then workflows should be enabled optimistically
@@ -5279,7 +5279,7 @@ describe('actions/Policy', () => {
             expect(updatedPolicy?.pendingFields?.areWorkflowsEnabled).toBeUndefined();
         });
 
-        it('should revert policy workflows when fail', async () => {
+        it('should disable policy workflows with instant submission optimistically and succeed', async () => {
             // Given a policy with workflows enabled
             const policyID = '1';
             const fakePolicy = {
@@ -5287,26 +5287,98 @@ describe('actions/Policy', () => {
                 areWorkflowsEnabled: true,
                 approvalMode: CONST.POLICY.APPROVAL_MODE.ADVANCED,
                 autoReporting: true,
-                harvesting: {enabled: true, jobID: 123},
+                autoReportingFrequency: CONST.POLICY.AUTO_REPORTING_FREQUENCIES.WEEKLY,
+                harvesting: {enabled: false},
                 reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
             };
             Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, fakePolicy);
             await waitForBatchedUpdates();
 
-            // When enablePolicyWorkflows is called to disable workflows and fails
-            mockFetch.fail();
-            Policy.enablePolicyWorkflows(policyID, false, fakePolicy.approvalMode, fakePolicy.autoReporting, fakePolicy.harvesting, fakePolicy.reimbursementChoice);
+            // When enablePolicyWorkflows is called to disable workflows
+            mockFetch.pause();
+            Policy.enablePolicyWorkflows(
+                policyID,
+                false,
+                fakePolicy.approvalMode,
+                fakePolicy.autoReporting,
+                fakePolicy.autoReportingFrequency,
+                fakePolicy.harvesting,
+                fakePolicy.reimbursementChoice,
+            );
             await waitForBatchedUpdates();
 
-            // Then workflows should be reverted to enabled and other fields restored
-            const updatedPolicy = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
-            expect(updatedPolicy?.areWorkflowsEnabled).toBe(true);
-            expect(updatedPolicy?.approvalMode).toBe(CONST.POLICY.APPROVAL_MODE.ADVANCED);
+            // Then workflows should be disabled with instant submission optimistically
+            let updatedPolicy = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
+            expect(updatedPolicy?.areWorkflowsEnabled).toBe(false);
+            expect(updatedPolicy?.approvalMode).toBe(CONST.POLICY.APPROVAL_MODE.OPTIONAL);
             expect(updatedPolicy?.autoReporting).toBe(true);
+            expect(updatedPolicy?.autoReportingFrequency).toBe(CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT);
             expect(updatedPolicy?.harvesting?.enabled).toBe(true);
-            expect(updatedPolicy?.reimbursementChoice).toBe(CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES);
+            expect(updatedPolicy?.reimbursementChoice).toBe(CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO);
+            expect(updatedPolicy?.pendingFields).toMatchObject({
+                areWorkflowsEnabled: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                approvalMode: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                autoReporting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                autoReportingFrequency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                harvesting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+            });
+
+            // When the fetch resumes and succeeds
+            await mockFetch.resume();
+
+            // Then all workflow pending fields should be cleared
+            updatedPolicy = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
             expect(updatedPolicy?.pendingFields?.areWorkflowsEnabled).toBeUndefined();
+            expect(updatedPolicy?.pendingFields?.approvalMode).toBeUndefined();
+            expect(updatedPolicy?.pendingFields?.autoReporting).toBeUndefined();
+            expect(updatedPolicy?.pendingFields?.autoReportingFrequency).toBeUndefined();
+            expect(updatedPolicy?.pendingFields?.harvesting).toBeUndefined();
+            expect(updatedPolicy?.pendingFields?.reimbursementChoice).toBeUndefined();
         });
+
+        it.each([CONST.POLICY.AUTO_REPORTING_FREQUENCIES.WEEKLY, undefined] as const)(
+            'should revert policy workflows when fail with auto reporting frequency %s',
+            async (autoReportingFrequency) => {
+                // Given a policy with workflows enabled
+                const policyID = '1';
+                const fakePolicy = {
+                    id: policyID,
+                    areWorkflowsEnabled: true,
+                    approvalMode: CONST.POLICY.APPROVAL_MODE.ADVANCED,
+                    autoReporting: true,
+                    autoReportingFrequency,
+                    harvesting: {enabled: true, jobID: 123},
+                    reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
+                };
+                Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, fakePolicy);
+                await waitForBatchedUpdates();
+
+                // When enablePolicyWorkflows is called to disable workflows and fails
+                mockFetch.fail();
+                Policy.enablePolicyWorkflows(
+                    policyID,
+                    false,
+                    fakePolicy.approvalMode,
+                    fakePolicy.autoReporting,
+                    fakePolicy.autoReportingFrequency,
+                    fakePolicy.harvesting,
+                    fakePolicy.reimbursementChoice,
+                );
+                await waitForBatchedUpdates();
+
+                // Then workflows should be reverted to enabled and other fields restored
+                const updatedPolicy = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
+                expect(updatedPolicy?.areWorkflowsEnabled).toBe(true);
+                expect(updatedPolicy?.approvalMode).toBe(CONST.POLICY.APPROVAL_MODE.ADVANCED);
+                expect(updatedPolicy?.autoReporting).toBe(true);
+                expect(updatedPolicy?.autoReportingFrequency).toBe(autoReportingFrequency);
+                expect(updatedPolicy?.harvesting?.enabled).toBe(true);
+                expect(updatedPolicy?.reimbursementChoice).toBe(CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES);
+                expect(updatedPolicy?.pendingFields?.areWorkflowsEnabled).toBeUndefined();
+                expect(updatedPolicy?.pendingFields?.autoReportingFrequency).toBeUndefined();
+            },
+        );
     });
     describe('enableDistanceRequestTax', () => {
         it('should enable distance request tax optimistically and succeed', async () => {


### PR DESCRIPTION
### Explanation of Change

Updates the App-side policy mirror used when Workflows are disabled so the workspace falls back to Submit & Close with Instant submission instead of turning scheduled submission Off. The optimistic update now enables auto reporting with the `INSTANT` frequency and harvesting, tracks the frequency as pending, and restores the previous frequency if the request fails. The sole caller now passes the current frequency, and focused action tests cover disable success and rollback.

The paired backend change must persist the same state in `EnablePolicyWorkflows`; this PR keeps NewDot's optimistic state aligned with the shared policy that OldDot consumes.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94391
PROPOSAL: https://github.com/Expensify/App/issues/94391#issuecomment-5072853402

### Tests

1. Sign in to New Expensify on desktop web as an admin of a workspace.
2. Open **Workspace settings > More features** and ensure **Workflows** is enabled.
3. Configure submissions to a non-Instant frequency, then return to **More features**.
4. Disable **Workflows**.
5. Verify the Workflows toggle remains off after reloading New Expensify.
6. Open the same workspace in Expensify Classic and verify **Schedule submit** is **Instantly**, not **Off**.
7. Verify no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. While online, open **Workspace settings > More features** for a workspace with Workflows enabled.
2. Force the app offline, then disable **Workflows**.
3. Verify the toggle updates optimistically without an error.
4. Reconnect, reload both New Expensify and Expensify Classic, and verify Workflows remains disabled while Expensify Classic shows **Schedule submit: Instantly**.
5. Verify no errors appear in the JS console.

### QA Steps

1. Sign in to New Expensify on desktop web as an admin of a workspace.
2. Open **Workspace settings > More features** and ensure **Workflows** is enabled.
3. Configure submissions to a non-Instant frequency, then return to **More features**.
4. Disable **Workflows**.
5. Verify the Workflows toggle remains off after reloading New Expensify.
6. Open the same workspace in Expensify Classic and verify **Schedule submit** is **Instantly**, not **Off**.
7. Verify no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
