### PR TITLE
[No QA] Align artifacts ruby scripts with RN 0.86

### DIFF
--- a/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
+++ b/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
@@ -18,8 +18,8 @@ module PatchedIOSArtifacts
     # Tarballs fetched during setup, keyed by remote URL, so nothing downloads mid-install.
     @prefetched = {}
 
-    # Our own tag rather than react-native's, so it is obvious which code produced a line.
-    LOG_PREFIX = '[PatchedIOSArtifacts]'
+    # Matches the resolver and Gradle, so one tag covers artifact logging on both platforms.
+    LOG_PREFIX = '[PatchedArtifacts]'
 
     def self.log(message, level = :info)
         return unless defined?(Pod::UI)

--- a/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
+++ b/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
@@ -114,7 +114,7 @@ module PatchedIOSArtifacts
     end
 
     # Fetches everything the install needs while the prebuilt/source decision is still reversible, so
-    # any failure downgrades to a source build. After pod resolution, switching would desync the sandbox.
+    # any failure downgrades to a source build. After pod resolution, switching would leave a mixed sandbox.
     def self.prefetch(resolution)
         return resolution if resolution['buildFromSource']
 

--- a/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
+++ b/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
@@ -3,6 +3,8 @@
 # download at our private GitHub Packages Maven repo (matched by patches hash).
 # Must be required after react_native_pods.rb, which defines ReactNativeCoreUtils.
 
+require 'digest'
+require 'fileutils'
 require 'json'
 
 module PatchedIOSArtifacts
@@ -13,13 +15,25 @@ module PatchedIOSArtifacts
     # setup never ran, prebuilt-only pod tweaks are a no-op rather than misapplied.
     @using_prebuilt = false
 
+    # Tarballs fetched during setup, keyed by remote URL, so nothing downloads mid-install.
+    @prefetched = {}
+
+    # Our own tag rather than react-native's, so it is obvious which code produced a line.
+    LOG_PREFIX = '[PatchedIOSArtifacts]'
+
+    def self.log(message, level = :info)
+        return unless defined?(Pod::UI)
+        level == :error ? Pod::UI.warn("#{LOG_PREFIX} #{message}") : Pod::UI.puts("#{LOG_PREFIX} #{message}")
+    end
+
     def self.setup
         is_hybrid = ENV['IS_HYBRID_APP'] == 'true'
         package_name = is_hybrid ? 'react-hybrid' : 'react-standalone'
 
         # Manual escape hatch: force a full from-source build (e.g. to unblock a prebuild issue).
         build_from_source = ENV['BUILD_RN_FROM_SOURCE'] == '1'
-        resolution = build_from_source ? {'buildFromSource' => true, 'version' => nil} : resolve(package_name, is_hybrid)
+        # The escape hatch short-circuits before anything touches the network: no resolver, no prefetch.
+        resolution = build_from_source ? {'buildFromSource' => true, 'version' => nil} : prefetch(resolve(package_name, is_hybrid))
 
         # A single decision drives both prebuilt flags, so we never land in a mixed
         # prebuilt-deps / source-core state (which desyncs the CocoaPods sandbox).
@@ -46,6 +60,8 @@ module PatchedIOSArtifacts
     def self.configure_prebuilt_pods(installer)
         return unless @using_prebuilt
 
+        assert_local_rncore_source(installer)
+
         installer.pod_targets.each do |pod|
             # RNFB and RNSentry #import non-modular <React/...> headers, which under
             # use_frameworks! with a prebuilt React Core trips Clang's modular-import
@@ -58,6 +74,109 @@ module PatchedIOSArtifacts
         end
     end
 
+    # CocoaPods downloads podspec sources itself, without our token, so a remote URL here always 401s.
+    # Runs before pods download, to name the cause instead of leaving a bare curl failure.
+    def self.assert_local_rncore_source(installer)
+        source = installer.pod_targets.find { |pod| pod.name == 'React-Core-prebuilt' }&.root_spec&.source
+        url = source.is_a?(Hash) ? source[:http].to_s : ''
+        return unless url.start_with?('http://', 'https://')
+        raise "#{LOG_PREFIX} React-Core-prebuilt resolved to the remote URL #{url}, which CocoaPods " \
+              'cannot authenticate against. Its source must be the tarball we download ourselves — check whether ' \
+              'react-native changed how it resolves the prebuilt RNCore podspec source.'
+    end
+
+    # Shared with stable_tarball_url, so the prefetch cannot miss a classifier the install asks for.
+    def self.classifier(build_type, dsyms)
+        "reactnative-core-#{dsyms ? 'dSYM-' : ''}#{build_type}"
+    end
+
+    def self.required_classifiers
+        build_types = [:debug, :release]
+        # dSYMs only when asked for, matching ReactNativeCoreUtils' @@download_dsyms.
+        dsym_types = ENV['RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS'] == '1' ? build_types : []
+        build_types.map { |type| classifier(type, false) } + dsym_types.map { |type| classifier(type, true) }
+    end
+
+    def self.prefetched_path(tarball_url)
+        @prefetched[tarball_url]
+    end
+
+    # Mirrors react-native's own artifact cache, keyed by artifact version because our filenames are
+    # indistinguishable from vanilla ones. Pruned to a single version, so it cannot grow over time.
+    CACHE_ROOT = File.join(Dir.home, 'Library', 'Caches', 'Expensify', 'react-native-artifacts')
+
+    def self.prune_cache(version)
+        Dir.glob(File.join(CACHE_ROOT, '*')).each do |entry|
+            next if File.basename(entry) == version
+            FileUtils.rm_rf(entry)
+            log("Removed stale cached artifacts for #{File.basename(entry)}")
+        end
+    end
+
+    # Fetches everything the install needs while the prebuilt/source decision is still reversible, so
+    # any failure downgrades to a source build. After pod resolution, switching would desync the sandbox.
+    def self.prefetch(resolution)
+        return resolution if resolution['buildFromSource']
+
+        version = resolution['version'].to_s
+        prefetched = {}
+        required_classifiers.each do |name|
+            url = "#{resolution['artifactUrlPrefix']}-#{name}.tar.gz"
+            destination = File.join(CACHE_ROOT, version, "#{name}.tar.gz")
+            prefetched[url] = download_and_verify(url, destination, resolution['githubToken'])
+        end
+        prune_cache(version)
+        @prefetched = prefetched
+        resolution
+    rescue => e
+        log("#{e.message} Building react-native from source.", :error)
+        @prefetched = {}
+        {'buildFromSource' => true, 'version' => nil}
+    end
+
+    # curl drops the Authorization header on the cross-host redirect to the object store.
+    def self.auth_header(github_token)
+        github_token ? %(-H "Authorization: Bearer #{github_token}") : ''
+    end
+
+    # react-native's validate_tarball, plus the token its own curl cannot carry. As upstream does, a
+    # checksum Maven does not serve skips validation rather than failing the fetch.
+    def self.checksum_valid?(path, name, url, github_token)
+        expected = `curl -sL #{auth_header(github_token)} "#{url}.sha1"`.strip.downcase
+        unless $?.success? && expected.match?(/\A[a-f0-9]{40}\z/)
+            log("SHA1 not available from Maven for #{name}. Skipping validation.")
+            return true
+        end
+        actual = Digest::SHA1.file(path).hexdigest
+        if actual == expected
+            log("SHA1 verified for #{name}")
+            return true
+        end
+        log("SHA1 mismatch for #{name}: expected #{expected}, got #{actual}", :error)
+        false
+    end
+
+    # Verified here because a corrupt archive would otherwise only surface at extraction, too late to fall back.
+    def self.download_and_verify(url, destination, github_token)
+        name = File.basename(destination)
+        if File.exist?(destination)
+            log("Cache hit: #{name} already in #{File.dirname(destination)}. Skipping download.")
+            return destination
+        end
+
+        log("Cache miss: downloading #{name} from #{url}")
+        tmp = "#{destination}.download"
+        FileUtils.mkdir_p(File.dirname(destination))
+        downloaded = system(%(curl --fail --location --proto '=https' #{auth_header(github_token)} "#{url}" -o "#{tmp}"))
+        log("Verifying checksum for #{name}...") if downloaded
+        unless downloaded && checksum_valid?(tmp, name, url, github_token)
+            FileUtils.rm_f(tmp)
+            raise "Could not fetch a usable #{name} from #{url}."
+        end
+        FileUtils.mv(tmp, destination)
+        destination
+    end
+
     def self.resolve(package_name, is_hybrid)
         cmd = [
             'bun', File.join(NEW_DOT_ROOT, 'scripts/artifacts-utils/resolve-artifacts.ts'),
@@ -68,7 +187,7 @@ module PatchedIOSArtifacts
         raise "resolver exited #{$?.exitstatus}" unless $?.success?
         JSON.parse(output)
     rescue => e
-        Pod::UI.warn("[PatchedIOSArtifacts] Resolver failed (#{e.message}); building from source.") if defined?(Pod::UI)
+        log("Resolver failed (#{e.message}); building from source.", :error)
         {'buildFromSource' => true, 'version' => nil}
     end
 end
@@ -84,22 +203,51 @@ class ReactNativeCoreUtils
     end
 
     def self.stable_tarball_url(_version, build_type, dsyms = false)
-        classifier = "reactnative-core-#{dsyms ? 'dSYM-' : ''}#{build_type}"
-        "#{@@patched_artifact_url_prefix}-#{classifier}.tar.gz"
+        "#{@@patched_artifact_url_prefix}-#{PatchedIOSArtifacts.classifier(build_type, dsyms)}.tar.gz"
     end
 
+    # Since 0.86 react-native returns the remote URL here unless dSYMs are downloaded, leaving the
+    # download to CocoaPods, which sends no Authorization header. Point the podspec at our own
+    # authenticated download instead — unconditionally, so RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS stops
+    # changing how the source resolves. Release is needed too: the script phase swaps it in at compile time.
+    def self.podspec_source_download_prebuild_stable_tarball
+        return if @@build_from_source
+
+        debug = download_stable_rncore(@@react_native_path, @@react_native_version, :debug)
+        release = download_stable_rncore(@@react_native_path, @@react_native_version, :release)
+
+        if @@download_dsyms
+            process_dsyms(debug, download_stable_rncore(@@react_native_path, @@react_native_version, :debug, true))
+            process_dsyms(release, download_stable_rncore(@@react_native_path, @@react_native_version, :release, true))
+        end
+
+        {:http => ReactNativePodsUtils.local_file_uri(debug)}
+    end
+
+    # Overriding this also keeps our artifacts out of react-native's shared cache, where their filenames
+    # would be indistinguishable from vanilla ones. That cache still serves ReactNativeDependencies.
     def self.download_rncore_tarball(_react_native_path, tarball_url, version, configuration, dsyms = false)
         dir = artifacts_dir
         destination = configuration.nil? ?
             "#{dir}/reactnative-core-#{version}#{dsyms ? '-dSYM' : ''}.tar.gz" :
             "#{dir}/reactnative-core-#{version}#{dsyms ? '-dSYM' : ''}-#{configuration}.tar.gz"
 
-        unless File.exist?(destination)
+        prefetched = PatchedIOSArtifacts.prefetched_path(tarball_url)
+        if prefetched
+            # Overwrite unconditionally: this filename carries only the react-native version, so a leftover
+            # from an earlier patches version looks identical to the one we actually resolved.
+            FileUtils.mkdir_p(dir)
+            FileUtils.cp(prefetched, destination)
+            PatchedIOSArtifacts.log("Installed #{File.basename(destination)} into Pods from cache")
+        elsif !File.exist?(destination)
+            # Only if something asks for a classifier the prefetch did not anticipate. abort, because
+            # react-native rescues exceptions here and carries on with a nil source.
+            FileUtils.mkdir_p(dir)
             tmp = "#{dir}/reactnative-core.download"
             # curl drops the Authorization header on the cross-host redirect to the object store.
             header = @@patched_github_token ? %(-H "Authorization: Bearer #{@@patched_github_token}") : ''
-            ok = system(%(mkdir -p "#{dir}" && curl --fail --location --proto '=https' #{header} "#{tarball_url}" -o "#{tmp}" && mv "#{tmp}" "#{destination}"))
-            raise "[PatchedIOSArtifacts] Failed to download #{tarball_url}" unless ok
+            ok = system(%(curl --fail --location --proto '=https' #{header} "#{tarball_url}" -o "#{tmp}" && mv "#{tmp}" "#{destination}"))
+            abort("#{PatchedIOSArtifacts::LOG_PREFIX} Failed to download #{tarball_url}") unless ok
         end
         destination
     end

--- a/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
+++ b/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
@@ -101,15 +101,17 @@ module PatchedIOSArtifacts
         @prefetched[tarball_url]
     end
 
-    # Mirrors react-native's own artifact cache, keyed by artifact version because our filenames are
-    # indistinguishable from vanilla ones. Pruned to a single version, so it cannot grow over time.
+    # Mirrors react-native's own artifact cache, keyed by package and artifact version: our filenames are
+    # indistinguishable from vanilla ones, and the hybrid and standalone packages number their versions
+    # independently, so a version alone does not identify an artifact. Each package keeps a single
+    # version, so the cache cannot grow over time and one package never evicts the other.
     CACHE_ROOT = File.join(Dir.home, 'Library', 'Caches', 'Expensify', 'react-native-artifacts')
 
-    def self.prune_cache(version)
-        Dir.glob(File.join(CACHE_ROOT, '*')).each do |entry|
+    def self.prune_cache(package, version)
+        Dir.glob(File.join(CACHE_ROOT, package, '*')).each do |entry|
             next if File.basename(entry) == version
             FileUtils.rm_rf(entry)
-            log("Removed stale cached artifacts for #{File.basename(entry)}")
+            log("Removed stale cached artifacts for #{package}:#{File.basename(entry)}")
         end
     end
 
@@ -118,14 +120,15 @@ module PatchedIOSArtifacts
     def self.prefetch(resolution)
         return resolution if resolution['buildFromSource']
 
+        package = resolution['packageName'].to_s
         version = resolution['version'].to_s
         prefetched = {}
         required_classifiers.each do |name|
             url = "#{resolution['artifactUrlPrefix']}-#{name}.tar.gz"
-            destination = File.join(CACHE_ROOT, version, "#{name}.tar.gz")
+            destination = File.join(CACHE_ROOT, package, version, "#{name}.tar.gz")
             prefetched[url] = download_and_verify(url, destination, resolution['githubToken'])
         end
-        prune_cache(version)
+        prune_cache(package, version)
         @prefetched = prefetched
         resolution
     rescue => e


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
### Problem

- RN 0.86 changed `rncore.rb`: unless dSYMs are requested, `podspec_source_download_prebuild_stable_tarball` returns the **remote Maven URL** as `React-Core-prebuilt`'s podspec source instead of the local file it just downloaded (0.85.3 always returned `file://`).
- Our authenticated download succeeds, but CocoaPods then re-fetches that URL with its own downloader, which sends no `Authorization` header → 401 on GitHub Packages → `Error installing React-Core-prebuilt` → pod install dies. Every hybrid iOS build on `main` has failed since the 0.86 upgrade; standalone is unaffected. `RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS=1` masks it, so manual testing could miss it.

### Fixes

- Point the podspec at the tarball we already fetched with the token, unconditionally on both the dSYM and non-dSYM paths.
- **Separate latent bug:** `download_rncore_tarball` skipped the download when the destination existed, but that filename encodes only the RN version — so after changing `patches/` the build silently reused the previous artifact. Now overwritten unconditionally.

### Improvements

- **Safe fallback:** artifact fetching moved into `setup`, before the prebuilt/source decision is irreversible. Missing token, 401, half-published version, truncated transfer or SHA1 mismatch now degrade to a source build instead of failing pod install. `BUILD_RN_FROM_SOURCE=1` still short-circuits before any network access.
- **SHA1 verification** mirroring RN's `validate_tarball`, plus the token its own curl cannot carry.
- **Cache** at `~/Library/Caches/Expensify/react-native-artifacts/<artifact-version>/`, keyed by artifact version (our filenames are indistinguishable from vanilla ones) and pruned to a single version, so it cannot grow. RN's own cache is left untouched and keeps serving `ReactNativeDependencies`.
- **Tripwire in `pre_install`** if `React-Core-prebuilt` ever resolves to a remote URL again, plus `raise` → `abort` on download failure (RN rescues exceptions here and continues with a `nil` source), and all artifact logging under one `[PatchedArtifacts]` tag shared with the resolver and Gradle.

### Companion PR

- Mobile-Expensify: regenerated `iOS/Podfile.lock` (adds `React-Core-prebuilt`; the committed lock came from a from-source install). Must land together.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98190
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:



--->

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/14052

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

All steps target **HybridApp iOS** — `npm run pod-install` without `STANDALONE_NEW_DOT` is the hybrid path. Standalone does not consume a prebuilt RNCore and is unaffected by this PR.

1. **Prerequisites** — `gh auth status` must list the `read:packages` scope, then run `npm install`.

2. **Happy path** — `npm run pod-install`, then `npm run ios`.
   Expected in the log:

    ```
    [PatchedArtifacts] Using patched react-native artifacts: react-hybrid:<version>
    [PatchedArtifacts] Cache miss: downloading reactnative-core-debug.tar.gz from https://...
    [PatchedArtifacts] SHA1 verified for reactnative-core-debug.tar.gz
    [PatchedArtifacts] Installed reactnative-core-<rn-version>-debug.tar.gz into Pods from cache
    ```

    The app builds and launches.

3. **Cache hit** — run `npm run pod-install` a second time. Expect `Cache hit: ... Skipping download.` for both classifiers and no download at all.

4. **Stale cache pruning** — plant a fake version and reinstall:

    ```bash
    mkdir -p ~/Library/Caches/Expensify/react-native-artifacts/0.0.0-0
    npm run pod-install
    ls ~/Library/Caches/Expensify/react-native-artifacts   # only the resolved version should remain
    ```

    Expect `Removed stale cached artifacts for 0.0.0-0`.

5. **Fallback to a source build** — pod install must complete successfully in both cases:
    ```bash
    BUILD_RN_FROM_SOURCE=1 npm run pod-install    # no artifact network access at all
    CI=1 GITHUB_TOKEN=invalid npm run pod-install  # warning, then "Building react-native from source."
    ```
    Note: these compile react-native from source, so the following build will take a while.


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
-

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
