### PR TITLE
Fix scan-failed expense sheet showing not found after reconnect by re…

### DIFF
--- a/src/libs/actions/IOU/Hold.ts
+++ b/src/libs/actions/IOU/Hold.ts
@@ -6,6 +6,7 @@ import {WRITE_COMMANDS} from '@libs/API/types';
 import DateUtils from '@libs/DateUtils';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
+import type {NavigationRoute} from '@libs/Navigation/types';
 import {buildOptimisticNextStep} from '@libs/NextStepUtils';
 import * as NumberUtils from '@libs/NumberUtils';
 import {getAllReportActions, getIOUActionForReportID, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
@@ -1059,6 +1060,39 @@ function getReportFromHoldRequestsOnyxData({
     };
 }
 
+/**
+ * Recursively walks the navigation state and repoints every route that still references the deleted optimistic report
+ * (via its `reportID` param or inside its `backTo` param) to the real report created by the backend. Patching only the
+ * focused route is not enough: with an RHP screen open, the report screen underneath keeps the stale ID and shows
+ * "not found" once the RHP is dismissed.
+ */
+function repointRoutesToRealReport(routes: NavigationRoute[], optimisticReportID: string, realReportID: string) {
+    for (const route of routes) {
+        const params: unknown = route.params;
+        const isParamsObject = !!params && typeof params === 'object';
+        const routeReportID = isParamsObject && 'reportID' in params && typeof params.reportID === 'string' ? params.reportID : undefined;
+        const routeBackTo = isParamsObject && 'backTo' in params && typeof params.backTo === 'string' ? params.backTo : undefined;
+        const updatedParams: {reportID?: string; backTo?: string} = {};
+        if (routeReportID === optimisticReportID) {
+            updatedParams.reportID = realReportID;
+        }
+        if (routeBackTo?.includes(optimisticReportID)) {
+            updatedParams.backTo = routeBackTo.replaceAll(optimisticReportID, realReportID);
+        }
+        if (!isEmptyObject(updatedParams) && route.key) {
+            Navigation.setParams(updatedParams, route.key);
+        }
+        if (route.state?.routes) {
+            repointRoutesToRealReport(route.state.routes, optimisticReportID, realReportID);
+        }
+    }
+}
+
+/**
+ * Once the backend report actions for a moved scan-failed expense arrive, re-parents the optimistic transaction thread
+ * under the real report action and repoints any navigation routes that still reference the deleted optimistic report,
+ * so the open expense/report screens keep working after reconnect.
+ */
 function repointMovedScanFailedThread(transactionID: string, optimisticReportID: string, optimisticReportActionID: string, realReportID: string) {
     // The backend's report actions for the moved expense may arrive after the transaction update, and this runs from the
     // action layer where no view exists to subscribe with useOnyx, so connectWithoutView is the only way to wait for them.
@@ -1089,24 +1123,19 @@ function repointMovedScanFailedThread(transactionID: string, optimisticReportID:
                 }
             }
 
-            const currentRouteParams: unknown = navigationRef.isReady() ? navigationRef.getCurrentRoute()?.params : undefined;
-            const isParamsObject = !!currentRouteParams && typeof currentRouteParams === 'object';
-            const routeReportID = isParamsObject && 'reportID' in currentRouteParams && typeof currentRouteParams.reportID === 'string' ? currentRouteParams.reportID : undefined;
-            const routeBackTo = isParamsObject && 'backTo' in currentRouteParams && typeof currentRouteParams.backTo === 'string' ? currentRouteParams.backTo : undefined;
-            const updatedParams: {reportID?: string; backTo?: string} = {};
-            if (routeReportID === optimisticReportID) {
-                updatedParams.reportID = realReportID;
-            }
-            if (routeBackTo?.includes(optimisticReportID)) {
-                updatedParams.backTo = routeBackTo.replaceAll(optimisticReportID, realReportID);
-            }
-            if (!isEmptyObject(updatedParams)) {
-                Navigation.setParams(updatedParams);
+            if (navigationRef.isReady()) {
+                repointRoutesToRealReport(navigationRef.getRootState()?.routes ?? [], optimisticReportID, realReportID);
             }
         },
     });
 }
 
+/**
+ * Watches transactions that were optimistically moved to a new report when paying a report with scan-failed expenses.
+ * The backend puts each moved expense in its own report instead of reusing the optimistic one, so when a transaction's
+ * reportID changes to the real report, the optimistic thread and any open routes are reconciled via
+ * `repointMovedScanFailedThread`.
+ */
 function watchMovedScanFailedTransactions(movedTransactions: MovedScanFailedTransaction[], optimisticReportID: string) {
     for (const {transactionID, optimisticReportActionID} of movedTransactions) {
         // The backend moves the expense into its own report instead of reusing optimisticReportID, and the only signal of

--- a/src/libs/actions/IOU/Hold.ts
+++ b/src/libs/actions/IOU/Hold.ts
@@ -5,7 +5,7 @@ import type {HoldMoneyRequestParams} from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import DateUtils from '@libs/DateUtils';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
-import Navigation from '@libs/Navigation/Navigation';
+import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import {buildOptimisticNextStep} from '@libs/NextStepUtils';
 import * as NumberUtils from '@libs/NumberUtils';
 import {getAllReportActions, getIOUActionForReportID, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
@@ -1089,8 +1089,19 @@ function repointMovedScanFailedThread(transactionID: string, optimisticReportID:
                 }
             }
 
-            if (Navigation.getActiveRoute().includes(optimisticReportID)) {
-                Navigation.setParams({reportID: realReportID});
+            const currentRouteParams: unknown = navigationRef.isReady() ? navigationRef.getCurrentRoute()?.params : undefined;
+            const isParamsObject = !!currentRouteParams && typeof currentRouteParams === 'object';
+            const routeReportID = isParamsObject && 'reportID' in currentRouteParams && typeof currentRouteParams.reportID === 'string' ? currentRouteParams.reportID : undefined;
+            const routeBackTo = isParamsObject && 'backTo' in currentRouteParams && typeof currentRouteParams.backTo === 'string' ? currentRouteParams.backTo : undefined;
+            const updatedParams: {reportID?: string; backTo?: string} = {};
+            if (routeReportID === optimisticReportID) {
+                updatedParams.reportID = realReportID;
+            }
+            if (routeBackTo?.includes(optimisticReportID)) {
+                updatedParams.backTo = routeBackTo.replaceAll(optimisticReportID, realReportID);
+            }
+            if (!isEmptyObject(updatedParams)) {
+                Navigation.setParams(updatedParams);
             }
         },
     });
@@ -1125,3 +1136,4 @@ function watchMovedScanFailedTransactions(movedTransactions: MovedScanFailedTran
 }
 
 export {getReportFromHoldRequestsOnyxData, putOnHold, putTransactionsOnHold, unholdRequest, watchMovedScanFailedTransactions};
+export type {MovedScanFailedTransaction};

--- a/src/libs/actions/IOU/Hold.ts
+++ b/src/libs/actions/IOU/Hold.ts
@@ -549,6 +549,11 @@ type OptimisticHoldReportExpenseActionID = {
     oldReportActionID: string;
 };
 
+type MovedScanFailedTransaction = {
+    transactionID: string;
+    optimisticReportActionID: string;
+};
+
 function getHoldReportActionsAndTransactions(
     reportID: string | undefined,
     iouReport?: OnyxEntry<OnyxTypes.Report>,
@@ -700,6 +705,7 @@ function getReportFromHoldRequestsOnyxData({
     optimisticCreatedReportForUnapprovedTransactionsActionID: string | undefined;
     optimisticHoldReportExpenseActionIDs: OptimisticHoldReportExpenseActionID[];
     optimisticReportActionCopyIDs: OptimisticReportActionCopyIDs;
+    movedScanFailedTransactions: MovedScanFailedTransaction[];
     optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.TRANSACTION>>;
     successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS>>;
     failureData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.TRANSACTION>>;
@@ -774,6 +780,7 @@ function getReportFromHoldRequestsOnyxData({
     const addHoldReportActionsSuccess: OnyxCollection<NullishDeep<OnyxTypes.ReportAction>> = {};
     const deleteHoldReportActions: Record<string, Pick<OnyxTypes.ReportAction, 'message'>> = {};
     const optimisticHoldReportExpenseActionIDs: OptimisticHoldReportExpenseActionID[] = [];
+    const movedScanFailedTransactions: MovedScanFailedTransaction[] = [];
 
     for (const holdReportAction of holdReportActions) {
         // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
@@ -802,6 +809,10 @@ function getReportFromHoldRequestsOnyxData({
         };
 
         optimisticHoldReportExpenseActionIDs.push({optimisticReportActionID: reportActionID, oldReportActionID: holdReportAction.reportActionID});
+
+        if (shouldMoveScanFailedTransactions && originalMessage.IOUTransactionID) {
+            movedScanFailedTransactions.push({transactionID: originalMessage.IOUTransactionID, optimisticReportActionID: reportActionID});
+        }
 
         const heldReport = getReportOrDraftReport(holdReportAction.childReportID);
         if (heldReport) {
@@ -1044,7 +1055,73 @@ function getReportFromHoldRequestsOnyxData({
         optimisticHoldReportID: optimisticExpenseReport.reportID,
         optimisticHoldReportExpenseActionIDs,
         optimisticReportActionCopyIDs,
+        movedScanFailedTransactions,
     };
 }
 
-export {getReportFromHoldRequestsOnyxData, putOnHold, putTransactionsOnHold, unholdRequest};
+function repointMovedScanFailedThread(transactionID: string, optimisticReportID: string, optimisticReportActionID: string, realReportID: string) {
+    // The backend's report actions for the moved expense may arrive after the transaction update, and this runs from the
+    // action layer where no view exists to subscribe with useOnyx, so connectWithoutView is the only way to wait for them.
+    const connection = Onyx.connectWithoutView({
+        key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${realReportID}`,
+        callback: (reportActions) => {
+            const realAction = Object.values(reportActions ?? {}).find(
+                (reportAction) => isMoneyRequestAction(reportAction) && getOriginalMessage(reportAction)?.IOUTransactionID === transactionID,
+            );
+            if (!realAction) {
+                return;
+            }
+            Onyx.disconnect(connection);
+
+            const threadReport = Object.values(getAllReports() ?? {}).find(
+                (report) => report?.parentReportActionID === optimisticReportActionID && report?.parentReportID === optimisticReportID,
+            );
+            if (threadReport?.reportID) {
+                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${threadReport.reportID}`, {
+                    parentReportID: realReportID,
+                    parentReportActionID: realAction.reportActionID,
+                    chatReportID: realReportID,
+                });
+                if (!realAction.childReportID) {
+                    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${realReportID}`, {
+                        [realAction.reportActionID]: {childReportID: threadReport.reportID},
+                    });
+                }
+            }
+
+            if (Navigation.getActiveRoute().includes(optimisticReportID)) {
+                Navigation.setParams({reportID: realReportID});
+            }
+        },
+    });
+}
+
+function watchMovedScanFailedTransactions(movedTransactions: MovedScanFailedTransaction[], optimisticReportID: string) {
+    for (const {transactionID, optimisticReportActionID} of movedTransactions) {
+        // The backend moves the expense into its own report instead of reusing optimisticReportID, and the only signal of
+        // the real report ID is the transaction's reportID changing. This runs from the action layer with no view to
+        // subscribe through, so connectWithoutView is required to observe that change.
+        let hasSeenOptimisticMove = false;
+        const connection = Onyx.connectWithoutView({
+            key: `${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`,
+            callback: (transaction) => {
+                if (!transaction) {
+                    Onyx.disconnect(connection);
+                    return;
+                }
+                const currentReportID = transaction.reportID;
+                if (currentReportID === optimisticReportID) {
+                    hasSeenOptimisticMove = true;
+                    return;
+                }
+                if (!hasSeenOptimisticMove || !currentReportID) {
+                    return;
+                }
+                Onyx.disconnect(connection);
+                repointMovedScanFailedThread(transactionID, optimisticReportID, optimisticReportActionID, currentReportID);
+            },
+        });
+    }
+}
+
+export {getReportFromHoldRequestsOnyxData, putOnHold, putTransactionsOnHold, unholdRequest, watchMovedScanFailedTransactions};

--- a/src/libs/actions/IOU/PayMoneyRequest.ts
+++ b/src/libs/actions/IOU/PayMoneyRequest.ts
@@ -51,7 +51,7 @@ import type {ValueOf} from 'type-fest';
 import Onyx from 'react-native-onyx';
 
 import {getAllPersonalDetails, getAllTransactionViolations} from '.';
-import {getReportFromHoldRequestsOnyxData} from './Hold';
+import {getReportFromHoldRequestsOnyxData, watchMovedScanFailedTransactions} from './Hold';
 import {getReportPreviewReportAction} from './MoneyRequestBuilder';
 
 type PayInvoiceArgs = {
@@ -90,6 +90,7 @@ type PayMoneyRequestData = {
         | typeof ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS
         | BuildPolicyDataKeys
     >;
+    movedScanFailedTransactions?: Array<{transactionID: string; optimisticReportActionID: string}>;
 };
 
 type SearchPayOnyxKey = typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE | typeof ONYXKEYS.COLLECTION.SNAPSHOT | typeof ONYXKEYS.COLLECTION.REPORT;
@@ -495,6 +496,7 @@ function getPayMoneyRequestParams({
     let optimisticHoldReportID;
     let optimisticHoldActionID;
     let optimisticHoldReportExpenseActionIDs;
+    let movedScanFailedTransactions;
     if (!full || shouldMoveScanFailedTransactions) {
         const holdReportOnyxData = getReportFromHoldRequestsOnyxData({
             chatReport,
@@ -514,6 +516,7 @@ function getPayMoneyRequestParams({
         optimisticHoldReportID = holdReportOnyxData.optimisticHoldReportID;
         optimisticHoldActionID = holdReportOnyxData.optimisticHoldActionID;
         optimisticHoldReportExpenseActionIDs = JSON.stringify(holdReportOnyxData.optimisticHoldReportExpenseActionIDs);
+        movedScanFailedTransactions = holdReportOnyxData.movedScanFailedTransactions;
     }
 
     return {
@@ -531,6 +534,7 @@ function getPayMoneyRequestParams({
             ...policyParams,
         },
         onyxData,
+        movedScanFailedTransactions,
     };
 }
 
@@ -818,7 +822,11 @@ function payMoneyRequest(params: PayMoneyRequestFunctionParams) {
     completePaymentOnboarding(paymentSelected, introSelected, isSelfTourViewed, betas, currentUserAccountID, conciergeChat);
 
     const recipient = {accountID: iouReport?.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID};
-    const {params: payMoneyRequestParams, onyxData} = getPayMoneyRequestParams({
+    const {
+        params: payMoneyRequestParams,
+        onyxData,
+        movedScanFailedTransactions,
+    } = getPayMoneyRequestParams({
         initialChatReport: chatReport,
         iouReport,
         recipient,
@@ -850,6 +858,9 @@ function payMoneyRequest(params: PayMoneyRequestFunctionParams) {
         playSound(SOUNDS.SUCCESS);
     }
     API.write(apiCommand, payMoneyRequestParams, mergeAdditionalPayOnyxData(onyxData, additionalOnyxData));
+    if (movedScanFailedTransactions?.length && payMoneyRequestParams.optimisticHoldReportID) {
+        watchMovedScanFailedTransactions(movedScanFailedTransactions, payMoneyRequestParams.optimisticHoldReportID);
+    }
     notifyNewAction(!full ? (Navigation.getTopmostReportId() ?? iouReport?.reportID) : iouReport?.reportID, undefined, true);
     return payMoneyRequestParams.optimisticHoldReportID;
 }

--- a/src/libs/actions/IOU/PayMoneyRequest.ts
+++ b/src/libs/actions/IOU/PayMoneyRequest.ts
@@ -50,6 +50,8 @@ import type {ValueOf} from 'type-fest';
 
 import Onyx from 'react-native-onyx';
 
+import type {MovedScanFailedTransaction} from './Hold';
+
 import {getAllPersonalDetails, getAllTransactionViolations} from '.';
 import {getReportFromHoldRequestsOnyxData, watchMovedScanFailedTransactions} from './Hold';
 import {getReportPreviewReportAction} from './MoneyRequestBuilder';
@@ -90,7 +92,7 @@ type PayMoneyRequestData = {
         | typeof ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS
         | BuildPolicyDataKeys
     >;
-    movedScanFailedTransactions?: Array<{transactionID: string; optimisticReportActionID: string}>;
+    movedScanFailedTransactions?: MovedScanFailedTransaction[];
 };
 
 type SearchPayOnyxKey = typeof ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE | typeof ONYXKEYS.COLLECTION.SNAPSHOT | typeof ONYXKEYS.COLLECTION.REPORT;

--- a/tests/actions/IOUTest/PayMoneyRequestTest.ts
+++ b/tests/actions/IOUTest/PayMoneyRequestTest.ts
@@ -59,7 +59,8 @@ jest.mock('@src/libs/Navigation/Navigation', () => ({
     isNavigationReady: jest.fn(() => Promise.resolve()),
     getReportRouteByID: jest.fn(),
     getActiveRouteWithoutParams: jest.fn(),
-    getActiveRoute: jest.fn(),
+    getActiveRoute: jest.fn(() => ''),
+    setParams: jest.fn(),
     navigationRef: {
         getRootState: jest.fn(),
         isReady: jest.fn(() => true),
@@ -1104,6 +1105,56 @@ describe('actions/IOU/PayMoneyRequest', () => {
                 const reportActions = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${expenseReport.reportID}`);
                 const payAction = Object.values(reportActions ?? {}).find((action) => isMoneyRequestAction(action) && getOriginalMessage(action)?.type === CONST.IOU.REPORT_ACTION_TYPE.PAY);
                 expect(payAction && isMoneyRequestAction(payAction) ? getOriginalMessage(payAction)?.amount : undefined).toBe(3000);
+            });
+
+            it('re-points the expense thread to the backend report once the server moves the scan-failed expense', async () => {
+                const validTransaction = buildTransaction('valid1', -3000, false);
+                const scanFailedTransaction = buildTransaction('scanFailed1', 0, true);
+                const expenseReport = await setUpReport([validTransaction, scanFailedTransaction]);
+
+                mockFetch?.pause?.();
+                const optimisticReportID = pay(expenseReport);
+                await waitForBatchedUpdates();
+
+                const optimisticActions = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${optimisticReportID}`);
+                const copiedAction = Object.values(optimisticActions ?? {}).find(
+                    (action) => isMoneyRequestAction(action) && getOriginalMessage(action)?.IOUTransactionID === scanFailedTransaction.transactionID,
+                );
+                expect(copiedAction).toBeDefined();
+
+                const threadReportID = '999';
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${threadReportID}`, {
+                    reportID: threadReportID,
+                    type: CONST.REPORT.TYPE.CHAT,
+                    parentReportID: optimisticReportID,
+                    parentReportActionID: copiedAction?.reportActionID,
+                });
+                await waitForBatchedUpdates();
+
+                jest.mocked(Navigation.getActiveRoute).mockReturnValue(`/r/${optimisticReportID}`);
+                await mockFetch?.resume?.();
+
+                const backendReportID = '777';
+                const backendAction = buildOptimisticIOUReportAction({
+                    type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+                    amount: 0,
+                    currency: 'USD',
+                    comment: '',
+                    participants: [],
+                    transactionID: scanFailedTransaction.transactionID,
+                    getCurrencyDecimals: getCurrencyDecimalsLocal,
+                });
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${backendReportID}`, {reportID: backendReportID, type: CONST.REPORT.TYPE.EXPENSE, chatReportID: chatReport.reportID});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${backendReportID}`, {[backendAction.reportActionID]: backendAction as ReportAction});
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${scanFailedTransaction.transactionID}`, {reportID: backendReportID});
+                await waitForBatchedUpdates();
+
+                const threadReport = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${threadReportID}`);
+                expect(threadReport?.parentReportID).toBe(backendReportID);
+                expect(threadReport?.parentReportActionID).toBe(backendAction.reportActionID);
+                const backendActions = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${backendReportID}`);
+                expect(backendActions?.[backendAction.reportActionID]?.childReportID).toBe(threadReportID);
+                expect(Navigation.setParams).toHaveBeenCalledWith({reportID: backendReportID});
             });
 
             it('does not create a new report when every expense in the report is scan-failed', async () => {

--- a/tests/actions/IOUTest/PayMoneyRequestTest.ts
+++ b/tests/actions/IOUTest/PayMoneyRequestTest.ts
@@ -13,7 +13,7 @@ import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
 import DateUtils from '@src/libs/DateUtils';
-import Navigation from '@src/libs/Navigation/Navigation';
+import Navigation, {navigationRef} from '@src/libs/Navigation/Navigation';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {IntroSelected, Policy, Report} from '@src/types/onyx';
@@ -63,6 +63,7 @@ jest.mock('@src/libs/Navigation/Navigation', () => ({
     setParams: jest.fn(),
     navigationRef: {
         getRootState: jest.fn(),
+        getCurrentRoute: jest.fn(),
         isReady: jest.fn(() => true),
     },
 }));
@@ -1131,7 +1132,12 @@ describe('actions/IOU/PayMoneyRequest', () => {
                 });
                 await waitForBatchedUpdates();
 
-                jest.mocked(Navigation.getActiveRoute).mockReturnValue(`/r/${optimisticReportID}`);
+                expect(optimisticReportID).toBeDefined();
+                if (!optimisticReportID) {
+                    return;
+                }
+                // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mocks don't rely on `this` binding
+                jest.mocked(navigationRef.getCurrentRoute).mockReturnValue({key: 'test', name: 'ReportAttachments', params: {reportID: optimisticReportID}});
                 await mockFetch?.resume?.();
 
                 const backendReportID = '777';

--- a/tests/actions/IOUTest/PayMoneyRequestTest.ts
+++ b/tests/actions/IOUTest/PayMoneyRequestTest.ts
@@ -1137,7 +1137,24 @@ describe('actions/IOU/PayMoneyRequest', () => {
                     return;
                 }
                 // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mocks don't rely on `this` binding
-                jest.mocked(navigationRef.getCurrentRoute).mockReturnValue({key: 'test', name: 'ReportAttachments', params: {reportID: optimisticReportID}});
+                jest.mocked(navigationRef.getRootState).mockReturnValue({
+                    key: 'root',
+                    index: 1,
+                    routeNames: ['Report', 'RightModalNavigator'],
+                    routes: [
+                        {key: 'report-screen', name: 'Report', params: {reportID: optimisticReportID}},
+                        {
+                            key: 'rhp',
+                            name: 'RightModalNavigator',
+                            state: {
+                                stale: true,
+                                routes: [{key: 'report-details', name: 'Report_Details_Root', params: {reportID: optimisticReportID, backTo: `r/${optimisticReportID}`}}],
+                            },
+                        },
+                    ],
+                    type: 'stack',
+                    stale: false,
+                });
                 await mockFetch?.resume?.();
 
                 const backendReportID = '777';
@@ -1160,7 +1177,8 @@ describe('actions/IOU/PayMoneyRequest', () => {
                 expect(threadReport?.parentReportActionID).toBe(backendAction.reportActionID);
                 const backendActions = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${backendReportID}`);
                 expect(backendActions?.[backendAction.reportActionID]?.childReportID).toBe(threadReportID);
-                expect(Navigation.setParams).toHaveBeenCalledWith({reportID: backendReportID});
+                expect(Navigation.setParams).toHaveBeenCalledWith({reportID: backendReportID}, 'report-screen');
+                expect(Navigation.setParams).toHaveBeenCalledWith({reportID: backendReportID, backTo: `r/${backendReportID}`}, 'report-details');
             });
 
             it('does not create a new report when every expense in the report is scan-failed', async () => {


### PR DESCRIPTION
### Explanation of Change

When a scan-failed expense is optimistically moved to a new report on Pay (#97084), the backend creates its own report instead of reusing `optimisticHoldReportID`, so the optimistic report is dropped in `successData` on reconnect. If the user opened the moved expense while offline, its sheet stayed pointed at the dropped optimistic report and its client-only copied action, so on reconnect the sheet showed the "Hmm... it's not here" page instead of the expense.

This PR adds `watchMovedScanFailedTransactions`: after Pay is sent, it watches each moved transaction until the backend assigns its real report ID, then re-points the expense thread (`parentReportID` / `parentReportActionID` / `chatReportID`) to the backend report and its real IOU action, and redirects any route still showing the optimistic report to the real one. The reconciliation also handles the failure path (transaction returning to its original report).

Known limitation: the watcher lives in memory, so if the app is reloaded between the offline Pay and reconnect, the reconciliation does not run. Fully closing that edge requires the backend to reuse `optimisticHoldReportID`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96257
$ https://github.com/Expensify/App/issues/98821
PROPOSAL: https://github.com/Expensify/App/issues/96257#issuecomment-5020184399

### Tests

Precondition: workspace with payments enabled, a report containing one valid manual expense and one scan-failed expense (amount 0, missing merchant), approved and ready to pay.

1. Open the report and go **offline**.
2. Click **Mark as paid**. Verify the scan-failed expense moves to a new Draft report in the workspace chat.
3. Open the new Draft report (the sheet shows the scan-failed expense details).
4. Go **online** while the sheet is open.
5. Verify the sheet keeps showing the expense data, the URL switches to the backend's report, and the "Hmm... it's not here" page never appears.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Steps 1–3 above.
2. Verify the sheet shows the expense data while offline.
3. Go online and verify step 5 above.

### QA Steps

1. Go to a workspace chat and create a manual expense and a scan expense with an invalid receipt; wait for the scan to fail.
2. Submit and approve the report, then go **offline**.
3. Click **Mark as paid** and open the new report containing the scan-failed expense.
4. Go **online**.
5. Verify the report keeps showing the expense data and no "Hmm... it's not here" page appears.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
After fix:


https://github.com/user-attachments/assets/1f26b65c-91f4-4704-9a97-952e16451a3f



</details>
