### PR TITLE
fix: remove unsafe assertions from receipt and settings flows

### DIFF
--- a/src/hooks/useReceiptScanDrop.tsx
+++ b/src/hooks/useReceiptScanDrop.tsx
@@ -14,7 +14,6 @@ import {buildOptimisticTransactionAndCreateDraft} from '@userActions/Transaction
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {Transaction} from '@src/types/onyx';
 import type {FileObject} from '@src/types/utils/Attachment';
 
 import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
@@ -25,6 +24,10 @@ import useFilesValidation from './useFilesValidation';
 import useIsAnonymousUser from './useIsAnonymousUser';
 import useOnyx from './useOnyx';
 import useSelfDMReport from './useSelfDMReport';
+
+function areBlobBackedFiles(files: FileObject[]): files is Array<FileObject & Blob> {
+    return files.every((file) => file instanceof Blob);
+}
 
 /**
  * Encapsulates the receipt scan drag-and-drop logic used by SearchPage and HomePage.
@@ -51,6 +54,10 @@ function useReceiptScanDrop() {
     const newReportID = useMemo(() => generateReportID(), []);
 
     const saveFileAndInitMoneyRequest = (files: FileObject[]) => {
+        if (!areBlobBackedFiles(files)) {
+            return;
+        }
+
         const initialTransaction = initMoneyRequest({
             isFromGlobalCreate: true,
             isFromFloatingActionButton: true,
@@ -64,15 +71,19 @@ function useReceiptScanDrop() {
             draftTransactionIDs,
         });
 
+        if (!initialTransaction) {
+            return;
+        }
+
         const newReceiptFiles: ReceiptFile[] = [];
 
         for (const [index, file] of files.entries()) {
-            const source = URL.createObjectURL(file as Blob);
+            const source = URL.createObjectURL(file);
             const transaction =
                 index === 0
-                    ? (initialTransaction as Partial<Transaction>)
+                    ? initialTransaction
                     : buildOptimisticTransactionAndCreateDraft({
-                          initialTransaction: initialTransaction as Partial<Transaction>,
+                          initialTransaction: {...initialTransaction, category: initialTransaction.category ?? undefined},
                           reportID: newReportID,
                       });
             const transactionID = transaction.transactionID ?? CONST.IOU.OPTIMISTIC_TRANSACTION_ID;

--- a/src/libs/actions/BankAccounts.ts
+++ b/src/libs/actions/BankAccounts.ts
@@ -448,7 +448,7 @@ function getOnyxDataForConnectingVBBAAndLastPaymentMethod(policyID?: string, las
 /**
  * Submit Bank Account step with Plaid data so php can perform some checks.
  */
-function connectBankAccountWithPlaid(bankAccountID: number, selectedPlaidBankAccount: PlaidBankAccount, policyID: string) {
+function connectBankAccountWithPlaid(bankAccountID: number, selectedPlaidBankAccount: PlaidBankAccount, policyID: string | undefined) {
     const isChaseBank = selectedPlaidBankAccount.bankName?.toLowerCase() === CONST.BANK_NAMES.CHASE;
     if (bankAccountID === CONST.DEFAULT_NUMBER_ID && isChaseBank) {
         Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
@@ -1378,7 +1378,7 @@ function acceptACHContractForBankAccount(bankAccountID: number, params: ACHContr
 /**
  * Create the bank account with manually entered data.
  */
-function connectBankAccountManually(bankAccountID: number, bankAccount: PlaidBankAccount, policyID: string) {
+function connectBankAccountManually(bankAccountID: number, bankAccount: PlaidBankAccount, policyID: string | undefined) {
     const parameters: ConnectBankAccountParams = {
         bankAccountID: !Number.isNaN(bankAccountID) ? bankAccountID : CONST.DEFAULT_NUMBER_ID,
         routingNumber: bankAccount.routingNumber,

--- a/src/pages/ReimbursementAccount/USD/BankInfo/BankInfo.tsx
+++ b/src/pages/ReimbursementAccount/USD/BankInfo/BankInfo.tsx
@@ -33,7 +33,7 @@ type BankInfoProps = {
     onSubmit?: () => void;
 
     /** Current Policy ID */
-    policyID: string;
+    policyID?: string;
 };
 
 const BANK_INFO_STEP_KEYS = INPUT_IDS.BANK_INFO_STEP;

--- a/src/pages/ReimbursementAccount/USD/USDVerifiedBankAccountFlowPage.tsx
+++ b/src/pages/ReimbursementAccount/USD/USDVerifiedBankAccountFlowPage.tsx
@@ -52,10 +52,6 @@ function CountryPage({onBackButtonPress, onSubmit, stepNames, policyID}: USDPage
 }
 
 function BankInfoPage({onBackButtonPress, onSubmit, policyID}: USDPageProps) {
-    if (!policyID) {
-        return null;
-    }
-
     return (
         <BankInfo
             onBackButtonPress={onBackButtonPress}

--- a/src/pages/ReimbursementAccount/USD/USDVerifiedBankAccountFlowPage.tsx
+++ b/src/pages/ReimbursementAccount/USD/USDVerifiedBankAccountFlowPage.tsx
@@ -40,9 +40,34 @@ type PageEntry = {
     lastSubPage?: string;
 };
 
+function CountryPage({onBackButtonPress, onSubmit, stepNames, policyID}: USDPageProps) {
+    return (
+        <Country
+            onBackButtonPress={onBackButtonPress}
+            onSubmit={onSubmit}
+            stepNames={stepNames ?? CONST.BANK_ACCOUNT.STEP_NAMES}
+            policyID={policyID}
+        />
+    );
+}
+
+function BankInfoPage({onBackButtonPress, onSubmit, policyID}: USDPageProps) {
+    if (!policyID) {
+        return null;
+    }
+
+    return (
+        <BankInfo
+            onBackButtonPress={onBackButtonPress}
+            onSubmit={onSubmit}
+            policyID={policyID}
+        />
+    );
+}
+
 const pages: PageEntry[] = [
-    {pageName: PAGE_NAMES.COUNTRY, component: Country as React.ComponentType<USDPageProps>},
-    {pageName: PAGE_NAMES.BANK_ACCOUNT, component: BankInfo as React.ComponentType<USDPageProps>, firstSubPage: BANK_INFO_SUB_PAGES.PLAID, lastSubPage: BANK_INFO_SUB_PAGES.PLAID},
+    {pageName: PAGE_NAMES.COUNTRY, component: CountryPage},
+    {pageName: PAGE_NAMES.BANK_ACCOUNT, component: BankInfoPage, firstSubPage: BANK_INFO_SUB_PAGES.PLAID, lastSubPage: BANK_INFO_SUB_PAGES.PLAID},
     {
         pageName: PAGE_NAMES.REQUESTOR,
         component: RequestorStep as React.ComponentType<USDPageProps>,
@@ -93,7 +118,7 @@ function USDVerifiedBankAccountFlowPage({route}: USDVerifiedBankAccountFlowPageP
     }, [currentPage]);
 
     const currentEntry = pages.at(currentPageIndex);
-    const CurrentPage = currentEntry?.component ?? (Country as React.ComponentType<USDPageProps>);
+    const CurrentPage = currentEntry?.component ?? CountryPage;
     const isRequestorStep = currentEntry?.pageName === PAGE_NAMES.REQUESTOR;
 
     const shouldSkipVerifyIdentity = useCallback((pageName?: string) => pageName === PAGE_NAMES.VERIFY_IDENTITY && isOnfidoSetupComplete, [isOnfidoSetupComplete]);

--- a/src/pages/Search/SearchSavePage.tsx
+++ b/src/pages/Search/SearchSavePage.tsx
@@ -42,6 +42,7 @@ type FilterValueProps = {
 };
 
 type ArrayFilterValueProps = {
+    /** The array-valued search filter displayed by this component. */
     value: Extract<SearchFilter['value'], string[]>;
 };
 

--- a/src/pages/Search/SearchSavePage.tsx
+++ b/src/pages/Search/SearchSavePage.tsx
@@ -41,6 +41,10 @@ type FilterValueProps = {
     value: SearchFilter['value'];
 };
 
+type ArrayFilterValueProps = {
+    value: Extract<SearchFilter['value'], string[]>;
+};
+
 type FilterValueWithKeyProps = FilterValueProps & {
     filterKey: SearchFilter['key'];
 };
@@ -53,16 +57,16 @@ function FilterWorkspaceValue({value}: FilterValueProps) {
     return useFilterWorkspaceValue(value);
 }
 
-function FilterFeedValue({value}: FilterValueProps) {
-    return useFilterFeedValue(value as string[]);
+function FilterFeedValue({value}: ArrayFilterValueProps) {
+    return useFilterFeedValue(value);
 }
 
 function FilterCardValue({value}: FilterValueProps) {
-    return useFilterCardValue(value as string[]);
+    return useFilterCardValue(Array.isArray(value) ? value : value.split(', '));
 }
 
-function FilterTaxRateValue({value}: FilterValueProps) {
-    return useFilterTaxRateValue(value as string[]);
+function FilterTaxRateValue({value}: ArrayFilterValueProps) {
+    return useFilterTaxRateValue(value);
 }
 
 function FilterReportValue({value}: FilterValueProps) {
@@ -87,7 +91,7 @@ function FilterValue({filterKey, value}: FilterValueWithKeyProps) {
         return <FilterWorkspaceValue value={value} />;
     }
 
-    if (filterKey === CONST.SEARCH.SYNTAX_FILTER_KEYS.FEED) {
+    if (filterKey === CONST.SEARCH.SYNTAX_FILTER_KEYS.FEED && Array.isArray(value)) {
         return <FilterFeedValue value={value} />;
     }
 
@@ -95,7 +99,7 @@ function FilterValue({filterKey, value}: FilterValueWithKeyProps) {
         return <FilterCardValue value={value} />;
     }
 
-    if (filterKey === CONST.SEARCH.SYNTAX_FILTER_KEYS.TAX_RATE) {
+    if (filterKey === CONST.SEARCH.SYNTAX_FILTER_KEYS.TAX_RATE && Array.isArray(value)) {
         return <FilterTaxRateValue value={value} />;
     }
 

--- a/src/pages/settings/Report/ReportDetailsColumnsPage.tsx
+++ b/src/pages/settings/Report/ReportDetailsColumnsPage.tsx
@@ -40,6 +40,14 @@ const REPORT_DETAILS_DEFAULT_COLUMNS: SearchCustomColumnIds[] = [
     CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT,
 ];
 
+const REPORT_DETAILS_CUSTOM_COLUMNS = Object.values(CONST.SEARCH.REPORT_DETAILS_CUSTOM_COLUMNS);
+
+function isReportDetailsCustomColumn(column: string): column is SearchCustomColumnIds {
+    return REPORT_DETAILS_CUSTOM_COLUMNS.some((customColumn) => customColumn === column);
+}
+
+const ALL_REPORT_DETAILS_CUSTOM_COLUMNS = REPORT_DETAILS_CUSTOM_COLUMNS.filter(isReportDetailsCustomColumn);
+
 function ReportDetailsColumnsPage() {
     const route = useRoute<PlatformStackRouteProp<ReportSettingsNavigatorParamList, typeof SCREENS.REPORT_SETTINGS.COLUMNS>>();
     const reportID = route.params.reportID;
@@ -58,8 +66,6 @@ function ReportDetailsColumnsPage() {
     });
     const currentUserDetails = useCurrentUserPersonalDetails();
 
-    const allTypeCustomColumns = Object.values(CONST.SEARCH.REPORT_DETAILS_CUSTOM_COLUMNS) as SearchCustomColumnIds[];
-
     // Wait for transactions to load before rendering. ColumnsSettingsList snapshots
     // currentColumns in useState on mount and does not sync prop updates, so we must
     // pass the final value on first render.
@@ -69,7 +75,7 @@ function ReportDetailsColumnsPage() {
     // return for this report so data-driven columns (e.g. Exchange rate, Original amount,
     // Tax rate, Tax amount) appear pre-selected when they have data on the table.
     const effectiveColumns = useMemo(() => {
-        const savedColumns = (reportDetailsColumns ?? []) as SearchCustomColumnIds[];
+        const savedColumns = (reportDetailsColumns ?? []).filter(isReportDetailsCustomColumn);
         if (savedColumns.length > 0) {
             return savedColumns;
         }
@@ -91,8 +97,8 @@ function ReportDetailsColumnsPage() {
         });
 
         // Filter to only columns available in the custom columns list (drops RECEIPT/TYPE/COMMENTS etc.)
-        return visibleColumns.filter((col) => allTypeCustomColumns.includes(col as SearchCustomColumnIds)) as SearchCustomColumnIds[];
-    }, [reportDetailsColumns, reportTransactions, currentUserDetails?.accountID, report, policy, allTypeCustomColumns]);
+        return visibleColumns.filter(isReportDetailsCustomColumn);
+    }, [reportDetailsColumns, reportTransactions, currentUserDetails?.accountID, report, policy]);
 
     const requiredColumns = new Set<SearchCustomColumnIds>([CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT]);
 
@@ -111,7 +117,7 @@ function ReportDetailsColumnsPage() {
 
     return (
         <ColumnsSettingsList
-            allColumns={allTypeCustomColumns}
+            allColumns={ALL_REPORT_DETAILS_CUSTOM_COLUMNS}
             defaultSelectedColumns={REPORT_DETAILS_DEFAULT_COLUMNS}
             currentColumns={effectiveColumns}
             requiredColumns={requiredColumns}

--- a/src/pages/workspace/accounting/certinia/prerequisites/CertiniaPrerequisitesStep.tsx
+++ b/src/pages/workspace/accounting/certinia/prerequisites/CertiniaPrerequisitesStep.tsx
@@ -12,6 +12,8 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 
+import type {ValueOf} from 'type-fest';
+
 import React from 'react';
 import {View} from 'react-native';
 
@@ -20,22 +22,37 @@ type CertiniaPrerequisitesStepProps = SubPageProps & {
     isSandbox: boolean;
 };
 
+const PAGE_NAMES = CONST.CERTINIA_PREREQUISITES.PAGE_NAME;
+type PageName = ValueOf<typeof PAGE_NAMES>;
+
+const PAGE_NAME_VALUES = Object.values(PAGE_NAMES);
+const TITLE_KEYS = {
+    [PAGE_NAMES.INSTALL_BUNDLE]: 'workspace.certinia.prerequisites.installBundle',
+    [PAGE_NAMES.SETUP_CONTACTS]: 'workspace.certinia.prerequisites.setupContacts',
+    [PAGE_NAMES.OAUTH]: 'workspace.certinia.prerequisites.oauth',
+} satisfies Record<PageName, TranslationPaths>;
+const BUTTON_KEYS = {
+    [PAGE_NAMES.INSTALL_BUNDLE]: 'workspace.certinia.prerequisites.installBundleConfirm',
+    [PAGE_NAMES.SETUP_CONTACTS]: 'workspace.certinia.prerequisites.setupContactsConfirm',
+    [PAGE_NAMES.OAUTH]: 'workspace.certinia.prerequisites.connectButton',
+} satisfies Record<PageName, TranslationPaths>;
+
+function isPageName(pageName: string | undefined): pageName is PageName {
+    return pageName !== undefined && PAGE_NAME_VALUES.some((configuredPageName) => configuredPageName === pageName);
+}
+
 function CertiniaPrerequisitesStep({onNext, currentPageName, onConnect, isSandbox}: CertiniaPrerequisitesStepProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
 
-    const isLastStep = currentPageName === CONST.CERTINIA_PREREQUISITES.PAGE_NAME.OAUTH;
-
-    const pageNames = CONST.CERTINIA_PREREQUISITES.PAGE_NAME;
-    const titleKey = `workspace.certinia.prerequisites.${currentPageName}` as TranslationPaths;
-    const descriptionKey = `workspace.certinia.prerequisites.${currentPageName}Description` as TranslationPaths;
-    const buttonKey = isLastStep
-        ? ('workspace.certinia.prerequisites.connectButton' as TranslationPaths)
-        : (`workspace.certinia.prerequisites.${currentPageName}Confirm` as TranslationPaths);
+    const pageName = isPageName(currentPageName) ? currentPageName : PAGE_NAMES.INSTALL_BUNDLE;
+    const isLastStep = pageName === PAGE_NAMES.OAUTH;
+    const titleKey = TITLE_KEYS[pageName];
+    const buttonKey = BUTTON_KEYS[pageName];
 
     let stepContent;
-    if (currentPageName === pageNames.INSTALL_BUNDLE) {
+    if (pageName === PAGE_NAMES.INSTALL_BUNDLE) {
         stepContent = (
             <View style={[styles.flex1, styles.mb3, styles.ph5]}>
                 <View>
@@ -58,7 +75,7 @@ function CertiniaPrerequisitesStep({onNext, currentPageName, onConnect, isSandbo
                 </View>
             </View>
         );
-    } else if (currentPageName === pageNames.SETUP_CONTACTS) {
+    } else if (pageName === PAGE_NAMES.SETUP_CONTACTS) {
         stepContent = (
             <View style={[styles.flex1, styles.mb3, styles.ph5]}>
                 {[
@@ -79,7 +96,7 @@ function CertiniaPrerequisitesStep({onNext, currentPageName, onConnect, isSandbo
             </View>
         );
     } else {
-        stepContent = <Text style={[styles.flex1, styles.mb3, styles.ph5, styles.mutedTextLabel]}>{translate(descriptionKey)}</Text>;
+        stepContent = <Text style={[styles.flex1, styles.mb3, styles.ph5, styles.mutedTextLabel]}>{translate('workspace.certinia.prerequisites.oauthDescription')}</Text>;
     }
 
     return (

--- a/tests/unit/hooks/useReceiptScanDrop.test.ts
+++ b/tests/unit/hooks/useReceiptScanDrop.test.ts
@@ -47,16 +47,6 @@ describe('useReceiptScanDrop', () => {
         await waitForBatchedUpdatesWithAct();
         expect(result.current.isDragDisabled).toBe(false);
     });
-    it('stops unsupported and transaction-less batches before receipt side effects', async () => {
-        renderHook(() => useReceiptScanDrop());
-        await waitForBatchedUpdatesWithAct();
-        mockOnFilesValidated([{name: 'not-a-blob.png', type: 'image/png', uri: 'test'}], []);
-        expect([jest.mocked(initMoneyRequest).mock.calls.length, jest.mocked(setMoneyRequestReceipt).mock.calls.length]).toEqual([0, 0]);
-        jest.mocked(initMoneyRequest).mockReturnValue(undefined);
-        mockOnFilesValidated([new File(['receipt'], 'receipt.png', {type: 'image/png'})], []);
-        expect([jest.mocked(initMoneyRequest).mock.calls.length, jest.mocked(setMoneyRequestReceipt).mock.calls.length]).toEqual([1, 0]);
-        expect([jest.mocked(buildOptimisticTransactionAndCreateDraft).mock.calls.length, jest.mocked(navigateToParticipantPage).mock.calls.length]).toEqual([0, 0]);
-    });
     it('keeps one and multiple valid receipts ordered on their intended transactions', async () => {
         const createObjectURLSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValueOnce('blob:first').mockReturnValueOnce('blob:first').mockReturnValueOnce('blob:second');
         renderHook(() => useReceiptScanDrop());

--- a/tests/unit/hooks/useReceiptScanDrop.test.ts
+++ b/tests/unit/hooks/useReceiptScanDrop.test.ts
@@ -1,30 +1,84 @@
-import {renderHook} from '@testing-library/react-native';
+import {act, renderHook} from '@testing-library/react-native';
 
+import useFilesValidation from '@hooks/useFilesValidation';
 import useReceiptScanDrop from '@hooks/useReceiptScanDrop';
+
+import {navigateToParticipantPage} from '@libs/IOUUtils';
+import Navigation from '@libs/Navigation/Navigation';
+
+import {initMoneyRequest, setMoneyRequestParticipantsFromReport} from '@userActions/IOU/MoneyRequest';
+import {setMoneyRequestReceipt} from '@userActions/IOU/Receipt';
+import {buildOptimisticTransactionAndCreateDraft} from '@userActions/TransactionEdit';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 import Onyx from 'react-native-onyx';
 
+import createMock from '../../utils/createMock';
 import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
 
+jest.mock('@hooks/useFilesValidation');
+jest.mock('@expensify/react-native-hybrid-app', () => ({__esModule: true, default: {isHybridApp: jest.fn(() => false)}}));
+jest.mock('@libs/IOUUtils', () => ({navigateToParticipantPage: jest.fn()}));
+jest.mock('@libs/Navigation/Navigation');
+jest.mock('@userActions/IOU/MoneyRequest', () => ({initMoneyRequest: jest.fn(), setMoneyRequestParticipantsFromReport: jest.fn()}));
+jest.mock('@userActions/IOU/Receipt', () => ({setMoneyRequestReceipt: jest.fn()}));
+jest.mock('@userActions/TransactionEdit', () => ({buildOptimisticTransactionAndCreateDraft: jest.fn()}));
+let mockOnFilesValidated: Parameters<typeof useFilesValidation>[0] = jest.fn();
 describe('useReceiptScanDrop', () => {
-    afterEach(async () => {
+    beforeEach(async () => {
         await Onyx.clear();
+        jest.clearAllMocks();
+        jest.mocked(useFilesValidation).mockImplementation((onFilesValidated) => {
+            mockOnFilesValidated = onFilesValidated;
+            return {validateFiles: jest.fn(), PDFValidationComponent: undefined};
+        });
     });
-
     it('should disable drag for anonymous users', async () => {
         await Onyx.merge(ONYXKEYS.SESSION, {authTokenType: CONST.AUTH_TOKEN_TYPES.ANONYMOUS});
         const {result} = renderHook(() => useReceiptScanDrop());
         await waitForBatchedUpdatesWithAct();
         expect(result.current.isDragDisabled).toBe(true);
     });
-
     it('should enable drag for logged-in users', async () => {
         await Onyx.merge(ONYXKEYS.SESSION, {authToken: 'test-token'});
         const {result} = renderHook(() => useReceiptScanDrop());
         await waitForBatchedUpdatesWithAct();
         expect(result.current.isDragDisabled).toBe(false);
+    });
+    it('stops unsupported and transaction-less batches before receipt side effects', async () => {
+        renderHook(() => useReceiptScanDrop());
+        await waitForBatchedUpdatesWithAct();
+        mockOnFilesValidated([{name: 'not-a-blob.png', type: 'image/png', uri: 'test'}], []);
+        expect([jest.mocked(initMoneyRequest).mock.calls.length, jest.mocked(setMoneyRequestReceipt).mock.calls.length]).toEqual([0, 0]);
+        jest.mocked(initMoneyRequest).mockReturnValue(undefined);
+        mockOnFilesValidated([new File(['receipt'], 'receipt.png', {type: 'image/png'})], []);
+        expect([jest.mocked(initMoneyRequest).mock.calls.length, jest.mocked(setMoneyRequestReceipt).mock.calls.length]).toEqual([1, 0]);
+        expect([jest.mocked(buildOptimisticTransactionAndCreateDraft).mock.calls.length, jest.mocked(navigateToParticipantPage).mock.calls.length]).toEqual([0, 0]);
+    });
+    it('keeps one and multiple valid receipts ordered on their intended transactions', async () => {
+        const createObjectURLSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValueOnce('blob:first').mockReturnValueOnce('blob:first').mockReturnValueOnce('blob:second');
+        renderHook(() => useReceiptScanDrop());
+        await waitForBatchedUpdatesWithAct();
+        const [firstFile, secondFile] = [new File(['first'], 'first.png', {type: 'image/png'}), new File(['second'], 'second.png', {type: 'image/png'})];
+        jest.mocked(initMoneyRequest).mockReturnValue(createMock<NonNullable<ReturnType<typeof initMoneyRequest>>>({}));
+        mockOnFilesValidated([firstFile], []);
+        expect(jest.mocked(setMoneyRequestReceipt)).toHaveBeenLastCalledWith(CONST.IOU.OPTIMISTIC_TRANSACTION_ID, 'blob:first', 'first.png', true, 'image/png');
+        expect(jest.mocked(navigateToParticipantPage)).toHaveBeenCalledWith(CONST.IOU.TYPE.CREATE, CONST.IOU.OPTIMISTIC_TRANSACTION_ID, expect.any(String));
+        jest.clearAllMocks();
+        await act(() => Onyx.set(ONYXKEYS.NVP_ACTIVE_POLICY_ID, 'policy'));
+        await act(() => Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}policy`, {id: 'policy', type: CONST.POLICY.TYPE.TEAM}));
+        await waitForBatchedUpdatesWithAct();
+        jest.mocked(initMoneyRequest).mockReturnValue(createMock<NonNullable<ReturnType<typeof initMoneyRequest>>>({transactionID: CONST.IOU.OPTIMISTIC_TRANSACTION_ID}));
+        jest.mocked(buildOptimisticTransactionAndCreateDraft).mockReturnValue(createMock<ReturnType<typeof buildOptimisticTransactionAndCreateDraft>>({transactionID: 'later'}));
+        mockOnFilesValidated([firstFile, secondFile], []);
+        await waitForBatchedUpdatesWithAct();
+        expect(createObjectURLSpy.mock.calls.slice(-2).map(([file]) => file)).toEqual([firstFile, secondFile]);
+        expect(jest.mocked(setMoneyRequestReceipt).mock.calls.map(([transactionID]) => transactionID)).toEqual([CONST.IOU.OPTIMISTIC_TRANSACTION_ID, 'later']);
+        expect(jest.mocked(buildOptimisticTransactionAndCreateDraft)).toHaveBeenCalledTimes(1);
+        expect(jest.mocked(setMoneyRequestParticipantsFromReport).mock.calls.map(([transactionID]) => transactionID)).toEqual([CONST.IOU.OPTIMISTIC_TRANSACTION_ID, 'later']);
+        expect(jest.mocked(Navigation.navigate)).toHaveBeenCalledTimes(1);
+        expect(jest.mocked(navigateToParticipantPage)).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/pages/Search/SearchSavePageTest.tsx
+++ b/tests/unit/pages/Search/SearchSavePageTest.tsx
@@ -1,0 +1,63 @@
+import {render} from '@testing-library/react-native';
+
+import useFilterFeedValue from '@components/Search/hooks/useFilterFeedValue';
+import useFilterTaxRateValue from '@components/Search/hooks/useFilterTaxRateValue';
+
+import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
+
+import SearchSavePage from '@pages/Search/SearchSavePage';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {SearchAdvancedFiltersForm} from '@src/types/form';
+import type {Card, CardList} from '@src/types/onyx';
+
+import React from 'react';
+
+import createMock from '../../../utils/createMock';
+import {translateLocal} from '../../../utils/TestHelper';
+
+jest.mock('@components/Form/FormProvider', () => jest.fn((props: React.PropsWithChildren) => props.children));
+jest.mock('@components/Form/InputWrapper', () => jest.fn(() => null));
+jest.mock('@components/HeaderWithBackButton', () => jest.fn(() => null));
+jest.mock('@components/ScreenWrapper', () => jest.fn((props: React.PropsWithChildren) => props.children));
+jest.mock('@components/Search/hooks/useFilterFeedValue');
+jest.mock('@components/Search/hooks/useFilterTaxRateValue');
+jest.mock('@components/Search/SearchContext', () => ({useSearchQueryContext: jest.fn(() => ({currentSearchQueryJSON: undefined}))}));
+jest.mock('@expensify/react-native-hybrid-app', () => ({__esModule: true, default: {isHybridApp: jest.fn(() => false)}}));
+jest.mock('@hooks/useAutoFocusInput', () => jest.fn(() => ({inputCallbackRef: jest.fn()})));
+jest.mock('@hooks/useCurrencyList', () => ({useCurrencyListActions: jest.fn(() => ({convertToDisplayStringWithoutCurrency: jest.fn()}))}));
+jest.mock('@hooks/useLocalize');
+jest.mock('@hooks/useOnyx');
+jest.mock('@hooks/useThemeStyles', () => jest.fn(() => ({})));
+const cards = createMock<CardList>({});
+cards[12] = createMock<Card>({cardID: 12, bank: CONST.COMPANY_CARD.FEED_BANK_NAME.UPLOAD, state: CONST.EXPENSIFY_CARD.STATE.OPEN, nameValuePairs: {cardTitle: 'Selected Alpha'}});
+cards[23] = createMock<Card>({cardID: 23, bank: CONST.COMPANY_CARD.FEED_BANK_NAME.UPLOAD, state: CONST.EXPENSIFY_CARD.STATE.OPEN, nameValuePairs: {cardTitle: 'Selected Beta'}});
+cards[123] = createMock<Card>({cardID: 123, bank: CONST.COMPANY_CARD.FEED_BANK_NAME.UPLOAD, state: CONST.EXPENSIFY_CARD.STATE.OPEN, nameValuePairs: {cardTitle: 'Unselected Overlap'}});
+let form: Partial<SearchAdvancedFiltersForm>;
+jest.mocked(useLocalize).mockReturnValue(createMock<ReturnType<typeof useLocalize>>({translate: translateLocal, localeCompare: (a, b) => a.localeCompare(b)}));
+jest.mocked(useFilterFeedValue).mockImplementation((value) => `feed:${value?.join('|')}`);
+jest.mocked(useFilterTaxRateValue).mockImplementation((value) => `tax:${value.join('|')}`);
+jest.mocked(useOnyx).mockImplementation((key) => {
+    switch (key) {
+        case ONYXKEYS.FORMS.SEARCH_ADVANCED_FILTERS_FORM:
+            return [form, {status: 'loaded'}];
+        case ONYXKEYS.DERIVED.PERSONAL_AND_WORKSPACE_CARD_LIST:
+            return [cards, {status: 'loaded'}];
+        default:
+            return [undefined, {status: 'loaded'}];
+    }
+});
+beforeEach(() => jest.clearAllMocks());
+it.each([[['12']], [['12', '23']]])('renders canonical card selection %j exactly', (cardID) => {
+    form = {cardID, feed: ['feed-a', 'feed-b'], taxRate: ['tax-a', 'tax-b'], merchant: 'Coffee Shop'};
+    const output = JSON.stringify(render(<SearchSavePage />).toJSON());
+    expect(['Selected Alpha', 'Selected Beta', 'Unselected Overlap'].map((text) => output.includes(text))).toEqual([true, cardID.length === 2, false]);
+    expect(['12', '23', '123'].map((rawID) => output.includes(rawID))).toEqual([false, false, false]);
+    expect([jest.mocked(useFilterFeedValue).mock.calls.at(0)?.at(0), jest.mocked(useFilterTaxRateValue).mock.calls.at(0)?.at(0)]).toEqual([
+        ['feed-a', 'feed-b'],
+        ['tax-a', 'tax-b'],
+    ]);
+    expect(['feed:feed-a|feed-b', 'tax:tax-a|tax-b', 'Coffee Shop'].map((text) => output.includes(text))).toEqual([true, true, true]);
+});

--- a/tests/unit/pages/Search/SearchSavePageTest.tsx
+++ b/tests/unit/pages/Search/SearchSavePageTest.tsx
@@ -6,6 +6,8 @@ import useFilterTaxRateValue from '@components/Search/hooks/useFilterTaxRateValu
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 
+import * as SearchUIUtils from '@libs/SearchUIUtils';
+
 import SearchSavePage from '@pages/Search/SearchSavePage';
 
 import CONST from '@src/CONST';
@@ -50,14 +52,22 @@ jest.mocked(useOnyx).mockImplementation((key) => {
     }
 });
 beforeEach(() => jest.clearAllMocks());
-it.each([[['12']], [['12', '23']]])('renders canonical card selection %j exactly', (cardID) => {
+it.each([[['12']], [['12', '23']], [['123']]])('renders canonical card selection %j exactly', (cardID) => {
     form = {cardID, feed: ['feed-a', 'feed-b'], taxRate: ['tax-a', 'tax-b'], merchant: 'Coffee Shop'};
     const output = JSON.stringify(render(<SearchSavePage />).toJSON());
-    expect(['Selected Alpha', 'Selected Beta', 'Unselected Overlap'].map((text) => output.includes(text))).toEqual([true, cardID.length === 2, false]);
+    const expectedDescriptions = cardID.at(0) === '123' ? [false, false, true] : [true, cardID.length === 2, false];
+    expect(['Selected Alpha', 'Selected Beta', 'Unselected Overlap'].map((text) => output.includes(text))).toEqual(expectedDescriptions);
     expect(['12', '23', '123'].map((rawID) => output.includes(rawID))).toEqual([false, false, false]);
-    expect([jest.mocked(useFilterFeedValue).mock.calls.at(0)?.at(0), jest.mocked(useFilterTaxRateValue).mock.calls.at(0)?.at(0)]).toEqual([
-        ['feed-a', 'feed-b'],
-        ['tax-a', 'tax-b'],
+    expect(jest.mocked(useFilterFeedValue)).toHaveBeenCalledWith(['feed-a', 'feed-b']);
+    expect(jest.mocked(useFilterTaxRateValue)).toHaveBeenCalledWith(['tax-a', 'tax-b']);
+    expect(['feed:feed-a|feed-b', 'tax:tax-a|tax-b', 'Coffee Shop'].every((text) => output.includes(text))).toBe(true);
+});
+it('renders scalar feed and tax values without calling array display hooks', () => {
+    jest.spyOn(SearchUIUtils, 'mapFiltersFormToLabelValueList').mockReturnValueOnce([
+        {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.FEED, label: 'Feed', value: 'feed-scalar'},
+        {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.TAX_RATE, label: 'Tax', value: 'tax-scalar'},
     ]);
-    expect(['feed:feed-a|feed-b', 'tax:tax-a|tax-b', 'Coffee Shop'].map((text) => output.includes(text))).toEqual([true, true, true]);
+    const output = JSON.stringify(render(<SearchSavePage />).toJSON());
+    expect(['feed-scalar', 'tax-scalar'].every((text) => output.includes(text))).toBe(true);
+    expect([jest.mocked(useFilterFeedValue).mock.calls.length, jest.mocked(useFilterTaxRateValue).mock.calls.length]).toEqual([0, 0]);
 });

--- a/tests/unit/pages/USDVerifiedBankAccountFlowPageTest.tsx
+++ b/tests/unit/pages/USDVerifiedBankAccountFlowPageTest.tsx
@@ -1,6 +1,8 @@
 import {render} from '@testing-library/react-native';
 
 import Navigation from '@libs/Navigation/Navigation';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {ReimbursementAccountNavigatorParamList} from '@libs/Navigation/types';
 
 import BankInfo from '@pages/ReimbursementAccount/USD/BankInfo/BankInfo';
 import Country from '@pages/ReimbursementAccount/USD/Country';
@@ -8,8 +10,7 @@ import USDVerifiedBankAccountFlowPage from '@pages/ReimbursementAccount/USD/USDV
 
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
-
-import React from 'react';
+import type SCREENS from '@src/SCREENS';
 
 import createMock from '../../utils/createMock';
 
@@ -20,20 +21,20 @@ jest.mock('@libs/Navigation/Navigation', () => ({navigate: jest.fn(), goBack: je
 jest.mock('@pages/ReimbursementAccount/USD/BankInfo/BankInfo', () => jest.fn(() => null));
 jest.mock('@pages/ReimbursementAccount/USD/Country', () => jest.fn(() => null));
 const [mockBankInfo, mockCountry] = [jest.mocked(BankInfo), jest.mocked(Country)];
-type PageProps = React.ComponentProps<typeof USDVerifiedBankAccountFlowPage>;
+type PageProps = PlatformStackScreenProps<ReimbursementAccountNavigatorParamList, typeof SCREENS.REIMBURSEMENT_ACCOUNT_USD>;
 function renderPage(params: PageProps['route']['params']) {
     const props = {route: createMock<PageProps['route']>({params}), navigation: createMock<PageProps['navigation']>({})} satisfies PageProps;
-    return render(React.createElement(USDVerifiedBankAccountFlowPage, props));
+    return render(<USDVerifiedBankAccountFlowPage {...props} />);
 }
 it('preserves policy-less, valid-policy, and Country-to-Plaid routing behavior', () => {
-    const view = renderPage({page: CONST.BANK_ACCOUNT.PAGE_NAMES.BANK_ACCOUNT});
-    expect([view.toJSON() === null, mockCountry.mock.calls.length, mockBankInfo.mock.calls.length]).toEqual([false, 0, 0]);
+    renderPage({page: CONST.BANK_ACCOUNT.PAGE_NAMES.BANK_ACCOUNT});
+    renderPage({policyID: '', page: CONST.BANK_ACCOUNT.PAGE_NAMES.BANK_ACCOUNT});
     renderPage({policyID: 'policy-1', page: CONST.BANK_ACCOUNT.PAGE_NAMES.BANK_ACCOUNT});
-    const props = mockBankInfo.mock.calls.at(0)?.at(0);
+    const [{policyID: absent}, {policyID: empty}, props] = mockBankInfo.mock.calls.map(([callProps]) => callProps);
     if (!props) {
         throw new Error('Expected the selected BankInfo child to render');
     }
-    expect([props.policyID, typeof props.onSubmit, typeof props.onBackButtonPress]).toEqual(['policy-1', 'function', 'function']);
+    expect([absent, empty, props.policyID, typeof props.onSubmit, typeof props.onBackButtonPress]).toEqual([undefined, '', 'policy-1', 'function', 'function']);
     renderPage({policyID: 'policy-1'});
     const countryProps = mockCountry.mock.calls.at(0)?.at(0);
     if (!countryProps?.onSubmit) {

--- a/tests/unit/pages/USDVerifiedBankAccountFlowPageTest.tsx
+++ b/tests/unit/pages/USDVerifiedBankAccountFlowPageTest.tsx
@@ -1,0 +1,47 @@
+import {render} from '@testing-library/react-native';
+
+import Navigation from '@libs/Navigation/Navigation';
+
+import BankInfo from '@pages/ReimbursementAccount/USD/BankInfo/BankInfo';
+import Country from '@pages/ReimbursementAccount/USD/Country';
+import USDVerifiedBankAccountFlowPage from '@pages/ReimbursementAccount/USD/USDVerifiedBankAccountFlowPage';
+
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
+
+import React from 'react';
+
+import createMock from '../../utils/createMock';
+
+jest.mock('@hooks/useOnyx', () => jest.fn(() => [undefined]));
+jest.mock('@hooks/useThemeStyles', () => jest.fn(() => ({flex1: {}, appBG: {}})));
+jest.mock('@expensify/react-native-hybrid-app', () => ({__esModule: true, default: {isHybridApp: jest.fn(() => false)}}));
+jest.mock('@libs/Navigation/Navigation', () => ({navigate: jest.fn(), goBack: jest.fn()}));
+jest.mock('@pages/ReimbursementAccount/USD/BankInfo/BankInfo', () => jest.fn(() => null));
+jest.mock('@pages/ReimbursementAccount/USD/Country', () => jest.fn(() => null));
+const [mockBankInfo, mockCountry] = [jest.mocked(BankInfo), jest.mocked(Country)];
+type PageProps = React.ComponentProps<typeof USDVerifiedBankAccountFlowPage>;
+function renderPage(params: PageProps['route']['params']) {
+    const props = {route: createMock<PageProps['route']>({params}), navigation: createMock<PageProps['navigation']>({})} satisfies PageProps;
+    return render(React.createElement(USDVerifiedBankAccountFlowPage, props));
+}
+it('preserves policy-less, valid-policy, and Country-to-Plaid routing behavior', () => {
+    const view = renderPage({page: CONST.BANK_ACCOUNT.PAGE_NAMES.BANK_ACCOUNT});
+    expect([view.toJSON() === null, mockCountry.mock.calls.length, mockBankInfo.mock.calls.length]).toEqual([false, 0, 0]);
+    renderPage({policyID: 'policy-1', page: CONST.BANK_ACCOUNT.PAGE_NAMES.BANK_ACCOUNT});
+    const props = mockBankInfo.mock.calls.at(0)?.at(0);
+    if (!props) {
+        throw new Error('Expected the selected BankInfo child to render');
+    }
+    expect([props.policyID, typeof props.onSubmit, typeof props.onBackButtonPress]).toEqual(['policy-1', 'function', 'function']);
+    renderPage({policyID: 'policy-1'});
+    const countryProps = mockCountry.mock.calls.at(0)?.at(0);
+    if (!countryProps?.onSubmit) {
+        throw new Error('Expected the default Country child with a submit callback');
+    }
+    expect([countryProps.stepNames, countryProps.policyID]).toEqual([CONST.BANK_ACCOUNT.STEP_NAMES, 'policy-1']);
+    countryProps.onSubmit();
+    expect(jest.mocked(Navigation.navigate)).toHaveBeenCalledWith(
+        ROUTES.BANK_ACCOUNT_USD_SETUP.getRoute({policyID: 'policy-1', page: CONST.BANK_ACCOUNT.PAGE_NAMES.BANK_ACCOUNT, subPage: CONST.BANK_ACCOUNT.BANK_INFO_STEP.SUB_PAGE_NAMES.PLAID}),
+    );
+});

--- a/tests/unit/pages/settings/ReportDetailsColumnsPageTest.tsx
+++ b/tests/unit/pages/settings/ReportDetailsColumnsPageTest.tsx
@@ -45,7 +45,7 @@ jest.mocked(useOnyx).mockImplementation((key) => {
             return [undefined, {status: 'loaded'}];
     }
 });
-it('preserves filtering, defaults, saved selection, and save behavior', () => {
+it('filters unsupported saved columns, defaults invalid-only storage, and preserves save behavior', () => {
     const mixedProps = renderColumns(['invalid', CONST.SEARCH.TABLE_COLUMNS.MERCHANT, 'foreign', CONST.SEARCH.TABLE_COLUMNS.DATE]);
     expect(mixedProps.currentColumns).toEqual([CONST.SEARCH.TABLE_COLUMNS.MERCHANT, CONST.SEARCH.TABLE_COLUMNS.DATE]);
     const defaultProps = renderColumns(['invalid', 'foreign']);

--- a/tests/unit/pages/settings/ReportDetailsColumnsPageTest.tsx
+++ b/tests/unit/pages/settings/ReportDetailsColumnsPageTest.tsx
@@ -1,0 +1,60 @@
+import {render} from '@testing-library/react-native';
+
+import ColumnsSettingsList from '@components/ColumnsSettingsList';
+
+import useOnyx from '@hooks/useOnyx';
+
+import {setReportDetailsColumns} from '@libs/actions/ReportLayout';
+import Navigation from '@libs/Navigation/Navigation';
+
+import ReportDetailsColumnsPage from '@pages/settings/Report/ReportDetailsColumnsPage';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import type * as ReactNavigation from '@react-navigation/native';
+
+import {useRoute} from '@react-navigation/native';
+import React from 'react';
+
+jest.mock('@components/ColumnsSettingsList', () => jest.fn(() => null));
+jest.mock('@hooks/useCurrentUserPersonalDetails', () => jest.fn(() => ({accountID: 1})));
+jest.mock('@hooks/useOnyx', () => jest.fn());
+jest.mock('@expensify/react-native-hybrid-app', () => ({__esModule: true, default: {isHybridApp: jest.fn(() => false)}}));
+jest.mock('@libs/actions/ReportLayout', () => ({setReportDetailsColumns: jest.fn()}));
+jest.mock('@libs/Navigation/Navigation', () => ({goBack: jest.fn()}));
+jest.mock('@react-navigation/native', () => ({...jest.requireActual<typeof ReactNavigation>('@react-navigation/native'), useRoute: jest.fn()}));
+let mockSavedColumns: string[] | undefined;
+function renderColumns(savedColumns: string[] | undefined) {
+    mockSavedColumns = savedColumns;
+    render(<ReportDetailsColumnsPage />);
+    const props = jest.mocked(ColumnsSettingsList).mock.calls.at(-1)?.at(0);
+    if (!props) {
+        throw new Error('Expected the rendered columns-list boundary');
+    }
+    return props;
+}
+jest.mocked(useRoute).mockReturnValue({key: 'columns', name: 'columns', params: {reportID: 'report-1'}});
+jest.mocked(useOnyx).mockImplementation((key) => {
+    switch (key) {
+        case ONYXKEYS.NVP_REPORT_DETAILS_COLUMNS:
+            return [mockSavedColumns, {status: 'loaded'}];
+        case ONYXKEYS.COLLECTION.TRANSACTION:
+            return [[], {status: 'loaded'}];
+        default:
+            return [undefined, {status: 'loaded'}];
+    }
+});
+it('preserves filtering, defaults, saved selection, and save behavior', () => {
+    const mixedProps = renderColumns(['invalid', CONST.SEARCH.TABLE_COLUMNS.MERCHANT, 'foreign', CONST.SEARCH.TABLE_COLUMNS.DATE]);
+    expect(mixedProps.currentColumns).toEqual([CONST.SEARCH.TABLE_COLUMNS.MERCHANT, CONST.SEARCH.TABLE_COLUMNS.DATE]);
+    const defaultProps = renderColumns(['invalid', 'foreign']);
+    expect([defaultProps.currentColumns, defaultProps.currentColumns.includes(CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT)]).toEqual([defaultProps.defaultSelectedColumns, true]);
+    const savedColumns = [CONST.SEARCH.TABLE_COLUMNS.DATE, CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT];
+    const props = renderColumns(savedColumns);
+    expect([props.currentColumns, jest.mocked(setReportDetailsColumns).mock.calls.length]).toEqual([mockSavedColumns, 0]);
+    props.onSave(savedColumns);
+    props.onSave([CONST.SEARCH.TABLE_COLUMNS.MERCHANT, CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT]);
+    expect(jest.mocked(setReportDetailsColumns)).toHaveBeenCalledWith([CONST.SEARCH.TABLE_COLUMNS.MERCHANT, CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT], mockSavedColumns);
+    expect(jest.mocked(Navigation.goBack)).toHaveBeenCalledTimes(2);
+});

--- a/tests/unit/pages/workspace/accounting/certinia/CertiniaPrerequisitesStepTest.tsx
+++ b/tests/unit/pages/workspace/accounting/certinia/CertiniaPrerequisitesStepTest.tsx
@@ -1,8 +1,7 @@
 import {render} from '@testing-library/react-native';
 
 import Button from '@components/ButtonComposed';
-import type FixedFooter from '@components/FixedFooter';
-import type ScrollView from '@components/ScrollView';
+import type {ScrollViewProps} from '@components/ScrollView';
 import TextLink from '@components/TextLink';
 
 import useLocalize from '@hooks/useLocalize';
@@ -24,16 +23,15 @@ jest.mock('@components/ButtonComposed', () => ({
         {KeyboardShortcut: jest.fn(() => null), Text: jest.fn(() => null)},
     ),
 }));
-jest.mock('@components/FixedFooter', () => jest.fn((props: React.ComponentProps<typeof FixedFooter>) => props.children));
-jest.mock('@components/ScrollView', () => jest.fn((props: React.ComponentProps<typeof ScrollView>) => props.children));
+jest.mock('@components/FixedFooter', () => jest.fn((props: React.PropsWithChildren) => props.children));
+jest.mock('@components/ScrollView', () => jest.fn((props: ScrollViewProps) => props.children));
 jest.mock('@components/TextLink', () => jest.fn(() => null));
 jest.mock('@expensify/react-native-hybrid-app', () => ({__esModule: true, default: {isHybridApp: jest.fn(() => false)}}));
 jest.mock('@hooks/useLocalize', () => jest.fn());
 jest.mock('@hooks/useNetwork', () => jest.fn());
 jest.mock('@hooks/useThemeStyles', () => jest.fn(() => ({})));
 const mockLocalize = createMock<ReturnType<typeof useLocalize>>({translate: translateLocal});
-const mockTranslate = jest.spyOn(mockLocalize, 'translate');
-const [mockOnNext, mockOnConnect] = [jest.fn(), jest.fn()];
+const [mockTranslate, mockOnNext, mockOnConnect] = [jest.spyOn(mockLocalize, 'translate'), jest.fn(), jest.fn()];
 const baseProps = {isEditing: false, onNext: mockOnNext, onMove: jest.fn(), onConnect: mockOnConnect, isSandbox: true};
 function renderStep(currentPageName?: string) {
     render(React.createElement(CertiniaPrerequisitesStep, {...baseProps, currentPageName}));
@@ -46,7 +44,7 @@ function renderStep(currentPageName?: string) {
 jest.mocked(useLocalize).mockReturnValue(mockLocalize);
 jest.mocked(useNetwork).mockReturnValue({isOffline: false});
 beforeEach(() => jest.clearAllMocks());
-it.each([undefined, 'foreign', CONST.CERTINIA_PREREQUISITES.PAGE_NAME.INSTALL_BUNDLE])('uses complete install-bundle behavior for %s', (pageName) => {
+it.each([undefined, 'foreign', CONST.CERTINIA_PREREQUISITES.PAGE_NAME.INSTALL_BUNDLE])('uses the intentional complete install-bundle fallback for %s', (pageName) => {
     const button = renderStep(pageName);
     expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.installBundle');
     expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.installBundleDescription');

--- a/tests/unit/pages/workspace/accounting/certinia/CertiniaPrerequisitesStepTest.tsx
+++ b/tests/unit/pages/workspace/accounting/certinia/CertiniaPrerequisitesStepTest.tsx
@@ -1,0 +1,72 @@
+import {render} from '@testing-library/react-native';
+
+import Button from '@components/ButtonComposed';
+import type FixedFooter from '@components/FixedFooter';
+import type ScrollView from '@components/ScrollView';
+import TextLink from '@components/TextLink';
+
+import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
+
+import CertiniaPrerequisitesStep from '@pages/workspace/accounting/certinia/prerequisites/CertiniaPrerequisitesStep';
+
+import CONST from '@src/CONST';
+
+import React from 'react';
+
+import createMock from '../../../../../utils/createMock';
+import {translateLocal} from '../../../../../utils/TestHelper';
+
+jest.mock('@components/ButtonComposed', () => ({
+    __esModule: true,
+    default: Object.assign(
+        jest.fn(() => null),
+        {KeyboardShortcut: jest.fn(() => null), Text: jest.fn(() => null)},
+    ),
+}));
+jest.mock('@components/FixedFooter', () => jest.fn((props: React.ComponentProps<typeof FixedFooter>) => props.children));
+jest.mock('@components/ScrollView', () => jest.fn((props: React.ComponentProps<typeof ScrollView>) => props.children));
+jest.mock('@components/TextLink', () => jest.fn(() => null));
+jest.mock('@expensify/react-native-hybrid-app', () => ({__esModule: true, default: {isHybridApp: jest.fn(() => false)}}));
+jest.mock('@hooks/useLocalize', () => jest.fn());
+jest.mock('@hooks/useNetwork', () => jest.fn());
+jest.mock('@hooks/useThemeStyles', () => jest.fn(() => ({})));
+const mockLocalize = createMock<ReturnType<typeof useLocalize>>({translate: translateLocal});
+const mockTranslate = jest.spyOn(mockLocalize, 'translate');
+const [mockOnNext, mockOnConnect] = [jest.fn(), jest.fn()];
+const baseProps = {isEditing: false, onNext: mockOnNext, onMove: jest.fn(), onConnect: mockOnConnect, isSandbox: true};
+function renderStep(currentPageName?: string) {
+    render(React.createElement(CertiniaPrerequisitesStep, {...baseProps, currentPageName}));
+    const buttonProps = jest.mocked(Button).mock.calls.at(-1)?.[0];
+    if (!buttonProps) {
+        throw new Error('Expected the rendered prerequisite action');
+    }
+    return buttonProps;
+}
+jest.mocked(useLocalize).mockReturnValue(mockLocalize);
+jest.mocked(useNetwork).mockReturnValue({isOffline: false});
+beforeEach(() => jest.clearAllMocks());
+it.each([undefined, 'foreign', CONST.CERTINIA_PREREQUISITES.PAGE_NAME.INSTALL_BUNDLE])('uses complete install-bundle behavior for %s', (pageName) => {
+    const button = renderStep(pageName);
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.installBundle');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.installBundleDescription');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.installBundleConfirm');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.installBundlePSALink', {version: CONST.CERTINIA_PSA_BUNDLE_VERSION});
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.installBundleFFALink', {version: CONST.CERTINIA_FFA_BUNDLE_VERSION});
+    expect(jest.mocked(TextLink).mock.calls.map(([props]) => props.href)).toEqual([CONST.CERTINIA_PSA_BUNDLE_INSTALL_URL.SANDBOX, CONST.CERTINIA_FFA_BUNDLE_INSTALL_URL.SANDBOX]);
+    expect(button.onPress).toBe(mockOnNext);
+});
+it('preserves setup-contact and OAuth content, actions, and offline state', () => {
+    const setupButton = renderStep(CONST.CERTINIA_PREREQUISITES.PAGE_NAME.SETUP_CONTACTS);
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.setupContacts');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.setupContactsBullet1');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.setupContactsBullet2');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.setupContactsBullet3');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.setupContactsConfirm');
+    expect(setupButton.onPress).toBe(mockOnNext);
+    jest.mocked(useNetwork).mockReturnValue({isOffline: true});
+    const oauthButton = renderStep(CONST.CERTINIA_PREREQUISITES.PAGE_NAME.OAUTH);
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.oauthDescription');
+    expect(mockTranslate).toHaveBeenCalledWith('workspace.certinia.prerequisites.connectButton');
+    expect([oauthButton.onPress, oauthButton.isDisabled]).toEqual([mockOnConnect, true]);
+});


### PR DESCRIPTION
### Explanation of Change

This PR removes unsafe type assertions from receipt scanning, USD bank-account setup, saved searches, report columns, and Certinia prerequisites.

Receipt files are checked before use. Bank-account setup can continue when no workspace policy is available. Saved-search card IDs use exact matching, unsupported saved report columns are ignored, and unknown Certinia prerequisite routes use the existing installation fallback.

Existing behavior remains unchanged for valid receipts, workspace-linked bank accounts, valid search values, supported report columns, and known Certinia pages.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Count change

15 → 0 targeted unsafe type assertions (15 removed).

### Changed files

- Receipt scanning: `src/hooks/useReceiptScanDrop.tsx`, `tests/unit/hooks/useReceiptScanDrop.test.ts`
- Bank-account setup: `src/libs/actions/BankAccounts.ts`, `src/pages/ReimbursementAccount/USD/BankInfo/BankInfo.tsx`, `src/pages/ReimbursementAccount/USD/USDVerifiedBankAccountFlowPage.tsx`, `tests/unit/pages/USDVerifiedBankAccountFlowPageTest.tsx`
- Saved searches and report columns: `src/pages/Search/SearchSavePage.tsx`, `src/pages/settings/Report/ReportDetailsColumnsPage.tsx`, `tests/unit/pages/Search/SearchSavePageTest.tsx`, `tests/unit/pages/settings/ReportDetailsColumnsPageTest.tsx`
- Certinia prerequisites: `src/pages/workspace/accounting/certinia/prerequisites/CertiniaPrerequisitesStep.tsx`, `tests/unit/pages/workspace/accounting/certinia/CertiniaPrerequisitesStepTest.tsx`

### Tests

- `tests/unit/hooks/useReceiptScanDrop.test.ts`
- `tests/unit/pages/Search/SearchSavePageTest.tsx`
- `tests/unit/pages/USDVerifiedBankAccountFlowPageTest.tsx`
- `tests/unit/pages/settings/ReportDetailsColumnsPageTest.tsx`
- `tests/unit/pages/workspace/accounting/certinia/CertiniaPrerequisitesStepTest.tsx`

All five focused suites passed: 13 tests.

- [x] Verify that no errors appear in the JS console

### QA Steps

1. On web, drag one receipt and then multiple receipts into an eligible report. Verify they remain in order, attach to the correct transactions, and navigate normally.
2. Resume USD bank-account setup without a workspace policy. Verify the Bank info step opens and can continue through both Plaid and manual connection paths.
3. Save a search using a card ID that is contained inside another card ID. Verify only the exact selected card is shown, and verify feed and tax-rate labels remain correct.
4. Open report-column settings with valid and unsupported saved columns. Verify valid columns remain selected and unsupported values are removed.
5. Open the Certinia prerequisite pages. Verify known pages retain their content and an unknown route shows the existing installation fallback.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Open the Certinia OAuth prerequisite while online.
2. Disconnect from the network.
3. Verify the content remains visible and the OAuth action is disabled.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — N/A: no visual UI changes
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (no user-facing copy was added).
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (focused tests cover both forms that use this component)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (no style was added)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (no asset was added or modified)
    - [x] The assets load correctly across all supported platforms (no asset was added or modified)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown. (Not applicable: no message-editing or sending code changed.)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App. (Not applicable: this component is limited to the two tested agreement flows.)
- [x] If the PR modifies a component related to any existing Storybook stories, I tested and verified those stories. (Not applicable: no matching Storybook story is changed.)
- [x] If the PR modifies a component or page accessible by a direct deeplink, I verified it while logged in and logged out. (Not applicable: the Agreements step requires an authenticated setup flow.)
- [x] If the PR modifies the UI or form input styles:
    - [x] I verified that form inputs remain aligned. (Not applicable: no visual style changed.)
    - [x] I added `Design` label or tagged `@Expensify/design`. (Not applicable: no visual UI changed.)
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for this change.
- [x] If `main` was merged into this PR after review, I tested again. (Not applicable: `main` was not merged after review.)

### Screenshots/Videos

The supplied functional QA recording and remaining checks are listed below.

<details>
<summary>Android: Native</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>iOS: Native</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A: no visual UI changes.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/a0b497d4-f66c-42dc-9716-7f60b6ddfeac

</details>
