### PR TITLE
[CP Staging] Revert "fix: stop Search re-firing an identical query on unrelated Onyx updates"

### DIFF
--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -85,16 +85,18 @@ function useSearchHighlightAndScroll({
         const previousTransactionIDsLocal = Object.keys(previousTransactions ?? {});
         const transactionsIDs = Object.keys(transactions ?? {});
 
+        const reportActionsIDs = Object.values(reportActions ?? {})
+            .map((actions) => Object.keys(actions ?? {}))
+            .flat();
+        const previousReportActionsIDs = Object.values(previousReportActions ?? {})
+            .map((actions) => Object.keys(actions ?? {}))
+            .flat();
+
         // Only proceed if we have previous data to compare against
         // This prevents triggering on initial data load
-        const hasPreviousReportActions = Object.values(previousReportActions ?? {}).some((actions) => Object.keys(actions ?? {}).length > 0);
-        if ((previousTransactionIDsLocal.length === 0 && !hasPreviousReportActions) || searchTriggeredRef.current) {
+        if ((previousTransactionIDsLocal.length === 0 && previousReportActionsIDs.length === 0) || searchTriggeredRef.current) {
             return;
         }
-
-        // Only chat searches are driven by report actions, so the rest skip walking that collection entirely.
-        const reportActionsIDs = isChat ? Object.values(reportActions ?? {}).flatMap((actions) => Object.keys(actions ?? {})) : [];
-        const previousReportActionsIDs = isChat ? Object.values(previousReportActions ?? {}).flatMap((actions) => Object.keys(actions ?? {})) : [];
 
         const previousTransactionsIDsSet = new Set(previousTransactionIDsLocal);
         const previousReportActionsIDsSet = new Set(previousReportActionsIDs);
@@ -102,7 +104,7 @@ function useSearchHighlightAndScroll({
         const hasReportActionsIDsChange = reportActionsIDs.some((id) => !previousReportActionsIDsSet.has(id));
 
         // Check if there is a change in the transactions or report actions list
-        if ((isChat ? hasReportActionsIDsChange : hasTransactionsIDsChange) || hasPendingSearchRef.current) {
+        if ((!isChat && hasTransactionsIDsChange) || hasReportActionsIDsChange || hasPendingSearchRef.current) {
             // Skip if offline, or if the user has navigated to a different fullscreen page entirely.
             // An RHP layered on top of Search makes `isFocused` false but keeps Search as the topmost
             // fullscreen route, so we still want to refetch — otherwise the snapshot can't reflect
@@ -114,32 +116,19 @@ function useSearchHighlightAndScroll({
             }
             hasPendingSearchRef.current = false;
 
-            // Transaction Onyx keys are `transactions_<id>` but search results yield bare IDs, so read the ID off the value.
-            const addedTransactionIDs: string[] = [];
-            const currentTransactionIDs: string[] = [];
-            for (const [key, transaction] of Object.entries(transactions ?? {})) {
-                const transactionID = transaction?.transactionID;
-                if (!transactionID) {
-                    continue;
-                }
-                currentTransactionIDs.push(transactionID);
-                if (!previousTransactionsIDsSet.has(key)) {
-                    addedTransactionIDs.push(transactionID);
-                }
-            }
-
+            const newIDs = isChat ? reportActionsIDs : transactionsIDs;
             let currentSearchResultIDs: string[] = [];
             if (searchResultsData) {
                 currentSearchResultIDs = isChat ? extractReportActionIDsFromSearchResults(searchResultsData) : extractTransactionIDsFromSearchResults(searchResultsData);
             }
             const existingSearchResultIDsSet = new Set(currentSearchResultIDs);
-            const hasAGenuinelyNewID = (isChat ? reportActionsIDs : addedTransactionIDs).some((id) => !existingSearchResultIDsSet.has(id));
+            const hasAGenuinelyNewID = newIDs.some((id) => !existingSearchResultIDsSet.has(id));
 
             // Only skip search if there are no new items AND search results aren't empty
             // This ensures deletions that result in empty data still trigger search
             if (!hasAGenuinelyNewID && currentSearchResultIDs.length > 0) {
-                const currentIDsSet = new Set(isChat ? reportActionsIDs : currentTransactionIDs);
-                const hasDeletedID = currentSearchResultIDs.some((id) => !currentIDsSet.has(id));
+                const newIDsSet = new Set(newIDs);
+                const hasDeletedID = currentSearchResultIDs.some((id) => !newIDsSet.has(id));
                 if (!hasDeletedID) {
                     return;
                 }

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-// These tests build the hook props partially, so every rerender/initialProps call needs a @ts-expect-error.
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {renderHook} from '@testing-library/react-native';
 
 import useSearchHighlightAndScroll from '@hooks/useSearchHighlightAndScroll';
@@ -83,11 +81,12 @@ describe('useSearchHighlightAndScroll', () => {
     it('should trigger search when new transaction added and focused', () => {
         const initialProps = {
             ...baseProps,
-            transactions: {transactions_1: {transactionID: '1'}},
-            previousTransactions: {transactions_1: {transactionID: '1'}},
+            transactions: {'1': {transactionID: '1'}},
+            previousTransactions: {'1': {transactionID: '1'}},
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -95,12 +94,13 @@ describe('useSearchHighlightAndScroll', () => {
         const updatedProps = {
             ...baseProps,
             transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_2: {transactionID: '2'},
+                '1': {transactionID: '1'},
+                '2': {transactionID: '2'},
             },
-            previousTransactions: {transactions_1: {transactionID: '1'}},
+            previousTransactions: {'1': {transactionID: '1'}},
         };
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
@@ -115,9 +115,10 @@ describe('useSearchHighlightAndScroll', () => {
 
         const updatedProps = {
             ...baseProps,
-            transactions: {transactions_1: {transactionID: '1'}},
+            transactions: {'1': {transactionID: '1'}},
         };
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -142,6 +143,7 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps: chatProps,
         });
@@ -156,6 +158,7 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).toHaveBeenCalledWith({queryJSON: chatProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
@@ -165,16 +168,17 @@ describe('useSearchHighlightAndScroll', () => {
         const initialProps = {
             ...baseProps,
             transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_2: {transactionID: '2'},
+                '1': {transactionID: '1'},
+                '2': {transactionID: '2'},
             },
             previousTransactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_2: {transactionID: '2'},
+                '1': {transactionID: '1'},
+                '2': {transactionID: '2'},
             },
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps,
         });
@@ -182,170 +186,11 @@ describe('useSearchHighlightAndScroll', () => {
         const updatedProps = {
             ...baseProps,
             transactions: {
-                transactions_1: {transactionID: '1'},
+                '1': {transactionID: '1'},
             },
         };
 
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).not.toHaveBeenCalled();
-    });
-
-    it('should trigger search when a transaction that is absent from the results is added', () => {
-        const initialProps = {
-            ...baseProps,
-            searchResults: {
-                ...baseProps.searchResults,
-                data: {
-                    transactions_1: {transactionID: '1'},
-                },
-            },
-            transactions: {
-                transactions_1: {transactionID: '1'},
-            },
-            previousTransactions: {
-                transactions_1: {transactionID: '1'},
-            },
-        };
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // @ts-expect-error
-            initialProps,
-        });
-
-        const updatedProps = {
-            ...initialProps,
-            transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_2: {transactionID: '2'},
-            },
-        };
-
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
-    });
-
-    it('should not trigger search when the added transaction is already in the search results', () => {
-        const initialProps = {
-            ...baseProps,
-            searchResults: {
-                ...baseProps.searchResults,
-                data: {
-                    transactions_1: {transactionID: '1'},
-                    transactions_2: {transactionID: '2'},
-                },
-            },
-            transactions: {
-                transactions_1: {transactionID: '1'},
-            },
-            previousTransactions: {
-                transactions_1: {transactionID: '1'},
-            },
-        };
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // @ts-expect-error
-            initialProps,
-        });
-
-        const updatedProps = {
-            ...initialProps,
-            transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_2: {transactionID: '2'},
-            },
-        };
-
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).not.toHaveBeenCalled();
-    });
-
-    it('should not trigger search on a non-chat search when a report action was added and Onyx holds a transaction the query filters out', () => {
-        const initialProps = {
-            ...baseProps,
-            searchResults: {
-                ...baseProps.searchResults,
-                data: {
-                    transactions_1: {transactionID: '1'},
-                },
-            },
-            // `transactions_99` is held by the client but filtered out by the query, the normal paginated/filtered state.
-            transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_99: {transactionID: '99'},
-            },
-            previousTransactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_99: {transactionID: '99'},
-            },
-            reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                },
-            },
-            previousReportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                },
-            },
-        };
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // @ts-expect-error
-            initialProps,
-        });
-
-        const updatedProps = {
-            ...initialProps,
-            reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                    '2': {actionName: 'ADDCOMMENT', reportActionID: '2'},
-                },
-            },
-        };
-
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).not.toHaveBeenCalled();
-    });
-
-    it('should not trigger search when the added transaction is already in the results and Onyx holds one the query filters out', () => {
-        const initialProps = {
-            ...baseProps,
-            searchResults: {
-                ...baseProps.searchResults,
-                data: {
-                    transactions_1: {transactionID: '1'},
-                    transactions_2: {transactionID: '2'},
-                },
-            },
-            transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_99: {transactionID: '99'},
-            },
-            previousTransactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_99: {transactionID: '99'},
-            },
-        };
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // @ts-expect-error
-            initialProps,
-        });
-
-        const updatedProps = {
-            ...initialProps,
-            transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_99: {transactionID: '99'},
-                transactions_2: {transactionID: '2'},
-            },
-        };
-
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -372,6 +217,7 @@ describe('useSearchHighlightAndScroll', () => {
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps: chatProps,
         });
@@ -385,6 +231,7 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(search).not.toHaveBeenCalled();
@@ -408,14 +255,15 @@ describe('useSearchHighlightAndScroll', () => {
                 },
             },
             transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_2: {transactionID: '2'},
-                transactions_3: {transactionID: '3'},
+                '1': {transactionID: '1'},
+                '2': {transactionID: '2'},
+                '3': {transactionID: '3'},
             },
             previousTransactions: {
-                transactions_1: {transactionID: '1'},
+                '1': {transactionID: '1'},
             },
         };
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(result.current.newSearchResultKeys?.size).toBe(2);
@@ -429,8 +277,10 @@ describe('useSearchHighlightAndScroll', () => {
             focusTextInput: jest.fn(),
         };
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         result.current.handleSelectionListScroll([{transactionID: '1'}, {transactionID: '2'}], ref);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         result.current.handleSelectionListScroll([{transactionID: '2'}, {transactionID: '1'}], ref);
 
@@ -466,12 +316,12 @@ describe('useSearchHighlightAndScroll', () => {
                 },
             },
             transactions: {
-                transactions_1: {transactionID: '1'},
-                transactions_2: {transactionID: '2'},
-                transactions_3: {transactionID: '3'},
+                '1': {transactionID: '1'},
+                '2': {transactionID: '2'},
+                '3': {transactionID: '3'},
             },
             previousTransactions: {
-                transactions_1: {transactionID: '1'},
+                '1': {transactionID: '1'},
             },
         } as unknown as UseSearchHighlightAndScroll;
 
@@ -518,6 +368,7 @@ describe('useSearchHighlightAndScroll', () => {
             },
         };
         const {rerender, result} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             initialProps: chatProps,
         });
@@ -551,6 +402,7 @@ describe('useSearchHighlightAndScroll', () => {
                 },
             },
         };
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         rerender(updatedProps);
         expect(result.current.newSearchResultKeys?.size).toBe(2);


### PR DESCRIPTION
Reverts Expensify/App#98305

### Fixed issues

$ https://github.com/Expensify/App/issues/98494
$ https://github.com/Expensify/App/issues/98502
$ https://github.com/Expensify/App/issues/98543
$ https://github.com/Expensify/App/issues/98544