### PR TITLE
[No QA] Fix flaky SignInBackButtonTest caused by the openApp Onyx race

### DIFF
--- a/tests/unit/SignInBackButtonTest.tsx
+++ b/tests/unit/SignInBackButtonTest.tsx
@@ -4,10 +4,13 @@ import SignInModal from '@pages/signin/SignInModal';
 import type {SignInPageRef} from '@pages/signin/SignInPage';
 import {SignInPage} from '@pages/signin/SignInPage';
 
+import CONST from '@src/CONST';
+
 import React, {createRef} from 'react';
 
 const mockGoBack = jest.fn();
 let mockCanGoBack = true;
+const mockAnonymousAuthTokenType = CONST.AUTH_TOKEN_TYPES.ANONYMOUS;
 
 jest.mock('@libs/Navigation/Navigation', () => ({
     __esModule: true,
@@ -16,6 +19,8 @@ jest.mock('@libs/Navigation/Navigation', () => ({
         goBack: () => {
             mockGoBack();
         },
+        dismissModal: jest.fn(),
+        navigate: jest.fn(),
     },
     navigationRef: {
         get current() {
@@ -46,8 +51,12 @@ jest.mock('@pages/signin/SignUpWelcomeForm', () => 'SignUpWelcomeForm');
 jest.mock('@components/ColorSchemeWrapper', () => 'ColorSchemeWrapper');
 jest.mock('@components/CustomStatusBarAndBackground', () => 'CustomStatusBarAndBackground');
 
-// SignInModal reads the session to decide when to dismiss itself. The back listener does not depend on it.
-jest.mock('@components/OnyxListItemProvider', () => ({useSession: () => undefined}));
+// SignInModal reads the session to decide when to dismiss itself, and treats any non anonymous session as signed
+// in. Report the anonymous session that a rendered sign-in modal actually has, so the dismiss effect stays idle
+// and does not call openApp. openApp writes IS_LOADING_APP asynchronously, which would otherwise dismiss the
+// modal partway through the test. The back listener does not depend on the session.
+// Read lazily: jest hoists this factory above the constant below.
+jest.mock('@components/OnyxListItemProvider', () => ({useSession: () => ({authTokenType: mockAnonymousAuthTokenType})}));
 jest.mock('@components/ScreenWrapper', () => 'ScreenWrapper');
 jest.mock('@components/HeaderWithBackButton', () => 'HeaderWithBackButton');
 


### PR DESCRIPTION
### Explanation of Change

`tests/unit/SignInBackButtonTest.tsx` fails intermittently on `main` with:

```
TypeError: _Navigation.default.dismissModal is not a function
  at dismissModal (src/pages/signin/SignInModal.tsx:60:19)
```

Reported in [this Slack thread](https://expensify.slack.com/archives/C01GTK53T8Q/p1786615752269259), and it has hit at least six unrelated PRs, so it is a `main` regression rather than a fault in any one PR.

**Cause.** The test mocked `useSession()` as `undefined`. `SignInModal` treats any non anonymous session as signed in, so `hasSignedInRef` became `true` and the first effect called `waitForIdle().then(() => openApp(true))`. `openApp` writes `IS_LOADING_APP` to Onyx asynchronously. When that write lands before the test ends, the second effect runs and calls `Navigation.dismissModal()`, which the partial `Navigation` mock does not define.

The timing decides the outcome. The test passes on an idle machine because it finishes before the Onyx write resolves. It fails on a loaded CI worker (`--maxWorkers=6`) because the write resolves first. That is why the test passed at merge time and started failing later.

**Fix.** Two changes, both in the test:

1. Mock `useSession()` as an anonymous session. That is the session a rendered sign-in modal actually has, so the sign-in effect stays idle and `openApp` never runs. This removes the race at its source.
2. Add `dismissModal` and `navigate` to the `Navigation` mock, so the mock matches the surface `SignInModal` uses and the test cannot crash this way again.

No production code changes.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98583
https://expensify.slack.com/archives/C01GTK53T8Q/p1786615752269259

PROPOSAL:

### Tests

1. Check out this branch and run `npx jest tests/unit/SignInBackButtonTest.tsx`.
2. Verify all 4 tests pass.
3. Reproduce the CI condition: copy the test file, add `import Onyx from 'react-native-onyx';` and `import ONYXKEYS from '@src/ONYXKEYS';`, then add `beforeEach(async () => { await Onyx.set(ONYXKEYS.IS_LOADING_APP, false); });` inside the `SignInModal` describe block.
4. Run the copy and verify all 4 tests still pass.
5. Revert the two mock changes from this PR in that copy, run it again, and verify it now fails with `TypeError: _Navigation.default.dismissModal is not a function`. This confirms the copy reproduces the CI failure and that this PR fixes it.
6. Verify that no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable. This PR only changes a unit test.

### Offline steps

Not applicable. This PR only changes a unit test.

### QA Steps

Not applicable, this PR only changes a Jest unit test and ships no production code. Title includes [No QA].

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not yet tested — needs manual QA.

</details>
