### PR TITLE
fix: stop Search re-firing an identical query on unrelated Onyx updates

### DIFF
--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -114,25 +114,36 @@ function useSearchHighlightAndScroll({
             }
             hasPendingSearchRef.current = false;
 
-            // Read the IDs off the transactions themselves: `transactionsIDs` are Onyx collection keys
-            // (`transactions_<id>`) while the search results yield bare IDs, so the two never compare equal.
-            const newIDs = isChat
-                ? reportActionsIDs
-                : Object.values(transactions ?? {})
-                      .map((transaction) => transaction?.transactionID)
-                      .filter((id): id is string => !!id);
+            // Read the IDs off the transactions themselves: their Onyx keys are `transactions_<id>` while the
+            // search results yield bare IDs, so the two never compare equal.
+            // `addedIDs` drives the new-item check and `currentIDs` the deletion check. They cannot be the same
+            // list: the collection holds every transaction cached on the account, so on a filtered or paginated
+            // query it always contains an ID the results omit, which would make every pass look like a new item.
+            const addedIDs: string[] = [];
+            const currentIDs: string[] = [];
+            for (const [key, transaction] of Object.entries(transactions ?? {})) {
+                const transactionID = transaction?.transactionID;
+                if (!transactionID) {
+                    continue;
+                }
+                currentIDs.push(transactionID);
+                if (!previousTransactionsIDsSet.has(key)) {
+                    addedIDs.push(transactionID);
+                }
+            }
+
             let currentSearchResultIDs: string[] = [];
             if (searchResultsData) {
                 currentSearchResultIDs = isChat ? extractReportActionIDsFromSearchResults(searchResultsData) : extractTransactionIDsFromSearchResults(searchResultsData);
             }
             const existingSearchResultIDsSet = new Set(currentSearchResultIDs);
-            const hasAGenuinelyNewID = newIDs.some((id) => !existingSearchResultIDsSet.has(id));
+            const hasAGenuinelyNewID = (isChat ? reportActionsIDs : addedIDs).some((id) => !existingSearchResultIDsSet.has(id));
 
             // Only skip search if there are no new items AND search results aren't empty
             // This ensures deletions that result in empty data still trigger search
             if (!hasAGenuinelyNewID && currentSearchResultIDs.length > 0) {
-                const newIDsSet = new Set(newIDs);
-                const hasDeletedID = currentSearchResultIDs.some((id) => !newIDsSet.has(id));
+                const currentIDsSet = new Set(isChat ? reportActionsIDs : currentIDs);
+                const hasDeletedID = currentSearchResultIDs.some((id) => !currentIDsSet.has(id));
                 if (!hasDeletedID) {
                     return;
                 }

--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -114,11 +114,7 @@ function useSearchHighlightAndScroll({
             }
             hasPendingSearchRef.current = false;
 
-            // Read the IDs off the transactions themselves: their Onyx keys are `transactions_<id>` while the
-            // search results yield bare IDs, so the two never compare equal.
-            // `addedIDs` drives the new-item check and `currentIDs` the deletion check. They cannot be the same
-            // list: the collection holds every transaction cached on the account, so on a filtered or paginated
-            // query it always contains an ID the results omit, which would make every pass look like a new item.
+            // Transaction Onyx keys are `transactions_<id>` but search results yield bare IDs, so read the ID off the value.
             const addedIDs: string[] = [];
             const currentIDs: string[] = [];
             for (const [key, transaction] of Object.entries(transactions ?? {})) {

--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -115,16 +115,16 @@ function useSearchHighlightAndScroll({
             hasPendingSearchRef.current = false;
 
             // Transaction Onyx keys are `transactions_<id>` but search results yield bare IDs, so read the ID off the value.
-            const addedIDs: string[] = [];
-            const currentIDs: string[] = [];
+            const addedTransactionIDs: string[] = [];
+            const currentTransactionIDs: string[] = [];
             for (const [key, transaction] of Object.entries(transactions ?? {})) {
                 const transactionID = transaction?.transactionID;
                 if (!transactionID) {
                     continue;
                 }
-                currentIDs.push(transactionID);
+                currentTransactionIDs.push(transactionID);
                 if (!previousTransactionsIDsSet.has(key)) {
-                    addedIDs.push(transactionID);
+                    addedTransactionIDs.push(transactionID);
                 }
             }
 
@@ -133,12 +133,12 @@ function useSearchHighlightAndScroll({
                 currentSearchResultIDs = isChat ? extractReportActionIDsFromSearchResults(searchResultsData) : extractTransactionIDsFromSearchResults(searchResultsData);
             }
             const existingSearchResultIDsSet = new Set(currentSearchResultIDs);
-            const hasAGenuinelyNewID = (isChat ? reportActionsIDs : addedIDs).some((id) => !existingSearchResultIDsSet.has(id));
+            const hasAGenuinelyNewID = (isChat ? reportActionsIDs : addedTransactionIDs).some((id) => !existingSearchResultIDsSet.has(id));
 
             // Only skip search if there are no new items AND search results aren't empty
             // This ensures deletions that result in empty data still trigger search
             if (!hasAGenuinelyNewID && currentSearchResultIDs.length > 0) {
-                const currentIDsSet = new Set(isChat ? reportActionsIDs : currentIDs);
+                const currentIDsSet = new Set(isChat ? reportActionsIDs : currentTransactionIDs);
                 const hasDeletedID = currentSearchResultIDs.some((id) => !currentIDsSet.has(id));
                 if (!hasDeletedID) {
                     return;

--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -85,18 +85,16 @@ function useSearchHighlightAndScroll({
         const previousTransactionIDsLocal = Object.keys(previousTransactions ?? {});
         const transactionsIDs = Object.keys(transactions ?? {});
 
-        const reportActionsIDs = Object.values(reportActions ?? {})
-            .map((actions) => Object.keys(actions ?? {}))
-            .flat();
-        const previousReportActionsIDs = Object.values(previousReportActions ?? {})
-            .map((actions) => Object.keys(actions ?? {}))
-            .flat();
-
         // Only proceed if we have previous data to compare against
         // This prevents triggering on initial data load
-        if ((previousTransactionIDsLocal.length === 0 && previousReportActionsIDs.length === 0) || searchTriggeredRef.current) {
+        const hasPreviousReportActions = Object.values(previousReportActions ?? {}).some((actions) => Object.keys(actions ?? {}).length > 0);
+        if ((previousTransactionIDsLocal.length === 0 && !hasPreviousReportActions) || searchTriggeredRef.current) {
             return;
         }
+
+        // Only chat searches are driven by report actions, so the rest skip walking that collection entirely.
+        const reportActionsIDs = isChat ? Object.values(reportActions ?? {}).flatMap((actions) => Object.keys(actions ?? {})) : [];
+        const previousReportActionsIDs = isChat ? Object.values(previousReportActions ?? {}).flatMap((actions) => Object.keys(actions ?? {})) : [];
 
         const previousTransactionsIDsSet = new Set(previousTransactionIDsLocal);
         const previousReportActionsIDsSet = new Set(previousReportActionsIDs);
@@ -104,7 +102,7 @@ function useSearchHighlightAndScroll({
         const hasReportActionsIDsChange = reportActionsIDs.some((id) => !previousReportActionsIDsSet.has(id));
 
         // Check if there is a change in the transactions or report actions list
-        if ((!isChat && hasTransactionsIDsChange) || (isChat && hasReportActionsIDsChange) || hasPendingSearchRef.current) {
+        if ((isChat ? hasReportActionsIDsChange : hasTransactionsIDsChange) || hasPendingSearchRef.current) {
             // Skip if offline, or if the user has navigated to a different fullscreen page entirely.
             // An RHP layered on top of Search makes `isFocused` false but keeps Search as the topmost
             // fullscreen route, so we still want to refetch — otherwise the snapshot can't reflect
@@ -116,9 +114,13 @@ function useSearchHighlightAndScroll({
             }
             hasPendingSearchRef.current = false;
 
-            // `transactionsIDs` are Onyx collection keys (`transactions_<id>`), while the search results yield bare
-            // transaction IDs, so the prefix has to come off before the two can be compared.
-            const newIDs = isChat ? reportActionsIDs : transactionsIDs.map((key) => key.slice(ONYXKEYS.COLLECTION.TRANSACTION.length));
+            // Read the IDs off the transactions themselves: `transactionsIDs` are Onyx collection keys
+            // (`transactions_<id>`) while the search results yield bare IDs, so the two never compare equal.
+            const newIDs = isChat
+                ? reportActionsIDs
+                : Object.values(transactions ?? {})
+                      .map((transaction) => transaction?.transactionID)
+                      .filter((id): id is string => !!id);
             let currentSearchResultIDs: string[] = [];
             if (searchResultsData) {
                 currentSearchResultIDs = isChat ? extractReportActionIDsFromSearchResults(searchResultsData) : extractTransactionIDsFromSearchResults(searchResultsData);

--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -104,7 +104,7 @@ function useSearchHighlightAndScroll({
         const hasReportActionsIDsChange = reportActionsIDs.some((id) => !previousReportActionsIDsSet.has(id));
 
         // Check if there is a change in the transactions or report actions list
-        if ((!isChat && hasTransactionsIDsChange) || hasReportActionsIDsChange || hasPendingSearchRef.current) {
+        if ((!isChat && hasTransactionsIDsChange) || (isChat && hasReportActionsIDsChange) || hasPendingSearchRef.current) {
             // Skip if offline, or if the user has navigated to a different fullscreen page entirely.
             // An RHP layered on top of Search makes `isFocused` false but keeps Search as the topmost
             // fullscreen route, so we still want to refetch — otherwise the snapshot can't reflect
@@ -116,7 +116,9 @@ function useSearchHighlightAndScroll({
             }
             hasPendingSearchRef.current = false;
 
-            const newIDs = isChat ? reportActionsIDs : transactionsIDs;
+            // `transactionsIDs` are Onyx collection keys (`transactions_<id>`), while the search results yield bare
+            // transaction IDs, so the prefix has to come off before the two can be compared.
+            const newIDs = isChat ? reportActionsIDs : transactionsIDs.map((key) => key.slice(ONYXKEYS.COLLECTION.TRANSACTION.length));
             let currentSearchResultIDs: string[] = [];
             if (searchResultsData) {
                 currentSearchResultIDs = isChat ? extractReportActionIDsFromSearchResults(searchResultsData) : extractTransactionIDsFromSearchResults(searchResultsData);

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+// These tests build the hook props partially, so every rerender/initialProps call needs a @ts-expect-error.
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {renderHook} from '@testing-library/react-native';
 
 import useSearchHighlightAndScroll from '@hooks/useSearchHighlightAndScroll';
@@ -86,7 +88,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -100,7 +101,6 @@ describe('useSearchHighlightAndScroll', () => {
             previousTransactions: {transactions_1: {transactionID: '1'}},
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
@@ -118,7 +118,6 @@ describe('useSearchHighlightAndScroll', () => {
             transactions: {transactions_1: {transactionID: '1'}},
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -143,7 +142,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps: chatProps,
         });
@@ -158,7 +156,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).toHaveBeenCalledWith({queryJSON: chatProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
@@ -178,7 +175,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -190,7 +186,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -214,7 +209,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -227,7 +221,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
@@ -252,7 +245,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -265,7 +257,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -302,7 +293,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -317,7 +307,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -344,7 +333,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -358,7 +346,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -385,7 +372,6 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps: chatProps,
         });
@@ -399,7 +385,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -431,7 +416,6 @@ describe('useSearchHighlightAndScroll', () => {
                 transactions_1: {transactionID: '1'},
             },
         };
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(result.current.newSearchResultKeys?.size).toBe(2);
@@ -445,10 +429,8 @@ describe('useSearchHighlightAndScroll', () => {
             focusTextInput: jest.fn(),
         };
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         result.current.handleSelectionListScroll([{transactionID: '1'}, {transactionID: '2'}], ref);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         result.current.handleSelectionListScroll([{transactionID: '2'}, {transactionID: '1'}], ref);
 
@@ -536,7 +518,6 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
         const {rerender, result} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps: chatProps,
         });
@@ -570,7 +551,6 @@ describe('useSearchHighlightAndScroll', () => {
                 },
             },
         };
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(result.current.newSearchResultKeys?.size).toBe(2);

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -323,6 +323,47 @@ describe('useSearchHighlightAndScroll', () => {
         expect(search).not.toHaveBeenCalled();
     });
 
+    it('should not trigger search when the added transaction is already in the results and Onyx holds one the query filters out', () => {
+        const initialProps = {
+            ...baseProps,
+            searchResults: {
+                ...baseProps.searchResults,
+                data: {
+                    transactions_1: {transactionID: '1'},
+                    transactions_2: {transactionID: '2'},
+                },
+            },
+            transactions: {
+                transactions_1: {transactionID: '1'},
+                transactions_99: {transactionID: '99'},
+            },
+            previousTransactions: {
+                transactions_1: {transactionID: '1'},
+                transactions_99: {transactionID: '99'},
+            },
+        };
+
+        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            initialProps,
+        });
+
+        const updatedProps = {
+            ...initialProps,
+            transactions: {
+                transactions_1: {transactionID: '1'},
+                transactions_99: {transactionID: '99'},
+                transactions_2: {transactionID: '2'},
+            },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        rerender(updatedProps);
+        expect(search).not.toHaveBeenCalled();
+    });
+
     it('should not trigger search for chat when report actions removed and focused', () => {
         mockUseIsFocused.mockReturnValue(true);
 

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -81,8 +81,8 @@ describe('useSearchHighlightAndScroll', () => {
     it('should trigger search when new transaction added and focused', () => {
         const initialProps = {
             ...baseProps,
-            transactions: {'1': {transactionID: '1'}},
-            previousTransactions: {'1': {transactionID: '1'}},
+            transactions: {transactions_1: {transactionID: '1'}},
+            previousTransactions: {transactions_1: {transactionID: '1'}},
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
@@ -94,10 +94,10 @@ describe('useSearchHighlightAndScroll', () => {
         const updatedProps = {
             ...baseProps,
             transactions: {
-                '1': {transactionID: '1'},
-                '2': {transactionID: '2'},
+                transactions_1: {transactionID: '1'},
+                transactions_2: {transactionID: '2'},
             },
-            previousTransactions: {'1': {transactionID: '1'}},
+            previousTransactions: {transactions_1: {transactionID: '1'}},
         };
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -115,7 +115,7 @@ describe('useSearchHighlightAndScroll', () => {
 
         const updatedProps = {
             ...baseProps,
-            transactions: {'1': {transactionID: '1'}},
+            transactions: {transactions_1: {transactionID: '1'}},
         };
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -168,12 +168,12 @@ describe('useSearchHighlightAndScroll', () => {
         const initialProps = {
             ...baseProps,
             transactions: {
-                '1': {transactionID: '1'},
-                '2': {transactionID: '2'},
+                transactions_1: {transactionID: '1'},
+                transactions_2: {transactionID: '2'},
             },
             previousTransactions: {
-                '1': {transactionID: '1'},
-                '2': {transactionID: '2'},
+                transactions_1: {transactionID: '1'},
+                transactions_2: {transactionID: '2'},
             },
         };
 
@@ -186,7 +186,7 @@ describe('useSearchHighlightAndScroll', () => {
         const updatedProps = {
             ...baseProps,
             transactions: {
-                '1': {transactionID: '1'},
+                transactions_1: {transactionID: '1'},
             },
         };
 
@@ -196,9 +196,7 @@ describe('useSearchHighlightAndScroll', () => {
         expect(search).not.toHaveBeenCalled();
     });
 
-    // The `transactions` prop comes straight from `useOnyx(ONYXKEYS.COLLECTION.TRANSACTION)`, so its keys carry the
-    // `transactions_` prefix. The two tests below use that production shape rather than bare transaction IDs.
-    it('should not trigger search on a non-chat search when only a report action was added', () => {
+    it('should trigger search when a transaction that is absent from the results is added', () => {
         const initialProps = {
             ...baseProps,
             searchResults: {
@@ -213,16 +211,6 @@ describe('useSearchHighlightAndScroll', () => {
             previousTransactions: {
                 transactions_1: {transactionID: '1'},
             },
-            reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                },
-            },
-            previousReportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                },
-            },
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
@@ -231,21 +219,18 @@ describe('useSearchHighlightAndScroll', () => {
             initialProps,
         });
 
-        // An unrelated chat message arrives. No transaction changed, so the expense search must not refetch.
         const updatedProps = {
             ...initialProps,
-            reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                    '2': {actionName: 'ADDCOMMENT', reportActionID: '2'},
-                },
+            transactions: {
+                transactions_1: {transactionID: '1'},
+                transactions_2: {transactionID: '2'},
             },
         };
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
-        expect(search).not.toHaveBeenCalled();
+        expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
     });
 
     it('should not trigger search when the added transaction is already in the search results', () => {
@@ -272,7 +257,6 @@ describe('useSearchHighlightAndScroll', () => {
             initialProps,
         });
 
-        // The transaction lands in the Onyx collection, but the results already list it, so there is nothing to fetch.
         const updatedProps = {
             ...initialProps,
             transactions: {
@@ -296,8 +280,7 @@ describe('useSearchHighlightAndScroll', () => {
                     transactions_1: {transactionID: '1'},
                 },
             },
-            // `transactions_99` belongs to a report the user opened; it does not match the current query, so it is
-            // absent from the results. That is the normal state for any filtered or paginated search.
+            // `transactions_99` is held by the client but filtered out by the query, the normal paginated/filtered state.
             transactions: {
                 transactions_1: {transactionID: '1'},
                 transactions_99: {transactionID: '99'},
@@ -399,12 +382,12 @@ describe('useSearchHighlightAndScroll', () => {
                 },
             },
             transactions: {
-                '1': {transactionID: '1'},
-                '2': {transactionID: '2'},
-                '3': {transactionID: '3'},
+                transactions_1: {transactionID: '1'},
+                transactions_2: {transactionID: '2'},
+                transactions_3: {transactionID: '3'},
             },
             previousTransactions: {
-                '1': {transactionID: '1'},
+                transactions_1: {transactionID: '1'},
             },
         };
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -460,12 +443,12 @@ describe('useSearchHighlightAndScroll', () => {
                 },
             },
             transactions: {
-                '1': {transactionID: '1'},
-                '2': {transactionID: '2'},
-                '3': {transactionID: '3'},
+                transactions_1: {transactionID: '1'},
+                transactions_2: {transactionID: '2'},
+                transactions_3: {transactionID: '3'},
             },
             previousTransactions: {
-                '1': {transactionID: '1'},
+                transactions_1: {transactionID: '1'},
             },
         } as unknown as UseSearchHighlightAndScroll;
 

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -196,6 +196,150 @@ describe('useSearchHighlightAndScroll', () => {
         expect(search).not.toHaveBeenCalled();
     });
 
+    // The `transactions` prop comes straight from `useOnyx(ONYXKEYS.COLLECTION.TRANSACTION)`, so its keys carry the
+    // `transactions_` prefix. The two tests below use that production shape rather than bare transaction IDs.
+    it('should not trigger search on a non-chat search when only a report action was added', () => {
+        const initialProps = {
+            ...baseProps,
+            searchResults: {
+                ...baseProps.searchResults,
+                data: {
+                    transactions_1: {transactionID: '1'},
+                },
+            },
+            transactions: {
+                transactions_1: {transactionID: '1'},
+            },
+            previousTransactions: {
+                transactions_1: {transactionID: '1'},
+            },
+            reportActions: {
+                reportActions_1: {
+                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                },
+            },
+            previousReportActions: {
+                reportActions_1: {
+                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                },
+            },
+        };
+
+        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            initialProps,
+        });
+
+        // An unrelated chat message arrives. No transaction changed, so the expense search must not refetch.
+        const updatedProps = {
+            ...initialProps,
+            reportActions: {
+                reportActions_1: {
+                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                    '2': {actionName: 'ADDCOMMENT', reportActionID: '2'},
+                },
+            },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        rerender(updatedProps);
+        expect(search).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger search when the added transaction is already in the search results', () => {
+        const initialProps = {
+            ...baseProps,
+            searchResults: {
+                ...baseProps.searchResults,
+                data: {
+                    transactions_1: {transactionID: '1'},
+                    transactions_2: {transactionID: '2'},
+                },
+            },
+            transactions: {
+                transactions_1: {transactionID: '1'},
+            },
+            previousTransactions: {
+                transactions_1: {transactionID: '1'},
+            },
+        };
+
+        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            initialProps,
+        });
+
+        // The transaction lands in the Onyx collection, but the results already list it, so there is nothing to fetch.
+        const updatedProps = {
+            ...initialProps,
+            transactions: {
+                transactions_1: {transactionID: '1'},
+                transactions_2: {transactionID: '2'},
+            },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        rerender(updatedProps);
+        expect(search).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger search on a non-chat search when a report action was added and Onyx holds a transaction the query filters out', () => {
+        const initialProps = {
+            ...baseProps,
+            searchResults: {
+                ...baseProps.searchResults,
+                data: {
+                    transactions_1: {transactionID: '1'},
+                },
+            },
+            // `transactions_99` belongs to a report the user opened; it does not match the current query, so it is
+            // absent from the results. That is the normal state for any filtered or paginated search.
+            transactions: {
+                transactions_1: {transactionID: '1'},
+                transactions_99: {transactionID: '99'},
+            },
+            previousTransactions: {
+                transactions_1: {transactionID: '1'},
+                transactions_99: {transactionID: '99'},
+            },
+            reportActions: {
+                reportActions_1: {
+                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                },
+            },
+            previousReportActions: {
+                reportActions_1: {
+                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                },
+            },
+        };
+
+        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            initialProps,
+        });
+
+        const updatedProps = {
+            ...initialProps,
+            reportActions: {
+                reportActions_1: {
+                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                    '2': {actionName: 'ADDCOMMENT', reportActionID: '2'},
+                },
+            },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        rerender(updatedProps);
+        expect(search).not.toHaveBeenCalled();
+    });
+
     it('should not trigger search for chat when report actions removed and focused', () => {
         mockUseIsFocused.mockReturnValue(true);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Search sends a byte-identical request every 2 to 8 seconds with no user interaction. Issue #98048 measured this at roughly 26 percent of all Search calls in a sampled hour, across web, iOS, and Android, costing about 28 minutes of Auth compute per hour. It is not a recent regression. The repeat share has stayed flat at 24 to 28 percent across the whole retained log window.

Two defects in the same effect in `src/hooks/useSearchHighlightAndScroll.ts` cause this.

First, the skip guard could never fire on a non-chat search. `newIDs` was built from `Object.keys(transactions)`, which are Onyx collection keys shaped `transactions_<id>`, and compared against the bare `transactionID` values that `extractTransactionIDsFromSearchResults` returns. Those two sets can never intersect, so `hasAGenuinelyNewID` was always true, the early return meant to skip the refetch was unreachable, and the `hasDeletedID` branch below it was dead code.

Second, report actions triggered refetches on searches that have nothing to do with report actions. The condition was `(!isChat && hasTransactionsIDsChange) || hasReportActionsIDsChange`, so any new report action anywhere in the account, an incoming chat message for example, re-fired an expense search. The comment right above the effect already describes the intended behavior: trigger a search when a new report action is added while on chat, or when a new transaction is added for the other search types. The code did not match its own comment.

The second defect pumps the loop, and the first defect is the safety valve that should have caught it but could not. Together they produce exactly the reported signature: an identical query hash, no user interaction, and a cadence that tracks request latency, because the internal `searchTriggeredRef` latch is released once per response by the reset effect right below.

The fix is two lines. Gate the report action trigger behind `isChat` so it matches the documented intent, and strip the collection key prefix before comparing against the search result IDs.

This bug survived because the existing unit tests build the `transactions` fixture with bare keys, for example `{'1': {transactionID: '1'}}`, while production passes `useOnyx(ONYXKEYS.COLLECTION.TRANSACTION)`, whose keys carry the `transactions_` prefix. Every existing test agreed with itself and never exercised the mismatch.

Three new tests were written before the fix, and each one was watched failing, all showing a single spurious call with the identical query hash. They cover a report action arriving on a non-chat search with no transaction change, an added transaction that is already present in the results, and a report action arriving while Onyx holds a transaction the query filters out. That third test still failed after gating the report action trigger alone, which is what proved the ID prefix fix was needed too.

**Note for reviewers:** a non-chat search no longer refetches on a report action that changes no transaction, for example approving a report from an RHP while on the approve todo view. The flows that need that refresh already call `refreshSearchAfterReportAction` explicitly right after the action, at `src/hooks/useLifecycleActions.tsx:252` and `src/hooks/useSelectionModePayment.ts:235`, which is what `src/libs/SearchRefreshUtils.ts` exists for. This change also makes the `hasDeletedID` branch reachable for the first time on non-chat searches, so deletion from search results is worth explicit QA attention.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98048
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Preconditions**

1. Sign in to two accounts, Account 1 and Account 2, on two devices or browsers.
2. On Device 1, open DevTools > Network and filter the requests to `Search`.

**The fix**

1. Account 1: open Spend > Expenses.
2. Account 1: clear the network log in DevTools.
3. Account 2: open the DM with Account 1 and send a message.
4. Account 1: verify that no `Search` request appears in DevTools.

**Regression checks**

5. Account 1: create an expense from the right hand panel of the Expenses page, and verify that it appears in the list with its row highlighted.
6. Account 1: delete an expense from the list, and verify that it disappears from the list.
7. Account 1: use the search router to run a keyword search and open the Chats results. Have Account 2 send a message to that chat, and verify that the chat results refresh.
8. Account 1: open Needs approval, approve a report, and verify that the list refreshes.
9. Account 1: enter selection mode on Ready to pay, pay a report, and verify that the list refreshes.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ca55865a-f048-4e81-b39c-8e010d38e80c


</details>



