### PR TITLE
[CP Staging] Patch Skia to fix iOS chart crash and charts stuck loading

### DIFF
--- a/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.14+003+fix-dispose-symbol-eval.patch
+++ b/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.14+003+fix-dispose-symbol-eval.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/@shopify/react-native-skia/cpp/jsi/JsiHostObject.cpp b/node_modules/@shopify/react-native-skia/cpp/jsi/JsiHostObject.cpp
+index ef1654d..b41fbfd 100644
+--- a/node_modules/@shopify/react-native-skia/cpp/jsi/JsiHostObject.cpp
++++ b/node_modules/@shopify/react-native-skia/cpp/jsi/JsiHostObject.cpp
+@@ -85,8 +85,11 @@ jsi::Value JsiHostObject::get(jsi::Runtime &runtime,
+ 
+   // Check for dispose symbol as last resort
+   static const auto disposeSymbol = jsi::PropNameID::forSymbol(
+-      runtime,
+-      eval(runtime, "Symbol.for('Symbol.dispose');").getSymbol(runtime));
++      runtime, runtime.global()
++                   .getPropertyAsObject(runtime, "Symbol")
++                   .getPropertyAsFunction(runtime, "for")
++                   .call(runtime, "Symbol.dispose")
++                   .getSymbol(runtime));
+   if (jsi::PropNameID::compare(runtime, disposeSymbol, name)) {
+     // Recursively call get with "dispose" string
+     auto disposeName = jsi::PropNameID::forAscii(runtime, "dispose");

--- a/patches/@shopify/react-native-skia/details.md
+++ b/patches/@shopify/react-native-skia/details.md
@@ -96,3 +96,4 @@
 
 - Upstream PR/issue: https://github.com/Shopify/react-native-skia/pull/3855 — the same fix, merged upstream on 2026-05-26. Drop this patch once the Skia dependency is bumped to >= 2.6.9.
 - E/App issue: https://github.com/Expensify/App/issues/98331, https://github.com/Expensify/App/issues/95905
+- PR introducing patch: https://github.com/Expensify/App/pull/98437

--- a/patches/@shopify/react-native-skia/details.md
+++ b/patches/@shopify/react-native-skia/details.md
@@ -68,3 +68,31 @@
 - Upstream PR/issue: https://github.com/Shopify/react-native-skia/pull/3996 — applies the same defensive handling (and the `skia-surface-unavailable` event) to upstream `main`, where the throws now live in the renderer constructor and `onResize`. Once it ships in a release we consume, this patch can be dropped.
 - E/App issue: https://github.com/Expensify/App/issues/97104
 - PR introducing patch: https://github.com/Expensify/App/pull/97219
+
+### [@shopify+react-native-skia+2.4.14+003+fix-dispose-symbol-eval.patch](@shopify+react-native-skia+2.4.14+003+fix-dispose-symbol-eval.patch)
+
+- Reason:
+
+    ```
+    Fixes two iOS failures with one cause: the Top merchants pie chart killing the app
+    (Sentry APP-K19, fatal unhandled "SyntaxError: Parsing source code unsupported:
+    Symbol.for('Symbol.dispose');"), and every Line and Bar chart sitting on an indefinite
+    loading spinner because their fonts never load.
+
+    JsiHostObject::get() falls back to a "dispose symbol" check for any property it does
+    not recognise, and that check calls jsi::eval(). Hermes without a runtime compiler
+    rejects that, so any unknown property read on a Skia host object throws instead of
+    returning undefined:
+
+    - Pie: <Path path={Skia.Path.Make()} /> reaches skia's ReanimatedRecorder, whose
+      isSharedValue worklet reads _isReanimatedSharedValue on the SkPath. Nothing catches
+      the throw, so the app terminates.
+    - Line/Bar: Skia.Data.fromURI resolves with an SkData host object and promise
+      resolution reads .then on it, so every typeface load rejects, the font manager is
+      never built, and the charts never leave their loading state.
+
+    Fix: obtain the symbol through runtime.global() instead of eval.
+    ```
+
+- Upstream PR/issue: https://github.com/Shopify/react-native-skia/pull/3855 — the same fix, merged upstream on 2026-05-26. Drop this patch once the Skia dependency is bumped to >= 2.6.9.
+- E/App issue: https://github.com/Expensify/App/issues/98331, https://github.com/Expensify/App/issues/95905


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Adds a patch to `@shopify/react-native-skia` 2.4.14 that removes a JS `eval` from its native JSI layer. `JsiHostObject::get` falls back to a "dispose symbol" check whenever a property isn't found on a Skia host object, and that check calls `jsi::eval(runtime, "Symbol.for('Symbol.dispose');")`. Hermes without a runtime compiler rejects it, so the lookup throws `SyntaxError: Parsing source code unsupported` instead of returning `undefined`. The patch obtains the symbol through `runtime.global()` instead, which is byte-identical to the upstream fix in [Shopify/react-native-skia#3855](https://github.com/Shopify/react-native-skia/pull/3855). It can be dropped once we bump Skia to >= 2.6.9. This reproduces only in builds whose Hermes lacks the compiler (Release builds).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98327
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open Home.
2. Verify the Insights widget loads correctly.
3. Go to Spend > Top merchants.
4. Verify the app doesn't crash.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/b0513cfc-c83b-472d-b5c1-3388ef63777d

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
