### PR TITLE
Fix submissions thread headers

### DIFF
--- a/src/libs/ReportNameUtils.ts
+++ b/src/libs/ReportNameUtils.ts
@@ -90,6 +90,7 @@ import {
     getTravelUpdateMessage,
     getUnassignedCompanyCardMessage,
     getUpdateACHAccountMessage,
+    getUpdatedAutoHarvestingMessage,
     getUpdatedCardFeedLiabilityMessage,
     getUpdatedCardFeedStatementPeriodMessage,
     getUpdatedProhibitedExpensesMessage,
@@ -646,6 +647,9 @@ function computeReportNameBasedOnReportAction(
     }
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_DEFAULT_TITLE)) {
         return getPolicyChangeLogDefaultTitleMessage(translate, parentReportAction);
+    }
+    if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_AUTO_HARVESTING)) {
+        return getUpdatedAutoHarvestingMessage(translate, parentReportAction);
     }
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_IS_ATTENDEE_TRACKING_ENABLED)) {
         return getWorkspaceAttendeeTrackingUpdateMessage(translate, parentReportAction);

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -475,6 +475,46 @@ describe('ReportNameUtils', () => {
             );
             expect(name).toBe(expected);
         });
+        test('Disabled auto harvesting parent action uses the localized submissions message', () => {
+            const thread: Report = {
+                ...createWorkspaceThread(54),
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_ADMINS,
+                reportName: '#admins',
+            };
+            const parentAction: ReportAction = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_AUTO_HARVESTING,
+                reportActionID: String(thread.parentReportActionID),
+                message: [],
+                created: '',
+                lastModified: '',
+                actorAccountID: 1,
+                person: [],
+                originalMessage: {
+                    value: false,
+                },
+            } as unknown as ReportAction;
+
+            const parentId = String(thread.parentReportID);
+            const actionId = String(thread.parentReportActionID);
+            const reportActionsCollection: Record<string, ReportActions> = {
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentId}`]: {
+                    [actionId]: parentAction,
+                },
+            };
+
+            const name = computeReportName(
+                thread,
+                emptyCollections.reports,
+                emptyCollections.policies,
+                undefined,
+                undefined,
+                participantsPersonalDetails,
+                reportActionsCollection,
+                currentUserAccountID,
+            );
+
+            expect(name).toBe(translate(CONST.LOCALES.EN, 'workspaceActions.updatedAutoHarvesting', false));
+        });
         test('VBBA pay parent action uses action accountNumber before current policy account', () => {
             const policyID = '123';
             const thread: Report = {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Adds the missing `UPDATE_AUTO_HARVESTING` report-action handler to report-name computation. Thread headers now reuse the existing localized message helper used by the in-chat message and LHN preview, so disabling Submissions displays `disabled submissions` consistently.

The root cause was that `computeReportNameBasedOnReportAction` did not handle this action type and admin-room thread names fell through to the raw backend text, `turned Scheduled Submit off`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98202
PROPOSAL: https://github.com/Expensify/App/issues/98202#issuecomment-5246278544

### Tests

1. Run `npm test -- tests/unit/ReportNameUtilsTest.ts --runInBand`.
2. As an admin, open Workspace settings > Workflows and disable Submissions.
3. Open the workspace admins room and reply in the `disabled submissions` system message thread.
4. Verify the thread header and LHN preview both show `disabled submissions`.
5. Enable Submissions and verify the corresponding message and thread header show `enabled submissions`.

The local automated test run was attempted but was blocked by the existing shared dependency setup: the checkout's available dependencies are from an older App revision and are missing the Babel module path required by this `origin/main` revision.

- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A. This change only computes a localized name from report-action data already available in the client and does not add network behavior.

### QA Steps

1. In staging, open Workspace settings > Workflows for a workspace where you are an admin.
2. Disable Submissions.
3. Open the workspace admins room and open the thread for the disabled-submissions system message.
4. Verify the thread header, parent message, and LHN preview use the same `disabled submissions` wording.
5. Re-enable Submissions and verify the corresponding enabled wording.
6. Confirm the app remains usable when the action data is incomplete and the existing raw-message fallback is used.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (the existing helper fallback is preserved)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior
    - [ ] I tested this PR with a High Traffic account against the staging or production API
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the tests on all platforms & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors
- [x] I followed proper code patterns and the review agent found no P1 or P2 issues
    - [x] No new comments were needed for this localized handler
    - [x] No new copy was added; the existing approved translation is reused
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the Review Guidelines
- [ ] I tested other components that can be impacted by my changes
- [x] No new CSS styles or assets were added
- [x] The change does not modify message editing, markdown handling, generic components, Storybook stories, or deeplinks
- [x] I added a unit test for this bug fix
- [x] The branch was created from the latest `origin/main`

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A. Logic-only change.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

QA steps above.

</details>

<details>
<summary>iOS: Native</summary>

N/A. Logic-only change.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A. Logic-only change.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

QA steps above.

</details>