### PR TITLE
Skip PR author checklist when melvin-bot[bot] is the author

### DIFF
--- a/.github/workflows/authorChecklist.yml
+++ b/.github/workflows/authorChecklist.yml
@@ -16,6 +16,7 @@ jobs:
     if: |
       github.actor != 'OSBotify'
       && github.actor != 'imgbot[bot]'
+      && github.actor != 'melvin-bot[bot]'
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1


### PR DESCRIPTION
### Explanation of Change

The `PR Author Checklist` workflow (`.github/workflows/authorChecklist.yml`) runs on every PR opened against `main`. Its `checklist` job already skips known bots by comparing `github.actor` (`OSBotify`, `imgbot[bot]`). PRs authored by the Melvin GitHub App run through this job unnecessarily — Melvin is not an external contributor and has no author checklist to fill out.

This adds `melvin-bot[bot]` to the job-level `if` skip. `melvin-bot[bot]` is the `github.actor` value for the Melvin GitHub App (`CONST.NAME_MELVIN_BOT`), and matches the existing exclusion precedent in `proposalPolice.yml`.

### Fixed Issues
$ https://expensify.slack.com/archives/C02NK2DQWUX/p1786470305341269?thread_ts=1786111493.247829&cid=C02NK2DQWUX
PROPOSAL:

### Tests

This is a CI-only change to a `pull_request_target` workflow condition; there is no in-app behavior to test.

1. Open a PR authored by `melvin-bot[bot]` against `main` and verify the `checklist` job is skipped.
2. Open a PR authored by a normal user and verify the `checklist` job still runs.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — CI workflow change.

### QA Steps

// [No QA]

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
- [ ] I verified there are no console errors

### Screenshots/Videos

N/A — CI workflow change.
