### PR TITLE
[TESTING ONLY] Pin react-native-onyx to disk-pressure classification (Onyx PR #816)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "react-native-nitro-fetch": "1.5.4",
         "react-native-nitro-modules": "0.36.3",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.92",
+        "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#d7abb2c7b77009990fa7ed62a7b8a609788a8261",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -36071,9 +36071,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.92",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.92.tgz",
-      "integrity": "sha512-DEbqL7Pu9b6U2plmW0RN9d9R58L70OlXo/LEYXaxOkIfBM+C3ZHbv17rr1nwDPPKBQMM8NyAEJypmnD3+atjAg==",
+      "version": "3.0.94",
+      "resolved": "git+ssh://git@github.com/callstack-internal/react-native-onyx.git#d7abb2c7b77009990fa7ed62a7b8a609788a8261",
+      "integrity": "sha512-KyJ+UwsLwtf1HbW1skVX7BKF4bhiO/qkBUEAqhhQVukU7YR3Tkq4WlStmc0PhFyRWtgH531bJlVL/rlfcbHrWQ==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "react-native-nitro-fetch": "1.5.4",
         "react-native-nitro-modules": "0.36.3",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#d7abb2c7b77009990fa7ed62a7b8a609788a8261",
+        "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#c78c5786743e1a198908a2921a3fc49effd525b5",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -36072,8 +36072,8 @@
     },
     "node_modules/react-native-onyx": {
       "version": "3.0.94",
-      "resolved": "git+ssh://git@github.com/callstack-internal/react-native-onyx.git#d7abb2c7b77009990fa7ed62a7b8a609788a8261",
-      "integrity": "sha512-KyJ+UwsLwtf1HbW1skVX7BKF4bhiO/qkBUEAqhhQVukU7YR3Tkq4WlStmc0PhFyRWtgH531bJlVL/rlfcbHrWQ==",
+      "resolved": "git+ssh://git@github.com/callstack-internal/react-native-onyx.git#c78c5786743e1a198908a2921a3fc49effd525b5",
+      "integrity": "sha512-7FoxOKuRBCENfKWUHGs1bCdXmNfdCOcyFPKIEHXYxGX0zsyrTH4BAaHUW3vsLmlXJuzD193ggY0+GDfZ3rm3fw==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-native-nitro-fetch": "1.5.4",
     "react-native-nitro-modules": "0.36.3",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#d7abb2c7b77009990fa7ed62a7b8a609788a8261",
+    "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#c78c5786743e1a198908a2921a3fc49effd525b5",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-native-nitro-fetch": "1.5.4",
     "react-native-nitro-modules": "0.36.3",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.92",
+    "react-native-onyx": "git+https://github.com/callstack-internal/react-native-onyx.git#d7abb2c7b77009990fa7ed62a7b8a609788a8261",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",


### PR DESCRIPTION
### Explanation of Change

**This is a TESTING ONLY companion PR** for the react-native-onyx PR https://github.com/Expensify/react-native-onyx/pull/816 ("Classify SQLite disk-pressure errors and stop retrying them"). It is not intended to merge as-is: once Onyx #816 merges and ships in a released version, this PR will either be updated to the released npm version or closed in favor of the regular version bump.

The only change here is pinning `react-native-onyx` in `package.json` / `package-lock.json` from `3.0.92` to the Onyx PR's head commit (`callstack-internal/react-native-onyx#c78c578`, branch `eliran/87869-classify-disk-pressure`, which resolves to version 3.0.94 from the git ref), so the full E/App CI suite and adhoc builds can exercise the Onyx change, per the onyx repo's "Linked E/App PR" requirement.

**What Onyx #816 does:** addresses the app-side symptom of https://github.com/Expensify/App/issues/87869 — iOS bursts of `NitroSQLiteError: ... disk I/O error` (Sentry APP-19Q) caused by a full device disk at database (re)open (`SQLITE_IOERR_SHMSIZE` on the `-shm` WAL-index file, plus the related `unable to open database file` and `cannot rollback - no transaction is active` shapes). Previously these fell in the `UNKNOWN` storage error class: 5 blind retries per operation plus a per-operation alert, amplifying the log storm (~70x amplification seen in prod logs). The Onyx PR:

- Adds a new `DISK_PRESSURE` storage error class and routes the two SQLite full-disk error messages to it (`disk I/O error`, `unable to open database file`); `cannot rollback - no transaction is active` deliberately stays `UNKNOWN` since it is a mask, not a cause
- Stops retrying and stops cache eviction on these errors (neither can free OS-level disk space; the in-memory cache stays authoritative)
- Logs a single throttled alert (60s window) plus one storage quota snapshot per burst, including `getFreeDiskStorage()` bytes on native so prod telemetry can confirm disk pressure as the root cause

### Fixed Issues

$ https://github.com/Expensify/App/issues/87869
$ https://github.com/Expensify/App/issues/97908
PROPOSAL: N/A (testing-only dependency-pin companion PR; the change itself is reviewed in https://github.com/Expensify/react-native-onyx/pull/816)

### Automated Tests

Automated coverage for the change lives in the paired onyx PR (https://github.com/Expensify/react-native-onyx/pull/816), in `tests/unit/onyxUtilsTest.ts`: an `it.each` over the two disk-pressure error strings asserting the operation is not retried, and a burst test asserting exactly one throttled alert + one storage quota snapshot per burst. This PR only pins the dependency so the full E/App CI suite runs against it.

### Tests

Regression smoke only — the pinned Onyx change alters internal error classification/logging with no user-facing behavior change:

1. Sign in and use the app normally: open a report, create an expense, send a message.
2. Kill and relaunch the app — verify data loads correctly.
3. Verify no crashes or console errors during normal usage.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, create an expense, kill and relaunch the app — verify the offline change is still there and syncs when back online.

### QA Steps

Same as Tests. (Testing-only PR — not intended to reach staging as-is.)

- [x] Verify that no errors appear in the JS console
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — dependency pin only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — dependency pin only.

</details>

<details>
<summary>iOS: Native</summary>

N/A — dependency pin only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — dependency pin only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — dependency pin only.

</details>


