### PR TITLE
fix: refresh Search after moving expenses to another report

### DIFF
--- a/src/pages/Search/SearchTransactionsChangeReport.tsx
+++ b/src/pages/Search/SearchTransactionsChangeReport.tsx
@@ -1,5 +1,5 @@
 import {usePersonalDetails, useSession} from '@components/OnyxListItemProvider';
-import {useSearchResultsContext, useSearchSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
+import {useSearchQueryContext, useSearchResultsContext, useSearchSelectionActions, useSearchSelectionContext} from '@components/Search/SearchContext';
 import type {ListItem} from '@components/SelectionList/types';
 
 import useChangeTransactionsReportReports from '@hooks/useChangeTransactionsReportReports';
@@ -7,10 +7,12 @@ import useConditionalCreateEmptyReportConfirmation from '@hooks/useConditionalCr
 import {useCurrencyListActions} from '@hooks/useCurrencyList';
 import useDelegateAccountID from '@hooks/useDelegateAccountID';
 import useHasPerDiemTransactions from '@hooks/useHasPerDiemTransactions';
+import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePermissions from '@hooks/usePermissions';
 import usePersonalPolicy from '@hooks/usePersonalPolicy';
 import usePolicyForMovingExpenses from '@hooks/usePolicyForMovingExpenses';
+import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
 
 import {createNewReport} from '@libs/actions/Report';
 import {changeTransactionsReport} from '@libs/actions/Transaction';
@@ -19,6 +21,7 @@ import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/crea
 import setNavigationActionToMicrotaskQueue from '@libs/Navigation/helpers/setNavigationActionToMicrotaskQueue';
 import Navigation from '@libs/Navigation/Navigation';
 import {generateReportID, getPersonalDetailsForAccountID, getReportOrDraftReport, hasViolations as hasViolationsReportUtils} from '@libs/ReportUtils';
+import refreshSearchAfterReportAction from '@libs/SearchRefreshUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
 import {isManualDistanceRequest as isManualDistanceRequestUtil, isOdometerDistanceRequest as isOdometerDistanceRequestUtil, isUnreportedManagedCardTransaction} from '@libs/TransactionUtils';
 
@@ -43,6 +46,21 @@ function SearchTransactionsChangeReport() {
     const delegateAccountID = useDelegateAccountID();
     const {clearSelectedTransactions} = useSearchSelectionActions();
     const {currentSearchResults} = useSearchResultsContext();
+    const {currentSearchQueryJSON, currentSearchKey} = useSearchQueryContext();
+    const {isOffline} = useNetwork();
+    const shouldCalculateTotals = useSearchShouldCalculateTotals(currentSearchKey, currentSearchQueryJSON?.hash, true);
+
+    // Moving expenses creates or updates reports and report actions without adding or removing any transaction, so the
+    // Search snapshot is not refetched on its own and the moved rows keep serving their pre-move report context (which
+    // hides Submit, Hold and Move to report). Refetch explicitly, the same way approving and paying from Search do.
+    const refreshSearch = () =>
+        refreshSearchAfterReportAction({
+            currentSearchQueryJSON,
+            currentSearchKey,
+            shouldCalculateTotals,
+            isOffline,
+            isLoading: !!currentSearchResults?.search?.isLoading,
+        });
     const selectedTransactionsKeys = useMemo(() => Object.keys(selectedTransactions), [selectedTransactions]);
     // Search-selected transactions are not in COLLECTION.TRANSACTION — extract from `selectedTransactions` directly.
     const transactions = Object.values(selectedTransactions)
@@ -190,6 +208,7 @@ function SearchTransactionsChangeReport() {
                 delegateAccountID,
                 getCurrencyDecimals,
             });
+            refreshSearch();
             clearSelectedTransactions();
         });
         Navigation.goBack();
@@ -277,6 +296,7 @@ function SearchTransactionsChangeReport() {
             delegateAccountID,
             getCurrencyDecimals,
         });
+        refreshSearch();
         Navigation.goBack(undefined, {afterTransition: clearSelectedTransactions});
     };
 
@@ -301,6 +321,7 @@ function SearchTransactionsChangeReport() {
             delegateAccountID,
             getCurrencyDecimals,
         });
+        refreshSearch();
         clearSelectedTransactions();
         Navigation.goBack();
     };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

After moving an expense to another report from Search (Spend > Expenses > select > Move expense), reselecting that expense no longer offered **Submit**, **Hold** or **Move to report**. The options only came back after leaving and reopening Spend > Expenses.

All three options are gated on fields that the Search row derives from the **snapshot**, not from live Onyx:

- Submit — `selectedTransactions[id].action === SUBMIT` (`src/hooks/useSearchBulkActions.ts`)
- Hold — `selectedTransactions[id].canHold`
- Move to report — `selectedTransactions[id].canChangeReport`

`action` comes from `getActions()`, which resolves the row's report snapshot-only via `getReportFromKey(data, key)` (`data[report_<reportID>]`), and `reportAction` comes from `moneyRequestReportActionsByTransactionID`, built only from the snapshot's `reportActions_*` keys (both in `src/libs/SearchUIUtils.ts`).

Moving expenses creates a brand-new `report_<id>` and `reportActions_<id>`. Onyx's `updateSnapshots` only merges keys that already exist inside a snapshot, so those new keys never land there. The row therefore keeps serving its pre-move (unreported) report context, `getActions()` falls through to `VIEW`, and `canHold` / `canChangeReport` both evaluate to `false` — which is why all three options disappear together.

Until now the snapshot was refetched incidentally: `useSearchHighlightAndScroll` re-fired a search on **any** new report action, on every search type. https://github.com/Expensify/App/pull/98305 correctly gated that trigger behind `isChat` (it was responsible for ~26% of all Search API calls), which left non-chat searches refetching only when the transaction ID set changes. Moving an expense changes no transaction key — only `reportID` on an existing one — so no refetch happens.

That PR explicitly called this out and pointed at `refreshSearchAfterReportAction` as the escape hatch for flows that need the refresh. Only two call sites existed (`useLifecycleActions.tsx` for approve, `useSelectionModePayment.ts` for pay); change-report was never one of them. This PR adds the third, covering all three `changeTransactionsReport` paths in `SearchTransactionsChangeReport`: create a new report, move to an existing report, and remove from report.

`refreshSearchAfterReportAction` no-ops while offline and `search()` waits for pending writes, so the refetch is ordered after the change-report write.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98494
PROPOSAL:

### Tests

1. Sign in and open Spend > Expenses.
2. Go to a workspace chat and create an expense.
3. Go back to Spend > Expenses.
4. Select the expense via checkbox.
5. Click the dropdown button > Move expense.
6. Click Create report.
7. Select the expense via checkbox again.
8. Click the dropdown button.
9. Verify Submit, Hold and Move to report are all present, without reopening Spend > Expenses.
10. Click the dropdown button > Move expense, and this time pick an existing report instead of creating one.
11. Select the expense via checkbox and open the dropdown button.
12. Verify the options reflect the destination report (Submit, Hold and Move to report are present).
13. Select the expense, click the dropdown button > Move expense > Remove from report.
14. Select the expense via checkbox and open the dropdown button.
15. Verify the expense is back to unreported and its options match an unreported expense (Move to report present, Submit absent).

**Regression checks**

16. Open Spend > Expenses and create an expense from the right hand panel, and verify it appears in the list with its row highlighted.
17. Delete an expense from the list, and verify it disappears from the list.
18. Open Needs approval, approve a report, and verify the list refreshes.
19. Enter selection mode on Ready to pay, pay a report, and verify the list refreshes.
20. Open Spend > Expenses, leave the page idle, open DevTools > Network filtered to `Search`, and verify no `Search` request fires with no user interaction (the behavior https://github.com/Expensify/App/pull/98305 fixed is preserved).

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open Spend > Expenses, select an expense, and move it to a new report.
3. Verify no `Search` request is attempted while offline (`refreshSearchAfterReportAction` returns early when offline) and the app does not error.
4. Go back online.
5. Verify the list reconciles with the server and the moved expense shows its post-move options.

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
