### PR TITLE
[CP Staging] fix Expense - Per diem expense receipt loads infinitely after reset app

### DIFF
--- a/src/components/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading.tsx
@@ -51,6 +51,10 @@ function ImageWithLoading({
     const isLoadedRef = useRef<boolean | null>(null);
     const [isImageCached, setIsImageCached] = useState(true);
     const [isLoading, setIsLoading] = useState(false);
+    // The full-resolution image is not guaranteed to ever emit `onLoad`/`onError` (e.g. a receipt derivative that is
+    // still being generated server-side), so `isLoading` can stay `true` indefinitely. Once the low-resolution preview
+    // is on screen we have something readable to show, so the loading state must stop being visible at that point.
+    const [isThumbnailLoading, setIsThumbnailLoading] = useState(!!previewUri);
     const {isOffline} = useNetwork();
 
     const handleError = () => {
@@ -97,9 +101,12 @@ function ImageWithLoading({
                     <Image
                         {...rest}
                         source={{uri: previewUri}}
-                        style={[styles.w100, styles.h100, styles.opacitySemiTransparent, style]}
+                        style={[styles.w100, styles.h100, style]}
                         resizeMode={resizeMode}
-                        onLoad={onLoad}
+                        onLoad={(e) => {
+                            setIsThumbnailLoading(false);
+                            onLoad?.(e);
+                        }}
                         loadingIconSize={loadingIconSize}
                         loadingIndicatorStyles={loadingIndicatorStyles}
                     />
@@ -125,12 +132,13 @@ function ImageWithLoading({
                     isLoadedRef.current = false;
                     setIsImageCached(false);
                     setIsLoading(true);
+                    setIsThumbnailLoading(!!previewUri);
                     waitForSession?.();
                 }}
                 loadingIconSize={loadingIconSize}
                 loadingIndicatorStyles={loadingIndicatorStyles}
             />
-            {(previewUri ? isLoading : isLoading && !isImageCached) && !isOffline && (
+            {isLoading && (!previewUri || isThumbnailLoading) && !isImageCached && !isOffline && (
                 <LoadingIndicator
                     iconSize={loadingIconSize}
                     style={[styles.opacity1, styles.bgTransparent, loadingIndicatorStyles]}


### PR DESCRIPTION
### Explanation of Change

The receipt isn't actually blank. The low-res `.320.jpg` preview renders fine, but it sits at 50% opacity with a spinner on top of it, permanently — `ImageWithLoading`'s loading state latched on forever.

**Why it latches:** the full-res `.1024.jpg` never emits `onLoad` _or_ `onError`, so `isLoading` is never cleared. This part is pre-existing on production. `Reset and refresh` just happens to expose it on web, because `clearCache` wipes the `AUTH_IMAGES` and service-worker `user-media` caches and forces both derivatives back onto the network.

**Why it became visible:** #97313 changed how that latched state renders. On production, `ImageWithLoading` stops showing the loading state once the low-res preview is on screen, so the latch renders as an ordinary thumbnail and nobody notices. #97313 removed that in three places:

- the preview is drawn with `opacitySemiTransparent` instead of at full opacity
- `isThumbnailLoading` was deleted
- the spinner condition became `previewUri ? isLoading : isLoading && !isImageCached`, so when a preview exists the spinner stays up for the entire (unbounded) full-res load and skips the 200ms anti-flash gate

**This PR** restores those three things. `ImageWithLoading` is now byte-identical to production apart from a comment explaining why the loading state must not depend on the full-res image ever settling, and the `ImageWithSizeLoadingProps` type export that `DeferredImageWithLoading` imports. The spinner condition is back to:

```js
isLoading && (!previewUri || isThumbnailLoading) && !isImageCached && !isOffline;
```

i.e. show the spinner only when nothing readable is on screen yet _and_ we've been waiting long enough that it won't just flash.

#97313's actual feature is unaffected: the `previewUri` / `thumbnail320` plumbing already shipped to production, and loading the higher-res original so hover-zoom stays sharp (#96999) still works. The only thing dropped is the dimming and the always-on spinner, which is cosmetic polish that can come back once the full-res load reliably settles.

**Not fixed here:** `useCachedImageSource` returns `null` to `expo-image` while its `fetch` is in flight, and on failure falls back to a source carrying `headers` that `<img>` can't use on web — so there are paths where the consumer's `onError` never fires. That's pre-existing on production and is the reason the full-res image can hang with no event at all. It deserves its own issue rather than a deploy-blocker patch.


### Fixed Issues
$ https://github.com/Expensify/App/issues/98587

### Tests
Precondition:
- Workspace has per diem rates.

1. Go to workspace chat.
2. Create a per diem expense.
3. Go to Account > Troubleshoot > Clear cache and restart > Reset and refresh.
4. Go back to workspace chat.
5. Verify that Per diem expense receipt will not load infinitely after reset app.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests

### QA Steps
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>



</details>

<details>
<summary>Android: mWeb Chrome</summary>



</details>

<details>
<summary>iOS: Native</summary>



</details>

<details>
<summary>iOS: mWeb Safari</summary>



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/e858427f-24c3-4011-8d34-57f0b682ed0a



</details>
