### PR TITLE
Unify distance display to 2 decimal places

### DIFF
--- a/ios/LiveActivity/GpsTripLiveActivity.swift
+++ b/ios/LiveActivity/GpsTripLiveActivity.swift
@@ -8,7 +8,7 @@ private extension Color {
 }
 
 private func distanceString(distance: Double) -> String {
-    String(format: "%.1f", distance)
+    String(format: "%.2f", distance)
 }
 
 private func distanceStringShort(distance: Double, distanceUnit: String) -> String {

--- a/src/libs/DistanceRequestUtils.ts
+++ b/src/libs/DistanceRequestUtils.ts
@@ -233,7 +233,7 @@ function getDistanceForDisplay(
 
     const distanceUnit = unit === CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES ? translate('common.miles') : translate('common.kilometers');
     const singularDistanceUnit = unit === CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES ? translate('common.mile') : translate('common.kilometer');
-    const unitString = distanceInUnits === '1' ? singularDistanceUnit : distanceUnit;
+    const unitString = Number(distanceInUnits) === 1 ? singularDistanceUnit : distanceUnit;
 
     return `${distanceInUnits} ${unitString}`;
 }

--- a/src/pages/iou/request/step/IOURequestStepDistanceGPS/Waypoints/DistanceCounter.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceGPS/Waypoints/DistanceCounter.tsx
@@ -28,7 +28,7 @@ function DistanceCounter({unit}: DistanceCounterProps) {
 
     const [gpsDraftDetails] = useOnyx(ONYXKEYS.GPS_DRAFT_DETAILS);
 
-    const distance = DistanceRequestUtils.convertDistanceUnit(getEffectiveDistance(gpsDraftDetails), unit).toFixed(1);
+    const distance = DistanceRequestUtils.getRoundedDistanceInUnits(getEffectiveDistance(gpsDraftDetails), unit);
 
     return (
         <MenuItemWithTopDescription

--- a/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
@@ -708,7 +708,7 @@ function IOURequestStepDistanceOdometer({
                     {/* Total Distance Display - always shown, updated live */}
                     <View style={[styles.borderRadiusComponentNormal, {backgroundColor: theme.componentBG}]}>
                         <Text style={[styles.textSupporting]}>
-                            {`${translate('distance.odometer.totalDistance')}: ${totalDistance !== null ? roundToTwoDecimalPlaces(totalDistance) : 0} ${unit}`}
+                            {`${translate('distance.odometer.totalDistance')}: ${(totalDistance ?? 0).toFixed(CONST.DISTANCE_DECIMAL_PLACES)} ${unit}`}
                         </Text>
                     </View>
                 </View>

--- a/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
@@ -708,7 +708,7 @@ function IOURequestStepDistanceOdometer({
                     {/* Total Distance Display - always shown, updated live */}
                     <View style={[styles.borderRadiusComponentNormal, {backgroundColor: theme.componentBG}]}>
                         <Text style={[styles.textSupporting]}>
-                            {`${translate('distance.odometer.totalDistance')}: ${(totalDistance ?? 0).toFixed(CONST.DISTANCE_DECIMAL_PLACES)} ${unit}`}
+                            {`${translate('distance.odometer.totalDistance')}: ${totalDistance !== null ? roundToTwoDecimalPlaces(totalDistance) : 0} ${unit}`}
                         </Text>
                     </View>
                 </View>

--- a/src/pages/iou/request/step/IOURequestStepGPSTripEdit/index.tsx
+++ b/src/pages/iou/request/step/IOURequestStepGPSTripEdit/index.tsx
@@ -80,7 +80,7 @@ function IOURequestStepGPSTripEdit({
     const gpsWaypointMarkers = useGPSWaypointMarkers({gpsDraftDetails, trimmedEndPoint});
 
     const unit = gpsDraftDetails?.unit ?? 'mi';
-    const displayDistance = DistanceRequestUtils.convertDistanceUnit(trimmedDistance, unit).toFixed(1);
+    const displayDistance = DistanceRequestUtils.getRoundedDistanceInUnits(trimmedDistance, unit);
 
     const saveTrimmedTrip = async () => {
         if (!gpsDraftDetails) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Standardizes distance display to 2 decimal places across GPS/odometer surfaces. Replaces ad-hoc `.toFixed(1)`/`roundToTwoDecimalPlaces` calls with `DistanceRequestUtils.getRoundedDistanceInUnits` and `CONST.DISTANCE_DECIMAL_PLACES` in `DistanceCounter`, `IOURequestStepGPSTripEdit` and updates the iOS Live Activity to `%.2f`. Also fixes `getDistanceForDisplay` so the singular unit label is picked by numeric comparison instead of a `'1'` string match, which no longer matched the 2-decimal `"1.00"` output.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97488
PROPOSAL: N/A
MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/14047


<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

GPS:

1. FAB > Track distance > GPS
2. Start tracking a trip and let the device move until some distance accumulates.
3. Verify the distance shown in the tracking counter is formatted with 2 decimal places (e.g. `0.42 mi`, not `0.4 mi`).
4. On iOS, verify the distance in the Live Activity iOS is also formatted with **2 decimal places** and matches the in-app counter.
5. Stop the trip, then open the GPS trip edit screen and trim the trip using the start/end handles.
6. Verify the displayed trip distance updates with 2 decimal places as you trim.
7. Go back and then to the confirmation screen, verify that the distance on the GPS screen matches how it is displayed on the confirmation screen

Singular unit label:

1. FAB > Track distance > Manual
2. Enter 1 mi/km
3. Go to confirmation screen
4. Verify that it shows 1.00 mile/kilometer instead of miles/kilometers
5. Change to a different distance value (other than 1).
6. Verify that it shows miles/kilometers on the confirmation screen

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Odometer changes reverted to keep displaying 1 decimal digit

https://github.com/user-attachments/assets/e02c86b6-634c-4b32-b5e3-77e38cc90c19


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

Odometer changes reverted to keep displaying 1 decimal digit

https://github.com/user-attachments/assets/da3c8ec5-c076-44cc-99a1-00204b8c68d3


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

Odometer changes reverted to keep displaying 1 decimal digit

https://github.com/user-attachments/assets/51ab9681-d4c5-485b-8ff6-e31969735644


</details>
