### PR TITLE
[CP Stg] fix chart cut off in concierge room

### DIFF
--- a/src/components/Charts/SkiaWebChart/index.tsx
+++ b/src/components/Charts/SkiaWebChart/index.tsx
@@ -79,7 +79,10 @@ function SkiaWebChart<TProps extends object>({getComponent, componentProps}: Ski
     );
 
     return (
-        <View ref={viewRef(containerRef)}>
+        <View
+            ref={viewRef(containerRef)}
+            style={styles.mw100}
+        >
             <WithSkiaWeb
                 opts={{locateFile: (file: string) => `/${file}`}}
                 getComponent={getComponent}


### PR DESCRIPTION
### Explanation of Change

Victory charts in Concierge rooms stopped scaling down to the message column, so they got cut off — most visibly on narrow viewports (mWeb).

Charts size themselves by shrinking their wrapper: `VictoryChartExpandable` renders the chart at its design width capped with `mw100` (`maxWidth: 100%`), and `VictoryChartContainerResponsive` measures that shrunken width via `onLayout` and feeds it to `computeChartScale` to scale the chart down.

#97219 added a wrapper `<View>` around `WithSkiaWeb` in `SkiaWebChart` to host the listener for the `skia-surface-unavailable` event. That View had no styles, so it inherited react-native-web's View defaults: `flex-shrink: 0` and no `max-width`. Wherever the chart's parent doesn't stretch its children, the new View sized itself to the chart's full design width instead of the available width. The chart's `maxWidth: 100%` then resolved against that full design width rather than the message column, so it never shrank, `onLayout` measured the un-shrunk width, and `computeChartScale` always returned `1` — the chart rendered at full size and overflowed.

Adding `styles.mw100` to that wrapper keeps it transparent to layout — it still hosts the event listener, but no longer blocks the chart from shrinking. Verified in the browser with react-native-web's exact View defaults (300px container, 600px design-width chart): the extra wrapper renders the chart at 600px in a non-stretching parent (row or `align-items: flex-start`) and at 300px once `max-width: 100%` is applied, matching pre-regression behavior.

Native is unaffected — it renders through `VictoryChartRenderer/index.native.tsx` and never mounts `SkiaWebChart`.


### Fixed Issues
$ https://github.com/Expensify/App/issues/98456
PROPOSAL: https://expensify.slack.com/archives/C049HHMV9SM/p1786554921065069?thread_ts=1786553440.497139&cid=C049HHMV9SM

### Tests
1. Ensure the selected test account has some expenses across several months this year.
2. Start a 1-on-1 DM with Concierge.
3. Ask it something like "Give me a spend bar chart of my monthly expenses for this year."
4. Wait for the response with an embedded vertical Victory bar chart.
5. Verify that the rendered chart is not cut off and fully visible and fits window width whenever resize

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests

### QA Steps
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>



</details>

<details>
<summary>Android: mWeb Chrome</summary>



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/63abcf7b-7067-44cb-900b-23a7f547c0c8



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/3f63d9a7-9fb9-4dad-9ad8-81a1106b1aa4



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/722dac41-0fa8-4726-b564-a6f452ddbec0



</details>
