### PR TITLE
Patch react-native-nitro-sqlite so failed ROLLBACKs stop masking real SQLite errors

### DIFF
--- a/patches/react-native-nitro-sqlite/details.md
+++ b/patches/react-native-nitro-sqlite/details.md
@@ -1,0 +1,17 @@
+# `react-native-nitro-sqlite` patches
+
+### [react-native-nitro-sqlite+9.6.0+001+dont-mask-original-error-on-rollback-failure.patch](react-native-nitro-sqlite+9.6.0+001+dont-mask-original-error-on-rollback-failure.patch)
+
+- Reason:
+
+    ```
+    When a statement inside executeBatch fails and SQLite has already auto-rolled the transaction
+    back (disk-full I/O errors do this), the library's own ROLLBACK fails with "cannot rollback -
+    no transaction is active" and that error is thrown instead of the original one, hiding the real
+    failure (~2.8k masked log lines/day on iOS). The patch wraps both ROLLBACK calls in try/catch
+    so the original error is rethrown.
+    ```
+
+- Upstream PR/issue: Already fixed upstream in 9.7.0 via https://github.com/margelo/react-native-nitro-sqlite/pull/292. We stay on 9.6.0 because the 9.7.0 podspec force-enables `SQLITE_THREADSAFE=0` on iOS and its new per-database queue breaks second opens of the same database (used by `src/libs/ExportOnyxState/index.native.ts`). The patch can be dropped when those are resolved and we bump.
+- E/App issue: https://github.com/Expensify/App/issues/97908
+- PR introducing patch: https://github.com/Expensify/App/pull/97954

--- a/patches/react-native-nitro-sqlite/react-native-nitro-sqlite+9.6.0+001+dont-mask-original-error-on-rollback-failure.patch
+++ b/patches/react-native-nitro-sqlite/react-native-nitro-sqlite+9.6.0+001+dont-mask-original-error-on-rollback-failure.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.cpp b/node_modules/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.cpp
+index 4aca8b5..2ea8581 100644
+--- a/node_modules/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.cpp
++++ b/node_modules/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.cpp
+@@ -51,7 +51,11 @@ SQLiteOperationResult sqliteExecuteBatch(const std::string& dbName, const std::v
+         auto result = sqliteExecute(dbName, command.sql, command.params);
+         rowsAffected += result->getRowsAffected();
+       } catch (NitroSQLiteException& e) {
+-        sqliteExecuteLiteral(dbName, "ROLLBACK");
++        // A failed ROLLBACK (SQLite may have already rolled back on its own) must not mask the original error.
++        try {
++          sqliteExecuteLiteral(dbName, "ROLLBACK");
++        } catch (...) {
++        }
+         throw e;
+       }
+     }
+@@ -61,7 +65,11 @@ SQLiteOperationResult sqliteExecuteBatch(const std::string& dbName, const std::v
+         .commands = (int)commandCount,
+     };
+   } catch (NitroSQLiteException& e) {
+-    sqliteExecuteLiteral(dbName, "ROLLBACK");
++    // A failed ROLLBACK (SQLite may have already rolled back on its own) must not mask the original error.
++    try {
++      sqliteExecuteLiteral(dbName, "ROLLBACK");
++    } catch (...) {
++    }
+     throw e;
+   }
+ }


### PR DESCRIPTION
### Explanation of Change

Adds a `patch-package` patch to `react-native-nitro-sqlite@9.6.0` so a failed `ROLLBACK` no longer masks the original SQLite error in the batch-write path (the path react-native-onyx uses for every write).

**The bug:** when a statement inside `executeBatch` fails and SQLite has already auto-rolled the transaction back (which disk-full I/O errors do), the library's own `ROLLBACK` fails with `cannot rollback - no transaction is active` — and that error is thrown instead of the original one. In production this hides the real failure: we log **~2,800 `cannot rollback - no transaction is active` lines per day (iOS)**, none of which say what actually broke. After this patch those surface as the true underlying errors (e.g. `disk I/O error`, `database or disk is full`), which the disk-pressure classification in https://github.com/Expensify/react-native-onyx/pull/816 then handles with throttled alerts and free-disk telemetry instead of blind retries.

The patch mirrors the fix upstream already shipped in 9.7.0 (margelo/react-native-nitro-sqlite#292): wrap the two `ROLLBACK` calls in try/catch and rethrow the original exception.

**Why a patch instead of bumping to 9.7.0** (this PR originally bumped; deliberately reverted):

1. **9.7.0 force-enables a thread-unsafe SQLite build on iOS.** Its podspec hardcodes `performance_mode = 1` → `-DSQLITE_THREADSAFE=0` (all SQLite mutexes compiled out), with no opt-out. On 9.6.0 this never actually applied — the podspec compared the int `1` against the string `'1'`, so the flag block was dead code and we've been shipping SQLite's default thread-safe build all along. 9.7.0 fixes that comparison, so the bump silently flips production iOS to a mutex-free SQLite.
2. **9.7.0 breaks second opens of the same database.** It adds a JS-side per-database operation queue whose `open()` throws `Database OnyxDB is already open` — and `src/libs/ExportOnyxState/index.native.ts` opens `OnyxDB` a second time (alongside Onyx's own connection) to export state. That call throws on 9.7.0.

The patch delivers the one behavior we need now with zero build-flag or API changes. The bump can follow once upstream makes `performance_mode` configurable (its own TODO says it should be) and our double-open in `ExportOnyxState` is reworked.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97908
PROPOSAL: N/A (dependency patch surfacing masked SQLite errors; part of the disk-pressure work in https://github.com/Expensify/App/issues/97908, symptom tracked in https://github.com/Expensify/App/issues/87869)

### Automated Tests

None added here — this PR only patches the dependency's native error propagation. The classification behavior that consumes the now-unmasked errors is tested in the paired onyx PR (https://github.com/Expensify/react-native-onyx/pull/816, `tests/unit/onyxUtilsTest.ts` and `tests/unit/storage/providers/SQLiteProviderTest.ts`).

### Tests

Regression smoke — the patch only changes which error is thrown when a batch write fails; success paths are untouched:

1. Sign in and use the app normally on iOS: open a report, create an expense, send a message.
2. Kill and relaunch the app — verify all data loads correctly.
3. Create an expense with a receipt photo — verify it persists after relaunch (exercises the batch-write path).
4. Verify no crashes or console errors during normal usage.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, send a message and create an expense, kill and relaunch the app — verify the offline changes are still there and sync when back online.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/86be7d28-056c-4ad3-bd5e-a09f13cfdce3




</details>
