### PR TITLE
[No QA] Fix flaky SignInBackButtonTest

### DIFF
--- a/tests/unit/SignInBackButtonTest.tsx
+++ b/tests/unit/SignInBackButtonTest.tsx
@@ -1,5 +1,7 @@
 import {render} from '@testing-library/react-native';
 
+import type * as AppActions from '@libs/actions/App';
+
 import SignInModal from '@pages/signin/SignInModal';
 import type {SignInPageRef} from '@pages/signin/SignInPage';
 import {SignInPage} from '@pages/signin/SignInPage';
@@ -16,12 +18,23 @@ jest.mock('@libs/Navigation/Navigation', () => ({
         goBack: () => {
             mockGoBack();
         },
+        dismissModal: jest.fn(),
+        navigate: jest.fn(),
+        isNavigationReady: () => Promise.resolve(),
     },
     navigationRef: {
         get current() {
             return {canGoBack: () => mockCanGoBack};
         },
     },
+}));
+
+// SignInModal fires a real OpenApp request on mount. The global fetch mock in jest/setup.ts resolves it,
+// so `finallyData` merges IS_LOADING_APP: false, which re-runs the effect that dismisses the modal while
+// the test is still running. Stubbing openApp keeps that async work out of this unit test.
+jest.mock('@libs/actions/App', () => ({
+    ...jest.requireActual<typeof AppActions>('@libs/actions/App'),
+    openApp: jest.fn(),
 }));
 
 // Record the callbacks handed to the hook so the test can replay them. Jest resolves the platform-neutral


### PR DESCRIPTION
### Explanation of Change
`tests/unit/SignInBackButtonTest.tsx` (added in #98401) is flaky and is currently failing on most open PRs, e.g. https://github.com/Expensify/App/actions/runs/31686180988/job/94402673478:

```
FAIL tests/unit/SignInBackButtonTest.tsx
  ● sign-in Android hardware back handling › SignInModal › registers no back listener that consumes the press without navigating
    TypeError: _Navigation.default.dismissModal is not a function
      at src/pages/signin/SignInModal.tsx:60:19
```

Root cause:

1. The test mocks `@libs/Navigation/Navigation` with only `goBack` and `navigationRef`.
2. Rendering `SignInModal` runs an effect that ends in `openApp(true)` (the mocked `useSession` returns `undefined`, so the user is treated as non-anonymous and `hasSignedInRef` is set).
3. `openApp` issues a real `OpenApp` request. `jest/setup.ts` installs a global `fetch` mock that resolves `{jsonCode: 200}`, so the request succeeds and `finallyData` merges `IS_LOADING_APP: false`.
4. That Onyx write re-renders the modal, the second effect's `isLoadingApp !== false` guard now passes, and it calls `Navigation.dismissModal()` — which the mock doesn't define → `TypeError`.

Whether that round trip lands before the test file finishes is a race, which is why the same shard (`test (job 1)`, 2799 tests) passes in some runs and fails in others with no change on `main` in between:

| Run | Time (UTC) | Result |
| --- | --- | --- |
| 31682152902 / 31682289042 / 31682575899 | 08:27–08:33 | PASS |
| 31682721109 / 31683280022 / 31684038938 / 31685112441 | 08:35–09:06 | FAIL |
| 31686180988 / 31686714790 / 31686932462 / 31688812358 / 31689714043 / 31690207448 / 31690340714 / 31691728068 | 09:21–10:34 | FAIL |

Fix:

- Stub `openApp` so the unit test doesn't fire a real API request whose response lands mid-test (this also removes leaked async work — the failing job logs *"A worker process has failed to exit gracefully"*).
- Complete the `Navigation` mock with the members `SignInModal`/`SignInPage` actually use (`dismissModal`, `navigate`, `isNavigationReady`), so the test can't break again on timing alone.

The assertions themselves are unchanged, so the regression coverage added by #98401 for https://github.com/Expensify/App/issues/96869 is preserved.


### Fixed Issues
$ N/A — CI-only fix for the flaky test added in #98401

### Tests
N/A

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
N/A

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>



</details>

<details>
<summary>Android: mWeb Chrome</summary>



</details>

<details>
<summary>iOS: Native</summary>



</details>

<details>
<summary>iOS: mWeb Safari</summary>



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



</details>
