### PR TITLE
[CP Staging] Revert #96772: failed SmartScan amount handling

### DIFF
--- a/src/components/MoneyRequestConfirmationList/hooks/useConfirmationAmount.ts
+++ b/src/components/MoneyRequestConfirmationList/hooks/useConfirmationAmount.ts
@@ -3,7 +3,7 @@ import useLocalize from '@hooks/useLocalize';
 
 import {computePerDiemExpenseAmount} from '@libs/actions/IOU/PerDiem';
 import type {getAttendees} from '@libs/TransactionUtils';
-import {isFailedScanAmountPlaceholder, isScanning, isScanRequest as isScanRequestUtil} from '@libs/TransactionUtils';
+import {isScanning, isScanRequest as isScanRequestUtil} from '@libs/TransactionUtils';
 
 import type * as OnyxTypes from '@src/types/onyx';
 
@@ -96,8 +96,6 @@ function useConfirmationAmount({
         formattedAmount = '';
     } else if (isScanning(transaction)) {
         formattedAmount = translate('iou.receiptStatusTitle');
-    } else if (isFailedScanAmountPlaceholder(transaction)) {
-        formattedAmount = '';
     }
 
     const attendeeCount = iouAttendees?.length && iouAttendees.length > 0 ? iouAttendees.length : 1;

--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -116,7 +116,6 @@ import {
     isDistanceRequest as isDistanceRequestTransactionUtils,
     isDistanceTypeRequest,
     isExpenseUnreported as isExpenseUnreportedTransactionUtils,
-    isFailedScanAmountPlaceholder,
     isGPSDistanceRequest as isGPSDistanceRequestTransactionUtils,
     isManagedCardTransaction as isManagedCardTransactionTransactionUtils,
     isManualDistanceRequest as isManualDistanceRequestTransactionUtils,
@@ -331,7 +330,6 @@ function MoneyRequestView({
     const isOdometerDistanceRequest = isOdometerDistanceRequestTransactionUtils(transaction);
     const isMapDistanceRequest = isMapDistanceRequestTransactionUtils(transaction) || isDistanceTypeRequest(transaction);
     const isTransactionScanning = isScanning(updatedTransaction ?? transaction);
-    const hasFailedScanAmountPlaceholder = isFailedScanAmountPlaceholder(updatedTransaction ?? transaction);
     const hasRoute = hasRouteTransactionUtils(transactionBackup ?? transaction, isDistanceRequest);
 
     const rawActualAttendees = isFromMergeTransaction && updatedTransaction ? updatedTransaction.comment?.attendees : transactionAttendees;
@@ -628,8 +626,6 @@ function MoneyRequestView({
     if (isTransactionScanning) {
         merchantTitle = translate('iou.receiptStatusTitle');
         amountTitle = translate('iou.receiptStatusTitle');
-    } else if (hasFailedScanAmountPlaceholder) {
-        amountTitle = '';
     }
 
     const updatedTransactionDescription = getDescription(updatedTransaction) || undefined;
@@ -791,10 +787,6 @@ function MoneyRequestView({
             date: {
                 isError: transactionDate === '',
                 translationPath: canEditDate ? 'common.error.enterDate' : 'common.error.missingDate',
-            },
-            amount: {
-                isError: !isSettled && !isCancelled && hasFailedScanAmountPlaceholder,
-                translationPath: canEditAmount ? 'common.error.enterAmount' : 'common.error.missingAmount',
             },
         };
 

--- a/src/components/TransactionItemRow/DataCells/TotalCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/TotalCell.tsx
@@ -14,14 +14,7 @@ import {formatToParts} from '@libs/NumberFormatUtils';
 import {parseFloatAnyLocale, roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import {isGroupPolicy} from '@libs/PolicyUtils';
 import {isExpenseReport, isInvoiceReport, shouldEnableNegative} from '@libs/ReportUtils';
-import {
-    getAmount as getTransactionAmount,
-    getCurrency as getTransactionCurrency,
-    isDeletedTransaction,
-    isExpenseUnreported,
-    isFailedScanAmountPlaceholder,
-    isScanning,
-} from '@libs/TransactionUtils';
+import {getAmount as getTransactionAmount, getCurrency as getTransactionCurrency, isDeletedTransaction, isExpenseUnreported, isScanning} from '@libs/TransactionUtils';
 
 import CONST from '@src/CONST';
 import type {Policy, Report} from '@src/types/onyx';
@@ -61,12 +54,9 @@ function TotalCell({shouldShowTooltip, transactionItem, canEdit, onSave, report,
     const isDeleted = isDeletedTransaction(transactionItem);
     const isFromExpenseReport = (!isEmptyObject(effectiveReport) && isExpenseReport(effectiveReport)) || isGroupPolicy(effectivePolicy);
     const amount = getTransactionAmount(transactionItem, isFromExpenseReport, transactionItem.reportID === CONST.REPORT.UNREPORTED_REPORT_ID, isDeleted);
-    const hasFailedScanAmountPlaceholder = isFailedScanAmountPlaceholder(transactionItem);
     let amountToDisplay = convertToDisplayString(amount, currency);
     if (isScanning(transactionItem)) {
         amountToDisplay = translate('iou.receiptStatusTitle');
-    } else if (hasFailedScanAmountPlaceholder) {
-        amountToDisplay = '';
     }
 
     const iouType = getTransactionItemIouType({...transactionItem, report: effectiveReport});
@@ -77,9 +67,6 @@ function TotalCell({shouldShowTooltip, transactionItem, canEdit, onSave, report,
     const absoluteAmount = Math.abs(amount ?? 0);
     const isOriginalAmountNegative = (amount ?? 0) < 0;
     const [isNegative, setIsNegative] = useState(isOriginalAmountNegative);
-    // Tracks whether the user actually typed in this edit session, so that merely opening and
-    // closing the cell without input isn't mistaken for an explicit confirmation of the amount.
-    const hasUserTypedRef = useRef(false);
 
     const getNormalizedValue = (amountString: string, isAmountNegative: boolean) => {
         const parsedValue = parseFloatAnyLocale(amountString);
@@ -105,11 +92,7 @@ function TotalCell({shouldShowTooltip, transactionItem, canEdit, onSave, report,
                   onSave(normalizedValue);
               }
             : undefined,
-        // A failed-scan placeholder amount that the user actually typed into is treated as changed so that
-        // explicitly re-entering 0 still submits and clears the scan-failure error, mirroring submitEditAmount in
-        // IOUAmountSubmission.ts. Merely opening and blurring the cell without typing is left as a no-op.
-        (value, originalValue) =>
-            !(hasFailedScanAmountPlaceholder && hasUserTypedRef.current) && getNormalizedValue(value, isNegative) === getNormalizedValue(originalValue, isOriginalAmountNegative),
+        (value, originalValue) => getNormalizedValue(value, isNegative) === getNormalizedValue(originalValue, isOriginalAmountNegative),
     );
 
     // Ref used to programmatically focus the input when edit mode starts
@@ -122,12 +105,10 @@ function TotalCell({shouldShowTooltip, transactionItem, canEdit, onSave, report,
 
     const handleStartEditing = () => {
         setIsNegative(isOriginalAmountNegative);
-        hasUserTypedRef.current = false;
         startEditing();
     };
 
     const handleAmountChange = (amountString: string) => {
-        hasUserTypedRef.current = true;
         setLocalValue(amountString);
     };
 

--- a/src/libs/IOUAmountSubmission.ts
+++ b/src/libs/IOUAmountSubmission.ts
@@ -51,17 +51,7 @@ import {getLoginByAccountID} from './PersonalDetailsUtils';
 import {isTaxTrackingEnabled} from './PolicyUtils';
 import {getPolicyExpenseChat, getTransactionDetails, isMoneyRequestReport, isPolicyExpenseChat, isSelfDM, shouldEnableNegative} from './ReportUtils';
 import shouldUseDefaultExpensePolicy from './shouldUseDefaultExpensePolicy';
-import {
-    calculateTaxAmount,
-    getAmount,
-    getCurrency,
-    getDefaultTaxCode,
-    getIsFromGlobalCreate,
-    getTaxValue,
-    hasReceipt,
-    isExpenseUnreported,
-    isFailedScanAmountPlaceholder,
-} from './TransactionUtils';
+import {calculateTaxAmount, getAmount, getCurrency, getDefaultTaxCode, getIsFromGlobalCreate, getTaxValue, hasReceipt, isExpenseUnreported} from './TransactionUtils';
 
 type SubmitAmountArgs = {
     dateFnsLocale: DateFnsLocale | undefined;
@@ -613,8 +603,7 @@ function submitEditAmount(args: SubmitAmountArgs, ctx: SubmitAmountContext): voi
 
     // If the value hasn't changed, don't request to save changes on the server and just close the modal
     const transactionCurrency = getCurrency(currentTransaction);
-    const hasFailedScanAmountPlaceholder = isFailedScanAmountPlaceholder(currentTransaction);
-    if (!hasFailedScanAmountPlaceholder && newAmount === getAmount(currentTransaction, false, false, allowNegative, disableOppositeConversion) && selectedCurrency === transactionCurrency) {
+    if (newAmount === getAmount(currentTransaction, false, false, allowNegative, disableOppositeConversion) && selectedCurrency === transactionCurrency) {
         navigateBack();
         return;
     }

--- a/src/libs/TransactionPreviewUtils.ts
+++ b/src/libs/TransactionPreviewUtils.ts
@@ -378,8 +378,6 @@ function getTransactionPreviewTextAndTranslationPaths({
     let displayAmountText: TranslationPathOrText = isTransactionScanning ? {translationPath: 'iou.receiptStatusTitle'} : {text: convertToDisplayString(amount, requestCurrency)};
     if (isFetchingWaypoints && !requestAmount) {
         displayAmountText = {translationPath: 'iou.fieldPending'};
-    } else if (hasFieldErrors && isAmountMissing(transaction, isExpenseReport(iouReport))) {
-        displayAmountText = {text: ''};
     }
 
     const iouOriginalMessage: OnyxEntry<OnyxTypes.OriginalMessageIOU> = isMoneyRequestAction(action) ? (getOriginalMessage(action) ?? undefined) : undefined;

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -557,24 +557,11 @@ function isPartialMerchant(merchant: string): boolean {
     return merchant === CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT;
 }
 
-function isFailedScanAmountPlaceholder(transaction: OnyxEntry<Transaction>) {
-    return (
-        isScanRequest(transaction) &&
-        transaction?.receipt?.state === CONST.IOU.RECEIPT_STATE.SCAN_FAILED &&
-        (transaction?.amount === 0 || transaction?.amount === undefined) &&
-        !hasValidModifiedAmount(transaction)
-    );
-}
-
 function isAmountMissing(transaction: OnyxEntry<Transaction>, isFromExpenseReport = true) {
-    if (isFailedScanAmountPlaceholder(transaction)) {
-        return true;
-    }
-
     if (isFromExpenseReport) {
         return transaction?.amount === undefined && (transaction?.modifiedAmount === undefined || transaction?.modifiedAmount === '');
     }
-    return (transaction?.amount === 0 || transaction?.amount === undefined) && !hasValidModifiedAmount(transaction);
+    return (transaction?.amount === 0 || transaction?.amount === undefined) && (!transaction?.modifiedAmount || transaction?.modifiedAmount === 0 || transaction?.modifiedAmount === '');
 }
 
 function hasValidModifiedAmount(transaction: OnyxEntry<Transaction> | null): boolean {
@@ -609,7 +596,7 @@ function isCreatedMissing(transaction: OnyxEntry<Transaction>) {
 
 function areRequiredFieldsEmpty(transaction: OnyxEntry<Transaction>, transactionReport: OnyxEntry<Report>): boolean {
     const isFromExpenseReport = transactionReport?.type === CONST.REPORT.TYPE.EXPENSE;
-    return (isFromExpenseReport && isMerchantMissing(transaction)) || isCreatedMissing(transaction) || isAmountMissing(transaction, isFromExpenseReport);
+    return (isFromExpenseReport && isMerchantMissing(transaction)) || isCreatedMissing(transaction) || (!isFromExpenseReport && getAmount(transaction) === 0);
 }
 
 function getClearedPendingFields(transactionChanges: TransactionChanges) {
@@ -3588,7 +3575,6 @@ export {
     hasSmartScanFailedWithMissingFields,
     isScanFailedTransactionMovedOnPayment,
     shouldSplitScanFailedTransactions,
-    isFailedScanAmountPlaceholder,
     isDeletedTransaction,
     getDistanceRequestType,
     isUnreportedManagedCardTransaction,


### PR DESCRIPTION
### Summary

This reverts [PR #96772](https://github.com/Expensify/App/pull/96772), which introduced failed-SmartScan placeholder amount handling across the expense confirmation flow, expense details, inline amount editing, amount submission, previews, and transaction utilities.

The revert is needed to unblock the linked deploy blockers:

- [#98697](https://github.com/Expensify/App/issues/98697)
- [#98737](https://github.com/Expensify/App/issues/98737)
- [#98783](https://github.com/Expensify/App/issues/98783)
- [#98784](https://github.com/Expensify/App/issues/98784)
- [#98786](https://github.com/Expensify/App/issues/98786)
- [#98788](https://github.com/Expensify/App/issues/98788)

The inverse was applied against current `main` (`12b0038e`), not the original merge base. One conflict in `src/libs/TransactionUtils/index.ts` was resolved by preserving the later scan-failed payment-flow helpers while removing only the behavior introduced by #96772.

### Validation

- ESLint passed for all six changed files.
- Onyx-connect bypass check passed.
- oxfmt pre-commit hook passed.
- `tsgo` is blocked by an unrelated existing error in `tests/unit/hooks/useDiscardChangesConfirmationNative.test.ts`: `HardwareBackPressEvent` is not exported by the installed React Native module.
- Focused Jest suites could not initialize in the isolated worktree because the repository's React Native Jest module mapping expects the full local dependency layout.