### PR TITLE
Fix Android device back button on the public room sign-in modal

### DIFF
--- a/src/pages/signin/SignInModal.tsx
+++ b/src/pages/signin/SignInModal.tsx
@@ -2,7 +2,6 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {useSession} from '@components/OnyxListItemProvider';
 import ScreenWrapper from '@components/ScreenWrapper';
 
-import useAndroidBackButtonHandler from '@hooks/useAndroidBackButtonHandler';
 import useOnyx from '@hooks/useOnyx';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
@@ -35,13 +34,6 @@ function SignInModal() {
     // This allows better scrolling experience after keyboard shows for modals with input, that are larger than remaining screen height.
     // More info https://github.com/Expensify/App/pull/62799#issuecomment-2943136220.
     const SignInPageBase = useMemo(() => (isMobileSafari() ? SignInPageWrapped : SignInPage), []);
-
-    // The SignInPage (child component of SignInModal) uses useAndroidBackButtonHandler, which adds a hardwareBackPress listener that remains active in the SignInModal.
-    // Use of useAndroidBackButtonHandler with a returning true callback disables the default SignInModal hardware Android button behaviour, leaving only SignInPage handling (https://github.com/Expensify/App/issues/69391).
-    // The SignInPage Android back button behavior needs to remain because it is a fix for issue (https://github.com/Expensify/App/issues/67883) that occurs in the SignInModal.
-    useAndroidBackButtonHandler(() => {
-        return true;
-    });
 
     useEffect(() => {
         const isAnonymousUser = session?.authTokenType === CONST.AUTH_TOKEN_TYPES.ANONYMOUS;

--- a/src/pages/signin/SignInPage.tsx
+++ b/src/pages/signin/SignInPage.tsx
@@ -16,7 +16,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import {isClientTheLeader as isClientTheLeaderActiveClientManager} from '@libs/ActiveClientManager';
 import Log from '@libs/Log';
-import Navigation from '@libs/Navigation/Navigation';
+import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import Visibility from '@libs/Visibility';
 
 import {clearSignInData, isSupportalSession as isSupportalSessionUtils} from '@userActions/Session';
@@ -58,7 +58,7 @@ type SignInPageProps = {
 };
 
 type SignInPageRef = {
-    navigateBack: () => void;
+    navigateBack: () => boolean;
 };
 
 type RenderOption = {
@@ -327,8 +327,12 @@ function SignInPage({ref, shouldResetTabTitle = true}: SignInPageProps) {
             return true;
         }
 
+        // Report the press as handled whenever we actually navigate, otherwise react-navigation's own
+        // BackHandler listener pops a second time (https://github.com/Expensify/App/issues/69391).
+        // At the public sign-in root there is nothing to pop, so return false and let Android background the app.
+        const didNavigate = !!navigationRef.current?.canGoBack();
         Navigation.goBack();
-        return false;
+        return didNavigate;
     };
     useImperativeHandle(ref, () => ({
         navigateBack,

--- a/tests/unit/SignInBackButtonTest.tsx
+++ b/tests/unit/SignInBackButtonTest.tsx
@@ -1,0 +1,113 @@
+import {render} from '@testing-library/react-native';
+
+import SignInModal from '@pages/signin/SignInModal';
+import type {SignInPageRef} from '@pages/signin/SignInPage';
+import {SignInPage} from '@pages/signin/SignInPage';
+
+import React, {createRef} from 'react';
+
+const mockGoBack = jest.fn();
+let mockCanGoBack = true;
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    // Referenced lazily: jest hoists this factory above the mock declarations below.
+    default: {
+        goBack: () => {
+            mockGoBack();
+        },
+    },
+    navigationRef: {
+        get current() {
+            return {canGoBack: () => mockCanGoBack};
+        },
+    },
+}));
+
+// Record the callbacks handed to the hook so the test can replay them. Jest resolves the platform-neutral
+// no-op variant, so the callbacks are never invoked for real here.
+const mockUseAndroidBackButtonHandler = jest.fn((callback: () => boolean) => callback);
+jest.mock('@hooks/useAndroidBackButtonHandler', () => ({
+    __esModule: true,
+    default: (callback: () => boolean) => {
+        mockUseAndroidBackButtonHandler(callback);
+    },
+}));
+
+// SignInPage renders a full themed layout with form children; none of it participates in navigateBack.
+jest.mock('@pages/signin/SignInPageLayout', () => 'SignInPageLayout');
+jest.mock('@pages/signin/LoginForm', () => 'LoginForm');
+jest.mock('@pages/signin/ValidateCodeForm', () => 'ValidateCodeForm');
+jest.mock('@pages/signin/UnlinkLoginForm', () => 'UnlinkLoginForm');
+jest.mock('@pages/signin/ChooseSSOOrValidateCode', () => 'ChooseSSOOrValidateCode');
+jest.mock('@pages/signin/EmailDeliveryFailurePage', () => 'EmailDeliveryFailurePage');
+jest.mock('@pages/signin/SMSDeliveryFailurePage', () => 'SMSDeliveryFailurePage');
+jest.mock('@pages/signin/SignUpWelcomeForm', () => 'SignUpWelcomeForm');
+jest.mock('@components/ColorSchemeWrapper', () => 'ColorSchemeWrapper');
+jest.mock('@components/CustomStatusBarAndBackground', () => 'CustomStatusBarAndBackground');
+
+// SignInModal reads the session to decide when to dismiss itself; the back listener does not depend on it.
+jest.mock('@components/OnyxListItemProvider', () => ({useSession: () => undefined}));
+jest.mock('@components/ScreenWrapper', () => 'ScreenWrapper');
+jest.mock('@components/HeaderWithBackButton', () => 'HeaderWithBackButton');
+
+describe('sign-in Android hardware back handling', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCanGoBack = true;
+    });
+
+    describe('SignInPage.navigateBack on the login form', () => {
+        const renderSignInPage = () => {
+            const ref = createRef<SignInPageRef>();
+            render(<SignInPage ref={ref} />);
+            return ref;
+        };
+
+        it('reports the press as handled when there is something to pop', () => {
+            const ref = renderSignInPage();
+
+            expect(ref.current?.navigateBack()).toBe(true);
+            expect(mockGoBack).toHaveBeenCalledTimes(1);
+        });
+
+        it('reports the press as unhandled at the public sign-in root so Android can background the app', () => {
+            mockCanGoBack = false;
+            const ref = renderSignInPage();
+
+            expect(ref.current?.navigateBack()).toBe(false);
+        });
+
+        it('still calls goBack when it reports the press as unhandled', () => {
+            // goBack() also runs clearSelectedText() and the shouldPopToSidebar branch, which navigate even when
+            // canGoBack() is false. Only the returned boolean may depend on canGoBack().
+            mockCanGoBack = false;
+            const ref = renderSignInPage();
+
+            ref.current?.navigateBack();
+
+            expect(mockGoBack).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('SignInModal', () => {
+        it('registers no back listener that consumes the press without navigating', () => {
+            // SignInModal used to register a second listener that unconditionally returned true. Because React
+            // Native dispatches subscriptions in reverse order and stops at the first true, that no-op could swallow
+            // the press before SignInPage.navigateBack ran, leaving the device back button dead
+            // (https://github.com/Expensify/App/issues/96869).
+            render(<SignInModal />);
+
+            const handlers = mockUseAndroidBackButtonHandler.mock.calls.map(([callback]) => callback);
+            expect(handlers.length).toBeGreaterThan(0);
+
+            for (const handler of handlers) {
+                mockGoBack.mockClear();
+                const consumed = handler();
+
+                // On the login form every registered handler must actually navigate before claiming the press.
+                expect({consumed, navigated: mockGoBack.mock.calls.length > 0}).toEqual({consumed: true, navigated: true});
+            }
+        });
+    });
+});

--- a/tests/unit/SignInBackButtonTest.tsx
+++ b/tests/unit/SignInBackButtonTest.tsx
@@ -34,7 +34,7 @@ jest.mock('@hooks/useAndroidBackButtonHandler', () => ({
     },
 }));
 
-// SignInPage renders a full themed layout with form children; none of it participates in navigateBack.
+// SignInPage renders a full themed layout with form children. None of it participates in navigateBack.
 jest.mock('@pages/signin/SignInPageLayout', () => 'SignInPageLayout');
 jest.mock('@pages/signin/LoginForm', () => 'LoginForm');
 jest.mock('@pages/signin/ValidateCodeForm', () => 'ValidateCodeForm');
@@ -46,7 +46,7 @@ jest.mock('@pages/signin/SignUpWelcomeForm', () => 'SignUpWelcomeForm');
 jest.mock('@components/ColorSchemeWrapper', () => 'ColorSchemeWrapper');
 jest.mock('@components/CustomStatusBarAndBackground', () => 'CustomStatusBarAndBackground');
 
-// SignInModal reads the session to decide when to dismiss itself; the back listener does not depend on it.
+// SignInModal reads the session to decide when to dismiss itself. The back listener does not depend on it.
 jest.mock('@components/OnyxListItemProvider', () => ({useSession: () => undefined}));
 jest.mock('@components/ScreenWrapper', () => 'ScreenWrapper');
 jest.mock('@components/HeaderWithBackButton', () => 'HeaderWithBackButton');


### PR DESCRIPTION
### Explanation of Change

On Android, two `hardwareBackPress` listeners were active on the sign-in modal route:

- `SignInPage` registers the state-aware `navigateBack`.
- Its parent `SignInModal` registered a no-op that unconditionally returned `true` (added in #69609 to stop react-navigation from popping a second time, #69391).

Both subscribe from an effect in `useAndroidBackButtonHandler`, React flushes child effects before parent effects, and React Native walks `_backPressSubscriptions` backwards and stops at the first handler returning `true`. So on mount the modal's no-op is dispatched first, consumes the press, and `navigateBack` never runs — the device back button does nothing. The header chevron still works because it calls `navigateBack()` directly through the ref, bypassing `BackHandler`.

The underlying defect is older: `navigateBack`'s login-form branch called `Navigation.goBack()` and then returned `false` — it navigated but reported "not handled", which is what let react-navigation pop a second time. The `() => true` in `SignInModal` masked that instead of fixing it.

This PR fixes the return value at its source and drops the workaround, so a single listener owns the route and dispatch order stops mattering:

1. `SignInPage.navigateBack` now reports the press as handled whenever it actually navigates. The `canGoBack()` flag is captured _before_ `Navigation.goBack()` rather than used as an early return, so `goBack()` (and with it `clearSelectedText()` and the `shouldPopToSidebar` branch) still runs on every platform — the change is strictly to the returned boolean.
2. The `useAndroidBackButtonHandler(() => true)` block is removed from `SignInModal`.
3. `SignInPageRef.navigateBack` is widened to `() => boolean` so the contract isn't erased to `void`.

Resulting behavior:

| State                                           | Result                                                                        |
| ----------------------------------------------- | ----------------------------------------------------------------------------- |
| Login form inside the modal                     | pops once, returns `true` → #69391 stays fixed without the swallow            |
| Security code / SSO / unlink / delivery failure | untouched, already return `true` → #67883 stays fixed                         |
| Standalone sign-in root                         | `canGoBack()` false → returns `false` → Android backgrounds the app, as today |
| Header chevron                                  | unchanged, calls `navigateBack` via ref and ignores the return                |
| iOS / web                                       | unchanged, the hook is a no-op                                                |

### Fixed Issues

$ https://github.com/Expensify/App/issues/96869
PROPOSAL: https://github.com/Expensify/App/issues/96869#issuecomment-5062296389

### Tests

1. On Android native, make sure you are logged out.
2. Open a public room deep link (e.g. `https://staging.new.expensify.com/r/5583419180793784`) so the room opens anonymously.
3. Tap **Sign in** in the report footer — the sign-in modal opens.
4. Press the device back button.
5. Verify the sign-in modal is dismissed exactly once and the public room is revealed again (it must not do nothing, and it must not pop two screens).
6. Tap **Sign in** again, enter an email and tap **Continue** to reach the magic-code screen.
7. Press the device back button and verify it returns to the email step with the modal still open.
8. Press the device back button again and verify the modal is dismissed and the public room is revealed.
9. Tap **Sign in** again and press the header back chevron instead — verify it behaves exactly as in step 5.
10. Go to the standalone sign-in page (logged out, no modal, e.g. open the app from a cold start) and press the device back button. Verify Android backgrounds the app as before.
11. On iOS native and web, open the sign-in modal from a public room and verify the header back chevron still dismisses it, and that the sign-in flow (email → magic code → back) is unchanged.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests. The change only affects navigation and the value returned to Android's `BackHandler`; no network request is involved, so the behavior is identical online and offline.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

Notes on the checklist above:

- No new styles, assets, copy, UI, Storybook stories or message-editing code are touched by this PR, so those items have nothing to verify.
- Unit tests live in `tests/unit/SignInBackButtonTest.tsx`. Two of them fail against the pre-fix commit and pass with the fix: `navigateBack` must report the press as handled once it navigates, and no listener registered on this route may consume the press without navigating. The other two are guard rails that pass either way, covering the cases this fix must not break: the handler must still return `false` at the public sign-in root so Android can background the app, and it must still call `goBack()` when it reports the press as unhandled, so `clearSelectedText()` and the `shouldPopToSidebar` branch are not skipped. React Native's reverse dispatch order itself is native and still not reproducible in Jest, so the tests assert the contract that makes dispatch order irrelevant rather than the ordering.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/80e58ba1-ec4f-416c-9491-c3720a3739f8

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
