### PR TITLE
[CP Staging] Indent GL code subtitle to match the subcategory name in list rows

### DIFF
--- a/src/components/SelectionList/ListItem/BaseSelectListItem.tsx
+++ b/src/components/SelectionList/ListItem/BaseSelectListItem.tsx
@@ -1,5 +1,6 @@
 import TextWithTooltip from '@components/TextWithTooltip';
 
+import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import variables from '@styles/variables';
@@ -41,6 +42,7 @@ function BaseSelectListItem<TItem extends ListItem>({
     selectionButtonPosition,
 }: BaseSelectListItemProps<TItem>) {
     const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
     const fullTitle = isMultilineSupported ? item.text?.trimStart() : item.text;
     const indentsLength = (item.text?.length ?? 0) - (fullTitle?.length ?? 0);
     const paddingLeft = Math.floor(indentsLength / CONST.INDENTS.length) * styles.ml3.marginLeft;
@@ -81,7 +83,7 @@ function BaseSelectListItem<TItem extends ListItem>({
                             isMultilineSupported ? styles.preWrap : styles.pre,
                             item.alternateText || item.alternateTextComponent ? styles.mb1 : null,
                             isDisabled && styles.colorMuted,
-                            isMultilineSupported ? {paddingLeft} : null,
+                            isMultilineSupported ? StyleUtils.getPaddingLeft(paddingLeft) : null,
                             titleStyles,
                             item.titleStyles,
                         ]}
@@ -98,7 +100,7 @@ function BaseSelectListItem<TItem extends ListItem>({
                                 styles.lh16,
                                 isAlternateTextMultilineSupported ? styles.preWrap : styles.pre,
                                 isAlternateTextMultilineSupported ? {maxWidth: alternateTextMaxWidth} : null,
-                                isMultilineSupported ? {paddingLeft} : null,
+                                isMultilineSupported ? StyleUtils.getPaddingLeft(paddingLeft) : null,
                             ]}
                             numberOfLines={isAlternateTextMultilineSupported ? alternateTextNumberOfLines : 1}
                         />

--- a/src/components/SelectionList/ListItem/BaseSelectListItem.tsx
+++ b/src/components/SelectionList/ListItem/BaseSelectListItem.tsx
@@ -98,6 +98,7 @@ function BaseSelectListItem<TItem extends ListItem>({
                                 styles.lh16,
                                 isAlternateTextMultilineSupported ? styles.preWrap : styles.pre,
                                 isAlternateTextMultilineSupported ? {maxWidth: alternateTextMaxWidth} : null,
+                                isMultilineSupported ? {paddingLeft} : null,
                             ]}
                             numberOfLines={isAlternateTextMultilineSupported ? alternateTextNumberOfLines : 1}
                         />


### PR DESCRIPTION
### Explanation of Change

In `BaseSelectListItem` the row indent is applied as a real `paddingLeft`, but only to the title — so the GL code in `alternateText` stayed flush left instead of lining up with the indented subcategory name. This applies the same `paddingLeft` to the alternate text. Rows without indentation are unaffected (`paddingLeft` is `0` for them).

### Fixed Issues

$ [https://github.com/Expensify/App/issues/93155](<https://github.com/Expensify/App/issues/93155>)  
$ https://github.com/Expensify/App/issues/98828

PROPOSAL: [https://github.com/Expensify/App/issues/93155#issuecomment-5077497484](<https://github.com/Expensify/App/issues/93155#issuecomment-5077497484>)


### Tests

Precondition: Control workspace with **Show GL codes when categorizing expenses** enabled, and categories `Lunch: Sushi` and `Lunch: Sushi: Nigiri`, each with a GL code.

1. Workspace chat > **+** > **Create expense** > **Manual** > enter an amount > **Next** > **Category**.
2. Verify each GL code starts at the same left edge as its indented subcategory name, at both nesting levels.
3. Search for `Sushi` and verify the alignment holds in the results.
4. Open a tag picker and the workspace members list, and verify their subtitles are unchanged.

- [x] Verify that no errors appear in the JS console

### Offline tests

Layout-only change, rendered from Onyx.

1. Go offline and repeat steps 1–2 above.
2. Verify the GL codes are still aligned.

### QA Steps

Precondition: Control workspace with **Show GL codes when categorizing expenses** enabled, and category `Lunch: Sushi` with a GL code.

1. Workspace chat > **+** > **Create expense** > **Manual** > enter an amount > **Next** > **Category**.
2. Scroll to the `Sushi` subcategory.
3. Verify its GL code starts at the same left edge as `Sushi` instead of being flush left.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
After fix:

https://github.com/user-attachments/assets/2e393d4c-ca38-4a25-8f79-13dea4fda1ca




</details>
