### PR TITLE
Fix Collect Rules regressions in More features, Require fields, and the upgrade paths

### DIFF
--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -36,6 +36,7 @@ import {
     hasAccountingConnections,
     hasAccountingFeatureConnection,
     hasVendorFeature,
+    isCollectPolicy,
     isControlPolicy,
     isPerDiemEnabled,
     isTimeTrackingEnabled,
@@ -516,7 +517,11 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
                                 if (!policyID) {
                                     return;
                                 }
-                                if (isEnabled && !isControlPolicy(policy) && !isRulesRevampEnabled) {
+                                // Only Control always has Rules, and Collect gains them with the revamp beta. Anything
+                                // else (Submit) can't hold Rules at all — arePolicyRulesEnabled would keep reading
+                                // false — so it has to keep going to the upgrade page rather than writing a flag that
+                                // never takes effect.
+                                if (isEnabled && !isControlPolicy(policy) && (!isRulesRevampEnabled || !isCollectPolicy(policy))) {
                                     Navigation.navigate(
                                         ROUTES.WORKSPACE_UPGRADE.getRoute(policyID, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, ROUTES.WORKSPACE_MORE_FEATURES.getRoute(policyID)),
                                     );

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -36,7 +36,6 @@ import {
     hasAccountingConnections,
     hasAccountingFeatureConnection,
     hasVendorFeature,
-    isCollectPolicy,
     isControlPolicy,
     isPerDiemEnabled,
     isTimeTrackingEnabled,
@@ -521,7 +520,7 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
                                 // else (Submit) can't hold Rules at all — arePolicyRulesEnabled would keep reading
                                 // false — so it has to keep going to the upgrade page rather than writing a flag that
                                 // never takes effect.
-                                if (isEnabled && !isControlPolicy(policy) && (!isRulesRevampEnabled || !isCollectPolicy(policy))) {
+                                if (isEnabled && !canPolicyAccessFeature(policy, CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED, isRulesRevampEnabled)) {
                                     Navigation.navigate(
                                         ROUTES.WORKSPACE_UPGRADE.getRoute(policyID, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, ROUTES.WORKSPACE_MORE_FEATURES.getRoute(policyID)),
                                     );

--- a/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
@@ -17,6 +17,7 @@ import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOpt
 import variables from '@styles/variables';
 
 import CONST from '@src/CONST';
+import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
@@ -47,7 +48,7 @@ type BasicRuleMenuItem = {
     title: string;
     description?: string;
     icon: IconAsset;
-    action: () => void;
+    route: Route;
     pendingAction?: PendingAction;
 };
 
@@ -100,10 +101,12 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
     const rulesUpgradeAlias = CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias;
 
     const handleMenuItemPress = (item: BasicRuleMenuItem) => {
-        if (isCollect && !COLLECT_ALLOWED_RULE_KEYS.has(item.key) && tryNavigateToControlPolicyUpgrade(policy, rulesUpgradeAlias, rulesUpgradeBackTo)) {
+        // Return to the row's own page after upgrading rather than the Rules list, so the user lands where they were
+        // headed — same as the GL code upgrade flow in tag settings.
+        if (isCollect && !COLLECT_ALLOWED_RULE_KEYS.has(item.key) && tryNavigateToControlPolicyUpgrade(policy, rulesUpgradeAlias, item.route)) {
             return;
         }
-        item.action();
+        Navigation.navigate(item.route);
     };
 
     const navigateToRulesControlUpgrade = () => {
@@ -133,7 +136,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             title: translate('workspace.rules.generalTab.expensesOlderThan'),
             description: maxExpenseAgeText,
             icon: icons.CalendarSolid,
-            action: () => Navigation.navigate(ROUTES.RULES_MAX_EXPENSE_AGE.getRoute(policyID)),
+            route: ROUTES.RULES_MAX_EXPENSE_AGE.getRoute(policyID),
             pendingAction: policy?.pendingFields?.maxExpenseAge,
         },
         {
@@ -141,7 +144,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             title: translate('workspace.rules.generalTab.expensesAboveAmount'),
             description: maxExpenseAmountText,
             icon: icons.Coins,
-            action: () => Navigation.navigate(ROUTES.RULES_MAX_EXPENSE_AMOUNT.getRoute(policyID)),
+            route: ROUTES.RULES_MAX_EXPENSE_AMOUNT.getRoute(policyID),
             pendingAction: policy?.pendingFields?.maxExpenseAmount,
         },
         {
@@ -149,7 +152,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             title: translate('workspace.rules.generalTab.flagReceiptLineItems'),
             description: prohibitedExpensesText,
             icon: icons.Receipt,
-            action: () => Navigation.navigate(ROUTES.RULES_PROHIBITED_DEFAULT.getRoute(policyID)),
+            route: ROUTES.RULES_PROHIBITED_DEFAULT.getRoute(policyID),
             pendingAction: !isEmptyObject(policy?.prohibitedExpenses?.pendingFields) ? CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE : undefined,
         },
         {
@@ -157,7 +160,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             title: translate('workspace.rules.generalTab.receiptRequirements'),
             description: receiptRequirementText,
             icon: icons.ReceiptCheck,
-            action: () => Navigation.navigate(ROUTES.RULES_REQUIRE_RECEIPTS.getRoute(policyID)),
+            route: ROUTES.RULES_REQUIRE_RECEIPTS.getRoute(policyID),
             pendingAction: policy?.pendingFields?.maxExpenseAmountNoReceipt ?? policy?.pendingFields?.maxExpenseAmountNoItemizedReceipt,
         },
         {
@@ -165,7 +168,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             title: translate('workspace.rules.generalTab.requireFieldsForAllExpenses'),
             description: requiredFieldsList,
             icon: icons.Task,
-            action: () => Navigation.navigate(ROUTES.RULES_REQUIRE_FIELDS.getRoute(policyID)),
+            route: ROUTES.RULES_REQUIRE_FIELDS.getRoute(policyID),
             pendingAction: policy?.pendingFields?.requiresCategory ?? policy?.pendingFields?.requiresTag,
         },
     ];
@@ -176,7 +179,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             title: translate('workspace.rules.generalTab.cashExpenses'),
             description: reimbursableModeText,
             icon: icons.Cash,
-            action: () => Navigation.navigate(ROUTES.RULES_REIMBURSABLE_DEFAULT.getRoute(policyID)),
+            route: ROUTES.RULES_REIMBURSABLE_DEFAULT.getRoute(policyID),
             pendingAction: policy?.pendingFields?.defaultReimbursable,
         },
         {
@@ -184,7 +187,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
             title: translate('workspace.rules.generalTab.billableExpenses'),
             description: billableModeText,
             icon: icons.Cash,
-            action: () => Navigation.navigate(ROUTES.RULES_BILLABLE_DEFAULT.getRoute(policyID)),
+            route: ROUTES.RULES_BILLABLE_DEFAULT.getRoute(policyID),
             pendingAction: getBillableExpensesPendingAction(policy),
         },
     ];

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -385,6 +385,7 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
                                 policyID={policyID}
                                 canWriteRules={canWriteRules}
                                 isAgentsRulesBannerDismissed={isAgentsRulesBannerDismissed}
+                                onOpenAgentsTab={() => handleTabPress(RULES_TAB.AGENTS)}
                             />
                         )}
                         {isTableTab && (

--- a/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
+++ b/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
@@ -55,7 +55,7 @@ function RulesRequireFieldsPage({
 
     const hasEnabledTags = hasEnabledOptions(Object.values(policyTags ?? {}).flatMap(({tags}) => Object.values(tags)));
     const isTagFeatureDisabled = !policy?.areTagsEnabled;
-    const isTagToggleDisabled = isTagFeatureDisabled || !hasEnabledTags;
+    const isTagToggleDisabled = isTagFeatureDisabled || !hasEnabledTags || isConnectedToAccounting;
     // For independent multi-level tags, Required is configured per level in each tag list's RHP, so the policy-wide toggle is hidden (same gate as WorkspaceTagsSettingsPage).
     const shouldShowTagToggle = !isMultiLevelTagsUtil(policyTags) || hasDependentTagsUtil(policy, policyTags);
     const initialCategoryRequired = !!policy?.requiresCategory;
@@ -102,7 +102,7 @@ function RulesRequireFieldsPage({
     // Lock UX only when the feature itself is off (or categories are accounting-controlled).
     // Feature on but no enabled items: toggle stays disabled without lock/modal.
     const shouldShowCategoryLock = isCategoryFeatureDisabled || isConnectedToAccounting;
-    const shouldShowTagLock = isTagFeatureDisabled;
+    const shouldShowTagLock = isTagFeatureDisabled || isConnectedToAccounting;
 
     const categoryDisabledText = (() => {
         if (!shouldShowCategoryLock) {
@@ -147,7 +147,33 @@ function RulesRequireFieldsPage({
         setCategoryRequired(true);
     }, [isCategoryFeatureDisabled, isConnectedToAccounting, policyData, policyID, showConfirmModal, translate]);
 
+    const tagDisabledText = (() => {
+        if (!shouldShowTagLock) {
+            return undefined;
+        }
+        if (isConnectedToAccounting) {
+            return translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledText');
+        }
+        return translate('workspace.rules.individualExpenseRules.enableTagsToUnlockPrompt');
+    })();
+
     const promptEnableTagsForRequireTag = useCallback(async () => {
+        // Accounting owns Tags while a connection is active, same as the Tags toggle on More features, so this must
+        // not force the feature on from here.
+        if (isConnectedToAccounting) {
+            const {action} = await showConfirmModal({
+                title: translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle'),
+                prompt: translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledText'),
+                confirmText: translate('workspace.moreFeatures.connectionsWarningModal.manageSettings'),
+                cancelText: translate('common.cancel'),
+            });
+            if (action !== ModalActions.CONFIRM) {
+                return;
+            }
+            Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
+            return;
+        }
+
         if (!isTagFeatureDisabled) {
             return;
         }
@@ -164,7 +190,7 @@ function RulesRequireFieldsPage({
         enablePolicyTags(policyData, true);
         setPolicyRequiresTag(policyData, true);
         setTagRequired(true);
-    }, [isTagFeatureDisabled, policyData, showConfirmModal, translate]);
+    }, [isConnectedToAccounting, isTagFeatureDisabled, policyData, policyID, showConfirmModal, translate]);
 
     return (
         <AccessOrNotFoundWrapper
@@ -214,7 +240,7 @@ function RulesRequireFieldsPage({
                             isActive={tagRequired}
                             disabled={isTagToggleDisabled}
                             showLockIcon={shouldShowTagLock}
-                            disabledText={shouldShowTagLock ? translate('workspace.rules.individualExpenseRules.enableTagsToUnlockPrompt') : undefined}
+                            disabledText={tagDisabledText}
                             disabledAction={shouldShowTagLock ? promptEnableTagsForRequireTag : undefined}
                             pendingAction={policy?.pendingFields?.requiresTag}
                             errors={policy?.errorFields?.requiresTag ?? undefined}

--- a/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
+++ b/src/pages/workspace/rules/RulesRequireFieldsPage.tsx
@@ -16,7 +16,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
-import {hasDependentTags as hasDependentTagsUtil, isMultiLevelTags as isMultiLevelTagsUtil} from '@libs/PolicyUtils';
+import {hasAccountingConnections, hasDependentTags as hasDependentTagsUtil, isMultiLevelTags as isMultiLevelTagsUtil} from '@libs/PolicyUtils';
 
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
@@ -48,7 +48,9 @@ function RulesRequireFieldsPage({
     const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
 
-    const isConnectedToAccounting = Object.keys(policy?.connections ?? {}).length > 0;
+    // Match the Categories/Tags toggles on WorkspaceMoreFeaturesPage: only an accounting connection owns these
+    // features. policy.connections also holds HR connections, which must not lock the Required toggles.
+    const isConnectedToAccounting = hasAccountingConnections(policy);
     const hasEnabledCategories = hasEnabledOptions(policyData.categories);
     const isCategoryFeatureDisabled = !policy?.areCategoriesEnabled;
     const isCategoryToggleDisabled = isCategoryFeatureDisabled || !hasEnabledCategories || isConnectedToAccounting;

--- a/src/pages/workspace/rules/tabs/RulesGeneralTab.tsx
+++ b/src/pages/workspace/rules/tabs/RulesGeneralTab.tsx
@@ -4,7 +4,6 @@ import useLocalize from '@hooks/useLocalize';
 import usePermissions from '@hooks/usePermissions';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import Tab from '@libs/actions/Tab';
 import {dismissProductTraining} from '@libs/actions/Welcome';
 
 import IndividualExpenseRulesSectionRevamp from '@pages/workspace/rules/IndividualExpenseRulesSectionRevamp';
@@ -17,9 +16,11 @@ type RulesGeneralTabProps = {
     policyID: string;
     canWriteRules: boolean;
     isAgentsRulesBannerDismissed: boolean;
+    /** Opens the Agents tab through the page's tab handler, so Collect gets the Control upgrade page instead. */
+    onOpenAgentsTab: () => void;
 };
 
-function RulesGeneralTab({policyID, canWriteRules, isAgentsRulesBannerDismissed}: RulesGeneralTabProps) {
+function RulesGeneralTab({policyID, canWriteRules, isAgentsRulesBannerDismissed, onOpenAgentsTab}: RulesGeneralTabProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {isBetaEnabled} = usePermissions();
@@ -36,7 +37,7 @@ function RulesGeneralTab({policyID, canWriteRules, isAgentsRulesBannerDismissed}
                     title={translate('workspace.rules.agentsPromoBanner.title')}
                     subtitle={translate('workspace.rules.agentsPromoBanner.subtitle')}
                     ctaText={translate('workspace.rules.agentsPromoBanner.cta')}
-                    onCtaPress={() => Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, CONST.TAB.RULES.AGENTS)}
+                    onCtaPress={onOpenAgentsTab}
                     ctaSentryLabel={CONST.SENTRY_LABEL.AGENTS_RULES_BANNER.CTA}
                     onDismiss={() => dismissProductTraining(CONST.AGENTS_RULES_BANNER, true)}
                     dismissSentryLabel={CONST.SENTRY_LABEL.AGENTS_RULES_BANNER.DISMISS}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

This PR fixes four follow-ups from **Rules for Collect**.

### 1. Rules toggle on Submit workspaces

With the Rules revamp beta enabled, the **Rules** toggle on a **Submit** workspace appeared to do nothing.

The upgrade redirect was gated only on the beta, so every non-Control workspace went down the enable path. However, `arePolicyRulesEnabled` only recognizes **Collect** and **Control**, so the flag was written but always read back as disabled.

Submit workspaces now continue to go through the **upgrade** flow, matching the existing behavior when the beta is off.

### 2. Tags bypassed the accounting integration guard

**Require fields for all expenses → Tags** could enable Tags even when they were managed by an accounting integration, bypassing the **"Not so fast"** modal shown elsewhere.

Tags now follow the same behavior as Categories:
- The row is locked.
- The **Accounting** modal is shown.
- The feature is no longer force-enabled.

### 3. Agents promo banner on Collect

The **Agents** promo banner switched directly to the **Agents** tab. On Collect workspaces, the page immediately switched back to **General** because of the existing redirect effect.

The CTA now goes through the normal tab handler, which routes Collect workspaces to the **Control upgrade** page.

### 4. Return to the correct page after upgrading

Upgrading from a row in **General** returned users to the **Rules** page instead of the row they originally opened.

Rows now carry their route instead of a navigation callback, and that route is passed as the upgrade `backTo`, matching the GL settings flow for tag settings.

Tabs continue to return to **Rules → General** since the selected tab is stored in Onyx rather than the route. Supporting that will require a separate change.


### Fixed Issues
$ https://github.com/Expensify/App/issues/97640
$ https://github.com/Expensify/App/issues/97639
$ https://github.com/Expensify/App/issues/97638
$ https://github.com/Expensify/App/issues/97625
PROPOSAL:

### Tests
- Precondition:
  - Log in with Expensifail account.
  - Create a Collect workspace.
  
### https://github.com/Expensify/App/issues/97640 Rules - Nothing happens after clicking on Rules toggle for Submit workspace

1. Create a Submit workspace on OD.
2. Go to staging.new.expensify.com
3. Go to Submit workspace settings > More features.
4. Enable Rules.  
5. Verify upgrade page is shown

### https://github.com/Expensify/App/issues/97639 Rules- Tags can be enabled in Require fields for all expenses RHP when accounting is connected
- Precondition:
  - Log in with Expensifail account.
  - Workspace is connected to Sage Intacct.
  - Disable tag import in Accounting > Import > Projects (Jobs) or any other import settings.
  - Enable Rules.

1. Go to Rules > General.
2. Click Require fields for all expenses.
3. Verify tags row is locked, tapping shows "Not so fast"

### https://github.com/Expensify/App/issues/97638 Rules - App returns to Rules > General after clicking Try it out on agent banner

1. Go to staging.new.expensify.com
2. Go to workspace settings > Rules > General.
3. Scroll down to agent banner.
4. Click Try it out.
5. → Agents page opens.
6. Go to workspace settings > Overview > Plan type.
7. Downgrade to Collect plan.
8. Go to workspace settings > Rules > General.
9. Scroll down to agent banner.
10. Click Try it out.
11. Verify upgrade RHP is shown.

### https://github.com/Expensify/App/issues/97625 Rules - RHP does not open after workspace upgrade

1. Go to staging.new.expensify.com
2. Go to Collect workspace settings > More features.
3. Enable Rules.
4. Go to Rules.
5. Enable Flag expenses older than.
6. Click Upgrade > Got it, thanks.
7. Verify Flag expenses older than RHP is shown


- [x] Verify that no errors appear in the JS console

### Offline tests
- Same as tests

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


https://github.com/user-attachments/assets/f16ffba0-1689-4301-a752-0e961e04ab7d



https://github.com/user-attachments/assets/d8110eeb-c11e-4bbd-a230-225cf2d4d3a5

