### PR TITLE
Use regular weight for LHN and Home widget rows

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRow/Title.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRow/Title.tsx
@@ -1,6 +1,7 @@
 import DisplayNames from '@components/DisplayNames';
 
 import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {shouldUseBoldText} from '@libs/OptionsListUtils';
@@ -22,8 +23,10 @@ type TitleProps = {
 function Title({optionItem, testID}: TitleProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
+    const theme = useTheme();
 
-    const textUnreadStyle = shouldUseBoldText(optionItem) ? [styles.sidebarLinkText, styles.sidebarLinkTextBold] : [styles.sidebarLinkText];
+    // Unread rows keep the heading color for emphasis but use regular weight instead of bold.
+    const textUnreadStyle = shouldUseBoldText(optionItem) ? [styles.sidebarLinkText, {color: theme.heading}] : [styles.sidebarLinkText];
     const displayNameStyle = [styles.optionDisplayName, styles.optionDisplayNameCompact, styles.pre, textUnreadStyle, styles.flexShrink0];
 
     const shouldParseFullTitle = optionItem?.parentReportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat(optionItem);

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRow/Title.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRow/Title.tsx
@@ -3,7 +3,6 @@ import DisplayNames from '@components/DisplayNames';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {shouldUseBoldText} from '@libs/OptionsListUtils';
 import type {OptionData} from '@libs/ReportUtils';
 import {isGroupChat, isSystemChat} from '@libs/ReportUtils';
 
@@ -23,9 +22,7 @@ function Title({optionItem, testID}: TitleProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
 
-    // Unread rows use the heading color so they stand out from read rows.
-    const textUnreadStyle = shouldUseBoldText(optionItem) ? [styles.sidebarLinkText, styles.sidebarLinkTextUnread] : [styles.sidebarLinkText];
-    const displayNameStyle = [styles.optionDisplayName, styles.optionDisplayNameCompact, styles.pre, textUnreadStyle, styles.flexShrink0];
+    const displayNameStyle = [styles.optionDisplayName, styles.optionDisplayNameCompact, styles.pre, styles.sidebarLinkText, styles.flexShrink0];
 
     const shouldParseFullTitle = optionItem?.parentReportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat(optionItem);
     const shouldUseFullTitle =

--- a/src/components/LHNOptionsList/OptionRowLHN/OptionRow/Title.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN/OptionRow/Title.tsx
@@ -1,7 +1,6 @@
 import DisplayNames from '@components/DisplayNames';
 
 import useLocalize from '@hooks/useLocalize';
-import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {shouldUseBoldText} from '@libs/OptionsListUtils';
@@ -23,10 +22,9 @@ type TitleProps = {
 function Title({optionItem, testID}: TitleProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
-    const theme = useTheme();
 
-    // Unread rows keep the heading color for emphasis but use regular weight instead of bold.
-    const textUnreadStyle = shouldUseBoldText(optionItem) ? [styles.sidebarLinkText, {color: theme.heading}] : [styles.sidebarLinkText];
+    // Unread rows use the heading color so they stand out from read rows.
+    const textUnreadStyle = shouldUseBoldText(optionItem) ? [styles.sidebarLinkText, styles.sidebarLinkTextUnread] : [styles.sidebarLinkText];
     const displayNameStyle = [styles.optionDisplayName, styles.optionDisplayNameCompact, styles.pre, textUnreadStyle, styles.flexShrink0];
 
     const shouldParseFullTitle = optionItem?.parentReportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat(optionItem);

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -4957,6 +4957,7 @@ function createBaseSavedSearchMenuItem(item: SaveSearchItem, key: string, index:
         query: item.query,
         shouldShowRightComponent: true,
         focused: isFocused,
+        shouldShowBasicTitle: true,
         pendingAction: item.pendingAction,
         disabled: item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
         shouldIconUseAutoWidthStyle: true,

--- a/src/pages/Search/SearchTypeMenuItem.tsx
+++ b/src/pages/Search/SearchTypeMenuItem.tsx
@@ -115,7 +115,7 @@ function SearchTypeMenuItem({title, icon, badgeText, focused = false, onPress}: 
                     )}
                     <Animated.View style={[styles.justifyContentCenter, styles.flex1, styles.ml3, labelAnimatedStyle]}>
                         <Text
-                            style={[styles.popoverMenuText, styles.textStrong]}
+                            style={styles.popoverMenuText}
                             numberOfLines={1}
                         >
                             {title}

--- a/src/pages/domain/DomainInitialPage.tsx
+++ b/src/pages/domain/DomainInitialPage.tsx
@@ -157,6 +157,7 @@ function DomainInitialPage({route}: DomainInitialPageProps) {
                                 key={item.translationKey}
                                 disabled={isExecuting}
                                 title={translate(item.translationKey)}
+                                shouldShowBasicTitle
                                 icon={item.icon}
                                 onPress={item.action}
                                 brickRoadIndicator={item.brickRoadIndicator}

--- a/src/pages/home/AnnouncementSection.tsx
+++ b/src/pages/home/AnnouncementSection.tsx
@@ -37,7 +37,6 @@ function AnnouncementSection() {
                     key={announcement.title}
                     description={announcement.subtitle}
                     title={announcement.title}
-                    shouldShowBasicTitle
                     onPress={() => Linking.openURL(announcement.url)}
                     shouldShowRightIcon
                     iconRight={icons.NewWindow}

--- a/src/pages/home/AnnouncementSection.tsx
+++ b/src/pages/home/AnnouncementSection.tsx
@@ -37,7 +37,7 @@ function AnnouncementSection() {
                     key={announcement.title}
                     description={announcement.subtitle}
                     title={announcement.title}
-                    titleStyle={styles.textBold}
+                    shouldShowBasicTitle
                     onPress={() => Linking.openURL(announcement.url)}
                     shouldShowRightIcon
                     iconRight={icons.NewWindow}

--- a/src/pages/home/DiscoverSection.tsx
+++ b/src/pages/home/DiscoverSection.tsx
@@ -87,7 +87,6 @@ function DiscoverSection() {
             <MenuItemWithTopDescription
                 shouldShowRightIcon
                 title={isCurrentUserPolicyAdmin ? translate('homePage.discoverSection.menuItemTitleAdmin') : translate('homePage.discoverSection.menuItemTitleNonAdmin')}
-                shouldShowBasicTitle
                 description={translate('homePage.discoverSection.menuItemDescription')}
                 onPress={handlePress}
                 style={shouldUseNarrowLayout ? styles.mb2 : styles.mb5}

--- a/src/pages/home/DiscoverSection.tsx
+++ b/src/pages/home/DiscoverSection.tsx
@@ -87,7 +87,7 @@ function DiscoverSection() {
             <MenuItemWithTopDescription
                 shouldShowRightIcon
                 title={isCurrentUserPolicyAdmin ? translate('homePage.discoverSection.menuItemTitleAdmin') : translate('homePage.discoverSection.menuItemTitleNonAdmin')}
-                titleStyle={styles.textBold}
+                shouldShowBasicTitle
                 description={translate('homePage.discoverSection.menuItemDescription')}
                 onPress={handlePress}
                 style={shouldUseNarrowLayout ? styles.mb2 : styles.mb5}

--- a/src/pages/home/UpcomingTravelSection/UpcomingTravelItem.tsx
+++ b/src/pages/home/UpcomingTravelSection/UpcomingTravelItem.tsx
@@ -114,7 +114,6 @@ function UpcomingTravelItem({reservation: upcomingReservation}: UpcomingTravelIt
         <MenuItemWithTopDescription
             description={formatCancelledDescription(translate('iou.canceled'), subtitle, isCancelled)}
             title={title}
-            shouldShowBasicTitle
             titleStyle={isCancelled ? styles.textSupporting : undefined}
             accessibilityLabel={isCancelled ? `${formatCancelledDescription(translate('iou.canceled'), subtitle, isCancelled)} ${title}` : undefined}
             onPress={handlePress}

--- a/src/pages/home/UpcomingTravelSection/UpcomingTravelItem.tsx
+++ b/src/pages/home/UpcomingTravelSection/UpcomingTravelItem.tsx
@@ -114,7 +114,8 @@ function UpcomingTravelItem({reservation: upcomingReservation}: UpcomingTravelIt
         <MenuItemWithTopDescription
             description={formatCancelledDescription(translate('iou.canceled'), subtitle, isCancelled)}
             title={title}
-            titleStyle={isCancelled ? [styles.textBold, styles.textSupporting] : styles.textBold}
+            shouldShowBasicTitle
+            titleStyle={isCancelled ? styles.textSupporting : undefined}
             accessibilityLabel={isCancelled ? `${formatCancelledDescription(translate('iou.canceled'), subtitle, isCancelled)} ${title}` : undefined}
             onPress={handlePress}
             shouldShowRightIcon

--- a/src/pages/home/YourSpendSection/CardRow.tsx
+++ b/src/pages/home/YourSpendSection/CardRow.tsx
@@ -86,7 +86,7 @@ function CardRow({cardRow, wrapperStyle}: CardRowProps) {
             <MenuItemWithTopDescription
                 description={translate('homePage.yourSpend.recentTransactions', {lastFour: cardRow.lastFour})}
                 title={cardTotal}
-                titleStyle={styles.textBold}
+                shouldShowBasicTitle
                 onPress={() => Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: cardRow.query}))}
                 shouldShowRightComponent
                 rightComponent={

--- a/src/pages/home/YourSpendSection/CardRow.tsx
+++ b/src/pages/home/YourSpendSection/CardRow.tsx
@@ -86,7 +86,6 @@ function CardRow({cardRow, wrapperStyle}: CardRowProps) {
             <MenuItemWithTopDescription
                 description={translate('homePage.yourSpend.recentTransactions', {lastFour: cardRow.lastFour})}
                 title={cardTotal}
-                shouldShowBasicTitle
                 onPress={() => Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: cardRow.query}))}
                 shouldShowRightComponent
                 rightComponent={

--- a/src/pages/home/YourSpendSection/SpendSummaryRow.tsx
+++ b/src/pages/home/YourSpendSection/SpendSummaryRow.tsx
@@ -108,7 +108,6 @@ function SpendSummaryRow({state, testIDPrefix, description, totals, iconSrc, onP
             <MenuItemWithTopDescription
                 description={description}
                 title={totals.total !== undefined ? convertToDisplayString(totals.total, totals.currency) : undefined}
-                shouldShowBasicTitle
                 onPress={onPress}
                 shouldShowRightIcon
                 leftComponent={

--- a/src/pages/home/YourSpendSection/SpendSummaryRow.tsx
+++ b/src/pages/home/YourSpendSection/SpendSummaryRow.tsx
@@ -108,7 +108,7 @@ function SpendSummaryRow({state, testIDPrefix, description, totals, iconSrc, onP
             <MenuItemWithTopDescription
                 description={description}
                 title={totals.total !== undefined ? convertToDisplayString(totals.total, totals.currency) : undefined}
-                titleStyle={styles.textBold}
+                shouldShowBasicTitle
                 onPress={onPress}
                 shouldShowRightIcon
                 leftComponent={

--- a/src/pages/settings/SettingsMenuItem.tsx
+++ b/src/pages/settings/SettingsMenuItem.tsx
@@ -71,6 +71,7 @@ function SettingsMenuItem({item, isFocused, keyTitle, isExecuting, isScreenFocus
             onSecondaryInteraction={onSecondaryInteraction}
             shouldShowContextMenuHint={!!item.link}
             focused={isFocused}
+            shouldShowBasicTitle
             role={CONST.ROLE.TAB}
             isPaneMenu
             sentryLabel={item.sentryLabel}

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -581,6 +581,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
                                     disabled={hasPolicyCreationError || isExecuting}
                                     interactive={!hasPolicyCreationError}
                                     title={translate(item.translationKey)}
+                                    shouldShowBasicTitle
                                     icon={item.icon}
                                     onPress={item.action}
                                     brickRoadIndicator={item.brickRoadIndicator}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -2163,10 +2163,6 @@ const staticStyles = (theme: ThemeColors) =>
             color: theme.heading,
         },
 
-        sidebarLinkTextUnread: {
-            color: theme.heading,
-        },
-
         optionItemAvatarNameWrapper: {
             minWidth: 0,
             flex: 1,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -2163,6 +2163,10 @@ const staticStyles = (theme: ThemeColors) =>
             color: theme.heading,
         },
 
+        sidebarLinkTextUnread: {
+            color: theme.heading,
+        },
+
         optionItemAvatarNameWrapper: {
             minWidth: 0,
             flex: 1,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4187,7 +4187,7 @@ const staticStyles = (theme: ThemeColors) =>
         },
 
         widgetItemTitle: {
-            ...FontUtils.fontFamily.platform.EXP_NEUE_BOLD,
+            ...FontUtils.fontFamily.platform.EXP_NEUE,
             fontSize: variables.fontSizeNormal,
             lineHeight: variables.fontSizeNormalHeight,
             color: theme.text,


### PR DESCRIPTION
### Explanation of Change

Switches Left Hand Navigation rows and Home widget rows from bold to regular font weight.

Affected areas:
- **Report/chat LHN** rows — unread rows drop the bold family but keep the heading color for emphasis.
- **Settings/Account** left pane, **Workspace Editor** left pane, **Domain Editor** left pane — nav row titles use regular weight (including the selected row).
- **Spend/Search** left pane — type-menu rows and saved-search rows (collapsed and expanded).
- **Home widgets** — Getting Started / Free Trial / base widget items, plus the Announcements, Discover, Your Spend (card + summary), and Upcoming Travel rows.

Scoping note: the shared styles `textBold`, `textStrong`, and `sidebarLinkTextBold` are used across the app, so they were left untouched. The change is applied at each call site instead (via the existing `shouldShowBasicTitle` MenuItem prop, or by dropping the bold style from the specific row), so no other surfaces are affected.

### Fixed Issues
$
PROPOSAL:

### Tests
1. Open the app on web.
2. Left Hand Navigation (chat list): verify report rows render in regular weight; unread rows are still distinguishable by color.
3. Settings → Account left pane: verify all rows (Profile, Wallet, Security, etc.) render in regular weight, including the currently selected row.
4. Open a Workspace → verify the workspace editor left pane rows (Members, Categories, Tags, etc.) render in regular weight.
5. Open a Domain → verify the domain editor left pane rows render in regular weight.
6. Search ("Spend"): verify the type-menu rows and saved-search rows render in regular weight in both the expanded and collapsed sidebar states.
7. Home page: verify widget rows (Announcements, Discover, Your Spend, Upcoming Travel, Getting Started) render in regular weight.
- [ ] Verify that no errors appear in the JS console

### Offline tests
Not applicable — visual/styling change only, no network behavior affected.

### QA Steps
Same as tests.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
