### PR TITLE
[CP Staging] fix: gate Download receipts on receipt presence in Search

### DIFF
--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -2382,15 +2382,16 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         }
 
         const isExpenseSearch = queryJSON?.type === CONST.SEARCH.DATA_TYPES.EXPENSE || searchResults?.search.type === CONST.SEARCH.DATA_TYPES.EXPENSE;
-        // A group selected before its children load is stored under a group_ key, which is not a real
-        // transaction ID. Drop those keys so ExportReceiptsToZip only receives valid transaction IDs.
-        const transactionIDs = selectedTransactionsKeys.filter((key) => !key.startsWith(CONST.SEARCH.GROUP_PREFIX));
-        if (
-            isExpenseSearch &&
-            selectedTransactionsKeys.length > 0 &&
-            transactionIDs.length > 0 &&
-            Object.values(selectedTransactions).some(({transaction}) => hasReceiptTransactionUtils(transaction))
-        ) {
+        // Only export transactions that have a downloadable receipt. Drop group_ keys (a group selected before its
+        // children load is not a real transaction ID) and deleted transactions so ExportReceiptsToZip gets a clean set.
+        const transactionIDs = selectedTransactionsKeys.filter((key) => {
+            if (key.startsWith(CONST.SEARCH.GROUP_PREFIX)) {
+                return false;
+            }
+            const selected = selectedTransactions[key];
+            return hasReceiptTransactionUtils(selected?.transaction) && !isDeletedTransaction(selected ?? {});
+        });
+        if (isExpenseSearch && transactionIDs.length > 0) {
             options.push({
                 icon: expensifyIcons.Download,
                 text: translate('common.downloadReceipts'),

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -77,6 +77,7 @@ import {
     getOriginalTransactionWithSplitInfo,
     hasCustomUnitOutOfPolicyViolation,
     hasOnlyPendingCardTransactions,
+    hasReceipt as hasReceiptTransactionUtils,
     hasTransactionBeenRejected,
     isDeletedTransaction,
     isDistanceRequest,
@@ -2360,8 +2361,10 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
             });
         }
 
-        const hasSelectedReportsWithExpenses = selectedReports.some((report) => (currentSearchResults?.data?.[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`]?.transactionCount ?? 0) > 0);
-        if (isExpenseReportSearch && selectedReportIDs.length > 0 && hasSelectedReportsWithExpenses) {
+        const hasSelectedReportsWithReceipts = Object.values(allTransactions ?? {}).some(
+            (transaction) => !!transaction && selectedReports.some((report) => report.reportID === transaction.reportID) && hasReceiptTransactionUtils(transaction),
+        );
+        if (isExpenseReportSearch && selectedReportIDs.length > 0 && hasSelectedReportsWithReceipts) {
             options.push({
                 icon: expensifyIcons.Download,
                 text: translate('common.downloadReceipts'),
@@ -2382,7 +2385,12 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         // A group selected before its children load is stored under a group_ key, which is not a real
         // transaction ID. Drop those keys so ExportReceiptsToZip only receives valid transaction IDs.
         const transactionIDs = selectedTransactionsKeys.filter((key) => !key.startsWith(CONST.SEARCH.GROUP_PREFIX));
-        if (isExpenseSearch && selectedTransactionsKeys.length > 0 && transactionIDs.length > 0) {
+        if (
+            isExpenseSearch &&
+            selectedTransactionsKeys.length > 0 &&
+            transactionIDs.length > 0 &&
+            Object.values(selectedTransactions).some(({transaction}) => hasReceiptTransactionUtils(transaction))
+        ) {
             options.push({
                 icon: expensifyIcons.Download,
                 text: translate('common.downloadReceipts'),

--- a/tests/unit/hooks/useSearchBulkActionsDownloadReceiptsTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsDownloadReceiptsTest.ts
@@ -11,7 +11,7 @@ import {exportReceiptsToZip} from '@libs/actions/Export';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Report, SearchResults} from '@src/types/onyx';
+import type {Report, SearchResults, Transaction} from '@src/types/onyx';
 
 import Onyx from 'react-native-onyx';
 
@@ -162,6 +162,19 @@ function makeSelectedReport(overrides: Partial<SelectedReports> = {}): SelectedR
     };
 }
 
+// Builds a Transaction, optionally carrying a receipt. hasReceipt() treats a truthy receipt.state as a downloadable receipt.
+function makeTransaction(transactionID: string, reportID: string, withReceipt = true): Transaction {
+    return {
+        transactionID,
+        reportID,
+        amount: 100,
+        currency: 'USD',
+        created: '2024-01-01',
+        merchant: '',
+        ...(withReceipt ? {receipt: {state: CONST.IOU.RECEIPT_STATE.SCAN_COMPLETE}} : {}),
+    } as Transaction;
+}
+
 function makeSelectedTransaction(overrides: Partial<SelectedTransactions[string]> = {}): SelectedTransactions[string] {
     return {
         isSelected: true,
@@ -178,22 +191,24 @@ function makeSelectedTransaction(overrides: Partial<SelectedTransactions[string]
         amount: 100,
         currency: 'USD',
         isFromOneTransactionReport: false,
+        transaction: makeTransaction('tx', '1'),
         ...overrides,
     };
 }
 
-// Builds a search snapshot whose report entries carry a transactionCount, which the Reports-page action uses to
-// decide whether any selected report has expenses (and therefore receipts) to download.
-function makeReportSearchResults(reports: Array<{reportID: string; transactionCount: number}>): SearchResults {
+// Builds a search snapshot whose report entries each get one transaction. The Reports-page action decides whether to
+// show "Download receipts" by looking for a selected report whose transaction actually has a receipt (withReceipt).
+function makeReportSearchResults(reports: Array<{reportID: string; withReceipt: boolean}>): SearchResults {
     const data: SearchResults['data'] = {};
     for (const report of reports) {
         const reportEntry: Report = {
             reportID: report.reportID,
-            transactionCount: report.transactionCount,
             type: CONST.REPORT.TYPE.EXPENSE,
             reportName: `Report ${report.reportID}`,
         };
         data[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = reportEntry;
+        const transactionID = `srchtx_${report.reportID}`;
+        data[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`] = makeTransaction(transactionID, report.reportID, report.withReceipt);
     }
     return {
         data,
@@ -250,10 +265,10 @@ describe('useSearchBulkActions - Download receipts', () => {
     });
 
     describe('Reports page (expense-report search)', () => {
-        it('shows the option when a selected report has expenses', async () => {
+        it('shows the option when a selected report has a receipt', async () => {
             mockSelectedReports = [makeSelectedReport()];
             mockSelectedTransactions = {tx1: makeSelectedTransaction()};
-            mockCurrentSearchResults = makeReportSearchResults([{reportID: '1', transactionCount: 2}]);
+            mockCurrentSearchResults = makeReportSearchResults([{reportID: '1', withReceipt: true}]);
 
             const {result} = renderHookWithProvider(() => useSearchBulkActions({queryJSON: expenseReportQueryJSON}));
 
@@ -262,10 +277,10 @@ describe('useSearchBulkActions - Download receipts', () => {
             });
         });
 
-        it('hides the option when every selected report has no expenses', async () => {
+        it('hides the option when no selected report has a receipt', async () => {
             mockSelectedReports = [makeSelectedReport()];
             mockSelectedTransactions = {tx1: makeSelectedTransaction()};
-            mockCurrentSearchResults = makeReportSearchResults([{reportID: '1', transactionCount: 0}]);
+            mockCurrentSearchResults = makeReportSearchResults([{reportID: '1', withReceipt: false}]);
 
             const {result} = renderHookWithProvider(() => useSearchBulkActions({queryJSON: expenseReportQueryJSON}));
 
@@ -285,8 +300,8 @@ describe('useSearchBulkActions - Download receipts', () => {
             mockSelectedReports = [makeSelectedReport(), makeSelectedReport({reportID: '2'})];
             mockSelectedTransactions = {tx1: makeSelectedTransaction(), tx2: makeSelectedTransaction({reportID: '2'})};
             mockCurrentSearchResults = makeReportSearchResults([
-                {reportID: '1', transactionCount: 2},
-                {reportID: '2', transactionCount: 0},
+                {reportID: '1', withReceipt: true},
+                {reportID: '2', withReceipt: false},
             ]);
 
             const {result} = renderHookWithProvider(() => useSearchBulkActions({queryJSON: expenseReportQueryJSON}));
@@ -308,7 +323,7 @@ describe('useSearchBulkActions - Download receipts', () => {
             mockIsOffline = true;
             mockSelectedReports = [makeSelectedReport()];
             mockSelectedTransactions = {tx1: makeSelectedTransaction()};
-            mockCurrentSearchResults = makeReportSearchResults([{reportID: '1', transactionCount: 2}]);
+            mockCurrentSearchResults = makeReportSearchResults([{reportID: '1', withReceipt: true}]);
 
             const {result} = renderHookWithProvider(() => useSearchBulkActions({queryJSON: expenseReportQueryJSON}));
 
@@ -362,6 +377,20 @@ describe('useSearchBulkActions - Download receipts', () => {
 
             expect(exportReceiptsToZip).toHaveBeenCalledTimes(1);
             expect(exportReceiptsToZip).toHaveBeenCalledWith({transactionIDs: ['tx1']});
+        });
+
+        it('hides the option when no selected transaction has a receipt', async () => {
+            mockSelectedTransactions = {
+                tx1: makeSelectedTransaction({transaction: makeTransaction('tx1', '1', false)}),
+                tx2: makeSelectedTransaction({reportID: '1', transaction: makeTransaction('tx2', '1', false)}),
+            };
+
+            const {result} = renderHookWithProvider(() => useSearchBulkActions({queryJSON: expenseQueryJSON}));
+
+            await waitFor(() => {
+                expect(result.current.headerButtonsOptions.length).toBeGreaterThan(0);
+            });
+            expect(getDownloadReceiptsOption(result.current.headerButtonsOptions)).toBeUndefined();
         });
 
         it('hides the option when only group_ keys are selected', async () => {

--- a/tests/unit/hooks/useSearchBulkActionsDownloadReceiptsTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsDownloadReceiptsTest.ts
@@ -393,6 +393,26 @@ describe('useSearchBulkActions - Download receipts', () => {
             expect(getDownloadReceiptsOption(result.current.headerButtonsOptions)).toBeUndefined();
         });
 
+        it('drops deleted transactions and only sends the live ones', async () => {
+            mockSelectedTransactions = {
+                tx1: makeSelectedTransaction(),
+                tx2: makeSelectedTransaction({reportID: CONST.REPORT.TRASH_REPORT_ID, transaction: makeTransaction('tx2', CONST.REPORT.TRASH_REPORT_ID)}),
+            };
+
+            const {result} = renderHookWithProvider(() => useSearchBulkActions({queryJSON: expenseQueryJSON}));
+
+            await waitFor(() => {
+                expect(getDownloadReceiptsOption(result.current.headerButtonsOptions)).toBeDefined();
+            });
+
+            await act(async () => {
+                await getDownloadReceiptsOption(result.current.headerButtonsOptions)?.onSelected?.();
+            });
+
+            expect(exportReceiptsToZip).toHaveBeenCalledTimes(1);
+            expect(exportReceiptsToZip).toHaveBeenCalledWith({transactionIDs: ['tx1']});
+        });
+
         it('hides the option when only group_ keys are selected', async () => {
             const groupKey = `${CONST.SEARCH.GROUP_PREFIX}123`;
             mockSelectedTransactions = {[groupKey]: makeSelectedTransaction({reportID: undefined})};

--- a/tests/unit/hooks/useSearchBulkActionsDownloadReceiptsTest.ts
+++ b/tests/unit/hooks/useSearchBulkActionsDownloadReceiptsTest.ts
@@ -207,7 +207,7 @@ function makeReportSearchResults(reports: Array<{reportID: string; withReceipt: 
             reportName: `Report ${report.reportID}`,
         };
         data[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = reportEntry;
-        const transactionID = `srchtx_${report.reportID}`;
+        const transactionID = `searchTransaction_${report.reportID}`;
         data[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`] = makeTransaction(transactionID, report.reportID, report.withReceipt);
     }
     return {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98833
$ https://github.com/Expensify/App/issues/98827
PROPOSAL: https://github.com/Expensify/App/issues/98833#issuecomment-5324049020


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
#### Test 1:
1. Go to staging.new.expensify.com
2. Go to workspace chat.
3. Create an expense without receipt.
4. Open the report.
5. Click More.
→ Download receipts option is hidden when there is no receipt.
6. Go to Spend > Reports or Spend > Expenses.
7. Select the report.
8. Click dropdown button.
9. Verify: Download receipts option is hidden when there is no receipt.

Test 2:
Precondition:
     - Create two expenses with receipt.
     - Delete one of the expenses.
1. Go to ND
2. Go to Spend > Expenses.
3. Open filters.
4. Go to Status.
5. Select Draft and Deleted > Apply.
6. Select the draft expense with receipt and deleted expense with receipt.
7. Click dropdown button > Download receipts.
8. Verify: "If it didn't automatically download, use the button below." message will be shown.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. ""offline"", ""spotty connection"", ""slow internet"", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write ""Same as tests"" if the QA team is able to run the tests in the above ""Tests"" section.
--->
// TODO: These must be filled out, or the issue title must include ""[No QA].""
Same as tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained ""why"" the code was doing something instead of only explaining ""what"" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named ""index.js"". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a25d8ce1-b67d-4548-acba-e31f3d634ba7

https://github.com/user-attachments/assets/2117119e-69af-4b94-b64a-7c8987fbe45e



</details>