### PR TITLE
Drop the vendorMatching beta gate from QBO vendor surfaces (R1 GA)

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -2439,9 +2439,9 @@ function isXeroActiveMatchingSource(policy: OnyxEntry<Policy>): boolean {
  *
  * The `vendorMatching` beta only gates the integrations that haven't reached GA yet, so
  * `isVendorMatchingBetaEnabled` is consulted on the Intacct and Xero branches but not on QBO:
- *   - QBO with non-reimbursable export = Credit Card or Debit Card (R1) — GA, no beta required
- *   - Sage Intacct with non-reimbursable export = Credit Card Charge (R2) — beta required
- *   - Xero (R3) — no export-destination enum, connection present is sufficient — beta required
+ *   - QBO (R1) with non-reimbursable export = Credit Card or Debit Card. GA, so no beta required
+ *   - Sage Intacct (R2) with non-reimbursable export = Credit Card Charge. Beta required
+ *   - Xero (R3) has no export destination enum, so a present connection is enough. Beta required
  */
 function hasVendorFeature(policy: OnyxEntry<Policy>, isVendorMatchingBetaEnabled: boolean): boolean {
     if (!policy) {

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -2432,21 +2432,25 @@ function isXeroActiveMatchingSource(policy: OnyxEntry<Policy>): boolean {
 }
 
 /**
- * Vendor matching feature gate. Returns true when the workspace has the `vendorMatching` beta
- * enabled AND a supported accounting integration is connected with a non-reimbursable export type
- * that scopes the vendor field. Mirrors the per-integration `hasVendorFeature` checks on the PHP
- * side so the App and backend agree on which workspaces see the field.
+ * Vendor matching feature gate. Returns true when a supported accounting integration is connected
+ * with a non-reimbursable export type that scopes the vendor field. Mirrors the per-integration
+ * `hasVendorFeature` checks on the PHP side so the App and backend agree on which workspaces see
+ * the field.
  *
- * Supported integrations:
- *   - QBO with non-reimbursable export = Credit Card or Debit Card (R1)
- *   - Sage Intacct with non-reimbursable export = Credit Card Charge (R2)
- *   - Xero (R4) — no export-destination enum; connection present is sufficient
+ * The `vendorMatching` beta only gates the integrations that haven't reached GA yet, so
+ * `isVendorMatchingBetaEnabled` is consulted on the Intacct and Xero branches but not on QBO:
+ *   - QBO with non-reimbursable export = Credit Card or Debit Card (R1) — GA, no beta required
+ *   - Sage Intacct with non-reimbursable export = Credit Card Charge (R2) — beta required
+ *   - Xero (R3) — no export-destination enum, connection present is sufficient — beta required
  */
 function hasVendorFeature(policy: OnyxEntry<Policy>, isVendorMatchingBetaEnabled: boolean): boolean {
-    if (!isVendorMatchingBetaEnabled || !policy) {
+    if (!policy) {
         return false;
     }
-    return isQBOVendorMatchingActive(policy) || isIntacctVendorMatchingActive(policy) || isXeroVendorMatchingActive(policy);
+    if (isQBOVendorMatchingActive(policy)) {
+        return true;
+    }
+    return isVendorMatchingBetaEnabled && (isIntacctVendorMatchingActive(policy) || isXeroVendorMatchingActive(policy));
 }
 
 /**

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -261,10 +261,11 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
 
     // The Vendors row gate below reads policy.connections (via hasVendorFeature and
     // isMatchingVendorListLoaded), which is empty on a non-active workspace until a page
-    // requiring connections is opened. Prefetch it here, gated on read-access + beta so this
-    // doesn't fire an accounting-page read on every workspace visit.
+    // requiring connections is opened. Prefetch it here, gated on read-access. It can't be
+    // narrowed to vendor-capable workspaces because that answer lives in the very data being
+    // fetched; the hook already self-guards on offline / accounting-disabled / already-fetched.
     const canReadVendors = canReadPolicyFeature(CONST.POLICY.POLICY_FEATURE.VENDORS);
-    usePolicyConnectionsPrefetch(policy, canReadVendors && isBetaEnabled(CONST.BETAS.VENDOR_MATCHING));
+    usePolicyConnectionsPrefetch(policy, canReadVendors);
 
     const workspaceMenuItems: WorkspaceMenuItem[] = [
         {

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -263,7 +263,8 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
     // isMatchingVendorListLoaded), which is empty on a non-active workspace until a page
     // requiring connections is opened. Prefetch it here, gated on read-access. It can't be
     // narrowed to vendor-capable workspaces because that answer lives in the very data being
-    // fetched; the hook already self-guards on offline / accounting-disabled / already-fetched.
+    // fetched. The hook already skips the fetch when the app is offline, when the workspace has
+    // no accounting connection, and when the data has already been fetched.
     const canReadVendors = canReadPolicyFeature(CONST.POLICY.POLICY_FEATURE.VENDORS);
     usePolicyConnectionsPrefetch(policy, canReadVendors);
 

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -152,12 +152,13 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
     // The Vendors toggle reads policy.connections (via hasVendorFeature), which is empty on a
     // non-active workspace until a connections-aware read runs. OpenPolicyMoreFeaturesPage doesn't
     // hydrate the detailed connection config, so prefetch it here to keep the toggle from showing
-    // off/non-navigable when the workspace actually supports vendors. It can't be narrowed to
-    // vendor-capable workspaces because that answer lives in the very data being fetched; the hook
-    // already self-guards on offline / accounting-disabled / already-fetched.
+    // off and non-navigable when the workspace actually supports vendors. It can't be narrowed to
+    // vendor-capable workspaces because that answer lives in the very data being fetched. The hook
+    // already skips the fetch when the app is offline, when the workspace has no accounting
+    // connection, and when the data has already been fetched.
     usePolicyConnectionsPrefetch(policy, true);
 
-    // Beta members see the row on any workspace so they can tell the feature exists; everyone else
+    // Beta members see the row on any workspace so they can tell the feature exists. Everyone else
     // only sees it once a connection actually scopes the vendor field, which post-GA means QBO.
     const shouldShowVendorsFeature = isVendorMatchingEnabled || hasVendorFeature(policy, isVendorMatchingEnabled);
 

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -149,11 +149,17 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
     const isTravelInvoicingEnabled = getIsTravelInvoicingEnabled(getCardSettings(travelCardSettings, CONST.TRAVEL.PROGRAM_TRAVEL_US));
     const {canWrite: canWriteMoreFeatures, withReadOnlyFallback} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.MORE_FEATURES);
 
-    // The Vendors toggle's active state reads policy.connections (via hasVendorFeature), which is
-    // empty on a non-active workspace until a connections-aware read runs. OpenPolicyMoreFeaturesPage
-    // doesn't hydrate the detailed connection config, so prefetch it here (gated on the beta) to keep
-    // the toggle from showing off/non-navigable when the workspace actually supports vendors.
-    usePolicyConnectionsPrefetch(policy, isVendorMatchingEnabled);
+    // The Vendors toggle reads policy.connections (via hasVendorFeature), which is empty on a
+    // non-active workspace until a connections-aware read runs. OpenPolicyMoreFeaturesPage doesn't
+    // hydrate the detailed connection config, so prefetch it here to keep the toggle from showing
+    // off/non-navigable when the workspace actually supports vendors. It can't be narrowed to
+    // vendor-capable workspaces because that answer lives in the very data being fetched; the hook
+    // already self-guards on offline / accounting-disabled / already-fetched.
+    usePolicyConnectionsPrefetch(policy, true);
+
+    // Beta members see the row on any workspace so they can tell the feature exists; everyone else
+    // only sees it once a connection actually scopes the vendor field, which post-GA means QBO.
+    const shouldShowVendorsFeature = isVendorMatchingEnabled || hasVendorFeature(policy, isVendorMatchingEnabled);
 
     const warnAccountingManagesOrganizeFeature = async () => {
         if (!hasAccountingConnection || !policyID) {
@@ -458,7 +464,7 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
                                 Navigation.navigate(ROUTES.WORKSPACE_TAXES.getRoute(policyID));
                             }}
                         />
-                        {isVendorMatchingEnabled && (
+                        {shouldShowVendorsFeature && (
                             <MoreFeatureToggle
                                 icon={illustrations.Briefcase}
                                 title={translate('workspace.moreFeatures.vendors.title')}

--- a/src/pages/workspace/accounting/qbo/export/DynamicQuickbooksCompanyCardExpenseAccountPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/DynamicQuickbooksCompanyCardExpenseAccountPage.tsx
@@ -6,7 +6,6 @@ import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import useAccordionAnimation from '@hooks/useAccordionAnimation';
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
 import useLocalize from '@hooks/useLocalize';
-import usePermissions from '@hooks/usePermissions';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {updateManyPolicyConnectionConfigs} from '@libs/actions/connections';
@@ -33,7 +32,6 @@ function DynamicQuickbooksCompanyCardExpenseAccountPage({policy}: WithPolicyConn
     const {translate} = useLocalize();
     const integrationName = getQuickbooksOnlineIntegrationName(policy, translate);
     const styles = useThemeStyles();
-    const {isBetaEnabled} = usePermissions();
     const policyID = policy?.id;
     const qboConfig = policy?.connections?.quickbooksOnline?.config;
     const {vendors} = policy?.connections?.quickbooksOnline?.data ?? {};
@@ -41,10 +39,9 @@ function DynamicQuickbooksCompanyCardExpenseAccountPage({policy}: WithPolicyConn
     const nonReimbursableCreditCardDefaultVendorObject = vendors?.find((vendor) => vendor.id === qboConfig?.nonReimbursableCreditCardDefaultVendor);
     // This page is the QBO-only default-vendor editor: gate the row on QBO's own non-reimbursable export mode rather than the cross-integration `hasVendorFeature`, so an Intacct workspace whose QBO connection is in Vendor Bill mode does not get a QBO default-vendor row whose target setting isn't active.
     const qboNonReimbursableDestination = qboConfig?.nonReimbursableExpensesExportDestination;
-    const isQBOVendorMatchingActive =
+    const isVendorFeatureAvailable =
         qboNonReimbursableDestination === CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD ||
         qboNonReimbursableDestination === CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD;
-    const isVendorFeatureAvailable = isBetaEnabled(CONST.BETAS.VENDOR_MATCHING) && isQBOVendorMatchingActive;
     const backPath = useDynamicBackPath(DYNAMIC_ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_ONLINE_COMPANY_CARD_EXPENSE_ACCOUNT.path);
     const {isAccordionExpanded, shouldAnimateAccordionSection} = useAccordionAnimation(!!qboConfig?.autoCreateVendor);
     let nonReimbursableExportDescription;

--- a/src/pages/workspace/rules/MerchantRules/AddVendorPage.tsx
+++ b/src/pages/workspace/rules/MerchantRules/AddVendorPage.tsx
@@ -51,10 +51,11 @@ function AddVendorPage({route}: AddVendorPageProps) {
 
     // This picker can be deep-linked directly, and its gate below reads policy.connections (via
     // hasVendorFeature and getMatchingVendorByID), which is empty on a non-active workspace until a page
-    // requiring connections is opened. Prefetch it here, gated on the beta alone (not hasVendorFeature,
-    // which itself depends on the connection data — a chicken-and-egg) so the picker becomes available and
-    // resolves the selected vendor once connections hydrate.
-    const {isFetchNeeded, isLoadingFetchedFlag} = usePolicyConnectionsPrefetch(policy, isBetaEnabled(CONST.BETAS.VENDOR_MATCHING));
+    // requiring connections is opened. Prefetch it here unconditionally (it can't be narrowed by
+    // hasVendorFeature, which itself depends on the connection data — a chicken-and-egg) so the picker
+    // becomes available and resolves the selected vendor once connections hydrate. The hook self-guards
+    // on offline / accounting-disabled / already-fetched.
+    const {isFetchNeeded, isLoadingFetchedFlag} = usePolicyConnectionsPrefetch(policy, true);
 
     const selectedVendorItem = getSelectedVendorItem(policy, form?.vendorID);
 

--- a/src/pages/workspace/rules/MerchantRules/AddVendorPage.tsx
+++ b/src/pages/workspace/rules/MerchantRules/AddVendorPage.tsx
@@ -51,10 +51,11 @@ function AddVendorPage({route}: AddVendorPageProps) {
 
     // This picker can be deep-linked directly, and its gate below reads policy.connections (via
     // hasVendorFeature and getMatchingVendorByID), which is empty on a non-active workspace until a page
-    // requiring connections is opened. Prefetch it here unconditionally (it can't be narrowed by
-    // hasVendorFeature, which itself depends on the connection data — a chicken-and-egg) so the picker
-    // becomes available and resolves the selected vendor once connections hydrate. The hook self-guards
-    // on offline / accounting-disabled / already-fetched.
+    // requiring connections is opened. Prefetch it here unconditionally so the picker becomes available
+    // and resolves the selected vendor once connections hydrate. It can't be narrowed by
+    // hasVendorFeature, because that itself depends on the connection data being fetched. The hook
+    // already skips the fetch when the app is offline, when the workspace has no accounting
+    // connection, and when the data has already been fetched.
     const {isFetchNeeded, isLoadingFetchedFlag} = usePolicyConnectionsPrefetch(policy, true);
 
     const selectedVendorItem = getSelectedVendorItem(policy, form?.vendorID);

--- a/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
+++ b/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
@@ -136,10 +136,11 @@ function MerchantRulePageBase({policyID, ruleID, initialCategoryName, titleKey, 
 
     // The "Set vendor to" row gate below reads policy.connections (via hasVendorFeature and
     // isMatchingVendorListLoaded), which is empty on a non-active workspace until a page requiring
-    // connections is opened. This editor only fetches categories/tags, so prefetch connections here,
-    // gated on the beta alone (not hasVendorFeature, which itself depends on the connection data — a
-    // chicken-and-egg) so the row appears and resolves the stored vendor once connections hydrate.
-    usePolicyConnectionsPrefetch(policy, isBetaEnabled(CONST.BETAS.VENDOR_MATCHING));
+    // connections is opened. This editor only fetches categories/tags, so prefetch connections here
+    // unconditionally (it can't be narrowed by hasVendorFeature, which itself depends on the
+    // connection data — a chicken-and-egg) so the row appears and resolves the stored vendor once
+    // connections hydrate. The hook self-guards on offline / accounting-disabled / already-fetched.
+    usePolicyConnectionsPrefetch(policy, true);
 
     // Get the existing rule from the policy (for edit mode)
     const existingRule = ruleID ? policy?.rules?.codingRules?.[ruleID] : undefined;

--- a/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
+++ b/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
@@ -136,10 +136,11 @@ function MerchantRulePageBase({policyID, ruleID, initialCategoryName, titleKey, 
 
     // The "Set vendor to" row gate below reads policy.connections (via hasVendorFeature and
     // isMatchingVendorListLoaded), which is empty on a non-active workspace until a page requiring
-    // connections is opened. This editor only fetches categories/tags, so prefetch connections here
-    // unconditionally (it can't be narrowed by hasVendorFeature, which itself depends on the
-    // connection data — a chicken-and-egg) so the row appears and resolves the stored vendor once
-    // connections hydrate. The hook self-guards on offline / accounting-disabled / already-fetched.
+    // connections is opened. This editor only fetches categories and tags, so prefetch connections
+    // here unconditionally so the row appears and resolves the stored vendor once connections
+    // hydrate. It can't be narrowed by hasVendorFeature, because that itself depends on the
+    // connection data being fetched. The hook already skips the fetch when the app is offline, when
+    // the workspace has no accounting connection, and when the data has already been fetched.
     usePolicyConnectionsPrefetch(policy, true);
 
     // Get the existing rule from the policy (for edit mode)

--- a/tests/ui/MoneyRequestViewTest.tsx
+++ b/tests/ui/MoneyRequestViewTest.tsx
@@ -520,7 +520,7 @@ describe('MoneyRequestView edit fields', () => {
         });
     });
 
-    it('shows the vendor row on QBO without the vendorMatching beta — QBO (R1) is generally available', async () => {
+    it('shows the vendor row on QBO without the vendorMatching beta because QBO (R1) is generally available', async () => {
         const threadReport = {
             ...LHNTestUtils.getFakeReport(),
             parentReportID: expenseReportID,
@@ -551,7 +551,7 @@ describe('MoneyRequestView edit fields', () => {
         });
     });
 
-    it('hides the vendor row on Xero without the vendorMatching beta — Xero (R3) is still pre-GA', async () => {
+    it('hides the vendor row on Xero without the vendorMatching beta because Xero (R3) is still pre-GA', async () => {
         const threadReport = {
             ...LHNTestUtils.getFakeReport(),
             parentReportID: expenseReportID,

--- a/tests/ui/MoneyRequestViewTest.tsx
+++ b/tests/ui/MoneyRequestViewTest.tsx
@@ -520,6 +520,69 @@ describe('MoneyRequestView edit fields', () => {
         });
     });
 
+    it('shows the vendor row on QBO without the vendorMatching beta — QBO (R1) is generally available', async () => {
+        const threadReport = {
+            ...LHNTestUtils.getFakeReport(),
+            parentReportID: expenseReportID,
+            parentReportActionID,
+        };
+
+        await setupTestData();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {
+                reimbursable: false,
+                comment: {vendor: {externalID: 'v-1', isManuallySet: false}},
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderMoneyRequestView(threadReport, {
+            connections: {
+                [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
+                    config: {nonReimbursableExpensesExportDestination: CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD},
+                    data: {vendors: [{id: 'v-1', name: 'Acme Co', currency: CONST.CURRENCY.USD}]},
+                },
+            },
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('menu-item-title-common.vendor')).toHaveTextContent('Acme Co');
+        });
+    });
+
+    it('hides the vendor row on Xero without the vendorMatching beta — Xero (R3) is still pre-GA', async () => {
+        const threadReport = {
+            ...LHNTestUtils.getFakeReport(),
+            parentReportID: expenseReportID,
+            parentReportActionID,
+        };
+
+        await setupTestData();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {
+                reimbursable: false,
+                comment: {vendor: {externalID: 'xc1', isManuallySet: false}},
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderMoneyRequestView(threadReport, {
+            connections: {
+                [CONST.POLICY.CONNECTIONS.NAME.XERO]: {
+                    config: {isConfigured: true},
+                    data: {contacts: {xc1: {id: 'xc1', name: 'Acme Xero', email: 'acme@example.com'}}},
+                },
+            },
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('menu-item-common.supplier')).not.toBeOnTheScreen();
+            expect(screen.queryByTestId('menu-item-common.vendor')).not.toBeOnTheScreen();
+        });
+    });
+
     it('falls back to the vendor externalID when the assigned vendor is missing from every connection', async () => {
         const threadReport = {
             ...LHNTestUtils.getFakeReport(),

--- a/tests/unit/AddVendorPageTest.ts
+++ b/tests/unit/AddVendorPageTest.ts
@@ -115,8 +115,12 @@ describe('AddVendorPage', () => {
         const qboPolicy = buildQBOPolicy([{id: 'v-1', name: 'Acme Co', currency: 'USD'}]);
         const xeroPolicy = buildXeroPolicy({xc1: {id: 'xc1', name: 'Acme Xero', email: 'acme@example.com'}});
 
-        it('hides the row when the beta is off even with a vendor integration connected', () => {
-            expect(hasVendorFeature(qboPolicy, false)).toBe(false);
+        it('shows the row on QBO with the beta off because QBO vendor matching is generally available', () => {
+            expect(hasVendorFeature(qboPolicy, false)).toBe(true);
+        });
+
+        it('hides the row on Xero when the beta is off because Xero vendor matching is not generally available yet', () => {
+            expect(hasVendorFeature(xeroPolicy, false)).toBe(false);
         });
 
         it('hides the row when no vendor integration is connected', () => {

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -3550,23 +3550,23 @@ describe('PolicyUtils', () => {
                 expect(hasVendorFeature(buildXeroPolicy(undefined, {isConfigured: false}), true)).toBe(false);
             });
 
-            it('returns true when beta is disabled and QBO non-reimbursable export is Credit Card — QBO (R1) is generally available', () => {
+            it('returns true when beta is disabled and QBO non-reimbursable export is Credit Card because QBO (R1) is generally available', () => {
                 expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD), false)).toBe(true);
             });
 
-            it('returns true when beta is disabled and QBO non-reimbursable export is Debit Card — QBO (R1) is generally available', () => {
+            it('returns true when beta is disabled and QBO non-reimbursable export is Debit Card because QBO (R1) is generally available', () => {
                 expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD), false)).toBe(true);
             });
 
-            it('returns false when beta is disabled and QBO non-reimbursable export is Vendor Bill — GA did not widen the export-mode gate', () => {
+            it('returns false when beta is disabled and QBO non-reimbursable export is Vendor Bill because GA did not widen the export mode gate', () => {
                 expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL), false)).toBe(false);
             });
 
-            it('returns false when beta is disabled and Intacct CC Charge export is configured — Intacct (R2) is still pre-GA', () => {
+            it('returns false when beta is disabled and Intacct CC Charge export is configured because Intacct (R2) is still pre-GA', () => {
                 expect(hasVendorFeature(buildIntacctPolicy(CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE), false)).toBe(false);
             });
 
-            it('returns false when beta is disabled and Xero is connected — Xero (R3) is still pre-GA', () => {
+            it('returns false when beta is disabled and Xero is connected because Xero (R3) is still pre-GA', () => {
                 expect(hasVendorFeature(buildXeroPolicy(), false)).toBe(false);
             });
 

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -3550,15 +3550,23 @@ describe('PolicyUtils', () => {
                 expect(hasVendorFeature(buildXeroPolicy(undefined, {isConfigured: false}), true)).toBe(false);
             });
 
-            it('returns false when beta is disabled, even with Credit Card export configured', () => {
-                expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD), false)).toBe(false);
+            it('returns true when beta is disabled and QBO non-reimbursable export is Credit Card — QBO (R1) is generally available', () => {
+                expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD), false)).toBe(true);
             });
 
-            it('returns false when beta is disabled, even with Intacct CC Charge export configured', () => {
+            it('returns true when beta is disabled and QBO non-reimbursable export is Debit Card — QBO (R1) is generally available', () => {
+                expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD), false)).toBe(true);
+            });
+
+            it('returns false when beta is disabled and QBO non-reimbursable export is Vendor Bill — GA did not widen the export-mode gate', () => {
+                expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL), false)).toBe(false);
+            });
+
+            it('returns false when beta is disabled and Intacct CC Charge export is configured — Intacct (R2) is still pre-GA', () => {
                 expect(hasVendorFeature(buildIntacctPolicy(CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE), false)).toBe(false);
             });
 
-            it('returns false when beta is disabled, even with Xero connected', () => {
+            it('returns false when beta is disabled and Xero is connected — Xero (R3) is still pre-GA', () => {
                 expect(hasVendorFeature(buildXeroPolicy(), false)).toBe(false);
             });
 

--- a/tests/unit/VendorMatchingMerchantRulesTest.ts
+++ b/tests/unit/VendorMatchingMerchantRulesTest.ts
@@ -237,8 +237,12 @@ describe('Vendor matching on merchant rules', () => {
             expect(hasVendorFeature(buildQBOPolicy([{id: 'v-1', name: 'Acme Co', currency: 'USD'}]), true)).toBe(true);
         });
 
-        it('is hidden when the beta is off', () => {
-            expect(hasVendorFeature(buildQBOPolicy([{id: 'v-1', name: 'Acme Co', currency: 'USD'}]), false)).toBe(false);
+        it('is visible on QBO when the beta is off because QBO (R1) is generally available', () => {
+            expect(hasVendorFeature(buildQBOPolicy([{id: 'v-1', name: 'Acme Co', currency: 'USD'}]), false)).toBe(true);
+        });
+
+        it('is hidden on Xero when the beta is off because Xero (R3) is still pre-GA', () => {
+            expect(hasVendorFeature(buildXeroPolicy({xc1: {id: 'xc1', name: 'Acme Xero', email: 'acme@example.com'}}), false)).toBe(false);
         });
 
         it('is hidden when no vendor integration is connected', () => {

--- a/tests/unit/ViolationUtilsTest.ts
+++ b/tests/unit/ViolationUtilsTest.ts
@@ -2892,7 +2892,7 @@ describe('getViolationsOnyxData', () => {
             expect(result.value).not.toContainEqual(inactiveVendorViolation);
         });
 
-        it('does not add the violation when the vendorMatching beta is disabled, even with QBO configured', () => {
+        it('adds the violation when the vendorMatching beta is disabled but QBO is configured, because QBO (R1) is generally available', () => {
             isBetaEnabledSpy.mockImplementation(() => false);
             policy = policyWithQBOVendorFeature();
             transaction.comment = {...transaction.comment, vendor: {externalID: 'v-missing', isManuallySet: true}};
@@ -2906,7 +2906,7 @@ describe('getViolationsOnyxData', () => {
                 hasDependentTags: false,
                 isInvoiceTransaction: false,
             });
-            expect(result.value).not.toContainEqual(inactiveVendorViolation);
+            expect(result.value).toEqual(expect.arrayContaining([inactiveVendorViolation]));
         });
 
         it('does not add the violation while the QBO vendor list is still hydrating (vendors undefined)', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Vendor matching R1 (QuickBooks Online) has shipped and gone GA, so QBO code paths should no longer consult the `vendorMatching` beta. R2 (Sage Intacct) and R3 (Xero) are still pre-GA, so the beta stays in place and keeps gating those two integrations.

The whole change hinges on one idea: `PolicyUtils.hasVendorFeature` now short-circuits to `true` on `isQBOVendorMatchingActive` **before** the beta is consulted, and only consults it on the Intacct and Xero branches.

```ts
if (!policy) {
    return false;
}
if (isQBOVendorMatchingActive(policy)) {
    return true;
}
return isVendorMatchingBetaEnabled && (isIntacctVendorMatchingActive(policy) || isXeroVendorMatchingActive(policy));
```

Because of that, the nine cross-integration call sites (`ViolationsUtils`, `MoneyRequestView`, `WorkspaceVendorsPage`, `WorkspaceInitialPage`, `WorkspaceMoreFeaturesPage`, `MerchantRulePageBase`, `AddVendorPage`, `IOURequestStepVendor`) already route through `hasVendorFeature` and needed no edit. Only the gates that read the beta directly changed:

- **`DynamicQuickbooksCompanyCardExpenseAccountPage.tsx`** — a QBO-only page, so the beta conjunction is dropped outright and the now-unused `usePermissions` import is removed.
- **`WorkspaceMoreFeaturesPage/index.tsx`** — the whole Vendors toggle was wrapped in `{isVendorMatchingEnabled && ...}`, which would have hidden the row from non-beta QBO workspaces. It now uses `shouldShowVendorsFeature = isVendorMatchingEnabled || hasVendorFeature(policy, isVendorMatchingEnabled)`, so beta members keep today's behavior (row always visible, active state from the connection) and everyone else sees it once QBO actually scopes the vendor field.
- **The four `usePolicyConnectionsPrefetch` call sites** — these passed the beta as `enabled` because `policy.connections` isn't loaded yet, so QBO-ness cannot be known at prefetch time. They now pass `true` (or just `canReadVendors` on `WorkspaceInitialPage`). This is safe and has precedent: the hook already self-guards on offline, no accounting connection, and already-fetched, and `withPolicyConnections.tsx` has always passed `true` unconditionally.

The two Xero-only pages (`DynamicXeroExportConfigurationPage`, `DynamicXeroNonReimbursableDefaultContactSelectPage`) are deliberately untouched, and `CONST.BETAS.VENDOR_MATCHING` stays because Xero and Sage Intacct still consume it.

### Fixed Issues

https://github.com/Expensify/Expensify/issues/670049

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Updated tests and run full suit locally.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
1. Sign in as an admin of a workspace whose owner is **not** in the `vendorMatching` beta.
2. Connect QuickBooks Online and set the non-reimbursable export destination to Credit Card, and verify the QBO Default vendor row appears under Company card expense account.
3. Open Workspace > More features and verify the Vendors toggle is present and shows as active.
4. Open Workspace > Vendors and verify the tab lists the vendors imported from QBO.
5. Open a non-reimbursable expense on that workspace and verify the Vendor row renders on the expense preview.
6. Tap the Vendor row, pick a vendor from the list, and verify the selection saves and the row shows the vendor name.
7. Open Workspace > Rules > Merchant rules, create or edit a rule, and verify the "Set vendor to" row is present and its picker lists the QBO vendors.
8. Open the Add vendor picker by direct URL (`/workspace/<policyID>/rules/merchant/<ruleID>/vendor`) and verify it loads the picker rather than a Not Found page.
9. Set a vendor on an expense, remove that vendor in QBO, re-sync the connection, and verify the `inactiveVendor` violation appears on the expense.
10. Repeat steps 2 to 9 on a Xero workspace whose owner is not in the beta and verify **none** of the vendor UI appears anywhere.
11. Add that Xero workspace's owner to the `vendorMatching` beta and verify all of the vendor UI comes back.
12. Set a QBO workspace's non-reimbursable export to Vendor Bill with the beta off and verify no vendor UI appears, confirming GA did not widen the export-mode gate.

We can tag @heyjennahay to help with this.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
