### PR TITLE
[CP Stg] Fix category change log thread header to match the system message

### DIFF
--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -89,6 +89,7 @@ import {
     isActionableMentionWhisper,
     isActionOfType,
     isAddCommentAction,
+    isCategoryModificationAction,
     isClosedAction,
     isCreatedAction,
     isCreatedTaskReportAction,
@@ -976,12 +977,7 @@ function getLastMessageTextForReport({
     if (isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_MCC_GROUP_CATEGORY)) {
         lastMessageTextFromReport = getMccGroupCategoryMessage(translate, lastReportAction);
     }
-    if (
-        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY) ||
-        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY) ||
-        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY) ||
-        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME)
-    ) {
+    if (lastReportAction?.actionName && isCategoryModificationAction(lastReportAction.actionName)) {
         lastMessageTextFromReport = getWorkspaceCategoryUpdateMessage(translate, lastReportAction, policy);
     }
     if (

--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -79,6 +79,7 @@ import {
     getUpdatedCardFeedLiabilityMessage,
     getUpdatedCardFeedStatementPeriodMessage,
     getUpdateRoomDescriptionMessage,
+    getWorkspaceCategoryUpdateMessage,
     getWorkspaceFeatureEnabledMessage,
     getWorkspaceTaxUpdateMessage,
     hasPendingDEWApprove,
@@ -974,6 +975,14 @@ function getLastMessageTextForReport({
     }
     if (isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_MCC_GROUP_CATEGORY)) {
         lastMessageTextFromReport = getMccGroupCategoryMessage(translate, lastReportAction);
+    }
+    if (
+        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY) ||
+        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY) ||
+        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY) ||
+        isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME)
+    ) {
+        lastMessageTextFromReport = getWorkspaceCategoryUpdateMessage(translate, lastReportAction, policy);
     }
     if (
         isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_TAX) ||

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1850,6 +1850,15 @@ function isTaskAction(reportAction: OnyxEntry<ReportAction>): boolean {
  * @param actionName - The name of the action
  * @returns - Whether the action is a tag modification action
  * */
+function isCategoryModificationAction(actionName: string): boolean {
+    return (
+        actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY ||
+        actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY ||
+        actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY ||
+        actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME
+    );
+}
+
 function isTagModificationAction(actionName: string): boolean {
     return (
         actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_TAG ||
@@ -4990,6 +4999,7 @@ export {
     getMostRecentActiveDEWApproveFailedAction,
     hasPendingDEWApprove,
     isWhisperActionTargetedToOthers,
+    isCategoryModificationAction,
     isTagModificationAction,
     isIOUActionMatchingTransactionList,
     isResolvedActionableWhisper,

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -3040,7 +3040,10 @@ function getWorkspaceCategoryUpdateMessage(translate: LocalizedTranslate, action
 
     if (action.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY && categoryName) {
         if (updatedField === 'commentHint') {
-            return translate('workspaceActions.updatedDescriptionHint', decodedOptionName, newValue as string | undefined, oldValue as string | undefined);
+            // Description hints are stored as HTML, so they have to be converted back to plain text to read correctly in a message
+            const newHint = typeof newValue === 'string' && newValue ? Parser.htmlToText(newValue) : undefined;
+            const oldHint = typeof oldValue === 'string' && oldValue ? Parser.htmlToText(oldValue) : undefined;
+            return translate('workspaceActions.updatedDescriptionHint', decodedOptionName, newHint, oldHint);
         }
 
         if (updatedField === 'enabled') {

--- a/src/libs/ReportNameUtils.ts
+++ b/src/libs/ReportNameUtils.ts
@@ -95,6 +95,7 @@ import {
     getUpdatedCardFeedStatementPeriodMessage,
     getUpdatedProhibitedExpensesMessage,
     getWorkspaceAttendeeTrackingUpdateMessage,
+    getWorkspaceCategoryUpdateMessage,
     getWorkspaceCurrencyUpdateMessage,
     getWorkspaceCustomUnitRateAddedMessage,
     getWorkspaceCustomUnitRateDeletedMessage,
@@ -697,6 +698,15 @@ function computeReportNameBasedOnReportAction({
     }
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_REIMBURSER)) {
         return getReimburserUpdateMessage(translate, parentReportAction);
+    }
+
+    if (
+        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY) ||
+        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY) ||
+        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY) ||
+        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME)
+    ) {
+        return getWorkspaceCategoryUpdateMessage(translate, parentReportAction, reportPolicy);
     }
 
     if (

--- a/src/libs/ReportNameUtils.ts
+++ b/src/libs/ReportNameUtils.ts
@@ -112,6 +112,7 @@ import {
     isActionableJoinRequest,
     isActionOfType,
     isCardIssuedAction,
+    isCategoryModificationAction,
     isDynamicExternalWorkflowApproveFailedAction,
     isDynamicExternalWorkflowSubmitFailedAction,
     isMarkAsClosedAction,
@@ -700,12 +701,7 @@ function computeReportNameBasedOnReportAction({
         return getReimburserUpdateMessage(translate, parentReportAction);
     }
 
-    if (
-        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY) ||
-        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY) ||
-        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY) ||
-        isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME)
-    ) {
+    if (parentReportAction?.actionName && isCategoryModificationAction(parentReportAction.actionName)) {
         return getWorkspaceCategoryUpdateMessage(translate, parentReportAction, reportPolicy);
     }
 

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -146,6 +146,7 @@ import {
     getWorkspaceUpdateFieldMessage,
     isActionOfType,
     isCardIssuedAction,
+    isCategoryModificationAction,
     isInviteOrRemovedAction,
     isLeavePolicyAction,
     isOldDotReportAction,
@@ -1108,12 +1109,7 @@ function getOptionData({
             result.alternateText = Parser.htmlToText(getCompanyCardConnectionBrokenMessage(translate, lastAction));
         } else if (isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.PLAID_BALANCE_FAILURE)) {
             result.alternateText = Parser.htmlToText(getPlaidBalanceFailureMessage(translate, lastAction));
-        } else if (
-            isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY) ||
-            isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY) ||
-            isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY) ||
-            isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME)
-        ) {
+        } else if (lastAction?.actionName && isCategoryModificationAction(lastAction.actionName)) {
             result.alternateText = getWorkspaceCategoryUpdateMessage(translate, lastAction);
         } else if (isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORIES)) {
             result.alternateText = getWorkspaceCategoriesUpdatedMessage(translate, lastAction);

--- a/src/pages/inbox/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/inbox/report/ContextMenu/ContextMenuActions.tsx
@@ -139,6 +139,7 @@ import {
     isActionableTrackExpense,
     isActionOfType,
     isCardIssuedAction,
+    isCategoryModificationAction,
     isCreatedAction,
     isCreatedTaskReportAction,
     isDeletedAction as isDeletedActionReportActionsUtils,
@@ -1057,12 +1058,7 @@ const ContextMenuActions: ContextMenuAction[] = [
                     Clipboard.setString(getWorkspaceCurrencyUpdateMessage(translate, reportAction));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_AUTO_REPORTING_FREQUENCY) {
                     Clipboard.setString(getWorkspaceFrequencyUpdateMessage(translate, reportAction));
-                } else if (
-                    reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY ||
-                    reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY ||
-                    reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY ||
-                    reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME
-                ) {
+                } else if (reportAction?.actionName && isCategoryModificationAction(reportAction.actionName)) {
                     Clipboard.setString(getWorkspaceCategoryUpdateMessage(translate, reportAction));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORIES) {
                     Clipboard.setString(getWorkspaceCategoriesUpdatedMessage(translate, reportAction));

--- a/tests/ui/components/HeaderViewTest.tsx
+++ b/tests/ui/components/HeaderViewTest.tsx
@@ -211,7 +211,7 @@ describe('HeaderView', () => {
         expect(screen.getByTestId('DisplayNames')).toHaveTextContent(/created this report for any held expenses from/);
     });
 
-    it('should display the localized category update message for a thread on a POLICYCHANGELOG_UPDATE_CATEGORY action', async () => {
+    it('should display the localized category update message for a thread on a category update action', async () => {
         // Given an #admins room with a report action that made attendees required on a category
         const policyID = '400';
         const adminsReportID = '401';

--- a/tests/ui/components/HeaderViewTest.tsx
+++ b/tests/ui/components/HeaderViewTest.tsx
@@ -211,6 +211,72 @@ describe('HeaderView', () => {
         expect(screen.getByTestId('DisplayNames')).toHaveTextContent(/created this report for any held expenses from/);
     });
 
+    it('should display the localized category update message for a thread on a POLICYCHANGELOG_UPDATE_CATEGORY action', async () => {
+        // Given an #admins room with a report action that made attendees required on a category
+        const policyID = '400';
+        const adminsReportID = '401';
+        const threadReportID = '402';
+        const rawServerMessage = 'updated the category "Advertising" by changing the Attendees from Not Required to Required';
+
+        const parentReportAction: ReportAction = {
+            reportActionID: '4001',
+            actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
+            created: '2026-01-01 00:00:00.000',
+            message: [{type: CONST.REPORT.MESSAGE.TYPE.COMMENT, html: rawServerMessage, text: rawServerMessage}],
+            originalMessage: {
+                categoryName: 'Advertising',
+                updatedField: 'areAttendeesRequired',
+                oldValue: false,
+                newValue: true,
+            },
+        };
+
+        const adminsReport = {
+            ...createRandomReport(Number(adminsReportID), CONST.REPORT.CHAT_TYPE.POLICY_ADMINS),
+            type: CONST.REPORT.TYPE.CHAT,
+            policyID,
+        };
+
+        // And a chat thread opened on that action
+        const threadReport = {
+            ...createRandomReport(Number(threadReportID), undefined),
+            type: CONST.REPORT.TYPE.CHAT,
+            policyID,
+            parentReportID: adminsReportID,
+            parentReportActionID: parentReportAction.reportActionID,
+        };
+
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${adminsReportID}`, {
+            [parentReportAction.reportActionID]: parentReportAction,
+        });
+        await waitForBatchedUpdates();
+
+        const policyKey = `${ONYXKEYS.COLLECTION.POLICY}${policyID}` as const;
+        const adminsReportKey = `${ONYXKEYS.COLLECTION.REPORT}${adminsReportID}` as const;
+        const threadReportKey = `${ONYXKEYS.COLLECTION.REPORT}${threadReportID}` as const;
+        await Onyx.multiSet(
+            createMock<KeyValueMapping>({
+                [policyKey]: {
+                    id: policyID,
+                    name: 'Test Workspace',
+                    type: CONST.POLICY.TYPE.CORPORATE,
+                    role: CONST.POLICY.ROLE.ADMIN,
+                    owner: 'admin@example.com',
+                    outputCurrency: 'USD',
+                    isPolicyExpenseChatEnabled: true,
+                },
+                [adminsReportKey]: adminsReport,
+                [threadReportKey]: threadReport,
+            }),
+        );
+
+        renderHeader(threadReport.reportID);
+        await waitForBatchedUpdatesWithAct();
+
+        // Then the thread header should show the same copy as the system message in the chat
+        await waitFor(() => expect(screen.getByTestId('DisplayNames')).toHaveTextContent(translateLocal('workspaceActions.updateAreAttendeesRequired', 'Advertising', true)));
+    });
+
     const accountManagerAccountID = 777;
     const otherAccountID = 888;
     const accountManagerCalendarLink = 'https://calendly.com/account-manager/expensify';

--- a/tests/ui/components/HeaderViewTest.tsx
+++ b/tests/ui/components/HeaderViewTest.tsx
@@ -211,6 +211,27 @@ describe('HeaderView', () => {
         expect(screen.getByTestId('DisplayNames')).toHaveTextContent(/created this report for any held expenses from/);
     });
 
+    const accountManagerAccountID = 777;
+    const otherAccountID = 888;
+    const accountManagerCalendarLink = 'https://calendly.com/account-manager/expensify';
+
+    const personalDetailsList = {
+        [currentUserAccountID]: {accountID: currentUserAccountID, login: 'me@example.com', displayName: 'My Account'},
+        [accountManagerAccountID]: {accountID: accountManagerAccountID, login: 'am@example.com', displayName: 'Account Manager'},
+        [otherAccountID]: {accountID: otherAccountID, login: 'other@example.com', displayName: 'Someone Else'},
+    };
+
+    function renderHeader(reportID: string) {
+        return render(
+            <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+                <HeaderView
+                    onNavigationMenuButtonClicked={() => {}}
+                    reportID={reportID}
+                />
+            </ComposeProviders>,
+        );
+    }
+
     it('should display the localized category update message for a thread on a category update action', async () => {
         // Given an #admins room with a report action that made attendees required on a category
         const policyID = '400';
@@ -226,7 +247,7 @@ describe('HeaderView', () => {
             originalMessage: {
                 categoryName: 'Advertising',
                 updatedField: 'areAttendeesRequired',
-                oldValue: false,
+                oldValue: '',
                 newValue: true,
             },
         };
@@ -251,20 +272,10 @@ describe('HeaderView', () => {
         });
         await waitForBatchedUpdates();
 
-        const policyKey = `${ONYXKEYS.COLLECTION.POLICY}${policyID}` as const;
         const adminsReportKey = `${ONYXKEYS.COLLECTION.REPORT}${adminsReportID}` as const;
         const threadReportKey = `${ONYXKEYS.COLLECTION.REPORT}${threadReportID}` as const;
         await Onyx.multiSet(
             createMock<KeyValueMapping>({
-                [policyKey]: {
-                    id: policyID,
-                    name: 'Test Workspace',
-                    type: CONST.POLICY.TYPE.CORPORATE,
-                    role: CONST.POLICY.ROLE.ADMIN,
-                    owner: 'admin@example.com',
-                    outputCurrency: 'USD',
-                    isPolicyExpenseChatEnabled: true,
-                },
                 [adminsReportKey]: adminsReport,
                 [threadReportKey]: threadReport,
             }),
@@ -276,27 +287,6 @@ describe('HeaderView', () => {
         // Then the thread header should show the same copy as the system message in the chat
         await waitFor(() => expect(screen.getByTestId('DisplayNames')).toHaveTextContent(translateLocal('workspaceActions.updateAreAttendeesRequired', 'Advertising', true)));
     });
-
-    const accountManagerAccountID = 777;
-    const otherAccountID = 888;
-    const accountManagerCalendarLink = 'https://calendly.com/account-manager/expensify';
-
-    const personalDetailsList = {
-        [currentUserAccountID]: {accountID: currentUserAccountID, login: 'me@example.com', displayName: 'My Account'},
-        [accountManagerAccountID]: {accountID: accountManagerAccountID, login: 'am@example.com', displayName: 'Account Manager'},
-        [otherAccountID]: {accountID: otherAccountID, login: 'other@example.com', displayName: 'Someone Else'},
-    };
-
-    function renderHeader(reportID: string) {
-        return render(
-            <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
-                <HeaderView
-                    onNavigationMenuButtonClicked={() => {}}
-                    reportID={reportID}
-                />
-            </ComposeProviders>,
-        );
-    }
 
     it('should display the Book a call button in the 1:1 DM with the account manager', async () => {
         // Given a 1:1 DM with the assigned account manager who has a calendar link

--- a/tests/unit/ContextMenuActionsCopyMessageTest.ts
+++ b/tests/unit/ContextMenuActionsCopyMessageTest.ts
@@ -149,4 +149,23 @@ describe('ContextMenuActions copy message', () => {
         expect(mockGetClipboardText).toHaveBeenCalledWith(expectedTranslationKey);
         expect(mockClipboard.setString).toHaveBeenCalledWith('mocked clipboard text');
     });
+
+    it('copies the localized message for a category update action', () => {
+        mockClipboard.canSetHtml.mockReturnValue(false);
+
+        if (!copyMessageAction?.onPress) {
+            throw new Error('Copy message context menu action was not found');
+        }
+
+        copyMessageAction.onPress(
+            false,
+            createReportActionPayload({
+                actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
+                message: [{html: ''}],
+                originalMessage: {categoryName: 'Advertising', updatedField: 'areAttendeesRequired', oldValue: '', newValue: true},
+            }),
+        );
+
+        expect(mockClipboard.setString).toHaveBeenCalledWith('workspaceActions.updateAreAttendeesRequired');
+    });
 });

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -895,6 +895,82 @@ describe('ReportNameUtils', () => {
             expect(name).toBe('changed the "Office Supplies" category default tax rate to "Tax Rate 1 (5%)" (previously "Tax Exempt (0%)")');
         });
 
+        test.each([
+            [CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY, {categoryName: 'Advertising'}, 'added the category "Advertising"'],
+            [CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY, {categoryName: 'Advertising'}, 'removed the category "Advertising"'],
+            [
+                CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
+                {categoryName: 'Advertising', updatedField: 'areAttendeesRequired', oldValue: '', newValue: true},
+                'changed the "Advertising" category attendees to required (previously not required)',
+            ],
+            [CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME, {oldName: 'Advertising', newName: 'Marketing'}, 'renamed the category "Advertising" to "Marketing"'],
+        ])('%s parent action renders the same message as the system message in the chat', (actionName, originalMessage, expected) => {
+            const thread: Report = createWorkspaceThread(161);
+            const parentAction = createMock<ReportAction>({
+                actionName,
+                reportActionID: String(thread.parentReportActionID),
+                message: [],
+                created: '',
+                lastModified: '',
+                actorAccountID: 1,
+                person: [],
+                originalMessage,
+            });
+
+            const reportActionsCollection: Record<string, ReportActions> = {
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${String(thread.parentReportID)}`]: {
+                    [String(thread.parentReportActionID)]: parentAction,
+                },
+            };
+
+            const name = computeReportName(
+                thread,
+                emptyCollections.reports,
+                emptyCollections.policies,
+                undefined,
+                undefined,
+                participantsPersonalDetails,
+                reportActionsCollection,
+                currentUserAccountID,
+            );
+            expect(name).toBe(expected);
+        });
+
+        test('UPDATE_CATEGORY parent action formats receipt amounts with the policy currency', () => {
+            const thread: Report = createWorkspaceThread(162);
+            const parentAction = createMock<ReportAction>({
+                actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
+                reportActionID: String(thread.parentReportActionID),
+                message: [],
+                created: '',
+                lastModified: '',
+                actorAccountID: 1,
+                person: [],
+                originalMessage: {
+                    categoryName: 'Advertising',
+                    updatedField: 'maxAmountNoReceipt',
+                    oldValue: 0,
+                    newValue: 2500,
+                },
+            });
+
+            const reportActionsCollection: Record<string, ReportActions> = {
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${String(thread.parentReportID)}`]: {
+                    [String(thread.parentReportActionID)]: parentAction,
+                },
+            };
+            const policies: OnyxCollection<Policy> = {
+                [`${ONYXKEYS.COLLECTION.POLICY}${String(thread.policyID)}`]: createMock<Policy>({
+                    id: String(thread.policyID),
+                    maxExpenseAmountNoReceipt: 5000,
+                    outputCurrency: 'EUR',
+                }),
+            };
+
+            const name = computeReportName(thread, emptyCollections.reports, policies, undefined, undefined, participantsPersonalDetails, reportActionsCollection, currentUserAccountID);
+            expect(name).toContain('€50');
+        });
+
         test('DELETE_CARD_FEED parent action', () => {
             const thread: Report = createWorkspaceThread(101);
             const parentAction = createMock<ReportAction>({

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -1005,7 +1005,7 @@ describe('ReportNameUtils', () => {
             };
 
             const name = computeReportName(thread, emptyCollections.reports, policies, undefined, undefined, participantsPersonalDetails, reportActionsCollection, currentUserAccountID);
-            expect(name).toContain('€50');
+            expect(name).toBe('changed the "Advertising" category to €50 • Default (previously Always require receipts)');
         });
 
         test('DELETE_CARD_FEED parent action', () => {

--- a/tests/unit/ReportNameUtilsTest.ts
+++ b/tests/unit/ReportNameUtilsTest.ts
@@ -936,7 +936,44 @@ describe('ReportNameUtils', () => {
             expect(name).toBe(expected);
         });
 
-        test('UPDATE_CATEGORY parent action formats receipt amounts with the policy currency', () => {
+        test('UPDATE_CATEGORY parent action renders the description hint as plain text', () => {
+            const thread: Report = createWorkspaceThread(163);
+            const parentAction = createMock<ReportAction>({
+                actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
+                reportActionID: String(thread.parentReportActionID),
+                message: [],
+                created: '',
+                lastModified: '',
+                actorAccountID: 1,
+                person: [],
+                originalMessage: {
+                    categoryName: 'Advertising',
+                    updatedField: 'commentHint',
+                    oldValue: '',
+                    newValue: 'Client&#x27;s &amp; partner&#x27;s names',
+                },
+            });
+
+            const reportActionsCollection: Record<string, ReportActions> = {
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${String(thread.parentReportID)}`]: {
+                    [String(thread.parentReportActionID)]: parentAction,
+                },
+            };
+
+            const name = computeReportName(
+                thread,
+                emptyCollections.reports,
+                emptyCollections.policies,
+                undefined,
+                undefined,
+                participantsPersonalDetails,
+                reportActionsCollection,
+                currentUserAccountID,
+            );
+            expect(name).toBe(`added the description hint "Client's & partner's names" to the category "Advertising"`);
+        });
+
+        test('UPDATE_CATEGORY parent action formats the workspace default receipt amount with the policy currency', () => {
             const thread: Report = createWorkspaceThread(162);
             const parentAction = createMock<ReportAction>({
                 actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
@@ -950,7 +987,7 @@ describe('ReportNameUtils', () => {
                     categoryName: 'Advertising',
                     updatedField: 'maxAmountNoReceipt',
                     oldValue: 0,
-                    newValue: 2500,
+                    newValue: '',
                 },
             });
 

--- a/tests/unit/SearchAutocompleteListTest.tsx
+++ b/tests/unit/SearchAutocompleteListTest.tsx
@@ -9,6 +9,7 @@ import Text from '@components/Text';
 
 import type {PrivateIsArchivedMap} from '@hooks/usePrivateIsArchivedMap';
 
+import initOnyxDerivedValues from '@libs/actions/OnyxDerived';
 import {setHasRadio} from '@libs/NetworkState';
 import type * as OptionsListUtilsModule from '@libs/OptionsListUtils';
 import * as OptionsListUtils from '@libs/OptionsListUtils';
@@ -18,9 +19,10 @@ import Navigation from '@navigation/Navigation';
 
 import ComposeProviders from '@src/components/ComposeProviders';
 import CONST from '@src/CONST';
+import IntlStore from '@src/languages/IntlStore';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {PersonalDetails, Report} from '@src/types/onyx';
+import type {PersonalDetails, Report, ReportAction} from '@src/types/onyx';
 
 import type * as NativeNavigation from '@react-navigation/native';
 import type ReactNative from 'react-native';
@@ -28,6 +30,7 @@ import type ReactNative from 'react-native';
 import React from 'react';
 import {StyleSheet} from 'react-native';
 import Onyx from 'react-native-onyx';
+import OnyxUtils from 'react-native-onyx/dist/OnyxUtils';
 
 import createCollection from '../utils/collections/createCollection';
 import createPersonalDetails from '../utils/collections/personalDetails';
@@ -224,6 +227,7 @@ describe('SearchAutocompleteList', () => {
             keys: ONYXKEYS,
             evictableKeys: [ONYXKEYS.COLLECTION.REPORT],
         });
+        initOnyxDerivedValues();
     });
 
     beforeEach(() => {
@@ -378,6 +382,92 @@ describe('SearchAutocompleteList', () => {
         // Then the contextual report (not part of recent reports) is built through createOptionFromReport
         expect(createOptionFromReportSpy).toHaveBeenCalled();
         expect(createOptionFromReportSpy.mock.calls.at(0)?.at(0)?.conciergeReportID).toBe('concierge-router-1');
+    });
+
+    it('should display the localized category update message for a thread on a category update action', async () => {
+        // Given an #admins room with a report action that made attendees required on a category
+        const policyID = '400';
+        const adminsReportID = '401';
+        const threadReportID = '402';
+        const rawServerMessage = 'updated the category "Advertising" by changing the Attendees from Not Required to Required';
+
+        const parentReportAction: ReportAction = {
+            reportActionID: '4001',
+            actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
+            created: '2026-01-01 00:00:00.000',
+            message: [{type: CONST.REPORT.MESSAGE.TYPE.COMMENT, html: rawServerMessage, text: rawServerMessage}],
+            originalMessage: {
+                categoryName: 'Advertising',
+                updatedField: 'areAttendeesRequired',
+                oldValue: '',
+                newValue: true,
+            },
+        };
+
+        const adminsReport = {
+            ...createRandomReport(Number(adminsReportID), CONST.REPORT.CHAT_TYPE.POLICY_ADMINS),
+            type: CONST.REPORT.TYPE.CHAT,
+            policyID,
+        };
+
+        // And a chat thread opened on that action. The thread needs a last message so it is not treated as an
+        // empty chat thread, which the option list hides.
+        const threadReport = {
+            ...createRandomReport(Number(threadReportID), undefined),
+            type: CONST.REPORT.TYPE.CHAT,
+            policyID,
+            parentReportID: adminsReportID,
+            parentReportActionID: parentReportAction.reportActionID,
+            participants: {[CURRENT_USER_ACCOUNT_ID]: {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS}},
+            lastMessageText: 'Thanks for the update',
+        };
+
+        // The derived report attributes translate the name, so the locale has to be loaded before they compute
+        await IntlStore.load(CONST.LOCALES.EN);
+        await waitForBatchedUpdates();
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${adminsReportID}`, {
+            [parentReportAction.reportActionID]: parentReportAction,
+        });
+        await Onyx.multiSet({
+            [ONYXKEYS.BETAS]: mockedBetas,
+            [ONYXKEYS.PERSONAL_DETAILS_LIST]: mockedPersonalDetails,
+        });
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${adminsReportID}`, adminsReport);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${threadReportID}`, threadReport);
+        await Onyx.set(ONYXKEYS.SESSION, {accountID: CURRENT_USER_ACCOUNT_ID, email: 'test@test.com'});
+        await flushAllUpdates();
+
+        // The row label is the derived report name, so the options have to be built from the derived attributes
+        const reportAttributes = await OnyxUtils.get(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES);
+        expect(reportAttributes?.reports?.[threadReportID]?.reportName).toBeTruthy();
+        mockUseFilteredOptions.mockReturnValue({
+            options: createFilteredOptionList(
+                mockedPersonalDetails,
+                {[`${ONYXKEYS.COLLECTION.REPORT}${threadReportID}`]: threadReport},
+                reportAttributes?.reports,
+                EMPTY_PRIVATE_IS_ARCHIVED_MAP,
+                undefined,
+                {
+                    currentUserAccountID: CURRENT_USER_ACCOUNT_ID,
+                    dateFnsLocale: undefined,
+                    conciergeReportID: undefined,
+                    isSearching: true,
+                },
+            ),
+            isLoading: false,
+            loadMore: jest.fn(),
+            hasMore: false,
+            isLoadingMore: false,
+        });
+
+        render(<SearchRouterWrapper />);
+        await flushAllUpdates();
+
+        // Then the search result shows the same copy as the system message in the chat, not the raw server text
+        await waitFor(() => {
+            expect(screen.getByText(TestHelper.translateLocal('workspaceActions.updateAreAttendeesRequired', 'Advertising', true))).toBeTruthy();
+        });
+        expect(screen.queryByText(rawServerMessage)).toBeNull();
     });
 
     describe('two-section chat switcher', () => {

--- a/tests/unit/SearchAutocompleteListTest.tsx
+++ b/tests/unit/SearchAutocompleteListTest.tsx
@@ -470,6 +470,95 @@ describe('SearchAutocompleteList', () => {
         expect(screen.queryByText(rawServerMessage)).toBeNull();
     });
 
+    it('should display the localized category update message as the subtitle of a thread it was posted in', async () => {
+        // Given a workspace change log thread whose newest message made attendees required on a category
+        const policyID = '500';
+        const adminsReportID = '501';
+        const threadReportID = '502';
+        const rawServerMessage = 'updated the category "Advertising" by changing the Attendees from Not Required to Required';
+
+        const upgradeAction: ReportAction = {
+            reportActionID: '5001',
+            actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+            created: '2026-01-01 00:00:00.000',
+            message: [{type: CONST.REPORT.MESSAGE.TYPE.COMMENT, html: 'upgraded this workspace', text: 'upgraded this workspace'}],
+            originalMessage: {},
+        };
+
+        const categoryAction: ReportAction = {
+            reportActionID: '5002',
+            actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY,
+            created: '2026-01-02 00:00:00.000',
+            message: [{type: CONST.REPORT.MESSAGE.TYPE.COMMENT, html: rawServerMessage, text: rawServerMessage}],
+            originalMessage: {
+                categoryName: 'Advertising',
+                updatedField: 'areAttendeesRequired',
+                oldValue: '',
+                newValue: true,
+            },
+        };
+
+        const adminsReport = {
+            ...createRandomReport(Number(adminsReportID), CONST.REPORT.CHAT_TYPE.POLICY_ADMINS),
+            type: CONST.REPORT.TYPE.CHAT,
+            policyID,
+        };
+
+        const threadReport = {
+            ...createRandomReport(Number(threadReportID), undefined),
+            type: CONST.REPORT.TYPE.CHAT,
+            policyID,
+            parentReportID: adminsReportID,
+            parentReportActionID: upgradeAction.reportActionID,
+            participants: {[CURRENT_USER_ACCOUNT_ID]: {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS}},
+            lastMessageText: rawServerMessage,
+        };
+
+        await IntlStore.load(CONST.LOCALES.EN);
+        await waitForBatchedUpdates();
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${adminsReportID}`, {[upgradeAction.reportActionID]: upgradeAction});
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${threadReportID}`, {[categoryAction.reportActionID]: categoryAction});
+        await Onyx.multiSet({
+            [ONYXKEYS.BETAS]: mockedBetas,
+            [ONYXKEYS.PERSONAL_DETAILS_LIST]: mockedPersonalDetails,
+        });
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${adminsReportID}`, adminsReport);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${threadReportID}`, threadReport);
+        await Onyx.set(ONYXKEYS.SESSION, {accountID: CURRENT_USER_ACCOUNT_ID, email: 'test@test.com'});
+        await flushAllUpdates();
+
+        const reportAttributes = await OnyxUtils.get(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES);
+        expect(reportAttributes?.reports?.[threadReportID]?.reportName).toBeTruthy();
+        mockUseFilteredOptions.mockReturnValue({
+            options: createFilteredOptionList(
+                mockedPersonalDetails,
+                {[`${ONYXKEYS.COLLECTION.REPORT}${threadReportID}`]: threadReport},
+                reportAttributes?.reports,
+                EMPTY_PRIVATE_IS_ARCHIVED_MAP,
+                undefined,
+                {
+                    currentUserAccountID: CURRENT_USER_ACCOUNT_ID,
+                    dateFnsLocale: undefined,
+                    conciergeReportID: undefined,
+                    isSearching: true,
+                },
+            ),
+            isLoading: false,
+            loadMore: jest.fn(),
+            hasMore: false,
+            isLoadingMore: false,
+        });
+
+        render(<SearchRouterWrapper />);
+        await flushAllUpdates();
+
+        // Then the subtitle shows the same copy as the system message in the chat, not the raw server text
+        await waitFor(() => {
+            expect(screen.getByText(TestHelper.translateLocal('workspaceActions.updateAreAttendeesRequired', 'Advertising', true))).toBeTruthy();
+        });
+        expect(screen.queryByText(rawServerMessage)).toBeNull();
+    });
+
     describe('two-section chat switcher', () => {
         // These tests use a controlled getSearchOptions mock to verify the section splitting logic
         // introduced for stable two-section chat switcher results (local + server).


### PR DESCRIPTION
### Explanation of Change

There are two parallel report-action → text resolvers in the App:

- the chat system message and the LHN preview go through `getWorkspaceCategoryUpdateMessage` in `src/libs/ReportActionsUtils.ts`
- the thread/report header goes through `computeReportNameBasedOnReportAction` in `src/libs/ReportNameUtils.ts`

https://github.com/Expensify/App/pull/97919 added the new `updateAreAttendeesRequired` copy to the first resolver, but the second has never had a branch for the category change log action types, so it fell through to the raw server-generated text. That's why the chat shows `changed the "Advertising" category attendees to required (previously not required)` while the thread header shows `updated the category "Advertising" by changing the Attendees from Not Required to Required`.

This routes more action types through `getWorkspaceCategoryUpdateMessage` in `computeReportNameBasedOnReportAction`, mirroring what `SidebarUtils.getOptionData`'s `categoryResolver` already does with the same action types. Since that resolver falls back to `getReportActionText` for anything it doesn't recognize, an unhandled `updatedField` keeps rendering exactly what it renders today.

**Second, smaller change.** Category description hints are persisted as HTML, so a hint of `Client's & partner's names` is stored as `Client&#x27;s &amp; partner&#x27;s names`. `getWorkspaceCategoryUpdateMessage` use that raw value. The chat happened to hide the entities because `ReportActionItemBasicMessage` applies `Str.htmlDecode` when rendering, but it still leaked tags there, and the entities leaked verbatim into the LHN preview and the copy-to-clipboard text. The `commentHint` branch now runs the values through `Parser.htmlToText`, which handles both entities and the `<br />` a multi-line hint produces.

Two related gaps found while working on this that are deliberately **not** in this PR:

1. `SidebarUtils` calls `getWorkspaceCategoryUpdateMessage` without the `policy` argument, so LHN previews for the two receipt-threshold fields can still disagree with the chat and header.
2. `POLICY_CHANGE_LOG.UPDATE_CATEGORIES` (plural) is still not routed in `ReportNameUtils`, so a thread on "updated N categories" keeps showing raw server text.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98482
PROPOSAL:

### Tests

1. Open a workspace's settings and enable **Rules** under More features, upgrading to the Control plan when prompted.
2. Open **Rules** and enable **Attendee tracking**.
3. Go to **Categories**, open the **Advertising** category, and open **Require fields**.
4. Enable **Require attendees**.
5. Go to `#admins` and open the workspace change log thread.
6. Verify the system message reads `changed the "Advertising" category attendees to required (previously not required)`.
7. Right click that message and select **Reply in thread**.
8. Verify the thread header reads `changed the "Advertising" category attendees to required (previously not required)` — the same copy as the system message, not `updated the category "Advertising" by changing the Attendees from Not Required to Required`.
9. Go back to the category's **Require fields** page and enable **Require description**.
10. Reply in thread on the resulting system message and verify the header again matches the system message.
11. Open the category's **Description hint**, enter `Client's & partner's names`, and save.
12. Reply in thread on the resulting system message and verify both the system message and the thread header read `added the description hint "Client's & partner's names" to the category "Advertising"` with no `&#x27;` or `&amp;` escapes, and that the LHN preview for that thread reads the same.

- [x] Verify that no errors appear in the JS console

### Offline tests
n/a - category change logs come from the server

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1272" height="870" alt="image" src="https://github.com/user-attachments/assets/88e592ce-b8fb-45a6-a384-fadb1191373b" />

<img width="1276" height="871" alt="image" src="https://github.com/user-attachments/assets/06965271-0962-4e5b-9a28-7e5083398b35" />

<img width="881" height="868" alt="image" src="https://github.com/user-attachments/assets/8b64deca-dec8-4486-92e6-b90638d89e39" />

</details>
