### PR TITLE
[No QA] Fix mixed clock domains in span duration logs

### DIFF
--- a/src/libs/telemetry/activeSpans.ts
+++ b/src/libs/telemetry/activeSpans.ts
@@ -2,7 +2,7 @@ import CONST from '@src/CONST';
 
 import type {Span, SpanAttributeValue, StartSpanOptions} from '@sentry/core';
 
-import {SPAN_STATUS_OK} from '@sentry/core';
+import {SPAN_STATUS_OK, spanTimeInputToSeconds} from '@sentry/core';
 import * as Sentry from '@sentry/react-native';
 import {AppState} from 'react-native';
 
@@ -12,6 +12,17 @@ type ActiveSpanEntry = {
 };
 
 const activeSpans = new Map<string, ActiveSpanEntry>();
+
+function getPerformanceStartTimeForLog(startTime: StartSpanOptions['startTime']): number {
+    const performanceTimestamp = performance.now();
+    if (startTime === undefined) {
+        return performanceTimestamp;
+    }
+
+    // Sentry start times are Unix timestamps, while performance.now() is relative to the process start. Translate the timestamp once so elapsed time stays monotonic.
+    const epochStartTime = spanTimeInputToSeconds(startTime) * 1000;
+    return performanceTimestamp - (Date.now() - epochStartTime);
+}
 
 function startSpan(spanId: string, options: StartSpanOptions) {
     if ((AppState.currentState ?? CONST.APP_STATE.ACTIVE) !== CONST.APP_STATE.ACTIVE) {
@@ -26,12 +37,7 @@ function startSpan(spanId: string, options: StartSpanOptions) {
     });
     const span = Sentry.startInactiveSpan(options);
 
-    let startTimeForLog: number;
-    if (typeof options.startTime === 'number') {
-        startTimeForLog = options.startTime;
-    } else {
-        startTimeForLog = performance.now();
-    }
+    const startTimeForLog = getPerformanceStartTimeForLog(options.startTime);
 
     activeSpans.set(spanId, {span, startTimeForLog});
 
@@ -45,9 +51,9 @@ function endSpan(spanId: string) {
         return;
     }
     const {span, startTimeForLog} = entry;
-    const now = performance.now();
-    const durationMs = Math.round(now - startTimeForLog);
-    console.debug(`[Sentry][${spanId}] Ending span (${durationMs}ms)`, {spanId, durationMs, timestamp: now, attributes: Sentry.spanToJSON(span).data});
+    const performanceTimestamp = performance.now();
+    const durationMs = Math.round(performanceTimestamp - startTimeForLog);
+    console.debug(`[Sentry][${spanId}] Ending span (${durationMs}ms)`, {spanId, durationMs, timestamp: Date.now(), attributes: Sentry.spanToJSON(span).data});
     span.setStatus({code: SPAN_STATUS_OK});
 
     span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_FINISHED_MANUALLY, true);

--- a/tests/unit/ActiveSpansTest.ts
+++ b/tests/unit/ActiveSpansTest.ts
@@ -1,0 +1,35 @@
+import {endSpan, startSpan} from '@libs/telemetry/activeSpans';
+
+import CONST from '@src/CONST';
+
+jest.mock('@sentry/react-native', () => ({
+    startInactiveSpan: () => ({
+        setAttribute: jest.fn(),
+        setStatus: jest.fn(),
+        end: jest.fn(),
+    }),
+    spanToJSON: () => ({data: {}}),
+}));
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe('activeSpans', () => {
+    it('calculates the duration from an epoch start time using the monotonic clock', () => {
+        const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_786_362_201_500);
+        const performanceNowSpy = jest.spyOn(performance, 'now').mockReturnValue(10_000);
+        const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+
+        startSpan(CONST.TELEMETRY.SPAN_APP_STARTUP_NETWORK_REQUEST, {
+            name: CONST.TELEMETRY.SPAN_APP_STARTUP_NETWORK_REQUEST,
+            startTime: 1_786_362_201_000,
+        });
+
+        dateNowSpy.mockReturnValue(1_786_362_201_750);
+        performanceNowSpy.mockReturnValue(10_250);
+        endSpan(CONST.TELEMETRY.SPAN_APP_STARTUP_NETWORK_REQUEST);
+
+        expect(consoleDebugSpy).toHaveBeenLastCalledWith(expect.stringContaining('Ending span (750ms)'), expect.objectContaining({durationMs: 750, timestamp: 1_786_362_201_750}));
+    });
+});


### PR DESCRIPTION
@roryabraham @mountiny @tgolen 

### Explanation of Change

Sentry span start times can be Unix epoch timestamps while `performance.now()` is relative to the process start. The existing lifecycle log subtracted those different clock domains directly, producing very large negative durations for native startup spans.

This change converts the supplied Sentry start time into the `performance.now()` clock domain once when tracking begins. Duration calculations then remain monotonic, while the ending log uses an epoch timestamp consistently with the starting log. A unit test covers a native timestamp that predates JS initialization.

Further used by https://github.com/Expensify/App/pull/98144 to improve local benchmark tooling.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98280
PROPOSAL:

### Tests

1. Run `npm run test tests/unit/ActiveSpansTest.ts --runInBand --watchman=false`.
2. Verify the test passes and reports a `750ms` duration for a span that starts 500ms before JS initialization and ends 250ms afterward.
3. Run `npm run lint-changed` and verify lint passes.
4. Run `npm run typecheck-tsgo` and verify type checking passes.

- [x] Verify that no errors appear in the JS console

### Offline tests

Offline testing is not applicable because this only corrects an in-memory timestamp calculation and performs no network access.

### QA Steps

No QA is required. The behavior is internal telemetry logging and is covered by the regression test above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

No screenshots or videos are included because this change has no user-interface impact.
