### PR TITLE
[Payment due @huult] Allow the Bank account filter on Expensify Card statement exports

### DIFF
--- a/src/libs/ExpensifyCardStatementUtils.ts
+++ b/src/libs/ExpensifyCardStatementUtils.ts
@@ -73,6 +73,9 @@ const STATEMENT_SCOPE_FILTER_KEYS = new Set<string>([
     CONST.SEARCH.SYNTAX_FILTER_KEYS.WITHDRAWAL_ID,
     CONST.SEARCH.SYNTAX_FILTER_KEYS.POLICY_ID,
     CONST.SEARCH.SYNTAX_FILTER_KEYS.FEED,
+    // A settlement debits one bank account, so filtering by it picks whole settlements (like feed), never rows inside
+    // one. Card programs each settle to their own account, so this is how a single program is isolated.
+    CONST.SEARCH.SYNTAX_FILTER_KEYS.BANK_ACCOUNT,
 ]);
 
 // Returns the single workspace the search is filtered to, or undefined. We scope the statement to a workspace only

--- a/tests/unit/ExpensifyCardStatementUtilsTest.ts
+++ b/tests/unit/ExpensifyCardStatementUtilsTest.ts
@@ -1,6 +1,6 @@
 import {getExpensifyCardStatementParamsFromFeed, getExpensifyCardStatementSelection, isExpensifyCardStatementSearch} from '@libs/ExpensifyCardStatementUtils';
 
-import type {SearchQueryJSON, SelectedTransactions} from '@src/components/Search/types';
+import type {QueryFilter, SearchQueryJSON, SelectedTransactions} from '@src/components/Search/types';
 import CONST from '@src/CONST';
 import type {SearchResultDataType} from '@src/types/onyx/SearchResults';
 
@@ -352,6 +352,68 @@ describe('ExpensifyCardStatementUtils', () => {
 
         const selection = getExpensifyCardStatementSelection(scopeFilteredQueryJSON, selectedTransactions, searchData);
         expect(selection?.feeds).toEqual([{policyID: 'policy1', feedCountry: 'US', fundID: 1, entryIDs: [123], canExportStatement: true}]);
+    });
+
+    it('keeps the export when a bank account filter is active', () => {
+        const groupKey = `${CONST.SEARCH.GROUP_PREFIX}123`;
+        const selectedTransactions = makeSettlementSelection(groupKey, 2);
+        const searchData = makeSearchData({[groupKey]: makeSettlementGroup({entryID: 123, count: 2})});
+        // A settlement debits exactly one bank account, so bankAccount keeps or drops whole settlements, never rows
+        // inside one - the PDF still matches the on-screen rows. That holds for every operator and account count, so a
+        // multi-account or negated filter is exportable too, unlike policyID which the statement has to scope.
+        const bankAccountFilterVariants: QueryFilter[][] = [
+            [{operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, value: '123456789'}],
+            [
+                {operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, value: '123456789'},
+                {operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, value: '987654321'},
+            ],
+            [{operator: CONST.SEARCH.SYNTAX_OPERATORS.NOT_EQUAL_TO, value: '123456789'}],
+        ];
+
+        for (const filters of bankAccountFilterVariants) {
+            const bankAccountFilteredQueryJSON: SearchQueryJSON = {
+                ...expensifyCardStatementQueryJSON,
+                flatFilters: [...expensifyCardStatementQueryJSON.flatFilters, {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.BANK_ACCOUNT, filters}],
+            };
+
+            const selection = getExpensifyCardStatementSelection(bankAccountFilteredQueryJSON, selectedTransactions, searchData);
+            expect(selection?.feeds).toEqual([{policyID: undefined, feedCountry: 'US', fundID: 1, entryIDs: [123], canExportStatement: true}]);
+        }
+    });
+
+    it('keeps the export scoped to the workspace when a bank account filter is also active', () => {
+        const groupKey = `${CONST.SEARCH.GROUP_PREFIX}123`;
+        const selectedTransactions = makeSettlementSelection(groupKey, 2);
+        const searchData = makeSearchData({[groupKey]: makeSettlementGroup({entryID: 123, count: 2})});
+        // Isolating one card program by its settlement account and then narrowing to a workspace is the reason the
+        // filter is allowed, so the statement still has to come back scoped to that workspace.
+        const scopedBankAccountQueryJSON: SearchQueryJSON = {
+            ...scopedQueryJSON,
+            flatFilters: [
+                ...scopedQueryJSON.flatFilters,
+                {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.BANK_ACCOUNT, filters: [{operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, value: '123456789'}]},
+            ],
+        };
+
+        expect(getStatementParamsForExport(scopedBankAccountQueryJSON, selectedTransactions, searchData)).toEqual({policyID: 'policy1', feedCountry: 'US', entryIDs: [123]});
+    });
+
+    it('hides the export when a bank account filter is mixed with a transaction-narrowing filter', () => {
+        const groupKey = `${CONST.SEARCH.GROUP_PREFIX}123`;
+        const selectedTransactions = makeSettlementSelection(groupKey, 2);
+        const searchData = makeSearchData({[groupKey]: makeSettlementGroup({entryID: 123, count: 2})});
+        // Allowing bankAccount must not make the rest of the query exportable: category still narrows the rows inside
+        // the settlement, so the PDF would disagree with them.
+        const mixedQueryJSON: SearchQueryJSON = {
+            ...expensifyCardStatementQueryJSON,
+            flatFilters: [
+                ...expensifyCardStatementQueryJSON.flatFilters,
+                {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.BANK_ACCOUNT, filters: [{operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, value: '123456789'}]},
+                {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.CATEGORY, filters: [{operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, value: 'Travel'}]},
+            ],
+        };
+
+        expect(getExpensifyCardStatementSelection(mixedQueryJSON, selectedTransactions, searchData)).toBeUndefined();
     });
 
     it('includes failed settlements in the selection (the statement labels their status)', () => {


### PR DESCRIPTION
### Explanation of Change

A company running several Expensify Card programs has no per-program statement in New Expensify. Each program settles to its own bank account, so the natural way to isolate one is to filter Bank Reconciliation by `Bank account` — but doing that hid **Download statement**, because the export is only offered when every active filter is a statement-scope filter.

`bankAccount` belongs in that set. Every settlement debits exactly one bank account (the backend resolves the filter against the withdrawal's own debit/credit account), so it keeps or drops whole settlements rather than narrowing the rows inside one. The PDF still matches what is on screen. That holds for a multi-account or negated filter too, which is why it needs no scoping treatment like `policyID` — the statement is either the whole settlement or nothing.

Adding a transaction-narrowing filter such as `Category` on top still hides the export, and there is a test covering that so allowing `bankAccount` cannot be read as widening the rule.

One note for reviewers: any filter the suggested search does not include drops the reconciliation search key, and the backend only appends the standalone cash back row for that key, so that row leaves the list. No exported total changes, because cash back is a separate reimbursement entry that is never statement-exportable (`0 AS canExportStatement`) and the PDF is scoped by entry ID — the row is only harder to find. Removing the date filter has the same effect, and so does `feed`, so whether the reconciliation key should survive settlement-level filters is worth deciding on its own.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/669912
PROPOSAL:

### Tests

1. Sign in as an admin of a domain with at least one Expensify Card program and settled card settlements.
2. Open Reports, then the Reconciliation suggested search (`group-by:withdrawal-id withdrawal-type:expensify-card`).
3. Select a settlement row, open the selection menu, and verify **Download statement** is offered.
4. Open Filters, set **Bank account** to the account the card program settles to, and apply it.
5. Verify the list still shows settlements, now only those debiting that account.
6. Select a settlement row, open the selection menu, and verify **Download statement** is still offered.
7. Download the statement and verify the PDF covers the same settlement shown on the row.
8. Add a **Category** filter on top of the bank account filter and verify **Download statement** is no longer offered.
9. Remove the category filter, set **Bank account** to two accounts, and verify **Download statement** is offered again.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Apply the **Bank account** filter on the Reconciliation search and select a settlement.
2. Turn off the network connection.
3. Select **Download statement** and verify the offline message appears instead of a download.
4. Restore the connection and verify the statement downloads.

### QA Steps

Same as tests, using a staging account that administers an Expensify Card program with settled settlements.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Not captured yet: verification so far is the unit tests in this PR. Recordings of the Bank Reconciliation flow to follow before merge.

<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/6d8df45c-a78d-4225-98e8-209b849389ff


</details>
