### PR TITLE
[No QA] Fix is_warm labeling on report-open spans

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -6,7 +6,6 @@ import {useIsReportLoadPending} from '@hooks/useInFlightRequests';
 import useIsReportActionsLoaded from '@hooks/useIsReportActionsLoaded';
 import useLoadReportActions from '@hooks/useLoadReportActions';
 import useLocalize from '@hooks/useLocalize';
-import useMarkOpenReportEndOnSkeleton from '@hooks/useMarkOpenReportEndOnSkeleton';
 import useNetworkWithOfflineStatus from '@hooks/useNetworkWithOfflineStatus';
 import useNewTransactions from '@hooks/useNewTransactions';
 import useOnyx from '@hooks/useOnyx';
@@ -212,9 +211,6 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
 
         return filteredActions.slice().reverse();
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
-
-    const shouldShowOpenReportLoadingSkeleton = isInitialReportLoadPending && visibleReportActions.length === 0;
-    useMarkOpenReportEndOnSkeleton(reportIDFromRoute, shouldShowOpenReportLoadingSkeleton);
 
     const lastAction = visibleReportActions.at(-1);
 
@@ -732,8 +728,8 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
 
         didLayout.current = true;
 
-        markOpenReportEnd(reportIDFromRoute, report, {warm: !shouldShowOpenReportLoadingSkeleton});
-    }, [reportIDFromRoute, report, shouldShowOpenReportLoadingSkeleton]);
+        markOpenReportEnd(reportIDFromRoute, report, {warm: true});
+    }, [reportIDFromRoute, report]);
 
     const isReportEmpty = isEmpty(visibleReportActions) && isEmpty(transactions) && !isInitialReportLoadPending;
     const showEmptyState = isReportEmpty;

--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -214,7 +214,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
     }, [reportActions, isOffline, canPerformWriteAction, reportTransactionIDs, shouldShowHarvestCreatedAction, visibleReportActionsData, reportID]);
 
     const shouldShowOpenReportLoadingSkeleton = isInitialReportLoadPending && visibleReportActions.length === 0;
-    useMarkOpenReportEndOnSkeleton(report, shouldShowOpenReportLoadingSkeleton);
+    useMarkOpenReportEndOnSkeleton(reportIDFromRoute, shouldShowOpenReportLoadingSkeleton);
 
     const lastAction = visibleReportActions.at(-1);
 
@@ -726,14 +726,14 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
      * Runs when the FlatList finishes laying out
      */
     const recordTimeToMeasureItemLayout = useCallback(() => {
-        if (didLayout.current || !report) {
+        if (didLayout.current || !reportIDFromRoute) {
             return;
         }
 
         didLayout.current = true;
 
-        markOpenReportEnd(report, {warm: !shouldShowOpenReportLoadingSkeleton});
-    }, [report, shouldShowOpenReportLoadingSkeleton]);
+        markOpenReportEnd(reportIDFromRoute, report, {warm: !shouldShowOpenReportLoadingSkeleton});
+    }, [reportIDFromRoute, report, shouldShowOpenReportLoadingSkeleton]);
 
     const isReportEmpty = isEmpty(visibleReportActions) && isEmpty(transactions) && !isInitialReportLoadPending;
     const showEmptyState = isReportEmpty;

--- a/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
@@ -210,7 +210,7 @@ function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, 
 
     const shouldShowEmptyActionsSkeleton = reportActions.length === 0;
     const shouldShowAppLoadSkeleton = !!report && isAppLoadPending;
-    // Route id, not report?.reportID: these skeletons render before the report lands in Onyx.
+    // These skeletons render before the report lands in Onyx, so the mark uses the route id.
     useMarkOpenReportEndOnSkeleton(reportIDFromRoute, shouldShowOpenReportLoadingSkeleton || shouldShowEmptyActionsSkeleton || shouldShowAppLoadSkeleton);
 
     if (shouldShowOpenReportLoadingSkeleton) {

--- a/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
@@ -205,13 +205,15 @@ function MoneyRequestReportView({report, reportLoadingState, shouldDisplayReport
         };
     }, [reportID]);
 
-    useMarkOpenReportEndOnSkeleton(report, shouldShowOpenReportLoadingSkeleton);
+    const shouldShowEmptyActionsSkeleton = reportActions.length === 0;
+    const shouldShowAppLoadSkeleton = !!report && isAppLoadPending;
+    useMarkOpenReportEndOnSkeleton(reportID, shouldShowOpenReportLoadingSkeleton || shouldShowEmptyActionsSkeleton || shouldShowAppLoadSkeleton);
 
     if (shouldShowOpenReportLoadingSkeleton) {
         return <InitialLoadingSkeleton styles={styles} />;
     }
 
-    if (reportActions.length === 0) {
+    if (shouldShowEmptyActionsSkeleton) {
         return <ReportActionsSkeletonView shouldAnimate={false} />;
     }
 
@@ -219,7 +221,7 @@ function MoneyRequestReportView({report, reportLoadingState, shouldDisplayReport
         return;
     }
 
-    if (isAppLoadPending) {
+    if (shouldShowAppLoadSkeleton) {
         return (
             <View style={styles.flex1}>
                 <ReportHeaderSkeletonView />

--- a/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
@@ -56,6 +56,9 @@ type MoneyRequestReportViewProps = {
     /** The report */
     report: OnyxEntry<OnyxTypes.Report>;
 
+    /** Report ID from the route, known before the report itself loads */
+    reportIDFromRoute: string | undefined;
+
     /** Loading state for report */
     reportLoadingState: OnyxEntry<OnyxTypes.ReportLoadingState>;
 
@@ -110,7 +113,7 @@ function InitialLoadingSkeleton({styles, onLayout}: {styles: ThemeStyles; onLayo
     );
 }
 
-function MoneyRequestReportView({report, reportLoadingState, shouldDisplayReportFooter, backToRoute, onLayout}: MoneyRequestReportViewProps) {
+function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, shouldDisplayReportFooter, backToRoute, onLayout}: MoneyRequestReportViewProps) {
     const styles = useThemeStyles();
     const {isOffline} = useNetwork();
 
@@ -207,7 +210,8 @@ function MoneyRequestReportView({report, reportLoadingState, shouldDisplayReport
 
     const shouldShowEmptyActionsSkeleton = reportActions.length === 0;
     const shouldShowAppLoadSkeleton = !!report && isAppLoadPending;
-    useMarkOpenReportEndOnSkeleton(reportID, shouldShowOpenReportLoadingSkeleton || shouldShowEmptyActionsSkeleton || shouldShowAppLoadSkeleton);
+    // Route id, not report?.reportID: these skeletons render before the report lands in Onyx.
+    useMarkOpenReportEndOnSkeleton(reportIDFromRoute, shouldShowOpenReportLoadingSkeleton || shouldShowEmptyActionsSkeleton || shouldShowAppLoadSkeleton);
 
     if (shouldShowOpenReportLoadingSkeleton) {
         return <InitialLoadingSkeleton styles={styles} />;

--- a/src/hooks/useMarkOpenReportEndOnSkeleton.ts
+++ b/src/hooks/useMarkOpenReportEndOnSkeleton.ts
@@ -9,7 +9,7 @@ import useOnyx from './useOnyx';
 
 /**
  * Closes the open-report span as a cold open (`warm: false`) while a skeleton shows. Call it from a component
- * mounted exactly while the skeleton is on screen — the list body that would otherwise close the span isn't
+ * mounted exactly while the skeleton is on screen. The list body that would otherwise close the span isn't
  * mounted yet.
  */
 function useMarkOpenReportEndOnSkeleton(reportID: string | undefined, isSkeletonVisible = true) {

--- a/src/hooks/useMarkOpenReportEndOnSkeleton.ts
+++ b/src/hooks/useMarkOpenReportEndOnSkeleton.ts
@@ -1,24 +1,26 @@
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import markOpenReportEnd from '@libs/telemetry/markOpenReportEnd';
 
-import type * as OnyxTypes from '@src/types/onyx';
-
-import type {OnyxEntry} from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 import {useEffect} from 'react';
 
+import useOnyx from './useOnyx';
+
 /**
- * Closes the open-report performance span as a cold open (`warm: false`) the moment a cold-load skeleton
- * appears. Shared by every report surface that gates its own skeleton (the chat-list guard, the route
- * orchestrator, and the money-request views): the open-report span must still close even though the list
- * body — which would otherwise own this mark once mounted — isn't mounted while the skeleton shows.
+ * Closes the open-report span as a cold open (`warm: false`) while a skeleton shows. Call it from a component
+ * mounted exactly while the skeleton is on screen — the list body that would otherwise close the span isn't
+ * mounted yet.
  */
-function useMarkOpenReportEndOnSkeleton(report: OnyxEntry<OnyxTypes.Report>, isSkeletonVisible: boolean) {
+function useMarkOpenReportEndOnSkeleton(reportID: string | undefined, isSkeletonVisible = true) {
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
+
     useEffect(() => {
-        if (!isSkeletonVisible || !report) {
+        if (!isSkeletonVisible || !reportID) {
             return;
         }
-        markOpenReportEnd(report, {warm: false});
-    }, [report, isSkeletonVisible]);
+        markOpenReportEnd(reportID, report, {warm: false});
+    }, [reportID, report, isSkeletonVisible]);
 }
 
 export default useMarkOpenReportEndOnSkeleton;

--- a/src/libs/telemetry/markOpenReportEnd.ts
+++ b/src/libs/telemetry/markOpenReportEnd.ts
@@ -17,17 +17,18 @@ type MarkOpenReportEndOptions = {
  * hasn't loaded. The report-shape attributes are then left off.
  */
 function markOpenReportEnd(reportID: string, report: OnyxEntry<OnyxTypes.Report>, options: MarkOpenReportEndOptions = {}) {
-    const isTransactionThread = isReportTransactionThread(report);
-    const isOneTransactionThread = isOneTransactionReport(report);
-
     const spanId = `${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`;
 
-    const attributes: SpanAttributes = {
-        [CONST.TELEMETRY.ATTRIBUTE_IS_TRANSACTION_THREAD]: isTransactionThread,
-        [CONST.TELEMETRY.ATTRIBUTE_IS_ONE_TRANSACTION_REPORT]: isOneTransactionThread,
-        [CONST.TELEMETRY.ATTRIBUTE_REPORT_TYPE]: report?.type,
-        [CONST.TELEMETRY.ATTRIBUTE_CHAT_TYPE]: report?.chatType,
-    };
+    const attributes: SpanAttributes = {};
+
+    // Cold opens close this span before the report reaches Onyx. Reading the shape off a missing report would
+    // report `false` for an unknown, so leave the attributes off and let the consumer read absence as unknown.
+    if (report) {
+        attributes[CONST.TELEMETRY.ATTRIBUTE_IS_TRANSACTION_THREAD] = isReportTransactionThread(report);
+        attributes[CONST.TELEMETRY.ATTRIBUTE_IS_ONE_TRANSACTION_REPORT] = isOneTransactionReport(report);
+        attributes[CONST.TELEMETRY.ATTRIBUTE_REPORT_TYPE] = report.type;
+        attributes[CONST.TELEMETRY.ATTRIBUTE_CHAT_TYPE] = report.chatType;
+    }
 
     if (options.warm !== undefined) {
         attributes[CONST.TELEMETRY.ATTRIBUTE_IS_WARM] = options.warm;

--- a/src/libs/telemetry/markOpenReportEnd.ts
+++ b/src/libs/telemetry/markOpenReportEnd.ts
@@ -4,6 +4,7 @@ import CONST from '@src/CONST';
 import type * as OnyxTypes from '@src/types/onyx';
 
 import type {SpanAttributes} from '@sentry/core';
+import type {OnyxEntry} from 'react-native-onyx';
 
 import {endSpanWithAttributes} from './activeSpans';
 
@@ -12,11 +13,10 @@ type MarkOpenReportEndOptions = {
 };
 
 /**
- * Mark all 'open_report*' telemetry spans as finished.
+ * Mark all 'open_report*' telemetry spans as finished. Keyed by `reportID` so it still ends when the report
+ * hasn't loaded; the report-shape attributes are then left off.
  */
-function markOpenReportEnd(report: OnyxTypes.Report, options: MarkOpenReportEndOptions = {}) {
-    const {reportID, type, chatType} = report;
-
+function markOpenReportEnd(reportID: string, report: OnyxEntry<OnyxTypes.Report>, options: MarkOpenReportEndOptions = {}) {
     const isTransactionThread = isReportTransactionThread(report);
     const isOneTransactionThread = isOneTransactionReport(report);
 
@@ -25,8 +25,8 @@ function markOpenReportEnd(report: OnyxTypes.Report, options: MarkOpenReportEndO
     const attributes: SpanAttributes = {
         [CONST.TELEMETRY.ATTRIBUTE_IS_TRANSACTION_THREAD]: isTransactionThread,
         [CONST.TELEMETRY.ATTRIBUTE_IS_ONE_TRANSACTION_REPORT]: isOneTransactionThread,
-        [CONST.TELEMETRY.ATTRIBUTE_REPORT_TYPE]: type,
-        [CONST.TELEMETRY.ATTRIBUTE_CHAT_TYPE]: chatType,
+        [CONST.TELEMETRY.ATTRIBUTE_REPORT_TYPE]: report?.type,
+        [CONST.TELEMETRY.ATTRIBUTE_CHAT_TYPE]: report?.chatType,
     };
 
     if (options.warm !== undefined) {

--- a/src/libs/telemetry/markOpenReportEnd.ts
+++ b/src/libs/telemetry/markOpenReportEnd.ts
@@ -14,7 +14,7 @@ type MarkOpenReportEndOptions = {
 
 /**
  * Mark all 'open_report*' telemetry spans as finished. Keyed by `reportID` so it still ends when the report
- * hasn't loaded; the report-shape attributes are then left off.
+ * hasn't loaded. The report-shape attributes are then left off.
  */
 function markOpenReportEnd(reportID: string, report: OnyxEntry<OnyxTypes.Report>, options: MarkOpenReportEndOptions = {}) {
     const isTransactionThread = isReportTransactionThread(report);

--- a/src/pages/Search/SearchMoneyRequestReportPage.tsx
+++ b/src/pages/Search/SearchMoneyRequestReportPage.tsx
@@ -409,6 +409,7 @@ function SearchMoneyRequestReportPage({route}: SearchMoneyRequestPageProps) {
                                 <DragAndDropProvider isDisabled={isEditingDisabled}>
                                     <MoneyRequestReportView
                                         report={report}
+                                        reportIDFromRoute={reportIDFromRoute}
                                         reportLoadingState={reportLoadingState}
                                         shouldDisplayReportFooter={isCurrentReportLoadedFromOnyx}
                                         key={report?.reportID}

--- a/src/pages/inbox/ReportActions.tsx
+++ b/src/pages/inbox/ReportActions.tsx
@@ -118,7 +118,7 @@ function ReportActionsWithInboxTabDeferredMount({reportID, shouldDefer}: ReportA
         <NavigationDeferredMount
             waitForUpcomingTransition={false}
             placeholder={
-                // Deferral, not a data wait — closing the span here would time the defer and tag a cached report cold.
+                // Deferral, not a data wait. Closing the span here would time the defer and tag a cached report cold.
                 <ReportActionsLoadingSkeleton
                     reportID={reportID}
                     skeletonName={CONST.TELEMETRY.CANCELED_BY_SKELETON.INBOX_TAB_DEFER}

--- a/src/pages/inbox/ReportActions.tsx
+++ b/src/pages/inbox/ReportActions.tsx
@@ -2,7 +2,6 @@ import MoneyRequestReportActionsList from '@components/MoneyRequestReportView/Mo
 import NavigationDeferredMount from '@components/NavigationDeferredMount';
 
 import {useIsAppLoadPending, useIsReportLoadPending} from '@hooks/useInFlightRequests';
-import useMarkOpenReportEndOnSkeleton from '@hooks/useMarkOpenReportEndOnSkeleton';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
@@ -62,15 +61,12 @@ function ReportActions() {
     // The app-load skeleton is hoisted out of the body so the body's data hooks/effects never run
     // during app boot. It only applies on the chat path (after the skeleton and money-request
     // branches below) — matching the previous behavior, where this skeleton lived inside the
-    // chat-only ReportActionsView. Because the body won't mount for this branch, it can't close the
-    // open-report span itself, so we close it here for the branch we gate.
+    // chat-only ReportActionsView.
     //
     // Concierge is excluded so the body still mounts under the app-load skeleton, seeding sessionStartTime
     // before content appeared.
     const isConciergeMainDM = isConciergeChatReport(report, conciergeReportID);
     const shouldShowAppLoadSkeleton = isAppLoadPending && !isOffline && !!report && !shouldWaitForTransactions && !shouldDisplayMoneyRequestActionsList && !isConciergeMainDM;
-
-    useMarkOpenReportEndOnSkeleton(report, shouldShowAppLoadSkeleton);
 
     if (!report || shouldWaitForTransactions) {
         return (
@@ -122,9 +118,11 @@ function ReportActionsWithInboxTabDeferredMount({reportID, shouldDefer}: ReportA
         <NavigationDeferredMount
             waitForUpcomingTransition={false}
             placeholder={
+                // Deferral, not a data wait — closing the span here would time the defer and tag a cached report cold.
                 <ReportActionsLoadingSkeleton
                     reportID={reportID}
                     skeletonName={CONST.TELEMETRY.CANCELED_BY_SKELETON.INBOX_TAB_DEFER}
+                    shouldMarkOpenReportEnd={false}
                 />
             }
         >

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -430,9 +430,7 @@ function ReportActionsListContent({reportID, onLayout}: ReportActionsListContent
 
         didLayout.current = true;
 
-        if (report) {
-            markOpenReportEnd(report, {warm: true});
-        }
+        markOpenReportEnd(reportID, report, {warm: true});
     };
 
     // The guard only mounts this content when the report is loaded, so this is effectively unreachable.

--- a/src/pages/inbox/report/ReportActionsListContext.tsx
+++ b/src/pages/inbox/report/ReportActionsListContext.tsx
@@ -120,7 +120,6 @@ function computeReportActionsSkeletonState(readinessSignals: ReportActionsReadin
     return {
         shouldShowLoadingSkeleton,
         shouldShowDerivedTimingSkeleton,
-        shouldShowInitialSkeleton,
     };
 }
 

--- a/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
+++ b/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
@@ -2,6 +2,7 @@ import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
 import useCancelSendMessageSpanOnSkeleton from '@hooks/useCancelSendMessageSpanOnSkeleton';
 import type {SkeletonName} from '@hooks/useCancelSendMessageSpanOnSkeleton';
+import useMarkOpenReportEndOnSkeleton from '@hooks/useMarkOpenReportEndOnSkeleton';
 
 import React from 'react';
 
@@ -14,14 +15,19 @@ type ReportActionsLoadingSkeletonProps = {
 
     /** Whether the skeleton rows animate */
     shouldAnimate?: boolean;
+
+    /** Whether this skeleton closes the open-report span as a cold open. Off when it isn't waiting on report data */
+    shouldMarkOpenReportEnd?: boolean;
 };
 
 /**
- * Report-actions loading skeleton. Mounted only while the skeleton shows, so it hosts the hook that cancels
- * the otherwise never-ending send-message span (tagged with `skeletonName`).
+ * Report-actions loading skeleton. Hosts the skeleton-phase span marks — cancelling the never-ending
+ * send-message span, and closing the open-report span as cold — because mounted here means visible, while a
+ * parent's copy of the skeleton condition can drift from what actually renders.
  */
-function ReportActionsLoadingSkeleton({reportID, skeletonName, shouldAnimate = true}: ReportActionsLoadingSkeletonProps) {
+function ReportActionsLoadingSkeleton({reportID, skeletonName, shouldAnimate = true, shouldMarkOpenReportEnd = true}: ReportActionsLoadingSkeletonProps) {
     useCancelSendMessageSpanOnSkeleton(reportID, skeletonName);
+    useMarkOpenReportEndOnSkeleton(reportID, shouldMarkOpenReportEnd);
     return <ReportActionsSkeletonView shouldAnimate={shouldAnimate} />;
 }
 

--- a/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
+++ b/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
@@ -21,9 +21,9 @@ type ReportActionsLoadingSkeletonProps = {
 };
 
 /**
- * Report-actions loading skeleton. Hosts the skeleton-phase span marks — cancelling the never-ending
- * send-message span, and closing the open-report span as cold — because mounted here means visible, while a
- * parent's copy of the skeleton condition can drift from what actually renders.
+ * Report-actions loading skeleton. Hosts the skeleton-phase span marks: cancelling the never-ending
+ * send-message span, and closing the open-report span as cold. Mounted here means visible, while a parent's
+ * copy of the skeleton condition can drift from what actually renders.
  */
 function ReportActionsLoadingSkeleton({reportID, skeletonName, shouldAnimate = true, shouldMarkOpenReportEnd = true}: ReportActionsLoadingSkeletonProps) {
     useCancelSendMessageSpanOnSkeleton(reportID, skeletonName);

--- a/src/pages/inbox/report/ReportActionsSkeletonGuard.tsx
+++ b/src/pages/inbox/report/ReportActionsSkeletonGuard.tsx
@@ -1,7 +1,6 @@
 import useBackfillWhenNoVisibleActions from '@hooks/useBackfillWhenNoVisibleActions';
 import useCopySelectionHelper from '@hooks/useCopySelectionHelper';
 import {useIsReportLoadPending} from '@hooks/useInFlightRequests';
-import useMarkOpenReportEndOnSkeleton from '@hooks/useMarkOpenReportEndOnSkeleton';
 import usePendingConciergeResponse from '@hooks/usePendingConciergeResponse';
 import useReportActionsListModel from '@hooks/useReportActionsListModel';
 import useStartConciergeSession from '@hooks/useStartConciergeSession';
@@ -34,10 +33,9 @@ type ReportActionsSkeletonGuardProps = {
 function ReportActionsSkeletonGuard({reportID, children}: ReportActionsSkeletonGuardProps) {
     const isReportLoadPending = useIsReportLoadPending(reportID);
     const {readinessSignals, state, actions} = useReportActionsListModel(reportID, isReportLoadPending);
-    const {shouldShowLoadingSkeleton, shouldShowDerivedTimingSkeleton, shouldShowInitialSkeleton} = computeReportActionsSkeletonState(readinessSignals);
+    const {shouldShowLoadingSkeleton, shouldShowDerivedTimingSkeleton} = computeReportActionsSkeletonState(readinessSignals);
 
     const {
-        report,
         isConciergeMainDM,
         oldestUnreadReportAction,
         hasOnceLoadedReportActions,
@@ -62,8 +60,6 @@ function ReportActionsSkeletonGuard({reportID, children}: ReportActionsSkeletonG
         hasOnceLoadedReportActions,
         hasCachedReportActions,
     });
-
-    useMarkOpenReportEndOnSkeleton(report, shouldShowInitialSkeleton);
 
     useBackfillWhenNoVisibleActions({
         reportID,

--- a/tests/ui/MoneyRequestReportViewTest.tsx
+++ b/tests/ui/MoneyRequestReportViewTest.tsx
@@ -117,6 +117,7 @@ const renderMoneyRequestReportView = (onLayout: (event: LayoutChangeEvent) => vo
     render(
         <MoneyRequestReportView
             report={mockReport}
+            reportIDFromRoute={mockReport.reportID}
             reportLoadingState={mockReportLoadingState}
             shouldDisplayReportFooter={false}
             backToRoute={undefined}

--- a/tests/ui/ReportActionsListTest.tsx
+++ b/tests/ui/ReportActionsListTest.tsx
@@ -386,7 +386,7 @@ describe('ReportActionsList (body)', () => {
             renderReportActionsList();
 
             expect(screen.getByTestId('ReportActionsSkeletonView')).toBeTruthy();
-            expect(mockMarkOpenReportEnd).toHaveBeenCalledWith(mockReport, {warm: false});
+            expect(mockMarkOpenReportEnd).toHaveBeenCalledWith(mockReport.reportID, mockReport, {warm: false});
             expect(mockUseIsReportLoadPending).toHaveBeenCalledWith(mockReport.reportID);
         });
 
@@ -575,10 +575,9 @@ describe('ReportActionsList (body)', () => {
 
             renderReportActionsList();
 
-            // The guard owns this mark now (it used to live in the body); it must still fire while the
-            // initial skeleton shows, otherwise the open-report span regresses.
+            // Must fire while the skeleton shows or the open-report span regresses.
             expect(screen.getByTestId('ReportActionsSkeletonView')).toBeTruthy();
-            expect(mockMarkOpenReportEnd).toHaveBeenCalledWith(mockReport, {warm: false});
+            expect(mockMarkOpenReportEnd).toHaveBeenCalledWith(mockReport.reportID, mockReport, {warm: false});
         });
 
         it('does not fire the warm:false mark once content is visible', () => {
@@ -589,7 +588,7 @@ describe('ReportActionsList (body)', () => {
             renderReportActionsList();
 
             expect(screen.queryByTestId('ReportActionsSkeletonView')).toBeNull();
-            expect(mockMarkOpenReportEnd).not.toHaveBeenCalledWith(mockReport, {warm: false});
+            expect(mockMarkOpenReportEnd).not.toHaveBeenCalledWith(mockReport.reportID, mockReport, {warm: false});
         });
     });
 

--- a/tests/ui/ReportActionsTest.tsx
+++ b/tests/ui/ReportActionsTest.tsx
@@ -199,7 +199,7 @@ describe('ReportActions (orchestrator)', () => {
 
         expect(screen.getByTestId('ReportActionsSkeletonView')).toBeTruthy();
         expect(mockReportActionsListBody).not.toHaveBeenCalled();
-        expect(mockMarkOpenReportEnd).toHaveBeenCalledWith(mockReport, {warm: false});
+        expect(mockMarkOpenReportEnd).toHaveBeenCalledWith(REPORT_ID, mockReport, {warm: false});
     });
 
     it('mounts the body (not the orchestrator app-load skeleton) for a Concierge report during app load', () => {

--- a/tests/unit/ReportActionsListContextTest.ts
+++ b/tests/unit/ReportActionsListContextTest.ts
@@ -58,27 +58,27 @@ function createReadinessSignals(overrides: Partial<ReportActionsReadinessSignals
 }
 
 describe('computeReportActionsSkeletonState', () => {
-    it('shows the initial skeleton for a pending OpenReport matching this report', () => {
+    it('shows the loading skeleton for a pending OpenReport matching this report', () => {
         const state = computeReportActionsSkeletonState(
             createReadinessSignals({
                 isReportLoadPending: true,
             }),
         );
 
-        expect(state.shouldShowInitialSkeleton).toBe(true);
+        expect(state.shouldShowLoadingSkeleton).toBe(true);
     });
 
-    it('does not show the initial skeleton when no OpenReport matching this report is pending', () => {
+    it('does not show the loading skeleton when no OpenReport matching this report is pending', () => {
         const state = computeReportActionsSkeletonState(
             createReadinessSignals({
                 isReportLoadPending: false,
             }),
         );
 
-        expect(state.shouldShowInitialSkeleton).toBe(false);
+        expect(state.shouldShowLoadingSkeleton).toBe(false);
     });
 
-    it('does not show the initial skeleton for a pending OpenReport while offline', () => {
+    it('does not show the loading skeleton for a pending OpenReport while offline', () => {
         const state = computeReportActionsSkeletonState(
             createReadinessSignals({
                 isOffline: true,
@@ -86,17 +86,17 @@ describe('computeReportActionsSkeletonState', () => {
             }),
         );
 
-        expect(state.shouldShowInitialSkeleton).toBe(false);
+        expect(state.shouldShowLoadingSkeleton).toBe(false);
     });
 
-    it('releases the initial skeleton after a terminal OpenReport failure', () => {
+    it('releases the loading skeleton after a terminal OpenReport failure', () => {
         const state = computeReportActionsSkeletonState(
             createReadinessSignals({
                 isReportLoadPending: false,
             }),
         );
 
-        expect(state.shouldShowInitialSkeleton).toBe(false);
+        expect(state.shouldShowLoadingSkeleton).toBe(false);
     });
 
     it('releases the unread initial load when no report load is pending', () => {
@@ -196,7 +196,7 @@ describe('computeReportActionsSkeletonState', () => {
             }),
         );
 
-        expect(state.shouldShowInitialSkeleton).toBe(false);
+        expect(state.shouldShowLoadingSkeleton).toBe(false);
     });
 
     it('preserves the linked message skeleton when the report load is pending', () => {
@@ -210,6 +210,6 @@ describe('computeReportActionsSkeletonState', () => {
             }),
         );
 
-        expect(state.shouldShowInitialSkeleton).toBe(true);
+        expect(state.shouldShowLoadingSkeleton).toBe(true);
     });
 });


### PR DESCRIPTION
### Explanation of Change

The `ManualOpenReport` span is closed by whichever component gets there first: a skeleton closes it and tags `is_warm=false`, the finished list closes it from `onLayout` and tags `is_warm=true`. The problem was that the decision "a skeleton is showing" lived in the parents, and every copy of it was wrong in a different way:

- `ReportActionsSkeletonGuard` checked `shouldShowInitialSkeleton`, but a skeleton actually renders on the wider `shouldShowLoadingSkeleton` and on `shouldShowDerivedTimingSkeleton`.
- `ReportActions` checked `shouldShowAppLoadSkeleton`, which excludes `shouldWaitForTransactions` — the exact case the line below it renders a skeleton for.
- `MoneyRequestReportView` checked one of its three skeleton branches and missed the other two.
- `MoneyRequestReportActionsList` checked a flag called `shouldShowOpenReportLoadingSkeleton` that renders nothing at all. It means "initial actions still loading", which stays true after the transaction table is on screen, so it fired cold _after_ the content was already visible.
- The hook bailed out on `!report`, which is the same condition one of those skeletons renders for, so that branch could never close at all.

The result: cold opens showed a skeleton, nobody tagged them, and the span kept running until the messages rendered — landing in the `is_warm=true` bucket with the full cold wait baked in. That's why warm p95 (~1.1s) looked worse than cold p95 (~600ms).

What changed:

- The cold mark now lives inside `ReportActionsLoadingSkeleton`, the component every chat-path skeleton renders through. Mounted means visible, so the mark can't drift from the condition. The two parent gates are deleted rather than corrected.
- `MoneyRequestReportView` shares named booleans between its three skeleton branches and the mark, and takes `reportIDFromRoute` as a prop — its skeletons render before the report lands in Onyx, so `report?.reportID` was `undefined` and the mark silently did nothing.
- `markOpenReportEnd` keys the span on `reportID` instead of reading it off the report object, so opens where the report isn't in Onyx yet can close at all. It also leaves the report-shape attributes (`is_transaction_thread`, `is_one_transaction_report`, `report_type`, `chat_type`) off when the report is missing, instead of reading them off `undefined` and reporting `false` for an unknown.
- `MoneyRequestReportActionsList` no longer marks cold — it renders no skeleton. Its layout close is now an unconditional `warm: true`, which is correct because a cold open would already have been closed by the skeleton, making this call a no-op.
- The inbox-tab-defer placeholder opts out via `shouldMarkOpenReportEnd={false}`. It's a deliberate deferral, not a wait on data, so timing it would tag a cached report as cold.

Nothing user-visible changes and nothing gets faster — only the span attributes. How cold opens are measured is unchanged: they still stop the clock when the skeleton appears, not when the content does.

One consequence for anyone querying this span: a cold open that closes before the report reaches Onyx now carries `is_warm` and no report-shape attributes. Queries that segment by `is_transaction_thread` or `report_type` have to treat a missing attribute as unknown rather than `false`, and they will no longer see those cold opens at all.

Expect warm p95 to drop as the mislabeled opens leave, and cold p95 to dip as those same opens join it as fast time-to-skeleton samples. Cold getting "faster" is bookkeeping, not a win. Sentry alert thresholds on this span should be re-baselined off the first clean week.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98880
PROPOSAL:

### Tests

1. Login into account and open console and filter by `ManualOpenReport`
2. Open report that is already in Onyx (no skeleton is visible)
3. Verify in End span object, the `is_warm: true`
4. Open report that is not yet in Onyx (skeletons are visible after opening)
5. Verify End span log shows up once skeletons are visible and attributes object have `is_warm: false`
6. Go to Spend -> Reports
7. Open any report that is not yet in Onyx (skeletons are visible after opening)
8. Verify End span log shows up once skeletons are visible and attributes object have `is_warm: false`

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

N/A

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
        - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
