### PR TITLE
Parse markdown in agent custom instructions on the profile page

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -302,10 +302,12 @@ function ProfilePage({route}: ProfilePageProps) {
                             >
                                 <MenuItemWithTopDescription
                                     description={translate('profilePage.customInstructions')}
-                                    title={agentPrompt?.prompt?.trim() ?? ''}
+                                    title={Str.htmlDecode(agentPrompt?.prompt?.trim() ?? '')}
+                                    shouldParseTitle
+                                    shouldTruncateTitle
+                                    characterLimit={CONST.AGENT_PROMPT_LIMIT}
                                     shouldShowRightIcon
                                     onPress={() => Navigation.navigate(ROUTES.SETTINGS_AGENTS_EDIT_PROMPT.getRoute(accountID))}
-                                    numberOfLinesTitle={2}
                                 />
                             </OfflineWithFeedback>
                         )}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -304,6 +304,7 @@ function ProfilePage({route}: ProfilePageProps) {
                                     description={translate('profilePage.customInstructions')}
                                     title={Str.htmlDecode(agentPrompt?.prompt?.trim() ?? '')}
                                     shouldParseTitle
+                                    excludedMarkdownRules={['reportMentions']}
                                     shouldTruncateTitle
                                     characterLimit={CONST.AGENT_PROMPT_LIMIT}
                                     shouldShowRightIcon

--- a/src/pages/settings/Agents/EditAgentPage.tsx
+++ b/src/pages/settings/Agents/EditAgentPage.tsx
@@ -144,6 +144,7 @@ function EditAgentPage({route}: EditAgentPageProps) {
                         description={translate('editAgentPage.instructions')}
                         title={Str.htmlDecode(agent?.prompt?.trim() ?? '')}
                         shouldParseTitle
+                        excludedMarkdownRules={['reportMentions']}
                         shouldTruncateTitle
                         characterLimit={CONST.AGENT_PROMPT_LIMIT}
                         shouldShowRightIcon

--- a/tests/ui/AgentProfilePageTest.tsx
+++ b/tests/ui/AgentProfilePageTest.tsx
@@ -1,0 +1,112 @@
+import {render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersonalDetailsProvider';
+import DelegateNoAccessModalProvider from '@components/DelegateNoAccessModalProvider';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
+import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
+
+import {navigationRef} from '@libs/Navigation/Navigation';
+import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
+import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
+
+import ProfilePage from '@pages/ProfilePage';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+import type {PersonalDetails, PersonalDetailsList} from '@src/types/onyx';
+
+import {PortalProvider} from '@gorhom/portal';
+import {NavigationContainer} from '@react-navigation/native';
+import {act} from 'react';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+// Surface the HTML that MenuItem hands to RenderHTML so the test can assert the prompt was parsed as markdown.
+jest.mock('@components/RenderHTML', () => {
+    const ReactMock = require('react') as typeof React;
+    const {Text} = require('react-native') as {Text: React.ComponentType<{children?: React.ReactNode}>};
+
+    return ({html}: {html: string}) => ReactMock.createElement(Text, null, html);
+});
+
+const CURRENT_USER_ACCOUNT_ID = 1;
+const AGENT_ACCOUNT_ID = 123;
+
+const Stack = createPlatformStackNavigator<ProfileNavigatorParamList>();
+
+describe('ProfilePage - agent custom instructions', () => {
+    beforeAll(async () => {
+        Onyx.init({keys: ONYXKEYS});
+
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, 'en' as const);
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    afterEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    async function setUpAgent(prompt: string) {
+        await TestHelper.signInWithTestUser(CURRENT_USER_ACCOUNT_ID, 'user@expensify.com');
+
+        const personalDetails: PersonalDetailsList = {
+            [CURRENT_USER_ACCOUNT_ID]: {
+                accountID: CURRENT_USER_ACCOUNT_ID,
+                login: 'user@expensify.com',
+                displayName: 'user@expensify.com',
+            } as PersonalDetails,
+            [AGENT_ACCOUNT_ID]: {
+                accountID: AGENT_ACCOUNT_ID,
+                login: `testbot_${AGENT_ACCOUNT_ID}@expensify.ai`,
+                displayName: 'Test Agent',
+                isCustomAgent: true,
+            } as PersonalDetails,
+        };
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${AGENT_ACCOUNT_ID}`, {prompt, pendingAction: null});
+            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        render(
+            <ComposeProviders components={[OnyxListItemProvider, CurrentUserPersonalDetailsProvider, LocaleContextProvider, CurrentReportIDContextProvider, DelegateNoAccessModalProvider]}>
+                <PortalProvider>
+                    <NavigationContainer ref={navigationRef}>
+                        <Stack.Navigator>
+                            <Stack.Screen
+                                name={SCREENS.DYNAMIC_PROFILE}
+                                component={ProfilePage}
+                                initialParams={{accountID: String(AGENT_ACCOUNT_ID)}}
+                            />
+                        </Stack.Navigator>
+                    </NavigationContainer>
+                </PortalProvider>
+            </ComposeProviders>,
+        );
+        await waitForBatchedUpdatesWithAct();
+    }
+
+    it('renders the prompt markdown as formatted HTML', async () => {
+        await setUpAgent('Reject *gambling* expenses.');
+
+        expect(screen.getByText('<comment>Reject <strong>gambling</strong> expenses.</comment>')).toBeDefined();
+    });
+
+    it('decodes the stored prompt before parsing it', async () => {
+        // The prompt is stored HTML-encoded, so an undecoded entity would be escaped again and shown to the user verbatim.
+        await setUpAgent('Reject *Bob&#39;s* expenses.');
+
+        expect(screen.getByText('<comment>Reject <strong>Bob&#x27;s</strong> expenses.</comment>')).toBeDefined();
+    });
+});

--- a/tests/ui/PublicProfilePageTest.tsx
+++ b/tests/ui/PublicProfilePageTest.tsx
@@ -70,7 +70,7 @@ describe('ProfilePage - agent custom instructions', () => {
             } as PersonalDetails,
             [AGENT_ACCOUNT_ID]: {
                 accountID: AGENT_ACCOUNT_ID,
-                login: `testbot_${AGENT_ACCOUNT_ID}@expensify.ai`,
+                login: `agent_${AGENT_ACCOUNT_ID}@expensify.ai`,
                 displayName: 'Test Agent',
                 isCustomAgent: true,
             } as PersonalDetails,

--- a/tests/ui/PublicProfilePageTest.tsx
+++ b/tests/ui/PublicProfilePageTest.tsx
@@ -5,6 +5,8 @@ import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersona
 import DelegateNoAccessModalProvider from '@components/DelegateNoAccessModalProvider';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import RenderHTML from '@components/RenderHTML';
+import Text from '@components/Text';
 
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 
@@ -29,10 +31,10 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 // Render the HTML that MenuItem produces as the plain text a user would see, so tests can assert on what is displayed.
 jest.mock('@components/RenderHTML', () => {
     const ReactMock = jest.requireActual<typeof React>('react');
-    const {Text} = jest.requireActual<{Text: React.ComponentType<{children?: React.ReactNode}>}>('react-native');
+    const {Text: RNText} = jest.requireActual<{Text: React.ComponentType<{children?: React.ReactNode}>}>('react-native');
     const {Str} = jest.requireActual<{Str: {htmlDecode: (text: string) => string}}>('expensify-common');
 
-    return ({html}: {html: string}) => ReactMock.createElement(Text, null, Str.htmlDecode(html.replaceAll(/<[^>]*>/g, '')));
+    return jest.fn(({html}: {html: string}) => ReactMock.createElement(RNText, null, Str.htmlDecode(html.replaceAll(/<[^>]*>/g, ''))));
 });
 
 const CURRENT_USER_ACCOUNT_ID = 1;
@@ -59,6 +61,8 @@ describe('ProfilePage - agent custom instructions', () => {
     it.each([
         ['parses markdown', 'Reject *gambling* expenses.', 'Reject gambling expenses.'],
         ['decodes HTML entities', 'Reject Bob&#39;s expenses.', "Reject Bob's expenses."],
+        // CONST.AGENT_PROMPT_LIMIT is 300; expensify-common's truncateHTML keeps exactly 300 characters before appending the ellipsis.
+        ['truncates content exceeding the character limit', 'A'.repeat(320), `${'A'.repeat(300)}...`],
     ])('%s in the custom instructions', async (_name, prompt, expectedText) => {
         await TestHelper.signInWithTestUser(CURRENT_USER_ACCOUNT_ID, 'user@expensify.com');
 
@@ -101,5 +105,60 @@ describe('ProfilePage - agent custom instructions', () => {
         await waitForBatchedUpdatesWithAct();
 
         expect(screen.getByText(expectedText)).toBeDefined();
+    });
+
+    it('does not convert a room name into a report mention', async () => {
+        await TestHelper.signInWithTestUser(CURRENT_USER_ACCOUNT_ID, 'user@expensify.com');
+
+        const personalDetails: PersonalDetailsList = {
+            [CURRENT_USER_ACCOUNT_ID]: {
+                accountID: CURRENT_USER_ACCOUNT_ID,
+                login: 'user@expensify.com',
+                displayName: 'user@expensify.com',
+            } as PersonalDetails,
+            [AGENT_ACCOUNT_ID]: {
+                accountID: AGENT_ACCOUNT_ID,
+                login: `agent_${AGENT_ACCOUNT_ID}@expensify.ai`,
+                displayName: 'Test Agent',
+                isCustomAgent: true,
+            } as PersonalDetails,
+        };
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${AGENT_ACCOUNT_ID}`, {prompt: 'Ignore #some-room mentions.', pendingAction: null});
+            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        // Strip only the wrapping <comment> tag that MenuItem always adds, but keep any other tag (like <mention-report>) intact, so a room mention would show up in the query below if the rule weren't disabled.
+        const mockRenderHTML = jest.mocked(RenderHTML);
+        const defaultImplementation = mockRenderHTML.getMockImplementation();
+        mockRenderHTML.mockImplementation(({html}) => React.createElement(Text, null, html.replaceAll(/<\/?comment>/g, '')));
+
+        try {
+            render(
+                <ComposeProviders
+                    components={[OnyxListItemProvider, CurrentUserPersonalDetailsProvider, LocaleContextProvider, CurrentReportIDContextProvider, DelegateNoAccessModalProvider]}
+                >
+                    <PortalProvider>
+                        <NavigationContainer ref={navigationRef}>
+                            <Stack.Navigator>
+                                <Stack.Screen
+                                    name={SCREENS.DYNAMIC_PROFILE}
+                                    component={ProfilePage}
+                                    initialParams={{accountID: String(AGENT_ACCOUNT_ID)}}
+                                />
+                            </Stack.Navigator>
+                        </NavigationContainer>
+                    </PortalProvider>
+                </ComposeProviders>,
+            );
+            await waitForBatchedUpdatesWithAct();
+
+            expect(screen.getByText('Ignore #some-room mentions.')).toBeDefined();
+        } finally {
+            mockRenderHTML.mockImplementation(defaultImplementation);
+        }
     });
 });

--- a/tests/ui/PublicProfilePageTest.tsx
+++ b/tests/ui/PublicProfilePageTest.tsx
@@ -20,19 +20,19 @@ import type {PersonalDetails, PersonalDetailsList} from '@src/types/onyx';
 
 import {PortalProvider} from '@gorhom/portal';
 import {NavigationContainer} from '@react-navigation/native';
-import {act} from 'react';
-import React from 'react';
+import React, {act} from 'react';
 import Onyx from 'react-native-onyx';
 
 import * as TestHelper from '../utils/TestHelper';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
 
-// Surface the HTML that MenuItem hands to RenderHTML so the test can assert the prompt was parsed as markdown.
+// Render the HTML that MenuItem produces as the plain text a user would see, so tests can assert on what is displayed.
 jest.mock('@components/RenderHTML', () => {
-    const ReactMock = require('react') as typeof React;
-    const {Text} = require('react-native') as {Text: React.ComponentType<{children?: React.ReactNode}>};
+    const ReactMock = jest.requireActual<typeof React>('react');
+    const {Text} = jest.requireActual<{Text: React.ComponentType<{children?: React.ReactNode}>}>('react-native');
+    const {Str} = jest.requireActual<{Str: {htmlDecode: (text: string) => string}}>('expensify-common');
 
-    return ({html}: {html: string}) => ReactMock.createElement(Text, null, html);
+    return ({html}: {html: string}) => ReactMock.createElement(Text, null, Str.htmlDecode(html.replaceAll(/<[^>]*>/g, '')));
 });
 
 const CURRENT_USER_ACCOUNT_ID = 1;
@@ -55,7 +55,11 @@ describe('ProfilePage - agent custom instructions', () => {
         await waitForBatchedUpdatesWithAct();
     });
 
-    async function setUpAgent(prompt: string) {
+    // The prompt is stored HTML-encoded, so it has to be decoded before it is parsed, otherwise entities are escaped again and shown verbatim.
+    it.each([
+        ['parses markdown', 'Reject *gambling* expenses.', 'Reject gambling expenses.'],
+        ['decodes HTML entities', 'Reject Bob&#39;s expenses.', "Reject Bob's expenses."],
+    ])('%s in the custom instructions', async (_name, prompt, expectedText) => {
         await TestHelper.signInWithTestUser(CURRENT_USER_ACCOUNT_ID, 'user@expensify.com');
 
         const personalDetails: PersonalDetailsList = {
@@ -95,18 +99,7 @@ describe('ProfilePage - agent custom instructions', () => {
             </ComposeProviders>,
         );
         await waitForBatchedUpdatesWithAct();
-    }
 
-    it('renders the prompt markdown as formatted HTML', async () => {
-        await setUpAgent('Reject *gambling* expenses.');
-
-        expect(screen.getByText('<comment>Reject <strong>gambling</strong> expenses.</comment>')).toBeDefined();
-    });
-
-    it('decodes the stored prompt before parsing it', async () => {
-        // The prompt is stored HTML-encoded, so an undecoded entity would be escaped again and shown to the user verbatim.
-        await setUpAgent('Reject *Bob&#39;s* expenses.');
-
-        expect(screen.getByText('<comment>Reject <strong>Bob&#x27;s</strong> expenses.</comment>')).toBeDefined();
+        expect(screen.getByText(expectedText)).toBeDefined();
     });
 });


### PR DESCRIPTION
### Explanation of Change

The agent prompt is stored as HTML-encoded Markdown source. On the agent chat details page, the "Custom instructions" field passed that raw source straight to `MenuItemWithTopDescription`, which renders a plain `<Text>` unless `shouldParseTitle` is set, so the user saw `*bold*` and `&#39;` verbatim.

This makes the field match the equivalent field on the Agents settings page (`EditAgentPage`): decode the stored prompt with `Str.htmlDecode`, parse it as Markdown with `shouldParseTitle`, and bound its length with `shouldTruncateTitle` / `characterLimit={CONST.AGENT_PROMPT_LIMIT}`.

`numberOfLinesTitle={2}` was dropped because `MenuItem` ignores it once the title is parsed as HTML — the 300 character limit now bounds the row instead, exactly as it does on the settings page.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98325
PROPOSAL: N/A

### Tests

1. Sign in.
2. Go to Account > Agents.
3. Click New agent, then Build custom agent.
4. Enter custom instructions containing markdown and an apostrophe, e.g. `Reject *gambling* and Bob's _personal_ expenses.`
5. Click Create agent.
6. Click on the chat header of the new agent chat.
7. Verify the "Custom instructions" field renders the markdown formatting (bold, italic, strikethrough, inline code) rather than the raw source, and that the apostrophe shows as `'` and not as an HTML entity.
8. Click the "Custom instructions" field, change the instructions, and save.
9. Verify the profile page shows the updated instructions, still formatted.
10. Enter instructions longer than 300 characters and verify the profile page truncates them with an ellipsis, matching Account > Agents > (agent) > Instructions.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open an agent chat, click the chat header, and click "Custom instructions".
3. Change the instructions and save.
4. Verify the profile page shows the new instructions with markdown formatting applied and the usual offline (greyed out) styling.
5. Go back online and verify the field keeps the same formatted content once the update is acknowledged.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Not tested yet.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not tested yet.

</details>

<details>
<summary>iOS: Native</summary>

Not tested yet.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not tested yet.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="384" height="869" alt="image" src="https://github.com/user-attachments/assets/adbab21c-65b8-4758-84bd-faa8e2c66360" />
<img width="393" height="867" alt="image" src="https://github.com/user-attachments/assets/2ba9d7da-ca9f-45c4-877c-1fe95b2b0f53" />

</details>
