### PR TITLE
Fix Distance badge overlaps with one another

### DIFF
--- a/src/components/MapView/Directions.tsx
+++ b/src/components/MapView/Directions.tsx
@@ -18,6 +18,13 @@ function Directions({directionCoordinates, alternateDirection, setIsAlternateDir
     const hasAlternateDirection = !!alternateDirection && !!alternateDirectionCoordinates?.length;
     const isAlternateDirectionSelected = !!alternateDirection?.isSelected;
 
+    // Both symbols are placed at once, so that they are never anchored on a stretch of the map the two routes share.
+    const {primary: distanceSymbolCoordinate, alternate: alternateDistanceSymbolCoordinate} = utils.getDistanceSymbolCoordinates(
+        waypoints?.map((waypoint) => waypoint.coordinate) ?? [],
+        utils.convertSegmentedRouteToSingleSegmentRoute(directionCoordinates),
+        utils.convertSegmentedRouteToSingleSegmentRoute(alternateDirectionCoordinates),
+    );
+
     return (
         <>
             {hasAlternateDirection ? (
@@ -31,8 +38,7 @@ function Directions({directionCoordinates, alternateDirection, setIsAlternateDir
                         distanceInMeters={alternateDirection.distanceInMeters}
                         distanceUnit={distanceUnit}
                         toggleDistanceUnit={toggleDistanceUnit}
-                        directionCoordinates={utils.convertSegmentedRouteToSingleSegmentRoute(alternateDirectionCoordinates)}
-                        waypoints={waypoints}
+                        distanceSymbolCoordinate={alternateDistanceSymbolCoordinate}
                         isSelected={isAlternateDirectionSelected}
                         selectDirection={() => setIsAlternateDirectionSelected?.(true)}
                     />
@@ -44,8 +50,7 @@ function Directions({directionCoordinates, alternateDirection, setIsAlternateDir
                 distanceInMeters={distanceInMeters}
                 distanceUnit={distanceUnit}
                 toggleDistanceUnit={toggleDistanceUnit}
-                directionCoordinates={utils.convertSegmentedRouteToSingleSegmentRoute(directionCoordinates)}
-                waypoints={waypoints}
+                distanceSymbolCoordinate={distanceSymbolCoordinate}
                 isSelected={!isAlternateDirectionSelected}
                 selectDirection={() => setIsAlternateDirectionSelected?.(false)}
             />

--- a/src/components/MapView/Directions.tsx
+++ b/src/components/MapView/Directions.tsx
@@ -18,7 +18,6 @@ function Directions({directionCoordinates, alternateDirection, setIsAlternateDir
     const hasAlternateDirection = !!alternateDirection && !!alternateDirectionCoordinates?.length;
     const isAlternateDirectionSelected = !!alternateDirection?.isSelected;
 
-    // Both symbols are placed at once, so that they are never anchored on a stretch of the map the two routes share.
     const {primary: distanceSymbolCoordinate, alternate: alternateDistanceSymbolCoordinate} = utils.getDistanceSymbolCoordinates(
         waypoints?.map((waypoint) => waypoint.coordinate) ?? [],
         utils.convertSegmentedRouteToSingleSegmentRoute(directionCoordinates),

--- a/src/components/MapView/DistanceSymbol.tsx
+++ b/src/components/MapView/DistanceSymbol.tsx
@@ -11,27 +11,11 @@ import {View} from 'react-native';
 import type {DistanceSymbolProps} from './MapViewTypes';
 
 import DistanceSymbolMarker from './DistanceSymbolMarker';
-import utils from './utils';
 
-function DistanceSymbol({distanceInMeters, distanceUnit, toggleDistanceUnit, directionCoordinates, waypoints, isSelected = true, selectDirection}: DistanceSymbolProps) {
+function DistanceSymbol({distanceInMeters, distanceUnit, toggleDistanceUnit, distanceSymbolCoordinate, isSelected = true, selectDirection}: DistanceSymbolProps) {
     const styles = useThemeStyles();
 
     const distanceLabelText = DistanceRequestUtils.getDistanceForDisplayLabel(distanceInMeters ?? 0, distanceUnit ?? CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS);
-
-    const getDistanceSymbolCoordinate = () => {
-        if (!directionCoordinates?.length || !waypoints?.length) {
-            return;
-        }
-        const {northEast, southWest} = utils.getBounds(
-            waypoints.map((waypoint) => waypoint.coordinate),
-            directionCoordinates,
-        );
-        const boundsCenter = utils.getBoundsCenter({northEast, southWest});
-
-        return utils.findClosestCoordinateOnLineFromCenter(boundsCenter, directionCoordinates);
-    };
-
-    const distanceSymbolCoordinate = getDistanceSymbolCoordinate();
 
     if (!distanceInMeters || !distanceUnit || !distanceSymbolCoordinate) {
         return null;

--- a/src/components/MapView/MapViewTypes.ts
+++ b/src/components/MapView/MapViewTypes.ts
@@ -117,11 +117,8 @@ type DistanceSymbolProps = {
     /** Toggles the unit of measurement for every symbol on the map. */
     toggleDistanceUnit: () => void;
 
-    /** List of coordinates which together forms a direction. */
-    directionCoordinates?: Coordinate[];
-
-    /** List of waypoints on the map */
-    waypoints?: WayPoint[];
+    /** Coordinate at which the symbol is anchored on the map. */
+    distanceSymbolCoordinate?: Coordinate | null;
 
     /**
      * Whether the direction to which the symbol is assigned to is selected, true by default if not provided.

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -3,6 +3,10 @@ import type {AlternateDirection, Coordinate} from './MapViewTypes';
 /** A geographic point as a plain longitude/latitude pair. Mapbox's `LngLat` became a class in mapbox-gl 3.x, but these helpers only read `.lng`/`.lat`, so a literal shape is all that's needed. */
 type LngLatLiteral = {lng: number; lat: number};
 
+/** Where along its own route each distance symbol sits, as a share of the route length */
+const PRIMARY_ROUTE_FRACTION = 0.33;
+const ALTERNATE_ROUTE_FRACTION = 0.66;
+
 function isSingleSegmentRoute(directionCoordinates: Coordinate[] | Coordinate[][]): directionCoordinates is Coordinate[] {
     const firstElement = directionCoordinates.at(0);
     if (!firstElement) {
@@ -139,6 +143,76 @@ function getBoundsCenter(bounds: {southWest: Coordinate; northEast: Coordinate})
     return {lng: latitudeCenter, lat: longitudeCenter};
 }
 
+/** Coordinate that lies `fraction` of the way along a route, measured by length rather than by index, as the density of the coordinates varies along a route. */
+function findCoordinateAtRouteFraction(lineCoordinates: Coordinate[], fraction: number): Coordinate | null {
+    let totalLength = 0;
+
+    for (let i = 0; i < lineCoordinates.length - 1; i++) {
+        const startPoint = lineCoordinates.at(i);
+        const endPoint = lineCoordinates.at(i + 1);
+
+        if (!startPoint || !endPoint) {
+            break;
+        }
+
+        totalLength += haversineDistance(startPoint, endPoint);
+    }
+
+    const targetLength = totalLength * fraction;
+    let walkedLength = 0;
+
+    for (let i = 0; i < lineCoordinates.length - 1; i++) {
+        const startPoint = lineCoordinates.at(i);
+        const endPoint = lineCoordinates.at(i + 1);
+
+        if (!startPoint || !endPoint) {
+            break;
+        }
+
+        const segmentLength = haversineDistance(startPoint, endPoint);
+
+        if (walkedLength + segmentLength >= targetLength) {
+            return simpleInterpolateCoordinate(startPoint, endPoint, segmentLength > 0 ? (targetLength - walkedLength) / segmentLength : 0);
+        }
+
+        walkedLength += segmentLength;
+    }
+
+    return lineCoordinates.at(-1) ?? null;
+}
+
+/**
+ * Coordinates at which the distance symbols of the primary and the alternate route should be anchored.
+ * Each symbol is anchored at a different share of its own route, so that the two always sit at a
+ * different point of the trip.
+ */
+function getDistanceSymbolCoordinates(
+    waypoints: Coordinate[],
+    primaryRouteCoordinates: Coordinate[] | undefined,
+    alternateRouteCoordinates: Coordinate[] | undefined,
+): {primary: Coordinate | null; alternate: Coordinate | null} {
+    const primaryRoute = primaryRouteCoordinates ?? [];
+    const alternateRoute = alternateRouteCoordinates ?? [];
+
+    if (!waypoints.length || primaryRoute.length < 2) {
+        return {primary: null, alternate: null};
+    }
+
+    // A single set of bounds is shared by both symbols, so that they are placed relative to the same map.
+    const bounds = getBounds(waypoints, [...primaryRoute, ...alternateRoute]);
+    const center = getBoundsCenter(bounds);
+
+    // A lone symbol has nothing to overlap with, so it stays at the point of its route closest to the center of the map.
+    if (alternateRoute.length < 2) {
+        return {primary: findClosestCoordinateOnLineFromCenter(center, primaryRoute), alternate: null};
+    }
+
+    return {
+        primary: findCoordinateAtRouteFraction(primaryRoute, PRIMARY_ROUTE_FRACTION),
+        alternate: findCoordinateAtRouteFraction(alternateRoute, ALTERNATE_ROUTE_FRACTION),
+    };
+}
+
 /** Flattens a route made of several segments into a single list of coordinates, leaving a single segment route as is. */
 function convertSegmentedRouteToSingleSegmentRoute(directionCoordinates: Coordinate[] | Coordinate[][]): Coordinate[];
 function convertSegmentedRouteToSingleSegmentRoute(directionCoordinates: Coordinate[] | Coordinate[][] | undefined): Coordinate[] | undefined;
@@ -161,6 +235,7 @@ export default {
     areCoordinatesEqual,
     findClosestCoordinateOnLineFromCenter,
     getBoundsCenter,
+    getDistanceSymbolCoordinates,
     simpleInterpolateCoordinate,
     isSingleSegmentRoute,
     convertSegmentedRouteToSingleSegmentRoute,

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -155,7 +155,8 @@ function findCoordinateAtRouteFraction(lineCoordinates: Coordinate[], fraction: 
             break;
         }
 
-        totalLength += haversineDistance(startPoint, endPoint);
+        // map Coordinates are [long, lat], but haversineDistance treats [0] as latitude and [1] as longitude
+        totalLength += haversineDistance([startPoint[1], startPoint[0]], [endPoint[1], endPoint[0]]);
     }
 
     const targetLength = totalLength * fraction;
@@ -169,7 +170,7 @@ function findCoordinateAtRouteFraction(lineCoordinates: Coordinate[], fraction: 
             break;
         }
 
-        const segmentLength = haversineDistance(startPoint, endPoint);
+        const segmentLength = haversineDistance([startPoint[1], startPoint[0]], [endPoint[1], endPoint[0]]);
 
         if (walkedLength + segmentLength >= targetLength) {
             return simpleInterpolateCoordinate(startPoint, endPoint, segmentLength > 0 ? (targetLength - walkedLength) / segmentLength : 0);

--- a/tests/unit/MapViewUtilsTest.ts
+++ b/tests/unit/MapViewUtilsTest.ts
@@ -79,6 +79,100 @@ describe('MapView utils', () => {
         });
     });
 
+    describe('getDistanceSymbolCoordinates', () => {
+        const WAYPOINTS: Coordinate[] = [
+            [0, 0],
+            [1, 0],
+        ];
+
+        /** Runs straight from the first waypoint to the second one, with most of its coordinates bunched up near the start. */
+        const STRAIGHT_ROUTE: Coordinate[] = [
+            [0, 0],
+            [0.05, 0],
+            [0.1, 0],
+            [0.15, 0],
+            [1, 0],
+        ];
+
+        /** Shares both waypoints with the straight route, but bulges north in between. */
+        const BULGING_ROUTE: Coordinate[] = [
+            [0, 0],
+            [0.25, 0.2],
+            [0.5, 0.3],
+            [0.75, 0.2],
+            [1, 0],
+        ];
+
+        it('anchors the symbol at the point of the route closest to the center when there is no alternate route', () => {
+            const {northEast, southWest} = utils.getBounds(WAYPOINTS, STRAIGHT_ROUTE);
+            const closestToCenter = utils.findClosestCoordinateOnLineFromCenter(utils.getBoundsCenter({northEast, southWest}), STRAIGHT_ROUTE);
+
+            expect(utils.getDistanceSymbolCoordinates(WAYPOINTS, STRAIGHT_ROUTE, undefined)).toEqual({primary: closestToCenter, alternate: null});
+        });
+
+        it('anchors each symbol at its own share of its own route', () => {
+            const {primary, alternate} = utils.getDistanceSymbolCoordinates(WAYPOINTS, STRAIGHT_ROUTE, BULGING_ROUTE);
+
+            // A third of the way along the straight route. Four of its five coordinates sit in its first sixth, so an
+            // anchor picked by the number of coordinates rather than by length would land far short of this.
+            expect(primary?.at(0)).toBeCloseTo(0.33);
+            expect(primary?.at(1)).toBe(0);
+
+            // Two thirds of the way along the bulging route, so past its northernmost point and on its way back down.
+            expect(alternate?.at(0)).toBeGreaterThan(0.5);
+            expect(alternate?.at(1)).toBeGreaterThan(0);
+            expect(alternate?.at(1)).toBeLessThan(0.3);
+        });
+
+        it('walks over the coordinates a route repeats', () => {
+            const repeatedRoute: Coordinate[] = [
+                [0, 0],
+                [0, 0],
+                [0.5, 0],
+                [1, 0],
+                [1, 0],
+            ];
+
+            expect(utils.getDistanceSymbolCoordinates(WAYPOINTS, repeatedRoute, BULGING_ROUTE).primary?.at(0)).toBeCloseTo(0.33);
+        });
+
+        it('anchors the symbol at the start of a route that has no length at all', () => {
+            const zeroLengthRoute: Coordinate[] = [
+                [0.5, 0],
+                [0.5, 0],
+                [0.5, 0],
+            ];
+
+            expect(utils.getDistanceSymbolCoordinates(WAYPOINTS, zeroLengthRoute, BULGING_ROUTE).primary).toEqual([0.5, 0]);
+        });
+
+        it('anchors the symbols away from the waypoints the two routes share', () => {
+            const {primary, alternate} = utils.getDistanceSymbolCoordinates(WAYPOINTS, STRAIGHT_ROUTE, BULGING_ROUTE);
+
+            for (const waypoint of WAYPOINTS) {
+                expect(primary).not.toEqual(waypoint);
+                expect(alternate).not.toEqual(waypoint);
+            }
+        });
+
+        it('keeps the symbols apart even when both routes are identical', () => {
+            const {primary, alternate} = utils.getDistanceSymbolCoordinates(WAYPOINTS, STRAIGHT_ROUTE, [...STRAIGHT_ROUTE]);
+
+            expect(primary?.at(0)).toBeCloseTo(0.33);
+            expect(alternate?.at(0)).toBeCloseTo(0.66);
+        });
+
+        it('returns no coordinates when there is nothing to anchor a symbol to', () => {
+            expect(utils.getDistanceSymbolCoordinates([], STRAIGHT_ROUTE, BULGING_ROUTE)).toEqual({primary: null, alternate: null});
+            expect(utils.getDistanceSymbolCoordinates(WAYPOINTS, undefined, BULGING_ROUTE)).toEqual({primary: null, alternate: null});
+            expect(utils.getDistanceSymbolCoordinates(WAYPOINTS, [[0, 0]], BULGING_ROUTE)).toEqual({primary: null, alternate: null});
+        });
+
+        it('ignores an alternate route that is too short to be drawn', () => {
+            expect(utils.getDistanceSymbolCoordinates(WAYPOINTS, STRAIGHT_ROUTE, [[0, 0]]).alternate).toBeNull();
+        });
+    });
+
     describe('isSingleSegmentRoute', () => {
         it('detects single segment, segmented and empty routes', () => {
             expect(utils.isSingleSegmentRoute(SINGLE_SEGMENT)).toBe(true);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The primary and alternate distance badges were both anchored at the point of their route closest to the map center, so they overlapped wherever the routes ran together. `getDistanceSymbolCoordinates` in `MapView/utils.ts` now anchors each badge at a different share of its own route (33% / 66%), measured by length. A lone badge keeps the old center-based placement. `DistanceSymbol` just receives the coordinate.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98492
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. FAB > Track distance > Map
2. Enter a start and a finish address for a route that has an alternate route available
3. Verify that two distance badges are shown, one on each route, and that they do not overlap or sit on top of each other.
4. Tap the alternate route to select it.
5. Verify that both badges stay in the same places and remain readable, and that the selected/unselected styling swaps correctly.
6. Repeat steps 2–3 with a route that has no alternate route
7. Verify that a single distance badge is shown and that it sits on the route near the center of the visible map, as before.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/6e6e0db5-f163-44cc-a7d0-955f4fbec8dd



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/4b706302-2b65-4540-88cb-bff1c4a72b47


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/885e6ae7-c55d-4c0e-80d0-736284816176



</details>
