### PR TITLE
[CP Staging] fix: refresh Search after an expense moves report or a report changes workspace

### DIFF
--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -383,11 +383,15 @@ function extractReportActionIDsFromSearchResults(searchResultsData: Partial<Sear
 }
 
 /**
- * Whether a transaction that the current search results already display has changed.
+ * Whether a transaction change invalidates what the current search results show.
  *
  * Onyx keeps one value object per collection member and only replaces the ones it writes, so an identity check is
  * enough to spot an edit. A refetch triggered from here can't feed itself, because a Search response only writes
  * snapshot keys and never touches the transaction collection.
+ *
+ * Two shapes of change count. An edit to a transaction the results already display, and a transaction moving into or
+ * out of a report the results display. The move matters even when the transaction itself was never on screen: the
+ * report row still owes its expense count and total to the snapshot, and the server computes both.
  */
 function hasChangedTransactionInSearchResults(
     transactions: OnyxCollection<Transaction>,
@@ -399,10 +403,16 @@ function hasChangedTransactionInSearchResults(
         return false;
     }
 
+    const isReportInSearchResults = (reportID: string | undefined) => !!reportID && !!searchResultsData[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
+
     const changedTransactionIDs: string[] = [];
     for (const [key, transaction] of Object.entries(transactions ?? {})) {
-        if (!transaction?.transactionID || !previousTransactionKeys.has(key) || previousTransactions?.[key] === transaction) {
+        const previousTransaction = previousTransactions?.[key];
+        if (!transaction?.transactionID || !previousTransactionKeys.has(key) || previousTransaction === transaction) {
             continue;
+        }
+        if (transaction.reportID !== previousTransaction?.reportID && (isReportInSearchResults(transaction.reportID) || isReportInSearchResults(previousTransaction?.reportID))) {
+            return true;
         }
         changedTransactionIDs.push(transaction.transactionID);
     }

--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -389,9 +389,7 @@ function extractReportActionIDsFromSearchResults(searchResultsData: Partial<Sear
  * enough to spot an edit. A refetch triggered from here can't feed itself, because a Search response only writes
  * snapshot keys and never touches the transaction collection.
  *
- * Two shapes of change count. An edit to a transaction the results already display, and a transaction moving into or
- * out of a report the results display. The move matters even when the transaction itself was never on screen: the
- * report row still owes its expense count and total to the snapshot, and the server computes both.
+ * A move counts too: the report row owes its count and total to the snapshot, so a transaction never on screen still invalidates it.
  */
 function hasChangedTransactionInSearchResults(
     transactions: OnyxCollection<Transaction>,

--- a/src/pages/DynamicReportChangeWorkspacePage.tsx
+++ b/src/pages/DynamicReportChangeWorkspacePage.tsx
@@ -2,6 +2,7 @@ import ActivityIndicator from '@components/ActivityIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {useSession} from '@components/OnyxListItemProvider';
 import ScreenWrapper from '@components/ScreenWrapper';
+import {useSearchQueryContext, useSearchResultsContext} from '@components/Search/SearchContext';
 import SelectionList from '@components/SelectionList';
 import type {WorkspaceListItemType} from '@components/SelectionList/ListItem/types';
 import UserListItem from '@components/SelectionList/ListItem/UserListItem';
@@ -19,6 +20,7 @@ import useParentReportAction from '@hooks/useParentReportAction';
 import usePermissions from '@hooks/usePermissions';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportTransactions from '@hooks/useReportTransactions';
+import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
 import useShouldSuppressPromotionalUI from '@hooks/useShouldSuppressPromotionalUI';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWorkspaceList from '@hooks/useWorkspaceList';
@@ -38,6 +40,7 @@ import {
     isSettled,
     isWorkspaceEligibleForReportChange,
 } from '@libs/ReportUtils';
+import refreshSearchAfterReportAction from '@libs/SearchRefreshUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
 import {hasAppliedCommuterExclusion, isManualDistanceRequest, isOdometerDistanceRequest} from '@libs/TransactionUtils';
 
@@ -110,6 +113,22 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
         isOdometerDistanceRequest: hasOdometerDistanceRequest,
     });
     const [isTrackIntentUser] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED, {selector: isTrackIntentUserSelector});
+    const {currentSearchQueryJSON, currentSearchKey} = useSearchQueryContext();
+    const {currentSearchResults} = useSearchResultsContext();
+    const shouldCalculateTotals = useSearchShouldCalculateTotals(currentSearchKey, currentSearchQueryJSON?.hash, true);
+
+    // Moving a report to another workspace only writes the new policy into the Search snapshot, never the report row
+    // itself, so a snapshot filtered by the old workspace keeps showing a report that no longer belongs to it. Only
+    // the server can decide whether the row still matches the query, so ask it.
+    const refreshSearch = () => {
+        refreshSearchAfterReportAction({
+            currentSearchQueryJSON,
+            currentSearchKey,
+            shouldCalculateTotals,
+            isOffline,
+            isLoading: !!currentSearchResults?.search?.isLoading,
+        });
+    };
 
     const selectPolicy = (policyID?: string) => {
         const policy = policies?.[`${ONYXKEYS.COLLECTION.POLICY}${policyID}`];
@@ -140,6 +159,7 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
             if (!invite?.policyExpenseChatReportID) {
                 moveIOUReportToPolicy(report, policy, reportPreviewAction, getCurrencyDecimals, false, reportTransactions);
             }
+            refreshSearch();
             return;
             // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
         }
@@ -169,6 +189,7 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
                 isTrackIntentUser,
                 reportTransactions,
             });
+            refreshSearch();
             return;
         }
 
@@ -189,6 +210,7 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
             isTrackIntentUser,
             reportTransactions,
         });
+        refreshSearch();
     };
 
     const {data, shouldShowNoResultsFoundMessage, shouldShowSearchInput} = useWorkspaceList({

--- a/src/pages/DynamicReportChangeWorkspacePage.tsx
+++ b/src/pages/DynamicReportChangeWorkspacePage.tsx
@@ -117,9 +117,7 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
     const {currentSearchResults} = useSearchResultsContext();
     const shouldCalculateTotals = useSearchShouldCalculateTotals(currentSearchKey, currentSearchQueryJSON?.hash, true);
 
-    // Moving a report to another workspace only writes the new policy into the Search snapshot, never the report row
-    // itself, so a snapshot filtered by the old workspace keeps showing a report that no longer belongs to it. Only
-    // the server can decide whether the row still matches the query, so ask it.
+    // The snapshot keeps the report row after a workspace change, and only the server can tell whether it still matches the query.
     const refreshSearch = () => {
         refreshSearchAfterReportAction({
             currentSearchQueryJSON,

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -316,6 +316,60 @@ describe('useSearchHighlightAndScroll', () => {
         expect(search).not.toHaveBeenCalled();
     });
 
+    it('should trigger search when a transaction moves into a report the results display', () => {
+        const movedTransaction = createMock<Transaction>({transactionID: '99', reportID: '5'});
+        const initialProps = createMock<UseSearchHighlightAndScroll>({
+            ...baseProps,
+            searchResults: {
+                ...baseProps.searchResults,
+                data: {
+                    report_2: {reportID: '2'},
+                },
+            },
+            transactions: {transactions_99: movedTransaction},
+            previousTransactions: {transactions_99: movedTransaction},
+        });
+
+        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            initialProps,
+        });
+
+        const updatedProps = createMock<UseSearchHighlightAndScroll>({
+            ...initialProps,
+            transactions: {transactions_99: {transactionID: '99', reportID: '2'}},
+        });
+
+        rerender(updatedProps);
+        expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, searchKey: undefined, offset: 0, shouldCalculateTotals: false, isLoading: false});
+    });
+
+    it('should not trigger search when a transaction moves between reports the results do not display', () => {
+        const movedTransaction = createMock<Transaction>({transactionID: '99', reportID: '5'});
+        const initialProps = createMock<UseSearchHighlightAndScroll>({
+            ...baseProps,
+            searchResults: {
+                ...baseProps.searchResults,
+                data: {
+                    report_2: {reportID: '2'},
+                },
+            },
+            transactions: {transactions_99: movedTransaction},
+            previousTransactions: {transactions_99: movedTransaction},
+        });
+
+        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
+            initialProps,
+        });
+
+        const updatedProps = createMock<UseSearchHighlightAndScroll>({
+            ...initialProps,
+            transactions: {transactions_99: {transactionID: '99', reportID: '7'}},
+        });
+
+        rerender(updatedProps);
+        expect(search).not.toHaveBeenCalled();
+    });
+
     it('should trigger the deferred search once Search is active again, after previousTransactions caught up', () => {
         const transaction = createMock<Transaction>({transactionID: '1', amount: 100});
         const editedTransaction = createMock<Transaction>({transactionID: '1', amount: 250});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Both blockers came from one removal in PR 98305, which is currently on main through the reland PR 98558. Before 98305 the trigger in `useSearchHighlightAndScroll` was `(!isChat && hasTransactionsIDsChange) || hasReportActionsIDsChange`, so `hasReportActionsIDsChange` applied to every search type. Any report action anywhere in the account refetched Search, which is the duplicate traffic reported in issue 98048, and it is also what made both of these flows work by accident. Restoring that condition is not an option, so each flow gets its own correct signal.

98698, expenses count does not update after adding an expense to a report. Moving an expense replaces the transaction object because `reportID` changes, but `hasChangedTransactionInSearchResults` only asked whether that transaction's own ID is in the results. In the repro the expense sits in a self DM that the Reports view does not show, so the answer was no and nothing refetched, while the report row still owes its expense count and total to the server computed snapshot. The check now also counts a transaction whose `reportID` moved into or out of a report the results display, which is a single lookup of the `report_<id>` key already present in the snapshot. This lives in the hook rather than the call site because `changeTransactionsReport` is called from many places across the app, and all of them were equally stale.

98723, report stays in the old workspace filter. Here there is no transaction side signal at all. `buildOptimisticChangePolicyData` sets `report.policyID` optimistically, writes only the policy object into the snapshot and never the report row, and touches transactions only when the destination currency differs. A filtered snapshot therefore keeps a report that no longer belongs to it, and no local patch can decide whether the row still matches the query, only the server can. So `selectPolicy` now calls the existing `refreshSearchAfterReportAction` from `@libs/SearchRefreshUtils` on all three exit paths (IOU, invite submitter, plain change). Other call sites in the codebase already follow that pattern, including `useLifecycleActions` and `useSelectionModePayment`. It is not done in the hook because the signal is `report.policyID` and `Search/index.tsx` does not subscribe to the REPORT collection. Adding a whole collection REPORT subscription to that component would be a performance regression in a hot path.

This also unblocks the open revert PR 98728, which would otherwise revert the reland again.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98698
$ https://github.com/Expensify/App/issues/98723
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
test steps described in linked tickets
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
98698:
1.Action Performed:
2.Go to staging.new.expensify.com
3.Create an empty report in workspace chat.
4.Create an expense in self DM.
5.Go to Spend > Reports.
6.Select the report via checkbox.
7.Open the report.
8.Click Add expense > Add existing expense.
9.Select self DM expense > Add to report.
10.Close the report.

98723:
Preconditions: User has an unvalidated account, has multiple workspaces, and has multiple reports in Workspace 1

1.Open the NewDot app
2.Navigate to the Spend - Report - Filter - Workspace 1
3.Select any report - More - Change Workspace - Select another Workspace (like Workspace 4)
4.Report move to the new Workspace and is no longer displayed in the filter anymore, like Prod

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

