### PR TITLE
[HOLD Github-Actions 97] [No QA] Skip AI reviews when they already ran for the PR head commit

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,23 +3,31 @@ name: PR Reviews with Claude Code
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 on:
   pull_request_target:
     types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.html_url }}
+  group: >-
+    claude-review-${{
+      github.event_name == 'pull_request_target' && github.event.pull_request.html_url ||
+      github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude review') && github.event.issue.html_url ||
+      github.run_id
+    }}
   cancel-in-progress: true
 
 jobs:
   review:
-    if: |
-      github.event.pull_request.draft != true
-      && !contains(github.event.pull_request.title, 'Revert')
+    if: >-
+      (github.event_name == 'pull_request_target' && github.event.pull_request.draft != true && !contains(github.event.pull_request.title, 'Revert')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude review'))
     runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
@@ -28,9 +36,9 @@ jobs:
         id: gate
         uses: ./.github/actions/javascript/isAuthorizedContributor
         with:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          ACTOR: ${{ github.event.pull_request.user.login }}
-          ACTOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          ACTOR: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.user.login || github.event.comment.user.login }}
+          ACTOR_ASSOCIATION: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.author_association || github.event.comment.author_association }}
           GITHUB_TOKEN: ${{ github.token }}
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
@@ -53,25 +61,34 @@ jobs:
         if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
         uses: ./.github/actions/composite/setupNode
 
-      - name: Filter paths
-        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          filters: |
-            code:
-              - 'src/**'
-            docs:
-              - 'docs/**/*.md'
-              - 'docs/**/*.csv'
-
       - name: Setup Claude review toolkit
         if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
         id: toolkit
-        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@2b751e9a86d8690f53443cce0ce886079eccea76
+        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@798cfb2277f46bff2bc86dd52c97f790fd25193a
+
+      - name: Check for an existing review of this commit
+        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
+        id: skip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: shouldSkipReview.sh "$PR_NUMBER" "ai-review/claude"
+
+      - name: Filter paths
+        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path' > changed-files.txt
+          if grep -q '^src/' changed-files.txt; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
+          if grep -qE '^docs/.*\.(md|csv)$' changed-files.txt; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Mark review as in progress
-        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
+        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -79,45 +96,50 @@ jobs:
 
       - name: Run Claude Code (code)
         id: code-review
-        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.filter.outputs.code == 'true'
+        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true' && steps.filter.outputs.code == 'true'
         uses: anthropics/claude-code-action@4d7e1f0cd85743fdc93b1c8040ab54395da024e2 # v1.0.149
         with:
           display_report: 'true'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
-          prompt: '/review-code-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
+          prompt: '/review-code-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
           claude_args: |
             --model claude-opus-4-8
             --effort xhigh
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(check-compiler.sh:*)" --json-schema '${{ steps.toolkit.outputs.schema_json }}'
 
       - name: Post code review results
-        if: |
-          steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
-          && steps.code-review.outcome == 'success'
-          && steps.filter.outputs.code == 'true'
+        if: steps.code-review.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           STRUCTURED_OUTPUT: ${{ steps.code-review.outputs.structured_output }}
         run: postCodeReviewResults.sh "$PR_NUMBER"
 
       - name: Run Claude Code (docs)
-        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.filter.outputs.docs == 'true'
+        id: docs-review
+        if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true' && steps.filter.outputs.docs == 'true'
         uses: anthropics/claude-code-action@4d7e1f0cd85743fdc93b1c8040ab54395da024e2 # v1.0.149
         with:
           display_report: 'true'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
-          prompt: '/review-helpdot-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
+          prompt: '/review-helpdot-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}'
           claude_args: |
             --model claude-opus-4-8
             --effort high
             --allowedTools "Task,Glob,Grep,Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
 
+      - name: Record review completion
+        if: steps.code-review.outcome == 'success' || steps.docs-review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.skip.outputs.head_sha }}
+        run: recordReviewComplete.sh "$HEAD_SHA" "ai-review/claude" "Reviewed at this commit - comment @claude review to re-run"
+
       - name: Remove in-progress indicator
-        if: always() && steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
+        if: always() && steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,14 +64,14 @@ jobs:
       - name: Setup Claude review toolkit
         if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
         id: toolkit
-        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@798cfb2277f46bff2bc86dd52c97f790fd25193a
+        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@096f415ac7bb77cae9189d1061350563def00a99
 
       - name: Check for an existing review of this commit
         if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true'
         id: skip
         env:
           GH_TOKEN: ${{ github.token }}
-        run: shouldSkipReview.sh "$PR_NUMBER" "ai-review/claude"
+        run: shouldSkipReview.sh "$PR_NUMBER" "ai-review-completed/claude"
 
       - name: Filter paths
         if: steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
@@ -136,7 +136,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ steps.skip.outputs.head_sha }}
-        run: recordReviewComplete.sh "$HEAD_SHA" "ai-review/claude" "Reviewed at this commit - comment @claude review to re-run"
+        run: recordReviewComplete.sh "$HEAD_SHA" "ai-review-completed/claude" "Reviewed at this commit - comment @claude review to re-run"
 
       - name: Remove in-progress indicator
         if: always() && steps.set-authorized.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -39,6 +39,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: write
+      statuses: write
     env:
       PR_NUMBER: ${{ case(github.event_name == 'pull_request_target', github.event.pull_request.number, github.event.issue.number) }}
       ACTOR: ${{ case(github.event_name == 'pull_request_target', github.event.pull_request.user.login, github.event.comment.user.login) }}
@@ -60,8 +61,20 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-      - name: Add review in progress reaction
+      - name: Setup Claude review toolkit
         if: steps.gate.outputs.IS_AUTHORIZED == 'true'
+        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@798cfb2277f46bff2bc86dd52c97f790fd25193a
+
+      - name: Check for an existing review of this commit
+        if: steps.gate.outputs.IS_AUTHORIZED == 'true'
+        id: skip
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: shouldSkipReview.sh "$PR_NUMBER" "ai-review/codex"
+
+      - name: Add review in progress reaction
+        if: steps.gate.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         env:
           PR_NUMBER: ${{ env.PR_NUMBER }}
@@ -87,7 +100,7 @@ jobs:
             });
 
       - name: Build Codex prompt from PR diff
-        if: steps.gate.outputs.IS_AUTHORIZED == 'true'
+        if: steps.gate.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -119,7 +132,7 @@ jobs:
           } > prompt.txt
 
       - name: Run Codex review
-        if: steps.gate.outputs.IS_AUTHORIZED == 'true'
+        if: steps.gate.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
         id: codex
         uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1
         with:
@@ -156,8 +169,15 @@ jobs:
               body,
             });
 
+      - name: Record review completion
+        if: steps.codex.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.skip.outputs.head_sha }}
+        run: recordReviewComplete.sh "$HEAD_SHA" "ai-review/codex" "Reviewed at this commit - comment /codex-review to re-run"
+
       - name: Remove review in progress reaction
-        if: always() && steps.gate.outputs.IS_AUTHORIZED == 'true'
+        if: always() && steps.gate.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         env:
           PR_NUMBER: ${{ env.PR_NUMBER }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Setup Claude review toolkit
         if: steps.gate.outputs.IS_AUTHORIZED == 'true'
-        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@798cfb2277f46bff2bc86dd52c97f790fd25193a
+        uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@096f415ac7bb77cae9189d1061350563def00a99
 
       - name: Check for an existing review of this commit
         if: steps.gate.outputs.IS_AUTHORIZED == 'true'
@@ -71,7 +71,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
-        run: shouldSkipReview.sh "$PR_NUMBER" "ai-review/codex"
+        run: shouldSkipReview.sh "$PR_NUMBER" "ai-review-completed/codex"
 
       - name: Add review in progress reaction
         if: steps.gate.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'
@@ -174,7 +174,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ steps.skip.outputs.head_sha }}
-        run: recordReviewComplete.sh "$HEAD_SHA" "ai-review/codex" "Reviewed at this commit - comment /codex-review to re-run"
+        run: recordReviewComplete.sh "$HEAD_SHA" "ai-review-completed/codex" "Reviewed at this commit - comment /codex-review to re-run"
 
       - name: Remove review in progress reaction
         if: always() && steps.gate.outputs.IS_AUTHORIZED == 'true' && steps.skip.outputs.skip != 'true'


### PR DESCRIPTION
### Explanation of Change

_(Neil's AI agent)_

Today, marking a PR ready for review runs both AI reviewers again on the exact same commit they already reviewed, reposting identical findings. This gates each reviewer on whether it has already completed for the PR's current head commit.

The marker is a commit status on the head SHA — `ai-review-completed/claude` and `ai-review-completed/codex` — which is the only durable record keyed by commit. Reactions and comments are not tied to a commit, and workflow-run history is not either (comment-triggered runs record `github.sha` as the base branch head, not the PR head). Both workflows gain two steps around the existing ones:

- **Check for an existing review of this commit** resolves the head SHA and sets `skip=true` if a `success` status with that context is already on it. Every step that costs money or posts to the PR is gated on `skip != 'true'`.
- **Record review completion** sets that status once the review finishes, against the SHA captured *before* the review started. If the author pushed mid-review, the status lands on the commit that was actually reviewed, so the next event correctly triggers a fresh review.

The status is named `ai-review-completed/*` rather than `ai-review/*` because it sits directly beside the review job in the PR's checks list. A neighbouring green row called `ai-review/claude` reads like a second review verdict; `ai-review-completed/claude` reads as the record of a past run, which is what it is.

The status is recorded whether or not the review found anything — re-running on an unchanged commit would only repost identical comments, so "already completed" is the right skip condition rather than "already passed".

Two knock-on changes in `claude-review.yml`, both required by the skip:

- **Added the `@claude review` comment trigger.** Auth and Web-Expensify already have it; App did not. A skip with no manual override would leave no way to force a re-review, so this is a prerequisite rather than a nice-to-have. It also closes the on-demand inconsistency called out in the issue. Codex already had `/codex-review`.
- **Replaced `dorny/paths-filter` with a `gh pr view --json files` filter.** `paths-filter` reads the `pull_request` event payload and has no PR context on an `issue_comment` event, so it cannot survive the new trigger without being handed an explicit base and ref (which in turn needs a full fetch of the PR head that `pull_request_target` deliberately does not do). One API call gives the same file list for both event types.

The shared scripts live in the toolkit action so Auth and Web-Expensify use the same implementation: https://github.com/Expensify/GitHub-Actions/pull/97. **This PR must not merge until that one does** — the toolkit refs here point at that PR's branch commit and need re-pinning to the merged SHA first.

Sibling PRs: https://github.com/Expensify/Auth/pull/23558, https://github.com/Expensify/Web-Expensify/pull/55193

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/669298
PROPOSAL: N/A

### Tests

_(Neil's AI agent)_

CI-only change with no product surface, so there is nothing to test in the app and no unit tests apply. `actionlint` passes on both workflows (only the pre-existing unknown-`blacksmith-*`-label warning), and `oxfmt` reports both formatted.

Not yet run end to end — the toolkit PR is not merged. Planned, on this PR itself:

1. Return this PR to draft and comment `@claude review`; wait for the review to finish.
2. Confirm an `ai-review-completed/claude` status appears on the head commit in the checks list, linking to the run.
3. Mark the PR ready for review — both `review` and `codex_review` should run and skip their review steps (Codex's own status is recorded when `/codex-review` runs, so verify it independently in step 6).
4. Push a new commit and mark ready again — both reviewers should run normally and record new statuses.
5. Comment `@claude review` on the already-reviewed commit — the review should run, confirming the manual override still works.
6. Comment `/codex-review` twice on the same commit — the second should skip.
7. On a PR touching only `docs/**/*.md`, confirm the docs reviewer still runs (verifying the replacement path filter).

- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A — CI configuration only.

### QA Steps

No QA — this changes GitHub Actions workflows only and has no staging or production surface.

- [ ] Verify that no errors appear in the JS console
