### PR TITLE
fix keyboard focus not returning to triggered element after closing modal

### DIFF
--- a/src/components/FocusTrap/FocusTrapForModal/FocusTrapForModalProps.ts
+++ b/src/components/FocusTrap/FocusTrapForModal/FocusTrapForModalProps.ts
@@ -1,4 +1,7 @@
 import type {FocusTrapProps} from 'focus-trap-react';
+import type {RefObject} from 'react';
+// eslint-disable-next-line no-restricted-imports -- type-only: the launcher union must cover every anchor shape popovers pass, including RN Text anchors
+import type {Text, View} from 'react-native';
 
 type FocusTrapOptions = Exclude<FocusTrapProps['focusTrapOptions'], undefined>;
 
@@ -8,6 +11,17 @@ type FocusTrapForModalProps = {
     initialFocus?: FocusTrapOptions['initialFocus'];
     shouldPreventScroll?: boolean;
     shouldReturnFocus?: boolean;
+
+    /**
+     * The element that opened this trap — a popover's anchor. Only consulted when `document.activeElement`
+     * is `body` at activation time: triggers that blur themselves to avoid a focus ring (the FAB, the composer
+     * "+") leave nothing to infer the launcher from, so both the dismiss-time focus return and the nav-back
+     * restore have no target. Pass the same ref the popover already uses to position itself.
+     *
+     * Deliberately covers every anchor shape in use (`View`, `Text`, DOM element): the trap narrows it with
+     * `instanceof HTMLElement` anyway, so a ref it cannot use is simply ignored rather than rejected.
+     */
+    launcherRef?: RefObject<View | Text | HTMLElement | null>;
 };
 
 export default FocusTrapForModalProps;

--- a/src/components/FocusTrap/FocusTrapForModal/index.web.tsx
+++ b/src/components/FocusTrap/FocusTrapForModal/index.web.tsx
@@ -9,7 +9,16 @@ import React, {useRef} from 'react';
 
 import type FocusTrapForModalProps from './FocusTrapForModalProps';
 
-function FocusTrapForModal({children, active, initialFocus = false, shouldPreventScroll = false, shouldReturnFocus = true}: FocusTrapForModalProps) {
+/** On web an RN `View` ref IS the DOM node, so narrow with `instanceof` rather than casting. A detached anchor can never take focus, so it is no better than nothing. */
+function resolveLauncherElement(ref: FocusTrapForModalProps['launcherRef']): HTMLElement | null {
+    const node = ref?.current;
+    if (!(node instanceof HTMLElement) || !document.contains(node)) {
+        return null;
+    }
+    return node;
+}
+
+function FocusTrapForModal({children, active, initialFocus = false, shouldPreventScroll = false, shouldReturnFocus = true, launcherRef}: FocusTrapForModalProps) {
     // Track this trap's own launcher so onPostDeactivate targets the right shared-stack entry.
     const cachedLauncherRef = useRef<HTMLElement | null>(null);
     return (
@@ -18,9 +27,12 @@ function FocusTrapForModal({children, active, initialFocus = false, shouldPreven
             focusTrapOptions={{
                 onActivate: () => {
                     // Capture for nav-back return — independent of shouldReturnFocus (which gates only focus-trap-react's same-screen return below).
-                    const launcher = document.activeElement;
+                    const activeElement = document.activeElement;
                     blurActiveElement();
-                    if (launcher instanceof HTMLElement && launcher !== document.body) {
+                    // What actually held focus wins; the anchor is the fallback for triggers that blur themselves
+                    // before opening, which would otherwise leave us with `body` and no launcher at all.
+                    const launcher = activeElement instanceof HTMLElement && activeElement !== document.body ? activeElement : resolveLauncherElement(launcherRef);
+                    if (launcher) {
                         cachedLauncherRef.current = launcher;
                         setActivePopoverLauncher(launcher);
                     }

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -67,6 +67,7 @@ function BaseModal({
     modalId,
     shouldEnableNewFocusManagement = false,
     shouldReturnFocus,
+    launcherRef,
     restoreFocusType,
     shouldUseModalPaddingStyle = true,
     initialFocus = false,
@@ -391,6 +392,7 @@ function BaseModal({
                         shouldEnableNewFocusManagement={shouldEnableNewFocusManagement}
                         supportedOrientations={['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right']}
                         shouldReturnFocus={shouldReturnFocus}
+                        launcherRef={launcherRef}
                     >
                         <Animated.View
                             onLayout={onViewLayout}

--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -59,6 +59,7 @@ function ReanimatedModal({
     shouldIgnoreBackHandlerDuringTransition = false,
     shouldEnableNewFocusManagement,
     shouldReturnFocus,
+    launcherRef,
     ...props
 }: ReanimatedModalProps) {
     const [isVisibleState, setIsVisibleState] = useState(isVisible);
@@ -142,7 +143,9 @@ function ReanimatedModal({
             transitionHandleRef.current = TransitionTracker.startTransition();
             onModalWillHide();
 
-            blurActiveElement();
+            // The focus trap deactivates first (child effects run before ours) and may have already returned focus to
+            // the launcher, which lives outside this modal — preserve it, and drop focus from anything else.
+            blurActiveElement(launcherRef?.current);
             setIsVisibleState(false);
             setIsTransitioning(true);
         }
@@ -268,6 +271,7 @@ function ReanimatedModal({
                         initialFocus={initialFocus}
                         shouldReturnFocus={shouldReturnFocus ?? !shouldEnableNewFocusManagement}
                         shouldPreventScroll={shouldPreventScrollOnFocus}
+                        launcherRef={launcherRef}
                     >
                         {isVisibleState && containerView}
                     </FocusTrapForModal>

--- a/src/components/Modal/ReanimatedModal/types.ts
+++ b/src/components/Modal/ReanimatedModal/types.ts
@@ -2,8 +2,9 @@ import type {FocusTrapOptions} from '@components/Modal/types';
 
 import type CONST from '@src/CONST';
 
-import type {ReactNode} from 'react';
-import type {NativeSyntheticEvent, StyleProp, ViewProps, ViewStyle} from 'react-native';
+import type {ReactNode, RefObject} from 'react';
+// eslint-disable-next-line no-restricted-imports -- type-only: the launcher union must cover every anchor shape popovers pass, including RN Text anchors
+import type {NativeSyntheticEvent, StyleProp, Text, View, ViewProps, ViewStyle} from 'react-native';
 import type {SharedValue} from 'react-native-reanimated';
 import type {ValueOf} from 'type-fest';
 
@@ -149,6 +150,12 @@ type ReanimatedModalProps = ViewProps &
          * Whether the focus of the previous element before showing the modal should be returned when the modal closes.
          */
         shouldReturnFocus?: boolean;
+
+        /**
+         * The element that opened this modal — a popover's anchor. Used only when nothing held focus at activation time,
+         * which is the case for triggers that blur themselves to avoid a focus ring (the FAB, the composer "+").
+         */
+        launcherRef?: RefObject<View | Text | HTMLElement | null>;
 
         /** Whether to ignore the back handler during transition */
         shouldIgnoreBackHandlerDuringTransition?: boolean;

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -126,6 +126,8 @@ function Popover(props: PopoverProps) {
                 animationIn={animationIn}
                 animationOut={animationOut}
                 enableEdgeToEdgeBottomSafeAreaPadding={enableEdgeToEdgeBottomSafeAreaPadding}
+                // The anchor is the launcher fallback for triggers that blur themselves before opening.
+                launcherRef={props.anchorRef}
             />,
             document.body,
         );
@@ -157,6 +159,8 @@ function Popover(props: PopoverProps) {
             animationIn={animationIn}
             animationOut={animationOut}
             enableEdgeToEdgeBottomSafeAreaPadding={enableEdgeToEdgeBottomSafeAreaPadding}
+            // The anchor is the launcher fallback for triggers that blur themselves before opening.
+            launcherRef={props.anchorRef}
         />
     );
 }

--- a/src/components/PopoverMenu/index.tsx
+++ b/src/components/PopoverMenu/index.tsx
@@ -710,6 +710,7 @@ function BasePopoverMenu({
             <FocusTrapForModal
                 active={isVisible}
                 shouldReturnFocus={!shouldEnableNewFocusManagement}
+                launcherRef={anchorRef}
             >
                 <CompactMenuContext.Provider value>
                     <View

--- a/src/components/PopoverMenu/v2/content/BaseContent.tsx
+++ b/src/components/PopoverMenu/v2/content/BaseContent.tsx
@@ -103,7 +103,10 @@ function BaseContentInner({
             shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode={shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode}
             testID={testID}
         >
-            <FocusTrapForModal active={isVisible}>
+            <FocusTrapForModal
+                active={isVisible}
+                launcherRef={activeAnchor.ref}
+            >
                 <CompactMenuContext.Provider value>
                     <ContentNavigationContext.Provider value={navigation}>
                         <ContentFocusContext.Provider value={focus}>

--- a/src/components/PopoverWithMeasuredContent/index.tsx
+++ b/src/components/PopoverWithMeasuredContent/index.tsx
@@ -41,6 +41,8 @@ function PopoverWithMeasuredContent({shouldWrapModalChildrenInScrollViewIfBottom
                 animationIn="slideInUp"
                 animationOut="slideOutDown"
                 shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode={shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode}
+                // The anchor is the launcher fallback for triggers that blur themselves before opening.
+                launcherRef={props.anchorRef}
             />
         );
     }

--- a/src/libs/Accessibility/blurActiveElement/index.native.ts
+++ b/src/libs/Accessibility/blurActiveElement/index.native.ts
@@ -1,3 +1,5 @@
-const blurActiveElement = () => {};
+/** No-op on native; the parameter exists only to match the web signature. */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const blurActiveElement = (_elementToPreserve?: unknown) => {};
 
 export default blurActiveElement;

--- a/src/libs/Accessibility/blurActiveElement/index.ts
+++ b/src/libs/Accessibility/blurActiveElement/index.ts
@@ -1,5 +1,15 @@
-const blurActiveElement = () => {
+/**
+ * Drops focus from whatever currently holds it.
+ *
+ * `elementToPreserve` opts a single element out. A closing modal blurs focus so it can't be left on content that is
+ * about to unmount — but by then its focus trap may have already returned focus to the launcher that opened it, and
+ * that element is outside the modal. Blurring it would silently undo the return.
+ */
+const blurActiveElement = (elementToPreserve?: unknown) => {
     if (!(document.activeElement instanceof HTMLElement)) {
+        return;
+    }
+    if (elementToPreserve === document.activeElement) {
         return;
     }
     document.activeElement.blur();

--- a/src/pages/inbox/sidebar/FABPopoverContent/FABPopoverMenu.tsx
+++ b/src/pages/inbox/sidebar/FABPopoverContent/FABPopoverMenu.tsx
@@ -132,6 +132,7 @@ function FABPopoverMenu({isVisible, onClose, onItemSelected, anchorRef, animatio
                 <FocusTrapForModal
                     active={isVisible}
                     shouldReturnFocus
+                    launcherRef={anchorRef}
                 >
                     <CompactMenuContext.Provider value>
                         <Activity mode={contentActivityMode}>

--- a/tests/unit/FocusTrapForModalTest.tsx
+++ b/tests/unit/FocusTrapForModalTest.tsx
@@ -122,4 +122,75 @@ describe('FocusTrapForModal — launcher capture', () => {
         expect(setActivePopoverLauncher).not.toHaveBeenCalled();
         expect(markActivePopoverLauncherDeactivated).not.toHaveBeenCalled();
     });
+
+    describe('launcherRef fallback', () => {
+        // Triggers that blur themselves to avoid a focus ring (the FAB, the composer "+") leave activeElement
+        // as body, so the anchor is the only thing left to identify the launcher with.
+        it('falls back to the anchor when activeElement is body, and returns focus to it on dismiss', () => {
+            const anchor = document.createElement('button');
+            document.body.appendChild(anchor);
+            const anchorRef = {current: anchor};
+
+            render(
+                <FocusTrapForModal
+                    active
+                    launcherRef={anchorRef}
+                >
+                    {null}
+                </FocusTrapForModal>,
+            );
+
+            withActiveElement(document.body, () => {
+                capturedOptions?.onActivate?.();
+                capturedOptions?.onPostDeactivate?.();
+            });
+
+            expect(setActivePopoverLauncher).toHaveBeenCalledWith(anchor);
+            expect(markActivePopoverLauncherDeactivated).toHaveBeenCalledWith(anchor);
+            expect(mockRestoreFocusWithModality).toHaveBeenCalledWith(anchor, expect.anything());
+        });
+
+        it('prefers the element that actually held focus over the anchor', () => {
+            const anchor = document.createElement('button');
+            const focused = document.createElement('input');
+            document.body.appendChild(anchor);
+            document.body.appendChild(focused);
+
+            render(
+                <FocusTrapForModal
+                    active
+                    launcherRef={{current: anchor}}
+                >
+                    {null}
+                </FocusTrapForModal>,
+            );
+
+            withActiveElement(focused, () => {
+                capturedOptions?.onActivate?.();
+            });
+
+            expect(setActivePopoverLauncher).toHaveBeenCalledWith(focused);
+        });
+
+        it('ignores an anchor that is not an attached DOM node (native ref / unmounted trigger)', () => {
+            const detached = document.createElement('button');
+
+            render(
+                <FocusTrapForModal
+                    active
+                    launcherRef={{current: detached}}
+                >
+                    {null}
+                </FocusTrapForModal>,
+            );
+
+            withActiveElement(document.body, () => {
+                capturedOptions?.onActivate?.();
+                capturedOptions?.onPostDeactivate?.();
+            });
+
+            expect(setActivePopoverLauncher).not.toHaveBeenCalled();
+            expect(markActivePopoverLauncherDeactivated).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
