### PR TITLE
Fix narrow screen view for Violations by submitter

### DIFF
--- a/src/components/Search/ExpenseGroupedSearchView.tsx
+++ b/src/components/Search/ExpenseGroupedSearchView.tsx
@@ -1,10 +1,16 @@
+import Icon from '@components/Icon';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
+import Text from '@components/Text';
 
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
 
 import getPlatform from '@libs/getPlatform';
-import {isTransactionGroupListItemType, isTransactionMatchWithGroupItem, splitGroupsIntoPairs} from '@libs/SearchUIUtils';
+import {getSearchColumnTranslationKey, isTransactionGroupListItemType, isTransactionMatchWithGroupItem, splitGroupsIntoPairs} from '@libs/SearchUIUtils';
 
 import variables from '@styles/variables';
 
@@ -16,6 +22,7 @@ import type {Transaction} from '@src/types/onyx';
 import type {NativeSyntheticEvent} from 'react-native';
 
 import React, {useImperativeHandle, useState} from 'react';
+import {View} from 'react-native';
 
 import type {SearchListItem} from './SearchList/ListItem/types';
 import type {CommonSearchViewProps, TransactionViewExtras} from './searchViewProps';
@@ -114,8 +121,12 @@ function ExpenseGroupedSearchView({
     containerStyle,
     ref,
 }: ExpenseGroupedSearchViewProps) {
-    const {type, groupBy} = queryJSON;
+    const {type, groupBy, sortBy, sortOrder} = queryJSON;
     const {isLargeScreenWidth} = useResponsiveLayout();
+    const styles = useThemeStyles();
+    const theme = useTheme();
+    const {translate} = useLocalize();
+    const sortArrowIcons = useMemoizedLazyExpensifyIcons(['ArrowDownLong', 'ArrowUpLong']);
 
     // Wide web layouts split each group into a sticky header row plus an expandable children-container row.
     // Computed here (not from the shared hook) because the split list feeds back into the hook as `listData`.
@@ -320,6 +331,18 @@ function ExpenseGroupedSearchView({
             safeAreaPaddingBottomStyle={safeAreaPaddingBottomStyle}
             containerStyle={containerStyle}
         >
+            {!isLargeScreenWidth && (
+                // Narrow layouts have no column header, so the active sort is otherwise invisible.
+                <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1, styles.ph4, styles.pv2]}>
+                    <Text style={styles.textMicroSupporting}>{`${translate('search.display.sortBy')}: ${translate(getSearchColumnTranslationKey(sortBy))}`}</Text>
+                    <Icon
+                        src={sortOrder === CONST.SEARCH.SORT_ORDER.ASC ? sortArrowIcons.ArrowUpLong : sortArrowIcons.ArrowDownLong}
+                        fill={theme.icon}
+                        height={12}
+                        width={12}
+                    />
+                </View>
+            )}
             {tableHeaderVisible && (
                 <SelectionTopBar
                     isLargeScreenWidth={isLargeScreenWidth}

--- a/src/components/Search/ExpenseGroupedSearchView.tsx
+++ b/src/components/Search/ExpenseGroupedSearchView.tsx
@@ -1,16 +1,10 @@
-import Icon from '@components/Icon';
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
-import Text from '@components/Text';
 
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
-import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
-import useTheme from '@hooks/useTheme';
-import useThemeStyles from '@hooks/useThemeStyles';
 
 import getPlatform from '@libs/getPlatform';
-import {getSearchColumnTranslationKey, isTransactionGroupListItemType, isTransactionMatchWithGroupItem, splitGroupsIntoPairs} from '@libs/SearchUIUtils';
+import {isTransactionGroupListItemType, isTransactionMatchWithGroupItem, splitGroupsIntoPairs} from '@libs/SearchUIUtils';
 
 import variables from '@styles/variables';
 
@@ -22,7 +16,6 @@ import type {Transaction} from '@src/types/onyx';
 import type {NativeSyntheticEvent} from 'react-native';
 
 import React, {useImperativeHandle, useState} from 'react';
-import {View} from 'react-native';
 
 import type {SearchListItem} from './SearchList/ListItem/types';
 import type {CommonSearchViewProps, TransactionViewExtras} from './searchViewProps';
@@ -121,12 +114,8 @@ function ExpenseGroupedSearchView({
     containerStyle,
     ref,
 }: ExpenseGroupedSearchViewProps) {
-    const {type, groupBy, sortBy, sortOrder} = queryJSON;
+    const {type, groupBy} = queryJSON;
     const {isLargeScreenWidth} = useResponsiveLayout();
-    const styles = useThemeStyles();
-    const theme = useTheme();
-    const {translate} = useLocalize();
-    const sortArrowIcons = useMemoizedLazyExpensifyIcons(['ArrowDownLong', 'ArrowUpLong']);
 
     // Wide web layouts split each group into a sticky header row plus an expandable children-container row.
     // Computed here (not from the shared hook) because the split list feeds back into the hook as `listData`.
@@ -331,18 +320,6 @@ function ExpenseGroupedSearchView({
             safeAreaPaddingBottomStyle={safeAreaPaddingBottomStyle}
             containerStyle={containerStyle}
         >
-            {!isLargeScreenWidth && (
-                // Narrow layouts have no column header, so the active sort is otherwise invisible.
-                <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1, styles.ph4, styles.pv2]}>
-                    <Text style={styles.textMicroSupporting}>{`${translate('search.display.sortBy')}: ${translate(getSearchColumnTranslationKey(sortBy))}`}</Text>
-                    <Icon
-                        src={sortOrder === CONST.SEARCH.SORT_ORDER.ASC ? sortArrowIcons.ArrowUpLong : sortArrowIcons.ArrowDownLong}
-                        fill={theme.icon}
-                        height={12}
-                        width={12}
-                    />
-                </View>
-            )}
             {tableHeaderVisible && (
                 <SelectionTopBar
                     isLargeScreenWidth={isLargeScreenWidth}

--- a/src/components/Search/SearchList/ListItem/MemberListItemHeader.tsx
+++ b/src/components/Search/SearchList/ListItem/MemberListItemHeader.tsx
@@ -2,6 +2,7 @@ import Avatar from '@components/Avatar';
 import Checkbox from '@components/Checkbox';
 import type {SearchColumnType} from '@components/Search/types';
 import type {ListItem} from '@components/SelectionList/types';
+import Text from '@components/Text';
 import TextWithTooltip from '@components/TextWithTooltip';
 import UserDetailsTooltip from '@components/UserDetailsTooltip';
 
@@ -159,32 +160,43 @@ function MemberListItemHeaderImpl({
                                     />
                                 </View>
                             </UserDetailsTooltip>
-                            <View style={[styles.gap1, styles.flexShrink1]}>
-                                <TextWithTooltip
-                                    text={formattedDisplayName}
-                                    style={[styles.optionDisplayName, styles.sidebarLinkTextBold, styles.pre, styles.fontWeightNormal]}
-                                />
-                                <TextWithTooltip
-                                    text={formattedLogin || formattedDisplayName}
-                                    style={[styles.textLabelSupporting, styles.lh16, styles.pre]}
-                                />
+                            <View style={[styles.gap1, styles.flex1]}>
+                                <View style={[styles.flexRow, styles.gap2]}>
+                                    <View style={styles.flex1}>
+                                        <TextWithTooltip
+                                            text={formattedDisplayName}
+                                            style={[styles.optionDisplayName, styles.sidebarLinkTextBold, styles.pre, styles.fontWeightNormal]}
+                                        />
+                                    </View>
+                                    <View style={styles.flexShrink0}>
+                                        <TotalCell
+                                            total={memberItem.total}
+                                            currency={memberItem.currency}
+                                        />
+                                    </View>
+                                </View>
+                                <View style={[styles.flexRow, styles.gap2]}>
+                                    <View style={styles.flex1}>
+                                        <TextWithTooltip
+                                            text={formattedLogin || formattedDisplayName}
+                                            style={[styles.textLabelSupporting, styles.lh16, styles.pre]}
+                                        />
+                                    </View>
+                                    <Text style={[styles.textLabelSupporting, styles.lh16, styles.flexShrink0, styles.textAlignRight]}>
+                                        {translate('iou.expenseCount', {count: memberItem.count ?? 0})}
+                                    </Text>
+                                </View>
                             </View>
                         </View>
                     )}
                     {!!isLargeScreenWidth && columns?.map((column) => columnComponents[column as keyof typeof columnComponents])}
                 </View>
-                {!isLargeScreenWidth && (
+                {!isLargeScreenWidth && !!onDownArrowClick && (
                     <View style={[styles.flexShrink0, styles.flexRow, styles.alignItemsCenter]}>
-                        <TotalCell
-                            total={memberItem.total}
-                            currency={memberItem.currency}
+                        <ExpandCollapseArrowButton
+                            isExpanded={isExpanded}
+                            onPress={onDownArrowClick}
                         />
-                        {!!onDownArrowClick && (
-                            <ExpandCollapseArrowButton
-                                isExpanded={isExpanded}
-                                onPress={onDownArrowClick}
-                            />
-                        )}
                     </View>
                 )}
             </View>

--- a/src/components/TransactionItemRow/TransactionItemRowNarrow.tsx
+++ b/src/components/TransactionItemRow/TransactionItemRowNarrow.tsx
@@ -2,8 +2,10 @@ import Checkbox from '@components/Checkbox';
 import Icon from '@components/Icon';
 import RadioButton from '@components/RadioButton';
 import DateCell from '@components/Search/SearchList/ListItem/DateCell';
+import Text from '@components/Text';
 
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -84,10 +86,12 @@ function TransactionItemRowNarrow({
     categoryForDisplay,
     createdAt,
     shouldRenderChatBubbleCell,
+    submittedViolations,
 }: TransactionItemRowNarrowProps) {
     const styles = useThemeStyles();
     const theme = useTheme();
     const StyleUtils = useStyleUtils();
+    const {translate} = useLocalize();
     const expensicons = useMemoizedLazyExpensifyIcons(['ArrowRight']);
 
     return (
@@ -181,7 +185,18 @@ function TransactionItemRowNarrow({
                         </View>
                     )}
                 </View>
-                {shouldShowErrors && (
+                {!!submittedViolations && (
+                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1, styles.mt3]}>
+                        <Text style={[styles.textMicroSupporting, styles.flexShrink0]}>{`${translate('common.violations')}:`}</Text>
+                        <Text
+                            numberOfLines={2}
+                            style={[styles.textMicroSupporting, styles.flexShrink1]}
+                        >
+                            {submittedViolations}
+                        </Text>
+                    </View>
+                )}
+                {shouldShowErrors && !submittedViolations && (
                     <DeferredTransactionItemRowRBR
                         shouldDefer={shouldDeferRBR}
                         transaction={transactionItem}

--- a/src/components/TransactionItemRow/TransactionItemRowNarrow.tsx
+++ b/src/components/TransactionItemRow/TransactionItemRowNarrow.tsx
@@ -196,11 +196,13 @@ function TransactionItemRowNarrow({
                         </Text>
                     </View>
                 )}
-                {shouldShowErrors && !submittedViolations && (
+                {shouldShowErrors && (
                     <DeferredTransactionItemRowRBR
                         shouldDefer={shouldDeferRBR}
                         transaction={transactionItem}
-                        violations={violations}
+                        // The submitted violations displayed above stand in for the live violation messages, but the
+                        // rest of the RBR (missing fields, transaction and thread errors) stays actionable.
+                        violations={submittedViolations ? undefined : violations}
                         report={report}
                         containerStyles={[styles.mt3, styles.minHeight4]}
                         missingFieldError={missingFieldError}

--- a/src/components/TransactionItemRow/TransactionItemRowWide.tsx
+++ b/src/components/TransactionItemRow/TransactionItemRowWide.tsx
@@ -26,7 +26,6 @@ import getBase62ReportID from '@libs/getBase62ReportID';
 import {getTagGLCode} from '@libs/PolicyUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import {getReimbursableTotal, isExpenseReport} from '@libs/ReportUtils';
-import {getSubmittedViolationsForTransaction} from '@libs/SearchUIUtils';
 import {getShiftKeyFromEvent} from '@libs/shiftRangeSelection';
 import {
     getAmount,
@@ -133,6 +132,7 @@ function TransactionItemRowWide({
     totalPerAttendee,
     transactionThreadReportID,
     createdAt,
+    submittedViolations,
     isMarkAsDone,
 }: TransactionItemRowWideProps) {
     const styles = useThemeStyles();
@@ -156,7 +156,6 @@ function TransactionItemRowWide({
     const submitterUserID = reportForCustomColumns?.submitterUserID;
     const submitterPayrollID = reportForCustomColumns?.submitterPayrollID;
     const orderDealNumbers = reportForCustomColumns?.orderDealNumbers;
-    const submittedViolations = getSubmittedViolationsForTransaction(reportActions, transactionItem.transactionID, translate);
     const hasValidationMessage = shouldShowErrors && (!!missingFieldError || !!violations?.length);
     let fullHeightMainRowStyle;
     if (shouldUseFullHeightEditableCellHoverTarget) {

--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -7,6 +7,7 @@ import {getCompanyCardDescription} from '@libs/CardUtils';
 import {getDecodedCategoryName, isCategoryMissing} from '@libs/CategoryUtils';
 import {getIOUActionForTransactionID} from '@libs/ReportActionsUtils';
 import {isExpenseReport, isSettled, shouldShowMarkAsDone} from '@libs/ReportUtils';
+import {getSubmittedViolationsForTransaction} from '@libs/SearchUIUtils';
 import {
     getAmount,
     getDescription,
@@ -137,6 +138,12 @@ function TransactionItemRow({
     };
     const missingFieldError = getMissingFieldError();
 
+    // The violations column reports what was flagged when the report was submitted, which can differ from the
+    // transaction's current violations, so it is only computed when that column is part of the search.
+    const submittedViolations = columns?.includes(CONST.SEARCH.TABLE_COLUMNS.VIOLATIONS)
+        ? getSubmittedViolationsForTransaction(reportActions, transactionItem.transactionID, translate)
+        : undefined;
+
     if (shouldUseNarrowLayout) {
         const description = getDescription(transactionItem);
         const merchantOrDescription = merchant || description;
@@ -179,6 +186,7 @@ function TransactionItemRow({
                 createdAt={createdAt}
                 transactionThreadReportID={transactionThreadReportID}
                 shouldRenderChatBubbleCell={shouldRenderChatBubbleCell}
+                submittedViolations={submittedViolations}
                 shouldDeferRBR={shouldDeferRBR}
             />
         );
@@ -263,6 +271,7 @@ function TransactionItemRow({
             totalPerAttendee={!attendeesCount || totalAmount === undefined ? undefined : totalAmount / attendeesCount}
             createdAt={createdAt}
             transactionThreadReportID={transactionThreadReportID}
+            submittedViolations={submittedViolations}
             shouldDeferRBR={shouldDeferRBR}
             isMarkAsDone={shouldUseMarkAsDoneCopy}
         />

--- a/src/components/TransactionItemRow/types.ts
+++ b/src/components/TransactionItemRow/types.ts
@@ -147,6 +147,9 @@ type TransactionItemRowNarrowComputedData = {
     createdAt: string;
     transactionThreadReportID: string | undefined;
     shouldRenderChatBubbleCell: boolean;
+
+    /** The violations captured when the transaction's report was submitted, set only when the violations column is shown */
+    submittedViolations: string | undefined;
 };
 
 /**

--- a/tests/ui/TransactionItemRowRBRTest.tsx
+++ b/tests/ui/TransactionItemRowRBRTest.tsx
@@ -42,7 +42,7 @@ const defaultProps = {
 };
 
 // Helper function to render TransactionItemRow with providers
-const renderTransactionItemRow = (transactionItem: TransactionWithOptionalSearchFields, reportActions?: ReportAction[]) => {
+const renderTransactionItemRow = (transactionItem: TransactionWithOptionalSearchFields, reportActions?: ReportAction[], overrideProps?: Partial<typeof defaultProps>) => {
     return render(
         <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
             <TransactionItemRow
@@ -52,6 +52,7 @@ const renderTransactionItemRow = (transactionItem: TransactionWithOptionalSearch
                 policy={transactionItem.policy}
                 reportActions={reportActions}
                 {...defaultProps}
+                {...overrideProps}
             />
         </ComposeProviders>,
     );
@@ -84,6 +85,22 @@ const createIOUReportAction = () =>
             currency: 'USD',
             comment: '',
             IOUTransactionID: MOCK_TRANSACTION_ID,
+        },
+    });
+
+// Helper function to create a submit report action carrying the violations flagged at submission time
+const createSubmittedReportAction = (violationName: string) =>
+    createBaseReportAction(3, {
+        actionName: CONST.REPORT.ACTIONS.TYPE.SUBMITTED,
+        reportID: MOCK_REPORT_ID,
+        originalMessage: {
+            amount: -100,
+            currency: 'USD',
+            violations: {
+                transactions: {
+                    [MOCK_TRANSACTION_ID]: [{name: violationName}],
+                },
+            },
         },
     });
 
@@ -384,5 +401,64 @@ describe('TransactionItemRowRBR', () => {
 
         // Then the RBR message should be displayed with transaction errors, missing merchant error, and violations
         expect(screen.getByText('Unexpected error posting the comment. Please try again later. Missing merchant. Missing category.')).toBeOnTheScreen();
+    });
+    it('should display the submitted violations in place of the live RBR on narrow layouts', async () => {
+        // Given a transaction whose current violation differs from the one flagged when its report was submitted
+        const mockViolations: TransactionViolations = [
+            {
+                name: CONST.VIOLATIONS.MISSING_CATEGORY,
+                type: CONST.VIOLATION_TYPES.VIOLATION,
+            },
+        ];
+        const mockTransaction = createBaseTransaction({violations: mockViolations});
+        const mockSubmittedAction = createSubmittedReportAction(CONST.VIOLATIONS.RECEIPT_REQUIRED);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${MOCK_TRANSACTION_ID}`, mockTransaction);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${MOCK_TRANSACTION_ID}`, mockViolations);
+
+        // When rendering the row on a narrow layout with the violations column in the search
+        renderTransactionItemRow(mockTransaction, [mockSubmittedAction], {shouldUseNarrowLayout: true});
+        await waitForBatchedUpdates();
+
+        // Then the submitted violation is labelled and shown, and the current violation is not
+        expect(screen.getByText('Violations:')).toBeOnTheScreen();
+        expect(screen.getByText('Receipt required')).toBeOnTheScreen();
+        expect(screen.queryByText('Missing category.')).not.toBeOnTheScreen();
+    });
+
+    it('should display the live RBR on narrow layouts when the violations column is not in the search', async () => {
+        // Given the same transaction rendered without the violations column
+        const mockViolations: TransactionViolations = [
+            {
+                name: CONST.VIOLATIONS.MISSING_CATEGORY,
+                type: CONST.VIOLATION_TYPES.VIOLATION,
+            },
+        ];
+        const mockTransaction = createBaseTransaction({violations: mockViolations});
+        const mockSubmittedAction = createSubmittedReportAction(CONST.VIOLATIONS.RECEIPT_REQUIRED);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${MOCK_TRANSACTION_ID}`, mockTransaction);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${MOCK_TRANSACTION_ID}`, mockViolations);
+
+        // When rendering the row on a narrow layout
+        renderTransactionItemRow(mockTransaction, [mockSubmittedAction], {shouldUseNarrowLayout: true, columns: [CONST.SEARCH.TABLE_COLUMNS.MERCHANT]});
+        await waitForBatchedUpdates();
+
+        // Then the current violation is shown and the submitted one is not
+        expect(screen.getByText('Missing category.')).toBeOnTheScreen();
+        expect(screen.queryByText('Receipt required')).not.toBeOnTheScreen();
+    });
+
+    it('should display the submitted violations in the violations column on wide layouts', async () => {
+        // Given a transaction flagged with a violation when its report was submitted
+        const mockTransaction = createBaseTransaction({violations: []});
+        const mockSubmittedAction = createSubmittedReportAction(CONST.VIOLATIONS.RECEIPT_REQUIRED);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${MOCK_TRANSACTION_ID}`, mockTransaction);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${MOCK_TRANSACTION_ID}`, []);
+
+        // When rendering the row on a wide layout with the violations column in the search
+        renderTransactionItemRow(mockTransaction, [mockSubmittedAction]);
+        await waitForBatchedUpdates();
+
+        // Then the submitted violation is shown
+        expect(screen.getByText('Receipt required')).toBeOnTheScreen();
     });
 });

--- a/tests/ui/TransactionItemRowRBRTest.tsx
+++ b/tests/ui/TransactionItemRowRBRTest.tsx
@@ -402,17 +402,28 @@ describe('TransactionItemRowRBR', () => {
         // Then the RBR message should be displayed with transaction errors, missing merchant error, and violations
         expect(screen.getByText('Unexpected error posting the comment. Please try again later. Missing merchant. Missing category.')).toBeOnTheScreen();
     });
-    it('should display the submitted violations in place of the live RBR on narrow layouts', async () => {
-        // Given a transaction whose current violation differs from the one flagged when its report was submitted
+    it('should replace only the live violations with the submitted violations on narrow layouts', async () => {
+        // Given a transaction with a current violation and a missing merchant error, whose report was submitted with a different violation
         const mockViolations: TransactionViolations = [
             {
                 name: CONST.VIOLATIONS.MISSING_CATEGORY,
                 type: CONST.VIOLATION_TYPES.VIOLATION,
             },
         ];
-        const mockTransaction = createBaseTransaction({violations: mockViolations});
+        const mockReport = {
+            ...createRandomReport(1, undefined),
+            pendingAction: null,
+            type: CONST.REPORT.TYPE.EXPENSE,
+        };
+        const mockTransaction = createBaseTransaction({
+            violations: mockViolations,
+            report: mockReport,
+            modifiedMerchant: '',
+            merchant: '',
+        });
         const mockSubmittedAction = createSubmittedReportAction(CONST.VIOLATIONS.RECEIPT_REQUIRED);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${MOCK_TRANSACTION_ID}`, mockTransaction);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${MOCK_REPORT_ID}`, mockReport);
         await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${MOCK_TRANSACTION_ID}`, mockViolations);
 
         // When rendering the row on a narrow layout with the violations column in the search
@@ -423,6 +434,9 @@ describe('TransactionItemRowRBR', () => {
         expect(screen.getByText('Violations:')).toBeOnTheScreen();
         expect(screen.getByText('Receipt required')).toBeOnTheScreen();
         expect(screen.queryByText('Missing category.')).not.toBeOnTheScreen();
+
+        // Then the RBR still reports the errors that remain actionable
+        expect(screen.getByText('Missing merchant.')).toBeOnTheScreen();
     });
 
     it('should display the live RBR on narrow layouts when the violations column is not in the search', async () => {


### PR DESCRIPTION
### Explanation of Change

The narrow screen display for the "Violations by submitter" suggested search results was missing some key information such as the expenses count. It was also displaying live violations for the expanded group transactions instead of the violations at submit time. Now these issues are resolved.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98085
PROPOSAL:

### Tests

**Set up**
1. Sign in with any account
2. Create a workspace
3. Add a member
4. Enable rules
5. Set a receipt required amount to $1 in the rules settings
6. Create an expense for $2 and submit it on a report without a receipt
7. Create another expense for $0.50 and submit it

**Manual test**
1. Go to the Spend page on a narrow screen, such as on mobile
2. Select the "Violations by submitter" suggested search
3. Verify you can see the submitter, total amount, and expense count for each group
4. Expand the group
5. Verify the transaction displays a Violations section with the Receipt required violation which was present at submit time
6. Verify the same live violation **does not** display in duplicate, in red text

<img width="335" height="720" alt="image" src="https://github.com/user-attachments/assets/802ead09-cbb6-4367-80aa-2be7cd9dbb9a" />

- [ ] Verify that no errors appear in the JS console

### Offline tests

(Neil's AI agent)

Same as tests. Both changes render from data already in Onyx, so with the network disconnected the expense count and submitted violations display exactly as they do online.

### QA Steps

(Neil's AI agent)

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
See above.

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
