### PR TITLE
Show Concierge thread title

### DIFF
--- a/src/libs/ReportNameUtils.ts
+++ b/src/libs/ReportNameUtils.ts
@@ -911,6 +911,11 @@ function computeChatThreadReportName(
         return undefined;
     }
 
+    // Concierge titles each of its threads with a summary of the question, so show that rather than the question itself.
+    if (report.reportName && isConciergeChatReport(getReportOrDraftReport(report.parentReportID))) {
+        return report.reportName;
+    }
+
     const parentReportActionMessage = getReportActionMessageFromActionsUtils(parentReportAction);
     const isArchivedNonExpense = isArchivedNonExpenseReport(report, isArchived);
 


### PR DESCRIPTION
### Explanation of Change

`computeChatThreadReportName` derives a chat thread's name from its parent action's message, so a Concierge thread always displays the raw question. The backend now titles those threads with a short summary, which was being stored and never shown.

This prefers `reportName` when the thread's parent is the Concierge DM. Every other chat thread is unchanged.

Requires https://github.com/Expensify/Web-Expensify/pull/55236 and https://github.com/Expensify/Auth/pull/23595.

### Fixed Issues
$ https://github.com/Expensify/App/issues/94503
PROPOSAL:

### Tests

1. Add your account to the `conciergeRespondInThread` beta and ask Concierge a question.
2. Verify the thread is named after the question at first, then switches to a short title once the backend renames it.
3. Open a thread in a non-Concierge chat and verify its name is still the parent message.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline and open an existing Concierge thread.
2. Verify it still shows its title.

### QA Steps

1. Add a test account to the `conciergeRespondInThread` beta and ask Concierge a question.
2. Verify the thread shows a short title rather than the full question in the LHN and header.
3. Verify threads in other chats are still named after the message they hang off.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
