### PR TITLE
perf: add getStablePermissions

### DIFF
--- a/src/selectors/Report.ts
+++ b/src/selectors/Report.ts
@@ -168,6 +168,27 @@ type StableReport = Omit<Report, TupleToUnion<ExcludedFields>>;
  * When adding a new `Report` field: include it in the return object below; only add to
  * `ExcludedFields` if it updates on every message/read and the subtree does not read it.
  */
+/**
+ * Onyx merge replaces arrays wholesale even when their content is identical (arrays are
+ * non-mergeable leaf values compared by reference), so `report.permissions` can arrive with a new
+ * reference on every report push. Intern the array by content so the projection keeps a stable
+ * reference and downstream shallow-equality (snapshot cache, memoized subtrees) holds.
+ * The cache is bounded: values are combinations of the few CONST.REPORT.PERMISSIONS members.
+ */
+const stablePermissionsByContent = new Map<string, Report['permissions']>();
+function getStablePermissions(permissions: Report['permissions']): Report['permissions'] {
+    if (!permissions) {
+        return permissions;
+    }
+    const contentKey = permissions.join(',');
+    const cached = stablePermissionsByContent.get(contentKey);
+    if (cached) {
+        return cached;
+    }
+    stablePermissionsByContent.set(contentKey, permissions);
+    return permissions;
+}
+
 function getStableReportSelector(report: OnyxEntry<Report>) {
     if (!report?.reportID) {
         return undefined;
@@ -230,7 +251,7 @@ function getStableReportSelector(report: OnyxEntry<Report>) {
         nonReimbursableTotal: report.nonReimbursableTotal,
         privateNotes: report.privateNotes,
         fieldList: report.fieldList,
-        permissions: report.permissions,
+        permissions: getStablePermissions(report.permissions),
         tripData: report.tripData,
         welcomeMessage: report.welcomeMessage,
         nextStep: report.nextStep,

--- a/src/selectors/Report.ts
+++ b/src/selectors/Report.ts
@@ -167,8 +167,7 @@ type StableReport = Omit<Report, TupleToUnion<ExcludedFields>>;
  *
  * When adding a new `Report` field: include it in the return object below; only add to
  * `ExcludedFields` if it updates on every message/read and the subtree does not read it.
- */
-/**
+ *
  * Onyx merge replaces arrays wholesale even when their content is identical (arrays are
  * non-mergeable leaf values compared by reference), so `report.permissions` can arrive with a new
  * reference on every report push. Intern the array by content so the projection keeps a stable

--- a/tests/unit/ReportSelectorTest.ts
+++ b/tests/unit/ReportSelectorTest.ts
@@ -1,6 +1,6 @@
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {createMoveExpenseReportNVPSelector, policyChatRoomsSelector} from '@src/selectors/Report';
+import {createMoveExpenseReportNVPSelector, getStableReportSelector, policyChatRoomsSelector} from '@src/selectors/Report';
 import type {Report} from '@src/types/onyx';
 
 describe('policyChatRoomsSelector', () => {
@@ -125,5 +125,35 @@ describe('createMoveExpenseReportNVPSelector', () => {
             [currentReportNVPKey]: {private_isArchived: archivedAt},
             [outstandingReportNVPKey]: {private_isArchived: archivedAt},
         });
+    });
+});
+
+describe('getStableReportSelector', () => {
+    const {READ, WRITE, SHARE} = CONST.REPORT.PERMISSIONS;
+
+    it('returns the same permissions reference for content-equal but referentially-new arrays', () => {
+        // Onyx merge replaces arrays wholesale even when content is identical, so consecutive
+        // report pushes deliver new `permissions` instances. The projection must intern them,
+        // otherwise its shallow equality breaks and subscribed subtrees re-render for no reason.
+        const first = getStableReportSelector({reportID: '1', permissions: [READ, WRITE]} as Report);
+        const second = getStableReportSelector({reportID: '1', permissions: [READ, WRITE]} as Report);
+        expect(second?.permissions).toBe(first?.permissions);
+    });
+
+    it('shares the interned permissions instance across different reports', () => {
+        const first = getStableReportSelector({reportID: '1', permissions: [READ, WRITE]} as Report);
+        const second = getStableReportSelector({reportID: '2', permissions: [READ, WRITE]} as Report);
+        expect(second?.permissions).toBe(first?.permissions);
+    });
+
+    it('returns a different permissions reference when content differs', () => {
+        const first = getStableReportSelector({reportID: '1', permissions: [READ, WRITE]} as Report);
+        const second = getStableReportSelector({reportID: '1', permissions: [READ, WRITE, SHARE]} as Report);
+        expect(second?.permissions).not.toBe(first?.permissions);
+        expect(second?.permissions).toEqual([READ, WRITE, SHARE]);
+    });
+
+    it('passes undefined permissions through', () => {
+        expect(getStableReportSelector({reportID: '1'} as Report)?.permissions).toBeUndefined();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Sending the first message in a chat re-rendered the whole `ReportActionsList` content. Prop-diff instrumentation showed a single changed field on `stableReport`:

```
[RerenderDebug] report prop (stableReport <id>): 1 field(s) changed
  key: "permissions", prev: ['read', 'write'], next: ['read', 'write'], refOnly: true
```

Same content, new array reference. This note explains where that reference comes from and how we fixed it in E/App.

### The chain

1. Some report pushes (server response or Pusher update) include `permissions` in the delta, even when it didn't change. The payload goes through `JSON.parse`, so every array in it is a brand new instance.

2. Onyx merge treats arrays as opaque leaf values. `isMergeableObject` explicitly excludes arrays, so an array in the delta hits the "not mergeable, set directly" branch of `mergeObject` and the fresh instance replaces the old one. The only comparison there is reference identity (`!==`), never content. Onyx does preserve references for unchanged nested objects (the merge returns the original target when nothing changed) and primitives compare by value, so arrays are the one leaf type where content-identical data still produces a new reference.

3. `getStableReportSelector` passes `report.permissions` through by reference. An already mounted subscriber is protected by its per-hook memoized selector, which keeps the old output via `deepEqual`. But a newly mounted subscriber (a new message row) has no cached output yet, so it computes a fresh projection holding the new array and publishes it into the shared snapshot cache slot.

4. The snapshot guard in `useOnyx` compares with `shallowEqual`, which is top-level `===` per field. Old array vs new array fails that check, so the guard correctly treats the foreign result as different and adopts it. Every consumer of the projection gets a new `report` prop identity and re-renders.

So the guard was working as designed. The instability lived one level down, in a nested array reference that Onyx merge mints on content-identical data.

### The fix

We intern the array by content inside `src/selectors/Report.ts`:

The projection now uses `permissions: getStablePermissions(report.permissions)`. Identical content always maps to one canonical array instance, so shallow equality holds across all subscribers and the snapshot guard keeps each hook's own result.

The concrete win: sending the first message in a chat no longer re-renders the whole list. That send mounts a new message row while the report push carries a fresh `permissions` array, which was exactly the combination that flipped the projection identity for every rendered row. With interning, the new row publishes a projection whose `permissions` is the same instance everyone else already holds, and the rest of the list stays untouched.



### Why the module-level Map is safe

- It's keyed by content, not by report. A client with 10k reports where most say `['read', 'write']` produces one entry. Size is bounded by distinct permission combinations, and with 5 enum values (`read`, `write`, `share`, `own`, `auditor`) that's a theoretical ceiling of ~325 ordered combos and a handful in practice.
- Nothing mutates the shared instance
- Per-call cost is a `join(',')` on a tiny array plus one Map lookup, right before the selector builds a 55-field object anyway.

### Alternatives we considered and rejected

- Deep equality in the Onyx snapshot guard. Would mask the symptom for every field, but I didn't want to change generic Onyx semantics for an app-level data quirk. Plus we avoid heavy deep checks there
- A prebuilt fixed lookup of all 31 sorted subsets. Provably constant size, but it costs a spread and sort per call and silently normalizes the array order, which is an observable data change. The lazy Map is cheaper and order-preserving.

### Result

Profiler send message: 367.10 ms -> 304.80 ms (-17%) improvement.

<img width="1356" height="875" alt="Screenshot 2026-08-05 at 13 13 58" src="https://github.com/user-attachments/assets/6f81e5ce-a75c-4adb-85eb-7024f41b0829" />

Before:

<img width="1037" height="927" alt="baseline-permissions" src="https://github.com/user-attachments/assets/eae1c000-c1ef-482e-b770-b3014544b21c" />

After:

<img width="1037" height="927" alt="fixed-permissions" src="https://github.com/user-attachments/assets/4580fdcc-da49-4b07-842d-2ba3249dabcf" />



### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/97901
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

Test 1: Normal chat write path

1. As Member, open the workspace chat.
2. Send a few messages and add a reaction to one.
3. Confirm the composer is enabled and messages send normally.
4. Confirm messages render correctly with no flicker in the report list.

Test 2: Read-only room stays read-only

Prerequisite: restrict #announce posting to admins only (workspace room settings).
1. As Member, open the #announce room.
2. Confirm the composer is hidden/read-only for Member.
3. As Admin, open the same room.
4. Confirm the Admin composer is enabled and a message can be sent.
5. Confirm Member sees Admin's message arrive while staying read-only.

Test 3: Permission change propagates live

1. As Member, keep the #announce room open with posting allowed to all.
2. Confirm Member's composer is enabled.
3. As Admin, change room posting permission to admins only.
4. Confirm Member's composer becomes read-only without a reload.
5. As Admin, revert to allow all members.
6. Confirm Member's composer becomes enabled again.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ca765630-f9e3-481a-b8dc-085f17f87f78


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/9bdc17cc-b9e4-4eff-8fa7-4f9a58cb52e3

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/1a50a4e3-a7d3-47d3-833a-001b8f4ed9da

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/05b9ffb6-3202-4889-80db-d6d83fd3a216

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c09b8b1e-9166-4b5b-9608-b8777545e986


</details>
