### PR TITLE
[Hold BE] Send duplicatedFromTransactionID when duplicating an expense or report

### DIFF
--- a/src/libs/API/parameters/CreateDistanceRequestParams.ts
+++ b/src/libs/API/parameters/CreateDistanceRequestParams.ts
@@ -38,6 +38,9 @@ type CreateDistanceRequestParams = {
 
     /** When true, the backend defers auto-submit so batch expense creation (e.g. duplicate report) can finish before the report is submitted */
     shouldDeferAutoSubmit?: boolean;
+
+    /** ID of the root expense this one was intentionally copied from, so the backend skips the duplicate violation */
+    duplicatedFromTransactionID?: string;
 };
 
 export default CreateDistanceRequestParams;

--- a/src/libs/API/parameters/CreatePerDiemRequestParams.ts
+++ b/src/libs/API/parameters/CreatePerDiemRequestParams.ts
@@ -27,6 +27,9 @@ type CreatePerDiemRequestParams = {
 
     /** When true, the backend defers auto-submit so batch expense creation (e.g. duplicate report) can finish before the report is submitted */
     shouldDeferAutoSubmit?: boolean;
+
+    /** ID of the root expense this one was intentionally copied from, so the backend skips the duplicate violation */
+    duplicatedFromTransactionID?: string;
 };
 
 export default CreatePerDiemRequestParams;

--- a/src/libs/API/parameters/RequestMoneyParams.ts
+++ b/src/libs/API/parameters/RequestMoneyParams.ts
@@ -49,6 +49,9 @@ type RequestMoneyParams = {
 
     /** When true, the backend defers auto-submit so batch expense creation (e.g. duplicate report) can finish before the report is submitted */
     shouldDeferAutoSubmit?: boolean;
+
+    /** ID of the root expense this one was intentionally copied from, so the backend skips the duplicate violation */
+    duplicatedFromTransactionID?: string;
 };
 
 export default RequestMoneyParams;

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -136,6 +136,7 @@ type TransactionParams = {
     rate?: number;
     unit?: ValueOf<typeof CONST.TIME_TRACKING.UNIT>;
     commentType?: ValueOf<typeof CONST.TRANSACTION.TYPE>;
+    duplicatedFromTransactionID?: string;
 };
 
 type BuildOptimisticTransactionParams = {
@@ -375,6 +376,7 @@ function buildOptimisticTransaction(params: BuildOptimisticTransactionParams): T
         rate,
         unit,
         commentType,
+        duplicatedFromTransactionID,
     } = transactionParams;
     // transactionIDs are random, positive, 64-bit numeric strings.
     // Because JS can only handle 53-bit numbers, transactionIDs are strings in the front-end (just like reportActionID)
@@ -389,6 +391,9 @@ function buildOptimisticTransaction(params: BuildOptimisticTransactionParams): T
     }
     if (isDemoTransactionParam) {
         commentJSON.isDemoTransaction = true;
+    }
+    if (duplicatedFromTransactionID) {
+        commentJSON.duplicatedFromTransactionID = duplicatedFromTransactionID;
     }
     if (source) {
         commentJSON.source = source;

--- a/src/libs/actions/IOU/Duplicate.ts
+++ b/src/libs/actions/IOU/Duplicate.ts
@@ -626,6 +626,9 @@ function buildDuplicateTransactionParams(transaction: OnyxTypes.Transaction, tra
         merchant: transaction.modifiedMerchant ? transaction.modifiedMerchant : (transaction.merchant ?? ''),
         modifiedAmount: undefined,
         originalTransactionID: undefined,
+
+        // Point at the root expense so a copy of a copy links back to the same one the backend already knows about
+        duplicatedFromTransactionID: transaction.comment?.duplicatedFromTransactionID ?? transaction.transactionID,
         odometerStart: transaction.comment?.odometerStart ?? undefined,
         odometerEnd: transaction.comment?.odometerEnd ?? undefined,
         receipt: undefined,

--- a/src/libs/actions/IOU/MoneyRequestBuilder.ts
+++ b/src/libs/actions/IOU/MoneyRequestBuilder.ts
@@ -129,6 +129,9 @@ type RequestMoneyTransactionParams = Omit<BaseTransactionParams, 'comment'> & {
     waypoints?: WaypointCollection;
     comment?: string;
     originalTransactionID?: string;
+
+    /** ID of the root expense this one was intentionally copied from */
+    duplicatedFromTransactionID?: string;
     isTestDrive?: boolean;
     source?: string;
     pendingAction?: PendingAction;
@@ -1496,6 +1499,7 @@ function getMoneyRequestInformation(moneyRequestInformation: MoneyRequestInforma
             waypoints,
             odometerStart,
             odometerEnd,
+            duplicatedFromTransactionID: transactionParams.duplicatedFromTransactionID,
         },
         isDemoTransactionParam: transactionParams.receipt?.isTestDriveReceipt,
     });

--- a/src/libs/actions/IOU/PerDiem.ts
+++ b/src/libs/actions/IOU/PerDiem.ts
@@ -214,6 +214,9 @@ type PerDiemExpenseTransactionParams = Omit<BaseTransactionParams, 'amount' | 'm
     attendees?: Attendee[];
     customUnit: TransactionCustomUnit;
     comment?: string;
+
+    /** ID of the root expense this one was intentionally copied from */
+    duplicatedFromTransactionID?: string;
 };
 
 type RecentlyUsedParams = {
@@ -440,6 +443,7 @@ function getPerDiemExpenseInformation(perDiemExpenseInformation: PerDiemExpenseI
             reimbursable,
             pendingFields: {subRates: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD},
             attendees,
+            duplicatedFromTransactionID: transactionParams.duplicatedFromTransactionID,
         },
     });
     iouReport.transactionCount = (iouReport.transactionCount ?? 0) + 1;
@@ -927,7 +931,7 @@ function submitPerDiemExpense(submitPerDiemExpenseInformation: PerDiemExpenseInf
         delegateAccountID,
         isTrackIntentUser,
     } = submitPerDiemExpenseInformation;
-    const {currency, comment = '', category, tag, created, customUnit, attendees, isFromGlobalCreate} = transactionParams;
+    const {currency, comment = '', category, tag, created, customUnit, attendees, isFromGlobalCreate, duplicatedFromTransactionID} = transactionParams;
 
     if (
         isEmptyObject(policyParams.policy) ||
@@ -1018,6 +1022,7 @@ function submitPerDiemExpense(submitPerDiemExpenseInformation: PerDiemExpenseInf
         attendees: attendees ? JSON.stringify(attendees) : undefined,
         customUnitPolicyID,
         shouldDeferAutoSubmit,
+        duplicatedFromTransactionID,
     };
 
     if (shouldPlaySoundParam) {

--- a/src/libs/actions/IOU/Split.ts
+++ b/src/libs/actions/IOU/Split.ts
@@ -122,6 +122,9 @@ type DistanceRequestTransactionParams = BaseTransactionParams & {
     odometerEnd?: number;
     gpsCoordinates?: string;
     distanceRequestType?: string;
+
+    /** ID of the root expense this one was intentionally copied from */
+    duplicatedFromTransactionID?: string;
 };
 
 type CreateDistanceRequestInformation = {
@@ -2021,6 +2024,7 @@ function createDistanceRequest(distanceRequestInformation: CreateDistanceRequest
         isFromGlobalCreate,
         gpsCoordinates,
         distanceRequestType,
+        duplicatedFromTransactionID,
     } = transactionParams;
 
     // If the report is an iou or expense report, we should get the linked chat report to be passed to the getMoneyRequestInformation function
@@ -2167,6 +2171,7 @@ function createDistanceRequest(distanceRequestInformation: CreateDistanceRequest
                 waypoints: validWaypoints,
                 odometerStart,
                 odometerEnd,
+                duplicatedFromTransactionID,
             },
             shouldGenerateTransactionThreadReport: false,
             isASAPSubmitBetaEnabled,
@@ -2238,6 +2243,7 @@ function createDistanceRequest(distanceRequestInformation: CreateDistanceRequest
             gpsCoordinates,
             distanceRequestType,
             shouldDeferAutoSubmit,
+            duplicatedFromTransactionID,
         };
     }
 

--- a/src/libs/actions/IOU/TrackExpense.ts
+++ b/src/libs/actions/IOU/TrackExpense.ts
@@ -1693,6 +1693,7 @@ function requestMoney(requestMoneyInformation: RequestMoneyInformation): {iouRep
         rate,
         unit,
         isFromGlobalCreate = false,
+        duplicatedFromTransactionID,
     } = transactionParams;
 
     const testDriveCommentReportActionID = isTestDrive ? NumberUtils.rand64() : undefined;
@@ -1912,6 +1913,7 @@ function requestMoney(requestMoneyInformation: RequestMoneyInformation): {iouRep
                       }
                     : {}),
                 shouldDeferAutoSubmit,
+                duplicatedFromTransactionID,
             };
 
             deferredAPIWrite = () => {

--- a/src/types/onyx/Transaction.ts
+++ b/src/types/onyx/Transaction.ts
@@ -104,6 +104,9 @@ type Comment = {
     /** ID of the original transaction */
     originalTransactionID?: string;
 
+    /** ID of the root expense this one was intentionally copied from, so duplicate detection can skip the copies */
+    duplicatedFromTransactionID?: string;
+
     /** In split transactions this is a collection of participant split data */
     splits?: Split[];
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

buildDuplicateTransactionParams sends the source's root ID (comment.duplicatedFromTransactionID ?? transactionID) so a copy of a copy points at the same root. Plumbs the field through the transaction type, optimistic transaction builder and the three create-expense param paths. tsc clean.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98146
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Create a report
2. Add a valid expense (no error)
3. Go to spend -> report
4. Select a report from step 1
5. Duplicate
6. Verify there's no error

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
10. Upload an image via copy paste
11. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/9245bf85-fbfe-49e8-9a0b-0be2cd42b4fd


</details>
