### PR TITLE
Refactor FAB create/track workspace checks to rely on group-policy

### DIFF
--- a/src/components/FloatingCameraButton/BaseFloatingCameraButton.tsx
+++ b/src/components/FloatingCameraButton/BaseFloatingCameraButton.tsx
@@ -13,6 +13,7 @@ import {startMoneyRequest} from '@libs/actions/IOU/MoneyRequest';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import Navigation from '@libs/Navigation/Navigation';
+import {isGroupPolicy} from '@libs/PolicyUtils';
 import {generateReportID, getWorkspaceChats} from '@libs/ReportUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
 import {getSpan, startSpan} from '@libs/telemetry/activeSpans';
@@ -58,7 +59,7 @@ function BaseFloatingCameraButton({icon}: BaseFloatingCameraButtonProps) {
     const [reportID] = useState(() => generateReportID());
 
     const policyChatForActivePolicySelector = (reports: OnyxCollection<OnyxTypes.Report>) => {
-        if (isEmptyObject(activePolicy) || !activePolicy?.isPolicyExpenseChatEnabled) {
+        if (isEmptyObject(activePolicy) || !isGroupPolicy(activePolicy)) {
             return undefined;
         }
         const policyChatsForActivePolicy = getWorkspaceChats(activePolicyID, [accountID], reports);

--- a/src/pages/inbox/sidebar/FABPopoverContent/menuItems/QuickActionMenuItem.tsx
+++ b/src/pages/inbox/sidebar/FABPopoverContent/menuItems/QuickActionMenuItem.tsx
@@ -14,6 +14,7 @@ import {navigateToQuickAction} from '@libs/actions/QuickActionNavigation';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import Navigation from '@libs/Navigation/Navigation';
+import {isGroupPolicy} from '@libs/PolicyUtils';
 import {getQuickActionIcon, getQuickActionTitle, isQuickActionAllowed} from '@libs/QuickActionUtils';
 import {deprecatedGetReportName} from '@libs/ReportNameUtils';
 import {getDisplayNameForParticipant, getIcons, getWorkspaceChats, isPolicyExpenseChat} from '@libs/ReportUtils';
@@ -71,7 +72,7 @@ function QuickActionMenuItem({reportID}: QuickActionMenuItemProps) {
     const isValidReport = !(isEmptyObject(quickActionReport) || isReportArchived);
 
     const policyChatForActivePolicy: OnyxTypes.Report =
-        !isEmptyObject(activePolicy) && activePolicy?.isPolicyExpenseChatEnabled && policyChats.length > 0 ? (policyChats.at(0) ?? ({} as OnyxTypes.Report)) : ({} as OnyxTypes.Report);
+        !isEmptyObject(activePolicy) && isGroupPolicy(activePolicy) && policyChats.length > 0 ? (policyChats.at(0) ?? ({} as OnyxTypes.Report)) : ({} as OnyxTypes.Report);
 
     const quickActionReportPolicyID = getNonEmptyStringOnyxID(quickActionReport?.policyID);
     const policyChatForActivePolicyPolicyID = getNonEmptyStringOnyxID(policyChatForActivePolicy?.policyID);

--- a/src/pages/inbox/sidebar/FABPopoverContent/useScanActions.ts
+++ b/src/pages/inbox/sidebar/FABPopoverContent/useScanActions.ts
@@ -5,6 +5,7 @@ import {startMoneyRequest} from '@libs/actions/IOU/MoneyRequest';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import Navigation from '@libs/Navigation/Navigation';
+import {isGroupPolicy} from '@libs/PolicyUtils';
 import {generateReportID, getWorkspaceChats} from '@libs/ReportUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
 
@@ -38,7 +39,7 @@ function useScanActions() {
     const [reportID] = useState(() => generateReportID());
 
     const policyChatForActivePolicy: OnyxTypes.Report =
-        !isEmptyObject(activePolicy) && activePolicy?.isPolicyExpenseChatEnabled && policyChats.length > 0 ? (policyChats.at(0) ?? ({} as OnyxTypes.Report)) : ({} as OnyxTypes.Report);
+        !isEmptyObject(activePolicy) && isGroupPolicy(activePolicy) && policyChats.length > 0 ? (policyChats.at(0) ?? ({} as OnyxTypes.Report)) : ({} as OnyxTypes.Report);
 
     const startScan = () => {
         interceptAnonymousUser(() => {

--- a/tests/unit/QuickActionMenuItemTest.tsx
+++ b/tests/unit/QuickActionMenuItemTest.tsx
@@ -114,14 +114,14 @@ describe('QuickActionMenuItem', () => {
         expect(mockTranslate).toHaveBeenCalledWith('quickAction.paySomeone', 'SPY_NAME');
     });
 
-    it('shows the workspace fallback quick action for a group policy even if the policy flag is absent', async () => {
+    it('shows the workspace fallback quick action for a group policy even if the policy expense chat flag is absent', async () => {
         const props = await renderWithActivePolicy(CONST.POLICY.TYPE.TEAM);
 
         expect(mockFABFocusableMenuItem).toHaveBeenCalled();
         expect(props).toEqual(expect.objectContaining({isVisible: true}));
     });
 
-    it('hides the workspace fallback quick action for a personal policy even if the policy flag is absent', async () => {
+    it('hides the workspace fallback quick action for a personal policy even if the policy expense chat flag is absent', async () => {
         const props = await renderWithActivePolicy(CONST.POLICY.TYPE.PERSONAL);
 
         expect(mockFABFocusableMenuItem).toHaveBeenCalled();

--- a/tests/unit/QuickActionMenuItemTest.tsx
+++ b/tests/unit/QuickActionMenuItemTest.tsx
@@ -12,6 +12,8 @@ import QuickActionMenuItem from '@pages/inbox/sidebar/FABPopoverContent/menuItem
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
+import type {ValueOf} from 'type-fest';
+
 import React from 'react';
 import Onyx from 'react-native-onyx';
 
@@ -67,7 +69,7 @@ describe('QuickActionMenuItem', () => {
         mockGetDisplayNameForParticipant.mockClear();
     });
 
-    const renderWithActivePolicy = async (policyType: (typeof CONST.POLICY.TYPE)[keyof typeof CONST.POLICY.TYPE]) => {
+    const renderWithActivePolicy = async (policyType: ValueOf<typeof CONST.POLICY.TYPE>) => {
         const activePolicy = createRandomPolicy(Number(ACTIVE_POLICY_ID), policyType);
         Reflect.deleteProperty(activePolicy as Record<string, unknown>, 'isPolicyExpenseChatEnabled');
 

--- a/tests/unit/QuickActionMenuItemTest.tsx
+++ b/tests/unit/QuickActionMenuItemTest.tsx
@@ -2,8 +2,11 @@ import {render} from '@testing-library/react-native';
 
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+
 import {getDisplayNameForParticipant} from '@libs/ReportUtils';
 
+import FABFocusableMenuItem from '@pages/inbox/sidebar/FABPopoverContent/FABFocusableMenuItem';
 import QuickActionMenuItem from '@pages/inbox/sidebar/FABPopoverContent/menuItems/QuickActionMenuItem';
 
 import CONST from '@src/CONST';
@@ -12,13 +15,15 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 
-import {createRegularChat} from '../utils/collections/reports';
+import createRandomPolicy from '../utils/collections/policies';
+import {createPolicyExpenseChat, createRegularChat} from '../utils/collections/reports';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
 const mockTranslate = jest.fn((path: string) => path);
 const mockFormatPhoneNumber = jest.fn((value: string) => value);
 
 jest.mock('@hooks/useLocalize', () => () => ({translate: mockTranslate, formatPhoneNumber: mockFormatPhoneNumber}));
+jest.mock('@hooks/useCurrentUserPersonalDetails');
 
 jest.mock('@hooks/useLazyAsset', () => ({
     useMemoizedLazyExpensifyIcons: () => new Proxy({}, {get: (_, name) => String(name)}),
@@ -41,14 +46,53 @@ jest.mock('@libs/ReportUtils', () => {
 });
 
 const mockGetDisplayNameForParticipant = jest.mocked(getDisplayNameForParticipant);
+const mockUseCurrentUserPersonalDetails = jest.mocked(useCurrentUserPersonalDetails);
+const mockFABFocusableMenuItem = jest.mocked(FABFocusableMenuItem);
 
 const QUICK_ACTION_REPORT_ID = '991001';
+const ACTIVE_POLICY_ID = '1234';
+const POLICY_CHAT_REPORT_ID = '1235';
 
 describe('QuickActionMenuItem', () => {
     beforeAll(() => {
         Onyx.init({keys: ONYXKEYS});
         return waitForBatchedUpdates();
     });
+
+    beforeEach(() => {
+        mockUseCurrentUserPersonalDetails.mockReturnValue({accountID: 1});
+        mockFABFocusableMenuItem.mockClear();
+        mockTranslate.mockClear();
+        mockFormatPhoneNumber.mockClear();
+        mockGetDisplayNameForParticipant.mockClear();
+    });
+
+    const renderWithActivePolicy = async (policyType: (typeof CONST.POLICY.TYPE)[keyof typeof CONST.POLICY.TYPE]) => {
+        const activePolicy = createRandomPolicy(Number(ACTIVE_POLICY_ID), policyType);
+        Reflect.deleteProperty(activePolicy as Record<string, unknown>, 'isPolicyExpenseChatEnabled');
+
+        const policyExpenseChat = {
+            ...createPolicyExpenseChat(Number(POLICY_CHAT_REPORT_ID)),
+            reportID: POLICY_CHAT_REPORT_ID,
+            policyID: ACTIVE_POLICY_ID,
+            ownerAccountID: 1,
+        };
+
+        await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, ACTIVE_POLICY_ID);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${ACTIVE_POLICY_ID}`, activePolicy);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${POLICY_CHAT_REPORT_ID}`, policyExpenseChat);
+        await Onyx.merge(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE, null);
+        await waitForBatchedUpdates();
+
+        render(
+            <OnyxListItemProvider>
+                <QuickActionMenuItem reportID={QUICK_ACTION_REPORT_ID} />
+            </OnyxListItemProvider>,
+        );
+        await waitForBatchedUpdates();
+
+        return mockFABFocusableMenuItem.mock.calls.at(-1)?.[0];
+    };
 
     it('resolves the pay-someone title name through the translate function from useLocalize', async () => {
         const report = {...createRegularChat(Number(QUICK_ACTION_REPORT_ID), [1, AVATAR_ACCOUNT_ID]), reportID: QUICK_ACTION_REPORT_ID};
@@ -66,5 +110,19 @@ describe('QuickActionMenuItem', () => {
         // The pay-someone quick action resolves the payee name via getDisplayNameForParticipant, which must receive the translate from useLocalize.
         expect(mockGetDisplayNameForParticipant).toHaveBeenCalledWith(expect.objectContaining({accountID: AVATAR_ACCOUNT_ID, shouldUseShortForm: true, translate: mockTranslate}));
         expect(mockTranslate).toHaveBeenCalledWith('quickAction.paySomeone', 'SPY_NAME');
+    });
+
+    it('shows the workspace fallback quick action for a group policy even if the policy flag is absent', async () => {
+        const props = await renderWithActivePolicy(CONST.POLICY.TYPE.TEAM);
+
+        expect(mockFABFocusableMenuItem).toHaveBeenCalled();
+        expect(props).toEqual(expect.objectContaining({isVisible: true}));
+    });
+
+    it('hides the workspace fallback quick action for a personal policy even if the policy flag is absent', async () => {
+        const props = await renderWithActivePolicy(CONST.POLICY.TYPE.PERSONAL);
+
+        expect(mockFABFocusableMenuItem).toHaveBeenCalled();
+        expect(props).toEqual(expect.objectContaining({isVisible: false}));
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

This is a small follow-up for the `isPolicyExpenseChatEnabled` removal work in https://github.com/Expensify/Expensify/issues/370320.

The FAB workspace-chat fallback paths were still using `activePolicy?.isPolicyExpenseChatEnabled` to decide whether the active policy could provide a workspace chat. That check is no longer the right guard once the deprecated field disappears.

This PR replaces those checks with `isGroupPolicy(activePolicy)` in the FAB quick-action, scan-action, and floating-camera paths so that:

- group workspaces still use the workspace-chat fallback
- personal policies stay excluded

It also adds focused unit coverage for the two policy-type branches when the deprecated flag is absent.

### Fixed Issues

$ Part of https://github.com/Expensify/Expensify/issues/370320

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Clear any saved Quick Action destination so the FAB uses the workspace fallback.
2. Select a Team or Corporate workspace as the active policy.
3. Open the FAB and verify the fallback Quick Action entry is shown.
4. Go to OldDot and Switch the active policy back to Personal.
5. Open the FAB again and verify the fallback Quick Action entry is hidden.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Load the relevant workspace and personal-policy data once while online.
2. Go offline.
3. Repeat steps 2-5 from Tests.
4. Verify the fallback still follows the active policy type.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/8dcfcc67-8738-4657-b5e0-fafc95c13941
