### PR TITLE
Recover lazy chunk and locale loads after an offline blip

### DIFF
--- a/src/hooks/usePageRefresh/index.ts
+++ b/src/hooks/usePageRefresh/index.ts
@@ -1,4 +1,5 @@
 import clearWorkboxRecoveryCaches from '@libs/clearWorkboxRecoveryCaches';
+import {getIsOffline} from '@libs/NetworkState';
 
 import CONST from '@src/CONST';
 
@@ -21,7 +22,7 @@ const usePageRefresh: UsePageRefresh = () => {
         }
 
         sessionStorage.removeItem(CONST.SESSION_STORAGE_KEYS.LAST_REFRESH_TIMESTAMP);
-        if (isChunkLoadError && navigator.onLine) {
+        if (isChunkLoadError && !getIsOffline()) {
             // The error page is shown after lazyRetry has already done a plain reload and it did
             // not fix the problem. When online, clear the service worker cache so the next load
             // fetches a fresh app shell from the CDN. When offline we must not clear it: the

--- a/src/languages/IntlStore.ts
+++ b/src/languages/IntlStore.ts
@@ -1,4 +1,5 @@
 import extractModuleDefaultExport from '@libs/extractModuleDefaultExport';
+import {getIsOffline, onReachabilityConfirmed} from '@libs/NetworkState';
 import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 
 import CONST from '@src/CONST';
@@ -167,13 +168,6 @@ class IntlStore {
         return this.currentLocale;
     }
 
-    /**
-     * An empty cache is never treated as final, because `translate()` would then render its raw key
-     * forever.
-     *
-     * NetworkState is imported lazily: it pulls in the whole network stack, and IntlStore is imported
-     * almost everywhere, so a static import would load that onto graphs that never fetch a locale.
-     */
     public static load(locale: Locale): Promise<void> {
         if (this.currentLocale === locale) {
             return Promise.resolve();
@@ -195,7 +189,6 @@ class IntlStore {
             try {
                 await loaderPromise();
             } catch (error) {
-                const {getIsOffline, onReachabilityConfirmed} = await import('@libs/NetworkState');
                 if (!getIsOffline()) {
                     throw error;
                 }

--- a/src/languages/IntlStore.ts
+++ b/src/languages/IntlStore.ts
@@ -167,7 +167,14 @@ class IntlStore {
         return this.currentLocale;
     }
 
-    public static load(locale: Locale) {
+    /**
+     * An empty cache is never treated as final, because `translate()` would then render its raw key
+     * forever.
+     *
+     * NetworkState is imported lazily: it pulls in the whole network stack, and IntlStore is imported
+     * almost everywhere, so a static import would load that onto graphs that never fetch a locale.
+     */
+    public static load(locale: Locale): Promise<void> {
         if (this.currentLocale === locale) {
             return Promise.resolve();
         }
@@ -184,7 +191,26 @@ class IntlStore {
             });
         }
 
-        return loaderPromise()
+        const loadWithOfflineRetry = async (): Promise<void> => {
+            try {
+                await loaderPromise();
+            } catch (error) {
+                const {getIsOffline, onReachabilityConfirmed} = await import('@libs/NetworkState');
+                if (!getIsOffline()) {
+                    throw error;
+                }
+                console.error('Failed to load translations while offline, waiting for the internet to come back.', error);
+                await new Promise<void>((resolve) => {
+                    const unsubscribe = onReachabilityConfirmed(() => {
+                        unsubscribe();
+                        resolve();
+                    });
+                });
+                await loadWithOfflineRetry();
+            }
+        };
+
+        return loadWithOfflineRetry()
             .then(() => {
                 this.currentLocale = locale;
                 // Set the default date-fns locale

--- a/src/utils/lazyRetry.ts
+++ b/src/utils/lazyRetry.ts
@@ -1,5 +1,6 @@
 import clearWorkboxRecoveryCaches from '@libs/clearWorkboxRecoveryCaches';
 import isChunkLoadError from '@libs/isChunkLoadError';
+import {getIsOffline, onReachabilityConfirmed} from '@libs/NetworkState';
 
 import CONST from '@src/CONST';
 
@@ -29,59 +30,53 @@ function getRetryStateKey(retryKey: string): string {
 }
 
 /**
- * Attempts to lazily import a React component with a graduated retry strategy.
+ * The offline path deliberately consumes no retry state: a blip must not burn the reload attempt,
+ * and must not clear the service worker cache that is the only thing keeping the PWA usable until
+ * connectivity returns. Clearing it while online instead recovers a post-deploy stale shell, where
+ * the SW serves an index.html referencing chunk hashes no longer on the CDN.
  *
- * - First failure: plain reload — handles transient network blips without touching caches.
- * - Second failure that is a ChunkLoadError AND the device is online: clear the service worker
- *   cache and reload — handles the post-deploy stale-shell scenario where the SW is serving an
- *   old index.html that references chunk hashes no longer on the CDN.
- *   The online guard is critical: a chunk fetch that fails while offline also produces a
- *   ChunkLoadError, and clearing the service worker cache in that case would destroy the cached
- *   app shell that is the only thing keeping the PWA usable until connectivity returns.
- * - Any subsequent failure, a second failure that is not a ChunkLoadError, or a second failure
- *   while offline: propagate to the React error boundary so the user sees the error page.
- *
- * @param componentImport - A function that returns a promise resolving to a lazily imported React component.
- * @param retryKey - A stable identifier unique to this import, used to scope the retry state so
- *                    sibling imports do not interfere with each other's recovery cycle.
- * @returns A promise that resolves to the imported component or rejects after all recovery attempts.
+ * @param retryKey - Stable identifier unique to this import, so sibling imports do not interfere
+ *                   with each other's recovery cycle.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ComponentType requires any for the generic constraint to accept all component shapes
 const lazyRetry = function <T extends ComponentType<any>>(componentImport: ComponentImport<T>, retryKey: string): Import<T> {
     return new Promise((resolve, reject) => {
         const stateKey = getRetryStateKey(retryKey);
-        const retryState = sessionStorage.getItem(stateKey) ?? RETRY_STATE.INITIAL;
 
-        componentImport()
-            .then((component) => {
-                sessionStorage.setItem(stateKey, RETRY_STATE.INITIAL);
-                resolve(component);
-            })
-            .catch((error: unknown) => {
-                if (retryState === RETRY_STATE.INITIAL) {
-                    // First failure: plain reload to handle transient errors cheaply.
-                    console.error('Failed to lazily import a React component, refreshing the page in order to retry the operation.', error);
-                    sessionStorage.setItem(stateKey, RETRY_STATE.RELOADED);
-                    window.location.reload();
-                } else if (retryState === RETRY_STATE.RELOADED && isChunkLoadError(error) && navigator.onLine) {
-                    // Second failure, it is a ChunkLoadError, and the device is online: the plain
-                    // reload did not fix it — likely the SW is serving a stale shell after a deploy.
-                    // Clear the service worker cache and reload. Keep the flag at CACHE_CLEARED so
-                    // a third failure surfaces the error boundary instead of starting over.
-                    console.error('Failed to lazily import a React component after reload, clearing SW caches and reloading.', error);
-                    sessionStorage.setItem(stateKey, RETRY_STATE.CACHE_CLEARED);
-                    clearWorkboxRecoveryCaches().then(() => window.location.reload());
-                } else {
-                    // All recovery options exhausted, the device is offline, or the second failure is
-                    // not a ChunkLoadError: propagate to the error boundary. The flag is left at its
-                    // current advanced state (not reset), so a later failure of this same import does
-                    // not restart the full reload cycle — it either fails fast (already cache-cleared)
-                    // or retries the cache clear once the device is back online. A successful import
-                    // resets the flag to INITIAL.
-                    console.error('Failed to lazily import a React component after all recovery attempts.', error);
-                    reject(error instanceof Error ? error : new Error(String(error)));
-                }
-            });
+        const attemptImport = () => {
+            componentImport()
+                .then((component) => {
+                    sessionStorage.setItem(stateKey, RETRY_STATE.INITIAL);
+                    resolve(component);
+                })
+                .catch((error: unknown) => {
+                    if (getIsOffline()) {
+                        console.error('Failed to lazily import a React component while offline, waiting for the internet to come back.', error);
+                        const unsubscribe = onReachabilityConfirmed(() => {
+                            unsubscribe();
+                            attemptImport();
+                        });
+                        return;
+                    }
+
+                    const retryState = sessionStorage.getItem(stateKey) ?? RETRY_STATE.INITIAL;
+
+                    if (retryState === RETRY_STATE.INITIAL) {
+                        console.error('Failed to lazily import a React component, refreshing the page in order to retry the operation.', error);
+                        sessionStorage.setItem(stateKey, RETRY_STATE.RELOADED);
+                        window.location.reload();
+                    } else if (retryState === RETRY_STATE.RELOADED && isChunkLoadError(error)) {
+                        console.error('Failed to lazily import a React component after reload, clearing SW caches and reloading.', error);
+                        sessionStorage.setItem(stateKey, RETRY_STATE.CACHE_CLEARED);
+                        clearWorkboxRecoveryCaches().then(() => window.location.reload());
+                    } else {
+                        console.error('Failed to lazily import a React component after all recovery attempts.', error);
+                        reject(error instanceof Error ? error : new Error(String(error)));
+                    }
+                });
+        };
+
+        attemptImport();
     });
 };
 

--- a/tests/unit/IntlStoreOfflineTest.ts
+++ b/tests/unit/IntlStoreOfflineTest.ts
@@ -1,0 +1,80 @@
+import {LOCALES} from '@src/CONST/LOCALES';
+import IntlStore from '@src/languages/IntlStore';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import Onyx from 'react-native-onyx';
+
+import getOnyxValue from '../utils/getOnyxValue';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+let mockIsOffline = false;
+let mockShouldChunkFail = false;
+const mockReachabilityListeners = new Set<() => void>();
+
+jest.mock('@libs/NetworkState', () => ({
+    getIsOffline: () => mockIsOffline,
+    onReachabilityConfirmed: (callback: () => void) => {
+        mockReachabilityListeners.add(callback);
+        return () => mockReachabilityListeners.delete(callback);
+    },
+}));
+
+// Throwing from the module factory makes the dynamic import inside IntlStore's loader reject
+// the same way a ChunkLoadError does in the browser.
+jest.mock('@src/languages/de', () => {
+    if (mockShouldChunkFail) {
+        mockShouldChunkFail = false;
+        throw new Error('ChunkLoadError: Loading chunk languages_de failed');
+    }
+    return {__esModule: true, default: {common: {cancel: 'Abbrechen'}}};
+});
+
+function confirmReachability() {
+    for (const callback of [...mockReachabilityListeners]) {
+        callback();
+    }
+}
+
+describe('IntlStore.load offline recovery', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        mockReachabilityListeners.clear();
+        mockIsOffline = false;
+        mockShouldChunkFail = false;
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('retries on reachability and keeps translations loading until the chunk arrives', async () => {
+        mockIsOffline = true;
+        mockShouldChunkFail = true;
+
+        const onRejected = jest.fn();
+        const promise = IntlStore.load(LOCALES.DE).catch(onRejected);
+        await waitForBatchedUpdates();
+
+        expect(onRejected).not.toHaveBeenCalled();
+        expect(IntlStore.getCurrentLocale()).not.toBe(LOCALES.DE);
+        expect(IntlStore.get('common.cancel', LOCALES.DE)).toBeNull();
+        await expect(getOnyxValue(ONYXKEYS.RAM_ONLY_ARE_TRANSLATIONS_LOADING)).resolves.toBe(true);
+        expect(mockReachabilityListeners.size).toBe(1);
+
+        mockIsOffline = false;
+        confirmReachability();
+        await promise;
+        await waitForBatchedUpdates();
+
+        expect(onRejected).not.toHaveBeenCalled();
+        expect(IntlStore.getCurrentLocale()).toBe(LOCALES.DE);
+        expect(IntlStore.get('common.cancel', LOCALES.DE)).toBe('Abbrechen');
+        expect(mockReachabilityListeners.size).toBe(0);
+        await expect(getOnyxValue(ONYXKEYS.RAM_ONLY_ARE_TRANSLATIONS_LOADING)).resolves.toBe(false);
+    });
+});

--- a/tests/unit/IntlStoreOfflineTest.ts
+++ b/tests/unit/IntlStoreOfflineTest.ts
@@ -26,7 +26,7 @@ jest.mock('@src/languages/de', () => {
         mockShouldChunkFail = false;
         throw new Error('ChunkLoadError: Loading chunk languages_de failed');
     }
-    return {__esModule: true, default: {common: {cancel: 'Abbrechen'}}};
+    return {__esModule: true, default: {common: {cancel: 'Cancel (translated)'}}};
 });
 
 function confirmReachability() {
@@ -73,7 +73,7 @@ describe('IntlStore.load offline recovery', () => {
 
         expect(onRejected).not.toHaveBeenCalled();
         expect(IntlStore.getCurrentLocale()).toBe(LOCALES.DE);
-        expect(IntlStore.get('common.cancel', LOCALES.DE)).toBe('Abbrechen');
+        expect(IntlStore.get('common.cancel', LOCALES.DE)).toBe('Cancel (translated)');
         expect(mockReachabilityListeners.size).toBe(0);
         await expect(getOnyxValue(ONYXKEYS.RAM_ONLY_ARE_TRANSLATIONS_LOADING)).resolves.toBe(false);
     });

--- a/tests/unit/chunkLoadErrorRecoveryTest.ts
+++ b/tests/unit/chunkLoadErrorRecoveryTest.ts
@@ -6,9 +6,9 @@
  * already on the second failure by the time the user taps it).
  *
  * lazyRetry uses a three-state strategy:
- *   - First failure                        → plain reload.
+ *   - Any failure while offline              → park the promise and re-attempt on reconnect.
+ *   - First failure                          → plain reload.
  *   - Second failure, ChunkLoadError, online → clear SW cache then reload.
- *   - Second failure, ChunkLoadError, offline→ reject to error boundary (keep cached offline assets).
  *   - Second failure, non-ChunkLoadError     → reject to error boundary.
  *   - Third failure                          → reject to error boundary (loop prevention).
  */
@@ -22,6 +22,24 @@ import lazyRetry from '@src/utils/lazyRetry';
 import type {ComponentType} from 'react';
 
 type ComponentImport<T> = () => Promise<{default: T}>;
+
+// The real NetworkState reports offline part-way through a jest run (NetInfo's listener fires
+// asynchronously after module init), which would make these tests order-dependent.
+let mockIsOffline = false;
+const mockReachabilityListeners = new Set<() => void>();
+jest.mock('@libs/NetworkState', () => ({
+    getIsOffline: () => mockIsOffline,
+    onReachabilityConfirmed: (callback: () => void) => {
+        mockReachabilityListeners.add(callback);
+        return () => mockReachabilityListeners.delete(callback);
+    },
+}));
+
+function confirmReachability() {
+    for (const callback of [...mockReachabilityListeners]) {
+        callback();
+    }
+}
 
 const mockClearWorkboxRecoveryCaches = jest.fn();
 jest.mock('@libs/clearWorkboxRecoveryCaches', () => ({
@@ -88,6 +106,8 @@ describe('ChunkLoadError recovery', () => {
         reloadMock.mockClear();
         mockClearWorkboxRecoveryCaches.mockClear();
         sessionStorage.clear();
+        mockIsOffline = false;
+        mockReachabilityListeners.clear();
     });
 
     describe('usePageRefresh (web)', () => {
@@ -131,6 +151,15 @@ describe('ChunkLoadError recovery', () => {
         const RETRY_KEY = 'test';
         const stateKey = `${CONST.SESSION_STORAGE_KEYS.RETRY_LAZY_REFRESHED}:${RETRY_KEY}`;
 
+        function createFlakyImport(failures: number) {
+            let attempts = 0;
+            const componentImport: ComponentImport<ComponentType> = () => {
+                attempts += 1;
+                return attempts <= failures ? Promise.reject(chunkError) : Promise.resolve({default: () => null});
+            };
+            return {componentImport, getAttempts: () => attempts};
+        }
+
         it('plain-reloads on the first failure without clearing caches', async () => {
             sessionStorage.removeItem(stateKey);
             const failingImport = jest.fn().mockRejectedValue(chunkError) as unknown as ComponentImport<ComponentType>;
@@ -145,7 +174,6 @@ describe('ChunkLoadError recovery', () => {
 
         it('clears SW caches before reloading on the second ChunkLoadError failure when online', async () => {
             sessionStorage.setItem(stateKey, 'true');
-            jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
             const failingImport = jest.fn().mockRejectedValue(chunkError) as unknown as ComponentImport<ComponentType>;
 
             lazyRetry(failingImport, RETRY_KEY);
@@ -156,16 +184,68 @@ describe('ChunkLoadError recovery', () => {
             expect(callOrder).toEqual(['clear', 'reload']);
         });
 
-        it('rejects to the error boundary on second ChunkLoadError failure when offline to preserve the offline cache', async () => {
-            sessionStorage.setItem(stateKey, 'true');
-            jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
-            const failingImport = jest.fn().mockRejectedValue(chunkError) as unknown as ComponentImport<ComponentType>;
+        it('parks the promise and re-imports on reconnect when the import fails while offline', async () => {
+            mockIsOffline = true;
+            const {componentImport, getAttempts} = createFlakyImport(1);
 
-            await expect(lazyRetry(failingImport, RETRY_KEY)).rejects.toBeDefined();
+            const onRejected = jest.fn();
+            const promise = lazyRetry(componentImport, RETRY_KEY).catch(onRejected);
             await flushMicrotasks();
 
-            expect(mockClearWorkboxRecoveryCaches).not.toHaveBeenCalled();
+            expect(getAttempts()).toBe(1);
+            expect(onRejected).not.toHaveBeenCalled();
             expect(reloadMock).not.toHaveBeenCalled();
+            expect(mockClearWorkboxRecoveryCaches).not.toHaveBeenCalled();
+            expect(sessionStorage.getItem(stateKey)).toBeNull();
+
+            mockIsOffline = false;
+            confirmReachability();
+            await promise;
+
+            expect(getAttempts()).toBe(2);
+            expect(onRejected).not.toHaveBeenCalled();
+            expect(sessionStorage.getItem(stateKey)).toBe('false');
+        });
+
+        it('re-arms the wait when the retried import fails while still offline', async () => {
+            mockIsOffline = true;
+            const {componentImport, getAttempts} = createFlakyImport(2);
+
+            const onRejected = jest.fn();
+            const promise = lazyRetry(componentImport, RETRY_KEY).catch(onRejected);
+            await flushMicrotasks();
+
+            confirmReachability();
+            await flushMicrotasks();
+
+            expect(getAttempts()).toBe(2);
+            expect(onRejected).not.toHaveBeenCalled();
+            expect(mockReachabilityListeners.size).toBe(1);
+
+            mockIsOffline = false;
+            confirmReachability();
+            await promise;
+
+            expect(getAttempts()).toBe(3);
+            expect(onRejected).not.toHaveBeenCalled();
+            expect(reloadMock).not.toHaveBeenCalled();
+        });
+
+        it('does not burn a reload attempt on an offline failure, so a later online failure still gets its plain reload', async () => {
+            mockIsOffline = true;
+            const {componentImport} = createFlakyImport(Number.POSITIVE_INFINITY);
+
+            lazyRetry(componentImport, RETRY_KEY);
+            await flushMicrotasks();
+            expect(reloadMock).not.toHaveBeenCalled();
+
+            mockIsOffline = false;
+            confirmReachability();
+            await flushMicrotasks();
+
+            expect(sessionStorage.getItem(stateKey)).toBe('true');
+            expect(reloadMock).toHaveBeenCalledTimes(1);
+            expect(mockClearWorkboxRecoveryCaches).not.toHaveBeenCalled();
         });
 
         it('rejects to the error boundary on second failure when the error is not a ChunkLoadError', async () => {


### PR DESCRIPTION
### Explanation of Change

On laptop wake, the browser tab loses network for about 30 seconds. Two lazy loads fail inside that window, and neither load recovers when the network returns. The `AppNavigator` chunk fails with a `ChunkLoadError`, `lazyRetry` exhausts its retry ladder, and the rejection reaches the root error boundary. The error page then stays until the user refreshes the page. The locale chunk fails too. `IntlStore.load()` had no `catch`, so the translation cache stayed empty and `translate()` returned raw keys such as the reported `genericErrorPage.title`.

Both loads now park on failure. When an import fails while `getIsOffline()` reports offline, the import waits for `NetworkState` to confirm reachability, then runs again. The promise stays pending, so Suspense keeps the splash screen up and the error boundary never renders. A second offline failure re-arms the wait.

The offline check runs before `lazyRetry`'s online ladder. An offline blip therefore keeps its plain-reload attempt, and never clears the service worker cache. That cache holds the only app shell available while the network is down. `usePageRefresh` moves from `navigator.onLine` to `getIsOffline()` for the same reason. During a flap, `navigator.onLine` reports `true` while `getIsOffline()` reports offline, so the Refresh button used to wipe that cache mid-flap.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97969
PROPOSAL:

### Tests

All three checks are web-only, since lazy chunk loading and the service worker only exist there.

**A. Locale chunk parks and recovers** (`npm run web`)

1. Sign in on web in a fresh tab. Open DevTools → Application → Service Workers, tick **Bypass for network**, then Network → **Disable cache**, so the locale chunk is fetched over the wire.
2. Go to Settings → Preferences → Language and leave it on English.
3. Switch DevTools → Network throttling to **Offline**.
4. Select **Spanish** (or any language not yet selected in this tab).
5. Verify no raw translation keys such as `genericErrorPage.title` appear anywhere, and the generic error page does not render.
6. Verify the console shows `Failed to load translations while offline, waiting for the internet to come back.`
7. Switch throttling back to **No throttling**.
8. Verify the UI flips to Spanish on its own within a few seconds, with no manual refresh.

**B. Stale-shell regression check** (`npm run web`)

1. With the network online and the app loaded, run `sessionStorage.setItem('RETRY_LAZY_REFRESHED:appNavigator', 'true')` in the console.
2. Network → **Request blocking** → add the pattern `*appNavigator*`, then reload.
3. Verify the console shows exactly one `Failed to lazily import a React component after reload, clearing SW caches and reloading.` followed by the error page. Verify it does not loop.

**C. Lazy chunk parks and recovers**

`lazyRetry` wraps only the three boot chunks (`appNavigator`, `authScreens`, `publicScreens`), so this needs a production-shaped bundle — in dev the unminified bundle makes throttled loading take minutes rather than seconds.

1. Run `npm run build-staging`, then `npm run web:dist`, open the served URL and sign in.
2. DevTools → Application → Service Workers, tick **Bypass for network**, then Network → **Disable cache**.
3. Set Network throttling to **Slow 3G** and hard-reload.
4. While `authScreens.…js` is still pending in the Network tab, switch throttling to **Offline**.
5. Verify the app stays on the splash screen, does **not** show the generic error page, and does **not** show raw translation keys.
6. Verify the console shows `Failed to lazily import a React component while offline, waiting for the internet to come back.` and `[NetworkState] NetInfo state change: isConnected=false`.
7. Switch throttling back to **No throttling**.
8. Verify the console shows `[NetworkState] Internet reachability restored` and the app loads through to the LHN on its own within a few seconds, with no manual refresh, fully translated.
9. Verify the offline indicator disappears and the app behaves normally afterwards.

- [ ] Verify that no errors appear in the JS console

(The `console.error` lines expected in A6 and C6 are the intentional diagnostics for this flow.)

### Offline tests

This PR is entirely about offline behavior, so the steps above are the offline test.

Note that TestToolMenu → **Force offline** cannot exercise this fix: it only fails requests made through `HttpUtils`, while lazy chunk and locale imports are fetched by the bundler. The import succeeds, so nothing to recover from. DevTools throttling is the only lever that both fails the fetch and makes `getIsOffline()` report offline.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English.
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
