### PR TITLE
Fix stale thinking indicators for tagged admin agents

### DIFF
--- a/src/pages/inbox/AgentZeroStatusContext.tsx
+++ b/src/pages/inbox/AgentZeroStatusContext.tsx
@@ -13,10 +13,10 @@ import type {OnyxEntry} from 'react-native-onyx';
 
 import {getCustomAgentParticipantAccountID, getReportParticipantAccountIDs} from '@selectors/AgentZeroChat';
 import {getReportChatType} from '@selectors/Report';
-import {getNewestReportActionSelector} from '@selectors/ReportAction';
+import {getLatestReportActionForActorSelector, getNewestReportActionSelector} from '@selectors/ReportAction';
 import {agentZeroProcessingAgentIDsSelector} from '@selectors/ReportNameValuePairs';
 import {accountIDSelector} from '@selectors/Session';
-import React, {createContext, useContext, useEffect} from 'react';
+import React, {createContext, useContext, useEffect, useMemo, useRef, useState} from 'react';
 
 type AgentZeroStatusState = {
     /**
@@ -106,6 +106,7 @@ function AgentZeroStatusProvider({reportID, children}: React.PropsWithChildren<{
             isActive={!!reportID && isAgentZeroChat}
             serverAgentIDs={serverAgentIDs}
             includeConcierge={isConciergeChat || isAdmin}
+            isAdmin={isAdmin}
             customAgentDMAccountID={customAgentDMAccountID}
         >
             {children}
@@ -118,9 +119,17 @@ function AgentZeroStatusGate({
     isActive,
     serverAgentIDs,
     includeConcierge,
+    isAdmin,
     customAgentDMAccountID,
     children,
-}: React.PropsWithChildren<{reportID: string | undefined; isActive: boolean; serverAgentIDs: number[] | undefined; includeConcierge: boolean; customAgentDMAccountID?: number}>) {
+}: React.PropsWithChildren<{
+    reportID: string | undefined;
+    isActive: boolean;
+    serverAgentIDs: number[] | undefined;
+    includeConcierge: boolean;
+    isAdmin: boolean;
+    customAgentDMAccountID?: number;
+}>) {
     const [currentUserAccountID] = useOnyx(ONYXKEYS.SESSION, {selector: accountIDSelector});
 
     // When the agent's reply (ADDCOMMENT) lands before the server's indicator-clear NVP update,
@@ -130,6 +139,56 @@ function AgentZeroStatusGate({
     // Keyed on the report only while an agent responds here: the gate mounts for every report, and
     // this selector re-runs on every report-action change.
     const [newestReportAction] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${isActive ? reportID : undefined}`, {selector: getNewestReportActionSelector});
+    const latestUserReportActionSelector = useMemo(() => getLatestReportActionForActorSelector(currentUserAccountID), [currentUserAccountID]);
+    const [latestUserReportAction] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${isActive ? reportID : undefined}`, {selector: latestUserReportActionSelector});
+
+    // In an admins room, Auth may leave a processing label for an unrelated agent after the user
+    // explicitly tags a different agent. Keep the set of agents named by the current user request
+    // for the duration of that processing cycle so the UI only renders bubbles for the requested
+    // agent(s). A null value means the request was untagged and all server-named agents are valid;
+    // an empty array means a tagged request has no matching active agent yet, so no unrelated
+    // bubble should be shown.
+    const [taggedAgentIDs, setTaggedAgentIDs] = useState<number[] | null>(null);
+    const isServerProcessing = (serverAgentIDs ?? []).length > 0;
+    const processingCycleRef = useRef(false);
+    const handledRequestActionIDRef = useRef<string | undefined>(undefined);
+    const isCurrentUserComment =
+        newestReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT &&
+        newestReportAction.actorAccountID !== undefined &&
+        newestReportAction.actorAccountID === currentUserAccountID;
+
+    useEffect(() => {
+        if (!isActive || !isAdmin) {
+            processingCycleRef.current = false;
+            handledRequestActionIDRef.current = undefined;
+            setTaggedAgentIDs(null);
+            return;
+        }
+
+        const isNewProcessingCycle = !processingCycleRef.current;
+        const isNewUserRequest = latestUserReportAction?.reportActionID !== handledRequestActionIDRef.current;
+        if (isNewUserRequest || (isServerProcessing && isNewProcessingCycle)) {
+            const mentionedAccountIDs = latestUserReportAction?.mentionedAccountIDs ?? [];
+            setTaggedAgentIDs(mentionedAccountIDs.length > 0 ? mentionedAccountIDs : null);
+            handledRequestActionIDRef.current = latestUserReportAction?.reportActionID;
+        }
+
+        if (!isServerProcessing) {
+            // Keep a tag captured from the user's optimistic request long enough to suppress the
+            // default Concierge bubble before the server's per-agent labels arrive. Once the
+            // newest action is no longer the user's request, the cycle is complete and the filter
+            // can be cleared for the next untagged request.
+            if (!isCurrentUserComment) {
+                processingCycleRef.current = false;
+                handledRequestActionIDRef.current = undefined;
+                setTaggedAgentIDs(null);
+            } else {
+                processingCycleRef.current = false;
+            }
+            return;
+        }
+        processingCycleRef.current = true;
+    }, [isActive, isAdmin, isServerProcessing, isCurrentUserComment, latestUserReportAction]);
 
     // One reasoning Pusher subscription per report (not per agent). The handler in Report
     // actions routes each event to the right agent's reasoning history by its actorAccountID.
@@ -172,6 +231,14 @@ function AgentZeroStatusGate({
     }
     if (currentUserAccountID !== undefined) {
         candidateIDs.delete(currentUserAccountID);
+    }
+    if (isAdmin && taggedAgentIDs !== null) {
+        const taggedAgentIDSet = new Set(taggedAgentIDs);
+        for (const candidateAgentID of candidateIDs) {
+            if (!taggedAgentIDSet.has(candidateAgentID)) {
+                candidateIDs.delete(candidateAgentID);
+            }
+        }
     }
     // Suppress an agent whose reply is already the newest action. The server's indicator-clear NVP
     // can arrive up to ~250ms after the reply Pusher event, leaving the bubble visible on top of

--- a/src/selectors/ReportAction.ts
+++ b/src/selectors/ReportAction.ts
@@ -1,4 +1,4 @@
-import {filterOutDeprecatedReportActions, getLinkedTransactionID, getSortedReportActions, isActionOfType} from '@libs/ReportActionsUtils';
+import {filterOutDeprecatedReportActions, getLinkedTransactionID, getOriginalMessage, getSortedReportActions, isActionOfType} from '@libs/ReportActionsUtils';
 
 import CONST from '@src/CONST';
 import type {ReportAction, ReportActions} from '@src/types/onyx';
@@ -8,7 +8,10 @@ import type {OnyxEntry} from 'react-native-onyx';
 
 import lodashFindLast from 'lodash/findLast';
 
-type NewestReportAction = Pick<ReportAction, 'reportActionID' | 'actorAccountID' | 'actionName'>;
+type NewestReportAction = Pick<ReportAction, 'reportActionID' | 'actorAccountID' | 'actionName'> & {
+    /** Account IDs mentioned by an add-comment action, used to identify a tagged agent request. */
+    mentionedAccountIDs?: number[];
+};
 
 /**
  * Scopes VISIBLE_REPORT_ACTIONS to one report, pre-wrapped in the `{[reportID]: slice}` shape
@@ -82,6 +85,42 @@ function getNewestReportActionSelector(reportActions: OnyxEntry<ReportActions>):
 }
 
 /**
+ * Selector factory for the latest comment authored by a specific account. Unlike the newest
+ * action selector, this remains useful after an agent reply lands because the user request that
+ * started the processing cycle is still present in the report actions collection.
+ */
+function getLatestReportActionForActorSelector(actorAccountID: number | undefined) {
+    return (reportActions: OnyxEntry<ReportActions>): NewestReportAction | undefined => {
+        if (actorAccountID === undefined) {
+            return undefined;
+        }
+
+        const userComments = Object.values(reportActions ?? {}).filter((action) => action?.actionName === CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && action.actorAccountID === actorAccountID);
+        if (userComments.length === 0) {
+            return undefined;
+        }
+
+        const latestComment = userComments.reduce((a, b) => {
+            const createdA = a.created ?? '';
+            const createdB = b.created ?? '';
+            if (createdA !== createdB) {
+                return createdA > createdB ? a : b;
+            }
+            return a.reportActionID > b.reportActionID ? a : b;
+        });
+        const originalMessage = getOriginalMessage(latestComment);
+        const mentionedAccountIDs = originalMessage && 'mentionedAccountIDs' in originalMessage ? originalMessage.mentionedAccountIDs : undefined;
+
+        return {
+            reportActionID: latestComment.reportActionID,
+            actorAccountID: latestComment.actorAccountID,
+            actionName: latestComment.actionName,
+            mentionedAccountIDs,
+        };
+    };
+}
+
+/**
  * Finds the IOU action associated with a RECEIPT_SCAN_FAILED report action.
  * Prefer parentReportActionID (specific IOU action when `report` is a transaction thread).
  * Fall back to childReportID match, then to the only IOU action for one-transaction reports.
@@ -129,6 +168,7 @@ export {
     getParentReportActionSelector,
     getLastClosedReportAction,
     getNewestReportActionSelector,
+    getLatestReportActionForActorSelector,
     getReportActionByIDSelector,
     getReceiptScanFailedIOUActionDataSelector,
     reportVisibleActionsSelector,

--- a/tests/unit/AgentZeroStatusContextTest.ts
+++ b/tests/unit/AgentZeroStatusContextTest.ts
@@ -325,6 +325,84 @@ describe('AgentZeroStatusContext', () => {
             expect(result.current.candidateAgentIDs).not.toContain(CUSTOM_AGENT);
             expect(result.current.candidateAgentIDs).toContain(CONST.ACCOUNT_ID.CONCIERGE);
         });
+
+        it('renders only the tagged agent when an admins room has a stale label for another agent', async () => {
+            const taggedAgentID = 222;
+            const staleAgentID = 333;
+
+            await Onyx.merge(ONYXKEYS.CONCIERGE_REPORT_ID, '999');
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: currentUserAccountID});
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
+                reportID,
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_ADMINS,
+                participants: {
+                    [currentUserAccountID]: participant,
+                    [taggedAgentID]: participant,
+                    [staleAgentID]: participant,
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
+                userRequest: {
+                    reportActionID: 'userRequest',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                    actorAccountID: currentUserAccountID,
+                    created: '2026-08-01 00:00:00.000',
+                    originalMessage: {mentionedAccountIDs: [taggedAgentID]},
+                    message: [{type: 'TEXT', text: '@agent please help'}],
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportID}`, {
+                agentZeroProcessingRequestIndicator: {
+                    [taggedAgentID]: 'Thinking...',
+                    [staleAgentID]: 'Thinking...',
+                },
+            });
+
+            const {result} = renderHook(() => useAgentZeroStatus(), {wrapper});
+            await waitForBatchedUpdates();
+
+            expect(result.current.candidateAgentIDs).toEqual([taggedAgentID]);
+        });
+
+        it('renders every active agent when the current admins request is untagged', async () => {
+            const firstAgentID = 222;
+            const secondAgentID = 333;
+
+            await Onyx.merge(ONYXKEYS.CONCIERGE_REPORT_ID, '999');
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: currentUserAccountID});
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
+                reportID,
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_ADMINS,
+                participants: {
+                    [currentUserAccountID]: participant,
+                    [firstAgentID]: participant,
+                    [secondAgentID]: participant,
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
+                userRequest: {
+                    reportActionID: 'userRequest',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                    actorAccountID: currentUserAccountID,
+                    created: '2026-08-01 00:00:00.000',
+                    originalMessage: {mentionedAccountIDs: []},
+                    message: [{type: 'TEXT', text: 'please help'}],
+                },
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportID}`, {
+                agentZeroProcessingRequestIndicator: {
+                    [firstAgentID]: 'Thinking...',
+                    [secondAgentID]: 'Thinking...',
+                },
+            });
+
+            const {result} = renderHook(() => useAgentZeroStatus(), {wrapper});
+            await waitForBatchedUpdates();
+
+            expect(result.current.candidateAgentIDs).toEqual([CONST.ACCOUNT_ID.CONCIERGE, firstAgentID, secondAgentID]);
+        });
     });
 
     describe('kickoffWaitingIndicator', () => {


### PR DESCRIPTION
### Explanation of Change

When an admins-room request tags a specific agent, the backend can still return stale “thinking” labels for other agent participants. The UI now latches the account IDs mentioned on the current user request for that processing cycle and filters stale labels to the tagged agents. Untagged admins requests continue to show all active agents, and regular Concierge chats are unchanged.

This also adds a selector that finds the latest user comment by actor and unit coverage for tagged and untagged admins requests.

### Fixed Issues

$ https://github.com/Expensify/App/issues/91700
PROPOSAL: https://github.com/Expensify/App/issues/91700#issuecomment-5110201185

### Tests

1. Added unit coverage for tagged admins requests with a stale label for another agent.
2. Added unit coverage confirming untagged admins requests show Concierge plus every active agent.
3. `npx --yes oxfmt@0.55.0 --check src/pages/inbox/AgentZeroStatusContext.tsx src/selectors/ReportAction.ts tests/unit/AgentZeroStatusContextTest.ts` — passed.
4. `git diff --check` — passed.
5. `npm run lint-changed` — blocked because dependencies are not installed locally (`@eslint/eslintrc` missing).

### Offline tests

No network or offline behavior changed.

### QA Steps

1. In an admins room with multiple agents, tag one agent and send a request.
2. Verify only the tagged agent shows a thinking indicator while the response is processing.
3. Send an untagged admins request and verify all active agents plus Concierge can show thinking indicators.
4. Verify a regular Concierge chat is unchanged.