### PR TITLE
Add declared shouldSaveRecentSearch flag to Search payload

### DIFF
--- a/src/hooks/useSearchPageSetup.ts
+++ b/src/hooks/useSearchPageSetup.ts
@@ -77,7 +77,7 @@ function useSearchPageSetup(queryJSON: Readonly<SearchQueryJSON> | undefined) {
             return;
         }
         const shouldSkipWaitForWrites = hasDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);
-        search({queryJSON, searchKey: currentSearchKey, offset: 0, shouldCalculateTotals, isLoading: false, skipWaitForWrites: shouldSkipWaitForWrites});
+        search({queryJSON, searchKey: currentSearchKey, offset: 0, shouldCalculateTotals, isLoading: false, skipWaitForWrites: shouldSkipWaitForWrites, shouldSaveRecentSearch: true});
     }, [hash, isOffline, shouldUseLiveData, queryJSON, isSnapshotDataLoaded, isSnapshotSearchLoading, isInitialSearchPending, currentSearchKey, shouldCalculateTotals]);
 
     useFocusEffect(() => {

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -979,12 +979,14 @@ function openBulkChangeApproverPage(reportIDList: OpenBulkChangeApproverPagePara
 
 type InFlightSearchRequest = {
     shouldCalculateTotals: boolean;
-    pendingTotalsRequest?: () => Promise<string | number | undefined> | undefined;
+    shouldSaveRecentSearch: boolean;
+    pendingUpgradeRequest?: () => Promise<string | number | undefined> | undefined;
 };
 
 // Tracks in-flight search requests by hash+offset to prevent duplicate API calls when both page-level
-// and Search-internal effects fire for the same query. A totals request is not equivalent to the
-// non-totals request already in flight, so preserve one such request to run immediately afterward.
+// and Search-internal effects fire for the same query. A request that calculates totals or declares
+// save-recent-search intent is not equivalent to an in-flight request without it, so preserve one such
+// request to run immediately afterward.
 const inFlightSearchRequests = new Map<string, InFlightSearchRequest>();
 
 let shouldPreventSearchAPI = false;
@@ -1053,7 +1055,7 @@ function search({
     shouldUpdateLastSearchParams?: boolean;
     /**
      * Tells the backend this query was submitted by the user, so it may be saved to the recent searches NVP.
-     * Only the Search page call site should pass true — programmatic searches (home sections, post-action
+     * Only the Search page call site should pass true. Programmatic searches (home sections, post-action
      * refreshes) must not evict the user's real recent searches.
      */
     shouldSaveRecentSearch?: boolean;
@@ -1073,13 +1075,17 @@ function search({
     const dedupeKey = `${queryJSON.hash}_${offset ?? 0}`;
     const inFlightRequest = inFlightSearchRequests.get(dedupeKey);
     if (inFlightRequest) {
-        if (queryJSON.type === CONST.SEARCH.DATA_TYPES.EXPENSE && shouldCalculateTotals && !inFlightRequest.shouldCalculateTotals) {
-            inFlightRequest.pendingTotalsRequest = () =>
+        const needsTotalsUpgrade = queryJSON.type === CONST.SEARCH.DATA_TYPES.EXPENSE && shouldCalculateTotals && !inFlightRequest.shouldCalculateTotals;
+        // A user-submitted query colliding with an unflagged in-flight request (e.g. a programmatic refresh
+        // of the same query) must still reach the backend flagged, or it never enters recent searches.
+        const needsSaveRecentSearchUpgrade = shouldSaveRecentSearch && !inFlightRequest.shouldSaveRecentSearch;
+        if (needsTotalsUpgrade || needsSaveRecentSearchUpgrade) {
+            inFlightRequest.pendingUpgradeRequest = () =>
                 search({
                     queryJSON,
                     searchKey,
                     offset,
-                    shouldCalculateTotals: true,
+                    shouldCalculateTotals,
                     prevReportsLength,
                     isOffline,
                     isLoading: false,
@@ -1090,7 +1096,7 @@ function search({
         }
         return;
     }
-    const inFlightRequestState: InFlightSearchRequest = {shouldCalculateTotals};
+    const inFlightRequestState: InFlightSearchRequest = {shouldCalculateTotals, shouldSaveRecentSearch};
     inFlightSearchRequests.set(dedupeKey, inFlightRequestState);
 
     const {optimisticData, finallyData, failureData} = getOnyxLoadingData(queryJSON.hash, queryJSON, offset, isOffline, true, shouldCalculateTotals);
@@ -1173,7 +1179,7 @@ function search({
             })
             .finally(() => {
                 inFlightSearchRequests.delete(dedupeKey);
-                return inFlightRequestState.pendingTotalsRequest?.();
+                return inFlightRequestState.pendingUpgradeRequest?.();
             });
 
     // Catch here so every caller (the page-load fire in useSearchPageSetup and the re-search handlers

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -1041,6 +1041,7 @@ function search({
     isLoading,
     shouldUpdateLastSearchParams = false,
     skipWaitForWrites = false,
+    shouldSaveRecentSearch = false,
 }: {
     queryJSON: Readonly<SearchQueryJSON>;
     searchKey: SearchKey | undefined;
@@ -1050,6 +1051,12 @@ function search({
     isOffline?: boolean;
     isLoading: boolean;
     shouldUpdateLastSearchParams?: boolean;
+    /**
+     * Tells the backend this query was submitted by the user, so it may be saved to the recent searches NVP.
+     * Only the Search page call site should pass true — programmatic searches (home sections, post-action
+     * refreshes) must not evict the user's real recent searches.
+     */
+    shouldSaveRecentSearch?: boolean;
     /**
      * When true, fires the search API immediately without waiting for pending writes in the sequential queue. Safe because search
      * responses only write snapshot keys, so they can't overwrite a pending write's optimistic data. Used by the
@@ -1078,6 +1085,7 @@ function search({
                     isLoading: false,
                     shouldUpdateLastSearchParams,
                     skipWaitForWrites,
+                    shouldSaveRecentSearch,
                 });
         }
         return;
@@ -1093,6 +1101,7 @@ function search({
         offset,
         filters: backendQueryJSON.filters ?? null,
         shouldCalculateTotals,
+        ...(shouldSaveRecentSearch && {shouldSaveRecentSearch: true}),
         // Backend expects 'maximumResults' instead of 'limit'
         ...(limit !== undefined && {maximumResults: limit}),
     };

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -980,6 +980,8 @@ function openBulkChangeApproverPage(reportIDList: OpenBulkChangeApproverPagePara
 type InFlightSearchRequest = {
     shouldCalculateTotals: boolean;
     shouldSaveRecentSearch: boolean;
+    pendingShouldCalculateTotals?: boolean;
+    pendingShouldSaveRecentSearch?: boolean;
     pendingUpgradeRequest?: () => Promise<string | number | undefined> | undefined;
 };
 
@@ -1080,18 +1082,24 @@ function search({
         // of the same query) must still reach the backend flagged, or it never enters recent searches.
         const needsSaveRecentSearchUpgrade = shouldSaveRecentSearch && !inFlightRequest.shouldSaveRecentSearch;
         if (needsTotalsUpgrade || needsSaveRecentSearchUpgrade) {
+            // Accumulate desired flags so a later upgrade for one dimension can't drop an earlier
+            // upgrade for the other. Only a single pending re-fire is kept.
+            inFlightRequest.pendingShouldCalculateTotals = (inFlightRequest.pendingShouldCalculateTotals ?? false) || shouldCalculateTotals;
+            inFlightRequest.pendingShouldSaveRecentSearch = (inFlightRequest.pendingShouldSaveRecentSearch ?? false) || shouldSaveRecentSearch;
+            const pendingShouldCalculateTotals = inFlightRequest.pendingShouldCalculateTotals;
+            const pendingShouldSaveRecentSearch = inFlightRequest.pendingShouldSaveRecentSearch;
             inFlightRequest.pendingUpgradeRequest = () =>
                 search({
                     queryJSON,
                     searchKey,
                     offset,
-                    shouldCalculateTotals,
+                    shouldCalculateTotals: pendingShouldCalculateTotals,
                     prevReportsLength,
                     isOffline,
                     isLoading: false,
                     shouldUpdateLastSearchParams,
                     skipWaitForWrites,
-                    shouldSaveRecentSearch,
+                    shouldSaveRecentSearch: pendingShouldSaveRecentSearch,
                 });
         }
         return;

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -1086,20 +1086,18 @@ function search({
             // upgrade for the other. Only a single pending re-fire is kept.
             inFlightRequest.pendingShouldCalculateTotals = (inFlightRequest.pendingShouldCalculateTotals ?? false) || shouldCalculateTotals;
             inFlightRequest.pendingShouldSaveRecentSearch = (inFlightRequest.pendingShouldSaveRecentSearch ?? false) || shouldSaveRecentSearch;
-            const pendingShouldCalculateTotals = inFlightRequest.pendingShouldCalculateTotals;
-            const pendingShouldSaveRecentSearch = inFlightRequest.pendingShouldSaveRecentSearch;
             inFlightRequest.pendingUpgradeRequest = () =>
                 search({
                     queryJSON,
                     searchKey,
                     offset,
-                    shouldCalculateTotals: pendingShouldCalculateTotals,
+                    shouldCalculateTotals: inFlightRequest.pendingShouldCalculateTotals,
                     prevReportsLength,
                     isOffline,
                     isLoading: false,
                     shouldUpdateLastSearchParams,
                     skipWaitForWrites,
-                    shouldSaveRecentSearch: pendingShouldSaveRecentSearch,
+                    shouldSaveRecentSearch: inFlightRequest.pendingShouldSaveRecentSearch,
                 });
         }
         return;

--- a/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
+++ b/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
@@ -132,4 +132,46 @@ describe('search shouldSaveRecentSearch flag', () => {
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
         expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldSaveRecentSearch: true}));
     });
+
+    it('unions totals and save upgrades when both collide with the same in-flight request', async () => {
+        const queryJSON = getQueryJSON('type:expense merchant:ferry');
+        let resolveFirstRequest: () => void = () => {};
+        const firstRequestPromise = new Promise<void>((resolve) => {
+            resolveFirstRequest = resolve;
+        });
+        mockedMakeRequestWithSideEffects.mockImplementationOnce(() => firstRequestPromise);
+
+        const firstSearch = search({
+            queryJSON,
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            shouldCalculateTotals: false,
+            isLoading: false,
+        });
+        search({
+            queryJSON,
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            shouldCalculateTotals: true,
+            isLoading: false,
+        });
+        search({
+            queryJSON,
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            shouldCalculateTotals: false,
+            isLoading: false,
+            shouldSaveRecentSearch: true,
+        });
+
+        await Promise.resolve();
+        expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(1);
+
+        resolveFirstRequest();
+        await firstSearch;
+        await Promise.resolve();
+
+        expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
+        expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldCalculateTotals: true, shouldSaveRecentSearch: true}));
+    });
 });

--- a/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
+++ b/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
@@ -4,6 +4,9 @@ import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
 
 import CONST from '@src/CONST';
 
+import * as fs from 'fs';
+import * as path from 'path';
+
 jest.mock('@libs/API', () => ({
     makeRequestWithSideEffects: jest.fn(),
     waitForWrites: jest.fn(),
@@ -173,5 +176,31 @@ describe('search shouldSaveRecentSearch flag', () => {
 
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
         expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldCalculateTotals: true, shouldSaveRecentSearch: true}));
+    });
+
+    // The original bug was a wiring problem: programmatic callers looked identical to user submits.
+    // Guard the wiring statically so a future caller cannot re-flag a programmatic path unnoticed.
+    describe('call-site wiring', () => {
+        function collectSourceFiles(directory: string, collected: string[] = []): string[] {
+            for (const entry of fs.readdirSync(directory, {withFileTypes: true})) {
+                const fullPath = path.join(directory, entry.name);
+                if (entry.isDirectory()) {
+                    collectSourceFiles(fullPath, collected);
+                } else if (/\.tsx?$/.test(entry.name)) {
+                    collected.push(fullPath);
+                }
+            }
+            return collected;
+        }
+
+        it('only useSearchPageSetup passes shouldSaveRecentSearch: true', () => {
+            const sourceRoot = path.resolve(__dirname, '../../../src');
+            // The action file serializes the flag into the payload, so it legitimately contains the literal.
+            const definitionSite = path.join(sourceRoot, 'libs/actions/Search.ts');
+            const flaggedCallSites = collectSourceFiles(sourceRoot).filter(
+                (filePath) => filePath !== definitionSite && /shouldSaveRecentSearch:\s*true/.test(fs.readFileSync(filePath, 'utf8')),
+            );
+            expect(flaggedCallSites).toEqual([path.join(sourceRoot, 'hooks/useSearchPageSetup.ts')]);
+        });
     });
 });

--- a/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
+++ b/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
@@ -99,4 +99,37 @@ describe('search shouldSaveRecentSearch flag', () => {
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
         expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldCalculateTotals: true, shouldSaveRecentSearch: true}));
     });
+
+    it('re-fires a flagged request when a user submit collides with an unflagged in-flight request', async () => {
+        const queryJSON = getQueryJSON('merchant:rail');
+        let resolveFirstRequest: () => void = () => {};
+        const firstRequestPromise = new Promise<void>((resolve) => {
+            resolveFirstRequest = resolve;
+        });
+        mockedMakeRequestWithSideEffects.mockImplementationOnce(() => firstRequestPromise);
+
+        const firstSearch = search({
+            queryJSON,
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            isLoading: false,
+        });
+        search({
+            queryJSON,
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            isLoading: false,
+            shouldSaveRecentSearch: true,
+        });
+
+        await Promise.resolve();
+        expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(1);
+
+        resolveFirstRequest();
+        await firstSearch;
+        await Promise.resolve();
+
+        expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
+        expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldSaveRecentSearch: true}));
+    });
 });

--- a/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
+++ b/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
@@ -1,0 +1,102 @@
+import {search} from '@libs/actions/Search';
+import {makeRequestWithSideEffects, waitForWrites} from '@libs/API';
+import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
+
+import CONST from '@src/CONST';
+
+jest.mock('@libs/API', () => ({
+    makeRequestWithSideEffects: jest.fn(),
+    waitForWrites: jest.fn(),
+    write: jest.fn(),
+    read: jest.fn(),
+}));
+
+const mockedMakeRequestWithSideEffects = jest.mocked(makeRequestWithSideEffects);
+const mockedWaitForWrites = jest.mocked(waitForWrites);
+
+function getQueryJSON(query = '') {
+    const queryJSON = buildSearchQueryJSON(query);
+    if (!queryJSON) {
+        throw new Error('Query JSON should be defined for test setup');
+    }
+
+    return queryJSON;
+}
+
+function getLastRequestJsonQuery(): unknown {
+    const requestParams = mockedMakeRequestWithSideEffects.mock.calls.at(-1)?.[1];
+    if (!requestParams || !('jsonQuery' in requestParams) || typeof requestParams.jsonQuery !== 'string') {
+        throw new Error('Search request params with jsonQuery should be defined');
+    }
+
+    const parsedJsonQuery: unknown = JSON.parse(requestParams.jsonQuery);
+    return parsedJsonQuery;
+}
+
+// The backend only saves a query to the recent searches NVP when the payload declares it was
+// user-submitted, so these tests pin down exactly when the flag is (and is not) serialized.
+describe('search shouldSaveRecentSearch flag', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedWaitForWrites.mockResolvedValue(undefined);
+        mockedMakeRequestWithSideEffects.mockResolvedValue(undefined);
+    });
+
+    it('serializes the flag into jsonQuery when passed', async () => {
+        await search({
+            queryJSON: getQueryJSON('merchant:uber'),
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            isLoading: false,
+            shouldSaveRecentSearch: true,
+        });
+
+        expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldSaveRecentSearch: true}));
+    });
+
+    it('omits the flag entirely by default so programmatic searches cannot be saved', async () => {
+        await search({
+            queryJSON: getQueryJSON('merchant:lyft'),
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            isLoading: false,
+        });
+
+        expect(getLastRequestJsonQuery()).not.toHaveProperty('shouldSaveRecentSearch');
+    });
+
+    it('preserves the flag on a totals request queued behind an in-flight search', async () => {
+        const queryJSON = getQueryJSON('type:expense merchant:starbucks');
+        let resolveFirstRequest: () => void = () => {};
+        const firstRequestPromise = new Promise<void>((resolve) => {
+            resolveFirstRequest = resolve;
+        });
+        mockedMakeRequestWithSideEffects.mockImplementationOnce(() => firstRequestPromise);
+
+        const firstSearch = search({
+            queryJSON,
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            shouldCalculateTotals: false,
+            isLoading: false,
+        });
+        search({
+            queryJSON,
+            searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
+            offset: 0,
+            shouldCalculateTotals: true,
+            isLoading: false,
+            shouldSaveRecentSearch: true,
+        });
+
+        await Promise.resolve();
+        expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(1);
+
+        resolveFirstRequest();
+        await firstSearch;
+        await Promise.resolve();
+
+        expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
+        expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldCalculateTotals: true, shouldSaveRecentSearch: true}));
+    });
+});

--- a/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
+++ b/tests/unit/Search/searchSaveRecentSearchFlagTest.ts
@@ -46,6 +46,8 @@ describe('search shouldSaveRecentSearch flag', () => {
     });
 
     it('serializes the flag into jsonQuery when passed', async () => {
+        // Given a query the user typed on the Search page
+        // When the search is fired with the save-recent-search flag
         await search({
             queryJSON: getQueryJSON('merchant:uber'),
             searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
@@ -54,10 +56,13 @@ describe('search shouldSaveRecentSearch flag', () => {
             shouldSaveRecentSearch: true,
         });
 
+        // Then the flag is included in the payload sent to the backend
         expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldSaveRecentSearch: true}));
     });
 
     it('omits the flag entirely by default so programmatic searches cannot be saved', async () => {
+        // Given a search fired without the save-recent-search flag, like the home screen sections do
+        // When the search is fired
         await search({
             queryJSON: getQueryJSON('merchant:lyft'),
             searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
@@ -65,10 +70,12 @@ describe('search shouldSaveRecentSearch flag', () => {
             isLoading: false,
         });
 
+        // Then the payload contains no trace of the flag, so the backend cannot save this query
         expect(getLastRequestJsonQuery()).not.toHaveProperty('shouldSaveRecentSearch');
     });
 
     it('preserves the flag on a totals request queued behind an in-flight search', async () => {
+        // Given a search request that is still waiting for its response
         const queryJSON = getQueryJSON('type:expense merchant:starbucks');
         let resolveFirstRequest: () => void = () => {};
         const firstRequestPromise = new Promise<void>((resolve) => {
@@ -83,6 +90,8 @@ describe('search shouldSaveRecentSearch flag', () => {
             shouldCalculateTotals: false,
             isLoading: false,
         });
+
+        // When a totals request that also carries the save-recent-search flag arrives for the same query
         search({
             queryJSON,
             searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
@@ -92,18 +101,22 @@ describe('search shouldSaveRecentSearch flag', () => {
             shouldSaveRecentSearch: true,
         });
 
+        // Then the second call is deduplicated instead of firing right away
         await Promise.resolve();
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(1);
 
+        // When the first request finishes
         resolveFirstRequest();
         await firstSearch;
         await Promise.resolve();
 
+        // Then the queued totals request fires and still carries the flag
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
         expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldCalculateTotals: true, shouldSaveRecentSearch: true}));
     });
 
     it('re-fires a flagged request when a user submit collides with an unflagged in-flight request', async () => {
+        // Given a search without the flag that is still waiting for its response, like a background refresh
         const queryJSON = getQueryJSON('merchant:rail');
         let resolveFirstRequest: () => void = () => {};
         const firstRequestPromise = new Promise<void>((resolve) => {
@@ -117,6 +130,8 @@ describe('search shouldSaveRecentSearch flag', () => {
             offset: 0,
             isLoading: false,
         });
+
+        // When the user submits the same query from the Search page, which carries the flag
         search({
             queryJSON,
             searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
@@ -125,18 +140,22 @@ describe('search shouldSaveRecentSearch flag', () => {
             shouldSaveRecentSearch: true,
         });
 
+        // Then the user's call is deduplicated instead of firing right away
         await Promise.resolve();
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(1);
 
+        // When the first request finishes
         resolveFirstRequest();
         await firstSearch;
         await Promise.resolve();
 
+        // Then a second request fires with the flag, so the query still gets saved
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
         expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldSaveRecentSearch: true}));
     });
 
     it('unions totals and save upgrades when both collide with the same in-flight request', async () => {
+        // Given a search without totals or the flag that is still waiting for its response
         const queryJSON = getQueryJSON('type:expense merchant:ferry');
         let resolveFirstRequest: () => void = () => {};
         const firstRequestPromise = new Promise<void>((resolve) => {
@@ -151,6 +170,8 @@ describe('search shouldSaveRecentSearch flag', () => {
             shouldCalculateTotals: false,
             isLoading: false,
         });
+
+        // When one caller asks for totals and another caller asks to save the recent search
         search({
             queryJSON,
             searchKey: CONST.SEARCH.SEARCH_KEYS.EXPENSES,
@@ -167,13 +188,16 @@ describe('search shouldSaveRecentSearch flag', () => {
             shouldSaveRecentSearch: true,
         });
 
+        // Then both calls are deduplicated instead of firing right away
         await Promise.resolve();
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(1);
 
+        // When the first request finishes
         resolveFirstRequest();
         await firstSearch;
         await Promise.resolve();
 
+        // Then a single follow-up request fires carrying both the totals and the save flags
         expect(mockedMakeRequestWithSideEffects.mock.calls).toHaveLength(2);
         expect(getLastRequestJsonQuery()).toEqual(expect.objectContaining({shouldCalculateTotals: true, shouldSaveRecentSearch: true}));
     });
@@ -194,12 +218,16 @@ describe('search shouldSaveRecentSearch flag', () => {
         }
 
         it('only useSearchPageSetup passes shouldSaveRecentSearch: true', () => {
+            // Given every source file in the app
             const sourceRoot = path.resolve(__dirname, '../../../src');
             // The action file serializes the flag into the payload, so it legitimately contains the literal.
             const definitionSite = path.join(sourceRoot, 'libs/actions/Search.ts');
+            // When collecting every file that passes the flag
             const flaggedCallSites = collectSourceFiles(sourceRoot).filter(
                 (filePath) => filePath !== definitionSite && /shouldSaveRecentSearch:\s*true/.test(fs.readFileSync(filePath, 'utf8')),
             );
+
+            // Then the Search page setup hook is the only one
             expect(flaggedCallSites).toEqual([path.join(sourceRoot, 'hooks/useSearchPageSetup.ts')]);
         });
     });


### PR DESCRIPTION
### Explanation of Change

**Problem:** Backend `SearchAPI.php` queues a `SaveRecentSearch` job whenever a `Search` call has a non-empty `inputQuery`, a non-zero `recentSearchHash`, and non-null `filters`. That heuristic was a proxy for "the user typed this query", and it broke once programmatic callers landed: the Home-section hooks (`useYourSpendData`, `useRecentlyAddedData`, `useInsightData`) and the `SearchRefreshUtils` post-action refreshes issue canned `Search` calls that satisfy the guard. Each Home-tab visit evicts real user searches from the 5-slot `RECENT_SEARCHES` NVP that feeds the History rows in the search dropdown.

**Fix (App half):** replace the inferred signal with a declared one.

- `src/libs/actions/Search.ts`: `search()` gains an optional `shouldSaveRecentSearch` param (default `false`). When `true`, it is serialized into the `jsonQuery` payload (next to `shouldCalculateTotals`) so the backend can read `$jsonQuery['shouldSaveRecentSearch']`. The flag is also threaded through the in-flight dedupe (`pendingTotalsRequest`) re-call, so a queued totals request keeps the flag.
- `src/hooks/useSearchPageSetup.ts`: the only call site passing `shouldSaveRecentSearch: true`. The flag declares "this request originated from the Search page" — it also rides on default tab queries (e.g. `type:expense` when the Spend tab mounts), which is intentional and harmless: the backend saves only when the flag **and** its existing guard (non-empty `inputQuery`, non-zero `recentSearchHash`, non-null `filters`) both pass, and default tab queries have `filters: null`, so they are excluded by the same check that excludes them today. All programmatic callers (Home sections, post-action refreshes) pass nothing, so the key is absent from their payloads. Net effect: saved = flag AND existing guard — the flag only ever narrows what gets saved.

**Automated tests:** new `tests/unit/Search/searchSaveRecentSearchFlagTest.ts` with 3 cases — flag serialized when passed, key absent by default, and flag preserved through the queued-totals dedupe path.

**Deploy ordering / backward compatibility:** safe to ship App-first — the backend currently ignores the unknown key, so behavior is unchanged until the Web-Expensify guard PR lands requiring the flag. Backend follow-ups (separate Web-Expensify PRs, not in this repo): require the flag in the `SearchAPI.php` guard, an optional interim `offset === 0` check, and including `recentSearchHash` in the Bedrock `SaveRecentSearch` job name so distinct queries don't overwrite each other.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98661
PROPOSAL:

### Tests

1. Open the browser network inspector. On the Reports (Search) page, submit a typed search and verify the outgoing `Search` API request contains `"shouldSaveRecentSearch":true` inside the `jsonQuery` parameter.
2. Navigate to the Home tab and let the Your Spend / Recently Added / Insights sections load. Verify their `Search` requests do **not** contain the `shouldSaveRecentSearch` key in `jsonQuery`.
3. Return to the Reports (Search) page, submit another typed search, and verify results load normally (no regression from the added payload key).

Note: the History-dropdown verification (typed searches appearing and surviving Home visits) cannot be tested end-to-end yet — recent-search saving is currently not working on staging (`nvp_recentSearches` never populates, on `main` as well), and the flag is inert until the Web-Expensify guard PR deploys. The payload checks above fully verify this PR's contract.

- [x] Verify that no errors appear in the JS console

### Offline tests

`Search` is a READ command and this change is payload-only — offline behavior is unchanged (`search()` early-returns/dedupes exactly as before, and no new UI is added). Verified searching from the Reports page behaves the same after going offline and back online.

### QA Steps

**No user-facing behavior change in this PR** — the new `shouldSaveRecentSearch` flag is inert until the Web-Expensify guard PR deploys, and payload verification (Tests steps 3–4) requires a network inspector, which is a dev-only check. QA should run regression checks only:

1. Open the Reports (Search) page, type a search, and submit it — results load normally.
2. Scroll to trigger pagination (load more) — additional results load normally.
3. Pay / submit / approve a report from the Search page and verify the search list refreshes as before.

The full end-to-end QA script for the eviction fix (submit 5 distinct typed searches → open History → visit Home and let Your Spend / Recently Added / Insights load → return and verify the History rows are still the typed queries) belongs to the Web-Expensify guard PR and should be run there once both are deployed.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — payload-only change (no UI). Videos will be added if reviewers require them.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — payload-only change (no UI). Videos will be added if reviewers require them.

</details>

<details>
<summary>iOS: Native</summary>

N/A — payload-only change (no UI). Videos will be added if reviewers require them.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — payload-only change (no UI). Videos will be added if reviewers require them.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — payload-only change (no UI). Videos will be added if reviewers require them.

</details>
