### PR TITLE
Send the fund ID when requesting an Expensify Card limit increase

### DIFF
--- a/src/libs/API/parameters/RequestExpensifyCardLimitIncreaseParams.ts
+++ b/src/libs/API/parameters/RequestExpensifyCardLimitIncreaseParams.ts
@@ -1,5 +1,6 @@
 type RequestExpensifyCardLimitIncreaseParams = {
     settlementBankAccountID: number;
+    fundID?: number;
 };
 
 export default RequestExpensifyCardLimitIncreaseParams;

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -4222,13 +4222,20 @@ function openDraftWorkspaceRequest(policyID: string) {
     API.read(READ_COMMANDS.OPEN_DRAFT_WORKSPACE_REQUEST, params);
 }
 
-function requestExpensifyCardLimitIncrease(settlementBankAccountID?: number) {
+/**
+ * Ask Concierge to raise the Expensify Card limit of a card feed.
+ *
+ * The settlement account belongs to one user, usually the workspace owner. The backend needs the fundID to let
+ * another admin of the same feed make this request, because that admin cannot read the account on their own.
+ */
+function requestExpensifyCardLimitIncrease(settlementBankAccountID?: number, fundID?: number) {
     if (!settlementBankAccountID) {
         return;
     }
 
     const params: RequestExpensifyCardLimitIncreaseParams = {
         settlementBankAccountID,
+        fundID,
     };
 
     API.write(WRITE_COMMANDS.REQUEST_EXPENSIFY_CARD_LIMIT_INCREASE, params);

--- a/src/pages/workspace/expensifyCard/WorkspaceCardsListLabel.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceCardsListLabel.tsx
@@ -109,7 +109,7 @@ function WorkspaceCardsListLabel({type, value, style}: WorkspaceCardsListLabelPr
     }, [isVisible, windowWidth]);
 
     const requestLimitIncrease = () => {
-        requestExpensifyCardLimitIncrease(settings?.paymentBankAccountID);
+        requestExpensifyCardLimitIncrease(settings?.paymentBankAccountID, defaultFundID);
         setVisible(false);
         navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas, false);
     };


### PR DESCRIPTION
@MariaHCD please review

### Explanation of Change

Requesting an Expensify Card limit increase failed for any workspace admin who was not the owner of the settlement account, because the backend looked the account up in the requester's own bank account list. The backend fix is https://github.com/Expensify/Web-Expensify/pull/55327, and it needs to know which card feed the request is for so it can check that the requester administers it. This sends the `fundID` the page is already using.

Deploy https://github.com/Expensify/Web-Expensify/pull/55327 first — until it is out, the extra parameter is simply ignored.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94559
PROPOSAL: N/A — internal fix, the bug is in the backend.

### Tests

1. Sign in as a workspace owner and add a verified business bank account.
2. Enable Expensify Cards on a workspace and pick that account for settlement.
3. Invite a second user to the workspace as an admin.
4. Sign in as that second admin and open Workspace > Expensify Card.
5. Click the (i) next to Remaining limit, then click Request limit increase.
6. Verify Concierge replies asking for the desired limit and the last 3 months of statements for the settlement account.
7. Sign back in as the owner and repeat steps 4-6.
8. Verify the owner also gets the Concierge reply.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open Workspace > Expensify Card, click the (i) next to Remaining limit, then click Request limit increase.
3. Verify the app navigates to Concierge without an error.
4. Go back online.
5. Verify the queued request goes out and Concierge replies.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)

Note: this change adds one optional API parameter and has no UI. The unchecked boxes above are the on-device and staging runs I have not done — the end-to-end behavior needs the backend PR deployed first. Verified locally: oxfmt, `typecheck-tsgo` (no new errors), and the React Compiler compliance check.
