### PR TITLE
Fix layers ordering in GPSMapView

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -9491,6 +9491,9 @@ const CONST = {
         ROUTE_BORDER: 'route-border',
         WAYPOINTS_SOURCE: 'waypoints-source',
         WAYPOINTS: 'waypoints',
+        LAYER_ORDER_ANCHOR_SOURCE: 'layer-order-anchor-source',
+        ROUTE_ANCHOR: 'route-anchor',
+        WAYPOINTS_ANCHOR: 'waypoints-anchor',
     },
 
     ALTERNATE_DIRECTIONS_MAP_VIEW_LAYERS: {

--- a/src/components/MapView/GPSMapView.tsx
+++ b/src/components/MapView/GPSMapView.tsx
@@ -26,7 +26,7 @@ import type {GPSMapViewProps} from './MapViewTypes';
 import Compass from './Compass';
 import GPSDirection from './GPSDirection';
 import GPSWaypointLayer from './GPSWaypointLayer';
-import LOCATION_PUCK_LAYER_ID from './locationPuckLayerId';
+import LayerOrderAnchors from './LayerOrderAnchors';
 import PendingMapView from './PendingMapView';
 import responder from './responder';
 import useAccessToken from './useAccessToken';
@@ -92,8 +92,6 @@ function GPSMapView({accessToken, style, mapPadding, styleURL, pitchEnabled, way
     const [userInteractedWithMap, setUserInteractedWithMap] = useState(false);
     const [shouldUseImmediateFollowTransition, setShouldUseImmediateFollowTransition] = useState(noWaypoints || isTrackingGPS);
     const [lastLocation, setLastLocation] = useState<{longitude: number; latitude: number} | undefined>();
-    const [isLocationPuckLayerReady, setIsLocationPuckLayerReady] = useState(false);
-    const hasSetLocationPuckLayerReady = useRef(false);
 
     // Determines if map can be panned to user's detected location without bothering the user. It will return
     // false if user has already started dragging the map or if there are one or more waypoints present
@@ -174,25 +172,6 @@ function GPSMapView({accessToken, style, mapPadding, styleURL, pitchEnabled, way
         setLastLocation({longitude: coords.longitude, latitude: coords.latitude});
     };
 
-    // On first render LocationPuck layer is not ready to be used as belowLayerID prop
-    // for GPSDirection and GPSWaypointLayer, so we need to wait for the layer to be ready
-    const onDidFinishRenderingFrameFully = () => {
-        if (hasSetLocationPuckLayerReady.current && foregroundLocationPermissionsGranted) {
-            return;
-        }
-
-        // We need to reset the state to false to ensure we later remount the components with the new belowLayerID prop
-        // if user changes location permissions in the meantime (so fallback location marker is shown instead of the location puck)
-        if (!foregroundLocationPermissionsGranted) {
-            hasSetLocationPuckLayerReady.current = false;
-            setIsLocationPuckLayerReady(false);
-            return;
-        }
-
-        hasSetLocationPuckLayerReady.current = true;
-        setIsLocationPuckLayerReady(true);
-    };
-
     const shouldFollowFallbackLocation = noWaypoints && foregroundLocationPermissionsGranted === false;
 
     const cameraPadding: Mapbox.CameraPadding | undefined =
@@ -226,9 +205,10 @@ function GPSMapView({accessToken, style, mapPadding, styleURL, pitchEnabled, way
                 compassEnabled={false}
                 onCameraChanged={onCameraChanged}
                 logoPosition={{...styles.l2, ...styles.b2}}
-                onDidFinishRenderingFrameFully={onDidFinishRenderingFrameFully}
                 {...responder.panHandlers}
             >
+                <LayerOrderAnchors />
+
                 <Mapbox.Viewport
                     onStatusChanged={(event) => {
                         if (!shouldUseImmediateFollowTransition) {
@@ -291,12 +271,7 @@ function GPSMapView({accessToken, style, mapPadding, styleURL, pitchEnabled, way
 
                 <GPSWaypointLayer
                     waypoints={waypoints}
-                    // To ensure that waypoints are shown below the location puck we need to pass belowLayerID prop
-                    // Android does not support dynamic belowLayerID prop change, so we pass key to remount this component with belowLayerID change
-                    key={isLocationPuckLayerReady ? 'below-location-puck' : 'default-waypoints'}
-                    // The native Mapbox SDK renders the user-location puck on its own dedicated layer. We render waypoints below
-                    // that layer so the puck always stays on top of the waypoints. The layer id differs per platform.
-                    belowLayerID={isLocationPuckLayerReady ? LOCATION_PUCK_LAYER_ID : undefined}
+                    belowLayerID={CONST.MAP_VIEW_LAYERS.WAYPOINTS_ANCHOR}
                 />
 
                 {!noWaypoints && (
@@ -304,9 +279,7 @@ function GPSMapView({accessToken, style, mapPadding, styleURL, pitchEnabled, way
                         directionCoordinates={directionCoordinatesProp}
                         isTrackingGPS={isTrackingGPS}
                         lastLocation={lastLocation}
-                        // Similarly to GPSWaypointLayer, we want to show the direction below the location puck and also below the waypoints
-                        key={isLocationPuckLayerReady ? 'below-waypoints' : 'default-direction'}
-                        belowLayerID={isLocationPuckLayerReady ? CONST.MAP_VIEW_LAYERS.WAYPOINTS : undefined}
+                        belowLayerID={CONST.MAP_VIEW_LAYERS.ROUTE_ANCHOR}
                     />
                 )}
             </Mapbox.MapView>

--- a/src/components/MapView/LayerOrderAnchors.tsx
+++ b/src/components/MapView/LayerOrderAnchors.tsx
@@ -1,0 +1,28 @@
+import CONST from '@src/CONST';
+
+import Mapbox from '@rnmapbox/maps';
+
+// The source has no features, so the anchor layers never render anything - they only exist as positions in the layer stack
+const EMPTY_SHAPE = {
+    type: 'FeatureCollection' as const,
+    features: [],
+};
+
+/**
+ * Empty layers whose only purpose is to give other layers a stable position to anchor to via `belowLayerID`/`aboveLayerID`.
+ * This is needed as `belowLayerID`and `aboveLayerID` don't work well on native when they target layers that may not be
+ * mounted yet and on GPSMapView we have to keep LocationPuck > Waypoints > Route order.
+ */
+function LayerOrderAnchors() {
+    return (
+        <Mapbox.ShapeSource
+            id={CONST.MAP_VIEW_LAYERS.LAYER_ORDER_ANCHOR_SOURCE}
+            shape={EMPTY_SHAPE}
+        >
+            <Mapbox.CircleLayer id={CONST.MAP_VIEW_LAYERS.ROUTE_ANCHOR} />
+            <Mapbox.CircleLayer id={CONST.MAP_VIEW_LAYERS.WAYPOINTS_ANCHOR} />
+        </Mapbox.ShapeSource>
+    );
+}
+
+export default LayerOrderAnchors;

--- a/src/components/MapView/LayerOrderAnchors.tsx
+++ b/src/components/MapView/LayerOrderAnchors.tsx
@@ -10,7 +10,7 @@ const EMPTY_SHAPE = {
 
 /**
  * Empty layers whose only purpose is to give other layers a stable position to anchor to via `belowLayerID`/`aboveLayerID`.
- * This is needed as `belowLayerID`and `aboveLayerID` don't work well on native when they target layers that may not be
+ * This is needed as `belowLayerID` and `aboveLayerID` don't work well on native when they target layers that may not be
  * mounted yet and on GPSMapView we have to keep LocationPuck > Waypoints > Route order.
  */
 function LayerOrderAnchors() {

--- a/src/components/MapView/locationPuckLayerId/index.android.ts
+++ b/src/components/MapView/locationPuckLayerId/index.android.ts
@@ -1,3 +1,0 @@
-const LOCATION_PUCK_LAYER_ID = 'mapbox-location-indicator-layer';
-
-export default LOCATION_PUCK_LAYER_ID;

--- a/src/components/MapView/locationPuckLayerId/index.ios.ts
+++ b/src/components/MapView/locationPuckLayerId/index.ios.ts
@@ -1,3 +1,0 @@
-const LOCATION_PUCK_LAYER_ID = 'puck';
-
-export default LOCATION_PUCK_LAYER_ID;

--- a/src/components/MapView/locationPuckLayerId/index.ts
+++ b/src/components/MapView/locationPuckLayerId/index.ts
@@ -1,4 +1,0 @@
-// LOCATION_PUCK_LAYER_ID is only used on mobile apps
-const LOCATION_PUCK_LAYER_ID = '';
-
-export default LOCATION_PUCK_LAYER_ID;


### PR DESCRIPTION
### Explanation of Change

Fixes layer ordering in `GPSMapView`. Drops the current fragile logic (`onDidFinishRenderingFrameFully` + remounting via `key`) in favour of a new `LayerOrderAnchors` component rendering empty anchor layers. Waypoints and route now anchor to stable layer ids, keeping LocationPuck > Waypoints > Route order. Removes the platform-specific `locationPuckLayerId` files. This should fix bug where we don't show route & waypoints on the GPS map on iOS when `belowLayerID` points to a layer that has not been mounted yet. 

### Fixed Issues

$ https://github.com/Expensify/App/issues/98965
PROPOSAL: N/A

### Tests

1. FAB > Track distance > GPS
3. Verify that the map renders with the blue location puck visible on top of the map.
4. Start GPS trip
5. Verify that the route line is drawn **below** the waypoint markers (waypoint pins are not covered by the route line).
6. Verify that the location puck is drawn **on top of** both the waypoint markers and the route line
7. Stop GPS trip and verify 5. and 6. still applies
8. Close and reopen the GPS screen, verify 5. and 6. still applies
9. With waypoints and a route on the map, edit stop and save it.
10. Verify that the layer ordering is still correct (puck above waypoints, waypoints above route) and there is no flicker or reordering of layers.
11. Deny (or revoke in system settings) foreground location permissions and reopen the GPS tab.
11. Verify that the fallback location marker is shown instead of the location puck, and that the route is still rendered below the waypoints.


backgrounded app:
1. Start GPS distance tracking.
2. Background the app and go on a trip (extended time backgrounded).
3. Finish the trip and reopen the app.
4. The route line should be drawn on the map when returning to the app after the trip.



- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/0d7cf1c9-4556-406f-9938-2374dfedcef7


<!-- add screenshots or videos here -->

</details>



<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/b59056cc-6838-4da0-9571-893014059777


<!-- add screenshots or videos here -->

</details>


