### PR TITLE
Fix footer Reset falling back to a stale selected-expense currency

### DIFF
--- a/src/components/Search/SearchPageFooter.tsx
+++ b/src/components/Search/SearchPageFooter.tsx
@@ -69,11 +69,13 @@ function SearchPageFooter({count, total, currency, defaultCurrency, isTotalLoadi
             return;
         }
 
+        // Reset (no item) selects the default explicitly, so resetting after the default moved (e.g. a Preferences >
+        // Payment currency change) converts the figures to it instead of leaving them in the loaded denomination.
         const nextCurrency = item?.value ?? defaultCurrency;
         if (!nextCurrency) {
             return;
         }
-        onCurrencyChange(nextCurrency === defaultCurrency ? undefined : nextCurrency);
+        onCurrencyChange(nextCurrency);
     };
 
     const renderCurrencyPopup: FilterPopupButtonProps['PopoverComponent'] = ({closeOverlay, isExpanded}) => (

--- a/src/components/Search/SearchPageFooter.tsx
+++ b/src/components/Search/SearchPageFooter.tsx
@@ -69,11 +69,14 @@ function SearchPageFooter({count, total, currency, defaultCurrency, isTotalLoadi
             return;
         }
 
+        // Reset (no item) selects the default explicitly rather than clearing the choice: the loaded figures can be
+        // denominated in another currency (e.g. after changing Preferences > Payment currency), and only an explicit
+        // selection converts them to it.
         const nextCurrency = item?.value ?? defaultCurrency;
         if (!nextCurrency) {
             return;
         }
-        onCurrencyChange(nextCurrency === defaultCurrency ? undefined : nextCurrency);
+        onCurrencyChange(nextCurrency);
     };
 
     const renderCurrencyPopup: FilterPopupButtonProps['PopoverComponent'] = ({closeOverlay, isExpanded}) => (

--- a/src/components/Search/SearchPageFooter.tsx
+++ b/src/components/Search/SearchPageFooter.tsx
@@ -42,7 +42,7 @@ type SearchPageFooterProps = {
     isTotalLoading: boolean;
 
     /** Function to call when the footer currency changes */
-    onCurrencyChange: (currency: string | undefined) => void;
+    onCurrencyChange: (currency: string) => void;
 };
 
 function SearchPageFooter({count, total, currency, defaultCurrency, isTotalLoading, onCurrencyChange}: SearchPageFooterProps) {
@@ -69,9 +69,7 @@ function SearchPageFooter({count, total, currency, defaultCurrency, isTotalLoadi
             return;
         }
 
-        // Reset (no item) selects the default explicitly rather than clearing the choice: the loaded figures can be
-        // denominated in another currency (e.g. after changing Preferences > Payment currency), and only an explicit
-        // selection converts them to it.
+        // Reset (no item) selects the default explicitly so figures loaded in another currency get converted to it.
         const nextCurrency = item?.value ?? defaultCurrency;
         if (!nextCurrency) {
             return;

--- a/src/components/Search/SearchPageFooter.tsx
+++ b/src/components/Search/SearchPageFooter.tsx
@@ -69,13 +69,11 @@ function SearchPageFooter({count, total, currency, defaultCurrency, isTotalLoadi
             return;
         }
 
-        // Reset (no item) selects the default explicitly, so resetting after the default moved (e.g. a Preferences >
-        // Payment currency change) converts the figures to it instead of leaving them in the loaded denomination.
         const nextCurrency = item?.value ?? defaultCurrency;
         if (!nextCurrency) {
             return;
         }
-        onCurrencyChange(nextCurrency);
+        onCurrencyChange(nextCurrency === defaultCurrency ? undefined : nextCurrency);
     };
 
     const renderCurrencyPopup: FilterPopupButtonProps['PopoverComponent'] = ({closeOverlay, isExpanded}) => (

--- a/src/components/Search/SearchResultsProvider.tsx
+++ b/src/components/Search/SearchResultsProvider.tsx
@@ -36,7 +36,7 @@ const defaultSearchInfo: SearchResultsInfo = {
     isLoading: false,
     count: 0,
     total: 0,
-    currency: '',
+    currency: undefined,
 };
 
 function SearchResultsProvider({children}: SearchResultsProviderProps) {

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -407,12 +407,15 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             return {count: undefined, total: undefined, currency: undefined};
         }
 
+        const selectedTransactionItems = Object.values(selectedTransactions);
+        const fallbackCurrency = effectiveDefaultCurrency ?? selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency;
+
         if (shouldUseClientTotal) {
             const shouldUseConvertedSelectedTotal = hasCustomFooterCurrency && areAllSelectedConverted && !hasConversionFailed && !!selectedCurrency;
 
             // Reports sum each selected report's converted total; other searches sum per row — whole groups from the
-            // groups cache, individual transactions from the transactions cache — falling back to the unconverted
-            // per-row amount until the conversion is ready, which keeps the footer on that currency meanwhile.
+            // groups cache, individual transactions from the transactions cache — falling back to the default per-row
+            // amount until the conversion is ready, which keeps the footer on the default currency meanwhile.
             let total;
             if (shouldUseConvertedSelectedTotal && isReportsSearch && selectedCurrency) {
                 total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[selectedCurrency] ?? 0), 0);
@@ -431,27 +434,26 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
                 }, 0);
             }
 
-            // Unconverted figures keep the currency they're denominated in instead of borrowing the default's symbol,
-            // which can move away from the loaded figures (e.g. after changing Preferences > Payment currency).
-            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : loadedFiguresCurrency};
+            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : fallbackCurrency};
         }
 
         if (hasCustomFooterCurrency && isSearchTotalFresh && !hasConversionFailed && selectedCurrencyConvertedTotal) {
             return {count: selectedCurrencyConvertedTotal.count, total: selectedCurrencyConvertedTotal.total, currency: selectedCurrency};
         }
 
-        return {count: metadataCount, total: metadataTotal, currency: loadedFiguresCurrency};
+        return {count: metadataCount, total: metadataTotal, currency: effectiveDefaultCurrency ?? metadataCurrency};
     }, [
         areAllSelectedConverted,
         convertedGroups,
         convertedReports,
         convertedTransactions,
+        effectiveDefaultCurrency,
         hasConversionFailed,
         hasCustomFooterCurrency,
         isReportsSearch,
         isSearchTotalFresh,
-        loadedFiguresCurrency,
         metadataCount,
+        metadataCurrency,
         metadataTotal,
         selectedCurrency,
         selectedCurrencyConvertedTotal,

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -407,15 +407,12 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             return {count: undefined, total: undefined, currency: undefined};
         }
 
-        const selectedTransactionItems = Object.values(selectedTransactions);
-        const fallbackCurrency = effectiveDefaultCurrency ?? selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency;
-
         if (shouldUseClientTotal) {
             const shouldUseConvertedSelectedTotal = hasCustomFooterCurrency && areAllSelectedConverted && !hasConversionFailed && !!selectedCurrency;
 
             // Reports sum each selected report's converted total; other searches sum per row — whole groups from the
-            // groups cache, individual transactions from the transactions cache — falling back to the default per-row
-            // amount until the conversion is ready, which keeps the footer on the default currency meanwhile.
+            // groups cache, individual transactions from the transactions cache — falling back to the unconverted
+            // per-row amount until the conversion is ready, which keeps the footer on that currency meanwhile.
             let total;
             if (shouldUseConvertedSelectedTotal && isReportsSearch && selectedCurrency) {
                 total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[selectedCurrency] ?? 0), 0);
@@ -434,26 +431,27 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
                 }, 0);
             }
 
-            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : fallbackCurrency};
+            // Unconverted figures keep the currency they're denominated in instead of borrowing the default's symbol,
+            // which can move away from the loaded figures (e.g. after changing Preferences > Payment currency).
+            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : loadedFiguresCurrency};
         }
 
         if (hasCustomFooterCurrency && isSearchTotalFresh && !hasConversionFailed && selectedCurrencyConvertedTotal) {
             return {count: selectedCurrencyConvertedTotal.count, total: selectedCurrencyConvertedTotal.total, currency: selectedCurrency};
         }
 
-        return {count: metadataCount, total: metadataTotal, currency: effectiveDefaultCurrency ?? metadataCurrency};
+        return {count: metadataCount, total: metadataTotal, currency: loadedFiguresCurrency};
     }, [
         areAllSelectedConverted,
         convertedGroups,
         convertedReports,
         convertedTransactions,
-        effectiveDefaultCurrency,
         hasConversionFailed,
         hasCustomFooterCurrency,
         isReportsSearch,
         isSearchTotalFresh,
+        loadedFiguresCurrency,
         metadataCount,
-        metadataCurrency,
         metadataTotal,
         selectedCurrency,
         selectedCurrencyConvertedTotal,

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -1,5 +1,6 @@
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import usePreferredCurrency from '@hooks/usePreferredCurrency';
 import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
 
 import {getFooterConvertedAmounts} from '@libs/actions/Search';
@@ -88,6 +89,7 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     const {currentSearchHash, currentSearchKey, currentSearchQueryJSON} = useSearchQueryContext();
     const shouldAllowFooterTotals = useSearchShouldCalculateTotals(currentSearchKey, currentSearchQueryJSON?.hash, true, areAllMatchingItemsSelected);
     const {isOffline} = useNetwork();
+    const preferredCurrency = usePreferredCurrency();
     const [footerCurrencyState, setFooterCurrencyState] = useState<FooterCurrencyState>({
         searchHash: undefined,
         selectedCurrency: undefined,
@@ -241,10 +243,10 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // Use the per-selection (client) total for a partial selection; nothing-selected and everything-selected both fall
     // to the whole-search grand total, which every search type now returns converted, keyed by the search hash.
     const shouldUseClientTotal = !metadataCount || hasPartialSelection;
-    const firstSelectedTransactionKey = selectedTransactionsKeys.at(0);
-    const firstSelectedTransaction = firstSelectedTransactionKey ? selectedTransactions[firstSelectedTransactionKey] : undefined;
-    const selectedTransactionDefaultCurrency = firstSelectedTransaction?.groupCurrency ?? firstSelectedTransaction?.currency;
-    const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? selectedTransactionDefaultCurrency;
+    // metadataCurrency is empty for a fresh no-workspace account until a search populates search.currency (e.g. after
+    // visiting Reports), so fall back to the user's live payment currency instead of an arbitrary selected expense's currency.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const effectiveDefaultCurrency = defaultFooterCurrency || metadataCurrency || preferredCurrency;
     const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -250,17 +250,7 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // metadataCurrency is unset for a fresh no-workspace account until a search populates search.currency (e.g. after
     // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
     const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
-
-    // The currency the loaded figures are denominated in: the whole-search grand total in metadataCurrency, per-row
-    // figures in the server-converted groupCurrency (or the row's own currency when no conversion happened). A chosen
-    // currency needs converting when it differs from this — comparing against the default instead would skip the
-    // conversion whenever the default itself moved away from the loaded figures (e.g. resetting to a just-changed
-    // Preferences > Payment currency).
-    const firstSelectedTransactionKey = selectedTransactionsKeys.at(0);
-    const firstSelectedTransaction = firstSelectedTransactionKey ? selectedTransactions[firstSelectedTransactionKey] : undefined;
-    const selectionDenominationCurrency = isReportsSearch ? selectedReports.at(0)?.currency : (firstSelectedTransaction?.groupCurrency ?? firstSelectedTransaction?.currency);
-    const loadedFiguresCurrency = (shouldUseClientTotal ? selectionDenominationCurrency : metadataCurrency) ?? effectiveDefaultCurrency;
-    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== loadedFiguresCurrency;
+    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.
     const hasConversionFailed = hasCustomFooterCurrency && !!selectedCurrency && !!failedConversionCurrencies?.[selectedCurrency];
@@ -407,12 +397,15 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             return {count: undefined, total: undefined, currency: undefined};
         }
 
+        const selectedTransactionItems = Object.values(selectedTransactions);
+        const fallbackCurrency = effectiveDefaultCurrency ?? selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency;
+
         if (shouldUseClientTotal) {
             const shouldUseConvertedSelectedTotal = hasCustomFooterCurrency && areAllSelectedConverted && !hasConversionFailed && !!selectedCurrency;
 
             // Reports sum each selected report's converted total; other searches sum per row — whole groups from the
-            // groups cache, individual transactions from the transactions cache — falling back to the unconverted
-            // per-row amount until the conversion is ready, which keeps the footer on that currency meanwhile.
+            // groups cache, individual transactions from the transactions cache — falling back to the default per-row
+            // amount until the conversion is ready, which keeps the footer on the default currency meanwhile.
             let total;
             if (shouldUseConvertedSelectedTotal && isReportsSearch && selectedCurrency) {
                 total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[selectedCurrency] ?? 0), 0);
@@ -431,27 +424,26 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
                 }, 0);
             }
 
-            // Unconverted figures keep the currency they're denominated in instead of borrowing the default's symbol,
-            // which can move away from the loaded figures (e.g. after changing Preferences > Payment currency).
-            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : loadedFiguresCurrency};
+            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : fallbackCurrency};
         }
 
         if (hasCustomFooterCurrency && isSearchTotalFresh && !hasConversionFailed && selectedCurrencyConvertedTotal) {
             return {count: selectedCurrencyConvertedTotal.count, total: selectedCurrencyConvertedTotal.total, currency: selectedCurrency};
         }
 
-        return {count: metadataCount, total: metadataTotal, currency: loadedFiguresCurrency};
+        return {count: metadataCount, total: metadataTotal, currency: effectiveDefaultCurrency ?? metadataCurrency};
     }, [
         areAllSelectedConverted,
         convertedGroups,
         convertedReports,
         convertedTransactions,
+        effectiveDefaultCurrency,
         hasConversionFailed,
         hasCustomFooterCurrency,
         isReportsSearch,
         isSearchTotalFresh,
-        loadedFiguresCurrency,
         metadataCount,
+        metadataCurrency,
         metadataTotal,
         selectedCurrency,
         selectedCurrencyConvertedTotal,

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -251,27 +251,16 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
     const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
 
-    // A chosen currency needs converting when it differs from the currency the loaded figures are denominated in:
-    // the whole-search grand total in metadataCurrency, per-row figures in the server-converted groupCurrency (or the
-    // row's own currency when no conversion happened). Comparing against the default instead would skip the
+    // The currency the loaded figures are denominated in: the whole-search grand total in metadataCurrency, per-row
+    // figures in the server-converted groupCurrency (or the row's own currency when no conversion happened). A chosen
+    // currency needs converting when it differs from this — comparing against the default instead would skip the
     // conversion whenever the default itself moved away from the loaded figures (e.g. resetting to a just-changed
-    // Preferences > Payment currency). Report-view rows are skipped, mirroring areAllSelectedEntriesConverted.
-    const selectionNeedsConversion = useMemo(() => {
-        if (!selectedCurrency) {
-            return false;
-        }
-        if (isReportsSearch) {
-            return selectedReports.some((report) => report.currency !== selectedCurrency);
-        }
-        return selectedTransactionsKeys.some((key) => {
-            const entry = selectedTransactions[key];
-            if (!isGroupEntry(key) && entry.action === CONST.SEARCH.ACTION_TYPES.VIEW && key === entry.reportID) {
-                return false;
-            }
-            return (entry.groupCurrency ?? entry.currency) !== selectedCurrency;
-        });
-    }, [isReportsSearch, selectedCurrency, selectedReports, selectedTransactions, selectedTransactionsKeys]);
-    const hasCustomFooterCurrency = !!selectedCurrency && (shouldUseClientTotal ? selectionNeedsConversion : selectedCurrency !== (metadataCurrency ?? effectiveDefaultCurrency));
+    // Preferences > Payment currency).
+    const firstSelectedTransactionKey = selectedTransactionsKeys.at(0);
+    const firstSelectedTransaction = firstSelectedTransactionKey ? selectedTransactions[firstSelectedTransactionKey] : undefined;
+    const selectionDenominationCurrency = isReportsSearch ? selectedReports.at(0)?.currency : (firstSelectedTransaction?.groupCurrency ?? firstSelectedTransaction?.currency);
+    const loadedFiguresCurrency = (shouldUseClientTotal ? selectionDenominationCurrency : metadataCurrency) ?? effectiveDefaultCurrency;
+    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== loadedFiguresCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.
     const hasConversionFailed = hasCustomFooterCurrency && !!selectedCurrency && !!failedConversionCurrencies?.[selectedCurrency];

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -1,6 +1,6 @@
+import useActivePolicy from '@hooks/useActivePolicy';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePolicy from '@hooks/usePolicy';
 import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
 
 import {getFooterConvertedAmounts} from '@libs/actions/Search';
@@ -89,8 +89,7 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     const {currentSearchHash, currentSearchKey, currentSearchQueryJSON} = useSearchQueryContext();
     const shouldAllowFooterTotals = useSearchShouldCalculateTotals(currentSearchKey, currentSearchQueryJSON?.hash, true, areAllMatchingItemsSelected);
     const {isOffline} = useNetwork();
-    const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
-    const activePolicy = usePolicy(activePolicyID);
+    const activePolicy = useActivePolicy();
     // The server converts search figures to the active policy's currency when the query carries no explicit target.
     const searchTargetCurrency = activePolicy?.outputCurrency ?? CONST.CURRENCY.USD;
     const [footerCurrencyState, setFooterCurrencyState] = useState<FooterCurrencyState>({

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -250,7 +250,17 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // metadataCurrency is unset for a fresh no-workspace account until a search populates search.currency (e.g. after
     // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
     const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
-    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
+
+    // The currency the loaded figures are denominated in: the whole-search grand total in metadataCurrency, per-row
+    // figures in the server-converted groupCurrency (or the row's own currency when no conversion happened). A chosen
+    // currency needs converting when it differs from this — comparing against the default instead would skip the
+    // conversion whenever the default itself moved away from the loaded figures (e.g. resetting to a just-changed
+    // Preferences > Payment currency).
+    const firstSelectedTransactionKey = selectedTransactionsKeys.at(0);
+    const firstSelectedTransaction = firstSelectedTransactionKey ? selectedTransactions[firstSelectedTransactionKey] : undefined;
+    const selectionDenominationCurrency = isReportsSearch ? selectedReports.at(0)?.currency : (firstSelectedTransaction?.groupCurrency ?? firstSelectedTransaction?.currency);
+    const loadedFiguresCurrency = (shouldUseClientTotal ? selectionDenominationCurrency : metadataCurrency) ?? effectiveDefaultCurrency;
+    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== loadedFiguresCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.
     const hasConversionFailed = hasCustomFooterCurrency && !!selectedCurrency && !!failedConversionCurrencies?.[selectedCurrency];
@@ -397,15 +407,12 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             return {count: undefined, total: undefined, currency: undefined};
         }
 
-        const selectedTransactionItems = Object.values(selectedTransactions);
-        const fallbackCurrency = effectiveDefaultCurrency ?? selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency;
-
         if (shouldUseClientTotal) {
             const shouldUseConvertedSelectedTotal = hasCustomFooterCurrency && areAllSelectedConverted && !hasConversionFailed && !!selectedCurrency;
 
             // Reports sum each selected report's converted total; other searches sum per row — whole groups from the
-            // groups cache, individual transactions from the transactions cache — falling back to the default per-row
-            // amount until the conversion is ready, which keeps the footer on the default currency meanwhile.
+            // groups cache, individual transactions from the transactions cache — falling back to the unconverted
+            // per-row amount until the conversion is ready, which keeps the footer on that currency meanwhile.
             let total;
             if (shouldUseConvertedSelectedTotal && isReportsSearch && selectedCurrency) {
                 total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[selectedCurrency] ?? 0), 0);
@@ -424,26 +431,27 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
                 }, 0);
             }
 
-            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : fallbackCurrency};
+            // Unconverted figures keep the currency they're denominated in instead of borrowing the default's symbol,
+            // which can move away from the loaded figures (e.g. after changing Preferences > Payment currency).
+            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : loadedFiguresCurrency};
         }
 
         if (hasCustomFooterCurrency && isSearchTotalFresh && !hasConversionFailed && selectedCurrencyConvertedTotal) {
             return {count: selectedCurrencyConvertedTotal.count, total: selectedCurrencyConvertedTotal.total, currency: selectedCurrency};
         }
 
-        return {count: metadataCount, total: metadataTotal, currency: effectiveDefaultCurrency ?? metadataCurrency};
+        return {count: metadataCount, total: metadataTotal, currency: loadedFiguresCurrency};
     }, [
         areAllSelectedConverted,
         convertedGroups,
         convertedReports,
         convertedTransactions,
-        effectiveDefaultCurrency,
         hasConversionFailed,
         hasCustomFooterCurrency,
         isReportsSearch,
         isSearchTotalFresh,
+        loadedFiguresCurrency,
         metadataCount,
-        metadataCurrency,
         metadataTotal,
         selectedCurrency,
         selectedCurrencyConvertedTotal,

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -243,10 +243,9 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // Use the per-selection (client) total for a partial selection; nothing-selected and everything-selected both fall
     // to the whole-search grand total, which every search type now returns converted, keyed by the search hash.
     const shouldUseClientTotal = !metadataCount || hasPartialSelection;
-    // metadataCurrency is empty for a fresh no-workspace account until a search populates search.currency (e.g. after
+    // metadataCurrency is unset for a fresh no-workspace account until a search populates search.currency (e.g. after
     // visiting Reports), so fall back to the user's live payment currency instead of an arbitrary selected expense's currency.
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const effectiveDefaultCurrency = defaultFooterCurrency || metadataCurrency || preferredCurrency;
+    const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? preferredCurrency;
     const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -250,76 +250,48 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // metadataCurrency is unset for a fresh no-workspace account until a search populates search.currency (e.g. after
     // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
     const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
-
-    // The currency the footer wants to display: an explicit picker choice, otherwise the default. Conversion is keyed
-    // off this target rather than only picker choices because the default itself can move away from the loaded
-    // figures — changing Preferences > Payment currency updates it live while the loaded rows stay denominated in
-    // the currency the server converted to at fetch time.
-    const conversionTargetCurrency = selectedCurrency ?? effectiveDefaultCurrency;
-
-    // Whether some selected row's figure is denominated in a currency other than the target. Per-row figures come
-    // from getEntrySource: the server-converted groupAmount (denominated in groupCurrency) or the raw amount
-    // (denominated in the row's own currency). The Reports search sums report totals (denominated in each report's
-    // currency) instead, and report-view rows are ignored, both mirroring areAllSelectedConverted below.
-    const selectionNeedsConversion = useMemo(() => {
-        if (isReportsSearch) {
-            return selectedReports.some((report) => report.currency !== conversionTargetCurrency);
-        }
-        return selectedTransactionsKeys.some((key) => {
-            const entry = selectedTransactions[key];
-            if (!isGroupEntry(key) && entry.action === CONST.SEARCH.ACTION_TYPES.VIEW && key === entry.reportID) {
-                return false;
-            }
-            return (entry.groupCurrency ?? entry.currency) !== conversionTargetCurrency;
-        });
-    }, [conversionTargetCurrency, isReportsSearch, selectedReports, selectedTransactions, selectedTransactionsKeys]);
-
-    // The whole-search grand total is denominated in metadataCurrency (the server writes the two together), so it
-    // only needs converting when that differs from the target.
-    const needsSearchTotalConversion = !!metadataCurrency && metadataCurrency !== conversionTargetCurrency;
-
-    const needsFooterConversion = shouldUseClientTotal ? selectionNeedsConversion : needsSearchTotalConversion;
+    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.
-    const hasConversionFailed = needsFooterConversion && !!failedConversionCurrencies?.[conversionTargetCurrency];
+    const hasConversionFailed = hasCustomFooterCurrency && !!selectedCurrency && !!failedConversionCurrencies?.[selectedCurrency];
 
-    const targetConvertedSearchTotal = needsFooterConversion ? convertedSearchTotal?.[conversionTargetCurrency] : undefined;
+    const selectedCurrencyConvertedTotal = hasCustomFooterCurrency && selectedCurrency ? convertedSearchTotal?.[selectedCurrency] : undefined;
 
     // The whole-search grand total is fresh only while its stamped source still equals the live snapshot total.
-    const isSearchTotalFresh = !!targetConvertedSearchTotal && conversionSources?.searchTotals?.[currentSearchHash]?.[conversionTargetCurrency] === metadataTotal;
-    const wasSearchTotalRequested = metadataTotal !== undefined && conversionSources?.searchTotals?.[currentSearchHash]?.[conversionTargetCurrency] === metadataTotal;
+    const isSearchTotalFresh = !!selectedCurrencyConvertedTotal && !!selectedCurrency && conversionSources?.searchTotals?.[currentSearchHash]?.[selectedCurrency] === metadataTotal;
+    const wasSearchTotalRequested = !!selectedCurrency && metadataTotal !== undefined && conversionSources?.searchTotals?.[currentSearchHash]?.[selectedCurrency] === metadataTotal;
 
     // Whether the selection has anything to convert per-row: reports on the Reports search, otherwise selected whole
     // groups and/or individual transactions.
     const hasConvertibleSelection = isReportsSearch ? selectedReportIDs.length > 0 : selectedGroupKeys.length > 0 || selectedTransactionIDs.length > 0;
 
     const areAllSelectedConverted = useMemo(() => {
-        if (!needsFooterConversion) {
+        if (!hasCustomFooterCurrency || !selectedCurrency) {
             return false;
         }
         return isReportsSearch
-            ? areAllSelectedReportsConverted(selectedReportIDs, (reportID) => isReportFresh(reportID, conversionTargetCurrency))
+            ? areAllSelectedReportsConverted(selectedReportIDs, (reportID) => isReportFresh(reportID, selectedCurrency))
             : areAllSelectedEntriesConverted(
                   selectedTransactions,
-                  (key) => isGroupFresh(key, conversionTargetCurrency),
-                  (transactionID) => isTransactionFresh(transactionID, conversionTargetCurrency),
+                  (key) => isGroupFresh(key, selectedCurrency),
+                  (transactionID) => isTransactionFresh(transactionID, selectedCurrency),
               );
-    }, [conversionTargetCurrency, isGroupFresh, isReportFresh, isReportsSearch, isTransactionFresh, needsFooterConversion, selectedReportIDs, selectedTransactions]);
+    }, [hasCustomFooterCurrency, isGroupFresh, isReportFresh, isReportsSearch, isTransactionFresh, selectedCurrency, selectedReportIDs, selectedTransactions]);
 
     // Show the loading skeleton only while a conversion can still arrive — there is something to convert, the request
-    // can be made (online) and hasn't failed. Otherwise the footer stays on the unconverted total instead of a
+    // can be made (online) and hasn't failed. Otherwise the footer stays on the default-currency total instead of a
     // skeleton that would never resolve.
     const isFooterTotalConverting =
-        !isOffline && !hasConversionFailed && needsFooterConversion && (shouldUseClientTotal ? hasConvertibleSelection && !areAllSelectedConverted : !isSearchTotalFresh);
+        !isOffline && !hasConversionFailed && hasCustomFooterCurrency && (shouldUseClientTotal ? hasConvertibleSelection && !areAllSelectedConverted : !isSearchTotalFresh);
 
     const shouldShowFooter = (!areAllMatchingItemsSelected && selectedTransactionsKeys.length > 0) || (shouldAllowFooterTotals && !!metadata?.count);
 
-    // Fetch converted figures whenever the target currency isn't the one the loaded figures are denominated in and no
-    // request has covered what the footer needs. Each request stamps the source figures it converts, so the requested
-    // checks keep this to one request per out-of-coverage change (or per edit) rather than one per checkbox or render.
+    // Fetch converted figures whenever a custom currency is chosen and no request has covered what the footer needs.
+    // Each request stamps the source figures it converts, so the requested checks keep this to one request per
+    // out-of-coverage change (or per edit) rather than one per checkbox or render.
     useEffect(() => {
         // No conversion can complete offline, so don't queue reads that can't resolve; the effect re-runs on reconnect.
-        if (isOffline || !needsFooterConversion || !currentSearchQueryJSON) {
+        if (isOffline || !hasCustomFooterCurrency || !currentSearchQueryJSON || !selectedCurrency) {
             return;
         }
 
@@ -330,14 +302,14 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             if (isReportsSearch) {
                 // Request only the reports without a covering request: items already converted (or in flight) keep
                 // their cached figures, so growing a selection converts just the delta.
-                const reportIDsToConvert = selectedReportIDs.filter((reportID) => !wasReportRequested(reportID, conversionTargetCurrency));
+                const reportIDsToConvert = selectedReportIDs.filter((reportID) => !wasReportRequested(reportID, selectedCurrency));
                 if (reportIDsToConvert.length > 0) {
                     getFooterConvertedAmounts({
                         queryJSON: currentSearchQueryJSON,
                         searchKey: currentSearchKey,
-                        targetCurrency: conversionTargetCurrency,
+                        targetCurrency: selectedCurrency,
                         reportIDList: reportIDsToConvert.join(','),
-                        sources: {reports: Object.fromEntries(reportIDsToConvert.map((reportID) => [reportID, {[conversionTargetCurrency]: reportSourceByID[reportID]}]))},
+                        sources: {reports: Object.fromEntries(reportIDsToConvert.map((reportID) => [reportID, {[selectedCurrency]: reportSourceByID[reportID]}]))},
                     });
                 }
                 return;
@@ -347,28 +319,28 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             // converted total, so no ID list is sent. Stamp every loaded group (selected ones from their entries, so
             // the request always settles its own fire condition) — later selections of other groups then reuse the
             // cached response instead of re-running the grouped query.
-            if (selectedGroupKeys.some((key) => !wasGroupRequested(key, conversionTargetCurrency))) {
+            if (selectedGroupKeys.some((key) => !wasGroupRequested(key, selectedCurrency))) {
                 const groupSources = {...loadedGroupSourceByKey, ...groupSourceByKey};
                 getFooterConvertedAmounts({
                     queryJSON: currentSearchQueryJSON,
                     searchKey: currentSearchKey,
-                    targetCurrency: conversionTargetCurrency,
-                    sources: {groups: Object.fromEntries(Object.entries(groupSources).map(([key, source]) => [key, {[conversionTargetCurrency]: source}]))},
+                    targetCurrency: selectedCurrency,
+                    sources: {groups: Object.fromEntries(Object.entries(groupSources).map(([key, source]) => [key, {[selectedCurrency]: source}]))},
                 });
             }
 
             // Individually-selected transactions convert by transaction ID (the loose rows in a grouped view, or the
             // whole selection on a flat search). Request only the ones without a covering request, so growing a
             // selection converts just the delta.
-            const transactionIDsToConvert = selectedTransactionIDs.filter((transactionID) => !wasTransactionRequested(transactionID, conversionTargetCurrency));
+            const transactionIDsToConvert = selectedTransactionIDs.filter((transactionID) => !wasTransactionRequested(transactionID, selectedCurrency));
             if (transactionIDsToConvert.length > 0) {
                 getFooterConvertedAmounts({
                     queryJSON: currentSearchQueryJSON,
                     searchKey: currentSearchKey,
-                    targetCurrency: conversionTargetCurrency,
+                    targetCurrency: selectedCurrency,
                     transactionIDList: transactionIDsToConvert.join(','),
                     sources: {
-                        transactions: Object.fromEntries(transactionIDsToConvert.map((transactionID) => [transactionID, {[conversionTargetCurrency]: transactionSourceByID[transactionID]}])),
+                        transactions: Object.fromEntries(transactionIDsToConvert.map((transactionID) => [transactionID, {[selectedCurrency]: transactionSourceByID[transactionID]}])),
                     },
                 });
             }
@@ -381,17 +353,17 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             getFooterConvertedAmounts({
                 queryJSON: currentSearchQueryJSON,
                 searchKey: currentSearchKey,
-                targetCurrency: conversionTargetCurrency,
-                sources: metadataTotal !== undefined ? {searchTotals: {[currentSearchHash]: {[conversionTargetCurrency]: metadataTotal}}} : undefined,
+                targetCurrency: selectedCurrency,
+                sources: metadataTotal !== undefined ? {searchTotals: {[currentSearchHash]: {[selectedCurrency]: metadataTotal}}} : undefined,
             });
         }
     }, [
         areAllSelectedConverted,
-        conversionTargetCurrency,
         currentSearchHash,
         currentSearchKey,
         currentSearchQueryJSON,
         groupSourceByKey,
+        hasCustomFooterCurrency,
         loadedGroupSourceByKey,
         wasGroupRequested,
         isOffline,
@@ -400,8 +372,8 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
         wasSearchTotalRequested,
         wasTransactionRequested,
         metadataTotal,
-        needsFooterConversion,
         reportSourceByID,
+        selectedCurrency,
         selectedGroupKeys,
         selectedReportIDs,
         selectedTransactionIDs,
@@ -426,64 +398,61 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
         }
 
         const selectedTransactionItems = Object.values(selectedTransactions);
-        // Unconverted figures are denominated in groupCurrency (or the row's own currency), so label them with that
-        // when they're shown as-is (offline, failed, or unconvertible selections) instead of the target's symbol.
-        const fallbackCurrency = selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency ?? effectiveDefaultCurrency;
+        const fallbackCurrency = effectiveDefaultCurrency ?? selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency;
 
         if (shouldUseClientTotal) {
-            const shouldUseConvertedSelectedTotal = needsFooterConversion && areAllSelectedConverted && !hasConversionFailed;
+            const shouldUseConvertedSelectedTotal = hasCustomFooterCurrency && areAllSelectedConverted && !hasConversionFailed && !!selectedCurrency;
 
             // Reports sum each selected report's converted total; other searches sum per row — whole groups from the
-            // groups cache, individual transactions from the transactions cache — falling back to the unconverted
-            // per-row amount until the conversion is ready, which keeps the footer on that currency meanwhile.
+            // groups cache, individual transactions from the transactions cache — falling back to the default per-row
+            // amount until the conversion is ready, which keeps the footer on the default currency meanwhile.
             let total;
-            if (shouldUseConvertedSelectedTotal && isReportsSearch) {
-                total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[conversionTargetCurrency] ?? 0), 0);
+            if (shouldUseConvertedSelectedTotal && isReportsSearch && selectedCurrency) {
+                total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[selectedCurrency] ?? 0), 0);
             } else {
                 total = selectedTransactionsKeys.reduce((acc, key) => {
                     const transaction = selectedTransactions[key];
                     let convertedAmount;
-                    if (shouldUseConvertedSelectedTotal) {
+                    if (shouldUseConvertedSelectedTotal && selectedCurrency) {
                         if (isGroupEntry(key)) {
-                            convertedAmount = convertedGroups?.[key]?.[conversionTargetCurrency];
+                            convertedAmount = convertedGroups?.[key]?.[selectedCurrency];
                         } else if (transaction.transaction?.transactionID) {
-                            convertedAmount = convertedTransactions?.[transaction.transaction.transactionID]?.[conversionTargetCurrency];
+                            convertedAmount = convertedTransactions?.[transaction.transaction.transactionID]?.[selectedCurrency];
                         }
                     }
                     return acc - (convertedAmount ?? transaction.groupAmount ?? -Math.abs(transaction.amount));
                 }, 0);
             }
 
-            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal || !selectionNeedsConversion ? conversionTargetCurrency : fallbackCurrency};
+            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : fallbackCurrency};
         }
 
-        if (needsFooterConversion && isSearchTotalFresh && !hasConversionFailed && targetConvertedSearchTotal) {
-            return {count: targetConvertedSearchTotal.count, total: targetConvertedSearchTotal.total, currency: conversionTargetCurrency};
+        if (hasCustomFooterCurrency && isSearchTotalFresh && !hasConversionFailed && selectedCurrencyConvertedTotal) {
+            return {count: selectedCurrencyConvertedTotal.count, total: selectedCurrencyConvertedTotal.total, currency: selectedCurrency};
         }
 
-        return {count: metadataCount, total: metadataTotal, currency: metadataCurrency ?? effectiveDefaultCurrency};
+        return {count: metadataCount, total: metadataTotal, currency: effectiveDefaultCurrency ?? metadataCurrency};
     }, [
         areAllSelectedConverted,
-        conversionTargetCurrency,
         convertedGroups,
         convertedReports,
         convertedTransactions,
         effectiveDefaultCurrency,
         hasConversionFailed,
+        hasCustomFooterCurrency,
         isReportsSearch,
         isSearchTotalFresh,
         metadataCount,
         metadataCurrency,
         metadataTotal,
-        needsFooterConversion,
+        selectedCurrency,
+        selectedCurrencyConvertedTotal,
         selectedExpenseCount,
         selectedReportIDs,
         selectedTransactions,
         selectedTransactionsKeys,
-        selectionNeedsConversion,
         shouldAllowFooterTotals,
         shouldUseClientTotal,
-        targetConvertedSearchTotal,
     ]);
 
     if (!shouldShowFooter) {

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -91,9 +91,7 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     const {isOffline} = useNetwork();
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     const activePolicy = usePolicy(activePolicyID);
-    // The currency the server converts search figures to when the query carries no explicit target: the active
-    // policy's currency. For accounts without a workspace the active policy is the personal policy, whose output
-    // currency is what Preferences > Payment currency edits.
+    // The server converts search figures to the active policy's currency when the query carries no explicit target.
     const searchTargetCurrency = activePolicy?.outputCurrency ?? CONST.CURRENCY.USD;
     const [footerCurrencyState, setFooterCurrencyState] = useState<FooterCurrencyState>({
         searchHash: undefined,
@@ -248,9 +246,6 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // Use the per-selection (client) total for a partial selection; nothing-selected and everything-selected both fall
     // to the whole-search grand total, which every search type now returns converted, keyed by the search hash.
     const shouldUseClientTotal = !metadataCount || hasPartialSelection;
-    // The currency the loaded figures are denominated in (the server-converted per-row denomination when the snapshot
-    // metadata hasn't populated a currency). A chosen currency needs converting only when it differs from this, so
-    // choosing the currency the figures are already in — including Reset when nothing moved — stays a no-op.
     const firstSelectedTransactionKey = selectedTransactionsKeys.at(0);
     const firstSelectedTransaction = firstSelectedTransactionKey ? selectedTransactions[firstSelectedTransactionKey] : undefined;
     const selectedTransactionDefaultCurrency = firstSelectedTransaction?.groupCurrency ?? firstSelectedTransaction?.currency;
@@ -387,7 +382,7 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     ]);
 
     const handleFooterCurrencyChange = useCallback(
-        (currency: string | undefined) => {
+        (currency: string) => {
             setFooterCurrencyState({
                 searchHash: currentSearchHash,
                 selectedCurrency: currency,

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -91,12 +91,10 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     const {isOffline} = useNetwork();
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     const activePolicy = usePolicy(activePolicyID);
-    const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
-    const personalPolicy = usePolicy(personalPolicyID);
     // The currency the server converts search figures to when the query carries no explicit target: the active
     // policy's currency. For accounts without a workspace the active policy is the personal policy, whose output
     // currency is what Preferences > Payment currency edits.
-    const searchTargetCurrency = activePolicy?.outputCurrency ?? personalPolicy?.outputCurrency ?? CONST.CURRENCY.USD;
+    const searchTargetCurrency = activePolicy?.outputCurrency ?? CONST.CURRENCY.USD;
     const [footerCurrencyState, setFooterCurrencyState] = useState<FooterCurrencyState>({
         searchHash: undefined,
         selectedCurrency: undefined,

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -250,48 +250,76 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // metadataCurrency is unset for a fresh no-workspace account until a search populates search.currency (e.g. after
     // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
     const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
-    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
+
+    // The currency the footer wants to display: an explicit picker choice, otherwise the default. Conversion is keyed
+    // off this target rather than only picker choices because the default itself can move away from the loaded
+    // figures — changing Preferences > Payment currency updates it live while the loaded rows stay denominated in
+    // the currency the server converted to at fetch time.
+    const conversionTargetCurrency = selectedCurrency ?? effectiveDefaultCurrency;
+
+    // Whether some selected row's figure is denominated in a currency other than the target. Per-row figures come
+    // from getEntrySource: the server-converted groupAmount (denominated in groupCurrency) or the raw amount
+    // (denominated in the row's own currency). The Reports search sums report totals (denominated in each report's
+    // currency) instead, and report-view rows are ignored, both mirroring areAllSelectedConverted below.
+    const selectionNeedsConversion = useMemo(() => {
+        if (isReportsSearch) {
+            return selectedReports.some((report) => report.currency !== conversionTargetCurrency);
+        }
+        return selectedTransactionsKeys.some((key) => {
+            const entry = selectedTransactions[key];
+            if (!isGroupEntry(key) && entry.action === CONST.SEARCH.ACTION_TYPES.VIEW && key === entry.reportID) {
+                return false;
+            }
+            return (entry.groupCurrency ?? entry.currency) !== conversionTargetCurrency;
+        });
+    }, [conversionTargetCurrency, isReportsSearch, selectedReports, selectedTransactions, selectedTransactionsKeys]);
+
+    // The whole-search grand total is denominated in metadataCurrency (the server writes the two together), so it
+    // only needs converting when that differs from the target.
+    const needsSearchTotalConversion = !!metadataCurrency && metadataCurrency !== conversionTargetCurrency;
+
+    const needsFooterConversion = shouldUseClientTotal ? selectionNeedsConversion : needsSearchTotalConversion;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.
-    const hasConversionFailed = hasCustomFooterCurrency && !!selectedCurrency && !!failedConversionCurrencies?.[selectedCurrency];
+    const hasConversionFailed = needsFooterConversion && !!failedConversionCurrencies?.[conversionTargetCurrency];
 
-    const selectedCurrencyConvertedTotal = hasCustomFooterCurrency && selectedCurrency ? convertedSearchTotal?.[selectedCurrency] : undefined;
+    const targetConvertedSearchTotal = needsFooterConversion ? convertedSearchTotal?.[conversionTargetCurrency] : undefined;
 
     // The whole-search grand total is fresh only while its stamped source still equals the live snapshot total.
-    const isSearchTotalFresh = !!selectedCurrencyConvertedTotal && !!selectedCurrency && conversionSources?.searchTotals?.[currentSearchHash]?.[selectedCurrency] === metadataTotal;
-    const wasSearchTotalRequested = !!selectedCurrency && metadataTotal !== undefined && conversionSources?.searchTotals?.[currentSearchHash]?.[selectedCurrency] === metadataTotal;
+    const isSearchTotalFresh = !!targetConvertedSearchTotal && conversionSources?.searchTotals?.[currentSearchHash]?.[conversionTargetCurrency] === metadataTotal;
+    const wasSearchTotalRequested = metadataTotal !== undefined && conversionSources?.searchTotals?.[currentSearchHash]?.[conversionTargetCurrency] === metadataTotal;
 
     // Whether the selection has anything to convert per-row: reports on the Reports search, otherwise selected whole
     // groups and/or individual transactions.
     const hasConvertibleSelection = isReportsSearch ? selectedReportIDs.length > 0 : selectedGroupKeys.length > 0 || selectedTransactionIDs.length > 0;
 
     const areAllSelectedConverted = useMemo(() => {
-        if (!hasCustomFooterCurrency || !selectedCurrency) {
+        if (!needsFooterConversion) {
             return false;
         }
         return isReportsSearch
-            ? areAllSelectedReportsConverted(selectedReportIDs, (reportID) => isReportFresh(reportID, selectedCurrency))
+            ? areAllSelectedReportsConverted(selectedReportIDs, (reportID) => isReportFresh(reportID, conversionTargetCurrency))
             : areAllSelectedEntriesConverted(
                   selectedTransactions,
-                  (key) => isGroupFresh(key, selectedCurrency),
-                  (transactionID) => isTransactionFresh(transactionID, selectedCurrency),
+                  (key) => isGroupFresh(key, conversionTargetCurrency),
+                  (transactionID) => isTransactionFresh(transactionID, conversionTargetCurrency),
               );
-    }, [hasCustomFooterCurrency, isGroupFresh, isReportFresh, isReportsSearch, isTransactionFresh, selectedCurrency, selectedReportIDs, selectedTransactions]);
+    }, [conversionTargetCurrency, isGroupFresh, isReportFresh, isReportsSearch, isTransactionFresh, needsFooterConversion, selectedReportIDs, selectedTransactions]);
 
     // Show the loading skeleton only while a conversion can still arrive — there is something to convert, the request
-    // can be made (online) and hasn't failed. Otherwise the footer stays on the default-currency total instead of a
+    // can be made (online) and hasn't failed. Otherwise the footer stays on the unconverted total instead of a
     // skeleton that would never resolve.
     const isFooterTotalConverting =
-        !isOffline && !hasConversionFailed && hasCustomFooterCurrency && (shouldUseClientTotal ? hasConvertibleSelection && !areAllSelectedConverted : !isSearchTotalFresh);
+        !isOffline && !hasConversionFailed && needsFooterConversion && (shouldUseClientTotal ? hasConvertibleSelection && !areAllSelectedConverted : !isSearchTotalFresh);
 
     const shouldShowFooter = (!areAllMatchingItemsSelected && selectedTransactionsKeys.length > 0) || (shouldAllowFooterTotals && !!metadata?.count);
 
-    // Fetch converted figures whenever a custom currency is chosen and no request has covered what the footer needs.
-    // Each request stamps the source figures it converts, so the requested checks keep this to one request per
-    // out-of-coverage change (or per edit) rather than one per checkbox or render.
+    // Fetch converted figures whenever the target currency isn't the one the loaded figures are denominated in and no
+    // request has covered what the footer needs. Each request stamps the source figures it converts, so the requested
+    // checks keep this to one request per out-of-coverage change (or per edit) rather than one per checkbox or render.
     useEffect(() => {
         // No conversion can complete offline, so don't queue reads that can't resolve; the effect re-runs on reconnect.
-        if (isOffline || !hasCustomFooterCurrency || !currentSearchQueryJSON || !selectedCurrency) {
+        if (isOffline || !needsFooterConversion || !currentSearchQueryJSON) {
             return;
         }
 
@@ -302,14 +330,14 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             if (isReportsSearch) {
                 // Request only the reports without a covering request: items already converted (or in flight) keep
                 // their cached figures, so growing a selection converts just the delta.
-                const reportIDsToConvert = selectedReportIDs.filter((reportID) => !wasReportRequested(reportID, selectedCurrency));
+                const reportIDsToConvert = selectedReportIDs.filter((reportID) => !wasReportRequested(reportID, conversionTargetCurrency));
                 if (reportIDsToConvert.length > 0) {
                     getFooterConvertedAmounts({
                         queryJSON: currentSearchQueryJSON,
                         searchKey: currentSearchKey,
-                        targetCurrency: selectedCurrency,
+                        targetCurrency: conversionTargetCurrency,
                         reportIDList: reportIDsToConvert.join(','),
-                        sources: {reports: Object.fromEntries(reportIDsToConvert.map((reportID) => [reportID, {[selectedCurrency]: reportSourceByID[reportID]}]))},
+                        sources: {reports: Object.fromEntries(reportIDsToConvert.map((reportID) => [reportID, {[conversionTargetCurrency]: reportSourceByID[reportID]}]))},
                     });
                 }
                 return;
@@ -319,28 +347,28 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             // converted total, so no ID list is sent. Stamp every loaded group (selected ones from their entries, so
             // the request always settles its own fire condition) — later selections of other groups then reuse the
             // cached response instead of re-running the grouped query.
-            if (selectedGroupKeys.some((key) => !wasGroupRequested(key, selectedCurrency))) {
+            if (selectedGroupKeys.some((key) => !wasGroupRequested(key, conversionTargetCurrency))) {
                 const groupSources = {...loadedGroupSourceByKey, ...groupSourceByKey};
                 getFooterConvertedAmounts({
                     queryJSON: currentSearchQueryJSON,
                     searchKey: currentSearchKey,
-                    targetCurrency: selectedCurrency,
-                    sources: {groups: Object.fromEntries(Object.entries(groupSources).map(([key, source]) => [key, {[selectedCurrency]: source}]))},
+                    targetCurrency: conversionTargetCurrency,
+                    sources: {groups: Object.fromEntries(Object.entries(groupSources).map(([key, source]) => [key, {[conversionTargetCurrency]: source}]))},
                 });
             }
 
             // Individually-selected transactions convert by transaction ID (the loose rows in a grouped view, or the
             // whole selection on a flat search). Request only the ones without a covering request, so growing a
             // selection converts just the delta.
-            const transactionIDsToConvert = selectedTransactionIDs.filter((transactionID) => !wasTransactionRequested(transactionID, selectedCurrency));
+            const transactionIDsToConvert = selectedTransactionIDs.filter((transactionID) => !wasTransactionRequested(transactionID, conversionTargetCurrency));
             if (transactionIDsToConvert.length > 0) {
                 getFooterConvertedAmounts({
                     queryJSON: currentSearchQueryJSON,
                     searchKey: currentSearchKey,
-                    targetCurrency: selectedCurrency,
+                    targetCurrency: conversionTargetCurrency,
                     transactionIDList: transactionIDsToConvert.join(','),
                     sources: {
-                        transactions: Object.fromEntries(transactionIDsToConvert.map((transactionID) => [transactionID, {[selectedCurrency]: transactionSourceByID[transactionID]}])),
+                        transactions: Object.fromEntries(transactionIDsToConvert.map((transactionID) => [transactionID, {[conversionTargetCurrency]: transactionSourceByID[transactionID]}])),
                     },
                 });
             }
@@ -353,17 +381,17 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             getFooterConvertedAmounts({
                 queryJSON: currentSearchQueryJSON,
                 searchKey: currentSearchKey,
-                targetCurrency: selectedCurrency,
-                sources: metadataTotal !== undefined ? {searchTotals: {[currentSearchHash]: {[selectedCurrency]: metadataTotal}}} : undefined,
+                targetCurrency: conversionTargetCurrency,
+                sources: metadataTotal !== undefined ? {searchTotals: {[currentSearchHash]: {[conversionTargetCurrency]: metadataTotal}}} : undefined,
             });
         }
     }, [
         areAllSelectedConverted,
+        conversionTargetCurrency,
         currentSearchHash,
         currentSearchKey,
         currentSearchQueryJSON,
         groupSourceByKey,
-        hasCustomFooterCurrency,
         loadedGroupSourceByKey,
         wasGroupRequested,
         isOffline,
@@ -372,8 +400,8 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
         wasSearchTotalRequested,
         wasTransactionRequested,
         metadataTotal,
+        needsFooterConversion,
         reportSourceByID,
-        selectedCurrency,
         selectedGroupKeys,
         selectedReportIDs,
         selectedTransactionIDs,
@@ -398,61 +426,64 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
         }
 
         const selectedTransactionItems = Object.values(selectedTransactions);
-        const fallbackCurrency = effectiveDefaultCurrency ?? selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency;
+        // Unconverted figures are denominated in groupCurrency (or the row's own currency), so label them with that
+        // when they're shown as-is (offline, failed, or unconvertible selections) instead of the target's symbol.
+        const fallbackCurrency = selectedTransactionItems.at(0)?.groupCurrency ?? selectedTransactionItems.at(0)?.currency ?? effectiveDefaultCurrency;
 
         if (shouldUseClientTotal) {
-            const shouldUseConvertedSelectedTotal = hasCustomFooterCurrency && areAllSelectedConverted && !hasConversionFailed && !!selectedCurrency;
+            const shouldUseConvertedSelectedTotal = needsFooterConversion && areAllSelectedConverted && !hasConversionFailed;
 
             // Reports sum each selected report's converted total; other searches sum per row — whole groups from the
-            // groups cache, individual transactions from the transactions cache — falling back to the default per-row
-            // amount until the conversion is ready, which keeps the footer on the default currency meanwhile.
+            // groups cache, individual transactions from the transactions cache — falling back to the unconverted
+            // per-row amount until the conversion is ready, which keeps the footer on that currency meanwhile.
             let total;
-            if (shouldUseConvertedSelectedTotal && isReportsSearch && selectedCurrency) {
-                total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[selectedCurrency] ?? 0), 0);
+            if (shouldUseConvertedSelectedTotal && isReportsSearch) {
+                total = selectedReportIDs.reduce((acc, reportID) => acc - (convertedReports?.[reportID]?.[conversionTargetCurrency] ?? 0), 0);
             } else {
                 total = selectedTransactionsKeys.reduce((acc, key) => {
                     const transaction = selectedTransactions[key];
                     let convertedAmount;
-                    if (shouldUseConvertedSelectedTotal && selectedCurrency) {
+                    if (shouldUseConvertedSelectedTotal) {
                         if (isGroupEntry(key)) {
-                            convertedAmount = convertedGroups?.[key]?.[selectedCurrency];
+                            convertedAmount = convertedGroups?.[key]?.[conversionTargetCurrency];
                         } else if (transaction.transaction?.transactionID) {
-                            convertedAmount = convertedTransactions?.[transaction.transaction.transactionID]?.[selectedCurrency];
+                            convertedAmount = convertedTransactions?.[transaction.transaction.transactionID]?.[conversionTargetCurrency];
                         }
                     }
                     return acc - (convertedAmount ?? transaction.groupAmount ?? -Math.abs(transaction.amount));
                 }, 0);
             }
 
-            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal ? selectedCurrency : fallbackCurrency};
+            return {count: selectedExpenseCount, total, currency: shouldUseConvertedSelectedTotal || !selectionNeedsConversion ? conversionTargetCurrency : fallbackCurrency};
         }
 
-        if (hasCustomFooterCurrency && isSearchTotalFresh && !hasConversionFailed && selectedCurrencyConvertedTotal) {
-            return {count: selectedCurrencyConvertedTotal.count, total: selectedCurrencyConvertedTotal.total, currency: selectedCurrency};
+        if (needsFooterConversion && isSearchTotalFresh && !hasConversionFailed && targetConvertedSearchTotal) {
+            return {count: targetConvertedSearchTotal.count, total: targetConvertedSearchTotal.total, currency: conversionTargetCurrency};
         }
 
-        return {count: metadataCount, total: metadataTotal, currency: effectiveDefaultCurrency ?? metadataCurrency};
+        return {count: metadataCount, total: metadataTotal, currency: metadataCurrency ?? effectiveDefaultCurrency};
     }, [
         areAllSelectedConverted,
+        conversionTargetCurrency,
         convertedGroups,
         convertedReports,
         convertedTransactions,
         effectiveDefaultCurrency,
         hasConversionFailed,
-        hasCustomFooterCurrency,
         isReportsSearch,
         isSearchTotalFresh,
         metadataCount,
         metadataCurrency,
         metadataTotal,
-        selectedCurrency,
-        selectedCurrencyConvertedTotal,
+        needsFooterConversion,
         selectedExpenseCount,
         selectedReportIDs,
         selectedTransactions,
         selectedTransactionsKeys,
+        selectionNeedsConversion,
         shouldAllowFooterTotals,
         shouldUseClientTotal,
+        targetConvertedSearchTotal,
     ]);
 
     if (!shouldShowFooter) {

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -251,16 +251,27 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
     const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
 
-    // The currency the loaded figures are denominated in: the whole-search grand total in metadataCurrency, per-row
-    // figures in the server-converted groupCurrency (or the row's own currency when no conversion happened). A chosen
-    // currency needs converting when it differs from this — comparing against the default instead would skip the
+    // A chosen currency needs converting when it differs from the currency the loaded figures are denominated in:
+    // the whole-search grand total in metadataCurrency, per-row figures in the server-converted groupCurrency (or the
+    // row's own currency when no conversion happened). Comparing against the default instead would skip the
     // conversion whenever the default itself moved away from the loaded figures (e.g. resetting to a just-changed
-    // Preferences > Payment currency).
-    const firstSelectedTransactionKey = selectedTransactionsKeys.at(0);
-    const firstSelectedTransaction = firstSelectedTransactionKey ? selectedTransactions[firstSelectedTransactionKey] : undefined;
-    const selectionDenominationCurrency = isReportsSearch ? selectedReports.at(0)?.currency : (firstSelectedTransaction?.groupCurrency ?? firstSelectedTransaction?.currency);
-    const loadedFiguresCurrency = (shouldUseClientTotal ? selectionDenominationCurrency : metadataCurrency) ?? effectiveDefaultCurrency;
-    const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== loadedFiguresCurrency;
+    // Preferences > Payment currency). Report-view rows are skipped, mirroring areAllSelectedEntriesConverted.
+    const selectionNeedsConversion = useMemo(() => {
+        if (!selectedCurrency) {
+            return false;
+        }
+        if (isReportsSearch) {
+            return selectedReports.some((report) => report.currency !== selectedCurrency);
+        }
+        return selectedTransactionsKeys.some((key) => {
+            const entry = selectedTransactions[key];
+            if (!isGroupEntry(key) && entry.action === CONST.SEARCH.ACTION_TYPES.VIEW && key === entry.reportID) {
+                return false;
+            }
+            return (entry.groupCurrency ?? entry.currency) !== selectedCurrency;
+        });
+    }, [isReportsSearch, selectedCurrency, selectedReports, selectedTransactions, selectedTransactionsKeys]);
+    const hasCustomFooterCurrency = !!selectedCurrency && (shouldUseClientTotal ? selectionNeedsConversion : selectedCurrency !== (metadataCurrency ?? effectiveDefaultCurrency));
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.
     const hasConversionFailed = hasCustomFooterCurrency && !!selectedCurrency && !!failedConversionCurrencies?.[selectedCurrency];

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -91,8 +91,8 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     const {isOffline} = useNetwork();
     const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
     const personalPolicy = usePolicy(personalPolicyID);
-    // The Preferences > Payment currency setting; the server converts search totals to this same currency when a
-    // search has no explicit target, so it's the footer's conversion target whenever the snapshot carries none.
+    // The Preferences > Payment currency setting. The server falls back to this same currency for search.currency,
+    // so a default derived from it won't change once a snapshot arrives carrying server totals.
     const paymentCurrency = personalPolicy?.outputCurrency ?? CONST.CURRENCY.USD;
     const [footerCurrencyState, setFooterCurrencyState] = useState<FooterCurrencyState>({
         searchHash: undefined,

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -1,6 +1,6 @@
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
-import usePreferredCurrency from '@hooks/usePreferredCurrency';
+import usePolicy from '@hooks/usePolicy';
 import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
 
 import {getFooterConvertedAmounts} from '@libs/actions/Search';
@@ -89,7 +89,11 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     const {currentSearchHash, currentSearchKey, currentSearchQueryJSON} = useSearchQueryContext();
     const shouldAllowFooterTotals = useSearchShouldCalculateTotals(currentSearchKey, currentSearchQueryJSON?.hash, true, areAllMatchingItemsSelected);
     const {isOffline} = useNetwork();
-    const preferredCurrency = usePreferredCurrency();
+    const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
+    const personalPolicy = usePolicy(personalPolicyID);
+    // The Preferences > Payment currency setting; the server converts search totals to this same currency when a
+    // search has no explicit target, so it's the footer's conversion target whenever the snapshot carries none.
+    const paymentCurrency = personalPolicy?.outputCurrency ?? CONST.CURRENCY.USD;
     const [footerCurrencyState, setFooterCurrencyState] = useState<FooterCurrencyState>({
         searchHash: undefined,
         selectedCurrency: undefined,
@@ -244,8 +248,8 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // to the whole-search grand total, which every search type now returns converted, keyed by the search hash.
     const shouldUseClientTotal = !metadataCount || hasPartialSelection;
     // metadataCurrency is unset for a fresh no-workspace account until a search populates search.currency (e.g. after
-    // visiting Reports), so fall back to the user's live payment currency instead of an arbitrary selected expense's currency.
-    const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? preferredCurrency;
+    // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
+    const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
     const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.

--- a/src/components/Search/SearchSelectionFooter.tsx
+++ b/src/components/Search/SearchSelectionFooter.tsx
@@ -89,11 +89,14 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     const {currentSearchHash, currentSearchKey, currentSearchQueryJSON} = useSearchQueryContext();
     const shouldAllowFooterTotals = useSearchShouldCalculateTotals(currentSearchKey, currentSearchQueryJSON?.hash, true, areAllMatchingItemsSelected);
     const {isOffline} = useNetwork();
+    const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
+    const activePolicy = usePolicy(activePolicyID);
     const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
     const personalPolicy = usePolicy(personalPolicyID);
-    // The Preferences > Payment currency setting. The server falls back to this same currency for search.currency,
-    // so a default derived from it won't change once a snapshot arrives carrying server totals.
-    const paymentCurrency = personalPolicy?.outputCurrency ?? CONST.CURRENCY.USD;
+    // The currency the server converts search figures to when the query carries no explicit target: the active
+    // policy's currency. For accounts without a workspace the active policy is the personal policy, whose output
+    // currency is what Preferences > Payment currency edits.
+    const searchTargetCurrency = activePolicy?.outputCurrency ?? personalPolicy?.outputCurrency ?? CONST.CURRENCY.USD;
     const [footerCurrencyState, setFooterCurrencyState] = useState<FooterCurrencyState>({
         searchHash: undefined,
         selectedCurrency: undefined,
@@ -247,9 +250,13 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
     // Use the per-selection (client) total for a partial selection; nothing-selected and everything-selected both fall
     // to the whole-search grand total, which every search type now returns converted, keyed by the search hash.
     const shouldUseClientTotal = !metadataCount || hasPartialSelection;
-    // metadataCurrency is unset for a fresh no-workspace account until a search populates search.currency (e.g. after
-    // visiting Reports), so fall back to the live payment currency instead of an arbitrary selected expense's currency.
-    const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? paymentCurrency;
+    // The currency the loaded figures are denominated in (the server-converted per-row denomination when the snapshot
+    // metadata hasn't populated a currency). A chosen currency needs converting only when it differs from this, so
+    // choosing the currency the figures are already in — including Reset when nothing moved — stays a no-op.
+    const firstSelectedTransactionKey = selectedTransactionsKeys.at(0);
+    const firstSelectedTransaction = firstSelectedTransactionKey ? selectedTransactions[firstSelectedTransactionKey] : undefined;
+    const selectedTransactionDefaultCurrency = firstSelectedTransaction?.groupCurrency ?? firstSelectedTransaction?.currency;
+    const effectiveDefaultCurrency = defaultFooterCurrency ?? metadataCurrency ?? selectedTransactionDefaultCurrency;
     const hasCustomFooterCurrency = !!selectedCurrency && selectedCurrency !== effectiveDefaultCurrency;
 
     // The most recent conversion request for this currency failed, so stop waiting on a converted value that isn't coming.
@@ -469,7 +476,7 @@ function SearchSelectionFooter({searchResults}: SearchSelectionFooterProps) {
             count={footerData.count}
             total={footerData.total}
             currency={footerData.currency}
-            defaultCurrency={effectiveDefaultCurrency}
+            defaultCurrency={searchTargetCurrency}
             isTotalLoading={isFooterTotalLoading}
             onCurrencyChange={handleFooterCurrencyChange}
         />

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -1,7 +1,9 @@
-import {render} from '@testing-library/react-native';
+import {act, render} from '@testing-library/react-native';
 
 import SearchSelectionFooter from '@components/Search/SearchSelectionFooter';
 import type {SelectedTransactionInfo, SelectedTransactions} from '@components/Search/types';
+
+import {getFooterConvertedAmounts} from '@libs/actions/Search';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -29,10 +31,11 @@ jest.mock('@components/Search/SearchContext', () => ({
     useSearchSelectionContext: () => ({selectedTransactions: mockSelectedTransactions.current, areAllMatchingItemsSelected: false, selectedReports: []}),
 }));
 
-const mockCapturedFooterProps: {current: {defaultCurrency?: string; currency?: string} | undefined} = {current: undefined};
+type CapturedFooterProps = {defaultCurrency?: string; currency?: string; onCurrencyChange?: (currency: string | undefined) => void};
+const mockCapturedFooterProps: {current: CapturedFooterProps | undefined} = {current: undefined};
 jest.mock('@components/Search/SearchPageFooter', () => ({
     __esModule: true,
-    default: (props: {defaultCurrency?: string; currency?: string}) => {
+    default: (props: CapturedFooterProps) => {
         mockCapturedFooterProps.current = props;
         return null;
     },
@@ -49,10 +52,10 @@ const PAYMENT_CURRENCY = CONST.CURRENCY.GBP;
 const ACCOUNT_ID = 1;
 const PERSONAL_POLICY_ID = 'personalPolicy1';
 
-function buildSearchResults(currency: string | undefined): SearchResults {
+function buildSearchResults(currency: string | undefined, count = 1): SearchResults {
     return {
         search: {
-            count: 1,
+            count,
             currency,
             total: -100,
             offset: 0,
@@ -68,7 +71,7 @@ function buildSearchResults(currency: string | undefined): SearchResults {
     };
 }
 
-function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
+function buildSelectedTransaction(currency: string, groupCurrency?: string, groupAmount?: number): SelectedTransactionInfo {
     return {
         isSelected: true,
         canReject: false,
@@ -82,6 +85,8 @@ function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
         policyID: undefined,
         amount: 100,
         currency,
+        groupCurrency,
+        groupAmount,
         isFromOneTransactionReport: false,
     };
 }
@@ -95,6 +100,9 @@ describe('SearchSelectionFooter', () => {
         mockSearchQueryContext.current = {currentSearchHash: 1, currentSearchKey: undefined, currentSearchQueryJSON: {hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE}};
         mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY)};
         mockCapturedFooterProps.current = undefined;
+        // Clear here rather than in afterEach: Onyx.clear() there re-renders the previous test's still-mounted
+        // component (testing-library only unmounts it afterwards), and those renders can record mock calls.
+        jest.clearAllMocks();
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
         await Onyx.merge(ONYXKEYS.PERSONAL_POLICY_ID, PERSONAL_POLICY_ID);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${PERSONAL_POLICY_ID}`, {id: PERSONAL_POLICY_ID, outputCurrency: PAYMENT_CURRENCY});
@@ -103,7 +111,6 @@ describe('SearchSelectionFooter', () => {
 
     afterEach(async () => {
         await Onyx.clear();
-        jest.clearAllMocks();
     });
 
     it("falls back to the user's live payment currency when the search snapshot has no currency yet", async () => {
@@ -122,5 +129,42 @@ describe('SearchSelectionFooter', () => {
         await waitForBatchedUpdates();
 
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
+    });
+
+    it('labels the selected total with the currency its figures are denominated in, not the default', async () => {
+        // The payment currency changed after the snapshot loaded: the selected row's server-converted figure is still
+        // denominated in the old payment currency (INR), while the live default is now GBP.
+        mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
+
+        // A partial selection (1 of 2), so the footer uses the client-side selected total.
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
+        await waitForBatchedUpdates();
+
+        // The displayed total keeps its own denomination (INR) instead of borrowing the new default's symbol, while
+        // the Reset/default currency still follows the live payment currency.
+        expect(mockCapturedFooterProps.current?.currency).toBe('INR');
+        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
+    });
+
+    it('converts the figures to the default currency when Reset selects it explicitly', async () => {
+        // Same stale-denomination scenario as above: the selected group's server-converted figure is still
+        // denominated in the old payment currency (INR), while the live default is now GBP.
+        mockSelectedTransactions.current = {[`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
+
+        // A partial selection (1 of 2), so the footer uses the client-side selected total.
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
+        await waitForBatchedUpdates();
+
+        // The figures match no picker choice yet, so nothing converts.
+        expect(getFooterConvertedAmounts).not.toHaveBeenCalled();
+
+        // Reset selects the default currency explicitly (SearchPageFooter passes it through onCurrencyChange).
+        await act(async () => {
+            mockCapturedFooterProps.current?.onCurrencyChange?.(PAYMENT_CURRENCY);
+            await waitForBatchedUpdates();
+        });
+
+        // The chosen default differs from the figures' denomination, so a conversion to it is requested.
+        expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
     });
 });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -45,10 +45,22 @@ const SELECTED_EXPENSE_CURRENCY = 'JPY';
 const ACCOUNT_ID = 1;
 
 function buildSearchResults(currency: string | undefined): SearchResults {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     return {
-        search: {count: 1, currency, total: -100, offset: 0, isLoading: false, hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE},
-    } as unknown as SearchResults;
+        search: {
+            count: 1,
+            currency,
+            total: -100,
+            offset: 0,
+            isLoading: false,
+            hash: 1,
+            type: CONST.SEARCH.DATA_TYPES.EXPENSE,
+            sortBy: CONST.SEARCH.TABLE_COLUMNS.DATE,
+            sortOrder: CONST.SEARCH.SORT_ORDER.DESC,
+            hasMoreResults: false,
+            hasResults: true,
+        },
+        data: {},
+    };
 }
 
 function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
@@ -95,7 +107,7 @@ describe('SearchSelectionFooter', () => {
         await waitForBatchedUpdates();
 
         // The footer's Reset/default currency follows the live USD payment currency, not the selected expense's own
-        // (stale) currency — this was the bug in https://github.com/Expensify/App/issues/97583.
+        // (stale) currency.
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.USD);
     });
 

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -1,0 +1,108 @@
+import {render} from '@testing-library/react-native';
+
+import SearchSelectionFooter from '@components/Search/SearchSelectionFooter';
+import type {SelectedTransactionInfo, SelectedTransactions} from '@components/Search/types';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {SearchResults} from '@src/types/onyx';
+
+import Onyx from 'react-native-onyx';
+
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+
+jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
+
+jest.mock('@hooks/useSearchShouldCalculateTotals', () => jest.fn(() => true));
+
+jest.mock('@libs/actions/Search', () => ({
+    getFooterConvertedAmounts: jest.fn(),
+}));
+
+const mockSearchQueryContext: {current: {currentSearchHash: number; currentSearchKey: undefined; currentSearchQueryJSON: {hash: number; type: string} | undefined}} = {
+    current: {currentSearchHash: 1, currentSearchKey: undefined, currentSearchQueryJSON: {hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE}},
+};
+const mockSelectedTransactions: {current: SelectedTransactions} = {current: {}};
+jest.mock('@components/Search/SearchContext', () => ({
+    useSearchQueryContext: () => mockSearchQueryContext.current,
+    useSearchResultsContext: () => ({currentSearchResults: undefined}),
+    useSearchSelectionContext: () => ({selectedTransactions: mockSelectedTransactions.current, areAllMatchingItemsSelected: false, selectedReports: []}),
+}));
+
+const mockCapturedFooterProps: {current: {defaultCurrency?: string; currency?: string} | undefined} = {current: undefined};
+jest.mock('@components/Search/SearchPageFooter', () => ({
+    __esModule: true,
+    default: (props: {defaultCurrency?: string; currency?: string}) => {
+        mockCapturedFooterProps.current = props;
+        return null;
+    },
+}));
+
+// The currency of the selected expense — deliberately different from every other currency in this test so a leak
+// from any wrong fallback source is easy to spot.
+const SELECTED_EXPENSE_CURRENCY = 'JPY';
+
+const ACCOUNT_ID = 1;
+
+function buildSearchResults(currency: string | undefined): SearchResults {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return {
+        search: {count: 1, currency, total: -100, offset: 0, isLoading: false, hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE},
+    } as unknown as SearchResults;
+}
+
+function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
+    return {
+        isSelected: true,
+        canReject: false,
+        canHold: false,
+        canSplit: false,
+        hasBeenSplit: false,
+        canChangeReport: false,
+        isHeld: false,
+        canUnhold: false,
+        action: CONST.SEARCH.ACTION_TYPES.VIEW,
+        policyID: undefined,
+        amount: 100,
+        currency,
+        isFromOneTransactionReport: false,
+    };
+}
+
+describe('SearchSelectionFooter', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        mockSearchQueryContext.current = {currentSearchHash: 1, currentSearchKey: undefined, currentSearchQueryJSON: {hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE}};
+        mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY)};
+        mockCapturedFooterProps.current = undefined;
+        await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
+        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {[ACCOUNT_ID]: {accountID: ACCOUNT_ID, localCurrencyCode: CONST.CURRENCY.USD}});
+        await waitForBatchedUpdates();
+    });
+
+    afterEach(async () => {
+        await Onyx.clear();
+        jest.clearAllMocks();
+    });
+
+    it("falls back to the user's live payment currency when the search snapshot has no currency yet", async () => {
+        // A fresh no-workspace account: the Expenses search snapshot has not populated search.currency yet, and the
+        // only selected expense happens to be in a different currency (JPY) from the live payment currency (USD).
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined)} />);
+        await waitForBatchedUpdates();
+
+        // The footer's Reset/default currency follows the live USD payment currency, not the selected expense's own
+        // (stale) currency — this was the bug in https://github.com/Expensify/App/issues/97583.
+        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.USD);
+    });
+
+    it('prefers the search snapshot currency when one is already available', async () => {
+        render(<SearchSelectionFooter searchResults={buildSearchResults(CONST.CURRENCY.EUR)} />);
+        await waitForBatchedUpdates();
+
+        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
+    });
+});

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -1,9 +1,7 @@
-import {act, render} from '@testing-library/react-native';
+import {render} from '@testing-library/react-native';
 
 import SearchSelectionFooter from '@components/Search/SearchSelectionFooter';
 import type {SelectedTransactionInfo, SelectedTransactions} from '@components/Search/types';
-
-import {getFooterConvertedAmounts} from '@libs/actions/Search';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -31,11 +29,10 @@ jest.mock('@components/Search/SearchContext', () => ({
     useSearchSelectionContext: () => ({selectedTransactions: mockSelectedTransactions.current, areAllMatchingItemsSelected: false, selectedReports: []}),
 }));
 
-type CapturedFooterProps = {defaultCurrency?: string; currency?: string; onCurrencyChange?: (currency: string | undefined) => void};
-const mockCapturedFooterProps: {current: CapturedFooterProps | undefined} = {current: undefined};
+const mockCapturedFooterProps: {current: {defaultCurrency?: string; currency?: string} | undefined} = {current: undefined};
 jest.mock('@components/Search/SearchPageFooter', () => ({
     __esModule: true,
-    default: (props: CapturedFooterProps) => {
+    default: (props: {defaultCurrency?: string; currency?: string}) => {
         mockCapturedFooterProps.current = props;
         return null;
     },
@@ -52,10 +49,10 @@ const PAYMENT_CURRENCY = CONST.CURRENCY.GBP;
 const ACCOUNT_ID = 1;
 const PERSONAL_POLICY_ID = 'personalPolicy1';
 
-function buildSearchResults(currency: string | undefined, count = 1): SearchResults {
+function buildSearchResults(currency: string | undefined): SearchResults {
     return {
         search: {
-            count,
+            count: 1,
             currency,
             total: -100,
             offset: 0,
@@ -71,7 +68,7 @@ function buildSearchResults(currency: string | undefined, count = 1): SearchResu
     };
 }
 
-function buildSelectedTransaction(currency: string, groupCurrency?: string, groupAmount?: number): SelectedTransactionInfo {
+function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
     return {
         isSelected: true,
         canReject: false,
@@ -85,8 +82,6 @@ function buildSelectedTransaction(currency: string, groupCurrency?: string, grou
         policyID: undefined,
         amount: 100,
         currency,
-        groupCurrency,
-        groupAmount,
         isFromOneTransactionReport: false,
     };
 }
@@ -100,9 +95,6 @@ describe('SearchSelectionFooter', () => {
         mockSearchQueryContext.current = {currentSearchHash: 1, currentSearchKey: undefined, currentSearchQueryJSON: {hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE}};
         mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY)};
         mockCapturedFooterProps.current = undefined;
-        // Clear here rather than in afterEach: Onyx.clear() there re-renders the previous test's still-mounted
-        // component (testing-library only unmounts it afterwards), and those renders can record mock calls.
-        jest.clearAllMocks();
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
         await Onyx.merge(ONYXKEYS.PERSONAL_POLICY_ID, PERSONAL_POLICY_ID);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${PERSONAL_POLICY_ID}`, {id: PERSONAL_POLICY_ID, outputCurrency: PAYMENT_CURRENCY});
@@ -111,6 +103,7 @@ describe('SearchSelectionFooter', () => {
 
     afterEach(async () => {
         await Onyx.clear();
+        jest.clearAllMocks();
     });
 
     it("falls back to the user's live payment currency when the search snapshot has no currency yet", async () => {
@@ -129,42 +122,5 @@ describe('SearchSelectionFooter', () => {
         await waitForBatchedUpdates();
 
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
-    });
-
-    it('labels the selected total with the currency its figures are denominated in, not the default', async () => {
-        // The payment currency changed after the snapshot loaded: the selected row's server-converted figure is still
-        // denominated in the old payment currency (INR), while the live default is now GBP.
-        mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
-
-        // A partial selection (1 of 2), so the footer uses the client-side selected total.
-        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
-        await waitForBatchedUpdates();
-
-        // The displayed total keeps its own denomination (INR) instead of borrowing the new default's symbol, while
-        // the Reset/default currency still follows the live payment currency.
-        expect(mockCapturedFooterProps.current?.currency).toBe('INR');
-        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
-    });
-
-    it('converts the figures to the default currency when Reset selects it explicitly', async () => {
-        // Same stale-denomination scenario as above: the selected group's server-converted figure is still
-        // denominated in the old payment currency (INR), while the live default is now GBP.
-        mockSelectedTransactions.current = {[`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
-
-        // A partial selection (1 of 2), so the footer uses the client-side selected total.
-        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
-        await waitForBatchedUpdates();
-
-        // The figures match no picker choice yet, so nothing converts.
-        expect(getFooterConvertedAmounts).not.toHaveBeenCalled();
-
-        // Reset selects the default currency explicitly (SearchPageFooter passes it through onCurrencyChange).
-        await act(async () => {
-            mockCapturedFooterProps.current?.onCurrencyChange?.(PAYMENT_CURRENCY);
-            await waitForBatchedUpdates();
-        });
-
-        // The chosen default differs from the figures' denomination, so a conversion to it is requested.
-        expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
     });
 });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -3,6 +3,8 @@ import {render} from '@testing-library/react-native';
 import SearchSelectionFooter from '@components/Search/SearchSelectionFooter';
 import type {SelectedTransactionInfo, SelectedTransactions} from '@components/Search/types';
 
+import {getFooterConvertedAmounts} from '@libs/actions/Search';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {SearchResults} from '@src/types/onyx';
@@ -49,10 +51,10 @@ const PAYMENT_CURRENCY = CONST.CURRENCY.GBP;
 const ACCOUNT_ID = 1;
 const PERSONAL_POLICY_ID = 'personalPolicy1';
 
-function buildSearchResults(currency: string | undefined): SearchResults {
+function buildSearchResults(currency: string | undefined, count = 1): SearchResults {
     return {
         search: {
-            count: 1,
+            count,
             currency,
             total: -100,
             offset: 0,
@@ -68,7 +70,7 @@ function buildSearchResults(currency: string | undefined): SearchResults {
     };
 }
 
-function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
+function buildSelectedTransaction(currency: string, groupCurrency?: string, groupAmount?: number): SelectedTransactionInfo {
     return {
         isSelected: true,
         canReject: false,
@@ -82,6 +84,8 @@ function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
         policyID: undefined,
         amount: 100,
         currency,
+        groupCurrency,
+        groupAmount,
         isFromOneTransactionReport: false,
     };
 }
@@ -95,6 +99,9 @@ describe('SearchSelectionFooter', () => {
         mockSearchQueryContext.current = {currentSearchHash: 1, currentSearchKey: undefined, currentSearchQueryJSON: {hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE}};
         mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY)};
         mockCapturedFooterProps.current = undefined;
+        // Clear here rather than in afterEach: Onyx.clear() there re-renders the previous test's still-mounted
+        // component (testing-library only unmounts it afterwards), and those renders can record mock calls.
+        jest.clearAllMocks();
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
         await Onyx.merge(ONYXKEYS.PERSONAL_POLICY_ID, PERSONAL_POLICY_ID);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${PERSONAL_POLICY_ID}`, {id: PERSONAL_POLICY_ID, outputCurrency: PAYMENT_CURRENCY});
@@ -103,7 +110,6 @@ describe('SearchSelectionFooter', () => {
 
     afterEach(async () => {
         await Onyx.clear();
-        jest.clearAllMocks();
     });
 
     it("falls back to the user's live payment currency when the search snapshot has no currency yet", async () => {
@@ -122,5 +128,32 @@ describe('SearchSelectionFooter', () => {
         await waitForBatchedUpdates();
 
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
+    });
+
+    it('requests conversion to the payment currency when the loaded figures are denominated in another currency', async () => {
+        // The payment currency changed after the snapshot loaded: the selected group's server-converted figure is
+        // still denominated in the old payment currency (INR), while the live default is now GBP.
+        mockSelectedTransactions.current = {[`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
+
+        // A partial selection (1 of 2), so the footer uses the client-side selected total.
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
+        await waitForBatchedUpdates();
+
+        expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
+    });
+
+    it('labels an unconvertible total with the currency its figures are denominated in, not the default', async () => {
+        // Same stale-denomination scenario, but the selected row carries no transaction ID or group key, so no
+        // conversion request can be made for it.
+        mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
+
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
+        await waitForBatchedUpdates();
+
+        // The displayed total keeps its own denomination (INR) instead of borrowing the new default's symbol, while
+        // the Reset/default currency still follows the live payment currency.
+        expect(getFooterConvertedAmounts).not.toHaveBeenCalled();
+        expect(mockCapturedFooterProps.current?.currency).toBe('INR');
+        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
     });
 });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -152,24 +152,4 @@ describe('SearchSelectionFooter', () => {
         // The chosen default differs from the figures' denomination, so a conversion to it is requested.
         expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
     });
-
-    it('converts when any selected row is denominated differently, not just the first', async () => {
-        // The first selected group's figure already matches the default (GBP), but the second is still denominated
-        // in another currency (INR).
-        mockSelectedTransactions.current = {
-            [`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, PAYMENT_CURRENCY, -100),
-            [`${CONST.SEARCH.GROUP_PREFIX}category2`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100),
-        };
-
-        // A partial selection (2 of 3), so the footer uses the client-side selected total.
-        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 3)} />);
-        await waitForBatchedUpdates();
-
-        await act(async () => {
-            mockCapturedFooterProps.current?.onCurrencyChange?.(PAYMENT_CURRENCY);
-            await waitForBatchedUpdates();
-        });
-
-        expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
-    });
 });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -152,4 +152,24 @@ describe('SearchSelectionFooter', () => {
         // The chosen default differs from the figures' denomination, so a conversion to it is requested.
         expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
     });
+
+    it('converts when any selected row is denominated differently, not just the first', async () => {
+        // The first selected group's figure already matches the default (GBP), but the second is still denominated
+        // in another currency (INR).
+        mockSelectedTransactions.current = {
+            [`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, PAYMENT_CURRENCY, -100),
+            [`${CONST.SEARCH.GROUP_PREFIX}category2`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100),
+        };
+
+        // A partial selection (2 of 3), so the footer uses the client-side selected total.
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 3)} />);
+        await waitForBatchedUpdates();
+
+        await act(async () => {
+            mockCapturedFooterProps.current?.onCurrencyChange?.(PAYMENT_CURRENCY);
+            await waitForBatchedUpdates();
+        });
+
+        expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
+    });
 });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -31,7 +31,7 @@ jest.mock('@components/Search/SearchContext', () => ({
     useSearchSelectionContext: () => ({selectedTransactions: mockSelectedTransactions.current, areAllMatchingItemsSelected: false, selectedReports: []}),
 }));
 
-type CapturedFooterProps = {defaultCurrency?: string; currency?: string; onCurrencyChange?: (currency: string | undefined) => void};
+type CapturedFooterProps = {defaultCurrency?: string; currency?: string; onCurrencyChange?: (currency: string) => void};
 const mockCapturedFooterProps: {current: CapturedFooterProps | undefined} = {current: undefined};
 jest.mock('@components/Search/SearchPageFooter', () => ({
     __esModule: true,

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -1,7 +1,9 @@
-import {render} from '@testing-library/react-native';
+import {act, render} from '@testing-library/react-native';
 
 import SearchSelectionFooter from '@components/Search/SearchSelectionFooter';
 import type {SelectedTransactionInfo, SelectedTransactions} from '@components/Search/types';
+
+import {getFooterConvertedAmounts} from '@libs/actions/Search';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -29,10 +31,11 @@ jest.mock('@components/Search/SearchContext', () => ({
     useSearchSelectionContext: () => ({selectedTransactions: mockSelectedTransactions.current, areAllMatchingItemsSelected: false, selectedReports: []}),
 }));
 
-const mockCapturedFooterProps: {current: {defaultCurrency?: string; currency?: string} | undefined} = {current: undefined};
+type CapturedFooterProps = {defaultCurrency?: string; currency?: string; onCurrencyChange?: (currency: string | undefined) => void};
+const mockCapturedFooterProps: {current: CapturedFooterProps | undefined} = {current: undefined};
 jest.mock('@components/Search/SearchPageFooter', () => ({
     __esModule: true,
-    default: (props: {defaultCurrency?: string; currency?: string}) => {
+    default: (props: CapturedFooterProps) => {
         mockCapturedFooterProps.current = props;
         return null;
     },
@@ -48,11 +51,12 @@ const PAYMENT_CURRENCY = CONST.CURRENCY.GBP;
 
 const ACCOUNT_ID = 1;
 const PERSONAL_POLICY_ID = 'personalPolicy1';
+const WORKSPACE_POLICY_ID = 'workspacePolicy1';
 
-function buildSearchResults(currency: string | undefined): SearchResults {
+function buildSearchResults(currency: string | undefined, count = 1): SearchResults {
     return {
         search: {
-            count: 1,
+            count,
             currency,
             total: -100,
             offset: 0,
@@ -68,7 +72,7 @@ function buildSearchResults(currency: string | undefined): SearchResults {
     };
 }
 
-function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
+function buildSelectedTransaction(currency: string, groupCurrency?: string, groupAmount?: number): SelectedTransactionInfo {
     return {
         isSelected: true,
         canReject: false,
@@ -82,6 +86,8 @@ function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
         policyID: undefined,
         amount: 100,
         currency,
+        groupCurrency,
+        groupAmount,
         isFromOneTransactionReport: false,
     };
 }
@@ -95,6 +101,9 @@ describe('SearchSelectionFooter', () => {
         mockSearchQueryContext.current = {currentSearchHash: 1, currentSearchKey: undefined, currentSearchQueryJSON: {hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE}};
         mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY)};
         mockCapturedFooterProps.current = undefined;
+        // Clear here rather than in afterEach: Onyx.clear() there re-renders the previous test's still-mounted
+        // component (testing-library only unmounts it afterwards), and those renders can record mock calls.
+        jest.clearAllMocks();
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
         await Onyx.merge(ONYXKEYS.PERSONAL_POLICY_ID, PERSONAL_POLICY_ID);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${PERSONAL_POLICY_ID}`, {id: PERSONAL_POLICY_ID, outputCurrency: PAYMENT_CURRENCY});
@@ -103,12 +112,11 @@ describe('SearchSelectionFooter', () => {
 
     afterEach(async () => {
         await Onyx.clear();
-        jest.clearAllMocks();
     });
 
-    it("falls back to the user's live payment currency when the search snapshot has no currency yet", async () => {
-        // A fresh no-workspace account: the Expenses search snapshot has not populated search.currency yet, and the
-        // only selected expense happens to be in a different currency (JPY) from the live payment currency (GBP).
+    it("offers the user's live payment currency as the Reset target when there is no active workspace", async () => {
+        // A fresh no-workspace account: the active policy is the personal policy, and the only selected expense
+        // happens to be in a different currency (JPY) from the live payment currency (GBP).
         render(<SearchSelectionFooter searchResults={buildSearchResults(undefined)} />);
         await waitForBatchedUpdates();
 
@@ -117,10 +125,54 @@ describe('SearchSelectionFooter', () => {
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
     });
 
-    it('prefers the search snapshot currency when one is already available', async () => {
+    it("offers the active workspace's currency as the Reset target when one is set", async () => {
+        // The server converts search figures to the active policy's currency, so with an active workspace the Reset
+        // target is the workspace currency, not the personal payment currency.
+        await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, WORKSPACE_POLICY_ID);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${WORKSPACE_POLICY_ID}`, {id: WORKSPACE_POLICY_ID, outputCurrency: CONST.CURRENCY.EUR});
+        await waitForBatchedUpdates();
+
         render(<SearchSelectionFooter searchResults={buildSearchResults(CONST.CURRENCY.EUR)} />);
         await waitForBatchedUpdates();
 
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
+    });
+
+    it('converts the figures when Reset selects a default the figures are not denominated in', async () => {
+        // The payment currency changed after the snapshot loaded: the selected group's server-converted figure is
+        // still denominated in the old payment currency (INR), while the live default is now GBP.
+        mockSelectedTransactions.current = {[`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
+
+        // A partial selection (1 of 2), so the footer uses the client-side selected total.
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
+        await waitForBatchedUpdates();
+
+        // No picker choice yet, so nothing converts.
+        expect(getFooterConvertedAmounts).not.toHaveBeenCalled();
+
+        // Reset passes the default through onCurrencyChange as an explicit selection.
+        await act(async () => {
+            mockCapturedFooterProps.current?.onCurrencyChange?.(PAYMENT_CURRENCY);
+            await waitForBatchedUpdates();
+        });
+
+        // The chosen default differs from the figures' denomination, so a conversion to it is requested.
+        expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
+    });
+
+    it('does not convert when Reset selects the currency the figures are already denominated in', async () => {
+        mockSelectedTransactions.current = {[`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, PAYMENT_CURRENCY, -100)};
+
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
+        await waitForBatchedUpdates();
+
+        await act(async () => {
+            mockCapturedFooterProps.current?.onCurrencyChange?.(PAYMENT_CURRENCY);
+            await waitForBatchedUpdates();
+        });
+
+        // The figures are already in the chosen currency, so no request is made and the snapshot data is used as-is.
+        expect(getFooterConvertedAmounts).not.toHaveBeenCalled();
+        expect(mockCapturedFooterProps.current?.currency).toBe(PAYMENT_CURRENCY);
     });
 });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -3,8 +3,6 @@ import {render} from '@testing-library/react-native';
 import SearchSelectionFooter from '@components/Search/SearchSelectionFooter';
 import type {SelectedTransactionInfo, SelectedTransactions} from '@components/Search/types';
 
-import {getFooterConvertedAmounts} from '@libs/actions/Search';
-
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {SearchResults} from '@src/types/onyx';
@@ -51,10 +49,10 @@ const PAYMENT_CURRENCY = CONST.CURRENCY.GBP;
 const ACCOUNT_ID = 1;
 const PERSONAL_POLICY_ID = 'personalPolicy1';
 
-function buildSearchResults(currency: string | undefined, count = 1): SearchResults {
+function buildSearchResults(currency: string | undefined): SearchResults {
     return {
         search: {
-            count,
+            count: 1,
             currency,
             total: -100,
             offset: 0,
@@ -70,7 +68,7 @@ function buildSearchResults(currency: string | undefined, count = 1): SearchResu
     };
 }
 
-function buildSelectedTransaction(currency: string, groupCurrency?: string, groupAmount?: number): SelectedTransactionInfo {
+function buildSelectedTransaction(currency: string): SelectedTransactionInfo {
     return {
         isSelected: true,
         canReject: false,
@@ -84,8 +82,6 @@ function buildSelectedTransaction(currency: string, groupCurrency?: string, grou
         policyID: undefined,
         amount: 100,
         currency,
-        groupCurrency,
-        groupAmount,
         isFromOneTransactionReport: false,
     };
 }
@@ -99,9 +95,6 @@ describe('SearchSelectionFooter', () => {
         mockSearchQueryContext.current = {currentSearchHash: 1, currentSearchKey: undefined, currentSearchQueryJSON: {hash: 1, type: CONST.SEARCH.DATA_TYPES.EXPENSE}};
         mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY)};
         mockCapturedFooterProps.current = undefined;
-        // Clear here rather than in afterEach: Onyx.clear() there re-renders the previous test's still-mounted
-        // component (testing-library only unmounts it afterwards), and those renders can record mock calls.
-        jest.clearAllMocks();
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
         await Onyx.merge(ONYXKEYS.PERSONAL_POLICY_ID, PERSONAL_POLICY_ID);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${PERSONAL_POLICY_ID}`, {id: PERSONAL_POLICY_ID, outputCurrency: PAYMENT_CURRENCY});
@@ -110,6 +103,7 @@ describe('SearchSelectionFooter', () => {
 
     afterEach(async () => {
         await Onyx.clear();
+        jest.clearAllMocks();
     });
 
     it("falls back to the user's live payment currency when the search snapshot has no currency yet", async () => {
@@ -128,32 +122,5 @@ describe('SearchSelectionFooter', () => {
         await waitForBatchedUpdates();
 
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
-    });
-
-    it('requests conversion to the payment currency when the loaded figures are denominated in another currency', async () => {
-        // The payment currency changed after the snapshot loaded: the selected group's server-converted figure is
-        // still denominated in the old payment currency (INR), while the live default is now GBP.
-        mockSelectedTransactions.current = {[`${CONST.SEARCH.GROUP_PREFIX}category1`]: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
-
-        // A partial selection (1 of 2), so the footer uses the client-side selected total.
-        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
-        await waitForBatchedUpdates();
-
-        expect(getFooterConvertedAmounts).toHaveBeenCalledWith(expect.objectContaining({targetCurrency: PAYMENT_CURRENCY}));
-    });
-
-    it('labels an unconvertible total with the currency its figures are denominated in, not the default', async () => {
-        // Same stale-denomination scenario, but the selected row carries no transaction ID or group key, so no
-        // conversion request can be made for it.
-        mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
-
-        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
-        await waitForBatchedUpdates();
-
-        // The displayed total keeps its own denomination (INR) instead of borrowing the new default's symbol, while
-        // the Reset/default currency still follows the live payment currency.
-        expect(getFooterConvertedAmounts).not.toHaveBeenCalled();
-        expect(mockCapturedFooterProps.current?.currency).toBe('INR');
-        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
     });
 });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -131,21 +131,6 @@ describe('SearchSelectionFooter', () => {
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
     });
 
-    it('labels the selected total with the currency its figures are denominated in, not the default', async () => {
-        // The payment currency changed after the snapshot loaded: the selected row's server-converted figure is still
-        // denominated in the old payment currency (INR), while the live default is now GBP.
-        mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
-
-        // A partial selection (1 of 2), so the footer uses the client-side selected total.
-        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
-        await waitForBatchedUpdates();
-
-        // The displayed total keeps its own denomination (INR) instead of borrowing the new default's symbol, while
-        // the Reset/default currency still follows the live payment currency.
-        expect(mockCapturedFooterProps.current?.currency).toBe('INR');
-        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
-    });
-
     it('converts the figures to the default currency when Reset selects it explicitly', async () => {
         // Same stale-denomination scenario as above: the selected group's server-converted figure is still
         // denominated in the old payment currency (INR), while the live default is now GBP.

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -105,7 +105,8 @@ describe('SearchSelectionFooter', () => {
         // component (testing-library only unmounts it afterwards), and those renders can record mock calls.
         jest.clearAllMocks();
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
-        await Onyx.merge(ONYXKEYS.PERSONAL_POLICY_ID, PERSONAL_POLICY_ID);
+        // Accounts without a workspace have their personal policy as the active policy.
+        await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, PERSONAL_POLICY_ID);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${PERSONAL_POLICY_ID}`, {id: PERSONAL_POLICY_ID, outputCurrency: PAYMENT_CURRENCY});
         await waitForBatchedUpdates();
     });

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -131,6 +131,21 @@ describe('SearchSelectionFooter', () => {
         expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.EUR);
     });
 
+    it('labels the selected total with the currency its figures are denominated in, not the default', async () => {
+        // The payment currency changed after the snapshot loaded: the selected row's server-converted figure is still
+        // denominated in the old payment currency (INR), while the live default is now GBP.
+        mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY, 'INR', -100)};
+
+        // A partial selection (1 of 2), so the footer uses the client-side selected total.
+        render(<SearchSelectionFooter searchResults={buildSearchResults(undefined, 2)} />);
+        await waitForBatchedUpdates();
+
+        // The displayed total keeps its own denomination (INR) instead of borrowing the new default's symbol, while
+        // the Reset/default currency still follows the live payment currency.
+        expect(mockCapturedFooterProps.current?.currency).toBe('INR');
+        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
+    });
+
     it('converts the figures to the default currency when Reset selects it explicitly', async () => {
         // Same stale-denomination scenario as above: the selected group's server-converted figure is still
         // denominated in the old payment currency (INR), while the live default is now GBP.

--- a/tests/unit/Search/SearchSelectionFooterTest.tsx
+++ b/tests/unit/Search/SearchSelectionFooterTest.tsx
@@ -42,7 +42,12 @@ jest.mock('@components/Search/SearchPageFooter', () => ({
 // from any wrong fallback source is easy to spot.
 const SELECTED_EXPENSE_CURRENCY = 'JPY';
 
+// The Preferences > Payment currency setting, stored as the personal policy's output currency. Deliberately not USD
+// so the test can tell the real fallback apart from the USD last resort.
+const PAYMENT_CURRENCY = CONST.CURRENCY.GBP;
+
 const ACCOUNT_ID = 1;
+const PERSONAL_POLICY_ID = 'personalPolicy1';
 
 function buildSearchResults(currency: string | undefined): SearchResults {
     return {
@@ -91,7 +96,8 @@ describe('SearchSelectionFooter', () => {
         mockSelectedTransactions.current = {transaction1: buildSelectedTransaction(SELECTED_EXPENSE_CURRENCY)};
         mockCapturedFooterProps.current = undefined;
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: ACCOUNT_ID});
-        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {[ACCOUNT_ID]: {accountID: ACCOUNT_ID, localCurrencyCode: CONST.CURRENCY.USD}});
+        await Onyx.merge(ONYXKEYS.PERSONAL_POLICY_ID, PERSONAL_POLICY_ID);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${PERSONAL_POLICY_ID}`, {id: PERSONAL_POLICY_ID, outputCurrency: PAYMENT_CURRENCY});
         await waitForBatchedUpdates();
     });
 
@@ -102,13 +108,13 @@ describe('SearchSelectionFooter', () => {
 
     it("falls back to the user's live payment currency when the search snapshot has no currency yet", async () => {
         // A fresh no-workspace account: the Expenses search snapshot has not populated search.currency yet, and the
-        // only selected expense happens to be in a different currency (JPY) from the live payment currency (USD).
+        // only selected expense happens to be in a different currency (JPY) from the live payment currency (GBP).
         render(<SearchSelectionFooter searchResults={buildSearchResults(undefined)} />);
         await waitForBatchedUpdates();
 
-        // The footer's Reset/default currency follows the live USD payment currency, not the selected expense's own
-        // (stale) currency.
-        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(CONST.CURRENCY.USD);
+        // The footer's Reset/default currency follows the live payment currency (the personal policy's output
+        // currency), not the selected expense's own (stale) currency.
+        expect(mockCapturedFooterProps.current?.defaultCurrency).toBe(PAYMENT_CURRENCY);
     });
 
     it('prefers the search snapshot currency when one is already available', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The footer's Reset/default currency fell back to the selected expense's own currency, so after changing Preferences > Payment currency, Reset kept restoring the old currency.

The Reset/default currency now comes from the active policy's output currency (the personal policy's for accounts without a workspace, which is what Preferences > Payment currency edits). This mirrors the currency the server converts search figures to when the query has no explicit target.

Reset also passes that currency through as an explicit selection instead of clearing the choice. The existing default chain compares it against the currency the loaded figures are denominated in, so the conversion machinery runs exactly when the figures are in another currency and stays idle otherwise.

Also changed `SearchResultsProvider`'s `defaultSearchInfo.currency` from `''` to `undefined` so an unset search currency is always `undefined`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/97583
PROPOSAL:


### Tests

1. As a fresh account with no workspace, go to a self-DM and create an expense.
2. Go to Spend > Expenses and select the expense via checkbox.
3. Go to Account > Preferences > Payment currency and change it to a currency different from step 1's default (e.g. USD).
4. Go back to Spend > Expenses and select the expense via checkbox.
5. Click the currency selector on the footer, then click Reset.
6. Verify the currency resets to the payment currency chosen in step 3 and the total amount is converted to it.
7. Repeat steps 4-6 after switching to Reports and back to Expenses (the previously-working path) to confirm no regression.


https://github.com/user-attachments/assets/4e9a2db3-1e30-45ee-95c0-fc26d2a76911






- [x] Verify that no errors appear in the JS console

### Offline tests

Not affected — the payment currency is read from already-persisted Onyx data (`PERSONAL_POLICY_ID` and the personal policy), same as before; no new network requests are introduced.

### QA Steps

1. As a fresh account with no workspace, go to a self-DM and create an expense.
2. Go to Spend > Expenses and select the expense via checkbox.
3. Go to Account > Preferences > Payment currency and change it to a different currency.
4. Go back to Spend > Expenses, select the expense, open the footer currency selector, and click Reset.
5. Verify the currency resets to the payment currency chosen in step 3 and the total amount is converted to it.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>






