### PR TITLE
Hide the ProductMarketingWindowManager when user is inside 2FA flow

### DIFF
--- a/src/components/ProductMarketingWindow/ProductMarketingWindowManager.tsx
+++ b/src/components/ProductMarketingWindow/ProductMarketingWindowManager.tsx
@@ -1,9 +1,11 @@
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useOnyx from '@hooks/useOnyx';
+import useRootNavigationState from '@hooks/useRootNavigationState';
+import useShouldShowRequire2FAPage from '@hooks/useShouldShowRequire2FAPage';
 
 import {setNameValuePair} from '@libs/actions/User';
-import Navigation from '@libs/Navigation/Navigation';
+import Navigation, {getDeepestFocusedScreen, isTwoFactorSetupScreen} from '@libs/Navigation/Navigation';
 import {ACTIVE_PRODUCT_MARKETING_ANNOUNCEMENT, getProductMarketingAnnouncementVariant} from '@libs/ProductMarketingWindowUtils';
 
 import CONST from '@src/CONST';
@@ -16,6 +18,7 @@ import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 
+import {useNavigation} from '@react-navigation/core';
 import React from 'react';
 
 import ProductMarketingWindow from './ProductMarketingWindow';
@@ -68,8 +71,25 @@ function ProductMarketingWindowManager({topmostRouteName}: ProductMarketingWindo
     const variant = getProductMarketingAnnouncementVariant(announcement, !!targetAdminPolicyID, lastDismissedMarketingWindow);
     const isCoveredByCenteredModalScreen = !!topmostRouteName && CENTERED_MODAL_SCREEN_NAVIGATORS.has(topmostRouteName);
     const isLoading = isLoadingOnyxValue(lastDismissedMarketingWindowMetadata, activeAdminPoliciesMetadata, activePolicyIDMetadata, isLoadingAppMetadata, accountMetadata) || isLoadingApp;
+    const shouldShowRequire2FAPage = useShouldShowRequire2FAPage();
+    const navigation = useNavigation();
+    const isIn2FASetupFlow = useRootNavigationState((state) => {
+        // When navigation is not ready yet, use the navigation state from the navigation hook.
+        const focusedScreen = getDeepestFocusedScreen(state ?? navigation.getState());
+        return isTwoFactorSetupScreen(focusedScreen?.name);
+    });
 
-    if (!announcement || !variant || isLoading || isProductMarketingWindowCovered || isAnonymousSession || isActingAsDelegate || isCoveredByCenteredModalScreen) {
+    if (
+        !announcement ||
+        !variant ||
+        isLoading ||
+        isProductMarketingWindowCovered ||
+        isAnonymousSession ||
+        isActingAsDelegate ||
+        isCoveredByCenteredModalScreen ||
+        shouldShowRequire2FAPage ||
+        isIn2FASetupFlow
+    ) {
         return null;
     }
 

--- a/tests/unit/ProductMarketingWindowTest.tsx
+++ b/tests/unit/ProductMarketingWindowTest.tsx
@@ -29,6 +29,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
 import type {Policy} from '@src/types/onyx';
 
+import {NavigationContainer} from '@react-navigation/native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 
@@ -49,6 +50,10 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     goBack: jest.fn(),
     isNavigationReady: jest.fn(() => Promise.resolve()),
 }));
+
+// The manager derives whether the 2FA setup flow is focused from the root navigation state, which the bare
+// NavigationContainer below never populates. These tests cover the other visibility conditions, so the flag stays false.
+jest.mock('@hooks/useRootNavigationState', () => jest.fn(() => false));
 
 // Keep setNameValuePair's optimistic Onyx merge (so persistence behavior is exercised end-to-end) while
 // dropping its API call and letting tests assert that the previous value is supplied for failure rollback.
@@ -94,13 +99,15 @@ function buildAdminPolicy(policyID = POLICY_ID): Policy {
 
 const renderManager = (topmostRouteName?: string, theme: ThemePreferenceWithoutSystem = CONST.THEME.LIGHT) =>
     render(
-        <ThemeProvider theme={theme}>
-            <ThemeStylesProvider>
-                <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, CurrentUserPersonalDetailsProvider]}>
-                    <ProductMarketingWindowManager topmostRouteName={topmostRouteName} />
-                </ComposeProviders>
-            </ThemeStylesProvider>
-        </ThemeProvider>,
+        <NavigationContainer>
+            <ThemeProvider theme={theme}>
+                <ThemeStylesProvider>
+                    <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, CurrentUserPersonalDetailsProvider]}>
+                        <ProductMarketingWindowManager topmostRouteName={topmostRouteName} />
+                    </ComposeProviders>
+                </ThemeStylesProvider>
+            </ThemeProvider>
+        </NavigationContainer>,
     );
 
 async function setupOnyxBaseline({isAdmin, activePolicyID = POLICY_ID}: {isAdmin: boolean; activePolicyID?: string}) {
@@ -675,5 +682,26 @@ describe('ProductMarketingWindowManager', () => {
             width: '100%',
             aspectRatio: variables.productMarketingWindowVisualAspectRatio,
         });
+    });
+
+    it('renders nothing while the Require 2FA page is showing', async () => {
+        await act(async () => {
+            await setupOnyxBaseline({isAdmin: true});
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {needsTwoFactorAuthSetup: true, requiresTwoFactorAuth: false});
+            await waitForBatchedUpdatesWithAct();
+        });
+
+        renderManager();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByText(adminHeading)).toBeNull();
+
+        // Once 2FA is set up the requirement page goes away, so the window is free to show again.
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {needsTwoFactorAuthSetup: false, requiresTwoFactorAuth: true});
+            await waitForBatchedUpdatesWithAct();
+        });
+
+        expect(screen.getByText(adminHeading)).toBeTruthy();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

We still show the `ProductMarketingWindow` while we're in 2FA flow, when user presses `Dismiss`, we call the `SetNameValuePair` command. However `SetNameValuePair`will throw an error if 2FA is required and the user doesn't setup it.
In this PR, we hide the `ProductMarketingWindow` if the user is required to set up 2FA or they're inside the 2FA flow.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98140
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA steps.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
> [!NOTE]
> If you don't see 2FA required screen when logging in with account B, you probably need to relogin. 
// TODO: These must be filled out, or the issue title must include "[No QA]."
1. Login with account A, create a new workspace > enable Accounting > Connect to account software (QBO or Xero, or Sage Intacct...)
2. Invite account B as an admin of that workspace. (Account haven't setup 2FA yet).
3. Login with account B.
4. Verify that if the 2FA screen shows up, `ProductMarketingWindow` shouldn't appear.
5. If the 2FA screen shows up > Complete the 2FA flows > Verify that `ProductMarketingWindow` will appear and you will be able to dismiss it.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/6cba74a6-9334-40bd-b5cc-6aec1499011d



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/16d8b0b8-f4af-4815-8f0e-2f4b939b7014



</details>
