### PR TITLE
[CP Staging] fix - Android - Distance - Address suggestion list loads infinitely

### DIFF
--- a/patches/react-native-google-places-autocomplete/details.md
+++ b/patches/react-native-google-places-autocomplete/details.md
@@ -108,3 +108,53 @@
     ```
 
 - Upstream issue: not yet reported at the time of writing (2.6.4 is the latest release).
+
+### [react-native-google-places-autocomplete+2.6.4+005+fix-loader-stuck-on-abort.patch](react-native-google-places-autocomplete+2.6.4+005+fix-loader-stuck-on-abort.patch)
+
+- Reason:
+
+    ```
+    On Android the address suggestion list could spin forever instead of showing
+    results (Expensify/App#98825). Two 2.6.4 changes combine to cause it.
+
+    First, the effect that re-requests on query change gained `stateText` in its
+    dependency array, and its cleanup calls `_abortRequests()`. In 2.5.6 that cleanup
+    was keyed to `[props.query]` alone, so every abort was paired with a request that
+    replaced it. In 2.6.4 the cleanup runs on every keystroke, while the effect body
+    only re-requests when `queryString` changed — so typing aborts requests without
+    issuing new ones.
+
+    Second, `listLoaderDisplayed` is only ever cleared from `onreadystatechange` at
+    readyState 4, and `_abortRequests` detaches that handler (`onreadystatechange =
+    null`) before calling `abort()`. An aborted request therefore leaves the loader
+    flag stuck true with nothing to reset it.
+
+    AddressSearch passes no `debounce` prop, so `debounceMs` is 0 and the request is
+    issued from a `setTimeout(..., 0)`. When that timer wins the race against React
+    flushing passive effects, the request reaches readyState 1 (setting the loader
+    true) and is then aborted by the cleanup of the very render that scheduled it.
+    Nothing re-issues it and nothing clears the flag, so the loader spins forever.
+    The race is why this reproduces on Android/Hermes but not reliably on web, where
+    the scheduler drains passive effects on a different task queue.
+
+    Upstream 2.6.4 gates the whole list on `dataSource.length > 0`, which makes the
+    stuck loader invisible; patch 003 deliberately restores 2.5.6's reachable loader,
+    so the leak became user-visible in this app.
+
+    The fix drops `stateText` from that effect's dependency array, restoring 2.5.6's
+    `[props.query]` keying (2.5.6 carried the same eslint-disable for the same reason).
+    `stateText` is still read in the body, but only inside the `queryChanged` guard,
+    and the effect re-runs on every render where `queryString` changed, so the value
+    read there is always current. This leaves the four `_abortRequests()` call sites
+    exactly as 2.5.6 had them: the query-change/unmount cleanup, `_onPress`,
+    `_requestNearby`, and the top of `_request`.
+
+    It also clears the loader flag inside `_abortRequests`, so no abort path can strand
+    it — including `_request`'s short-text early return and row press, where 2.5.6 left
+    a stale `true` that happened to be invisible. Callers that immediately re-request
+    set the flag back to true in the same tick (`open()` moves the new request to
+    readyState 1 synchronously, and React batches), so there is no flicker.
+    ```
+
+- E/App issue: https://github.com/Expensify/App/issues/98825
+- Upstream issue: not yet reported at the time of writing (2.6.4 is the latest release).

--- a/patches/react-native-google-places-autocomplete/react-native-google-places-autocomplete+2.6.4+005+fix-loader-stuck-on-abort.patch
+++ b/patches/react-native-google-places-autocomplete/react-native-google-places-autocomplete+2.6.4+005+fix-loader-stuck-on-abort.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/react-native-google-places-autocomplete/GooglePlacesAutocomplete.js b/node_modules/react-native-google-places-autocomplete/GooglePlacesAutocomplete.js
+index 131b42b..adcb77b 100644
+--- a/node_modules/react-native-google-places-autocomplete/GooglePlacesAutocomplete.js
++++ b/node_modules/react-native-google-places-autocomplete/GooglePlacesAutocomplete.js
+@@ -244,6 +244,12 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
+       request.abort();
+     });
+     requestsRef.current = [];
++    // `listLoaderDisplayed` is only ever cleared from `onreadystatechange` at
++    // readyState 4, and the handler is detached just above, so an aborted request
++    // would leave the loader spinning forever. Callers that immediately issue a
++    // replacement request set it back to true synchronously (`open()` moves the new
++    // request to readyState 1 in the same tick), so this cannot flicker.
++    setListLoaderDisplayed(false);
+   }, []);
+ 
+   // ==========================================================================
+@@ -1131,7 +1137,14 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
+     return () => {
+       _abortRequests();
+     };
+-  }, [queryString, debounceData, stateText, minLength, _abortRequests]);
++    // `stateText` is deliberately omitted from the deps. It is read above, but only
++    // inside the `queryChanged` guard, and this effect re-runs on every render where
++    // `queryString` changed, so the value read there is always current. Depending on
++    // it made this cleanup abort the in-flight request on every keystroke without
++    // re-issuing one (the body only requests when `queryString` changed), which left
++    // the list stuck on the loader. 2.5.6 keyed this effect to `[props.query]` alone.
++    // eslint-disable-next-line react-hooks/exhaustive-deps
++  }, [queryString, debounceData, minLength, _abortRequests]);
+ 
+   // Auto-show list when dataSource has items in 'auto' mode
+   useEffect(() => {


### PR DESCRIPTION
### Explanation of Change

Follow-up to #98735, which upgraded `react-native-google-places-autocomplete` from 2.5.6 to 2.6.4. This adds patch `005` to fix the address suggestion list spinning forever on Android (#98825), rather than reverting the security upgrade.

**What broke.** 2.6.4 rewrote the effect that re-requests when the `query` prop changes. In 2.5.6 that effect was keyed to `[props.query]` (with an explicit `eslint-disable react-hooks/exhaustive-deps`); 2.6.4 dropped the disable and expanded the deps to everything the body reads, including `stateText`:

```js
return () => { _abortRequests(); };
}, [queryString, debounceData, stateText, minLength, _abortRequests]);
```

An effect's cleanup runs before *every* re-run, not just on unmount — so with `stateText` in the deps, **every keystroke aborts the in-flight request**. The effect body only re-requests when `queryString` changed, so nothing replaces it. Upstream compensated for the wider dep list in the body (`prevQueryStringRef` + the `queryChanged` guard) but not in the cleanup, which can't be guarded that way.

`_abortRequests` also detaches the handler before aborting:

```js
request.onreadystatechange = null;
request.abort();
```

and `setListLoaderDisplayed(false)` only ever runs inside that handler at `readyState === 4` — so the aborted request leaves the loader flag stuck `true`.

**Why it only showed on some Android devices.** `AddressSearch` passes no `debounce` prop, so `debounceMs` is `0` and the request is issued from a `setTimeout(…, 0)`. If that timer wins the race against React flushing passive effects, the request reaches `readyState 1` (loader → `true`) and is then aborted by the cleanup of the very render that scheduled it. Nothing re-issues it and nothing clears the flag. On web, React's scheduler uses `MessageChannel`, which reliably beats a clamped `setTimeout(0)` — hence Android app only, not mWeb. Between Android devices it comes down to ordinary scheduler timing, and it's self-masking: only the *last* keystroke sticks, so one more character that wins the race hides it.

Stock 2.6.4 gates the whole list on `dataSource.length > 0`, which makes the stuck loader unreachable; patch `003` deliberately restored 2.5.6's reachable loader, which is what made the leak user-visible here.

**The fix.** Patch `005` does two things:

1. Drops `stateText` from that effect's dependency array, restoring 2.5.6's `[props.query]` keying. `stateText` is still read in the body, but only inside the `queryChanged` guard, and the effect re-runs on every render where `queryString` changed — so the value read there is always current. This leaves the four `_abortRequests()` call sites exactly as 2.5.6 had them: the query-change/unmount cleanup, `_onPress`, `_requestNearby`, and the top of `_request`. **This is the fix for the reported bug** — every abort is paired with a replacement request again.
2. Clears the loader flag inside `_abortRequests`. This is defense-in-depth, not required for this issue: it closes the remaining paths where an abort strands the flag (`_request`'s short-text early return, row press) — cases where 2.5.6 also left a stale `true` that happened to be invisible. Callers that immediately re-request set it back to `true` in the same tick, so there is no flicker.

Full write-up in `patches/react-native-google-places-autocomplete/details.md`.

**Verification.** All five patches apply cleanly in order to a pristine 2.6.4 and reproduce the patched `node_modules` byte-for-byte; `005`'s base blob matches `004`'s output. Its hunks are disjoint from every earlier patch, and each earlier fix's markers are intact in the final file (`tabIndex`/`accessibilityRole` from 001, `useRef(null)` and `_disableRowLoaders` ordering from 002, `hasEmptyStateToShow` from 003, `EMPTY_PREDEFINED_PLACES` and `[buildRowsFromResults]` from 004).


### Fixed Issues
$ https://github.com/Expensify/App/issues/98825

### Tests
1. Launch Expensify app
2. Open FAB > Track distance > Map.
3. Tap Start.
4. Enter address.
5. Verify that address suggestion list will show up.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests

### QA Steps
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/12ccac37-bcd6-4580-80a6-6a626b5de38d

</details>

<details>
<summary>Android: mWeb Chrome</summary>



</details>

<details>
<summary>iOS: Native</summary>



</details>

<details>
<summary>iOS: mWeb Safari</summary>



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



</details>

