### PR TITLE
fix(telemetry): drop untraceable Cannot call a class as a function noise from Sentry

### DIFF
--- a/src/libs/telemetry/integrations/classCallCheckNoiseFilter.ts
+++ b/src/libs/telemetry/integrations/classCallCheckNoiseFilter.ts
@@ -11,7 +11,7 @@ const THIRD_PARTY_CODE_TAG = 'third_party_code';
  *
  * `app:///` is the spelling this noise arrives with: `createReactNativeRewriteFrames` produces it from any URL
  * with no basename, most notably `webkit-masked-url://hidden/` (WebKit's stand-in for a URL it withholds).
- * `''` is a frame the parser gave no filename; `[native code]`/`native` are native markers the rewrite leaves
+ * `''` is a frame the parser gave no filename. `[native code]`/`native` are native markers the rewrite leaves
  * untouched. The bare `<anonymous>` and `webkit-masked-url://hidden/` entries are guards in case the SDK ever
  * stops rewriting frames - today the rewrite always runs first, so neither can match.
  */
@@ -57,7 +57,7 @@ function isClassCallCheckNoise(event: Event): boolean {
  * Drops the GH #93837 noise the way the SDK's own `inboundFiltersIntegration` drops `ignoreErrors` matches: an
  * event processor, so the decision sits next to `thirdPartyErrorFilterIntegration` whose tag it consumes. It
  * must run after `createReactNativeRewriteFrames`, which deletes `abs_path` and strips the scheme from
- * `filename`; default integrations are set up before ours, so no `webkit-masked-url://` scheme is left by then.
+ * `filename`. Default integrations are set up before ours, so no `webkit-masked-url://` scheme is left by then.
  *
  * Drops leave no trace, same as `ignoreErrors`. To check the predicate has not gone inert, watch total
  * `third_party_code:True` volume per release (Discover query in GH #93837): zero means the tag or the frame

--- a/src/libs/telemetry/integrations/classCallCheckNoiseFilter.ts
+++ b/src/libs/telemetry/integrations/classCallCheckNoiseFilter.ts
@@ -1,0 +1,92 @@
+import type {Event, Integration} from '@sentry/core';
+
+/**
+ * Message Babel's `_classCallCheck` helper throws when a transpiled class is invoked without `new`.
+ * It is emitted by the class being called, never by the caller.
+ */
+const CLASS_CALL_CHECK_MESSAGE = 'Cannot call a class as a function';
+
+/** Tag `thirdPartyErrorFilterIntegration` sets on events whose every frame is foreign to our bundle. */
+const THIRD_PARTY_CODE_TAG = 'third_party_code';
+
+/**
+ * Filenames that mean "this frame has no URL".
+ *
+ * `app:///` is the spelling this noise actually arrives with: `createReactNativeRewriteFrames` produces
+ * it from any URL with no basename - most notably `webkit-masked-url://hidden/`, which is what WebKit
+ * reports for a script whose URL it withholds. `''` covers a frame the stack parser gave no filename at
+ * all. `[native code]` and `native` are the native-frame markers, which the rewrite iteratee returns
+ * unchanged, so those are the spellings that reach us.
+ *
+ * `app:///<anonymous>` is the rewritten form of the `<anonymous>` marker. The bare `<anonymous>` and
+ * `webkit-masked-url://hidden/` entries are guards in case the SDK ever stops rewriting frames; today the
+ * rewrite always runs first (see the note on the integration below), so neither can match.
+ */
+const ANONYMOUS_FILENAMES = new Set(['app:///', '', '[native code]', 'native', 'app:///<anonymous>', '<anonymous>', 'webkit-masked-url://hidden/']);
+
+/**
+ * True for the `TypeError: Cannot call a class as a function` noise tracked in
+ * https://github.com/Expensify/App/issues/93837 (Sentry APP-CN8, APP-JY0, APP-7WS, APP-8FN, APP-H5V).
+ *
+ * Why this is safe - three conditions must hold together, and App code cannot satisfy all three:
+ *
+ * 1. The message is Babel's `_classCallCheck`. That helper runs inside the class being called, so the
+ *    throwing frame always belongs to whoever *owns* the class, not to whoever called it, which is why
+ *    the frames alone are enough to attribute the error.
+ * 2. Every frame is anonymous. App code only ever ships in named, hashed chunks
+ *    (`app:///76-f662df2d477d1a4f.bundle.js`), and there is no `eval(` or `new Function(` anywhere in
+ *    `src/`, so we cannot produce a frame with no URL. The only non-chunk scripts we serve are the
+ *    third-party snippets inlined in `web/index.html` (Ketch, Convert, GTM), which we equally cannot act
+ *    on. A URL-bearing third party keeps its basename through the rewrite (the password-manager extension
+ *    in APP-J1W arrives as `app:///<extension-name>-script.js`), so an empty basename means the code
+ *    genuinely had no URL - injected inline, or served from a URL WebKit withholds.
+ * 3. `thirdPartyErrorFilterIntegration` found no frame carrying our bundle key. On an all-anonymous stack
+ *    this follows from condition 2 rather than testing anything new, but it is still worth requiring: the
+ *    tag can only be set when the bundler plugin stamped that build, so its presence proves the absence of
+ *    our key is real and not an artifact of an unstamped release. It also makes this filter inert wherever
+ *    `thirdPartyErrorFilterIntegration` is not installed.
+ *
+ * The Sentry evidence behind conditions 1-3 - the tag distribution per release, the browser and platform
+ * split against our own error volume, and why any `_classCallCheck` we ship fails condition 2 (all of them
+ * come from dependencies that land in named chunks) - is written up in GH #93837.
+ *
+ * Deliberately narrow: anything with a named frame is kept, including real third-party bugs we can still
+ * act on (APP-J2J is a genuine Convert-experiment bug). If this signature ever reappears with an
+ * attributable frame, it reaches Sentry normally.
+ */
+function isClassCallCheckNoise(event: Event): boolean {
+    if (event.tags?.[THIRD_PARTY_CODE_TAG] !== true) {
+        return false;
+    }
+
+    const values = event.exception?.values ?? [];
+    const isSignature = values.length > 0 && values.every((value) => value.value === CLASS_CALL_CHECK_MESSAGE);
+    if (!isSignature) {
+        return false;
+    }
+
+    const frames = values.flatMap((value) => value.stacktrace?.frames ?? []);
+    return frames.length > 0 && frames.every((frame) => ANONYMOUS_FILENAMES.has(frame.filename ?? ''));
+}
+
+/**
+ * Drops the GH #93837 noise, mirroring how the SDK's own `inboundFiltersIntegration` drops `ignoreErrors`
+ * and `denyUrls` matches: an event processor, so the decision lives next to `thirdPartyErrorFilterIntegration`
+ * whose tag it consumes.
+ *
+ * The check has to see the rewritten filename rather than the original URL scheme. `createReactNativeRewriteFrames`
+ * deletes `abs_path` and strips the scheme from `filename`, and default integrations are set up before ours,
+ * so by the time this runs no `webkit-masked-url://`-style scheme is left.
+ *
+ * Drops leave no trace, deliberately - same as `ignoreErrors`. To re-verify the predicate still matches
+ * rather than having gone inert, watch the mechanism it depends on rather than any single issue: total
+ * `third_party_code:True` volume per release (Discover query in GH #93837) must stay non-zero. If that
+ * goes to zero, the tag or the frame rewriting changed and this filter is dropping nothing.
+ */
+const classCallCheckNoiseFilterIntegration: Integration = {
+    name: 'ClassCallCheckNoiseFilter',
+    processEvent: (event) => (isClassCallCheckNoise(event) ? null : event),
+};
+
+export default classCallCheckNoiseFilterIntegration;
+export {isClassCallCheckNoise, CLASS_CALL_CHECK_MESSAGE, THIRD_PARTY_CODE_TAG};

--- a/src/libs/telemetry/integrations/classCallCheckNoiseFilter.ts
+++ b/src/libs/telemetry/integrations/classCallCheckNoiseFilter.ts
@@ -1,9 +1,6 @@
 import type {Event, Integration} from '@sentry/core';
 
-/**
- * Message Babel's `_classCallCheck` helper throws when a transpiled class is invoked without `new`.
- * It is emitted by the class being called, never by the caller.
- */
+/** Message Babel's `_classCallCheck` throws when a transpiled class is called without `new`, from inside the class, never the caller. */
 const CLASS_CALL_CHECK_MESSAGE = 'Cannot call a class as a function';
 
 /** Tag `thirdPartyErrorFilterIntegration` sets on events whose every frame is foreign to our bundle. */
@@ -12,15 +9,11 @@ const THIRD_PARTY_CODE_TAG = 'third_party_code';
 /**
  * Filenames that mean "this frame has no URL".
  *
- * `app:///` is the spelling this noise actually arrives with: `createReactNativeRewriteFrames` produces
- * it from any URL with no basename - most notably `webkit-masked-url://hidden/`, which is what WebKit
- * reports for a script whose URL it withholds. `''` covers a frame the stack parser gave no filename at
- * all. `[native code]` and `native` are the native-frame markers, which the rewrite iteratee returns
- * unchanged, so those are the spellings that reach us.
- *
- * `app:///<anonymous>` is the rewritten form of the `<anonymous>` marker. The bare `<anonymous>` and
- * `webkit-masked-url://hidden/` entries are guards in case the SDK ever stops rewriting frames; today the
- * rewrite always runs first (see the note on the integration below), so neither can match.
+ * `app:///` is the spelling this noise arrives with: `createReactNativeRewriteFrames` produces it from any URL
+ * with no basename, most notably `webkit-masked-url://hidden/` (WebKit's stand-in for a URL it withholds).
+ * `''` is a frame the parser gave no filename; `[native code]`/`native` are native markers the rewrite leaves
+ * untouched. The bare `<anonymous>` and `webkit-masked-url://hidden/` entries are guards in case the SDK ever
+ * stops rewriting frames - today the rewrite always runs first, so neither can match.
  */
 const ANONYMOUS_FILENAMES = new Set(['app:///', '', '[native code]', 'native', 'app:///<anonymous>', '<anonymous>', 'webkit-masked-url://hidden/']);
 
@@ -28,31 +21,22 @@ const ANONYMOUS_FILENAMES = new Set(['app:///', '', '[native code]', 'native', '
  * True for the `TypeError: Cannot call a class as a function` noise tracked in
  * https://github.com/Expensify/App/issues/93837 (Sentry APP-CN8, APP-JY0, APP-7WS, APP-8FN, APP-H5V).
  *
- * Why this is safe - three conditions must hold together, and App code cannot satisfy all three:
+ * Three conditions must hold together, and App code cannot satisfy all three:
  *
- * 1. The message is Babel's `_classCallCheck`. That helper runs inside the class being called, so the
- *    throwing frame always belongs to whoever *owns* the class, not to whoever called it, which is why
- *    the frames alone are enough to attribute the error.
- * 2. Every frame is anonymous. App code only ever ships in named, hashed chunks
- *    (`app:///76-f662df2d477d1a4f.bundle.js`), and there is no `eval(` or `new Function(` anywhere in
- *    `src/`, so we cannot produce a frame with no URL. The only non-chunk scripts we serve are the
- *    third-party snippets inlined in `web/index.html` (Ketch, Convert, GTM), which we equally cannot act
- *    on. A URL-bearing third party keeps its basename through the rewrite (the password-manager extension
- *    in APP-J1W arrives as `app:///<extension-name>-script.js`), so an empty basename means the code
- *    genuinely had no URL - injected inline, or served from a URL WebKit withholds.
- * 3. `thirdPartyErrorFilterIntegration` found no frame carrying our bundle key. On an all-anonymous stack
- *    this follows from condition 2 rather than testing anything new, but it is still worth requiring: the
- *    tag can only be set when the bundler plugin stamped that build, so its presence proves the absence of
- *    our key is real and not an artifact of an unstamped release. It also makes this filter inert wherever
- *    `thirdPartyErrorFilterIntegration` is not installed.
+ * 1. Babel's `_classCallCheck` message. That helper runs inside the class being called, so the throwing frame
+ *    belongs to whoever *owns* the class - which is why the frames alone attribute the error.
+ * 2. Every frame anonymous. App code only ships in named hashed chunks (`app:///76-f662df2d477d1a4f.bundle.js`)
+ *    and `src/` has no `eval(`/`new Function(`, so we cannot produce a frame with no URL. A URL-bearing third
+ *    party keeps its basename through the rewrite, so an empty basename means the code genuinely had no URL.
+ * 3. `thirdPartyErrorFilterIntegration` found no frame carrying our bundle key. On an all-anonymous stack this
+ *    follows from 2, but requiring the tag proves the bundler plugin stamped the build (so the missing key is
+ *    real, not an unstamped release) and makes this filter inert where that integration is not installed.
  *
- * The Sentry evidence behind conditions 1-3 - the tag distribution per release, the browser and platform
- * split against our own error volume, and why any `_classCallCheck` we ship fails condition 2 (all of them
- * come from dependencies that land in named chunks) - is written up in GH #93837.
+ * The Sentry evidence - tag distribution per release, browser/platform split, and why every `_classCallCheck`
+ * we ship fails condition 2 - is written up in GH #93837.
  *
- * Deliberately narrow: anything with a named frame is kept, including real third-party bugs we can still
- * act on (APP-J2J is a genuine Convert-experiment bug). If this signature ever reappears with an
- * attributable frame, it reaches Sentry normally.
+ * Deliberately narrow: anything with a named frame is kept, including third-party bugs we can still act on
+ * (APP-J2J is a genuine Convert-experiment bug).
  */
 function isClassCallCheckNoise(event: Event): boolean {
     if (event.tags?.[THIRD_PARTY_CODE_TAG] !== true) {
@@ -70,18 +54,14 @@ function isClassCallCheckNoise(event: Event): boolean {
 }
 
 /**
- * Drops the GH #93837 noise, mirroring how the SDK's own `inboundFiltersIntegration` drops `ignoreErrors`
- * and `denyUrls` matches: an event processor, so the decision lives next to `thirdPartyErrorFilterIntegration`
- * whose tag it consumes.
+ * Drops the GH #93837 noise the way the SDK's own `inboundFiltersIntegration` drops `ignoreErrors` matches: an
+ * event processor, so the decision sits next to `thirdPartyErrorFilterIntegration` whose tag it consumes. It
+ * must run after `createReactNativeRewriteFrames`, which deletes `abs_path` and strips the scheme from
+ * `filename`; default integrations are set up before ours, so no `webkit-masked-url://` scheme is left by then.
  *
- * The check has to see the rewritten filename rather than the original URL scheme. `createReactNativeRewriteFrames`
- * deletes `abs_path` and strips the scheme from `filename`, and default integrations are set up before ours,
- * so by the time this runs no `webkit-masked-url://`-style scheme is left.
- *
- * Drops leave no trace, deliberately - same as `ignoreErrors`. To re-verify the predicate still matches
- * rather than having gone inert, watch the mechanism it depends on rather than any single issue: total
- * `third_party_code:True` volume per release (Discover query in GH #93837) must stay non-zero. If that
- * goes to zero, the tag or the frame rewriting changed and this filter is dropping nothing.
+ * Drops leave no trace, same as `ignoreErrors`. To check the predicate has not gone inert, watch total
+ * `third_party_code:True` volume per release (Discover query in GH #93837): zero means the tag or the frame
+ * rewriting changed and this filter is dropping nothing.
  */
 const classCallCheckNoiseFilterIntegration: Integration = {
     name: 'ClassCallCheckNoiseFilter',

--- a/src/libs/telemetry/integrations/index.ts
+++ b/src/libs/telemetry/integrations/index.ts
@@ -14,9 +14,8 @@ const reportingObserverIntegration = undefined;
 // frame would look foreign. Stub for export shape parity; filtered out of the integrations list here.
 const thirdPartyErrorFilterIntegration = undefined;
 
-// The GH #93837 noise this drops is web-only (injected scripts; every event we have seen is macOS Safari) and its predicate reads the
-// `third_party_code` tag that only the web integration above sets. Stub for export shape parity; filtered out
-// of the integrations list here.
+// Web-only: the GH #93837 noise comes from injected scripts (every event so far is macOS Safari) and the predicate
+// reads a tag only the web integration above sets. Stub for export shape parity; filtered out of the list here.
 const classCallCheckNoiseFilterIntegration = undefined;
 
 export {

--- a/src/libs/telemetry/integrations/index.ts
+++ b/src/libs/telemetry/integrations/index.ts
@@ -14,4 +14,18 @@ const reportingObserverIntegration = undefined;
 // frame would look foreign. Stub for export shape parity; filtered out of the integrations list here.
 const thirdPartyErrorFilterIntegration = undefined;
 
-export {navigationIntegration, tracingIntegration, browserProfilingIntegration, breadcrumbsIntegration, consoleIntegration, reportingObserverIntegration, thirdPartyErrorFilterIntegration};
+// The GH #93837 noise this drops is web-only (injected scripts; every event we have seen is macOS Safari) and its predicate reads the
+// `third_party_code` tag that only the web integration above sets. Stub for export shape parity; filtered out
+// of the integrations list here.
+const classCallCheckNoiseFilterIntegration = undefined;
+
+export {
+    navigationIntegration,
+    tracingIntegration,
+    browserProfilingIntegration,
+    breadcrumbsIntegration,
+    consoleIntegration,
+    reportingObserverIntegration,
+    thirdPartyErrorFilterIntegration,
+    classCallCheckNoiseFilterIntegration,
+};

--- a/src/libs/telemetry/integrations/index.web.ts
+++ b/src/libs/telemetry/integrations/index.web.ts
@@ -2,6 +2,7 @@ import SENTRY_APPLICATION_KEY from '@libs/telemetry/sentryApplicationKey';
 
 import * as SentryReact from '@sentry/react';
 
+import classCallCheckNoiseFilterIntegration from './classCallCheckNoiseFilter';
 import {breadcrumbsIntegration, browserProfilingIntegration, consoleIntegration, navigationIntegration, shouldCreateSpanForRequest} from './common';
 
 /**
@@ -45,4 +46,13 @@ const thirdPartyErrorFilterIntegration = isApplicationKeyStamped()
       })
     : undefined;
 
-export {navigationIntegration, tracingIntegration, browserProfilingIntegration, breadcrumbsIntegration, consoleIntegration, reportingObserverIntegration, thirdPartyErrorFilterIntegration};
+export {
+    navigationIntegration,
+    tracingIntegration,
+    browserProfilingIntegration,
+    breadcrumbsIntegration,
+    consoleIntegration,
+    reportingObserverIntegration,
+    thirdPartyErrorFilterIntegration,
+    classCallCheckNoiseFilterIntegration,
+};

--- a/src/setup/telemetry/setupSentry.ts
+++ b/src/setup/telemetry/setupSentry.ts
@@ -2,6 +2,7 @@ import {isDevelopment} from '@libs/Environment/Environment';
 import {
     breadcrumbsIntegration,
     browserProfilingIntegration,
+    classCallCheckNoiseFilterIntegration,
     consoleIntegration,
     navigationIntegration,
     reportingObserverIntegration,
@@ -24,6 +25,16 @@ import makeDebugTransport from './debugTransport';
  */
 const EXTENSION_DENY_URLS = [/^chrome-extension:\/\//i, /^moz-extension:\/\//i, /^safari-extension:\/\//i, /^safari-web-extension:\/\//i];
 
+/**
+ * Ordered pair, not two independent entries. Sentry registers each integration's `processEvent` as an event
+ * processor in the order the integrations appear, and `classCallCheckNoiseFilterIntegration` reads the
+ * `third_party_code` tag that `thirdPartyErrorFilterIntegration` writes in its own `processEvent`. Swapped,
+ * the filter goes permanently inert and drops nothing, with no type error to catch it - so they are kept in
+ * one constant that a reorder of the list below moves as a unit, and `tests/unit/setupSentryIntegrationOrderTest.ts`
+ * pins the order inside the constant.
+ */
+const THIRD_PARTY_NOISE_INTEGRATIONS = [thirdPartyErrorFilterIntegration, classCallCheckNoiseFilterIntegration];
+
 function setupSentry(): void {
     const integrations = [
         navigationIntegration,
@@ -32,7 +43,7 @@ function setupSentry(): void {
         breadcrumbsIntegration,
         consoleIntegration,
         reportingObserverIntegration,
-        thirdPartyErrorFilterIntegration,
+        ...THIRD_PARTY_NOISE_INTEGRATIONS,
     ].filter((integration): integration is NonNullable<typeof integration> => integration !== undefined);
 
     Sentry.init({

--- a/src/setup/telemetry/setupSentry.ts
+++ b/src/setup/telemetry/setupSentry.ts
@@ -26,12 +26,10 @@ import makeDebugTransport from './debugTransport';
 const EXTENSION_DENY_URLS = [/^chrome-extension:\/\//i, /^moz-extension:\/\//i, /^safari-extension:\/\//i, /^safari-web-extension:\/\//i];
 
 /**
- * Ordered pair, not two independent entries. Sentry registers each integration's `processEvent` as an event
- * processor in the order the integrations appear, and `classCallCheckNoiseFilterIntegration` reads the
- * `third_party_code` tag that `thirdPartyErrorFilterIntegration` writes in its own `processEvent`. Swapped,
- * the filter goes permanently inert and drops nothing, with no type error to catch it - so they are kept in
- * one constant that a reorder of the list below moves as a unit, and `tests/unit/setupSentryIntegrationOrderTest.ts`
- * pins the order inside the constant.
+ * Ordered pair, not two independent entries: Sentry runs each integration's `processEvent` in list order, and
+ * `classCallCheckNoiseFilterIntegration` reads the `third_party_code` tag `thirdPartyErrorFilterIntegration`
+ * writes. Swapped, the filter goes inert with no type error to catch it - hence one constant that reorders as a
+ * unit, with the order pinned by `tests/unit/setupSentryIntegrationOrderTest.ts`.
  */
 const THIRD_PARTY_NOISE_INTEGRATIONS = [thirdPartyErrorFilterIntegration, classCallCheckNoiseFilterIntegration];
 

--- a/tests/unit/classCallCheckNoiseFilterTest.ts
+++ b/tests/unit/classCallCheckNoiseFilterTest.ts
@@ -1,4 +1,5 @@
 import classCallCheckNoiseFilterIntegration, {CLASS_CALL_CHECK_MESSAGE, isClassCallCheckNoise, THIRD_PARTY_CODE_TAG} from '@libs/telemetry/integrations/classCallCheckNoiseFilter';
+import {classCallCheckNoiseFilterIntegration as webClassCallCheckNoiseFilterIntegration} from '@libs/telemetry/integrations/index.web';
 
 import type {Client, ErrorEvent, Exception, StackFrame} from '@sentry/core';
 
@@ -117,6 +118,15 @@ describe('classCallCheckNoiseFilter', () => {
         it('passes anything else through untouched', () => {
             const event = buildClassCallCheckEvent([{filename: 'app:///76-f662df2d477d1a4f.bundle.js'}]);
             expect(processEvent(event)).toBe(event);
+        });
+    });
+
+    // `setupSentryIntegrationOrderTest` mocks the whole integrations module, so nothing there exercises the real
+    // web index. Web is the only platform this filter runs on, so assert the export is the real integration and
+    // not the `undefined` stub the native index ships.
+    describe('web export wiring', () => {
+        it('re-exports the real filter from the unmocked web index', () => {
+            expect(webClassCallCheckNoiseFilterIntegration).toBe(classCallCheckNoiseFilterIntegration);
         });
     });
 });

--- a/tests/unit/classCallCheckNoiseFilterTest.ts
+++ b/tests/unit/classCallCheckNoiseFilterTest.ts
@@ -1,0 +1,122 @@
+import classCallCheckNoiseFilterIntegration, {CLASS_CALL_CHECK_MESSAGE, isClassCallCheckNoise, THIRD_PARTY_CODE_TAG} from '@libs/telemetry/integrations/classCallCheckNoiseFilter';
+
+import type {Client, ErrorEvent, Exception, StackFrame} from '@sentry/core';
+
+const THIRD_PARTY_TAGS: ErrorEvent['tags'] = {[THIRD_PARTY_CODE_TAG]: true};
+
+/** The exact frames Sentry received for APP-JY0 on release 9.4.53-10. */
+const APP_JY0_FRAMES: StackFrame[] = [
+    {filename: 'app:///', lineno: 156, colno: 387215, function: 'r'},
+    {filename: 'app:///', lineno: 156, colno: 384862, function: 'G'},
+];
+
+/** `type: undefined` is what marks an error event in the SDK types, as opposed to `'transaction'`. */
+function buildEvent(values: Exception[], tags: ErrorEvent['tags'] = THIRD_PARTY_TAGS): ErrorEvent {
+    return {type: undefined, tags, exception: {values}};
+}
+
+function buildClassCallCheckEvent(frames: StackFrame[], tags: ErrorEvent['tags'] = THIRD_PARTY_TAGS): ErrorEvent {
+    return buildEvent([{type: 'TypeError', value: CLASS_CALL_CHECK_MESSAGE, stacktrace: {frames}}], tags);
+}
+
+describe('classCallCheckNoiseFilter', () => {
+    describe('recognizes the GH #93837 signature', () => {
+        it('matches the exact APP-JY0 event shape', () => {
+            expect(isClassCallCheckNoise(buildClassCallCheckEvent(APP_JY0_FRAMES))).toBe(true);
+        });
+
+        it('matches frames that carry no filename at all', () => {
+            expect(isClassCallCheckNoise(buildClassCallCheckEvent([{}, {filename: ''}]))).toBe(true);
+        });
+
+        it('matches the rewritten <anonymous> marker', () => {
+            expect(isClassCallCheckNoise(buildClassCallCheckEvent([{filename: 'app:///<anonymous>'}]))).toBe(true);
+        });
+
+        it('matches native frames, which the rewrite leaves untouched', () => {
+            expect(isClassCallCheckNoise(buildClassCallCheckEvent([{filename: 'app:///'}, {filename: '[native code]'}, {filename: 'native'}]))).toBe(true);
+        });
+
+        it('matches the pre-rewrite <anonymous> marker, so frame order relative to rewriteFrames does not matter', () => {
+            expect(isClassCallCheckNoise(buildClassCallCheckEvent([{filename: '<anonymous>'}]))).toBe(true);
+        });
+
+        it('matches the pre-rewrite WebKit masked URL, so frame order relative to rewriteFrames does not matter', () => {
+            expect(isClassCallCheckNoise(buildClassCallCheckEvent([{filename: 'webkit-masked-url://hidden/'}]))).toBe(true);
+        });
+
+        it('matches a chained error when every value is the signature and every frame is anonymous', () => {
+            const event = buildEvent([
+                {type: 'TypeError', value: CLASS_CALL_CHECK_MESSAGE, stacktrace: {frames: [{filename: 'app:///'}]}},
+                {type: 'TypeError', value: CLASS_CALL_CHECK_MESSAGE, stacktrace: {frames: [{filename: '<anonymous>'}]}},
+            ]);
+            expect(isClassCallCheckNoise(event)).toBe(true);
+        });
+    });
+
+    describe('leaves everything else alone', () => {
+        it('keeps a different error even when it is anonymous and tagged third-party', () => {
+            const event = buildEvent([{type: 'TypeError', value: "Cannot read properties of undefined (reading 'se')", stacktrace: {frames: [{filename: 'app:///'}]}}]);
+            expect(isClassCallCheckNoise(event)).toBe(false);
+        });
+
+        it('keeps the signature when a frame is attributable to our bundle', () => {
+            const event = buildClassCallCheckEvent([{filename: 'app:///'}, {filename: 'app:///76-f662df2d477d1a4f.bundle.js'}]);
+            expect(isClassCallCheckNoise(event)).toBe(false);
+        });
+
+        it('keeps the signature when the frame is a named vendor script, spelled as in APP-J2J', () => {
+            const event = buildClassCallCheckEvent([{filename: 'app:///10042537-100413459.js', lineno: 3448}]);
+            expect(isClassCallCheckNoise(event)).toBe(false);
+        });
+
+        it('keeps the signature when the frame is a named extension script, spelled as in APP-J1W', () => {
+            const event = buildClassCallCheckEvent([{filename: 'app:///extension-script.js'}]);
+            expect(isClassCallCheckNoise(event)).toBe(false);
+        });
+
+        it('keeps the signature when the event is not tagged third-party', () => {
+            expect(isClassCallCheckNoise(buildClassCallCheckEvent(APP_JY0_FRAMES, {}))).toBe(false);
+        });
+
+        it('keeps a chained error when only one value is the signature', () => {
+            const event = buildEvent([
+                {type: 'TypeError', value: CLASS_CALL_CHECK_MESSAGE, stacktrace: {frames: [{filename: 'app:///'}]}},
+                {type: 'Error', value: 'something real', stacktrace: {frames: [{filename: 'app:///'}]}},
+            ]);
+            expect(isClassCallCheckNoise(event)).toBe(false);
+        });
+
+        it('keeps a tagged event with no exception values', () => {
+            expect(isClassCallCheckNoise({type: undefined, tags: THIRD_PARTY_TAGS})).toBe(false);
+        });
+
+        it('keeps the signature when it carries no frames at all', () => {
+            expect(isClassCallCheckNoise(buildEvent([{type: 'TypeError', value: CLASS_CALL_CHECK_MESSAGE}]))).toBe(false);
+        });
+
+        it('keeps a transaction event, which never carries exception values', () => {
+            expect(isClassCallCheckNoise({type: 'transaction', tags: THIRD_PARTY_TAGS})).toBe(false);
+        });
+    });
+
+    describe('as a Sentry integration', () => {
+        // `processEvent` ignores its client argument, so an empty stub satisfies the signature without stubbing the SDK.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the filter never reads the client, this only satisfies the hook signature
+        const client = Object.create(null) as Client;
+        const processEvent = (event: ErrorEvent) => classCallCheckNoiseFilterIntegration.processEvent?.(event, {}, client);
+
+        it('is named so it can be identified in the integrations list', () => {
+            expect(classCallCheckNoiseFilterIntegration.name).toBe('ClassCallCheckNoiseFilter');
+        });
+
+        it('drops the noise', () => {
+            expect(processEvent(buildClassCallCheckEvent(APP_JY0_FRAMES))).toBeNull();
+        });
+
+        it('passes anything else through untouched', () => {
+            const event = buildClassCallCheckEvent([{filename: 'app:///76-f662df2d477d1a4f.bundle.js'}]);
+            expect(processEvent(event)).toBe(event);
+        });
+    });
+});

--- a/tests/unit/setupSentryIntegrationOrderTest.ts
+++ b/tests/unit/setupSentryIntegrationOrderTest.ts
@@ -1,0 +1,51 @@
+import setupSentry from '@src/setup/telemetry/setupSentry';
+
+import type {Integration} from '@sentry/core';
+
+/**
+ * `classCallCheckNoiseFilterIntegration` reads the `third_party_code` tag that
+ * `thirdPartyErrorFilterIntegration` writes in its own `processEvent`. Sentry runs the processors in
+ * integration order, so a swap makes the filter permanently inert without any type error. The native
+ * integrations index stubs both to `undefined`, so they are mocked here to observe the order
+ * `setupSentry` builds.
+ */
+jest.mock('@libs/telemetry/integrations', () => ({
+    navigationIntegration: {name: 'Navigation'},
+    tracingIntegration: {name: 'Tracing'},
+    browserProfilingIntegration: {name: 'BrowserProfiling'},
+    breadcrumbsIntegration: {name: 'Breadcrumbs'},
+    consoleIntegration: {name: 'Console'},
+    reportingObserverIntegration: undefined,
+    thirdPartyErrorFilterIntegration: {name: 'ThirdPartyErrorsFilter'},
+    classCallCheckNoiseFilterIntegration: {name: 'ClassCallCheckNoiseFilter'},
+}));
+
+jest.mock('@sentry/react-native', () => ({
+    init: jest.fn(),
+    setTag: jest.fn(),
+}));
+
+const sentryMock = jest.requireMock<{init: jest.Mock<void, [{integrations: Integration[]}]>; setTag: jest.Mock}>('@sentry/react-native');
+
+function initIntegrationNames(): string[] {
+    setupSentry();
+    return (sentryMock.init.mock.calls.at(0)?.at(0)?.integrations ?? []).map((integration) => integration.name);
+}
+
+describe('setupSentry integration order', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('registers thirdPartyErrorFilter before classCallCheckNoiseFilter, whose predicate reads its tag', () => {
+        const names = initIntegrationNames();
+
+        expect(names).toContain('ThirdPartyErrorsFilter');
+        expect(names).toContain('ClassCallCheckNoiseFilter');
+        expect(names.indexOf('ThirdPartyErrorsFilter')).toBeLessThan(names.indexOf('ClassCallCheckNoiseFilter'));
+    });
+
+    it('drops the integrations that are stubbed out on the current platform', () => {
+        expect(initIntegrationNames()).not.toContain(undefined);
+    });
+});

--- a/tests/unit/setupSentryIntegrationOrderTest.ts
+++ b/tests/unit/setupSentryIntegrationOrderTest.ts
@@ -3,11 +3,9 @@ import setupSentry from '@src/setup/telemetry/setupSentry';
 import type {Integration} from '@sentry/core';
 
 /**
- * `classCallCheckNoiseFilterIntegration` reads the `third_party_code` tag that
- * `thirdPartyErrorFilterIntegration` writes in its own `processEvent`. Sentry runs the processors in
- * integration order, so a swap makes the filter permanently inert without any type error. The native
- * integrations index stubs both to `undefined`, so they are mocked here to observe the order
- * `setupSentry` builds.
+ * Sentry runs event processors in integration order, so registering `classCallCheckNoiseFilterIntegration`
+ * before the `thirdPartyErrorFilterIntegration` that writes the tag it reads makes it inert. The native index
+ * stubs both to `undefined`, hence the mock, which also lets us observe the order `setupSentry` builds.
  */
 jest.mock('@libs/telemetry/integrations', () => ({
     navigationIntegration: {name: 'Navigation'},


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

This adds a web-only `classCallCheckNoiseFilterIntegration` that drops the untraceable `TypeError: Cannot call a class as a function` noise (APP-CN8 and siblings) coming from injected third-party scripts. It only discards an event when all three conditions hold: the message matches Babel's `_classCallCheck` signature, every stack frame is anonymous, and the event is already tagged `third_party_code`. The integration must run after `thirdPartyErrorFilterIntegration`, since it reads the tag that one sets - that ordering is pinned in `setupSentry` and covered by a dedicated unit test.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93837
PROPOSAL:

### Tests

1. Run `npx jest tests/unit/classCallCheckNoiseFilterTest.ts tests/unit/setupSentryIntegrationOrderTest.ts` and verify both suites pass. These cover the whole behavior of the change: the predicate (exact APP-JY0 frames dropped; named frame, missing `third_party_code` tag, other messages, chained errors and transactions all kept) and the fact that `classCallCheckNoiseFilterIntegration` is registered after `thirdPartyErrorFilterIntegration` in `setupSentry`.

   There is no useful manual browser step for the drop itself: on the dev server `sentryWebpackPlugin` is not installed (`config/rsbuild/rsbuild.common.ts:335`), so `__SENTRY_APPLICATION_KEY_STAMPED__` is false, `thirdPartyErrorFilterIntegration` is `undefined`, and the `third_party_code` tag this filter keys on is never set. The event has to be hand-built to reach the predicate, which is exactly what the unit tests do.

2. Start the web app (`npm run web`), open it in Chrome, and open the Troubleshoot panel (Settings > Troubleshoot). Turn **"Send data to Sentry" OFF** and **"Log Sentry to console" ON**. Trigger a normal app error (e.g. `throw new Error('sentry sanity check')` in the console) and verify it is still logged as an outgoing `[SENTRY]` envelope, confirming no regression in regular error reporting.

3. On Android/iOS native, launch the app and verify it boots with no JS console errors - the filter is stubbed to `undefined` on native and must not appear in the integration list.

### Offline tests

N/A - no API calls or Onyx operations; the change only filters events inside the Sentry SDK pipeline before transport.

### QA Steps

// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests (steps 1-2 are dev-only). On staging, verify the app loads on all platforms and that errors intentionally triggered in the app still appear in Sentry, while `third_party_code:True` `Cannot call a class as a function` events stop arriving for the staging release.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
