### PR TITLE
fix: resize Concierge chart to fit RHP width

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartContainer/VictoryChartContainerFixed.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartContainer/VictoryChartContainerFixed.tsx
@@ -26,6 +26,7 @@ function VictoryChartContainerFixed({children, layout, themeStyles}: VictoryChar
     const layoutKind = layout.kind;
     const fixedWidth = layout.kind === 'fixed' ? layout.width : undefined;
     const fixedHeight = layout.kind === 'fixed' ? layout.height : undefined;
+    const scaledDesignWidth = layout.kind === 'scaled' ? layout.designWidth : undefined;
     const scaledDesignHeight = layout.kind === 'scaled' ? layout.designHeight : undefined;
     const scaledScale = layout.kind === 'scaled' ? layout.scale : undefined;
     const isPolar = type === CHART_TYPE.POLAR;
@@ -35,9 +36,12 @@ function VictoryChartContainerFixed({children, layout, themeStyles}: VictoryChar
 
     if (layoutKind === 'fixed' && fixedWidth !== undefined && fixedHeight !== undefined) {
         containerStyle = [...containerStyleBase, {width: fixedWidth, height: fixedHeight, borderRadius: 0, overflow: 'hidden'}];
-    } else if (layoutKind === 'scaled' && scaledDesignHeight !== undefined && scaledScale !== undefined) {
+    } else if (layoutKind === 'scaled' && scaledDesignWidth !== undefined && scaledDesignHeight !== undefined && scaledScale !== undefined) {
         const effectiveHeight = isPolar ? scaledDesignHeight * POLAR_CONTAINER_HEIGHT_RATIO : scaledDesignHeight;
-        containerStyle = [...containerStyleBase, {borderRadius: isPolar ? borderRadius : 0, height: effectiveHeight * scaledScale, overflow: 'hidden'}];
+        containerStyle = [
+            ...containerStyleBase,
+            {borderRadius: isPolar ? borderRadius : 0, width: scaledDesignWidth * scaledScale, height: effectiveHeight * scaledScale, overflow: 'hidden'},
+        ];
     }
 
     const contentStyle: ViewStyle[] = [];

--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartContainer/VictoryChartContainerResponsive.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartContainer/VictoryChartContainerResponsive.tsx
@@ -33,7 +33,7 @@ function VictoryChartContainerResponsive({children}: {children: React.ReactNode}
         mw100: styles.mw100,
     };
 
-    const layout: VictoryChartContainerLayout = hasDesignDimensions && designHeight ? {kind: 'scaled', designHeight, scale} : {kind: 'fluid'};
+    const layout: VictoryChartContainerLayout = designWidth && designHeight ? {kind: 'scaled', designWidth, designHeight, scale} : {kind: 'fluid'};
 
     if (!hasDesignDimensions) {
         return (

--- a/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartContainer/types.ts
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/VictoryChartRenderer/components/VictoryChartContainer/types.ts
@@ -8,6 +8,7 @@ type VictoryChartContainerLayout =
       }
     | {
           kind: 'scaled';
+          designWidth: number;
           designHeight: number;
           scale: number;
       }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The VirtualCFO chart in RHP didn't resize, it scaled only `height`, not `width`, so the container kept the full unscaled design width.

### Fixed Issues
$ https://github.com/Expensify/App/issues/98534

### Tests
Pre-requisite: an account with expenses

1. Open Concierge chat in the RHP
2. Ask for `Analyze my expenses`
4. Verify chart resizes to fit RHP width, no overflow/clipping.
5. Open same chat in central pane (wide), verify chart still renders correctly (no regression).

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/d2d17a3d-100f-418b-9531-2be74bd0859c


<details>
<summary>Android: Native</summary>



</details>

<details>
<summary>Android: mWeb Chrome</summary>



</details>

<details>
<summary>iOS: Native</summary>



</details>

<details>
<summary>iOS: mWeb Safari</summary>



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



</details>