### PR TITLE
Follow-up: narrow useIsAgentAccount personal-details selector to avoid extra re-renders

### DIFF
--- a/src/hooks/useIsAgentAccount.ts
+++ b/src/hooks/useIsAgentAccount.ts
@@ -10,7 +10,14 @@ import useOnyx from './useOnyx';
 function useIsAgentAccount(): boolean | undefined {
     const accountID = useCurrentUserPersonalDetails().accountID;
     const [personalDetail, personalDetailsMetadata] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
-        selector: (personalDetails: OnyxEntry<PersonalDetailsList>) => (accountID ? personalDetails?.[accountID] : undefined),
+        selector: (personalDetails: OnyxEntry<PersonalDetailsList>) => {
+            const detail = accountID ? personalDetails?.[accountID] : undefined;
+            // Return only isCustomAgent, not the whole record: useOnyx compares selector output with deepEqual,
+            // so returning the full entry would recompute on any unrelated field change (avatar, displayName,
+            // status, timezone, pronouns, ...). `undefined` here still means "no entry for this account", which
+            // the guard below relies on to tell a wiped/not-yet-loaded entry apart from a loaded non-agent one.
+            return detail === undefined ? undefined : {isCustomAgent: detail?.isCustomAgent};
+        },
     });
     const [isLoadingApp, isLoadingAppMetadata] = useOnyx(ONYXKEYS.IS_LOADING_APP);
     const [hasLoadedApp, hasLoadedAppMetadata] = useOnyx(ONYXKEYS.HAS_LOADED_APP);

--- a/src/hooks/useIsAgentAccount.ts
+++ b/src/hooks/useIsAgentAccount.ts
@@ -1,15 +1,15 @@
-import {useSession} from '@components/OnyxListItemProvider';
-
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {PersonalDetailsList} from '@src/types/onyx';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
+import {accountIDSelector} from '@selectors/Session';
+
 import useOnyx from './useOnyx';
 
 function useIsAgentAccount(): boolean | undefined {
-    const accountID = useSession()?.accountID;
+    const [accountID] = useOnyx(ONYXKEYS.SESSION, {selector: accountIDSelector});
     const [personalDetail, personalDetailsMetadata] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
         selector: (personalDetails: OnyxEntry<PersonalDetailsList>) => {
             const detail = accountID ? personalDetails?.[accountID] : undefined;

--- a/src/hooks/useIsAgentAccount.ts
+++ b/src/hooks/useIsAgentAccount.ts
@@ -1,14 +1,15 @@
+import {useSession} from '@components/OnyxListItemProvider';
+
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {PersonalDetailsList} from '@src/types/onyx';
 import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
-import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
 import useOnyx from './useOnyx';
 
 function useIsAgentAccount(): boolean | undefined {
-    const accountID = useCurrentUserPersonalDetails().accountID;
+    const accountID = useSession()?.accountID;
     const [personalDetail, personalDetailsMetadata] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
         selector: (personalDetails: OnyxEntry<PersonalDetailsList>) => {
             const detail = accountID ? personalDetails?.[accountID] : undefined;

--- a/src/hooks/useIsAgentAccount.ts
+++ b/src/hooks/useIsAgentAccount.ts
@@ -13,7 +13,7 @@ function useIsAgentAccount(): boolean | undefined {
     const [personalDetail, personalDetailsMetadata] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
         selector: (personalDetails: OnyxEntry<PersonalDetailsList>) => {
             const detail = accountID ? personalDetails?.[accountID] : undefined;
-            return detail === undefined ? undefined : {isCustomAgent: detail?.isCustomAgent};
+            return detail ? {isCustomAgent: detail.isCustomAgent} : undefined;
         },
     });
     const [isLoadingApp, isLoadingAppMetadata] = useOnyx(ONYXKEYS.IS_LOADING_APP);

--- a/src/hooks/useIsAgentAccount.ts
+++ b/src/hooks/useIsAgentAccount.ts
@@ -12,10 +12,6 @@ function useIsAgentAccount(): boolean | undefined {
     const [personalDetail, personalDetailsMetadata] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
         selector: (personalDetails: OnyxEntry<PersonalDetailsList>) => {
             const detail = accountID ? personalDetails?.[accountID] : undefined;
-            // Return only isCustomAgent, not the whole record: useOnyx compares selector output with deepEqual,
-            // so returning the full entry would recompute on any unrelated field change (avatar, displayName,
-            // status, timezone, pronouns, ...). `undefined` here still means "no entry for this account", which
-            // the guard below relies on to tell a wiped/not-yet-loaded entry apart from a loaded non-agent one.
             return detail === undefined ? undefined : {isCustomAgent: detail?.isCustomAgent};
         },
     });

--- a/tests/ui/ProfilePageTest.tsx
+++ b/tests/ui/ProfilePageTest.tsx
@@ -94,7 +94,7 @@ describe('ProfilePage contact method indicator', () => {
     function renderPage() {
         return render(
             <NavigationContainer>
-                <ComposeProviders components={[DelegateNoAccessModalProvider]}>
+                <ComposeProviders components={[OnyxListItemProvider, DelegateNoAccessModalProvider]}>
                     <ProfilePage
                         // @ts-expect-error - route typing is not necessary for this test
                         route={{}}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Follow-up to #98604, addressing [this review comment](https://github.com/Expensify/App/pull/98604#discussion_r3784462422).

That PR's fix for the iOS 2FA blank screen needed to tell "no personal-details entry yet" apart from "entry loaded but not an agent," so the `useOnyx` selector in `useIsAgentAccount` was changed to return the whole personal-details record for the current user instead of just `isCustomAgent`. Since `useOnyx` compares selector output with `deepEqual`, returning the full record means any unrelated field change on the user's own personal details (`avatar`, `displayName`, `status`, `timezone`, `pronouns`, ...) now recomputes the hook and re-renders every consumer (`withAgentAccessDenied`, which gates `ProfilePage`, `AvatarPage`, `SecuritySettingsPage`, `CopilotPage`, etc.) — including cases like editing your own avatar on `AvatarPage`, which is itself gated by this hook.

This PR keeps the existence check (still needed to distinguish a wiped/not-yet-loaded entry from a loaded non-agent one) but narrows the selector to return only `{isCustomAgent}` instead of the whole record, so `deepEqual` only ever compares that one field. No behavior change — same test coverage in `withAgentAccessDenied.test.tsx` passes unmodified.

Narrowing the selector alone did not fully deliver the re-render reduction, though: the hook also read `accountID` via `useCurrentUserPersonalDetails()`, which subscribes the component to `CurrentUserPersonalDetailsContext`. That provider builds its context value by spreading the entire personal-details record, so any unrelated field change still updates the context and re-renders every consumer regardless of the narrowed selector. This PR now reads `accountID` from the session (`useSession()`) instead — the same value (the provider derives its `accountID` from `session.accountID`), but without the full record, so the optimization actually takes effect. This restores the `accountID` source used before #98151 (which had switched it to `useCurrentUserPersonalDetails()`), and is behavior-preserving — including copilot/delegate, where the session already reflects the acting account.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98519
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

Test it on both android and iOS

1. Open the app
2. Navigate to Account > Security > Two Factor Authentication (2FA)
3. Save the file in the local machine
4. Enter the 6 digit code provided by the authenticator app
5. Click Next
6. verify, a success screen is displayed after enabling 2FA, not a blank page for a split second.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
