### PR TITLE
Fix Rules revamp regressions on Collect workspaces

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -3365,7 +3365,7 @@ const ROUTES = {
     },
     WORKSPACE_RULES: {
         route: 'workspaces/:policyID/rules',
-        /** @param tab preselects a Rules tab; the page otherwise restores the last one used */
+        /** @param tab preselects a Rules tab. The page otherwise restores the last one used. */
         getRoute: (policyID: string | undefined, tab?: string) => {
             if (!policyID) {
                 Log.warn('Invalid policyID is used to build the WORKSPACE_RULES route');

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -3365,11 +3365,12 @@ const ROUTES = {
     },
     WORKSPACE_RULES: {
         route: 'workspaces/:policyID/rules',
-        getRoute: (policyID: string | undefined) => {
+        /** @param tab preselects a Rules tab; the page otherwise restores the last one used */
+        getRoute: (policyID: string | undefined, tab?: string) => {
             if (!policyID) {
                 Log.warn('Invalid policyID is used to build the WORKSPACE_RULES route');
             }
-            return `workspaces/${policyID}/rules` as const;
+            return `workspaces/${policyID}/rules${tab ? `?tab=${tab}` : ''}` as const;
         },
     },
     WORKSPACE_DISTANCE_RATES: {

--- a/src/components/Rule/RuleCategoriesDisabledEmptyState.tsx
+++ b/src/components/Rule/RuleCategoriesDisabledEmptyState.tsx
@@ -58,9 +58,10 @@ function RuleCategoriesDisabledEmptyState({policyID}: RuleCategoriesDisabledEmpt
 
     return (
         <View style={[styles.flex1]}>
-            {/* Scrolls so the section's fixed vertical padding can't clip in landscape, and centers on the space it
-                actually has rather than on the region above the footer. */}
-            <ScrollView contentContainerStyle={[styles.flexGrow1, styles.justifyContentCenter]}>
+            {/* Scrolls so the section's fixed vertical padding can't clip in landscape. alignItemsCenter is what keeps
+                it horizontally centered: workspaceSection caps the width without an alignSelf, so a stretched parent
+                pins it left once the viewport is wider than the cap. */}
+            <ScrollView contentContainerStyle={[styles.flexGrow1, styles.justifyContentCenter, styles.alignItemsCenter]}>
                 <WorkspaceEmptyStateSection
                     shouldStyleAsCard={false}
                     icon={illustrations.FolderOpen}

--- a/src/components/Rule/RuleCategoriesDisabledEmptyState.tsx
+++ b/src/components/Rule/RuleCategoriesDisabledEmptyState.tsx
@@ -1,15 +1,21 @@
 import Button from '@components/ButtonComposed';
 import FixedFooter from '@components/FixedFooter';
+import {ModalActions} from '@components/Modal/Global/ModalContext';
+import ScrollView from '@components/ScrollView';
 import WorkspaceEmptyStateSection from '@components/WorkspaceEmptyStateSection';
 
+import useConfirmModal from '@hooks/useConfirmModal';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import usePolicyData from '@hooks/usePolicyData';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {enablePolicyCategories, openPolicyCategoriesPage} from '@libs/actions/Policy/Category';
+import Navigation from '@libs/Navigation/Navigation';
+import {hasAccountingConnections} from '@libs/PolicyUtils';
 
 import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
 
 import React from 'react';
 import {View} from 'react-native';
@@ -24,8 +30,25 @@ function RuleCategoriesDisabledEmptyState({policyID}: RuleCategoriesDisabledEmpt
     const {translate} = useLocalize();
     const illustrations = useMemoizedLazyIllustrations(['FolderOpen']);
     const policyData = usePolicyData(policyID);
+    const {showConfirmModal} = useConfirmModal();
+    const isConnectedToAccounting = hasAccountingConnections(policyData.policy);
 
-    const enableCategories = () => {
+    const enableCategories = async () => {
+        // Accounting owns Categories while a connection is active, same as the Categories toggle on More features.
+        if (isConnectedToAccounting) {
+            const {action} = await showConfirmModal({
+                title: translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle'),
+                prompt: translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledText'),
+                confirmText: translate('workspace.moreFeatures.connectionsWarningModal.manageSettings'),
+                cancelText: translate('common.cancel'),
+            });
+            if (action !== ModalActions.CONFIRM) {
+                return;
+            }
+            Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
+            return;
+        }
+
         enablePolicyCategories(policyData, true, false);
 
         // The categories collection is empty while the feature is disabled, and enabling it only merges the
@@ -35,14 +58,17 @@ function RuleCategoriesDisabledEmptyState({policyID}: RuleCategoriesDisabledEmpt
 
     return (
         <View style={[styles.flex1]}>
-            <WorkspaceEmptyStateSection
-                shouldStyleAsCard={false}
-                icon={illustrations.FolderOpen}
-                title={translate('workspace.rules.categoriesDisabledEmptyState.title')}
-                subtitle={translate('workspace.rules.categoriesDisabledEmptyState.subtitle')}
-                containerStyle={[styles.flex1, styles.justifyContentCenter]}
-            />
-            <FixedFooter style={[styles.mtAuto, styles.pt5]}>
+            {/* Scrolls so the section's fixed vertical padding can't clip in landscape, and centers on the space it
+                actually has rather than on the region above the footer. */}
+            <ScrollView contentContainerStyle={[styles.flexGrow1, styles.justifyContentCenter]}>
+                <WorkspaceEmptyStateSection
+                    shouldStyleAsCard={false}
+                    icon={illustrations.FolderOpen}
+                    title={translate('workspace.rules.categoriesDisabledEmptyState.title')}
+                    subtitle={translate('workspace.rules.categoriesDisabledEmptyState.subtitle')}
+                />
+            </ScrollView>
+            <FixedFooter style={[styles.pt5]}>
                 <Button
                     variant={CONST.BUTTON_VARIANT.SUCCESS}
                     size={CONST.BUTTON_SIZE.LARGE}

--- a/src/components/Rule/RuleCategoriesDisabledEmptyState.tsx
+++ b/src/components/Rule/RuleCategoriesDisabledEmptyState.tsx
@@ -58,9 +58,6 @@ function RuleCategoriesDisabledEmptyState({policyID}: RuleCategoriesDisabledEmpt
 
     return (
         <View style={[styles.flex1]}>
-            {/* Scrolls so the section's fixed vertical padding can't clip in landscape. alignItemsCenter is what keeps
-                it horizontally centered: workspaceSection caps the width without an alignSelf, so a stretched parent
-                pins it left once the viewport is wider than the cap. */}
             <ScrollView contentContainerStyle={[styles.flexGrow1, styles.justifyContentCenter, styles.alignItemsCenter]}>
                 <WorkspaceEmptyStateSection
                     shouldStyleAsCard={false}

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -3027,6 +3027,9 @@ type WorkspaceSplitNavigatorParamList = {
     };
     [SCREENS.WORKSPACE.RULES]: {
         policyID: string;
+
+        /** Preselects a Rules tab; the page otherwise restores the last one used */
+        tab?: string;
     };
     [SCREENS.WORKSPACE.TIME_TRACKING]: {
         policyID: string;

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -3028,7 +3028,7 @@ type WorkspaceSplitNavigatorParamList = {
     [SCREENS.WORKSPACE.RULES]: {
         policyID: string;
 
-        /** Preselects a Rules tab; the page otherwise restores the last one used */
+        /** Preselects a Rules tab. The page otherwise restores the last one used. */
         tab?: string;
     };
     [SCREENS.WORKSPACE.TIME_TRACKING]: {

--- a/src/pages/workspace/categories/CategorySettingsPage.tsx
+++ b/src/pages/workspace/categories/CategorySettingsPage.tsx
@@ -83,7 +83,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
     const policyCurrency = policy?.outputCurrency ?? CONST.CURRENCY.USD;
     const policyCategoryExpenseLimitType = policyCategory?.expenseLimitType ?? CONST.POLICY.EXPENSE_LIMIT_TYPES.EXPENSE;
     const decodedCategoryName = getDecodedCategoryName(policyCategory?.name ?? '');
-    const categoryRulesEnabled = arePolicyRulesEnabled(policy, policyCategories);
+    const categoryRulesEnabled = arePolicyRulesEnabled(policy, policyCategories, isRulesRevampEnabled);
 
     const contextualRules = useMemo(() => {
         if (!isRulesRevampEnabled || !policyCategory) {

--- a/src/pages/workspace/categories/CategorySettingsPage.tsx
+++ b/src/pages/workspace/categories/CategorySettingsPage.tsx
@@ -273,10 +273,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
     const workflowApprovalsUnavailable = getWorkflowApprovalsUnavailable(policy);
     const approverDisabled = !policy?.areWorkflowsEnabled || workflowApprovalsUnavailable;
 
-    /**
-     * Collect sees the Category rules section for discoverability, but every destination is Control-only, so sell the
-     * upgrade instead of dropping them on a Not Found page. backTo is the row's own route so upgrading resumes it.
-     */
+    /** Collect sees this section but every destination is Control-only, so upgrade instead of hitting Not Found. */
     const navigateToCategoryRule = (dynamicRouteSuffix: string) => {
         const ruleRoute = createDynamicRoute(dynamicRouteSuffix);
         if (tryNavigateToControlPolicyUpgrade(policy, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, ruleRoute)) {

--- a/src/pages/workspace/categories/CategorySettingsPage.tsx
+++ b/src/pages/workspace/categories/CategorySettingsPage.tsx
@@ -39,7 +39,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import {isDisablingOrDeletingLastEnabledCategory} from '@libs/OptionsListUtils';
 import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
-import {arePolicyRulesEnabled, getWorkflowApprovalsUnavailable, hasTags, isAttendeeTrackingEnabled, isControlPolicy} from '@libs/PolicyUtils';
+import {arePolicyRulesEnabled, getWorkflowApprovalsUnavailable, hasTags, isAttendeeTrackingEnabled, isControlPolicy, tryNavigateToControlPolicyUpgrade} from '@libs/PolicyUtils';
 
 import type {SettingsNavigatorParamList} from '@navigation/types';
 
@@ -273,6 +273,18 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
     const workflowApprovalsUnavailable = getWorkflowApprovalsUnavailable(policy);
     const approverDisabled = !policy?.areWorkflowsEnabled || workflowApprovalsUnavailable;
 
+    /**
+     * Collect sees the Category rules section for discoverability, but every destination is Control-only, so sell the
+     * upgrade instead of dropping them on a Not Found page. backTo is the row's own route so upgrading resumes it.
+     */
+    const navigateToCategoryRule = (dynamicRouteSuffix: string) => {
+        const ruleRoute = createDynamicRoute(dynamicRouteSuffix);
+        if (tryNavigateToControlPolicyUpgrade(policy, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, ruleRoute)) {
+            return;
+        }
+        Navigation.navigate(ruleRoute);
+    };
+
     if (!policyCategory) {
         return <NotFoundPage />;
     }
@@ -391,7 +403,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
                                     title={policyCategory?.commentHint}
                                     description={translate('workspace.rules.categoryRules.descriptionHint')}
                                     onPress={() => {
-                                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_DESCRIPTION_HINT.path));
+                                        navigateToCategoryRule(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_DESCRIPTION_HINT.path);
                                     }}
                                     interactive={canWriteCategories}
                                     shouldShowRightIcon={canWriteCategories}
@@ -402,7 +414,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
                                 title={approverText}
                                 description={translate('workspace.rules.categoryRules.approver')}
                                 onPress={() => {
-                                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_APPROVER.path));
+                                    navigateToCategoryRule(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_APPROVER.path);
                                 }}
                                 interactive={canWriteCategories}
                                 shouldShowRightIcon={canWriteCategories}
@@ -419,7 +431,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
                                     title={defaultTaxRateText}
                                     description={translate('workspace.rules.categoryRules.defaultTaxRate')}
                                     onPress={() => {
-                                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_DEFAULT_TAX_RATE.path));
+                                        navigateToCategoryRule(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_DEFAULT_TAX_RATE.path);
                                     }}
                                     interactive={canWriteCategories}
                                     shouldShowRightIcon={canWriteCategories}
@@ -561,7 +573,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
                                         title={rule.summary}
                                         numberOfLinesTitle={3}
                                         shouldShowBasicTitle
-                                        onPress={() => Navigation.navigate(createDynamicRoute(rule.dynamicRoutePath))}
+                                        onPress={() => navigateToCategoryRule(rule.dynamicRoutePath)}
                                         shouldShowRightIcon={!rule.isDisabled}
                                         interactive={!rule.isDisabled}
                                         disabled={rule.isDisabled}
@@ -572,7 +584,7 @@ function CategorySettingsPage({route: {params, name}, navigation}: CategorySetti
                                 <MenuItem
                                     icon={expensifyIcons.Plus}
                                     title={translate('workspace.rules.categoryRules.createNewRule')}
-                                    onPress={() => Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_RULES_NEW.path))}
+                                    onPress={() => navigateToCategoryRule(DYNAMIC_ROUTES.WORKSPACE_CATEGORY_RULES_NEW.path)}
                                 />
                             )}
                         </>

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -115,13 +115,12 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
     }, [activeTab, policy]);
 
     useEffect(() => {
-        // The tab param is a one-shot entry hint; the selected tab lives in Onyx. Clear it so a refresh doesn't re-apply it.
+        // The tab param is an entry hint (deep link, post-upgrade bounce-back); the selected tab itself lives in Onyx.
         if (!requestedTab || !isRulesTab(requestedTab)) {
             return;
         }
 
         Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, requestedTab);
-        Navigation.setParams({tab: undefined});
     }, [requestedTab]);
 
     const clearAllTableSelection = useCallback(() => {
@@ -278,6 +277,11 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
         setSelectedRuleKeysByTab({});
         turnOffMobileSelectionMode();
         Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, key);
+
+        // Drop the entry hint once the user picks their own tab, otherwise a refresh would re-apply it over that choice.
+        if (requestedTab) {
+            Navigation.setParams({tab: undefined});
+        }
     };
 
     const getHeaderContent = () => {

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -115,13 +115,13 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
     }, [activeTab, policy]);
 
     useEffect(() => {
-        // The tab param is only an entry hint (deep link, post-upgrade bounce-back). The selected tab itself lives in
-        // Onyx so it survives leaving the page, which is why tab presses update Onyx rather than the URL.
+        // The tab param is a one-shot entry hint; the selected tab lives in Onyx. Clear it so a refresh doesn't re-apply it.
         if (!requestedTab || !isRulesTab(requestedTab)) {
             return;
         }
 
         Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, requestedTab);
+        Navigation.setParams({tab: undefined});
     }, [requestedTab]);
 
     const clearAllTableSelection = useCallback(() => {

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -40,7 +40,7 @@ import type DeepValueOf from '@src/types/utils/DeepValueOf';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 
 import type {RulesTab, TableSelectionTab} from './tabs/useRulesTableBulkActions';
@@ -76,7 +76,7 @@ const agentsRulesBannerDismissedSelector = (value: OnyxEntry<DismissedProductTra
 
 function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
     const {translate} = useLocalize();
-    const {policyID} = route.params;
+    const {policyID, tab: requestedTab} = route.params;
     const policy = usePolicy(policyID);
     useWorkspaceDocumentTitle(policy?.name, 'workspace.common.rules');
     const styles = useThemeStyles();
@@ -96,6 +96,7 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
     const resolvedTab: RulesTab = lastSelectedTabStr && isRulesTab(lastSelectedTabStr) ? lastSelectedTabStr : RULES_TAB.GENERAL;
     const activeTab: RulesTab = resolvedTab === RULES_TAB.AGENTS && !isCustomAgentBetaEnabled ? RULES_TAB.GENERAL : resolvedTab;
     const [selectedRuleKeysByTab, setSelectedRuleKeysByTab] = useState<Partial<Record<TableSelectionTab, string[]>>>({});
+    const appliedRequestedTabRef = useRef<string | undefined>(undefined);
 
     const {showConfirmModal} = useConfirmModal();
 
@@ -113,6 +114,17 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
 
         Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, RULES_TAB.GENERAL);
     }, [activeTab, policy]);
+
+    useEffect(() => {
+        // Returning from the upgrade flow carries the tab the user was heading to. Apply it once per value so a
+        // later manual tab press isn't undone by the param still sitting in the route.
+        if (!requestedTab || !isRulesTab(requestedTab) || appliedRequestedTabRef.current === requestedTab) {
+            return;
+        }
+
+        appliedRequestedTabRef.current = requestedTab;
+        Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, requestedTab);
+    }, [requestedTab]);
 
     const clearAllTableSelection = useCallback(() => {
         setSelectedRuleKeysByTab((prev) => (Object.keys(prev).length > 0 ? {} : prev));
@@ -260,7 +272,8 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
             return;
         }
 
-        if (key !== RULES_TAB.GENERAL && tryNavigateToControlPolicyUpgrade(policy, rulesUpgradeAlias, rulesUpgradeBackTo)) {
+        // Come back to the tab the user asked for, so upgrading lands them where they were headed.
+        if (key !== RULES_TAB.GENERAL && tryNavigateToControlPolicyUpgrade(policy, rulesUpgradeAlias, ROUTES.WORKSPACE_RULES.getRoute(policyID, key))) {
             return;
         }
 

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -116,8 +116,7 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
     }, [activeTab, policy]);
 
     useEffect(() => {
-        // Returning from the upgrade flow carries the tab the user was heading to. Apply it once per value so a
-        // later manual tab press isn't undone by the param still sitting in the route.
+        // Apply once per value, so a later manual tab press isn't undone by the param still sitting in the route.
         if (!requestedTab || !isRulesTab(requestedTab) || appliedRequestedTabRef.current === requestedTab) {
             return;
         }

--- a/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
+++ b/src/pages/workspace/rules/PolicyRulesPageRevamp.tsx
@@ -40,7 +40,7 @@ import type DeepValueOf from '@src/types/utils/DeepValueOf';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 
 import type {RulesTab, TableSelectionTab} from './tabs/useRulesTableBulkActions';
@@ -96,7 +96,6 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
     const resolvedTab: RulesTab = lastSelectedTabStr && isRulesTab(lastSelectedTabStr) ? lastSelectedTabStr : RULES_TAB.GENERAL;
     const activeTab: RulesTab = resolvedTab === RULES_TAB.AGENTS && !isCustomAgentBetaEnabled ? RULES_TAB.GENERAL : resolvedTab;
     const [selectedRuleKeysByTab, setSelectedRuleKeysByTab] = useState<Partial<Record<TableSelectionTab, string[]>>>({});
-    const appliedRequestedTabRef = useRef<string | undefined>(undefined);
 
     const {showConfirmModal} = useConfirmModal();
 
@@ -116,12 +115,12 @@ function PolicyRulesPageRevamp({route}: PolicyRulesPageRevampProps) {
     }, [activeTab, policy]);
 
     useEffect(() => {
-        // Apply once per value, so a later manual tab press isn't undone by the param still sitting in the route.
-        if (!requestedTab || !isRulesTab(requestedTab) || appliedRequestedTabRef.current === requestedTab) {
+        // The tab param is only an entry hint (deep link, post-upgrade bounce-back). The selected tab itself lives in
+        // Onyx so it survives leaving the page, which is why tab presses update Onyx rather than the URL.
+        if (!requestedTab || !isRulesTab(requestedTab)) {
             return;
         }
 
-        appliedRequestedTabRef.current = requestedTab;
         Tab.setSelectedTab(CONST.TAB.RULES_TAB_TYPE, requestedTab);
     }, [requestedTab]);
 

--- a/src/pages/workspace/rules/RequireFieldsRules/RequireFieldsRulePageBase.tsx
+++ b/src/pages/workspace/rules/RequireFieldsRules/RequireFieldsRulePageBase.tsx
@@ -161,8 +161,7 @@ function RequireFieldsRulePageBase({policyID, categoryName, initialCategoryName,
         }
     }
 
-    // The draft is otherwise only cleared on save, so backing out left it for the next rule to inherit — which the
-    // reassignment guard below then mistook for a deliberate category change. Matches FlagForReviewRulePageBase.
+    // Otherwise cleared only on save, so backing out left the draft for the next rule to inherit.
     useEffect(() => () => clearDraftRequireFieldsRule(), []);
 
     useEffect(() => {

--- a/src/pages/workspace/rules/RequireFieldsRules/RequireFieldsRulePageBase.tsx
+++ b/src/pages/workspace/rules/RequireFieldsRules/RequireFieldsRulePageBase.tsx
@@ -161,6 +161,10 @@ function RequireFieldsRulePageBase({policyID, categoryName, initialCategoryName,
         }
     }
 
+    // The draft is otherwise only cleared on save, so backing out left it for the next rule to inherit — which the
+    // reassignment guard below then mistook for a deliberate category change. Matches FlagForReviewRulePageBase.
+    useEffect(() => () => clearDraftRequireFieldsRule(), []);
+
     useEffect(() => {
         if (!isEditing) {
             if (initializedDraftForRuleKeyRef.current !== ROUTES.NEW) {

--- a/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
+++ b/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
@@ -13,6 +13,7 @@ import useDynamicBackPath from '@hooks/useDynamicBackPath';
 import useEnvironment from '@hooks/useEnvironment';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
+import usePermissions from '@hooks/usePermissions';
 import usePolicyData from '@hooks/usePolicyData';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -62,6 +63,8 @@ function DynamicTagSettingsPage({route, navigation}: DynamicTagSettingsPageProps
     const policyData = usePolicyData(policyID);
     const {policy, tags: policyTags} = policyData;
     const {canWrite: canWriteTags, withReadOnlyFallback} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.TAGS);
+    const {isBetaEnabled} = usePermissions();
+    const isRulesRevampEnabled = isBetaEnabled(CONST.BETAS.RULES_REVAMP);
     const policyTag = getTagListByOrderWeight(policyTags, orderWeight);
     const {environmentURL} = useEnvironment();
     const hasAccountingConnections = hasAccountingConnectionsPolicyUtils(policy);
@@ -209,7 +212,7 @@ function DynamicTagSettingsPage({route, navigation}: DynamicTagSettingsPageProps
                         </OfflineWithFeedback>
                     )}
 
-                    {arePolicyRulesEnabled(policy, policyData.categories) && !isMultiLevelTags && (
+                    {arePolicyRulesEnabled(policy, policyData.categories, isRulesRevampEnabled) && !isMultiLevelTags && (
                         <>
                             <View style={[styles.mh5, styles.mv3, styles.pt3, styles.borderTop]}>
                                 <Text style={[styles.textNormal, styles.textStrong, styles.mv3]}>{translate('workspace.tags.tagRules')}</Text>

--- a/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
+++ b/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
@@ -34,6 +34,7 @@ import {
     hasDependentTags as hasDependentTagsPolicyUtils,
     isControlPolicy,
     isMultiLevelTags as isMultiLevelTagsPolicyUtils,
+    tryNavigateToControlPolicyUpgrade,
 } from '@libs/PolicyUtils';
 
 import type {SettingsNavigatorParamList} from '@navigation/types';
@@ -134,7 +135,12 @@ function DynamicTagSettingsPage({route, navigation}: DynamicTagSettingsPageProps
     };
 
     const navigateToEditTagApprover = () => {
-        Navigation.navigate(isQuickSettingsFlow ? createDynamicRoute(DYNAMIC_ROUTES.SETTINGS_TAG_APPROVER.path) : createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_TAG_APPROVER.path));
+        const approverRoute = isQuickSettingsFlow ? createDynamicRoute(DYNAMIC_ROUTES.SETTINGS_TAG_APPROVER.path) : createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_TAG_APPROVER.path);
+        // Collect sees this section but the approver page is Control-only, so upgrade instead of hitting Not Found.
+        if (tryNavigateToControlPolicyUpgrade(policy, CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.alias, approverRoute)) {
+            return;
+        }
+        Navigation.navigate(approverRoute);
     };
 
     const isThereAnyAccountingConnection = Object.keys(policy?.connections ?? {}).length !== 0;

--- a/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
+++ b/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
@@ -171,7 +171,9 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.companyCards.id:
                 return route.params.backTo ? Navigation.goBack(route.params.backTo) : Navigation.goBack();
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.id:
-                return Navigation.goBack(route.params.backTo ?? ROUTES.WORKSPACE_MORE_FEATURES.getRoute(policyID));
+                // The Rules backTo can carry a tab the user was heading to. Comparing params would miss the already
+                // mounted Rules route and replace it instead of popping, so pop and let it take the new params.
+                return Navigation.goBack(route.params.backTo ?? ROUTES.WORKSPACE_MORE_FEATURES.getRoute(policyID), {compareParams: false});
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.perDiem.id:
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.invoicing.id:
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.companyCardSubmit.id:

--- a/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
+++ b/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
@@ -171,8 +171,7 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.companyCards.id:
                 return route.params.backTo ? Navigation.goBack(route.params.backTo) : Navigation.goBack();
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.id:
-                // The Rules backTo can carry a tab the user was heading to. Comparing params would miss the already
-                // mounted Rules route and replace it instead of popping, so pop and let it take the new params.
+                // The Rules backTo can carry a tab, and comparing params would replace the mounted route instead of popping.
                 return Navigation.goBack(route.params.backTo ?? ROUTES.WORKSPACE_MORE_FEATURES.getRoute(policyID), {compareParams: false});
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.perDiem.id:
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.invoicing.id:
@@ -251,7 +250,10 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
                 }
                 break;
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.rules.id:
-                enablePolicyRules(policy, true, false, policyDataRef.current);
+                // Re-enabling would re-run the sidebar's "just enabled" highlight on a row that already shows.
+                if (!policy?.areRulesEnabled) {
+                    enablePolicyRules(policy, true, false, policyDataRef.current);
+                }
                 break;
             case CONST.UPGRADE_FEATURE_INTRO_MAPPING.publicReceiptVisibility.id:
                 setPolicyReceiptVisibilityPublic(policyID, true, policy?.isReceiptVisibilityPublic);


### PR DESCRIPTION
### Explanation of Change

### Fixed Issues

$ [https://github.com/Expensify/App/issues/97641](<https://github.com/Expensify/App/issues/97641>)  <br>$ [https://github.com/Expensify/App/issues/97922](<https://github.com/Expensify/App/issues/97922>)  <br>$ [https://github.com/Expensify/App/issues/97840](<https://github.com/Expensify/App/issues/97840>)  <br>$ [https://github.com/Expensify/App/issues/97839](<https://github.com/Expensify/App/issues/97839>)  <br>PROPOSAL:

### Tests

## Expensify/App#97641 — Category rules on Collect

1. On a **Collect** workspace, go to **Settings → Categories → open a category**.
2. Verify **Description hint**, **Approver**, and **Category rules** are visible without upgrading.
3. Open **Description hint** and verify it goes to the **Rules upgrade** page, not **Not Here**. Upgrade and verify you return to Description hint.
4. On a fresh Collect workspace, repeat for **Approver**, **Create new rule**, and an existing Category rule.
5. From the upgrade page, press Back and verify you return to the category page.
6. Disable Rules from **More features** and verify **Category rules** is hidden.
7. On **Tags**, verify **Tag rules → Approver** is visible on Collect.
8. On **Control**, verify all category rows open directly without an upgrade page.

## Expensify/App#97839 — Categories blocked by accounting

1. On a workspace with Categories disabled, connect an accounting integration.
2. Go to **Rules → Field requirements → Create rule → Category → Enable categories**.
3. Verify the **Not so fast** modal appears. Confirm → Accounting page; Cancel → Categories remain disabled.
4. Repeat from **Flag for review → Create rule → Category**.
5. Disconnect accounting, repeat the flow, and verify Categories can be enabled.

## Expensify/App#97840 — Category empty state

1. On iOS/Android with Categories disabled, open **Rules → Field requirements → Create rule → Category**.
2. Rotate to landscape and verify the empty state is centered and **Enable categories** is fully visible.
3. Return to portrait and verify the layout remains correct.

## Expensify/App#97922 — Rules tab after upgrading

1. On Collect, go to **Rules → General → Agents banner → Try it out → Upgrade → Got it, thanks**.
2. Verify you land on **Agents**, and Back leaves Rules without an extra Rules page.
3. Repeat for **Card restrictions**, **Expense defaults**, **Field requirements**, and **Flag for review**; verify each returns to the selected tab.
4. Back out of an upgrade without upgrading and verify you return to **General**.
5. After landing on Agents, switch between tabs and verify the selected tab doesn't reset.
6. On Control, verify all tabs open directly.
7. Upgrade Rules via **More features** and verify you return to More features as before.

- [X] Verify that no errors appear in the JS console

### Offline tests

- Same as test

### QA Steps

- Same as tests
- [X] Verify that no errors appear in the JS console

### PR Author Checklist

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
  - [X] I added steps for local testing in the `Tests` section
  - [X] I added steps for the expected offline behavior in the `Offline steps` section
  - [X] I added steps for Staging and/or Production testing in the `QA steps` section
  - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [X] I tested this PR with a [High Traffic account](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts>) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](<https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms>)
- [X] I ran the tests on **all platforms** & verified they passed on:
  - [X] Android: Native
  - [X] Android: mWeb Chrome
  - [X] iOS: Native
  - [X] iOS: mWeb Safari
  - [X] MacOS: Chrome / Safari
  - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code>))
  - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [X] I verified that comments were added to code that is not self explanatory
  - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](<https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80>)
    - [X] If any non-english text was added/modified, I used [JaimeGPT](<https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt>) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](<https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123>)
  - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](<https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs>)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](<https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md>)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
  - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
  - [X] A similar style doesn't already exist
  - [X] The style can't be created with an existing [StyleUtils](<https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts>) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
  - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [X] I verified that all the inputs inside a form are aligned with each other.
  - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](<https://github.com/Expensify/App/blob/main/tests/README.md>) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details><summary>Android: Native</summary>

</details>

<details><summary>Android: mWeb Chrome</summary>

</details>

<details><summary>iOS: Native</summary>

https://github.com/user-attachments/assets/294a2cf5-0aa6-4629-8d1f-1a7fda6d104d

</details>

<details><summary>iOS: mWeb Safari</summary>

</details>

<details><summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/4326cee6-9f90-4189-8146-6053ed7d8d03

https://github.com/user-attachments/assets/26c0105b-b0ca-4afb-bcb6-06b52796f048

https://github.com/user-attachments/assets/1d2e0962-9c4a-43ed-aa89-0fb5e4f12a38

</details>