### PR TITLE
Do not block Search page payments on a missing chat report

### DIFF
--- a/src/components/Search/SearchList/ListItem/ActionCell/PayActionCell.tsx
+++ b/src/components/Search/SearchList/ListItem/ActionCell/PayActionCell.tsx
@@ -14,7 +14,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import {payInvoice, payMoneyRequest} from '@libs/actions/IOU/PayMoneyRequest';
 import {canIOUBePaid} from '@libs/actions/IOU/ReportWorkflow';
-import {getSearchPayOnyxData} from '@libs/actions/Search';
+import {getChatReportWithFallback, getSearchPayOnyxData} from '@libs/actions/Search';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Log from '@libs/Log';
 import {getReimbursableTotal, isIndividualInvoiceRoom, isInvoiceReport} from '@libs/ReportUtils';
@@ -150,8 +150,8 @@ function PayActionCell({isLoading, policyID, reportID, hash, amount, shouldDisab
         // The chat report is only needed for optimistic chat updates, so when it isn't loaded, pay with a fallback
         // built from the known IDs and let the server fill in the chat data.
         const fallbackChatReportID = iouReport?.chatReportID ?? iouReport?.parentReportID;
-        const fallbackChatReport = fallbackChatReportID ? {reportID: fallbackChatReportID, policyID: iouReport?.policyID ?? policyID} : undefined;
-        const chatReportForPayment = chatReport ?? fallbackChatReport;
+        const fallbackPolicyID = iouReport?.policyID ?? policyID;
+        const {chatReport: chatReportForPayment, isFallbackChatReport} = getChatReportWithFallback(chatReport, fallbackChatReportID, fallbackPolicyID);
         if (!chatReportForPayment) {
             Log.info('[SearchPay] Dropping row pay: chat report is not loaded and no chatReportID is available', false, {reportID});
             return;
@@ -161,7 +161,7 @@ function PayActionCell({isLoading, policyID, reportID, hash, amount, shouldDisab
             getCurrencyDecimals,
             paymentType: type,
             chatReport: chatReportForPayment,
-            isFallbackChatReport: !chatReport,
+            isFallbackChatReport,
             iouReport,
             introSelected,
             currentUserAccountID,

--- a/src/components/Search/SearchList/ListItem/ActionCell/PayActionCell.tsx
+++ b/src/components/Search/SearchList/ListItem/ActionCell/PayActionCell.tsx
@@ -149,7 +149,8 @@ function PayActionCell({isLoading, policyID, reportID, hash, amount, shouldDisab
 
         // The chat report is only needed for optimistic chat updates, so when it isn't loaded, pay with a fallback
         // built from the known IDs and let the server fill in the chat data.
-        const fallbackChatReport = iouReport?.chatReportID ? {reportID: iouReport.chatReportID, policyID: iouReport.policyID ?? policyID} : undefined;
+        const fallbackChatReportID = iouReport?.chatReportID ?? iouReport?.parentReportID;
+        const fallbackChatReport = fallbackChatReportID ? {reportID: fallbackChatReportID, policyID: iouReport?.policyID ?? policyID} : undefined;
         const chatReportForPayment = chatReport ?? fallbackChatReport;
         if (!chatReportForPayment) {
             Log.info('[SearchPay] Dropping row pay: chat report is not loaded and no chatReportID is available', false, {reportID});
@@ -160,6 +161,7 @@ function PayActionCell({isLoading, policyID, reportID, hash, amount, shouldDisab
             getCurrencyDecimals,
             paymentType: type,
             chatReport: chatReportForPayment,
+            isFallbackChatReport: !chatReport,
             iouReport,
             introSelected,
             currentUserAccountID,

--- a/src/components/Search/SearchList/ListItem/ActionCell/PayActionCell.tsx
+++ b/src/components/Search/SearchList/ListItem/ActionCell/PayActionCell.tsx
@@ -83,13 +83,12 @@ function PayActionCell({isLoading, policyID, reportID, hash, amount, shouldDisab
     const {currency} = iouReport ?? {};
 
     const confirmPayment = ({paymentType: type, payAsBusiness, methodID, paymentMethod}: PaymentActionParams) => {
-        if (!type || !reportID || !hash || !amount || !chatReport) {
+        if (!type || !reportID || !hash || !amount) {
             Log.info('[SearchPay] Dropping row pay: missing required data', false, {
                 hasPaymentType: !!type,
                 reportID,
                 hasHash: !!hash,
                 hasAmount: !!amount,
-                hasChatReport: !!chatReport,
             });
             return;
         }
@@ -102,6 +101,11 @@ function PayActionCell({isLoading, policyID, reportID, hash, amount, shouldDisab
         const additionalOnyxData = getSearchPayOnyxData(hash, reportID);
 
         if (isInvoiceReport(iouReport)) {
+            // Invoice payments rely on the invoice room data, so they can't proceed without the chat report.
+            if (!chatReport) {
+                Log.info('[SearchPay] Dropping invoice row pay: chat report is not loaded', false, {reportID});
+                return;
+            }
             const existingB2BInvoiceReport = getParticipantsInvoiceReport(
                 allReports,
                 reportNameValuePairs,
@@ -143,10 +147,19 @@ function PayActionCell({isLoading, policyID, reportID, hash, amount, shouldDisab
             return;
         }
 
+        // The chat report is only needed for optimistic chat updates, so when it isn't loaded, pay with a fallback
+        // built from the known IDs and let the server fill in the chat data.
+        const fallbackChatReport = iouReport?.chatReportID ? {reportID: iouReport.chatReportID, policyID: iouReport.policyID ?? policyID} : undefined;
+        const chatReportForPayment = chatReport ?? fallbackChatReport;
+        if (!chatReportForPayment) {
+            Log.info('[SearchPay] Dropping row pay: chat report is not loaded and no chatReportID is available', false, {reportID});
+            return;
+        }
+
         payMoneyRequest({
             getCurrencyDecimals,
             paymentType: type,
-            chatReport,
+            chatReport: chatReportForPayment,
             iouReport,
             introSelected,
             currentUserAccountID,

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -1401,6 +1401,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
 
                 const isItemInvoice = isInvoiceReport(item.reportID);
                 let chatReport = getChatReportForBulkPay(iouReport, item.chatReportID, searchData, allReports);
+                let isFallbackChatReport = false;
                 if (!chatReport) {
                     // The chat report is only needed for optimistic chat updates, so when it isn't loaded, pay with a fallback
                     // built from the known IDs and let the server fill in the chat data.
@@ -1415,6 +1416,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                         continue;
                     }
                     chatReport = {reportID: fallbackChatReportID, policyID: item.policyID ?? iouReport.policyID};
+                    isFallbackChatReport = true;
                 }
 
                 const rawPaymentMethod = paymentMethod ?? getLastPolicyPaymentMethod(item.policyID, personalPolicyID, lastPaymentMethods, undefined, isIOUReportUtil(item.reportID));
@@ -1512,6 +1514,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                     delegateAccountID,
                     isTrackIntentUser,
                     conciergeChat,
+                    isFallbackChatReport,
                 });
                 paidReportCount += 1;
             }

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -1405,7 +1405,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 if (!chatReport) {
                     // The chat report is only needed for optimistic chat updates, so when it isn't loaded, pay with a fallback
                     // built from the known IDs and let the server fill in the chat data.
-                    // Invoices are the exception — they genuinely need the invoice room data (receiver type, pay-as-business).
+                    // Invoices are the exception. They genuinely need the invoice room data such as receiver type and pay-as-business.
                     const fallbackChatReportID = item.chatReportID ?? iouReport.chatReportID ?? iouReport.parentReportID;
                     if (isItemInvoice || !fallbackChatReportID) {
                         Log.info('[BulkPay] Skipping report: chat report not found in the search snapshot or Onyx', false, {

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -25,6 +25,7 @@ import {
     getPolicyFromSearchSnapshot,
     getReportFromSearchSnapshot,
     getReportType,
+    getChatReportWithFallback,
     getSearchApproveOnyxData,
     getSearchPayOnyxData,
     getTotalFormattedAmount,
@@ -1400,23 +1401,22 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 }
 
                 const isItemInvoice = isInvoiceReport(iouReport);
-                let chatReport = getChatReportForBulkPay(iouReport, item.chatReportID, searchData, allReports);
-                let isFallbackChatReport = false;
-                if (!chatReport) {
-                    // The chat report is only needed for optimistic chat updates, so when it isn't loaded, pay with a fallback
-                    // built from the known IDs and let the server fill in the chat data.
-                    // Invoices are the exception. They genuinely need the invoice room data such as receiver type and pay-as-business.
-                    const fallbackChatReportID = item.chatReportID ?? iouReport.chatReportID ?? iouReport.parentReportID;
-                    if (isItemInvoice || !fallbackChatReportID) {
-                        Log.info('[BulkPay] Skipping report: chat report not found in the search snapshot or Onyx', false, {
-                            reportID: item.reportID,
-                            chatReportID: fallbackChatReportID,
-                            isItemInvoice,
-                        });
-                        continue;
-                    }
-                    chatReport = {reportID: fallbackChatReportID, policyID: item.policyID ?? iouReport.policyID};
-                    isFallbackChatReport = true;
+                const fallbackChatReportID = item.chatReportID ?? iouReport.chatReportID ?? iouReport.parentReportID;
+                const fallbackPolicyID = iouReport.policyID ?? item.policyID;
+                const {chatReport, isFallbackChatReport} = getChatReportWithFallback(
+                    getChatReportForBulkPay(iouReport, item.chatReportID, searchData, allReports),
+                    fallbackChatReportID,
+                    fallbackPolicyID,
+                );
+                // The fallback covers money requests only. Invoices genuinely need the invoice room data such as
+                // receiver type and pay-as-business, so skip them when the chat isn't loaded.
+                if (!chatReport || (isItemInvoice && isFallbackChatReport)) {
+                    Log.info('[BulkPay] Skipping report: chat report not found in the search snapshot or Onyx', false, {
+                        reportID: item.reportID,
+                        chatReportID: fallbackChatReportID,
+                        isItemInvoice,
+                    });
+                    continue;
                 }
 
                 const rawPaymentMethod = paymentMethod ?? getLastPolicyPaymentMethod(item.policyID, personalPolicyID, lastPaymentMethods, undefined, isIOUReportUtil(item.reportID));

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -1399,7 +1399,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                     continue;
                 }
 
-                const isItemInvoice = isInvoiceReport(item.reportID);
+                const isItemInvoice = isInvoiceReport(iouReport);
                 let chatReport = getChatReportForBulkPay(iouReport, item.chatReportID, searchData, allReports);
                 let isFallbackChatReport = false;
                 if (!chatReport) {
@@ -1431,7 +1431,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                     reportID: item.reportID,
                     amount: item.amount,
                     paymentType: resolvedPaymentType,
-                    ...(isInvoiceReport(item.reportID)
+                    ...(isItemInvoice
                         ? getPayMoneyOnSearchInvoiceParams(
                               item.policyID,
                               additionalData?.payAsBusiness ?? isBusinessInvoiceRoom(item.chatReportID),

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -1399,13 +1399,22 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                     continue;
                 }
 
-                const chatReport = getChatReportForBulkPay(iouReport, item.chatReportID, searchData, allReports);
+                const isItemInvoice = isInvoiceReport(item.reportID);
+                let chatReport = getChatReportForBulkPay(iouReport, item.chatReportID, searchData, allReports);
                 if (!chatReport) {
-                    Log.info('[BulkPay] Skipping report: chat report not found in the search snapshot or Onyx', false, {
-                        reportID: item.reportID,
-                        chatReportID: item.chatReportID ?? iouReport.chatReportID ?? iouReport.parentReportID,
-                    });
-                    continue;
+                    // The chat report is only needed for optimistic chat updates, so when it isn't loaded, pay with a fallback
+                    // built from the known IDs and let the server fill in the chat data.
+                    // Invoices are the exception — they genuinely need the invoice room data (receiver type, pay-as-business).
+                    const fallbackChatReportID = item.chatReportID ?? iouReport.chatReportID ?? iouReport.parentReportID;
+                    if (isItemInvoice || !fallbackChatReportID) {
+                        Log.info('[BulkPay] Skipping report: chat report not found in the search snapshot or Onyx', false, {
+                            reportID: item.reportID,
+                            chatReportID: fallbackChatReportID,
+                            isItemInvoice,
+                        });
+                        continue;
+                    }
+                    chatReport = {reportID: fallbackChatReportID, policyID: item.policyID ?? iouReport.policyID};
                 }
 
                 const rawPaymentMethod = paymentMethod ?? getLastPolicyPaymentMethod(item.policyID, personalPolicyID, lastPaymentMethods, undefined, isIOUReportUtil(item.reportID));
@@ -1436,7 +1445,6 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 const chatReportPolicy = getPolicyFromSearchSnapshot(chatReport.policyID, searchData, policies);
                 const reportPolicy = workspacePayPolicy ?? getPolicyFromSearchSnapshot(item.policyID, searchData, policies);
                 const additionalOnyxData = getSearchPayOnyxData(hash, item.reportID, currentSearchKey);
-                const isItemInvoice = isInvoiceReport(item.reportID);
 
                 if (isItemInvoice) {
                     const invoiceReceiverPolicyID = chatReport?.invoiceReceiver && 'policyID' in chatReport.invoiceReceiver ? chatReport.invoiceReceiver.policyID : undefined;

--- a/src/libs/actions/IOU/PayMoneyRequest.ts
+++ b/src/libs/actions/IOU/PayMoneyRequest.ts
@@ -323,12 +323,20 @@ function getPayMoneyRequestParams({
         };
     }
 
-    onyxData.optimisticData?.push(
-        {
+    if (!isFallbackChatReport) {
+        onyxData.optimisticData?.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
             value: optimisticChatReport,
-        },
+        });
+        onyxData.failureData?.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
+            value: chatReport,
+        });
+    }
+
+    onyxData.optimisticData?.push(
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReport?.reportID}`,
@@ -424,19 +432,6 @@ function getPayMoneyRequestParams({
                 ...iouReport,
             },
         },
-        isFallbackChatReport
-            ? {
-                  // The fallback chat report didn't exist in Onyx before the optimistic update, so restore that state.
-                  // Re-merging the fallback object can't undo the optimistic paid-state fields.
-                  onyxMethod: Onyx.METHOD.SET,
-                  key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
-                  value: null,
-              }
-            : {
-                  onyxMethod: Onyx.METHOD.MERGE,
-                  key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
-                  value: chatReport,
-              },
     );
 
     // In case the report preview action is loaded locally, let's update it.

--- a/src/libs/actions/IOU/PayMoneyRequest.ts
+++ b/src/libs/actions/IOU/PayMoneyRequest.ts
@@ -426,8 +426,8 @@ function getPayMoneyRequestParams({
         },
         isFallbackChatReport
             ? {
-                  // The fallback chat report didn't exist in Onyx before the optimistic update — restore that state,
-                  // since re-merging the fallback object can't undo the optimistic paid-state fields.
+                  // The fallback chat report didn't exist in Onyx before the optimistic update, so restore that state.
+                  // Re-merging the fallback object can't undo the optimistic paid-state fields.
                   onyxMethod: Onyx.METHOD.SET,
                   key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
                   value: null,

--- a/src/libs/actions/IOU/PayMoneyRequest.ts
+++ b/src/libs/actions/IOU/PayMoneyRequest.ts
@@ -126,6 +126,7 @@ type PayMoneyRequestFunctionParams = {
     chatReportActions: OnyxEntry<OnyxTypes.ReportActions>;
     isTrackIntentUser: boolean | undefined;
     getCurrencyDecimals: CurrencyListActionsContextType['getCurrencyDecimals'];
+    isFallbackChatReport?: boolean;
 };
 
 function mergeAdditionalPayOnyxData<
@@ -172,6 +173,7 @@ function getPayMoneyRequestParams({
     chatReportActions,
     isTrackIntentUser,
     getCurrencyDecimals,
+    isFallbackChatReport,
 }: {
     initialChatReport: OnyxTypes.Report;
     iouReport: OnyxEntry<OnyxTypes.Report>;
@@ -197,6 +199,7 @@ function getPayMoneyRequestParams({
     chatReportActions: OnyxEntry<OnyxTypes.ReportActions>;
     isTrackIntentUser: boolean | undefined;
     getCurrencyDecimals: CurrencyListActionsContextType['getCurrencyDecimals'];
+    isFallbackChatReport?: boolean;
 }): PayMoneyRequestData {
     // TODO: https://github.com/Expensify/App/issues/66512
     // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -421,11 +424,19 @@ function getPayMoneyRequestParams({
                 ...iouReport,
             },
         },
-        {
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
-            value: chatReport,
-        },
+        isFallbackChatReport
+            ? {
+                  // The fallback chat report didn't exist in Onyx before the optimistic update — restore that state,
+                  // since re-merging the fallback object can't undo the optimistic paid-state fields.
+                  onyxMethod: Onyx.METHOD.SET,
+                  key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
+                  value: null,
+              }
+            : {
+                  onyxMethod: Onyx.METHOD.MERGE,
+                  key: `${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`,
+                  value: chatReport,
+              },
     );
 
     // In case the report preview action is loaded locally, let's update it.
@@ -803,6 +814,7 @@ function payMoneyRequest(params: PayMoneyRequestFunctionParams) {
         chatReportActions,
         isTrackIntentUser,
         getCurrencyDecimals,
+        isFallbackChatReport,
     } = params;
     const policyForBillingRestriction = chatReportPolicy ?? (policy?.id === chatReport.policyID ? policy : undefined);
     if (
@@ -839,6 +851,7 @@ function payMoneyRequest(params: PayMoneyRequestFunctionParams) {
         chatReportActions,
         isTrackIntentUser,
         getCurrencyDecimals,
+        isFallbackChatReport,
     });
 
     // For now, we need to call the PayMoneyRequestWithWallet API since PayMoneyRequest was not updated to work with

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -129,6 +129,24 @@ function getChatReportForSearchPay(chatReport: OnyxEntry<Report>, snapshotReport
     return chatReport ?? snapshotChatReport ?? (chatReportID ? getReportOrDraftReport(chatReportID) : undefined);
 }
 
+/**
+ * Returns the chat report to pay with. When the chat isn't loaded, builds a fallback from the known IDs so the
+ * payment isn't blocked; isFallbackChatReport tells payMoneyRequest to skip the optimistic chat updates.
+ */
+function getChatReportWithFallback(
+    loadedChatReport: OnyxEntry<Report>,
+    fallbackChatReportID: string | undefined,
+    fallbackPolicyID: string | undefined,
+): {chatReport: OnyxEntry<Report>; isFallbackChatReport: boolean} {
+    if (loadedChatReport) {
+        return {chatReport: loadedChatReport, isFallbackChatReport: false};
+    }
+    if (!fallbackChatReportID) {
+        return {chatReport: undefined, isFallbackChatReport: false};
+    }
+    return {chatReport: {reportID: fallbackChatReportID, policyID: fallbackPolicyID}, isFallbackChatReport: true};
+}
+
 function getReportFromSearchSnapshot(reportID: string | undefined, searchData: SearchResultDataType | undefined, allReports: OnyxCollection<Report> | undefined): OnyxEntry<Report> {
     if (!reportID) {
         return undefined;
@@ -2183,6 +2201,7 @@ export {
     setSearchContext,
     deleteSavedSearch,
     getSearchPayOnyxData,
+    getChatReportWithFallback,
     getSearchApproveOnyxData,
     handleActionButtonPress,
     submitMoneyRequestOnSearch,

--- a/tests/ui/components/PayActionCellTest.tsx
+++ b/tests/ui/components/PayActionCellTest.tsx
@@ -6,7 +6,10 @@ import type {PaymentActionParams} from '@components/SettlementButton/types';
 import useOnyx from '@hooks/useOnyx';
 import useReportWithTransactionsAndViolations from '@hooks/useReportWithTransactionsAndViolations';
 
-import {payInvoice} from '@userActions/IOU/PayMoneyRequest';
+import type * as SearchActions from '@libs/actions/Search';
+import {isInvoiceReport} from '@libs/ReportUtils';
+
+import {payInvoice, payMoneyRequest} from '@userActions/IOU/PayMoneyRequest';
 
 import CONST from '@src/CONST';
 import type {Report} from '@src/types/onyx';
@@ -59,9 +62,21 @@ jest.mock('@userActions/IOU/ReportWorkflow', () => ({
     canIOUBePaid: jest.fn(() => true),
 }));
 
+const mockLogInfo = jest.fn();
+jest.mock('@libs/Log', () => ({
+    __esModule: true,
+    default: {
+        info: (...args: unknown[]) => {
+            mockLogInfo(...args);
+        },
+        warn: jest.fn(),
+    },
+}));
+
 jest.mock('@libs/actions/Search', () => ({
     __esModule: true,
     getSearchPayOnyxData: jest.fn(() => ({optimisticData: [], successData: [], failureData: []})),
+    getChatReportWithFallback: jest.requireActual<typeof SearchActions>('@libs/actions/Search').getChatReportWithFallback,
 }));
 
 jest.mock('@libs/ReportUtils', () => {
@@ -113,6 +128,19 @@ jest.mock('@components/DelegateNoAccessModalProvider', () => ({
 const mockedUseOnyx = jest.mocked(useOnyx);
 const mockedUseReportWithTransactionsAndViolations = jest.mocked(useReportWithTransactionsAndViolations);
 const mockedPayInvoice = jest.mocked(payInvoice);
+const mockedPayMoneyRequest = jest.mocked(payMoneyRequest);
+const mockedIsInvoiceReport = jest.mocked(isInvoiceReport);
+
+const TEST_EXPENSE_REPORT_ID = '3003';
+
+const expenseReport = {
+    reportID: TEST_EXPENSE_REPORT_ID,
+    chatReportID: TEST_CHAT_REPORT_ID,
+    type: CONST.REPORT.TYPE.EXPENSE,
+    currency: CONST.CURRENCY.USD,
+    policyID: 'policy1',
+    total: -5000,
+} as Report;
 
 describe('PayActionCell', () => {
     beforeEach(() => {
@@ -170,5 +198,92 @@ describe('PayActionCell', () => {
         });
 
         expect(mockedPayInvoice).not.toHaveBeenCalled();
+        expect(mockLogInfo).toHaveBeenCalledWith('[SearchPay] Dropping invoice row pay: chat report is not loaded', false, {reportID: TEST_INVOICE_REPORT_ID});
+    });
+
+    it('pays a money request with a fallback chat report when no chatReport prop is supplied', () => {
+        mockedIsInvoiceReport.mockReturnValue(false);
+        mockedUseReportWithTransactionsAndViolations.mockReturnValue([expenseReport, [], undefined]);
+
+        render(
+            <PayActionCell
+                isLoading={false}
+                policyID="policy1"
+                reportID={TEST_EXPENSE_REPORT_ID}
+                hash={TEST_HASH}
+                amount={5000}
+                chatReport={undefined}
+            />,
+        );
+
+        act(() => {
+            mockOnPressHolder.current?.({
+                paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE,
+                payAsBusiness: false,
+            });
+        });
+
+        expect(mockedPayMoneyRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+                chatReport: {reportID: TEST_CHAT_REPORT_ID, policyID: 'policy1'},
+                isFallbackChatReport: true,
+            }),
+        );
+    });
+
+    it('pays a money request with the loaded chat report when it is supplied', () => {
+        mockedIsInvoiceReport.mockReturnValue(false);
+        mockedUseReportWithTransactionsAndViolations.mockReturnValue([expenseReport, [], undefined]);
+
+        render(
+            <PayActionCell
+                isLoading={false}
+                policyID="policy1"
+                reportID={TEST_EXPENSE_REPORT_ID}
+                hash={TEST_HASH}
+                amount={5000}
+                chatReport={chatReport}
+            />,
+        );
+
+        act(() => {
+            mockOnPressHolder.current?.({
+                paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE,
+                payAsBusiness: false,
+            });
+        });
+
+        expect(mockedPayMoneyRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+                chatReport,
+                isFallbackChatReport: false,
+            }),
+        );
+    });
+
+    it('does not pay a money request and logs the reason when the chat is not loaded and no chatReportID is available', () => {
+        mockedIsInvoiceReport.mockReturnValue(false);
+        mockedUseReportWithTransactionsAndViolations.mockReturnValue([{...expenseReport, chatReportID: undefined, parentReportID: undefined}, [], undefined]);
+
+        render(
+            <PayActionCell
+                isLoading={false}
+                policyID="policy1"
+                reportID={TEST_EXPENSE_REPORT_ID}
+                hash={TEST_HASH}
+                amount={5000}
+                chatReport={undefined}
+            />,
+        );
+
+        act(() => {
+            mockOnPressHolder.current?.({
+                paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE,
+                payAsBusiness: false,
+            });
+        });
+
+        expect(mockedPayMoneyRequest).not.toHaveBeenCalled();
+        expect(mockLogInfo).toHaveBeenCalledWith('[SearchPay] Dropping row pay: chat report is not loaded and no chatReportID is available', false, {reportID: TEST_EXPENSE_REPORT_ID});
     });
 });

--- a/tests/unit/SearchActionsTest.ts
+++ b/tests/unit/SearchActionsTest.ts
@@ -1,6 +1,14 @@
 import type {LocalizedTranslate} from '@components/LocaleContextProvider';
 
-import {exportSearchItemsToCSV, getExportTemplates, getFooterConvertedAmounts, openSearch, queueExportSearchItemsToCSV, queueExportSearchWithTemplate} from '@libs/actions/Search';
+import {
+    exportSearchItemsToCSV,
+    getChatReportWithFallback,
+    getExportTemplates,
+    getFooterConvertedAmounts,
+    openSearch,
+    queueExportSearchItemsToCSV,
+    queueExportSearchWithTemplate,
+} from '@libs/actions/Search';
 import {read, write} from '@libs/API';
 import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import fileDownload from '@libs/fileDownload';
@@ -10,7 +18,7 @@ import type {SearchKey} from '@libs/SearchUIUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {ExportTemplate, Policy} from '@src/types/onyx';
+import type {ExportTemplate, Policy, Report} from '@src/types/onyx';
 import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
 
 import createRandomPolicy from '../utils/collections/policies';
@@ -346,5 +354,21 @@ describe('getExportTemplates', () => {
         const {defaultTemplates} = getExportTemplates([], {}, translateForTemplates, localeCompare, makePolicyWithOutputCurrency(CONST.CURRENCY.CAD), true, false, false);
 
         expect(defaultTemplates.map((template) => template.templateName)).not.toContain(CONST.REPORT.EXPORT_OPTIONS.MULTIPLE_TAX_EXPORT);
+    });
+});
+
+describe('getChatReportWithFallback', () => {
+    const loadedChatReport = {reportID: 'chat1', policyID: 'policyA', type: CONST.REPORT.TYPE.CHAT} as Report;
+
+    it('returns the loaded chat report when it is available', () => {
+        expect(getChatReportWithFallback(loadedChatReport, 'chat2', 'policyB')).toEqual({chatReport: loadedChatReport, isFallbackChatReport: false});
+    });
+
+    it('builds a fallback chat report from the known IDs when the chat is not loaded', () => {
+        expect(getChatReportWithFallback(undefined, 'chat2', 'policyB')).toEqual({chatReport: {reportID: 'chat2', policyID: 'policyB'}, isFallbackChatReport: true});
+    });
+
+    it('returns no chat report when the chat is not loaded and there is no fallback chatReportID', () => {
+        expect(getChatReportWithFallback(undefined, undefined, 'policyB')).toEqual({chatReport: undefined, isFallbackChatReport: false});
     });
 });

--- a/tests/unit/hooks/useSearchBulkActionsPayTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsPayTest.ts
@@ -6,7 +6,9 @@ import type {SearchQueryJSON, SelectedReports, SelectedTransactions} from '@comp
 import useSearchBulkActions from '@hooks/useSearchBulkActions';
 import type {SearchHeaderOptionValue} from '@hooks/useSearchBulkActions';
 
-import {payMoneyRequest} from '@libs/actions/IOU/PayMoneyRequest';
+import {payInvoice, payMoneyRequest} from '@libs/actions/IOU/PayMoneyRequest';
+import {getLastPolicyPaymentMethod} from '@libs/actions/Search';
+import type * as SearchActions from '@libs/actions/Search';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -30,24 +32,42 @@ jest.mock('@libs/deferModalPresentationAfterPopoverDismiss', () => ({
     default: (presentModal: () => void) => presentModal(),
 }));
 
-jest.mock('@libs/actions/Search', () => ({
-    getExportTemplates: jest.fn(() => ({customTemplates: [], defaultTemplates: []})),
-    exportSearchItemsToCSV: jest.fn(),
-    queueExportSearchItemsToCSV: jest.fn(),
-    queueExportSearchWithTemplate: jest.fn(),
-    getSearchApproveOnyxData: jest.fn(() => ({})),
-    getSearchPayOnyxData: jest.fn(() => ({})),
-    bulkDeleteReports: jest.fn(),
-    getLastPolicyBankAccountID: jest.fn(),
-    getLastPolicyPaymentMethod: jest.fn(),
-    getPayMoneyOnSearchInvoiceParams: jest.fn(),
-    getPayOption: jest.fn(() => ({shouldEnableBulkPayOption: mockShouldEnableBulkPayOption, isFirstTimePayment: false})),
-    getReportType: jest.fn(),
-    getTotalFormattedAmount: jest.fn(() => ''),
-    isCurrencySupportWalletBulkPay: jest.fn(() => false),
-    payMoneyRequestOnSearch: jest.fn(),
-    submitMoneyRequestOnSearch: jest.fn(),
-    unholdMoneyRequestOnSearch: jest.fn(),
+jest.mock('@libs/actions/Search', () => {
+    const actualSearch = jest.requireActual<typeof SearchActions>('@libs/actions/Search');
+    return {
+        getExportTemplates: jest.fn(() => ({customTemplates: [], defaultTemplates: []})),
+        exportSearchItemsToCSV: jest.fn(),
+        queueExportSearchItemsToCSV: jest.fn(),
+        queueExportSearchWithTemplate: jest.fn(),
+        getSearchApproveOnyxData: jest.fn(() => ({})),
+        getSearchPayOnyxData: jest.fn(() => ({})),
+        bulkDeleteReports: jest.fn(),
+        getLastPolicyBankAccountID: jest.fn(),
+        getLastPolicyPaymentMethod: jest.fn(),
+        getPayMoneyOnSearchInvoiceParams: jest.fn(),
+        getPayOption: jest.fn(() => ({shouldEnableBulkPayOption: mockShouldEnableBulkPayOption, isFirstTimePayment: false})),
+        getReportType: jest.fn(),
+        getTotalFormattedAmount: jest.fn(() => ''),
+        isCurrencySupportWalletBulkPay: jest.fn(() => false),
+        payMoneyRequestOnSearch: jest.fn(),
+        submitMoneyRequestOnSearch: jest.fn(),
+        unholdMoneyRequestOnSearch: jest.fn(),
+        getChatReportWithFallback: actualSearch.getChatReportWithFallback,
+        getReportFromSearchSnapshot: actualSearch.getReportFromSearchSnapshot,
+        getPolicyFromSearchSnapshot: actualSearch.getPolicyFromSearchSnapshot,
+        resolveSearchPayPaymentMethod: actualSearch.resolveSearchPayPaymentMethod,
+    };
+});
+
+const mockLogInfo = jest.fn();
+jest.mock('@libs/Log', () => ({
+    __esModule: true,
+    default: {
+        info: (...args: unknown[]) => {
+            mockLogInfo(...args);
+        },
+        warn: jest.fn(),
+    },
 }));
 
 jest.mock('@libs/actions/MergeTransaction', () => ({
@@ -300,5 +320,118 @@ describe('useSearchBulkActions - Pay option', () => {
             expect(result.current.headerButtonsOptions).toBeDefined();
         });
         expect(getPayOptionFromResult(result.current.headerButtonsOptions)).toBeUndefined();
+    });
+});
+
+describe('useSearchBulkActions - bulk pay chat report fallback', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        mockIsOffline = false;
+        mockShouldEnableBulkPayOption = true;
+        mockBulkPayButtonOptions = [{text: 'Mark as paid', key: CONST.IOU.PAYMENT_TYPE.ELSEWHERE}];
+        mockAreAllMatchingItemsSelected = false;
+        mockSelectedTransactions = {tx1: makeSelectedTransaction()};
+        mockSelectedReports = [
+            {
+                reportID: '1',
+                policyID: 'policy1',
+                chatReportID: '2',
+                total: 100,
+                action: CONST.SEARCH.ACTION_TYPES.PAY,
+                canPay: true,
+                canApprove: false,
+                canSubmit: false,
+                canChangeApprover: false,
+            },
+        ];
+        jest.mocked(getLastPolicyPaymentMethod).mockReturnValue(CONST.IOU.PAYMENT_TYPE.ELSEWHERE);
+
+        await Onyx.merge(ONYXKEYS.SESSION, {accountID: CURRENT_USER_ACCOUNT_ID, email: 'test@example.com'});
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}policy1`, {id: 'policy1', role: CONST.POLICY.ROLE.ADMIN});
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}1`, {reportID: '1', type: CONST.REPORT.TYPE.EXPENSE, chatReportID: '2', policyID: 'policy1'});
+    });
+
+    afterEach(async () => {
+        await Onyx.clear();
+    });
+
+    async function selectBulkPay() {
+        const {result} = renderHook(() => useSearchBulkActions({queryJSON: expenseReportQueryJSON}));
+        await waitFor(() => {
+            expect(getPayOptionFromResult(result.current.headerButtonsOptions)).toBeDefined();
+        });
+        const payOption = getPayOptionFromResult(result.current.headerButtonsOptions);
+        await act(async () => {
+            await payOption?.onSelected?.();
+        });
+    }
+
+    it('pays with a fallback chat report when the chat is not loaded', async () => {
+        await selectBulkPay();
+
+        expect(payMoneyRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+                chatReport: {reportID: '2', policyID: 'policy1'},
+                isFallbackChatReport: true,
+            }),
+        );
+    });
+
+    it('pays with the loaded chat report when it is available', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}2`, {reportID: '2', type: CONST.REPORT.TYPE.CHAT, policyID: 'policy1'});
+
+        await selectBulkPay();
+
+        expect(payMoneyRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+                chatReport: expect.objectContaining({reportID: '2', type: CONST.REPORT.TYPE.CHAT}),
+                isFallbackChatReport: false,
+            }),
+        );
+    });
+
+    it('skips an invoice whose chat is not loaded', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}1`, {type: CONST.REPORT.TYPE.INVOICE});
+
+        await selectBulkPay();
+
+        expect(payMoneyRequest).not.toHaveBeenCalled();
+        expect(payInvoice).not.toHaveBeenCalled();
+        expect(mockLogInfo).toHaveBeenCalledWith(
+            '[BulkPay] Skipping report: chat report not found in the search snapshot or Onyx',
+            false,
+            expect.objectContaining({reportID: '1', isItemInvoice: true}),
+        );
+    });
+
+    it('skips a report when the chat is not loaded and no chatReportID is available', async () => {
+        mockSelectedReports = [
+            {
+                reportID: '1',
+                policyID: 'policy1',
+                chatReportID: undefined,
+                total: 100,
+                action: CONST.SEARCH.ACTION_TYPES.PAY,
+                canPay: true,
+                canApprove: false,
+                canSubmit: false,
+                canChangeApprover: false,
+            },
+        ];
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}1`, {reportID: '1', type: CONST.REPORT.TYPE.EXPENSE, policyID: 'policy1'});
+
+        await selectBulkPay();
+
+        expect(payMoneyRequest).not.toHaveBeenCalled();
+        expect(mockLogInfo).toHaveBeenCalledWith(
+            '[BulkPay] Skipping report: chat report not found in the search snapshot or Onyx',
+            false,
+            expect.objectContaining({reportID: '1', isItemInvoice: false}),
+        );
+        expect(mockLogInfo).toHaveBeenCalledWith('[BulkPay] Bulk pay finished with skipped reports', false, {paidReportCount: 0, selectedCount: 1});
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Bulk **Mark as paid** on the Search page requires each report's chat report *object* to be resolvable from the search snapshot or Onyx. The `Search` snapshot contains matched expense reports but not their parent policy-expense chats, so any chat not already cached in Onyx caused the report to be silently unpayable in bulk. The row-level Pay dropdown (`PayActionCell`) had the same unlogged early return. Paying worked only after opening the report (which loads the chat via `OpenReport`) — matching the "sometimes nothing, sometimes only one" reports from the affected user.

The chat report object is only used by `payMoneyRequest` to build optimistic chat updates (chat preview, `iouReportID` clearing, last message); the API call itself needs just the IDs. This PR stops treating the missing object as a blocker for money requests:

- **`useSearchBulkActions.ts` (`onBulkPaySelected`)**: when `getChatReportForBulkPay` finds nothing, derive `chatReportID` from `item.chatReportID ?? iouReport.chatReportID ?? iouReport.parentReportID` and pay with a fallback `{reportID, policyID}`. The `policyID` (same workspace as the expense report) keeps the billing-restriction check inside `payMoneyRequest` working. Invoices — or items with no derivable chatReportID — are still skipped, now with a `[BulkPay]` log.
- **`PayActionCell.tsx` (row Pay dropdown)**: `chatReport` removed from the top guard; money requests use the same `fallbackChatReport` pattern; invoices keep the strict check with a `[SearchPay]` log.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98444
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. As a workspace admin on web, have 2+ **Approved** expense reports from another member (no VBBA connected, so Pay offers "Mark as paid").
2. Remember `chatReportID` of the chat where expenses are posted.
3. Go to Spend > Reports
4. In the dev console, evict one report's chat from Onyx: `Onyx.set('report_<chatReportID>', null)`.
5. Select expense reports, click **Pay > Mark as paid** (bulk payment).
6. Verify reports get paid (`PayMoneyRequest` sent for each, row label turns into paid).
7. Repeat the same steps but pay with the ROW-level Pay dropdown > "Mark as paid". Verify it works.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same, as in **Tests**

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

Same, as in **Tests**

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a403845e-48f2-4208-a156-664c29304f46


https://github.com/user-attachments/assets/4a9c2117-29c4-4607-8515-9c09873ceaba




</details>
