### PR TITLE
refactor: remove unsafe AgreementsFullStep assertions

### DIFF
--- a/src/components/SubStepForms/AgreementsFullStep.tsx
+++ b/src/components/SubStepForms/AgreementsFullStep.tsx
@@ -10,7 +10,7 @@ import UploadFile from '@components/UploadFile';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {getFieldRequiredErrors, isRequiredFulfilled} from '@libs/ValidationUtils';
+import {getFieldRequiredErrors} from '@libs/ValidationUtils';
 
 import requiresDocusignStep from '@pages/ReimbursementAccount/NonUSD/utils/requiresDocusignStep';
 
@@ -52,10 +52,10 @@ type AgreementsFullStepProps<TFormID extends keyof OnyxFormValuesMapping> = {
 
     /** Input IDs for field in the form */
     inputIDs: {
-        provideTruthfulInformation: FormOnyxKeys<TFormID>;
-        agreeToTermsAndConditions: FormOnyxKeys<TFormID>;
-        consentToPrivacyNotice: FormOnyxKeys<TFormID>;
-        authorizedToBindClientToAgreement: FormOnyxKeys<TFormID>;
+        provideTruthfulInformation: Extract<FormOnyxKeys<TFormID>, string>;
+        agreeToTermsAndConditions: Extract<FormOnyxKeys<TFormID>, string>;
+        consentToPrivacyNotice: Extract<FormOnyxKeys<TFormID>, string>;
+        authorizedToBindClientToAgreement: Extract<FormOnyxKeys<TFormID>, string>;
     };
 
     /** Indicates that action is being processed */
@@ -104,7 +104,12 @@ function AgreementsFullStep<TFormID extends keyof OnyxFormValuesMapping>({
 
     const isDocusignStepRequired = requiresDocusignStep(currency);
     const stepFields = useMemo(() => {
-        const fields = [inputIDs.authorizedToBindClientToAgreement, inputIDs.provideTruthfulInformation, inputIDs.agreeToTermsAndConditions, inputIDs.consentToPrivacyNotice];
+        const fields: Array<FormOnyxKeys<TFormID>> = [
+            inputIDs.authorizedToBindClientToAgreement,
+            inputIDs.provideTruthfulInformation,
+            inputIDs.agreeToTermsAndConditions,
+            inputIDs.consentToPrivacyNotice,
+        ];
         if (bankStatementInputID) {
             fields.push(bankStatementInputID);
         }
@@ -150,19 +155,19 @@ function AgreementsFullStep<TFormID extends keyof OnyxFormValuesMapping>({
         (values: FormOnyxValues<TFormID>): FormInputErrors<TFormID> => {
             const errors = getFieldRequiredErrors(values, stepFields, translate);
 
-            if (!isRequiredFulfilled(values[inputIDs.authorizedToBindClientToAgreement] as string)) {
+            if (Object.hasOwn(errors, inputIDs.authorizedToBindClientToAgreement)) {
                 errors[inputIDs.authorizedToBindClientToAgreement] = translate('agreementsStep.error.authorized');
             }
 
-            if (!isRequiredFulfilled(values[inputIDs.provideTruthfulInformation] as string)) {
+            if (Object.hasOwn(errors, inputIDs.provideTruthfulInformation)) {
                 errors[inputIDs.provideTruthfulInformation] = translate('agreementsStep.error.certify');
             }
 
-            if (!isRequiredFulfilled(values[inputIDs.agreeToTermsAndConditions] as string)) {
+            if (Object.hasOwn(errors, inputIDs.agreeToTermsAndConditions)) {
                 errors[inputIDs.agreeToTermsAndConditions] = translate('common.error.acceptTerms');
             }
 
-            if (!isRequiredFulfilled(values[inputIDs.consentToPrivacyNotice] as string)) {
+            if (Object.hasOwn(errors, inputIDs.consentToPrivacyNotice)) {
                 errors[inputIDs.consentToPrivacyNotice] = translate('agreementsStep.error.consent');
             }
 
@@ -194,7 +199,7 @@ function AgreementsFullStep<TFormID extends keyof OnyxFormValuesMapping>({
                 <InputWrapper
                     InputComponent={CheckboxWithLabel}
                     accessibilityLabel={translate('agreementsStep.iAmAuthorized')}
-                    inputID={inputIDs.authorizedToBindClientToAgreement as string}
+                    inputID={inputIDs.authorizedToBindClientToAgreement}
                     style={styles.mt6}
                     LabelComponent={IsAuthorizedToUseBankAccountLabel}
                     defaultValue={defaultValues[inputIDs.authorizedToBindClientToAgreement]}
@@ -203,7 +208,7 @@ function AgreementsFullStep<TFormID extends keyof OnyxFormValuesMapping>({
                 <InputWrapper
                     InputComponent={CheckboxWithLabel}
                     accessibilityLabel={translate('agreementsStep.iCertify')}
-                    inputID={inputIDs.provideTruthfulInformation as string}
+                    inputID={inputIDs.provideTruthfulInformation}
                     style={styles.mt6}
                     LabelComponent={CertifyTrueAndAccurateLabel}
                     defaultValue={defaultValues[inputIDs.provideTruthfulInformation]}
@@ -212,7 +217,7 @@ function AgreementsFullStep<TFormID extends keyof OnyxFormValuesMapping>({
                 <InputWrapper
                     InputComponent={CheckboxWithLabel}
                     accessibilityLabel={translate('agreementsStep.iAcceptTheTermsAndConditionsAccessibility')}
-                    inputID={inputIDs.agreeToTermsAndConditions as string}
+                    inputID={inputIDs.agreeToTermsAndConditions}
                     style={styles.mt6}
                     LabelComponent={TermsAndConditionsLabel}
                     defaultValue={defaultValues[inputIDs.agreeToTermsAndConditions]}
@@ -221,7 +226,7 @@ function AgreementsFullStep<TFormID extends keyof OnyxFormValuesMapping>({
                 <InputWrapper
                     InputComponent={CheckboxWithLabel}
                     accessibilityLabel={translate('agreementsStep.iConsentToThePrivacyNoticeAccessibility')}
-                    inputID={inputIDs.consentToPrivacyNotice as string}
+                    inputID={inputIDs.consentToPrivacyNotice}
                     style={styles.mt6}
                     LabelComponent={ConsentToPrivacyNoticeLabel}
                     defaultValue={defaultValues[inputIDs.consentToPrivacyNotice]}

--- a/tests/ui/components/SubStepForms/AgreementsFullStepTest.tsx
+++ b/tests/ui/components/SubStepForms/AgreementsFullStepTest.tsx
@@ -1,0 +1,159 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react-native';
+
+import type FormWrapper from '@components/Form/FormWrapper';
+import AgreementsFullStep from '@components/SubStepForms/AgreementsFullStep';
+
+import getSubStepValues from '@pages/ReimbursementAccount/utils/getSubStepValues';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+import GLOBAL_INPUT_IDS from '@src/types/form/EnableGlobalReimbursementsForm';
+import REIMBURSEMENT_INPUT_IDS from '@src/types/form/ReimbursementAccountForm';
+import type {FileObject} from '@src/types/utils/Attachment';
+
+import type HybridAppModuleType from '@expensify/react-native-hybrid-app/src/types';
+import type ReactNative from 'react-native';
+
+import React from 'react';
+
+import * as TestHelper from '../../../utils/TestHelper';
+
+type MockFormWrapperProps = React.ComponentProps<typeof FormWrapper>;
+const mockTranslate = TestHelper.translateLocal;
+jest.mock('@components/Form/FormWrapper', () => {
+    const reactNative = jest.requireActual<typeof ReactNative>('react-native');
+    return {
+        __esModule: true,
+        default: ({children, errors, onSubmit}: MockFormWrapperProps) => (
+            <reactNative.View>
+                <reactNative.Pressable
+                    testID="submit"
+                    onPress={onSubmit}
+                />
+                <reactNative.Text testID="form-errors">{JSON.stringify(errors)}</reactNative.Text>
+                {children}
+            </reactNative.View>
+        ),
+    };
+});
+jest.mock('@components/InteractiveStepWrapper', () => {
+    const reactNative = jest.requireActual<typeof ReactNative>('react-native');
+    return {__esModule: true, default: ({children}: {children: React.ReactNode}) => <reactNative.View>{children}</reactNative.View>};
+});
+jest.mock('@components/CheckboxWithLabel', () => ({__esModule: true, default: () => null}));
+jest.mock('@components/UploadFile', () => ({__esModule: true, default: () => null}));
+jest.mock('@components/RenderHTML', () => ({__esModule: true, default: () => null}));
+jest.mock('@expensify/react-native-hybrid-app', () => ({
+    __esModule: true,
+    default: {isHybridApp: jest.fn<ReturnType<HybridAppModuleType['isHybridApp']>, Parameters<HybridAppModuleType['isHybridApp']>>(() => false)},
+}));
+jest.mock('@hooks/useLocalize', () => () => ({translate: mockTranslate, preferredLocale: 'en'}));
+jest.mock('@hooks/useThemeStyles', () => () => new Proxy({}, {get: () => ({})}));
+jest.mock('@hooks/useNetwork', () => () => ({isOffline: false}));
+jest.mock('@hooks/useIsFocusedRef', () => () => ({current: true}));
+jest.mock('@hooks/usePressLoading', () => () => ({isLoading: false, startWithLoading: (callback: () => void) => callback()}));
+jest.mock('@src/utils/keyboard', () => ({dismiss: () => Promise.resolve(), dismissKeyboardAndExecute: (callback: () => void) => callback()}));
+
+const GLOBAL_FORM_ID = ONYXKEYS.FORMS.ENABLE_GLOBAL_REIMBURSEMENTS;
+const REIMBURSEMENT_FORM_ID = ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM;
+const BANK_STATEMENT_INPUT_ID = REIMBURSEMENT_INPUT_IDS.ADDITIONAL_DATA.CORPAY.BANK_STATEMENT;
+const GLOBAL_AGREEMENT_INPUTS = {
+    provideTruthfulInformation: GLOBAL_INPUT_IDS.PROVIDE_TRUTHFUL_INFORMATION,
+    agreeToTermsAndConditions: GLOBAL_INPUT_IDS.AGREE_TO_TERMS_AND_CONDITIONS,
+    consentToPrivacyNotice: GLOBAL_INPUT_IDS.CONSENT_TO_PRIVACY_NOTICE,
+    authorizedToBindClientToAgreement: GLOBAL_INPUT_IDS.AUTHORIZED_TO_BIND_CLIENT_TO_AGREEMENT,
+};
+const REIMBURSEMENT_AGREEMENT_INPUTS = {
+    provideTruthfulInformation: REIMBURSEMENT_INPUT_IDS.ADDITIONAL_DATA.CORPAY.PROVIDE_TRUTHFUL_INFORMATION,
+    agreeToTermsAndConditions: REIMBURSEMENT_INPUT_IDS.ADDITIONAL_DATA.CORPAY.AGREE_TO_TERMS_AND_CONDITIONS,
+    consentToPrivacyNotice: REIMBURSEMENT_INPUT_IDS.ADDITIONAL_DATA.CORPAY.CONSENT_TO_PRIVACY_NOTICE,
+    authorizedToBindClientToAgreement: REIMBURSEMENT_INPUT_IDS.ADDITIONAL_DATA.CORPAY.AUTHORIZED_TO_BIND_CLIENT_TO_AGREEMENT,
+};
+type AgreementErrorInputID = (typeof GLOBAL_AGREEMENT_INPUTS | typeof REIMBURSEMENT_AGREEMENT_INPUTS)[keyof typeof GLOBAL_AGREEMENT_INPUTS] | typeof BANK_STATEMENT_INPUT_ID;
+const ALL_GLOBAL_AGREEMENTS = {
+    [GLOBAL_AGREEMENT_INPUTS.provideTruthfulInformation]: true,
+    [GLOBAL_AGREEMENT_INPUTS.agreeToTermsAndConditions]: true,
+    [GLOBAL_AGREEMENT_INPUTS.consentToPrivacyNotice]: true,
+    [GLOBAL_AGREEMENT_INPUTS.authorizedToBindClientToAgreement]: true,
+} satisfies React.ComponentProps<typeof AgreementsFullStep<typeof GLOBAL_FORM_ID>>['defaultValues'];
+const ALL_REIMBURSEMENT_AGREEMENTS = {...ALL_GLOBAL_AGREEMENTS} satisfies React.ComponentProps<typeof AgreementsFullStep<typeof REIMBURSEMENT_FORM_ID>>['defaultValues'];
+type AgreementsTestProps<TFormID extends typeof GLOBAL_FORM_ID | typeof REIMBURSEMENT_FORM_ID> = Pick<
+    React.ComponentProps<typeof AgreementsFullStep<TFormID>>,
+    'bankStatementDefaultValue' | 'bankStatementInputID' | 'defaultValues' | 'formID' | 'inputIDs'
+>;
+
+function renderAgreements<TFormID extends typeof GLOBAL_FORM_ID | typeof REIMBURSEMENT_FORM_ID>(props: AgreementsTestProps<TFormID>) {
+    const onSubmit = jest.fn();
+    render(
+        <AgreementsFullStep<TFormID>
+            {...props}
+            isLoading={false}
+            onBackButtonPress={() => {}}
+            onSubmit={onSubmit}
+            currency="USD"
+            startStepIndex={1}
+        />,
+    );
+    return onSubmit;
+}
+
+async function submitAgreementsAndExpectErrors(errors: Partial<Readonly<Record<AgreementErrorInputID, string>>>) {
+    fireEvent.press(screen.getByTestId('submit'));
+    await waitFor(() => expect(screen.getByTestId('form-errors')).toHaveTextContent(JSON.stringify(errors)));
+}
+
+describe('AgreementsFullStep validation', () => {
+    it.each([
+        [GLOBAL_AGREEMENT_INPUTS.authorizedToBindClientToAgreement, TestHelper.translateLocal('agreementsStep.error.authorized')],
+        [GLOBAL_AGREEMENT_INPUTS.provideTruthfulInformation, TestHelper.translateLocal('agreementsStep.error.certify')],
+        [GLOBAL_AGREEMENT_INPUTS.agreeToTermsAndConditions, TestHelper.translateLocal('common.error.acceptTerms')],
+        [GLOBAL_AGREEMENT_INPUTS.consentToPrivacyNotice, TestHelper.translateLocal('agreementsStep.error.consent')],
+    ])('returns the specific required message for %s', async (rejectedInput, message) => {
+        renderAgreements({
+            formID: GLOBAL_FORM_ID,
+            inputIDs: GLOBAL_AGREEMENT_INPUTS,
+            defaultValues: {...ALL_GLOBAL_AGREEMENTS, [rejectedInput]: false},
+        });
+        await submitAgreementsAndExpectErrors({[rejectedInput]: message});
+    });
+
+    it('submits when every global-reimbursements agreement is fulfilled', async () => {
+        const onSubmit = renderAgreements({formID: GLOBAL_FORM_ID, inputIDs: GLOBAL_AGREEMENT_INPUTS, defaultValues: ALL_GLOBAL_AGREEMENTS});
+        await submitAgreementsAndExpectErrors({});
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    });
+
+    it('returns all four specific messages for the real NonUSD absent-value producer', async () => {
+        const absentValues = getSubStepValues(REIMBURSEMENT_AGREEMENT_INPUTS, undefined, undefined);
+        renderAgreements({formID: REIMBURSEMENT_FORM_ID, inputIDs: REIMBURSEMENT_AGREEMENT_INPUTS, defaultValues: absentValues});
+        await submitAgreementsAndExpectErrors({
+            [REIMBURSEMENT_AGREEMENT_INPUTS.authorizedToBindClientToAgreement]: TestHelper.translateLocal('agreementsStep.error.authorized'),
+            [REIMBURSEMENT_AGREEMENT_INPUTS.provideTruthfulInformation]: TestHelper.translateLocal('agreementsStep.error.certify'),
+            [REIMBURSEMENT_AGREEMENT_INPUTS.agreeToTermsAndConditions]: TestHelper.translateLocal('common.error.acceptTerms'),
+            [REIMBURSEMENT_AGREEMENT_INPUTS.consentToPrivacyNotice]: TestHelper.translateLocal('agreementsStep.error.consent'),
+        });
+    });
+
+    it('keeps the generic required error for an empty bank statement', async () => {
+        renderAgreements({
+            formID: REIMBURSEMENT_FORM_ID,
+            inputIDs: REIMBURSEMENT_AGREEMENT_INPUTS,
+            defaultValues: ALL_REIMBURSEMENT_AGREEMENTS,
+            bankStatementInputID: BANK_STATEMENT_INPUT_ID,
+            bankStatementDefaultValue: [],
+        });
+        await submitAgreementsAndExpectErrors({[BANK_STATEMENT_INPUT_ID]: TestHelper.translateLocal('common.error.fieldRequired')});
+    });
+
+    it('submits when the required bank statement contains a production-typed file', async () => {
+        const bankStatement: FileObject[] = [{name: 'statement.pdf', uri: 'file://statement.pdf', type: 'application/pdf'}];
+        const onSubmit = renderAgreements({
+            formID: REIMBURSEMENT_FORM_ID,
+            inputIDs: REIMBURSEMENT_AGREEMENT_INPUTS,
+            defaultValues: ALL_REIMBURSEMENT_AGREEMENTS,
+            bankStatementInputID: BANK_STATEMENT_INPUT_ID,
+            bankStatementDefaultValue: bankStatement,
+        });
+        await submitAgreementsAndExpectErrors({});
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    });
+});


### PR DESCRIPTION
### Explanation of Change

This PR removes unsafe type assertions from `AgreementsFullStep`.

Agreement field names now use their actual form types, and required-field validation reuses the existing validation result before applying the existing specific error messages. Checkbox order, labels, saved values, bank-statement validation, and both agreement flows remain unchanged.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Count change

8 → 0 targeted unsafe type assertions (8 removed).

### Changed files

- Component: `src/components/SubStepForms/AgreementsFullStep.tsx`
- Tests: `tests/ui/components/SubStepForms/AgreementsFullStepTest.tsx`

### Tests

- `tests/ui/components/SubStepForms/AgreementsFullStepTest.tsx`

The focused suite passed: 8 tests.

- [x] Verify that no errors appear in the JS console

### QA Steps

1. Open the Agreements step in the non-USD reimbursement-account setup flow.
2. Leave each agreement checkbox unchecked in turn and submit the form.
3. Verify the existing specific error appears for each unchecked agreement.
4. Select all four agreements and verify the flow can continue.
5. When a bank statement is required, verify an empty upload shows the required error and a valid upload allows the flow to continue.
6. Repeat the agreement validation in the global-reimbursements enablement flow.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A. This change does not affect requests or offline behavior.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — N/A: no visual UI changes
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (no user-facing copy was added).
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (focused tests cover both forms that use this component)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (no style was added)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (no asset was added or modified)
    - [x] The assets load correctly across all supported platforms (no asset was added or modified)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown. (Not applicable: no message-editing or sending code changed.)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App. (Not applicable: this component is limited to the two tested agreement flows.)
- [x] If the PR modifies a component related to any existing Storybook stories, I tested and verified those stories. (Not applicable: no matching Storybook story is changed.)
- [x] If the PR modifies a component or page accessible by a direct deeplink, I verified it while logged in and logged out. (Not applicable: the Agreements step requires an authenticated setup flow.)
- [x] If the PR modifies the UI or form input styles:
    - [x] I verified that form inputs remain aligned. (Not applicable: no visual style changed.)
    - [x] I added `Design` label or tagged `@Expensify/design`. (Not applicable: no visual UI changed.)
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for this change.
- [x] If `main` was merged into this PR after review, I tested again. (Not applicable: `main` was not merged after review.)

### Screenshots/Videos

The supplied functional QA recording is listed below.

<details>
<summary>Android: Native</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>iOS: Native</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Team QA recording in Chrome:

https://github.com/user-attachments/assets/e2461a40-cec8-475e-9185-b781f36ca96d

</details>
