### PR TITLE
feat: Add ManualSendMessageVisible

### DIFF
--- a/contributingGuides/OBSERVABILITY_METRICS.md
+++ b/contributingGuides/OBSERVABILITY_METRICS.md
@@ -148,18 +148,32 @@ This document lists all implemented telemetry metrics in the Expensify App.
 **Constant**: `CONST.TELEMETRY.SPAN_SEND_MESSAGE`
 **Sentry Name**: `ManualSendMessage`
 **Threshold**: 100ms (P90)
-**What's Measured**: Time from submitting message to message rendered
-**Start**: Message submitted in composer ([`src/pages/home/report/ReportActionCompose/ReportActionCompose.tsx`](https://github.com/Expensify/App/blob/8f123f449f1a4533830b18a1040c9a5f1949821d/src/pages/home/report/ReportActionCompose/ReportActionCompose.tsx#L344))
+**What's Measured**: Time from submitting message to the message's React flush. **Caveat**: the end is anchored in a `useEffect`, which fires before the frame is on screen — it does NOT measure visibility. Kept temporarily for comparison against `ManualSendMessageVisible` (below), then to be retired.
+**Start**: Message submitted in composer, only when scrolled to bottom ([`src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts`](https://github.com/Expensify/App/blob/main/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts))
 **End**:
-- User sees: Their message appears in chat
-- Technical: Message text rendered in report ([`src/pages/home/report/comment/TextCommentFragment.tsx`](https://github.com/Expensify/App/blob/8f123f449f1a4533830b18a1040c9a5f1949821d/src/pages/home/report/comment/TextCommentFragment.tsx#L70))
-**Span ID**: Based on reportID
+- User sees: nothing specific — the effect flush is invisible; the message usually appears later
+- Technical: Passive effect of the message fragment runs ([`src/pages/inbox/report/comment/TextCommentFragment.tsx`](https://github.com/Expensify/App/blob/main/src/pages/inbox/report/comment/TextCommentFragment.tsx))
+**Span ID**: `${CONST.TELEMETRY.SPAN_SEND_MESSAGE}_${reportActionID}` (optimistic report action ID)
 **Attributes**: `report_id`, `message_length`, `canceled_by_skeleton`, `send_message_source`, `report_action_count`, `money_request_preview_count`
 **Cancellation (report-actions skeleton)**: While a report-actions skeleton is on screen, we listen for `ManualSendMessage` spans started for that report and cancel them immediately, tagging `canceled: true` plus `canceled_by_skeleton` with the skeleton that caused it.
 - `canceled_by_skeleton` values (`CONST.TELEMETRY.CANCELED_BY_SKELETON`) based on skeleton condition
 **Cancellation (report unmount / navigate away)**: If the user leaves the report before their message renders, any pending `ManualSendMessage` span is cancelled via `cancelSpansByPrefix()` to avoid orphaned spans. Cancelled this way the span gets `canceled: true` but **no** `canceled_by_skeleton` (a blanket cancel by span-id prefix, not scoped to one `report_id`).
 **Notes**: `send_message_source` = `<tab>_<scenario>` (+ `_rhp` in the RHP, + `_from_report` when drilled in from a report) — slice the metric by send path.
 `report_action_count` / `money_request_preview_count` — how many renderable actions the chat's list holds and how many of them are `REPORT_PREVIEW` items — slice the metric by list weight (e.g. chats with many `MoneyRequestReportPreview` items).
+
+### Send Message (Visible)
+
+**Constant**: `CONST.TELEMETRY.SPAN_SEND_MESSAGE_VISIBLE`
+**Sentry Name**: `ManualSendMessageVisible`
+**Threshold**: TBD — will read higher than `ManualSendMessage` by design; recalibrate after the comparison window
+**What's Measured**: Time from submitting message to the message actually laid out on screen (`onLayout`), i.e. user-perceived send latency. Runs alongside the legacy `ManualSendMessage` span: same start, same attributes, different end anchor. Once validated in Sentry (~2 weeks), the legacy effect-anchored span gets removed and this becomes the send-message metric.
+**Start**: Started back-to-back with `ManualSendMessage` in the composer submit ([`src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts`](https://github.com/Expensify/App/blob/main/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts))
+**End**:
+- User sees: Their message appears in chat
+- Technical: Message layout complete (`onLayout` event) in [`src/pages/inbox/report/comment/TextCommentFragment.tsx`](https://github.com/Expensify/App/blob/main/src/pages/inbox/report/comment/TextCommentFragment.tsx)
+**Span ID**: `${CONST.TELEMETRY.SPAN_SEND_MESSAGE_VISIBLE}_${reportActionID}` (optimistic report action ID)
+**Attributes**: Same as `ManualSendMessage` (`report_id`, `message_length`, `send_message_source`, `report_action_count`, `money_request_preview_count`, plus cancellation tags)
+**Cancellation**: Same paths as `ManualSendMessage` — the skeleton listener matches both ops, and prefix cancels cover it automatically because `ManualSendMessage` is a prefix of `ManualSendMessageVisible`.
 
 ## Failure Rates
 

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2204,6 +2204,7 @@ const CONST = {
         SPAN_EXPENSE_SERVER_RESPONSE: 'ManualCreateExpenseServerResponse',
         SPAN_GEOLOCATION_WAIT: 'ManualGeolocationWait',
         SPAN_SEND_MESSAGE: 'ManualSendMessage',
+        SPAN_SEND_MESSAGE_VISIBLE: 'ManualSendMessageVisible',
         SPAN_NOT_FOUND_PAGE: 'ManualNotFoundPage',
         SPAN_SKELETON: 'ManualSkeleton',
         SPAN_ODOMETER_TO_CONFIRMATION: 'ManualOdometerToConfirmation',

--- a/src/hooks/useCancelSendMessageSpanOnSkeleton.ts
+++ b/src/hooks/useCancelSendMessageSpanOnSkeleton.ts
@@ -28,7 +28,7 @@ function useCancelSendMessageSpanOnSkeleton(reportID: string | undefined, skelet
         // `client.on` returns an unsubscribe function, used as the effect cleanup.
         return client.on('spanStart', (span) => {
             const {op, data} = Sentry.spanToJSON(span);
-            if (op !== CONST.TELEMETRY.SPAN_SEND_MESSAGE || data[CONST.TELEMETRY.ATTRIBUTE_REPORT_ID] !== reportID) {
+            if ((op !== CONST.TELEMETRY.SPAN_SEND_MESSAGE && op !== CONST.TELEMETRY.SPAN_SEND_MESSAGE_VISIBLE) || data[CONST.TELEMETRY.ATTRIBUTE_REPORT_ID] !== reportID) {
                 return;
             }
             // Defer so activeSpans has registered the span (set right after the `startInactiveSpan` that emits this).

--- a/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
+++ b/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts
@@ -160,18 +160,25 @@ function useComposerSubmit(reportID: string) {
         const optimisticReportActionID = rand64();
         const isScrolledToBottom = scrollOffsetRef.current < CONST.REPORT.ACTIONS.ACTION_VISIBLE_THRESHOLD;
         if (isScrolledToBottom) {
-            const spanID = `${CONST.TELEMETRY.SPAN_SEND_MESSAGE}_${optimisticReportActionID}`;
             const {reportActionCount, moneyRequestPreviewCount} = getSendMessageListWeight(getAllReportActions(reportID), reportID, canUserPerformWriteAction(report, isReportArchived));
-            startSpan(spanID, {
+            const attributes = {
+                [CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID,
+                [CONST.TELEMETRY.ATTRIBUTE_MESSAGE_LENGTH]: draftMessageTrimmed.length,
+                [CONST.TELEMETRY.ATTRIBUTE_SEND_MESSAGE_SOURCE]: getSendMessageSource({report, conciergeReportID, isInSidePanel, routeName: route.name}),
+                [CONST.TELEMETRY.ATTRIBUTE_REPORT_ACTION_COUNT]: reportActionCount,
+                [CONST.TELEMETRY.ATTRIBUTE_MONEY_REQUEST_PREVIEW_COUNT]: moneyRequestPreviewCount,
+            };
+            startSpan(`${CONST.TELEMETRY.SPAN_SEND_MESSAGE}_${optimisticReportActionID}`, {
                 name: 'send-message',
                 op: CONST.TELEMETRY.SPAN_SEND_MESSAGE,
-                attributes: {
-                    [CONST.TELEMETRY.ATTRIBUTE_REPORT_ID]: reportID,
-                    [CONST.TELEMETRY.ATTRIBUTE_MESSAGE_LENGTH]: draftMessageTrimmed.length,
-                    [CONST.TELEMETRY.ATTRIBUTE_SEND_MESSAGE_SOURCE]: getSendMessageSource({report, conciergeReportID, isInSidePanel, routeName: route.name}),
-                    [CONST.TELEMETRY.ATTRIBUTE_REPORT_ACTION_COUNT]: reportActionCount,
-                    [CONST.TELEMETRY.ATTRIBUTE_MONEY_REQUEST_PREVIEW_COUNT]: moneyRequestPreviewCount,
-                },
+                attributes,
+            });
+            // Dual-emit while validating the new anchor: same start, but ended at the message's onLayout
+            // (visibility) instead of the passive effect. Remove the effect-anchored span once compared.
+            startSpan(`${CONST.TELEMETRY.SPAN_SEND_MESSAGE_VISIBLE}_${optimisticReportActionID}`, {
+                name: 'send-message-visible',
+                op: CONST.TELEMETRY.SPAN_SEND_MESSAGE_VISIBLE,
+                attributes,
             });
         }
         addComment({

--- a/src/pages/inbox/report/comment/TextCommentFragment.tsx
+++ b/src/pages/inbox/report/comment/TextCommentFragment.tsx
@@ -71,7 +71,7 @@ function TextCommentFragment({fragment, styleAsDeleted, reportActionID, styleAsM
 
     const processedTextArray = splitTextWithEmojis(message);
 
-    // Original effect anchor — kept while the visible variant below is validated against it in Sentry.
+    // Original effect anchor, kept while the visible variant below is validated against it in Sentry.
     useEffect(() => {
         if (!reportActionID) {
             return;

--- a/src/pages/inbox/report/comment/TextCommentFragment.tsx
+++ b/src/pages/inbox/report/comment/TextCommentFragment.tsx
@@ -25,7 +25,8 @@ import type {StyleProp, TextStyle} from 'react-native';
 
 import {Str} from 'expensify-common';
 import isEmpty from 'lodash/isEmpty';
-import React, {useEffect} from 'react';
+import {useEffect} from 'react';
+import {View} from 'react-native';
 
 import RenderCommentHTML from './RenderCommentHTML';
 import shouldRenderAsText from './shouldRenderAsText';
@@ -70,12 +71,20 @@ function TextCommentFragment({fragment, styleAsDeleted, reportActionID, styleAsM
 
     const processedTextArray = splitTextWithEmojis(message);
 
+    // Original effect anchor — kept while the visible variant below is validated against it in Sentry.
     useEffect(() => {
         if (!reportActionID) {
             return;
         }
         endSpan(`${CONST.TELEMETRY.SPAN_SEND_MESSAGE}_${reportActionID}`);
     }, [reportActionID]);
+
+    const endSendMessageVisibleSpanOnLayout = () => {
+        if (!reportActionID) {
+            return;
+        }
+        endSpan(`${CONST.TELEMETRY.SPAN_SEND_MESSAGE_VISIBLE}_${reportActionID}`);
+    };
 
     // If the only difference between fragment.text and fragment.html is <br /> tags and emoji tag
     // on native, we render it as text, not as html
@@ -109,16 +118,19 @@ function TextCommentFragment({fragment, styleAsDeleted, reportActionID, styleAsM
         htmlWithTag = adjustExpensifyLinksForEnv(getHtmlWithAttachmentID(htmlWithTag, reportActionID));
 
         return (
-            <RenderCommentHTML
-                containsOnlyEmojis={containsOnlyEmojis}
-                source={source}
-                html={htmlWithTag}
-            />
+            <View onLayout={endSendMessageVisibleSpanOnLayout}>
+                <RenderCommentHTML
+                    containsOnlyEmojis={containsOnlyEmojis}
+                    source={source}
+                    html={htmlWithTag}
+                />
+            </View>
         );
     }
 
     return (
         <Text
+            onLayout={endSendMessageVisibleSpanOnLayout}
             style={[
                 containsOnlyEmojis && styles.onlyEmojisText,
                 styles.ltr,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

add `ManualSendMessageVisible` span (onLayout-anchored) alongside `ManualSendMessage`

#### What changed

Dual-emit: the existing `ManualSendMessage` span is untouched; a new `ManualSendMessageVisible` span starts at the same moment with identical attributes and ends at the message's `onLayout` (visibility) instead of the passive effect. After a comparison window in Sentry (~2 weeks), the effect-anchored span gets removed and `ManualSendMessageVisible` becomes the metric.

- `src/CONST/index.ts` — new `SPAN_SEND_MESSAGE_VISIBLE: 'ManualSendMessageVisible'`.
- `src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts` — starts both spans back-to-back with the same attributes (`report_id`, message length, source, list weight).
- `src/pages/inbox/report/comment/TextCommentFragment.tsx`
  - Original `useEffect` ending `ManualSendMessage` kept verbatim.
  - New `onLayout` handler ends `ManualSendMessageVisible`: on the existing outer `<Text>` (text path) and on a new plain `<View onLayout>` wrapper around `RenderCommentHTML` (HTML path — it has no layout hook of its own).
- `src/hooks/useCancelSendMessageSpanOnSkeleton.ts` — skeleton-cancel matches both ops. Prefix cancels (`ReportLifecycleHandler`, `SearchMoneyRequestReportPage`) cover the new span automatically since `ManualSendMessage` is a prefix of `ManualSendMessageVisible`.

#### Why

The span claims to measure "message sent → message visible", but its end is anchored in a passive effect.

<img width="1881" height="560" alt="Performance trace with marks" src="https://github.com/user-attachments/assets/b21848a3-5b98-4018-97f8-08b7fb0cab27" />

`onLayout` is the codebase convention for paint spans: `open_report` warm ends on the report list's `onLayout` (`ReportActionsList.tsx`), `ManualNavigateToReportsFirstPaint`/`ContentLoad` end on `onLayout` (`Search/index.tsx`, `SearchLoadingSkeleton.tsx`), and the `Visible` suffix follows `ManualSubmitToDestinationVisible`. The effect anchor in `send-message` was never a deliberate choice — PR #75551 piggybacked `endSpan` onto a pre-existing `useEffect` that held the legacy `Performance.markEnd(SEND_MESSAGE)` call.

#### Expected numbers

`ManualSendMessageVisible` will report **higher** durations than `ManualSendMessage`. That gap is the JS-thread post-commit burst + frame delivery the effect anchor never saw — honest user-perceived latency, not a regression. When the old span is retired, dashboards/alerts need recalibration to the new baseline.

#### Validation plan

1. Ship dual-emit.
2. In Sentry, compare `ManualSendMessage` vs `ManualSendMessageVisible` distributions per platform for ~2 weeks (same start, same attributes — per-event delta is directly attributable to the anchor).
3. Remove the effect anchor, `SPAN_SEND_MESSAGE` constant usage in `TextCommentFragment`/`useComposerSubmit`, and the extra op check in `useCancelSendMessageSpanOnSkeleton`.

#### Risk

- One extra layout-event dispatch per message mount (handler always attached).
- One permanent plain `View` wrapper around every HTML-path comment — verified layout-neutral (see `RENDER_COMMENT_HTML_TEST_MESSAGES.md` / `SEND_MESSAGE_SPAN_QA_TESTS.md`).
- Doubled span volume for send-message during the comparison window.
- Span-leak safety: `onLayout` always fires on mount for both paths; skeleton/navigation cancel paths cover both spans.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97902
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

## Test 1 — plain text message

1. Open any chat.
2. Send: `plain message`

**Expected:** Message renders as before — alignment, width, spacing unchanged.

## Test 2 — formatted (HTML) messages

Send each, compare rendering against staging/production side by side:

1. `*bold* _italic_ ~strike~ normal`
2. `` `inline code` inside a sentence ``
3. `# Heading message`
4. Multiline code block:
   ````
   ```
   const x = veryLongFunctionNameThatShouldNotWrapButScrollOrShrink(argument1, argument2);
   const y = 2;
   ```
   ````
5. `check https://staging.new.expensify.com/r/123 inline`
6. `[labeled link](https://google.com)`
7. `@<any user login> hello`
8. Blockquote:
   ```
   > quoted line one
   > quoted line two longer to force wrapping across the available width
   ```
9. `*bold with 😀 emoji* and text`
10. `*aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*` (long unbroken string)
11. `hello 😀 world` and `😀😀😀` (web renders these via the HTML path; native as plain text)

**Expected:** Each message identical to staging/production — message width, code-block width, blockquote left border, mention pill, link styling, emoji size. No horizontal shift or extra vertical spacing.

## Test 3 — edit and delete

1. Send `*edit me*`, then edit it to any other text.
2. Send `*delete me*`, go offline, delete it.

**Expected:** Edited label appears inline as before; deleted message shows strikethrough style; layout unchanged.

## Test 5 — telemetry still fires (dev console, optional)

1. With browser console open, send any message.

**Expected:** Two "Ending span" logs per sent message: `[Sentry][ManualSendMessage_<id>]` and `[Sentry][ManualSendMessageVisible_<id>]`, the Visible one with an equal or larger duration.


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console



### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="389" height="861" alt="android 1" src="https://github.com/user-attachments/assets/a3ea3241-172f-4c0d-a9d6-e3154e092f9a" />
<img width="389" height="861" alt="android 2" src="https://github.com/user-attachments/assets/62ac4be1-ae30-4c26-b363-cd0c1a12d032" />

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="389" height="861" alt="android web 1" src="https://github.com/user-attachments/assets/f5b6ada9-78b1-4907-b162-ac92853dd3ef" />
<img width="389" height="861" alt="android web 2" src="https://github.com/user-attachments/assets/80005179-e003-470f-8c90-230db7116632" />

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="418" height="977" alt="ios 2" src="https://github.com/user-attachments/assets/bd05eea2-fa14-4094-bb74-2c8e35d552a7" />
<img width="418" height="977" alt="ios 1" src="https://github.com/user-attachments/assets/296746b7-2626-474f-81cb-a2306539aa1d" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="442" height="855" alt="ios web 3" src="https://github.com/user-attachments/assets/09123d96-4544-472e-8c89-bec54fc63aab" />
<img width="442" height="855" alt="ios web 2" src="https://github.com/user-attachments/assets/1051c41a-c881-458d-915b-df7c77ac93b6" />
<img width="442" height="855" alt="ios web 1" src="https://github.com/user-attachments/assets/98a56a43-794b-4014-8b8a-df31f61e637a" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="743" height="1556" alt="web narrow" src="https://github.com/user-attachments/assets/3aa35de7-ebdd-41d6-a98d-92c2efd57554" />
<img width="986" height="1556" alt="web wide" src="https://github.com/user-attachments/assets/10117ec7-2620-4f43-a5d1-fefd5c223cd2" />

</details>
