### PR TITLE
Fix pinned reports showing GBR dot instead of Pay/Approve badge in LHN

### DIFF
--- a/src/libs/actions/IOU/ReportWorkflow.ts
+++ b/src/libs/actions/IOU/ReportWorkflow.ts
@@ -428,6 +428,17 @@ function getIOUReportActionWithBadge(
         }
     }
 
+    // A chat's hasOutstandingChildRequest flag can flip true before its REPORT_ACTIONS are hydrated locally
+    // (e.g. pinning a previously-hidden chat pulls it into the LHN ahead of OpenReport, see
+    // https://github.com/Expensify/Expensify/issues/670825). When that happens the loop above finds no
+    // REPORT_PREVIEW action to badge, so fall back to the chat's iouReportID directly.
+    if (!actionBadge && chatReport?.hasOutstandingChildRequest && chatReport?.iouReportID) {
+        const iouReport = getReportOrDraftReport(chatReport.iouReportID, undefined, undefined, undefined, allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${chatReport.iouReportID}`]);
+        if (iouReport && !isReportPendingDelete(iouReport)) {
+            actionBadge = getBadgeFromIOUReport(iouReport, chatReport, policy, reportMetadata, invoiceReceiverPolicy, currentUserLogin, currentUserAccountID);
+        }
+    }
+
     return {reportAction: earliestAction, actionBadge};
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
- `getIOUReportActionWithBadge` only scanned the chat's already-loaded `REPORT_ACTIONS` for a `REPORT_PREVIEW` to derive the Pay/Approve badge
- Pinning a previously-hidden chat can surface it in the LHN before its `REPORT_ACTIONS` are hydrated, while `hasOutstandingChildRequest` is already `true`
- Result: GBR dot shows, badge lookup finds nothing, so it falls back to a plain dot instead of Pay/Approve
- Fix: fall back to the chat's `iouReportID` directly to resolve the badge when no `REPORT_PREVIEW` action is loaded yet

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/670825
PROPOSAL:


### Tests
- [ ] Verify that no errors appear in the JS console
1. As a payer, have a workspace chat pinned that has an outstanding expense report awaiting payment but hasn't been opened recently (so its report actions aren't cached locally).
2. Reload the app so the LHN renders from a cold cache.
3. Confirm the pinned row shows the `Pay`/`Approve` badge, not a plain green dot.
4. Click into the report, confirm the same action badge/behavior as before.

### Offline tests
- Same steps as `Tests`, with network disabled after initial load — badge should still resolve from local Onyx data without a network round trip.

### QA Steps
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console
- Same as Tests

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
