### PR TITLE
refactor: remove unsafe TextInputWithSymbol assertions

### DIFF
--- a/src/components/TextInputWithSymbol/index.web.tsx
+++ b/src/components/TextInputWithSymbol/index.web.tsx
@@ -1,3 +1,5 @@
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+
 import type {TextInputSelectionChangeEvent} from 'react-native';
 
 import React, {useRef} from 'react';
@@ -7,32 +9,33 @@ import type {TextInputWithSymbolProps} from './types';
 import BaseTextInputWithSymbol from './BaseTextInputWithSymbol';
 
 function TextInputWithSymbol({onSelectionChange = () => {}, ref, ...props}: TextInputWithSymbolProps) {
-    const textInputRef = useRef<HTMLFormElement | null>(null);
+    const textInputRef = useRef<BaseTextInputRef | null>(null);
 
     return (
         <BaseTextInputWithSymbol
             {...props}
             ref={(element) => {
-                textInputRef.current = element as HTMLFormElement;
+                textInputRef.current = element;
 
                 if (!ref) {
                     return;
                 }
 
                 if (typeof ref === 'function') {
-                    ref(element as HTMLFormElement);
+                    ref(element);
                     return;
                 }
 
                 // eslint-disable-next-line no-param-reassign
-                ref.current = element as HTMLFormElement;
+                ref.current = element;
             }}
             onSelectionChange={(event: TextInputSelectionChangeEvent) => {
                 onSelectionChange(event.nativeEvent.selection.start, event.nativeEvent.selection.end);
             }}
             onPress={() => {
-                const selectionStart = (textInputRef.current?.selectionStart as number) ?? 0;
-                const selectionEnd = (textInputRef.current?.selectionEnd as number) ?? 0;
+                const input = textInputRef.current;
+                const selectionStart = input instanceof HTMLInputElement ? (input.selectionStart ?? 0) : 0;
+                const selectionEnd = input instanceof HTMLInputElement ? (input.selectionEnd ?? 0) : 0;
                 onSelectionChange(selectionStart, selectionEnd);
             }}
         />


### PR DESCRIPTION
### Explanation of Change

This PR removes unsafe type assertions from the web `TextInputWithSymbol` component.

The component now checks that its ref points to a real HTML input before reading the cursor position. Existing ref updates, focus, editing, cursor selection, and fallback behavior remain unchanged. Native implementations are not affected.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Count change

5 → 0 targeted unsafe type assertions (5 removed).

### Changed files

- `src/components/TextInputWithSymbol/index.web.tsx`

### Tests

No focused automated test is available for this component.

- [x] Verify that no errors appear in the JS console

### QA Steps

1. Sign in on staging using web or mWeb.
2. Open a money-request amount form.
3. Enter a multi-digit amount, move the cursor to different positions, and continue editing after focusing or pressing the input.
4. Clear the amount, then enter a valid amount again.
5. Verify focus, editing, cursor selection, validation, and the displayed value work normally.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A. This change does not affect requests or offline behavior.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — N/A: no visual UI changes
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (no user-facing copy was added).
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [v] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (no style was added)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (no asset was added or modified)
    - [x] The assets load correctly across all supported platforms (no asset was added or modified)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. (Not applicable: no message-editing or sending code changed.)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (Not applicable: no generic component changed.)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. (Not applicable: no Storybook-owned component changed.)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other. (Not applicable: no visual UI or form style changed.)
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes. (Not applicable: no visual UI changed.)
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow. (Not applicable: this cleanup does not add a feature or fix a product bug.)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps. (Not applicable: `main` was not merged after review.)

### Screenshots/Videos

N/A: no visual UI changes.

<details>
<summary>Android: Native</summary>

N/A: the changed implementation is web-only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>iOS: Native</summary>

N/A: the changed implementation is web-only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/5672c990-dc45-45f3-9ea9-83127c810179

</details>
