### PR TITLE
[$250] Workspace chat - Export to NetSuite button still shows while an export is in progress

### DIFF
--- a/src/components/MoneyReportHeaderPrimaryAction/ExportPrimaryAction.tsx
+++ b/src/components/MoneyReportHeaderPrimaryAction/ExportPrimaryAction.tsx
@@ -7,7 +7,7 @@ import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getValidConnectedIntegration} from '@libs/PolicyUtils';
 import {getFilteredReportActionsForReportView} from '@libs/ReportActionsUtils';
-import {isExported as isExportedUtils} from '@libs/ReportUtils';
+import {isExported as isExportedUtils, isExportInProgress as isExportInProgressUtils} from '@libs/ReportUtils';
 
 import {exportToIntegration} from '@userActions/Report';
 
@@ -30,12 +30,17 @@ function ExportPrimaryAction({reportID, onExportModalOpen}: ExportPrimaryActionP
     const {reportActions: unfilteredReportActions} = usePaginatedReportActions(moneyRequestReport?.reportID);
     const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
     const isExported = isExportedUtils(reportActions, moneyRequestReport);
+    const isExportInProgress = isExportInProgressUtils(reportActions, moneyRequestReport);
 
     return (
         <Button
             variant={CONST.BUTTON_VARIANT.SUCCESS}
+            isLoading={isExportInProgress}
             onPress={() => {
                 if (!connectedIntegration || !moneyRequestReport) {
+                    return;
+                }
+                if (isExportInProgress) {
                     return;
                 }
                 if (isExported) {

--- a/src/components/ReportActionItem/ExportWithDropdownMenu.tsx
+++ b/src/components/ReportActionItem/ExportWithDropdownMenu.tsx
@@ -11,7 +11,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import {savePreferredExportMethod as savePreferredExportMethodUtils} from '@libs/actions/Policy/Policy';
 import {exportToIntegration, markAsManuallyExported} from '@libs/actions/Report';
-import {canBeExported as canBeExportedUtils, getIntegrationIcon, isExported as isExportedUtils} from '@libs/ReportUtils';
+import {canBeExported as canBeExportedUtils, getIntegrationIcon, isExported as isExportedUtils, isExportInProgress as isExportInProgressUtils} from '@libs/ReportUtils';
 
 import variables from '@styles/variables';
 
@@ -72,6 +72,7 @@ function ExportWithDropdownMenu({
     const iconToDisplay = getIntegrationIcon(connectionName, expensifyIcons);
     const canBeExported = canBeExportedUtils(report);
     const isExported = isExportedUtils(reportActions, report);
+    const isExportInProgress = isExportInProgressUtils(reportActions, report);
     const flattenedWrapperStyle = StyleSheet.flatten([styles.flex1, wrapperStyle]);
 
     const dropdownOptions: Array<DropdownOption<ReportExportType>> = useMemo(() => {
@@ -105,6 +106,9 @@ function ExportWithDropdownMenu({
     }, [canBeExported, iconToDisplay, connectionName, report?.policyID, translate]);
 
     const handleExport = (exportType: ReportExportType) => {
+        if (isExportInProgress) {
+            return;
+        }
         if (!reportID) {
             return;
         }
@@ -127,6 +131,7 @@ function ExportWithDropdownMenu({
             variant={CONST.BUTTON_VARIANT.SUCCESS}
             pressOnEnter
             shouldAlwaysShowDropdownMenu
+            isLoading={isExportInProgress}
             anchorAlignment={dropdownAnchorAlignment}
             onPress={(_, value) => {
                 if (isExported) {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -13195,7 +13195,26 @@ function isExported(reportActions: OnyxEntry<ReportActions> | ReportAction[], re
     return lastSuccessfulExportCreated > lastResetCreated;
 }
 
-function hasExportError(reportActions: OnyxEntry<ReportActions> | ReportAction[], report?: OnyxEntry<Report>) {
+/**
+ * Returns true while an export to an integration is currently in flight for the report.
+ * The signal is an optimistic `EXPORTED_TO_INTEGRATION` report action whose `pendingAction` is ADD
+ * (the same state that renders the "started exporting this report to <integration>…" message),
+ * or the report-level optimistic field set by manual exports.
+ *
+ * NOTE: this is intentionally *not* the same as `isExported` (a completed export) and must not depend on
+ * any failure-rollback logic — on export failure the backend clears the pending action via push, so this
+ * flips back to false and the existing retry path (#72292/#87654) remains intact.
+ */
+function isExportInProgress(reportActions: OnyxEntry<ReportActions> | ReportAction[], report?: OnyxEntry<Report>): boolean {
+    if (report?.pendingFields?.export === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD) {
+        return true;
+    }
+
+    const reportActionList = Array.isArray(reportActions) ? reportActions : Object.values(reportActions ?? {});
+    return reportActionList.some((action) => isExportIntegrationAction(action) && action.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
+}
+
+function hasExportError(reportActions: OnyxEntry<ReportActions> | ReportAction[], report?: OnyxEntry<Report>): boolean {
     if (report?.hasExportError) {
         return true;
     }
@@ -14392,6 +14411,7 @@ export {
     getIntegrationIcon,
     canBeExported,
     isExported,
+    isExportInProgress,
     hasExportError,
     hasOnlyNonReimbursableTransactions,
     getReportLastMessage,

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -158,6 +158,7 @@ import {
     hasReportBeenForwardedSinceLastSubmit,
     hasEmptyReportsForPolicy,
     hasExportError,
+    isExportInProgress,
     hasNonReimbursableTransactions,
     hasReceiptError,
     hasSmartscanError,
@@ -21848,6 +21849,55 @@ describe('ReportUtils', () => {
                 },
             ]);
             expect(hasExportError(reportActions, report)).toBe(false);
+        });
+    });
+
+    describe('isExportInProgress', () => {
+        it('returns true when an EXPORTED_TO_INTEGRATION action has pendingAction ADD', () => {
+            const reportActions = createMock<ReportAction[]>([
+                {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.EXPORTED_TO_INTEGRATION,
+                    reportActionID: '1',
+                    created: '2024-01-01',
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
+                },
+            ]);
+            expect(isExportInProgress(reportActions, undefined)).toBe(true);
+        });
+
+        it('returns false when the EXPORTED_TO_INTEGRATION action is completed (no pendingAction)', () => {
+            const reportActions = createMock<ReportAction[]>([
+                {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.EXPORTED_TO_INTEGRATION,
+                    reportActionID: '1',
+                    created: '2024-01-01',
+                },
+            ]);
+            expect(isExportInProgress(reportActions, undefined)).toBe(false);
+        });
+
+        it('returns true when report.pendingFields.export is ADD (manual export)', () => {
+            const report = createMock<Report>({
+                pendingFields: {export: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD},
+            });
+            expect(isExportInProgress([], report)).toBe(true);
+        });
+
+        it('returns false when there is no export action and no pending export field', () => {
+            const report = createMock<Report>({});
+            expect(isExportInProgress([], report)).toBe(false);
+        });
+
+        it('returns false (retry available) once the pending action is cleared after failure', () => {
+            const reportActions = createMock<ReportAction[]>([
+                {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.EXPORTED_TO_INTEGRATION,
+                    reportActionID: '1',
+                    created: '2024-01-01',
+                    // pendingAction cleared by backend push on failure
+                },
+            ]);
+            expect(isExportInProgress(reportActions, undefined)).toBe(false);
         });
     });
 


### PR DESCRIPTION

### Details
$ #98025

While a report's export to an integration (e.g. NetSuite) is already running, the green
**Export to [integration]** button stayed fully clickable in two places, so a second click
fired a duplicate export. This adds an `isExportInProgress` guard (derived from the in-flight
`EXPORTED_TO_INTEGRATION` report action with `pendingAction === ADD`, plus the manual-export
`report.pendingFields.export === ADD` field) and wires it to `isLoading` on both the
header button (`ExportPrimaryAction.tsx`) and the workspace-chat dropdown (`ExportWithDropdownMenu.tsx`).

### Why this preserves #72292 / #87654 retry behavior
The guard keys *only* on `pendingAction === ADD` (an export still in flight). On failure the
backend pushes the `INTEGRATIONSMESSAGE` ("failed to export…") action and clears the pending
`EXPORTED_TO_INTEGRATION` action via Pusher/OpenReport push, so `isExportInProgress` flips back
to `false` and the existing retry path stays intact. No failure-rollback logic was touched
(MelvinBot confirmed `failureData` never fires because `Report_Export` always returns 200).

### Test plan
- [x] Unit test `isExportInProgress` added in `tests/unit/ReportUtilsTest.ts` (5 cases).
- [ ] Manual: with a NetSuite-connected workspace, submit/approve/pay a report → while
  "started exporting…" shows, the button is disabled + spinner and cannot be clicked again.
  After completion/failure the button returns to its normal/retry state.
- [ ] Verified on [device / simulator]  ← centang kalau Lo sudah tes di device

### Upwork
Contributor details already posted on the issue:
- Expensify email: irvaaanfauzi@gmail.com
- Upwork: https://www.upwork.com/freelancers/~013d87a682accf7eb0