### PR TITLE
Missing Canadian Multiple Tax Export when bulk selecting reports from…

### DIFF
--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -535,9 +535,10 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         [selectedTransactions],
     );
 
-    // A bulk selection can span several workspaces, so the Canadian Multiple Tax Export template is only offered when every selected item belongs to a workspace that outputs in CAD
+    // A bulk selection can span several workspaces, so the Canadian Multiple Tax Export template is only offered when every selected item belongs to a workspace that outputs in CAD.
+    // Reports and transactions are both checked because a selection can mix whole reports with individual transactions from other reports, and the export request covers all of them.
     const doAllSelectedItemsBelongToCADPolicies = useMemo(() => {
-        const selectedItems = selectedReports.length > 0 ? selectedReports : Object.values(selectedTransactions);
+        const selectedItems = [...selectedReports, ...Object.values(selectedTransactions)];
         if (selectedItems.length === 0) {
             return false;
         }

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -534,6 +534,17 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         ],
         [selectedTransactions],
     );
+
+    // A bulk selection can span several workspaces, so the Canadian Multiple Tax Export template is only offered when every selected item belongs to a workspace that outputs in CAD
+    const doAllSelectedItemsBelongToCADPolicies = useMemo(() => {
+        const selectedItems = selectedReports.length > 0 ? selectedReports : Object.values(selectedTransactions);
+        if (selectedItems.length === 0) {
+            return false;
+        }
+
+        return selectedItems.every((item) => !!item.policyID && policies?.[`${ONYXKEYS.COLLECTION.POLICY}${item.policyID}`]?.outputCurrency === CONST.CURRENCY.CAD);
+    }, [selectedReports, selectedTransactions, policies]);
+
     const selectedBulkCurrency = selectedReports.at(0)?.currency ?? Object.values(selectedTransactions).at(0)?.currency;
     const totalFormattedAmount = getTotalFormattedAmount(convertToDisplayString, selectedReports, selectedTransactions, selectedBulkCurrency);
 
@@ -1638,6 +1649,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 policy,
                 includeReportLevelExport,
                 !isGroupedSearch,
+                doAllSelectedItemsBelongToCADPolicies,
             );
 
             const exportOptions: PopoverMenuItem[] = [];
@@ -2436,6 +2448,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         personalPolicy?.outputCurrency,
         restrictedActionPolicyID,
         doSelectedItemsBelongToSubmitPolicy,
+        doAllSelectedItemsBelongToCADPolicies,
         openSearchReportSubmitToPopover,
         deleteTransactionsFromHook,
         duplicateTransactionViolations,

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -1718,6 +1718,8 @@ type ExportTemplateGroups = {
  * @param policy - The user's policy
  * @param includeReportLevelExport - Whether to include the report level export template
  * @param includeBasicExport - Whether to include the basic export (CSV download) template in the default group
+ * @param includeMultipleTaxExport - Whether to include the Canadian Multiple Tax Export template. Defaults to whether the given policy outputs in CAD, so callers that
+ * export across several workspaces (e.g. a bulk selection in Search) can instead pass whether every selected workspace outputs in CAD.
  * @returns The export templates pre-grouped into the custom group and the default group, each sorted alphabetically
  */
 function getExportTemplates(
@@ -1728,6 +1730,7 @@ function getExportTemplates(
     policy?: Policy,
     includeReportLevelExport = true,
     includeBasicExport = false,
+    includeMultipleTaxExport = policy?.outputCurrency === CONST.CURRENCY.CAD,
 ): ExportTemplateGroups {
     // Helper function to normalize template data into consistent ExportTemplate format
     const normalizeTemplate = (
@@ -1755,7 +1758,7 @@ function getExportTemplates(
     }
 
     // The Canadian Multiple Tax Export template is only relevant to workspaces that output in CAD, so it's hidden for every other currency
-    if (policy?.outputCurrency === CONST.CURRENCY.CAD) {
+    if (includeMultipleTaxExport) {
         exportTemplates.push(normalizeTemplate(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT, {name: translate('export.multipleTaxExport')}, CONST.EXPORT_TEMPLATE_TYPES.INTEGRATIONS));
     }
 

--- a/tests/unit/SearchActionsTest.ts
+++ b/tests/unit/SearchActionsTest.ts
@@ -9,6 +9,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {ExportTemplate, Policy} from '@src/types/onyx';
 import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
 
+import createRandomPolicy from '../utils/collections/policies';
 import {translateLocal} from '../utils/TestHelper';
 
 jest.mock('@libs/API');
@@ -219,6 +220,7 @@ describe('getExportTemplates', () => {
     const translate = translateLocal;
     const localeCompare = (first: string, second: string) => first.localeCompare(second);
     const makeTemplate = (name: string): ExportTemplate => ({name, templateName: name, type: '', policyID: undefined, description: ''});
+    const makePolicyWithOutputCurrency = (outputCurrency: string): Policy => ({...createRandomPolicy(1), outputCurrency});
 
     it('returns the custom templates and the default templates as separate groups, each sorted alphabetically', () => {
         const integrationsExportTemplates: ExportTemplate[] = [makeTemplate('Zebra integration'), makeTemplate('Apple integration')];
@@ -260,15 +262,13 @@ describe('getExportTemplates', () => {
     });
 
     it('includes the Canadian Multiple Tax Export template when the policy outputs in CAD', () => {
-        const policy = {outputCurrency: CONST.CURRENCY.CAD} as Policy;
-        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, policy);
+        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, makePolicyWithOutputCurrency(CONST.CURRENCY.CAD));
 
         expect(defaultTemplates.map((template) => template.templateName)).toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
     });
 
     it('excludes the Canadian Multiple Tax Export template when the policy outputs in another currency', () => {
-        const policy = {outputCurrency: CONST.CURRENCY.USD} as Policy;
-        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, policy);
+        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, makePolicyWithOutputCurrency(CONST.CURRENCY.USD));
 
         expect(defaultTemplates.map((template) => template.templateName)).not.toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
     });
@@ -280,8 +280,7 @@ describe('getExportTemplates', () => {
     });
 
     it('excludes the Canadian Multiple Tax Export template when includeMultipleTaxExport is false for a CAD policy', () => {
-        const policy = {outputCurrency: CONST.CURRENCY.CAD} as Policy;
-        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, policy, true, false, false);
+        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, makePolicyWithOutputCurrency(CONST.CURRENCY.CAD), true, false, false);
 
         expect(defaultTemplates.map((template) => template.templateName)).not.toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
     });

--- a/tests/unit/SearchActionsTest.ts
+++ b/tests/unit/SearchActionsTest.ts
@@ -6,7 +6,7 @@ import type {SearchKey} from '@libs/SearchUIUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {ExportTemplate} from '@src/types/onyx';
+import type {ExportTemplate, Policy} from '@src/types/onyx';
 import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
 
 import {translateLocal} from '../utils/TestHelper';
@@ -257,5 +257,32 @@ describe('getExportTemplates', () => {
 
         // Basic export is sorted alphabetically alongside the other default templates, not pinned to the bottom
         expect(names).toEqual([translate('export.expenseLevelExport'), translate('export.reportLevelExport'), translate('export.basicExport')].sort(localeCompare));
+    });
+
+    it('includes the Canadian Multiple Tax Export template when the policy outputs in CAD', () => {
+        const policy = {outputCurrency: CONST.CURRENCY.CAD} as Policy;
+        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, policy);
+
+        expect(defaultTemplates.map((template) => template.templateName)).toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
+    });
+
+    it('excludes the Canadian Multiple Tax Export template when the policy outputs in another currency', () => {
+        const policy = {outputCurrency: CONST.CURRENCY.USD} as Policy;
+        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, policy);
+
+        expect(defaultTemplates.map((template) => template.templateName)).not.toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
+    });
+
+    it('includes the Canadian Multiple Tax Export template when includeMultipleTaxExport is true without a policy', () => {
+        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, undefined, true, false, true);
+
+        expect(defaultTemplates.map((template) => template.templateName)).toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
+    });
+
+    it('excludes the Canadian Multiple Tax Export template when includeMultipleTaxExport is false for a CAD policy', () => {
+        const policy = {outputCurrency: CONST.CURRENCY.CAD} as Policy;
+        const {defaultTemplates} = getExportTemplates([], {}, translate, localeCompare, policy, true, false, false);
+
+        expect(defaultTemplates.map((template) => template.templateName)).not.toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
     });
 });

--- a/tests/unit/hooks/useSearchBulkActionsExportTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsExportTest.ts
@@ -5,6 +5,7 @@ import type {SearchQueryJSON, SelectedReports, SelectedTransactions} from '@comp
 
 import useSearchBulkActions from '@hooks/useSearchBulkActions';
 
+import {getExportTemplates} from '@libs/actions/Search';
 import type * as ReportSecondaryActionUtilsModule from '@libs/ReportSecondaryActionUtils';
 
 import CONST from '@src/CONST';
@@ -228,6 +229,8 @@ jest.mock('@components/Search/SearchContext', () => ({
         selectAllMatchingItems: mockSelectAllMatchingItems,
     }),
 }));
+
+const mockGetExportTemplates = jest.mocked(getExportTemplates);
 
 const CURRENT_USER_ACCOUNT_ID = 1;
 
@@ -484,6 +487,56 @@ describe('useSearchBulkActions - export options', () => {
 
         await waitFor(() => {
             expect(getExportOptionTexts(result.current.headerButtonsOptions)).toEqual(['export.currentView']);
+        });
+    });
+
+    describe('Canadian Multiple Tax Export eligibility', () => {
+        const SECOND_POLICY_ID = 'policy2';
+        const SECOND_REPORT_ID = 'report2';
+
+        /** The includeMultipleTaxExport argument getExportTemplates was last called with */
+        function getIncludeMultipleTaxExportArgument() {
+            return mockGetExportTemplates.mock.calls.at(-1)?.at(7);
+        }
+
+        beforeEach(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, {outputCurrency: CONST.CURRENCY.CAD});
+        });
+
+        it('offers the template when every selected workspace outputs in CAD, even across several workspaces', async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${SECOND_POLICY_ID}`, {id: SECOND_POLICY_ID, outputCurrency: CONST.CURRENCY.CAD});
+
+            mockCurrentSearchResults = makeSearchResults([makeSnapshotReport()]);
+            mockSelectedReports = [makeSelectedReport(), makeSelectedReport({reportID: SECOND_REPORT_ID, policyID: SECOND_POLICY_ID})];
+            mockSelectedTransactions = {
+                tx1: makeSelectedTransaction(),
+                tx2: makeSelectedTransaction({reportID: SECOND_REPORT_ID, policyID: SECOND_POLICY_ID}),
+            };
+
+            renderHook(() => useSearchBulkActions({queryJSON: expenseReportQueryJSON}), {wrapper: OnyxListItemProvider});
+
+            await waitFor(() => {
+                expect(getIncludeMultipleTaxExportArgument()).toBe(true);
+            });
+        });
+
+        it('hides the template when a transaction from a non-CAD workspace is selected alongside a CAD report', async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${SECOND_POLICY_ID}`, {id: SECOND_POLICY_ID, outputCurrency: CONST.CURRENCY.USD});
+
+            mockCurrentSearchResults = makeSearchResults([makeSnapshotReport()]);
+            // Only the CAD report is fully selected, but an extra transaction from a USD workspace is part of the same export request
+            mockSelectedReports = [makeSelectedReport()];
+            mockSelectedTransactions = {
+                tx1: makeSelectedTransaction(),
+                tx2: makeSelectedTransaction({reportID: SECOND_REPORT_ID, policyID: SECOND_POLICY_ID}),
+            };
+
+            renderHook(() => useSearchBulkActions({queryJSON: expenseReportQueryJSON}), {wrapper: OnyxListItemProvider});
+
+            await waitFor(() => {
+                expect(mockGetExportTemplates).toHaveBeenCalled();
+            });
+            expect(getIncludeMultipleTaxExportArgument()).toBe(false);
         });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

getExportTemplates gated the Canadian Multiple Tax Export template on a single policy's outputCurrency. In Search, useSearchBulkActions only resolves a concrete policy when exactly one workspace is selected (selectedPolicyIDs.length === 1) and otherwise passes undefined, so selecting reports from two CAD workspaces made the gate fail and the template disappeared — even though every selected report was CAD.

getExportTemplates now takes an includeMultipleTaxExport parameter that defaults to policy?.outputCurrency === CONST.CURRENCY.CAD, so single-policy callers behave exactly as before. The bulk-selection path passes its own value instead: a check that every selected report/transaction belongs to a workspace that outputs in CAD. Mixed-currency selections still hide the template, since it only applies when all selected reports are CAD.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97749
$ https://github.com/Expensify/App/issues/97760
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Test case 1:**

Precondition:

Create two workspaces with CAD currency.

1. Go to staging.new.expensify.com
2. Create an expense in both workspaces with CAD currency.
3. Go to Spend > Reports.
4. Select both reports.
5. Click dropdown button > Export.
6. Verify that Canadian Multiple Tax Export is present when bulk selecting reports from CAD workspaces.
7. Select several reports, but 1 of them isn't CAD
8. Verify that Canadian Multiple Tax Export isn't present when bulk selecting reports from CAD workspaces.

**Test case 2:**
Precondition:

Create a workspace with CAD currency.

1. Go to staging.new.expensify.com
2. Go to workspace chat.
3. Create a CAD expense.
4. Go to self DM.
5. Create a non-CAD expense.
6. Go to Spend > Expenses.
7. Verify that: When both expenses from CAD workspace and self DM are selected, Canadian Multiple Tax Export should be hidden.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
9. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
**Test case 1:**

Precondition:

Create two workspaces with CAD currency.

1. Go to staging.new.expensify.com
2. Create an expense in both workspaces with CAD currency.
3. Go to Spend > Reports.
4. Select both reports.
5. Click dropdown button > Export.
6. Verify that Canadian Multiple Tax Export is present when bulk selecting reports from CAD workspaces.
7. Select several reports, but 1 of them isn't CAD
8. Verify that Canadian Multiple Tax Export isn't present when bulk selecting reports from CAD workspaces.

**Test case 2:**
Precondition:

Create a workspace with CAD currency.

1. Go to staging.new.expensify.com
2. Go to workspace chat.
3. Create a CAD expense.
4. Go to self DM.
5. Create a non-CAD expense.
6. Go to Spend > Expenses.
7. Verify that: When both expenses from CAD workspace and self DM are selected, Canadian Multiple Tax Export should be hidden.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/51ac1f4b-1c48-4e91-bb01-9b28f0f2d0fd





</details>
