### PR TITLE
Fix - Add react-native-live-markdown to the Custom Agent Instructions input

### DIFF
--- a/src/pages/settings/Agents/AddAgentPage.tsx
+++ b/src/pages/settings/Agents/AddAgentPage.tsx
@@ -192,6 +192,8 @@ function AddAgentPageContent({route, template}: AddAgentPageContentProps) {
                             label={translate('addAgentPage.instructions')}
                             accessibilityLabel={translate('addAgentPage.instructions')}
                             role={CONST.ROLE.PRESENTATION}
+                            type="markdown"
+                            excludedMarkdownStyles={['mentionReport']}
                             defaultValue={defaultPrompt}
                             multiline
                             containerStyles={[styles.flex1]}

--- a/src/pages/settings/Agents/AddAgentPage.tsx
+++ b/src/pages/settings/Agents/AddAgentPage.tsx
@@ -72,7 +72,7 @@ function AddAgentPageContent({route, template}: AddAgentPageContentProps) {
             return;
         }
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            // The markdown input inserts a line break for any Enter keydown whose default is not already prevented, so the submit combo has to claim it first.
             event.preventDefault();
             formRef.current?.submit();
         }

--- a/src/pages/settings/Agents/AddAgentPage.tsx
+++ b/src/pages/settings/Agents/AddAgentPage.tsx
@@ -1,7 +1,7 @@
 import AvatarButtonWithIcon from '@components/AvatarButtonWithIcon';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
-import type {FormOnyxValues} from '@components/Form/types';
+import type {FormOnyxValues, FormRef} from '@components/Form/types';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -37,6 +37,8 @@ import type NewAgentTemplate from '@src/types/onyx/NewAgentTemplate';
 import type {Errors} from '@src/types/onyx/OnyxCommon';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
+import type {TextInputKeyPressEvent} from 'react-native';
+
 import React, {useCallback, useEffect, useRef} from 'react';
 import {View} from 'react-native';
 
@@ -63,6 +65,18 @@ function AddAgentPageContent({route, template}: AddAgentPageContentProps) {
     const [avatarDraft, avatarDraftMetadata] = useOnyx(ONYXKEYS.AGENT_NEW_AVATAR_DRAFT);
     const isDraftLoading = isLoadingOnyxValue(avatarDraftMetadata);
     const hasSubmittedRef = useRef(false);
+    const formRef = useRef<FormRef>(null);
+
+    const submitFormOnModEnter = (event: TextInputKeyPressEvent | KeyboardEvent) => {
+        if (!('key' in event)) {
+            return;
+        }
+        if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            event.preventDefault();
+            formRef.current?.submit();
+        }
+    };
 
     const uploadedAvatar = avatarDraft?.uploadedAvatar;
     const selectedPresetID = avatarDraft?.customExpensifyAvatarID && AGENT_AVATARS.isAvatarID(avatarDraft.customExpensifyAvatarID) ? avatarDraft.customExpensifyAvatarID : undefined;
@@ -150,6 +164,7 @@ function AddAgentPageContent({route, template}: AddAgentPageContentProps) {
                 onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_AGENTS_NEW.getRoute(policyID ? {policyID} : undefined))}
             />
             <FormProvider
+                ref={formRef}
                 formID={ONYXKEYS.FORMS.ADD_AGENT_FORM}
                 onSubmit={handleSubmit}
                 validate={validate}
@@ -194,6 +209,7 @@ function AddAgentPageContent({route, template}: AddAgentPageContentProps) {
                             role={CONST.ROLE.PRESENTATION}
                             type="markdown"
                             excludedMarkdownStyles={['mentionReport']}
+                            onKeyPress={submitFormOnModEnter}
                             defaultValue={defaultPrompt}
                             multiline
                             containerStyles={[styles.flex1]}

--- a/src/pages/settings/Agents/Fields/EditPromptPage.tsx
+++ b/src/pages/settings/Agents/Fields/EditPromptPage.tsx
@@ -99,6 +99,8 @@ function EditPromptPage({route}: EditPromptPageProps) {
                         label={translate('editAgentPage.instructions')}
                         accessibilityLabel={translate('editAgentPage.instructions')}
                         role={CONST.ROLE.PRESENTATION}
+                        type="markdown"
+                        excludedMarkdownStyles={['mentionReport']}
                         defaultValue={Str.htmlDecode(agentPrompt?.prompt ?? '')}
                         multiline
                         containerStyles={[styles.flex1]}

--- a/src/pages/settings/Profile/AgentAIPromptSection.tsx
+++ b/src/pages/settings/Profile/AgentAIPromptSection.tsx
@@ -203,6 +203,8 @@ function AgentAIPromptSection({accountID, parentScrollViewRef}: AgentAIPromptSec
     const handleKeyPress = (e: TextInputKeyPressEvent) => {
         const event = e as unknown as KeyboardEvent;
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            event.preventDefault();
             handleSave();
         }
     };
@@ -221,6 +223,8 @@ function AgentAIPromptSection({accountID, parentScrollViewRef}: AgentAIPromptSec
                     ref={inputRef}
                     label={translate('profilePage.aiPromptSection.prompt')}
                     accessibilityLabel={translate('profilePage.aiPromptSection.prompt')}
+                    type="markdown"
+                    excludedMarkdownStyles={['mentionReport']}
                     value={draftPrompt}
                     onChangeText={handleChangeText}
                     onKeyPress={handleKeyPress}

--- a/src/pages/settings/Profile/AgentAIPromptSection.tsx
+++ b/src/pages/settings/Profile/AgentAIPromptSection.tsx
@@ -203,7 +203,7 @@ function AgentAIPromptSection({accountID, parentScrollViewRef}: AgentAIPromptSec
     const handleKeyPress = (e: TextInputKeyPressEvent) => {
         const event = e as unknown as KeyboardEvent;
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            // The markdown input inserts a line break for any Enter keydown whose default is not already prevented, so the submit combo has to claim it first.
             event.preventDefault();
             handleSave();
         }

--- a/src/pages/workspace/rules/AgentRules/AddAgentRuleWriteTab.tsx
+++ b/src/pages/workspace/rules/AgentRules/AddAgentRuleWriteTab.tsx
@@ -43,7 +43,7 @@ function AddAgentRuleWriteTab({onSave}: AddAgentRuleWriteTabProps) {
             return;
         }
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            // The markdown input inserts a line break for any Enter keydown whose default is not already prevented, so the submit combo has to claim it first.
             event.preventDefault();
             formRef.current?.submit();
         }

--- a/src/pages/workspace/rules/AgentRules/AddAgentRuleWriteTab.tsx
+++ b/src/pages/workspace/rules/AgentRules/AddAgentRuleWriteTab.tsx
@@ -43,6 +43,8 @@ function AddAgentRuleWriteTab({onSave}: AddAgentRuleWriteTabProps) {
             return;
         }
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            event.preventDefault();
             formRef.current?.submit();
         }
     };
@@ -89,6 +91,8 @@ function AddAgentRuleWriteTab({onSave}: AddAgentRuleWriteTabProps) {
                         label={describeRuleLabel}
                         accessibilityLabel={describeRuleLabel}
                         role={CONST.ROLE.PRESENTATION}
+                        type="markdown"
+                        excludedMarkdownStyles={['mentionReport']}
                         onKeyPress={submitFormOnModEnter}
                         multiline
                         shouldSaveDraft

--- a/src/pages/workspace/rules/AgentRules/EditAgentRulePage.tsx
+++ b/src/pages/workspace/rules/AgentRules/EditAgentRulePage.tsx
@@ -60,6 +60,8 @@ function EditAgentRulePage({
             return;
         }
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            event.preventDefault();
             formRef.current?.submit();
         }
     };
@@ -158,6 +160,8 @@ function EditAgentRulePage({
                                 label={describeRuleLabel}
                                 accessibilityLabel={describeRuleLabel}
                                 role={CONST.ROLE.PRESENTATION}
+                                type="markdown"
+                                excludedMarkdownStyles={['mentionReport']}
                                 onKeyPress={submitFormOnModEnter}
                                 defaultValue={agentRule.prompt}
                                 multiline

--- a/src/pages/workspace/rules/AgentRules/EditAgentRulePage.tsx
+++ b/src/pages/workspace/rules/AgentRules/EditAgentRulePage.tsx
@@ -60,7 +60,7 @@ function EditAgentRulePage({
             return;
         }
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-            // The markdown input inserts a line break for any unprevented Enter keydown, so the submit combo has to claim it first.
+            // The markdown input inserts a line break for any Enter keydown whose default is not already prevented, so the submit combo has to claim it first.
             event.preventDefault();
             formRef.current?.submit();
         }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Agent instructions are stored and rendered as Markdown everywhere they're displayed, but the inputs used to *author* them rendered as plain text with no live formatting. All five prompt inputs pass `InputComponent={TextInput}` without a `type`, so `BaseTextInput` falls back to its default implementation instead of `RNMarkdownTextInput` — the `@expensify/react-native-live-markdown` component the chat composer already uses.

This adds `type="markdown"` to the prompt input on all five surfaces (create agent, edit agent instructions, Profile → AI Prompt, add agent rule, edit agent rule), along with `excludedMarkdownStyles={['mentionReport']}` — on these surfaces `@email` renders as a mention but `#room` does not, since a room mention can't resolve outside a report context, so without the exclusion the input would live-style `#room` as a mention that never renders once saved. The two rule pages and the AI Prompt section submit on Cmd/Ctrl+Enter through `onKeyPress`, and the markdown input inserts a line break for any Enter keydown that isn't already default-prevented, so those handlers now call `event.preventDefault()` before submitting. The agent-name field and the rule suggestions search box are left as plain inputs.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96902
PROPOSAL: https://github.com/Expensify/App/issues/96902#issuecomment-5063418525

### Tests

Pre-requisite: a workspace with **Rules** enabled (Workspace > More features).

Two checks are reused across the inputs below:

**Markdown check** — type `*bold*`, `_italic_`, `# heading`, `` `code` `` and `~ strike-through~`, and verify the formatting renders live as you type, matching the chat composer. Then type `#room` and verify it stays plain text, and type `@user@example.com` and verify it is styled as a mention.


1. **Account > Agents > Create agent → Instructions** — run the *Markdown check*. 
2. **Account > Agents > (any existing agent) > Instructions** — run the *Markdown check*. 
3. **Account > Profile > AI Prompt** (signed in as the agent) — run the *Markdown check*.
4. **Workspace > Rules > Agents > Add rule > Write your own** — run the *Markdown check* 
5. **Workspace > Rules > Agents > select any existing rule**— run the *Markdown check*


- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests

### QA Steps

Same as tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/9999fbd7-06fd-4e82-b0af-094ff5a73fbd


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/91d79a17-401f-4edd-ac29-92b869b29308


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/3d7d01e8-a591-42d5-8670-9ce3f1548ba7


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/134271d1-3a85-44a6-88f0-186562e3a80d


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/03862e2f-537f-4725-82e6-fb44a1a82402


<!-- add screenshots or videos here -->

</details>
