### PR TITLE
[NOQA] perf: restore thumbnail-gate span and attribute the confirmation receipt load

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -340,6 +340,7 @@ const CONST = {
         // Limit how long the shutter handler waits for thumbnail pre-generation before navigating
         // to the confirmation screen. Past this, we navigate and let the confirm-side hook
         // generate the thumbnail lazily (brief source swap is acceptable).
+        THUMBNAIL_NAV_TIMEOUT_MS: 150,
     },
 
     API_ATTACHMENT_VALIDATIONS: {

--- a/src/components/MoneyRequestConfirmationListFooter/ConfirmationReceiptThumbnail.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter/ConfirmationReceiptThumbnail.tsx
@@ -80,6 +80,9 @@ type ConfirmationReceiptThumbnailProps = {
     /** Callback when the PDF requests a password */
     onPDFPassword?: () => void;
 
+    /** Callback when the PDF thumbnail finishes rendering, used to end the receipt-load span */
+    onPDFLoadSuccess?: () => void;
+
     /** Layout callback used in compact mode to capture container width */
     onCompactReceiptContainerLayout: (event: LayoutChangeEvent) => void;
 
@@ -108,6 +111,7 @@ function ConfirmationReceiptThumbnail({
     compactReceiptContainerStyle,
     onPDFLoadError,
     onPDFPassword,
+    onPDFLoadSuccess,
     onCompactReceiptContainerLayout,
     onReceiptLoad,
 }: ConfirmationReceiptThumbnailProps) {
@@ -150,6 +154,7 @@ function ConfirmationReceiptThumbnail({
                             style={styles.h100}
                             onLoadError={onPDFLoadError}
                             onPassword={onPDFPassword}
+                            onLoadSuccess={onPDFLoadSuccess}
                         />
                     </PressableWithoutFocus>
                 ) : (

--- a/src/components/MoneyRequestConfirmationListFooter/hooks/useCompactReceiptDimensions.ts
+++ b/src/components/MoneyRequestConfirmationListFooter/hooks/useCompactReceiptDimensions.ts
@@ -34,11 +34,16 @@ function useCompactReceiptDimensions({showMoreFields, isScan, isInLandscapeMode,
     const [compactReceiptContainerWidth, setCompactReceiptContainerWidth] = useState(0);
     const hasEndedReceiptLoadSpan = useRef(false);
 
-    const handleReceiptLoad = (event?: {nativeEvent: {width: number; height: number}}) => {
-        if (!hasEndedReceiptLoadSpan.current) {
-            hasEndedReceiptLoadSpan.current = true;
-            endSpan(CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD);
+    const endReceiptLoadSpan = () => {
+        if (hasEndedReceiptLoadSpan.current) {
+            return;
         }
+        hasEndedReceiptLoadSpan.current = true;
+        endSpan(CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD);
+    };
+
+    const handleReceiptLoad = (event?: {nativeEvent: {width: number; height: number}}) => {
+        endReceiptLoadSpan();
         const width = event?.nativeEvent.width ?? 0;
         const height = event?.nativeEvent.height ?? 0;
         if (!width || !height) {
@@ -81,6 +86,7 @@ function useCompactReceiptDimensions({showMoreFields, isScan, isInLandscapeMode,
     return {
         isCompactMode,
         handleReceiptLoad,
+        endReceiptLoadSpan,
         handleCompactReceiptContainerLayout,
         compactReceiptStyle,
         compactReceiptContainerStyle,

--- a/src/components/MoneyRequestConfirmationListFooter/sections/ReceiptSection.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter/sections/ReceiptSection.tsx
@@ -112,6 +112,7 @@ function ReceiptSection({
                 compactReceiptContainerStyle={compact.compactReceiptContainerStyle}
                 onPDFLoadError={onPDFLoadError}
                 onPDFPassword={onPDFPassword}
+                onPDFLoadSuccess={compact.endReceiptLoadSpan}
                 onCompactReceiptContainerLayout={compact.handleCompactReceiptContainerLayout}
                 onReceiptLoad={compact.handleReceiptLoad}
             />

--- a/src/hooks/useLocalReceiptThumbnail.ts
+++ b/src/hooks/useLocalReceiptThumbnail.ts
@@ -1,4 +1,8 @@
+import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
+
 import {generateThumbnail} from '@pages/iou/request/step/IOURequestStepScan/cropImageToAspectRatio';
+
+import CONST from '@src/CONST';
 
 import {useEffect, useRef, useState, useTransition} from 'react';
 import {Image} from 'react-native';
@@ -30,11 +34,25 @@ function precacheReceiptImage(sourceUri: string): Promise<string | undefined> {
         return Promise.resolve(thumbnailCache.get(sourceUri));
     }
     thumbnailCache.set(sourceUri, sourceUri);
+
+    startSpan(CONST.TELEMETRY.SPAN_THUMBNAIL_GATE, {
+        name: CONST.TELEMETRY.SPAN_THUMBNAIL_GATE,
+        op: CONST.TELEMETRY.SPAN_THUMBNAIL_GATE,
+        parentSpan: getSpan(CONST.TELEMETRY.SPAN_SHUTTER_TO_CONFIRMATION),
+    });
+
     // Pre-decode the image in the native image pipeline so the
     // confirmation screen can display it instantly without decode latency.
     return Image.prefetch(sourceUri)
-        .then(() => sourceUri)
-        .catch(() => sourceUri);
+        .then(() => {
+            endSpan(CONST.TELEMETRY.SPAN_THUMBNAIL_GATE);
+            return sourceUri;
+        })
+        .catch(() => {
+            // The prefetch failure is swallowed and navigation still happens, so the span has to close here too.
+            endSpan(CONST.TELEMETRY.SPAN_THUMBNAIL_GATE);
+            return sourceUri;
+        });
 }
 
 /**

--- a/src/hooks/useLocalReceiptThumbnail.ts
+++ b/src/hooks/useLocalReceiptThumbnail.ts
@@ -41,10 +41,11 @@ function precacheReceiptImage(sourceUri: string): Promise<string | undefined> {
         parentSpan: getSpan(CONST.TELEMETRY.SPAN_SHUTTER_TO_CONFIRMATION),
     });
 
-    // Pre-decode the image in the native image pipeline so the confirmation screen can display it
-    // instantly without decode latency. Callers await this before navigating, so the wait is capped:
-    // past THUMBNAIL_NAV_TIMEOUT_MS we resolve anyway and let `useLocalReceiptThumbnail` generate the
-    // thumbnail lazily on the confirm screen. The prefetch itself keeps running in the background.
+    // Warm up the image decode so the confirmation screen doesn't have to do it on mount.
+    // We navigate as soon as this resolves, so don't let a slow decode hold the user on the camera:
+    // after THUMBNAIL_NAV_TIMEOUT_MS we move on and let the prefetch finish in the background.
+    // Either way the confirm screen shows `sourceUri` — generating a thumbnail instead would just
+    // trade a fast decode for a slow encode, which is what we're trying to avoid here.
     return Promise.race([
         // The catch matters: callers gate navigation on this promise, so a prefetch failure must not reject the race.
         Image.prefetch(sourceUri).catch(() => false),

--- a/src/hooks/useLocalReceiptThumbnail.ts
+++ b/src/hooks/useLocalReceiptThumbnail.ts
@@ -44,7 +44,7 @@ function precacheReceiptImage(sourceUri: string): Promise<string | undefined> {
     // Warm up the image decode so the confirmation screen doesn't have to do it on mount.
     // We navigate as soon as this resolves, so don't let a slow decode hold the user on the camera:
     // after THUMBNAIL_NAV_TIMEOUT_MS we move on and let the prefetch finish in the background.
-    // Either way the confirm screen shows `sourceUri` — generating a thumbnail instead would just
+    // Either way the confirm screen shows `sourceUri`. Generating a thumbnail instead would just
     // trade a fast decode for a slow encode, which is what we're trying to avoid here.
     return Promise.race([
         // The catch matters: callers gate navigation on this promise, so a prefetch failure must not reject the race.

--- a/src/hooks/useLocalReceiptThumbnail.ts
+++ b/src/hooks/useLocalReceiptThumbnail.ts
@@ -41,18 +41,20 @@ function precacheReceiptImage(sourceUri: string): Promise<string | undefined> {
         parentSpan: getSpan(CONST.TELEMETRY.SPAN_SHUTTER_TO_CONFIRMATION),
     });
 
-    // Pre-decode the image in the native image pipeline so the
-    // confirmation screen can display it instantly without decode latency.
-    return Image.prefetch(sourceUri)
-        .then(() => {
-            endSpan(CONST.TELEMETRY.SPAN_THUMBNAIL_GATE);
-            return sourceUri;
-        })
-        .catch(() => {
-            // The prefetch failure is swallowed and navigation still happens, so the span has to close here too.
-            endSpan(CONST.TELEMETRY.SPAN_THUMBNAIL_GATE);
-            return sourceUri;
-        });
+    // Pre-decode the image in the native image pipeline so the confirmation screen can display it
+    // instantly without decode latency. Callers await this before navigating, so the wait is capped:
+    // past THUMBNAIL_NAV_TIMEOUT_MS we resolve anyway and let `useLocalReceiptThumbnail` generate the
+    // thumbnail lazily on the confirm screen. The prefetch itself keeps running in the background.
+    return Promise.race([
+        // The catch matters: callers gate navigation on this promise, so a prefetch failure must not reject the race.
+        Image.prefetch(sourceUri).catch(() => false),
+        new Promise((resolve) => {
+            setTimeout(resolve, CONST.RECEIPT_CAMERA.THUMBNAIL_NAV_TIMEOUT_MS);
+        }),
+    ]).then(() => {
+        endSpan(CONST.TELEMETRY.SPAN_THUMBNAIL_GATE);
+        return sourceUri;
+    });
 }
 
 /**

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -819,7 +819,11 @@ function IOURequestStepConfirmation({
             shouldAvoidScrollOnVirtualViewport={!isMobileSafari()}
             testID="IOURequestStepConfirmation"
         >
-            <TelemetrySpanManager iouType={iouType} />
+            <TelemetrySpanManager
+                iouType={iouType}
+                requestType={requestType}
+                hasReceipt={!!transaction?.receipt}
+            />
             <DraftWorkspaceOpener
                 isCreatingTrackExpense={isCreatingTrackExpense}
                 policyID={policyID}

--- a/src/pages/iou/request/step/IOURequestStepScan/components/NavigateGlobalCreateContext.tsx
+++ b/src/pages/iou/request/step/IOURequestStepScan/components/NavigateGlobalCreateContext.tsx
@@ -11,6 +11,7 @@ import {getPolicyExpenseChat, isSelfDM} from '@libs/ReportUtils';
 import shouldUseDefaultExpensePolicy from '@libs/shouldUseDefaultExpensePolicy';
 import {endSpan} from '@libs/telemetry/activeSpans';
 
+import endScanProcessAndStartConfirmationMountSpan from '@pages/iou/request/step/IOURequestStepScan/utils/endScanProcessAndStartConfirmationMountSpan';
 import startScanProcessSpan from '@pages/iou/request/step/IOURequestStepScan/utils/startScanProcessSpan';
 
 import {setMoneyRequestParticipants, setMoneyRequestParticipantsFromReport} from '@userActions/IOU/MoneyRequest';
@@ -107,7 +108,7 @@ function NavigateGlobalCreateSubscriber({fnRef, iouType, reportID, transactionID
                 const setParticipantsPromises = transactionIDs.map((tid) => setMoneyRequestParticipants(tid, transaction.participants));
                 Promise.all(setParticipantsPromises).then(() => {
                     if (isTrackExpense) {
-                        endSpan(CONST.TELEMETRY.SPAN_SCAN_PROCESS_AND_NAVIGATE);
+                        endScanProcessAndStartConfirmationMountSpan();
                         Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(CONST.IOU.ACTION.CREATE, CONST.IOU.TYPE.TRACK, transactionID, selfDMReport?.reportID));
                     } else {
                         navigateToConfirmationPage(iouType, transactionID, reportID, backToReport, iouType === CONST.IOU.TYPE.CREATE, transaction.reportID);
@@ -121,7 +122,7 @@ function NavigateGlobalCreateSubscriber({fnRef, iouType, reportID, transactionID
                 return setMoneyRequestParticipantsFromReport(tid, targetReport, currentUserPersonalDetails.accountID);
             });
             Promise.all(setParticipantsPromises).then(() => {
-                endSpan(CONST.TELEMETRY.SPAN_SCAN_PROCESS_AND_NAVIGATE);
+                endScanProcessAndStartConfirmationMountSpan();
                 Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(CONST.IOU.ACTION.CREATE, iouTypeTrackOrSubmit, transactionID, targetReport?.reportID));
             });
         } else {

--- a/src/pages/iou/request/step/IOURequestStepScan/utils/endScanProcessAndStartConfirmationMountSpan.ts
+++ b/src/pages/iou/request/step/IOURequestStepScan/utils/endScanProcessAndStartConfirmationMountSpan.ts
@@ -1,0 +1,24 @@
+import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
+
+import CONST from '@src/CONST';
+
+/**
+ * Hands the shutter -> confirmation chain over from the navigate step to the mount step: ends the
+ * scan-process span and starts the confirmation-mount span as a child of the same parent.
+ *
+ * `navigateToConfirmationPage` in IOUUtils already does this, but the global-create scan route calls
+ * `Navigation.navigate` directly, so without this the mount segment goes unmeasured — the single
+ * largest part of ManualShutterToConfirmation on that route.
+ *
+ * Call immediately before `Navigation.navigate`.
+ */
+function endScanProcessAndStartConfirmationMountSpan() {
+    endSpan(CONST.TELEMETRY.SPAN_SCAN_PROCESS_AND_NAVIGATE);
+    startSpan(CONST.TELEMETRY.SPAN_CONFIRMATION_MOUNT, {
+        name: CONST.TELEMETRY.SPAN_CONFIRMATION_MOUNT,
+        op: CONST.TELEMETRY.SPAN_CONFIRMATION_MOUNT,
+        parentSpan: getSpan(CONST.TELEMETRY.SPAN_SHUTTER_TO_CONFIRMATION),
+    });
+}
+
+export default endScanProcessAndStartConfirmationMountSpan;

--- a/src/pages/iou/request/step/IOURequestStepScan/utils/endScanProcessAndStartConfirmationMountSpan.ts
+++ b/src/pages/iou/request/step/IOURequestStepScan/utils/endScanProcessAndStartConfirmationMountSpan.ts
@@ -3,12 +3,12 @@ import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 import CONST from '@src/CONST';
 
 /**
- * Hands the shutter -> confirmation chain over from the navigate step to the mount step: ends the
+ * Hands the shutter to confirmation chain over from the navigate step to the mount step: ends the
  * scan-process span and starts the confirmation-mount span as a child of the same parent.
  *
  * `navigateToConfirmationPage` in IOUUtils already does this, but the global-create scan route calls
- * `Navigation.navigate` directly, so without this the mount segment goes unmeasured — the single
- * largest part of ManualShutterToConfirmation on that route.
+ * `Navigation.navigate` directly, so without this the mount segment goes unmeasured. It is the
+ * single largest part of ManualShutterToConfirmation on that route.
  *
  * Call immediately before `Navigation.navigate`.
  */

--- a/src/pages/iou/request/step/confirmation/TelemetrySpanManager.tsx
+++ b/src/pages/iou/request/step/confirmation/TelemetrySpanManager.tsx
@@ -1,12 +1,20 @@
 import {cancelSpan, endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 
 import CONST from '@src/CONST';
-import type {IOUType} from '@src/CONST';
+import type {IOURequestType, IOUType} from '@src/CONST';
 
-import {useEffect} from 'react';
+import type {Span} from '@sentry/core';
+
+import {useEffect, useRef} from 'react';
 
 type TelemetrySpanManagerProps = {
     iouType: IOUType;
+
+    /** Request type of the transaction being confirmed (scan, manual, distance, ...) */
+    requestType: IOURequestType;
+
+    /** Whether the transaction has a receipt. Without one, the receipt-load span could never end. */
+    hasReceipt: boolean;
 };
 
 /**
@@ -14,24 +22,26 @@ type TelemetrySpanManagerProps = {
  * On mount: ends the open/mount spans, starts list-ready and receipt-load spans.
  * On unmount: cancels any still-open child spans.
  */
-function TelemetrySpanManager({iouType}: TelemetrySpanManagerProps) {
+function TelemetrySpanManager({iouType, requestType, hasReceipt}: TelemetrySpanManagerProps) {
+    // Parent of the receipt-load span. Kept in a ref because that span can only start once the
+    // transaction has hydrated, which may happen after this mount effect already ended the parent.
+    // Sentry preserves parent_span_id on an already-ended parent.
+    const receiptLoadParentSpanRef = useRef<Span | undefined>(undefined);
+    const hasStartedReceiptLoadSpanRef = useRef(false);
+
     useEffect(() => {
         endSpan(CONST.TELEMETRY.SPAN_OPEN_CREATE_EXPENSE);
         endSpan(CONST.TELEMETRY.SPAN_CONFIRMATION_MOUNT);
 
         // Grab parent ref before ending it — children need it for parent_span_id linking
         const parentSpan = getSpan(CONST.TELEMETRY.SPAN_SHUTTER_TO_CONFIRMATION) ?? getSpan(CONST.TELEMETRY.SPAN_ODOMETER_TO_CONFIRMATION);
+        receiptLoadParentSpanRef.current = parentSpan;
 
         startSpan(CONST.TELEMETRY.SPAN_CONFIRMATION_LIST_READY, {
             name: CONST.TELEMETRY.SPAN_CONFIRMATION_LIST_READY,
             op: CONST.TELEMETRY.SPAN_CONFIRMATION_LIST_READY,
             parentSpan,
             attributes: {[CONST.TELEMETRY.ATTRIBUTE_IOU_TYPE]: iouType},
-        });
-        startSpan(CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD, {
-            name: CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD,
-            op: CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD,
-            parentSpan,
         });
 
         // End parent AFTER children are created — Sentry preserves parent_span_id regardless
@@ -44,6 +54,19 @@ function TelemetrySpanManager({iouType}: TelemetrySpanManagerProps) {
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps -- we only want this to run on mount/unmount
     }, []);
+
+    useEffect(() => {
+        if (!hasReceipt || hasStartedReceiptLoadSpanRef.current) {
+            return;
+        }
+        hasStartedReceiptLoadSpanRef.current = true;
+        startSpan(CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD, {
+            name: CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD,
+            op: CONST.TELEMETRY.SPAN_CONFIRMATION_RECEIPT_LOAD,
+            parentSpan: receiptLoadParentSpanRef.current,
+            attributes: {[CONST.TELEMETRY.ATTRIBUTE_IOU_TYPE]: iouType, [CONST.TELEMETRY.ATTRIBUTE_IOU_REQUEST_TYPE]: requestType},
+        });
+    }, [hasReceipt, iouType, requestType]);
 
     return null;
 }


### PR DESCRIPTION


<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR adds two telemetry fixes to the scan capture.

  - Wires up the ManualThumbnailGate span, which had no call sites since useCapturePhoto.ts was deleted. It now measures the             
  Image.prefetch that gates navigation after the shutter, and ends on the rejection path too.
  - Adds `iou_type` / `iou_request_type` to `ManualConfirmationReceiptLoad`, and starts it only when the transaction has a receipt — it previously fired for manual and distance expenses, which can never end it.

  Telemetry only, no behavior change.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97903
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

 [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
