### PR TITLE
Refactor IOU default expense-policy logic to distinguish personal and group policies

### DIFF
--- a/src/hooks/useParticipantSubmission.ts
+++ b/src/hooks/useParticipantSubmission.ts
@@ -113,7 +113,6 @@ function useParticipantSubmission({
     const isActivePolicyRequest =
         iouType === CONST.IOU.TYPE.CREATE &&
         isGroupPolicy(activePolicy) &&
-        activePolicy?.isPolicyExpenseChatEnabled &&
         !shouldRestrictUserBillableActions(activePolicy, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, amountOwed, currentUserPersonalDetails.accountID);
 
     const dataRef = useRef({

--- a/src/hooks/useReceiptScanDrop.tsx
+++ b/src/hooks/useReceiptScanDrop.tsx
@@ -86,7 +86,6 @@ function useReceiptScanDrop() {
 
         if (
             isGroupPolicy(activePolicy) &&
-            activePolicy?.isPolicyExpenseChatEnabled &&
             !shouldRestrictUserBillableActions(activePolicy, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, amountOwed, currentUserPersonalDetails.accountID)
         ) {
             const shouldAutoReport = !!activePolicy?.autoReporting || !!personalPolicy?.autoReporting;

--- a/src/libs/shouldUseDefaultExpensePolicy.ts
+++ b/src/libs/shouldUseDefaultExpensePolicy.ts
@@ -18,7 +18,6 @@ function shouldUseDefaultExpensePolicy(
     return (
         iouType === CONST.IOU.TYPE.CREATE &&
         isGroupPolicy(defaultExpensePolicy) &&
-        defaultExpensePolicy?.isPolicyExpenseChatEnabled &&
         !shouldRestrictUserBillableActions(defaultExpensePolicy, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, amountOwed, currentUserAccountID)
     );
 }

--- a/src/libs/shouldUseDefaultExpensePolicy.ts
+++ b/src/libs/shouldUseDefaultExpensePolicy.ts
@@ -9,17 +9,17 @@ import {shouldRestrictUserBillableActions} from './SubscriptionUtils';
 
 function shouldUseDefaultExpensePolicy(
     iouType: IOUType,
-    defaultExpensePolicy: OnyxEntry<Policy>,
+    defaultExpensePolicy: OnyxEntry<Policy> | null,
     amountOwed: OnyxEntry<number>,
     userBillingGracePeriodEnds: OnyxCollection<BillingGraceEndPeriod>,
     ownerBillingGracePeriodEnd: OnyxEntry<number>,
     currentUserAccountID: number,
 ) {
-    return (
-        iouType === CONST.IOU.TYPE.CREATE &&
-        isGroupPolicy(defaultExpensePolicy) &&
-        !shouldRestrictUserBillableActions(defaultExpensePolicy, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, amountOwed, currentUserAccountID)
-    );
+    if (iouType !== CONST.IOU.TYPE.CREATE || !defaultExpensePolicy || !isGroupPolicy(defaultExpensePolicy)) {
+        return false;
+    }
+
+    return !shouldRestrictUserBillableActions(defaultExpensePolicy, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, amountOwed, currentUserAccountID);
 }
 
 export default shouldUseDefaultExpensePolicy;

--- a/src/libs/shouldUseDefaultExpensePolicy.ts
+++ b/src/libs/shouldUseDefaultExpensePolicy.ts
@@ -1,6 +1,6 @@
 import type {IOUType} from '@src/CONST';
 import CONST from '@src/CONST';
-import type {BillingGraceEndPeriod, OnyxInputOrEntry, Policy} from '@src/types/onyx';
+import type {BillingGraceEndPeriod, Policy} from '@src/types/onyx';
 
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 
@@ -9,7 +9,7 @@ import {shouldRestrictUserBillableActions} from './SubscriptionUtils';
 
 function shouldUseDefaultExpensePolicy(
     iouType: IOUType,
-    defaultExpensePolicy: OnyxInputOrEntry<Policy>,
+    defaultExpensePolicy: OnyxEntry<Policy>,
     amountOwed: OnyxEntry<number>,
     userBillingGracePeriodEnds: OnyxCollection<BillingGraceEndPeriod>,
     ownerBillingGracePeriodEnd: OnyxEntry<number>,

--- a/tests/actions/IOU/MoneyRequestTest.ts
+++ b/tests/actions/IOU/MoneyRequestTest.ts
@@ -1790,10 +1790,10 @@ describe('MoneyRequest', () => {
             expect(shouldUseDefaultExpensePolicy(CONST.IOU.TYPE.CREATE, policy, 0, undefined, undefined, currentUserAccountID)).toBe(false);
         });
 
-        it('should return false when isPolicyExpenseChatEnabled is false', () => {
+        it('should return false when policy is not a group policy', () => {
             const policy = {
                 ...fakePolicy,
-                type: CONST.POLICY.TYPE.TEAM,
+                type: CONST.POLICY.TYPE.PERSONAL,
                 isPolicyExpenseChatEnabled: false,
             };
 

--- a/tests/unit/shouldUseDefaultExpensePolicyTest.ts
+++ b/tests/unit/shouldUseDefaultExpensePolicyTest.ts
@@ -49,8 +49,8 @@ describe('shouldUseDefaultExpensePolicy', () => {
         expect(shouldUseDefaultExpensePolicy(CONST.IOU.TYPE.CREATE, policy, undefined, undefined, undefined, CONST.DEFAULT_NUMBER_ID)).toBeFalsy();
     });
 
-    it('returns false when isPolicyExpenseChatEnabled is false', () => {
-        const policy = makePaidGroupPolicy({isPolicyExpenseChatEnabled: false});
+    it('returns false when defaultExpensePolicy is not a group policy', () => {
+        const policy = makePaidGroupPolicy({type: CONST.POLICY.TYPE.PERSONAL, isPolicyExpenseChatEnabled: false});
         expect(shouldUseDefaultExpensePolicy(CONST.IOU.TYPE.CREATE, policy, undefined, undefined, undefined, CONST.DEFAULT_NUMBER_ID)).toBeFalsy();
     });
 


### PR DESCRIPTION
### Explanation of Change
This PR continues https://github.com/Expensify/Expensify/issues/370320 by removing the deprecated `isPolicyExpenseChatEnabled` check from active-policy IOU helpers that already gate on group policy. The behavior now depends on whether the active policy is a group workspace, which matches the real routing logic and avoids keeping the deprecated flag in these paths.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/370320
PROPOSAL: N/A

### Tests
1. In OldDot, set the active policy to a Team or Corporate workspace.
2. In NewDot, start a global Create expense flow that uses the default expense policy path.
3. Continue past the amount step.
4. Verify the app does not open participant selection.
5. Verify the app auto-routes to the default destination for that workspace flow:
    - either the workspace-backed destination, or
    - self-DM / Track if that workspace resolves to self-DM because auto-reporting is off.
6. In OldDot, switch the active policy to Personal.
7. Start the same Create expense flow again.
8. Continue past the amount step.
9. Verify the app opens participant selection instead of auto-routing to a default workspace destination.


- [x] Verify that no errors appear in the JS console

### Offline tests

1. Load the relevant policy data once while online.
2. Go offline.
3. Repeat steps 1-9 from Tests.
4. Verify the same branching still happens:
  - group policy skips participant selection
  - personal policy opens participant selection

### QA Steps
Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


https://github.com/user-attachments/assets/b1ad24bf-c6a3-448a-8f26-1d76a834efd5

