### PR TITLE
Refactor search submit CTA eligibility to use group-policy checks

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -1111,7 +1111,7 @@ function getSuggestedSearchesVisibility(
     defaultExpensifyCard: CardFeedForDisplay | undefined,
     hasReportAwaitingApproval = false,
     isTrackIntentUser = false,
-): {visibility: Record<ValueOf<typeof CONST.SEARCH.SEARCH_KEYS>, boolean>; hasGroupPoliciesWithExpenseChat: boolean; shouldShowExpensifyCard: boolean; topSpendersPolicyIDs: string[]} {
+): {visibility: Record<ValueOf<typeof CONST.SEARCH.SEARCH_KEYS>, boolean>; hasEligibleGroupPolicies: boolean; shouldShowExpensifyCard: boolean; topSpendersPolicyIDs: string[]} {
     let shouldShowSubmitSuggestion = false;
     let shouldShowPaySuggestion = false;
     let shouldShowApproveSuggestion = hasReportAwaitingApproval;
@@ -1124,7 +1124,7 @@ function getSuggestedSearchesVisibility(
     let shouldShowTopSpendersSuggestion = false;
     let shouldShowTopCategoriesSuggestion = false;
     let shouldShowTopMerchantsSuggestion = false;
-    let hasGroupPoliciesWithExpenseChat = false;
+    let hasEligibleGroupPolicies = false;
     let shouldShowSpendOverTimeSuggestion = false;
     const topSpendersPolicyIDs: string[] = [];
 
@@ -1187,9 +1187,8 @@ function getSuggestedSearchesVisibility(
         }
         shouldShowTopCategoriesSuggestion ||= isEligibleForTopCategoriesSuggestion;
         shouldShowTopMerchantsSuggestion ||= isEligibleForTopMerchantsSuggestion;
-        hasGroupPoliciesWithExpenseChat ||=
+        hasEligibleGroupPolicies ||=
             isGroupPolicyEligible &&
-            !!policy.isPolicyExpenseChatEnabled &&
             !policy.isJoinRequestPending &&
             (policy.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE || Object.keys(policy.errors ?? {}).length > 0) &&
             !!policy.role;
@@ -1213,7 +1212,7 @@ function getSuggestedSearchesVisibility(
             [CONST.SEARCH.SEARCH_KEYS.TOP_MERCHANTS]: shouldShowTopMerchantsSuggestion,
             [CONST.SEARCH.SEARCH_KEYS.SPEND_OVER_TIME]: shouldShowSpendOverTimeSuggestion,
         },
-        hasGroupPoliciesWithExpenseChat,
+        hasEligibleGroupPolicies,
         shouldShowExpensifyCard: shouldShowExpensifyCardSuggestion,
         topSpendersPolicyIDs,
     };
@@ -4767,7 +4766,7 @@ function createTypeMenuSections(params: TypeMenuSectionsParams): SearchTypeMenuS
 
     const {
         visibility: suggestedSearchesVisibility,
-        hasGroupPoliciesWithExpenseChat,
+        hasEligibleGroupPolicies,
         shouldShowExpensifyCard,
         topSpendersPolicyIDs,
     } = getSuggestedSearchesVisibility(currentUserEmail, cardFeedsByPolicy, policies, defaultExpensifyCard, hasReportAwaitingApproval, isTrackIntentUser);
@@ -4796,7 +4795,7 @@ function createTypeMenuSections(params: TypeMenuSectionsParams): SearchTypeMenuS
                     emptyState: {
                         title: 'search.searchResults.emptySubmitResults.title',
                         subtitle: 'search.searchResults.emptySubmitResults.subtitle',
-                        buttons: hasGroupPoliciesWithExpenseChat
+                        buttons: hasEligibleGroupPolicies
                             ? [
                                   {
                                       success: true,

--- a/tests/ui/components/EmptySearchViewTest.tsx
+++ b/tests/ui/components/EmptySearchViewTest.tsx
@@ -138,7 +138,7 @@ describe('EmptySearchView', () => {
                     <Wrapper>
                         <EmptySearchView
                             similarSearchHash={queryJSON?.similarSearchHash ?? 1}
-                            type={dataType}
+                            type={queryJSON?.type ?? dataType}
                             hasResults={false}
                         />
                     </Wrapper>,
@@ -172,17 +172,17 @@ describe('EmptySearchView', () => {
                     <Wrapper>
                         <EmptySearchView
                             similarSearchHash={queryJSON?.similarSearchHash ?? 1}
-                            type={dataType}
+                            type={queryJSON?.type ?? dataType}
                             hasResults={false}
                         />
                     </Wrapper>,
                 );
                 await waitForBatchedUpdatesWithAct();
 
-                // Then it should fall back to the generic expense empty state
-                expect(screen.getByText(translateLocal('search.searchResults.emptyExpenseResults.title'))).toBeVisible();
+                // Then it should fall back to the generic report empty state
+                expect(screen.getByText(translateLocal('search.searchResults.emptyReportResults.title'))).toBeVisible();
 
-                // And it should show the generic empty-expense actions instead of the submit suggestion CTA
+                // And it should show the generic report actions instead of the submit suggestion CTA
                 expect(screen.getByText(translateLocal('emptySearchView.takeATestDrive'))).toBeVisible();
             });
         });

--- a/tests/ui/components/EmptySearchViewTest.tsx
+++ b/tests/ui/components/EmptySearchViewTest.tsx
@@ -9,6 +9,7 @@ import EmptySearchView from '@pages/Search/EmptySearchView';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {Policy} from '@src/types/onyx';
 
 import React from 'react';
 import Onyx from 'react-native-onyx';
@@ -31,10 +32,9 @@ const SESSION = {
     accountID: CURRENT_USER_ACCOUNT_ID,
 };
 const POLICY_ID = '1';
-const createPaidGroupPolicy = (isPolicyExpenseChatEnabled = true) => ({
+const createPolicy = (type: Policy['type'] = CONST.POLICY.TYPE.TEAM) => ({
     id: POLICY_ID,
-    type: CONST.POLICY.TYPE.TEAM,
-    isPolicyExpenseChatEnabled,
+    type,
     role: CONST.POLICY.ROLE.ADMIN,
 });
 
@@ -118,9 +118,9 @@ describe('EmptySearchView', () => {
                 });
             });
 
-            it('should display "Create Report" button when user has a paid group policy with expense chat enabled', async () => {
-                // Given a paid group policy with expense chat enabled
-                const paidGroupPolicy = createPaidGroupPolicy();
+            it('should display "Create Report" button when user has a group policy', async () => {
+                // Given a group policy
+                const paidGroupPolicy = createPolicy();
                 await act(async () => {
                     await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${paidGroupPolicy.id}`, paidGroupPolicy);
                 });
@@ -152,9 +152,9 @@ describe('EmptySearchView', () => {
                 expect(screen.getByText(translateLocal('report.newReport.createExpense'))).toBeVisible();
             });
 
-            it('should hide "Create Report" button when user has a paid group policy with expense chat disabled', async () => {
-                // Given a paid group policy with expense chat disabled
-                const policy = createPaidGroupPolicy(false);
+            it('should hide "Create Report" button when user has a personal policy', async () => {
+                // Given a personal policy
+                const policy = createPolicy(CONST.POLICY.TYPE.PERSONAL);
                 await act(async () => {
                     await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
                 });
@@ -179,16 +179,16 @@ describe('EmptySearchView', () => {
                 );
                 await waitForBatchedUpdatesWithAct();
 
-                // Then it should display the submit empty results title
-                expect(screen.getByText(translateLocal('search.searchResults.emptySubmitResults.title'))).toBeVisible();
+                // Then it should fall back to the generic expense empty state
+                expect(screen.getByText(translateLocal('search.searchResults.emptyExpenseResults.title'))).toBeVisible();
 
-                // And it should not display the "Create Expense" button
-                expect(screen.queryByText(translateLocal('report.newReport.createExpense'))).not.toBeOnTheScreen();
+                // And it should show the generic empty-expense actions instead of the submit suggestion CTA
+                expect(screen.getByText(translateLocal('emptySearchView.takeATestDrive'))).toBeVisible();
             });
         });
 
         it('should show "emptyExpenseResults" when the user has deleted all expenses, even though hasResults remains true', async () => {
-            const policy = createPaidGroupPolicy();
+            const policy = createPolicy();
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
             });
@@ -221,7 +221,7 @@ describe('EmptySearchView', () => {
         const dataType = CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT;
 
         it('should show "emptyReportResults" when the user has deleted all expenses, even though hasResults remains true', async () => {
-            const policy = createPaidGroupPolicy();
+            const policy = createPolicy();
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
             });

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -9192,6 +9192,30 @@ describe('SearchUIUtils', () => {
             expect(response.visibility.topCategories).toBe(false);
         });
 
+        test('Should set hasEligibleGroupPolicies only for group workspaces', () => {
+            const groupPolicies: OnyxCollection<OnyxTypes.Policy> = {
+                [`policy_${policyID}`]: createMock<OnyxTypes.Policy>({
+                    id: policyID,
+                    type: CONST.POLICY.TYPE.TEAM,
+                    role: CONST.POLICY.ROLE.ADMIN,
+                }),
+            };
+
+            const personalPolicies: OnyxCollection<OnyxTypes.Policy> = {
+                [`policy_${policyID}`]: createMock<OnyxTypes.Policy>({
+                    id: policyID,
+                    type: CONST.POLICY.TYPE.PERSONAL,
+                    role: CONST.POLICY.ROLE.ADMIN,
+                }),
+            };
+
+            const groupResponse = SearchUIUtils.getSuggestedSearchesVisibility(adminEmail, {}, groupPolicies, undefined);
+            const personalResponse = SearchUIUtils.getSuggestedSearchesVisibility(adminEmail, {}, personalPolicies, undefined);
+
+            expect(groupResponse.hasEligibleGroupPolicies).toBe(true);
+            expect(personalResponse.hasEligibleGroupPolicies).toBe(false);
+        });
+
         test('Should show Top Categories if at least one policy has categories enabled', () => {
             const policies: OnyxCollection<OnyxTypes.Policy> = {
                 policyOne: createMock<OnyxTypes.Policy>({

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -7644,7 +7644,7 @@ describe('SearchUIUtils', () => {
                 cardFeedsByPolicy: {},
                 defaultCardFeed: undefined,
                 policies: {
-                    policy1: {
+                    policy1: createMock<OnyxTypes.Policy>({
                         id: 'policy1',
                         name: 'Test Policy',
                         owner: adminEmail,
@@ -7652,7 +7652,7 @@ describe('SearchUIUtils', () => {
                         role: CONST.POLICY.ROLE.ADMIN,
                         type: CONST.POLICY.TYPE.TEAM,
                         pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
-                    },
+                    }),
                 },
                 savedSearches: {},
                 isOffline: false,

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -7637,6 +7637,36 @@ describe('SearchUIUtils', () => {
             expect(menuItemKeys).toContain(CONST.SEARCH.SEARCH_KEYS.EXPORT);
         });
 
+        it('should keep Submit visible without CTA buttons for group workspaces that are not CTA-eligible', () => {
+            const sections = SearchUIUtils.createTypeMenuSections({
+                currentUserEmail: adminEmail,
+                currentUserAccountID: adminAccountID,
+                cardFeedsByPolicy: {},
+                defaultCardFeed: undefined,
+                policies: {
+                    policy1: {
+                        id: 'policy1',
+                        name: 'Test Policy',
+                        owner: adminEmail,
+                        outputCurrency: 'USD',
+                        role: CONST.POLICY.ROLE.ADMIN,
+                        type: CONST.POLICY.TYPE.TEAM,
+                        pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                    },
+                },
+                savedSearches: {},
+                isOffline: false,
+                defaultExpensifyCard: undefined,
+                draftTransactionIDs: [],
+                isTrackIntentUser: false,
+            });
+
+            const submitItem = sections.flatMap((section) => section.menuItems).find((item) => item.key === CONST.SEARCH.SEARCH_KEYS.SUBMIT);
+
+            expect(submitItem).toBeDefined();
+            expect(submitItem?.emptyState?.buttons).toEqual([]);
+        });
+
         it('should hide submit, approve, pay, export, and top spenders for track intent users without workflows enabled', () => {
             const mockPolicies = {
                 policy1: {
@@ -9214,6 +9244,22 @@ describe('SearchUIUtils', () => {
 
             expect(groupResponse.hasEligibleGroupPolicies).toBe(true);
             expect(personalResponse.hasEligibleGroupPolicies).toBe(false);
+        });
+
+        test('Should keep deleted group workspaces eligible when they still have errors', () => {
+            const policies: OnyxCollection<OnyxTypes.Policy> = {
+                [`policy_${policyID}`]: createMock<OnyxTypes.Policy>({
+                    id: policyID,
+                    type: CONST.POLICY.TYPE.TEAM,
+                    role: CONST.POLICY.ROLE.ADMIN,
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                    errors: {name: 'Workspace still has an error'},
+                }),
+            };
+
+            const response = SearchUIUtils.getSuggestedSearchesVisibility(adminEmail, {}, policies, undefined);
+
+            expect(response.hasEligibleGroupPolicies).toBe(true);
         });
 
         test('Should show Top Categories if at least one policy has categories enabled', () => {


### PR DESCRIPTION
### Explanation of Change

This PR continues https://github.com/Expensify/Expensify/issues/370320 by updating the Search empty submit-state CTA eligibility to rely on group-policy classification instead of the deprecated `isPolicyExpenseChatEnabled` flag.

The search visibility helper now treats eligible group workspaces as the deciding factor for the submit empty-state CTA, while personal policies fall back to the generic empty-expense state.

It also updates the focused UI coverage so the tests describe group vs personal policy behavior directly instead of describing the deprecated flag.

### Fixed Issues
$ Part of https://github.com/Expensify/Expensify/issues/370320
PROPOSAL: N/A

### Tests

1. Sign in to an account that has at least one group workspace and one personal policy.
2. Open Search and navigate to an empty Submit search state for expenses.
3. With a group workspace available, verify the submit empty state is shown (`No expenses to submit`).
4. Verify the empty state shows the `Create expense` CTA.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<img width="1540" height="962" alt="Screenshot 2026-08-16 at 9 25 50 PM" src="https://github.com/user-attachments/assets/f41a6991-795f-4268-896e-ce4defa7584f" />
