### PR TITLE
Only check for valid phone number in the deposit bank account flow

### DIFF
--- a/src/libs/ValidationUtils.ts
+++ b/src/libs/ValidationUtils.ts
@@ -341,27 +341,6 @@ function isValidUSPhone(phoneNumber = '', isCountryCodeOptional?: boolean): bool
     return parsedPhoneNumber.possible && validUSRegionCodes.includes(parsedPhoneNumber.regionCode ?? '');
 }
 
-/**
- * Validates a phone number from the North American Numbering Plan (+1 calling code).
- * Accepts the US, US territories, and Canada. Canada shares the +1 calling code under NANP
- * but parses to its own ISO region code (CA), so isValidUSPhone rejects it.
- */
-function isValidNANPPhone(phoneNumber = '', isCountryCodeOptional?: boolean): boolean {
-    const phone = phoneNumber || '';
-    const regionCode = isCountryCodeOptional ? CONST.COUNTRY.US : undefined;
-
-    // When we pass regionCode as an option to parsePhoneNumber it wrongly assumes inputs like '=15123456789' as valid
-    // so we need to check if it is a valid phone.
-    if (regionCode && !Str.isValidPhoneFormat(phone)) {
-        return false;
-    }
-
-    const parsedPhoneNumber = parsePhoneNumber(phone, {regionCode});
-
-    const validNANPRegionCodes: string[] = [CONST.COUNTRY.US, CONST.COUNTRY.PR, CONST.COUNTRY.GU, CONST.COUNTRY.VI, CONST.COUNTRY.AS, CONST.COUNTRY.MP, CONST.COUNTRY.CA];
-    return parsedPhoneNumber.possible && validNANPRegionCodes.includes(parsedPhoneNumber.regionCode ?? '');
-}
-
 function isValidPhoneNumber(phoneNumber: string): boolean {
     if (!CONST.ACCEPTED_PHONE_CHARACTER_REGEX.test(phoneNumber) || CONST.REPEATED_SPECIAL_CHAR_PATTERN.test(phoneNumber)) {
         return false;
@@ -897,7 +876,6 @@ export {
     isRequiredFulfilled,
     getFieldRequiredErrors,
     isValidUSPhone,
-    isValidNANPPhone,
     isValidPhoneNumber,
     isValidWebsite,
     isValidTwoFactorCode,

--- a/src/pages/AddPersonalBankAccountPage/substeps/PhoneNumberStep.tsx
+++ b/src/pages/AddPersonalBankAccountPage/substeps/PhoneNumberStep.tsx
@@ -6,8 +6,8 @@ import useOnyx from '@hooks/useOnyx';
 import usePersonalBankAccountDetailsFormSubmit from '@hooks/usePersonalBankAccountDetailsFormSubmit';
 import type {SubPageProps} from '@hooks/useSubPage/types';
 
-import {appendCountryCode, formatE164PhoneNumber} from '@libs/LoginUtils';
-import {getFieldRequiredErrors, isValidNANPPhone, isValidPhoneNumber} from '@libs/ValidationUtils';
+import {appendCountryCode} from '@libs/LoginUtils';
+import {getFieldRequiredErrors, isValidPhoneNumber} from '@libs/ValidationUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -38,9 +38,8 @@ function PhoneNumberStep({onNext, onMove, isEditing, shouldDelayAutoFocus, enabl
 
         if (values.phoneNumber) {
             const phoneNumberWithCountryCode = appendCountryCode(values.phoneNumber, countryCode);
-            const e164FormattedPhoneNumber = formatE164PhoneNumber(values.phoneNumber, countryCode);
 
-            if (!isValidPhoneNumber(phoneNumberWithCountryCode) || !isValidNANPPhone(e164FormattedPhoneNumber)) {
+            if (!isValidPhoneNumber(phoneNumberWithCountryCode)) {
                 errors.phoneNumber = translate('common.error.phoneNumber');
             }
         }

--- a/src/pages/AddPersonalBankAccountPage/substeps/PhoneNumberStep.tsx
+++ b/src/pages/AddPersonalBankAccountPage/substeps/PhoneNumberStep.tsx
@@ -6,7 +6,7 @@ import useOnyx from '@hooks/useOnyx';
 import usePersonalBankAccountDetailsFormSubmit from '@hooks/usePersonalBankAccountDetailsFormSubmit';
 import type {SubPageProps} from '@hooks/useSubPage/types';
 
-import {appendCountryCode} from '@libs/LoginUtils';
+import {appendCountryCode, formatE164PhoneNumber} from '@libs/LoginUtils';
 import {getFieldRequiredErrors, isValidPhoneNumber} from '@libs/ValidationUtils';
 
 import CONST from '@src/CONST';

--- a/src/pages/settings/Wallet/UpdatePersonalBankAccountPage.tsx
+++ b/src/pages/settings/Wallet/UpdatePersonalBankAccountPage.tsx
@@ -12,8 +12,8 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import {getCompletedStepsForBankAccount} from '@libs/BankAccountUtils';
 import Log from '@libs/Log';
+import {formatE164PhoneNumber} from '@libs/LoginUtils';
 import {getCurrentAddress, getStreetLines} from '@libs/PersonalDetailsUtils';
-import {parsePhoneNumber} from '@libs/PhoneNumber';
 
 import Navigation from '@navigation/Navigation';
 
@@ -111,6 +111,7 @@ function UpdatePersonalBankAccountPage() {
     const [homeAddressDraft] = useOnyx(ONYXKEYS.FORMS.HOME_ADDRESS_FORM_DRAFT);
     const [personalBankAccount, personalBankAccountResult] = useOnyx(ONYXKEYS.PERSONAL_BANK_ACCOUNT);
     const [bankAccountList] = useOnyx(ONYXKEYS.BANK_ACCOUNT_LIST);
+    const [countryCode = CONST.DEFAULT_COUNTRY_CODE] = useOnyx(ONYXKEYS.COUNTRY_CODE);
 
     const shouldShowSuccess = personalBankAccount?.shouldShowSuccess ?? false;
     const bankAccountID = personalBankAccount?.bankAccountID;
@@ -196,9 +197,10 @@ function UpdatePersonalBankAccountPage() {
             addressZipCode = '';
         }
 
+        // The BE reads companyPhone as the Plaid phone_number and assumes +1 for a bare 10 digit value, so send E.164.
+        // The form draft holds whatever the user typed, which can lack a calling code, so apply the country code here.
         const rawPhone = personalBankAccountDraft?.phoneNumber ?? privatePersonalDetails?.phoneNumber ?? existingData?.companyPhone ?? '';
-        const parsed = parsePhoneNumber(rawPhone, {regionCode: CONST.COUNTRY.US});
-        const phoneNumber = parsed.number?.significant ?? '';
+        const phoneNumber = formatE164PhoneNumber(rawPhone, countryCode) ?? '';
 
         updatePersonalBankAccountInfo(personalBankAccount.bankAccountID, {
             legalFirstName,

--- a/tests/unit/LoginUtilsTest.ts
+++ b/tests/unit/LoginUtilsTest.ts
@@ -71,7 +71,7 @@ describe('LoginUtils', () => {
         it('Should keep the calling code when it differs from the country code', () => {
             expect(formatE164PhoneNumber('+61255501234', CONST.DEFAULT_COUNTRY_CODE)).toBe('+61255501234');
         });
-        it('Should return undefined for an unparseable number', () => {
+        it('Should return undefined for a value that is not a phone number', () => {
             expect(formatE164PhoneNumber('abcdefg', CONST.DEFAULT_COUNTRY_CODE)).toBeUndefined();
         });
     });

--- a/tests/unit/LoginUtilsTest.ts
+++ b/tests/unit/LoginUtilsTest.ts
@@ -1,5 +1,6 @@
 import {
     appendCountryCode,
+    formatE164PhoneNumber,
     getEmailDomain,
     getPhoneLogin,
     getPhoneNumberWithoutSpecialChars,
@@ -55,6 +56,23 @@ describe('LoginUtils', () => {
             const countryCode = CONST.DEFAULT_COUNTRY_CODE;
             const parsedPhone = appendCountryCode(givenPhone, countryCode);
             expect(parsedPhone).toBe('+12345678901');
+        });
+    });
+    describe('formatE164PhoneNumber', () => {
+        it('Should keep the calling code of a number that already has one', () => {
+            expect(formatE164PhoneNumber('+442071234567', CONST.DEFAULT_COUNTRY_CODE)).toBe('+442071234567');
+        });
+        it('Should prepend the country code to a bare US number', () => {
+            expect(formatE164PhoneNumber('201 867 5309', CONST.DEFAULT_COUNTRY_CODE)).toBe('+12018675309');
+        });
+        it('Should prepend the country code to a bare UK number', () => {
+            expect(formatE164PhoneNumber('20 7123 4567', 44)).toBe('+442071234567');
+        });
+        it('Should keep the calling code when it differs from the country code', () => {
+            expect(formatE164PhoneNumber('+61255501234', CONST.DEFAULT_COUNTRY_CODE)).toBe('+61255501234');
+        });
+        it('Should return undefined for an unparseable number', () => {
+            expect(formatE164PhoneNumber('abcdefg', CONST.DEFAULT_COUNTRY_CODE)).toBeUndefined();
         });
     });
     describe('isEmailPublicDomain', () => {

--- a/tests/unit/ValidationUtilsTest.ts
+++ b/tests/unit/ValidationUtilsTest.ts
@@ -14,7 +14,6 @@ import {
     isValidExpirationDate,
     isValidInputLength,
     isValidLegalName,
-    isValidNANPPhone,
     isValidPastDate,
     isValidPaymentZipCode,
     isValidPersonName,
@@ -593,40 +592,6 @@ describe('ValidationUtils', () => {
 
         test('Should return false for an empty string', () => {
             expect(isValidUSPhone('')).toBe(false);
-        });
-    });
-
-    describe('isValidNANPPhone', () => {
-        test('Should return true for a standard US phone number', () => {
-            expect(isValidNANPPhone('+12018675309')).toBe(true);
-        });
-
-        test('Should return true for a Puerto Rico phone number', () => {
-            expect(isValidNANPPhone('+17873464732')).toBe(true);
-        });
-
-        test('Should return true for a US Virgin Islands phone number', () => {
-            expect(isValidNANPPhone('+13405551234')).toBe(true);
-        });
-
-        test('Should return true for a Guam phone number', () => {
-            expect(isValidNANPPhone('+16715551234')).toBe(true);
-        });
-
-        test('Should return true for a Northern Mariana Islands phone number', () => {
-            expect(isValidNANPPhone('+16705551234')).toBe(true);
-        });
-
-        test('Should return true for a Canadian phone number', () => {
-            expect(isValidNANPPhone('+14165551234')).toBe(true);
-        });
-
-        test('Should return false for a UK phone number', () => {
-            expect(isValidNANPPhone('+442071234567')).toBe(false);
-        });
-
-        test('Should return false for an empty string', () => {
-            expect(isValidNANPPhone('')).toBe(false);
         });
     });
 

--- a/tests/unit/ValidationUtilsTest.ts
+++ b/tests/unit/ValidationUtilsTest.ts
@@ -17,6 +17,7 @@ import {
     isValidPastDate,
     isValidPaymentZipCode,
     isValidPersonName,
+    isValidPhoneNumber,
     isValidPIN,
     isValidRegistrationNumber,
     isValidRoomName,
@@ -592,6 +593,36 @@ describe('ValidationUtils', () => {
 
         test('Should return false for an empty string', () => {
             expect(isValidUSPhone('')).toBe(false);
+        });
+    });
+
+    describe('isValidPhoneNumber', () => {
+        test('Should return true for a US phone number', () => {
+            expect(isValidPhoneNumber('+12018675309')).toBe(true);
+        });
+
+        test('Should return true for a Canadian phone number', () => {
+            expect(isValidPhoneNumber('+14165551234')).toBe(true);
+        });
+
+        test('Should return true for a UK phone number', () => {
+            expect(isValidPhoneNumber('+442071234567')).toBe(true);
+        });
+
+        test('Should return true for an Australian phone number', () => {
+            expect(isValidPhoneNumber('+61255501234')).toBe(true);
+        });
+
+        test('Should return false for a number that is too short to be possible', () => {
+            expect(isValidPhoneNumber('123')).toBe(false);
+        });
+
+        test('Should return false for letters', () => {
+            expect(isValidPhoneNumber('abcdefg')).toBe(false);
+        });
+
+        test('Should return false for an empty string', () => {
+            expect(isValidPhoneNumber('')).toBe(false);
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The phone number step in the deposit bank account flow validated the number twice. It ran `isValidPhoneNumber()` on the number with the country code appended, and it also ran `isValidNANPPhone()` on the E.164 formatted number.

`isValidNANPPhone()` only accepted numbers that parse to a North American Numbering Plan region: `US`, `PR`, `GU`, `VI`, `AS`, `MP`, and `CA`. This is the international deposit account flow, so the account holder can live anywhere. A user with a valid number such as `+44 20 7123 4567` saw `Please enter a valid phone number` and could not finish the step.

This PR keeps `isValidPhoneNumber()` as the only phone check in the step. It uses libphonenumber's `possible` check, so it accepts a valid number from any country and still rejects malformed input.

`isValidNANPPhone()` is removed from `ValidationUtils` because this step was its only caller. The genuinely US only callers, in the EnablePayments wallet flows and the USD `ReimbursementAccount` flow, use `isValidUSPhone()` and are unchanged.

Widening the step exposed a second bug in the update flow, which renders the same step. `UpdatePersonalBankAccountPage` normalized the phone with `parsePhoneNumber().number.significant`, which strips the calling code. That was harmless while the step guaranteed `+1`, because `significant` then yields exactly the 10 NANP digits. Once any country is accepted, `+442071234567` becomes `2071234567` and the backend reads it as a NANP number. The add flow already sent E.164, so the two flows disagreed on the format of the same `companyPhone` field.

Both flows now send E.164 through the shared `formatE164PhoneNumber()` helper. The helper appends the country code first, which matters because the form draft holds whatever the user typed and that can have no calling code.

Changed files:

- `src/pages/AddPersonalBankAccountPage/substeps/PhoneNumberStep.tsx` — drop the `isValidNANPPhone()` check and the E.164 formatting it needed.
- `src/pages/settings/Wallet/UpdatePersonalBankAccountPage.tsx` — send E.164 instead of the national significant number, matching the add flow.
- `src/libs/ValidationUtils.ts` — remove `isValidNANPPhone()` and its export.
- `tests/unit/ValidationUtilsTest.ts` — replace the `isValidNANPPhone` describe block with an `isValidPhoneNumber` block covering US, CA, GB, and AU numbers plus malformed input.
- `tests/unit/LoginUtilsTest.ts` — add a `formatE164PhoneNumber` describe block.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97806
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Log in to any account.
2. Go to Account > Wallet.
3. Tap Add bank account > Make payments
4. Continue to the phone number step.
5. Enter a UK phone number, `+44 20 7123 4567`.
6. Verify that no error appears and the step continues to the next page.
7. Go back to the phone number step.
8. Enter a US phone number, `+1 201 867 5309`.
9. Verify that no error appears and the step continues to the next page.
10. Go back to the phone number step.
11. Enter a Canadian phone number, `+1 416 555 1234`.
12. Verify that no error appears and the step continues to the next page.
13. Go back to the phone number step.
14. Enter an invalid number, `123`.
15. Verify that the field shows `Please enter a valid phone number` and the step does not continue.
16. Go back to the phone number step.
17. Enter letters, `abcdefg`.
18. Verify that the field shows `Please enter a valid phone number` and the step does not continue.
19. Complete the rest of the flow and verify that the bank account is added.
20. Reopen the flow and verify that the saved phone number is shown in E.164 format.
21. Go to Account > Wallet and tap a personal bank account that is missing information, to enter the update flow.
22. Continue to the phone number step.
23. Enter a UK phone number, `+44 20 7123 4567`, and finish the flow.
24. Open the network tab, find the `UpdatePersonalBankAccountInfo` request, and verify that `companyPhone` is `+442071234567` and not `2071234567`.
25. Repeat steps 21 to 23 with a US phone number, `201 867 5309`, and verify that `companyPhone` is `+12018675309`.
26. Run `npm run test -- tests/unit/ValidationUtilsTest.ts tests/unit/LoginUtilsTest.ts` and verify that both suites pass.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Turn off the network connection.
2. Go to Account > Wallet > Add bank account > Get reimbursed.
3. Continue to the phone number step.
4. Enter a UK phone number, `+44 20 7123 4567`.
5. Verify that no error appears and the step continues, because the validation runs on the client and needs no network call.
6. Enter an invalid number, `123`.
7. Verify that the field still shows `Please enter a valid phone number`.
8. Turn the network connection back on.
9. Verify that the step keeps the value entered while offline and the flow continues.

### QA Steps

1. Log in to any account.
2. Go to Account > Wallet.
3. Tap Add bank account > Make payments
4. Continue to the phone number step.
5. Enter a UK phone number, `+44 20 7123 4567`.
6. Verify that no error appears and the step continues to the next page.
7. Go back to the phone number step.
8. Enter an Australian phone number, `+61 2 5550 1234`.
9. Verify that no error appears and the step continues to the next page.
10. Go back to the phone number step.
11. Enter a US phone number, `+1 201 867 5309`.
12. Verify that no error appears and the step continues to the next page.
13. Go back to the phone number step.
14. Enter an invalid number, `123`.
15. Verify that the field shows `Please enter a valid phone number` and the step does not continue.
16. Complete the flow with a valid phone number.
17. Verify that the bank account is added and the phone number is saved.
18. Go to Account > Wallet and tap a personal bank account that is missing information, to enter the update flow.
19. Continue to the phone number step.
20. Enter a UK phone number, `+44 20 7123 4567`, and finish the flow.
21. Verify that the bank account updates without an error and the saved phone number still starts with `+44`.
22. Repeat steps 18 to 20 with a US phone number, `201 867 5309`.
23. Verify that the bank account updates without an error and the saved phone number starts with `+1`.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not yet tested — needs manual QA.

</details>