### PR TITLE
[No QA] stop the pong watchdog from reconnecting Pusher

### DIFF
--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -800,7 +800,6 @@ function playSoundForMessageType<TKey extends OnyxKey>(pushJSON: Array<OnyxServe
 
 let lastPingSentTimestamp = Date.now();
 let lastPongReceivedTimestamp = Date.now();
-let shouldSkipCheckAfterReconnect = false;
 function subscribeToPusherPong(currentUserAccountID: number) {
     // If there is no user accountID yet (because the app isn't fully setup yet), the channel can't be subscribed to so return early
     if (!currentUserAccountID) {
@@ -811,30 +810,21 @@ function subscribeToPusherPong(currentUserAccountID: number) {
         Log.info(`[Pusher PINGPONG] Received a PONG event from the server`, false, pushJSON);
         lastPongReceivedTimestamp = Date.now();
 
-        // Calculate the latency between the client and the server
         const pongEvent = pushJSON as PingPongEvent;
         const latency = Date.now() - Number(pongEvent.pingTimestamp);
         Log.info(`[Pusher PINGPONG] The event took ${latency} ms`);
     });
 }
 
-// Specify how long between each PING event to the server
 const PING_INTERVAL_LENGTH_IN_SECONDS = 30;
 
-// Specify how long between each check for missing PONG events
-const CHECK_LATE_PONG_INTERVAL_LENGTH_IN_SECONDS = 60;
-
-// Specify how long before a PING event is considered to be missing a PONG event, at which point the socket is presumed dead
-const SOCKET_PRESUMED_DEAD_THRESHOLD_IN_SECONDS = 2 * PING_INTERVAL_LENGTH_IN_SECONDS;
+const MISSING_PONG_THRESHOLD_IN_SECONDS = 2 * PING_INTERVAL_LENGTH_IN_SECONDS;
 
 function pingPusher() {
     if (getIsOffline()) {
         Log.info('[Pusher PINGPONG] Skipping PING because the client is offline');
         return;
     }
-    // Send a PING event to the server with a specific ID and timestamp
-    // The server will respond with a PONG event with the same ID and timestamp
-    // Then we can calculate the latency between the client and the server (or if the server never replies)
     const pingID = NumberUtils.rand64();
     const pingTimestamp = Date.now();
 
@@ -852,37 +842,14 @@ function pingPusher() {
     // eslint-disable-next-line rulesdir/no-api-side-effects-method
     API.makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.PUSHER_PING, parameters).catch(() => {});
     Log.info(`[Pusher PINGPONG] Sending a PING to the server: ${pingID} timestamp: ${pingTimestamp}`);
-}
 
-function checkForLatePongReplies() {
-    if (getIsOffline()) {
-        Log.info('[Pusher PINGPONG] Skipping checkForLatePongReplies because the client is offline');
-        return;
-    }
-
-    // A reconnect just happened, so give the fresh socket one full check interval to deliver a PONG
-    if (shouldSkipCheckAfterReconnect) {
-        shouldSkipCheckAfterReconnect = false;
-        return;
-    }
-
-    const now = Date.now();
-    const timeSinceLastPongReceived = now - lastPongReceivedTimestamp;
-
-    // A missing PONG while HTTP still works (the client is not offline) means the socket is presumed dead, so reconnect Pusher
-    if (timeSinceLastPongReceived > SOCKET_PRESUMED_DEAD_THRESHOLD_IN_SECONDS * 1000) {
-        Log.info(`[Pusher PINGPONG] The server has not sent a PONG in ${timeSinceLastPongReceived} ms so the socket is presumed dead and Pusher is being reconnected`);
-
-        // Retries stay unbounded: one reconnect every second check tick (~2 minutes) while PONGs are missing
-        shouldSkipCheckAfterReconnect = true;
-        Pusher.reconnect();
-    } else {
-        Log.info(`[Pusher PINGPONG] Last PONG event was ${timeSinceLastPongReceived} ms ago so the socket is presumed alive`);
+    const timeSinceLastPongReceived = pingTimestamp - lastPongReceivedTimestamp;
+    if (timeSinceLastPongReceived > MISSING_PONG_THRESHOLD_IN_SECONDS * 1000) {
+        Log.info(`[Pusher PINGPONG] The server has not sent a PONG in ${timeSinceLastPongReceived} ms, leaving recovery to the Pusher SDK`);
     }
 }
 
 let pingPusherIntervalID: ReturnType<typeof setInterval>;
-let checkForLatePongRepliesIntervalID: ReturnType<typeof setInterval>;
 function initializePusherPingPong(currentUserAccountID: number) {
     // Only run the ping pong from the leader client
     if (!ActiveClientManager.isClientTheLeader()) {
@@ -891,6 +858,8 @@ function initializePusherPingPong(currentUserAccountID: number) {
     }
 
     Log.info(`[Pusher PINGPONG] Starting Pusher PING PONG and pinging every ${PING_INTERVAL_LENGTH_IN_SECONDS} seconds`);
+
+    lastPongReceivedTimestamp = Date.now();
 
     // Subscribe to the pong event from Pusher. Unfortunately, there is no way of knowing when the client is actually subscribed
     // so there could be a little delay before the client is actually listening to this event.
@@ -901,19 +870,7 @@ function initializePusherPingPong(currentUserAccountID: number) {
         clearInterval(pingPusherIntervalID);
     }
 
-    // Send a ping to pusher on a regular interval
     pingPusherIntervalID = setInterval(pingPusher, PING_INTERVAL_LENGTH_IN_SECONDS * 1000);
-
-    // Delay the start of this by double the length of PING_INTERVAL_LENGTH_IN_SECONDS to give a chance for the first
-    // events to be sent and received
-    setTimeout(() => {
-        // If things are initializing again (which is fine because it will reinitialize each time Pusher authenticates), clear the old intervals
-        if (checkForLatePongRepliesIntervalID) {
-            clearInterval(checkForLatePongRepliesIntervalID);
-        }
-        // Check for any missing pong events on a regular interval
-        checkForLatePongRepliesIntervalID = setInterval(checkForLatePongReplies, CHECK_LATE_PONG_INTERVAL_LENGTH_IN_SECONDS * 1000);
-    }, PING_INTERVAL_LENGTH_IN_SECONDS * 2);
 }
 
 /**

--- a/tests/unit/PusherPingPongTest.ts
+++ b/tests/unit/PusherPingPongTest.ts
@@ -1,9 +1,9 @@
 import {subscribeToUserEvents} from '@libs/actions/User';
 import * as API from '@libs/API';
 import {SIDE_EFFECT_REQUEST_COMMANDS} from '@libs/API/types';
+import Log from '@libs/Log';
 import type * as NetworkStateModule from '@libs/NetworkState';
 import Pusher from '@libs/Pusher';
-import PusherUtils from '@libs/PusherUtils';
 
 import ONYXKEYS from '@src/ONYXKEYS';
 
@@ -23,14 +23,12 @@ jest.mock('@libs/NetworkState', () => ({
     getIsOffline: () => false,
 }));
 
-// The watchdog checks every 60s; each reconnect skips the following check, so while PONGs stay missing it fires on every second check tick (~2 minutes)
-const CHECK_INTERVAL_MS = 60_000;
-
 const PING_INTERVAL_MS = 30_000;
+const MISSING_PONG_THRESHOLD_MS = 60_000;
 
-describe('Pusher PINGPONG watchdog', () => {
+describe('Pusher PINGPONG', () => {
     let reconnectSpy: jest.SpyInstance;
-    let pongCallback: Parameters<typeof PusherUtils.subscribeToPrivateUserChannelEvent>[2];
+    let logSpy: jest.SpyInstance;
 
     beforeAll(() => {
         // jest/setupAfterEnv.ts calls jest.useRealTimers() after the globally-enabled fake timers are installed,
@@ -38,54 +36,25 @@ describe('Pusher PINGPONG watchdog', () => {
         jest.useFakeTimers();
         Onyx.init({keys: ONYXKEYS});
         reconnectSpy = jest.spyOn(Pusher, 'reconnect').mockImplementation(() => {});
+        logSpy = jest.spyOn(Log, 'info').mockImplementation(() => {});
 
         // The automock returns undefined, and pingPusher chains a .catch on the returned promise
         mockAPI.makeRequestWithSideEffects.mockResolvedValue(undefined);
 
         subscribeToUserEvents(123, 'test@example.com', () => undefined);
-
-        const callback = jest.mocked(PusherUtils.subscribeToPrivateUserChannelEvent).mock.calls.find(([eventName]) => eventName === Pusher.TYPE.PONG)?.[2];
-        if (!callback) {
-            throw new Error('The PONG subscription was not registered');
-        }
-        pongCallback = callback;
     });
 
     afterAll(() => {
         reconnectSpy.mockRestore();
+        logSpy.mockRestore();
         jest.useRealTimers();
     });
 
-    // Both tests share one continuous fake-timer timeline and must run in file order
+    it('logs a missing PONG without reconnecting, leaving recovery to the Pusher SDK', async () => {
+        await jest.advanceTimersByTimeAsync(5 * MISSING_PONG_THRESHOLD_MS);
 
-    it('reconnects once past the threshold and keeps retrying every second check tick while PONGs stay missing', async () => {
-        await jest.advanceTimersByTimeAsync(CHECK_INTERVAL_MS + 1_000);
-        expect(reconnectSpy).toHaveBeenCalledTimes(1);
-
-        // The check tick right after a reconnect is skipped
-        await jest.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
-        expect(reconnectSpy).toHaveBeenCalledTimes(1);
-
-        await jest.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
-        expect(reconnectSpy).toHaveBeenCalledTimes(2);
-
-        await jest.advanceTimersByTimeAsync(2 * CHECK_INTERVAL_MS);
-        expect(reconnectSpy).toHaveBeenCalledTimes(3);
-    });
-
-    it('defers the next reconnect when a PONG arrives', async () => {
-        reconnectSpy.mockClear();
-
-        // Let the skipped check tick pass, then deliver a PONG
-        await jest.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
-        pongCallback({pingID: '1', pingTimestamp: Date.now()});
-
-        // Without the PONG resetting the clock, this next check tick would reconnect
-        await jest.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
         expect(reconnectSpy).not.toHaveBeenCalled();
-
-        await jest.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
-        expect(reconnectSpy).toHaveBeenCalledTimes(1);
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('leaving recovery to the Pusher SDK'));
     });
 
     it('sends the PING off the durable write queue', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

<!-- Explain what your change does and how it addresses the linked issue -->

The watchdog declares a live socket dead. The 60 second threshold equals the PING cadence the app reaches in production.

This change deletes the reconnect. Recovery moves to the Pusher SDK, which detects a dead socket with a websocket ping frame on the connection under test. A false alarm no longer discards a working socket or pulls a full `ReconnectApp` sync behind it.

### Proof

Baseline window `2026-08-12T10:30:00Z` to `14:30:00Z`. The window matches the weekday and the hours of the original measurement. After values are the prediction this PR is measured against.

| Metric                                            | Before                                | After                                  |
| ------------------------------------------------- | ------------------------------------- | -------------------------------------- |
| `presumed dead` fires per 4h                      | 96,667 across 20,163 users, 4.79 each | **0**                                  |
| Watchdog reconnects per day                       | 565,054                               | **0**                                  |
| Users firing 20 or more times per 4h              | 541 users, 38,192 fires               | **0**                                  |
| `presumed alive` log lines per 4h                 | about 1,450,000                       | **0**                                  |
| Pushed `ReconnectApp` per user per 4h             | 5.45                                  | **4.25 to 4.47**, a fall of 18% to 22% |
| Control: `GetMissingOnyxMessages did not advance` | 1.10 per user                         | **must not rise**                      |

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/Expensify/App/issues/98886
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Run `npx jest tests/unit/PusherPingPongTest.ts`. Two tests pass. No PONG for 300 seconds produces the log line and no `Pusher.reconnect()` call. The PING still goes off the durable write queue.
2. Sign in on web. Confirm chat messages arrive. Put the machine to sleep for 5 minutes, then wake it. Confirm messages resume without a reload. Allow up to 150 seconds, because recovery now comes from `pusher-js`.
3. Sign in on iOS and Android. Background the app for 5 minutes, then foreground it. Confirm new messages arrive.
4. Toggle airplane mode on and off on both platforms. Confirm the socket returns.
5. Confirm the log shows `[Pusher PINGPONG] The server has not sent a PONG in ... leaving recovery to the Pusher SDK` in place of the old `presumed dead and Pusher is being reconnected`.

- [x] Verify that no errors appear in the JS console

### Offline tests

<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Go offline. Confirm the log shows `[Pusher PINGPONG] Skipping PING because the client is offline`. Confirm no PONG staleness line appears.
2. Come back online. Confirm the PING resumes and PONGs arrive.

### QA Steps

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

This PR changes `src/libs/actions/User.ts` and a unit test file. It has no UI change. There is nothing to capture in the sections below.

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>