### PR TITLE
[Onyx bump] Bump react-native-onyx from 3.0.101 to 3.0.102

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "react-native-nitro-fetch": "1.5.4",
         "react-native-nitro-modules": "0.36.3",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.101",
+        "react-native-onyx": "3.0.102",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -35907,9 +35907,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.101",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.101.tgz",
-      "integrity": "sha512-bSz9K8x8/2za4ouyiHssiK5AytGX6nG0ujIMe3fyOoAUj9Ddx7yDfYBLifb0N84rkByf4Qm0r/kRuNzNSFey+A==",
+      "version": "3.0.102",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.102.tgz",
+      "integrity": "sha512-rNUTLaJy94xDtcHC9+Tpkxx6qYzz+Ew5yUoLv3UF3eYdJ6OTVzdj2g2KrCarldrczr3jk0cfPZSSwaBZQrwvBw==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "react-native-nitro-fetch": "1.5.4",
         "react-native-nitro-modules": "0.36.3",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.91",
+        "react-native-onyx": "github:callstack-internal/react-native-onyx#ebca04f341ecfc3e7be0104bf4c1f2290362052b",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -36071,9 +36071,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.91",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.91.tgz",
-      "integrity": "sha512-G5LNhjsnAnGMcLRQI6IiZINy1ecO3/cNZyx/ldD9gu2zFlz3nHR5pC2uujb4asHBuy22VH8KhMRuQbvEZBNOUA==",
+      "version": "3.0.96",
+      "resolved": "git+ssh://git@github.com/callstack-internal/react-native-onyx.git#ebca04f341ecfc3e7be0104bf4c1f2290362052b",
+      "integrity": "sha512-ZXHp5eQ9cI/wi5GXr/1Xa4dkucdSClzJR1jex8drVTns5JVV8CIKXpmr44aFdYh2EQBO3o3i2q/VQgTrwiO99w==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-native-nitro-fetch": "1.5.4",
     "react-native-nitro-modules": "0.36.3",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.101",
+    "react-native-onyx": "3.0.102",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-native-nitro-fetch": "1.5.4",
     "react-native-nitro-modules": "0.36.3",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.91",
+    "react-native-onyx": "github:callstack-internal/react-native-onyx#ebca04f341ecfc3e7be0104bf4c1f2290362052b",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",


### PR DESCRIPTION
### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR bumps Onyx from 3.0.101 to 3.0.102 ([diff](https://github.com/Expensify/react-native-onyx/compare/3.0.101...3.0.102)), which includes the following change:

- **3.0.102** — https://github.com/Expensify/react-native-onyx/pull/818: Skip keyless update entries in `updateSnapshots` instead of crashing. `Onyx.update` skips update entries with non-string keys (and intentionally allows keyless `clear`/`multiset` entries), but it passed the _unfiltered_ updates array to `updateSnapshots`, which crashed on `key.startsWith` whenever a `snapshot_` collection entry was cached. This is Sentry issue [APP-6NT](https://expensify.sentry.io/issues/APP-6NT) — `TypeError: Cannot read properties of undefined (reading 'startsWith')` — ~94 production events / ~35 affected users since 2026-03-01 across groupings APP-6NT / APP-ED8 / APP-961 / APP-JT0 / APP-H8X, all on web and mostly on 2FA pages. In App it surfaced as an unhandled rejection from `QueuedOnyxUpdates.flushQueue`. A regression test was added in onyx `tests/unit/onyxTest.ts` ("should skip update entries without a key when updating Snapshots instead of rejecting"). Related to https://github.com/Expensify/App/issues/98438 (companion App PR: this one, which previously pinned the Onyx PR head for CI).

Kept deliberately to a single Onyx version so it can be reverted in isolation if it causes a regression. https://github.com/Expensify/App/pull/99436 (3.0.102 → 3.0.109) is on hold behind this one.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98438
PROPOSAL:

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

On Android / iOS (native or mWeb) against staging:

1. Sign in with an account that has chats and expenses.
2. Go to the **Reports/Search** tab and run a search (e.g. All expenses). Scroll through the results and open one or two of them. *(This caches search snapshot data — the precondition for the code path this PR touches.)*
3. Go back to **Inbox** and, in a report that appeared in those search results: send a message, edit an expense amount, and mark the report as unread.
4. Return to the **Search** tab and re-open the search. Verify the results reflect the changes (new amount, latest message) and the app does not crash or freeze at any point.
5. Enable airplane mode. Make 2–3 more changes (add a comment, rename a report, edit an expense). Disable airplane mode and wait for sync to finish. Verify the app stays responsive, nothing crashes, and search results reflect the offline changes.
6. Sign out and sign back in. Verify no crash during sign-out/sign-in.

Expected: no crash and no stuck/undelivered updates in any step. (Before this fix, a malformed keyless entry in any server update batch would crash the app with a `startsWith` TypeError whenever a search had previously been run — steps 2–5 keep that code path continuously active.)

<details>
<summary>Deterministic developer repro (web console)</summary>

1. In Expensify/App (web), sign in and run a Search so at least one `snapshot_` collection entry is cached.
2. In the dev console, dispatch an update containing a keyless entry alongside a valid one, e.g. `Onyx.update([{onyxMethod: 'merge', key: 'session', value: {}}, {onyxMethod: 'merge', value: {}}])`.
3. Without this fix: the promise rejects with `TypeError: Cannot read properties of undefined (reading 'startsWith')` from `updateSnapshots`.
4. With this fix: the promise resolves, the keyless entry is skipped, and the valid entry is applied to the cached snapshot.

</details>

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Covered by step 5 of the `Tests` section: with airplane mode on, make 2–3 changes (add a comment, rename a report, edit an expense), then go back online and verify the queued updates sync, the app stays responsive, and no `startsWith` error appears.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/fc78d56f-bcbd-492e-8033-d8f9d116f595

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>
