### PR TITLE
[No QA] Tag the cherry-pick requester in the automated retest request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -953,6 +953,17 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
 
+      # The retest request tags the cherry-pick requester, which means reading the employee whitelist in Salt.
+      # Only the OSBotify app token can read that repo.
+      - name: Setup git for OSBotify
+        id: setupGitForOSBotify
+        uses: Expensify/GitHub-Actions/setupGitForOSBotify@main
+        with:
+          OP_VAULT: ${{ vars.OP_VAULT }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
+
       - name: Load retest webhook from 1Password
         id: loadWebhook
         # v4.0.0
@@ -966,7 +977,7 @@ jobs:
       - name: File retest request
         run: npx bun scripts/createRetestRequestForCP.ts --deploy-sha=${{ needs.prep.outputs.DEPLOY_SHA }} --deploy-tag=${{ needs.prep.outputs.TAG }}
         env:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
           SLACK_RETEST_WEBHOOK: ${{ steps.loadWebhook.outputs.SLACK_RETEST_WEBHOOK }}
 
   createRelease:

--- a/scripts/createRetestRequestForCP.ts
+++ b/scripts/createRetestRequestForCP.ts
@@ -24,6 +24,13 @@ const TAGS_PER_PAGE = 100;
 // Slack workflow webhook trigger. Empty values are rejected by Slack, so blanks are sent as this instead.
 const EMPTY = 'N/A';
 
+// The employee whitelist in Salt is what maps a GitHub login to a Slack member ID.
+const WHITELIST_REPO = 'Salt';
+const WHITELIST_PATH = 'www/files/www-whitelist.php';
+
+// Each whitelist entry lists 'github' a few lines above 'slack', so keep the match bounded to one entry.
+const WHITELIST_ENTRY_REGEX = /'github'\s*=>\s*'([^']+)'[\s\S]{0,400}?'slack'\s*=>\s*'([^']+)'/g;
+
 // Marker left on a PR after we file its retest request, so a re-run of the deploy doesn't file a duplicate.
 const getRetestMarker = (tag: string) => `<!-- retest-requested:${tag} -->`;
 
@@ -34,6 +41,13 @@ type RetestHit = {
     // A single PR can fix more than one deploy blocker, so all of them go in one retest request.
     blockerIssueURLs: string[];
     prTitle: string;
+    // Who asked for the cherry-pick, so QA knows who to chase for clarifications.
+    author: string;
+};
+
+type CherryPick = {
+    sourceSHA: string;
+    actor: string;
 };
 
 /**
@@ -78,34 +92,77 @@ async function getDeployedCommitMessages(deploySHA: string, deployTag: string): 
 }
 
 /**
- * `git cherry-pick -x` records `(cherry picked from commit <sha>)` in each new commit.
- * For the picked PR, that source SHA is the PR's original merge commit on main,
- * so we can resolve it back to the original pull request.
+ * A cherry-pick commit carries two trailers we care about:
+ *   1. `(cherry picked from commit <sha>)` from `git cherry-pick -x`, which points at the PR's original merge commit.
+ *   2. `(cherry-picked to <target> by <login>)` amended by the cherry-pick workflow, which names who asked for it.
+ * They live in the same message, so each cherry-pick keeps its own requester.
  */
-function getCherryPickSourceSHAs(commitMessages: string[]): string[] {
-    const shas = new Set<string>();
+function getCherryPicks(commitMessages: string[]): CherryPick[] {
+    const actorBySHA = new Map<string, string>();
     for (const message of commitMessages) {
+        const actor = message.match(/\(cherry-picked to .* by (.+?)\)/)?.[1] ?? '';
         for (const match of message.matchAll(/cherry picked from commit ([0-9a-f]{7,40})/g)) {
-            shas.add(match[1]);
+            if (actorBySHA.has(match[1])) {
+                continue;
+            }
+            actorBySHA.set(match[1], actor);
         }
     }
-    return [...shas];
+    return [...actorBySHA].map(([sourceSHA, actor]) => ({sourceSHA, actor}));
 }
 
-/** Resolve the original App PRs that produced the given merge commits. */
-async function getPullRequestsForSHAs(shas: string[]): Promise<number[]> {
-    const prNumbers = new Set<number>();
-    for (const sha of shas) {
+/** Resolve the original App PRs that produced the cherry-picked commits, keeping who requested each one. */
+async function getCherryPickActorByPullRequest(cherryPicks: CherryPick[]): Promise<Map<number, string>> {
+    const actorByPR = new Map<number, string>();
+    for (const {sourceSHA, actor} of cherryPicks) {
         const {data: pulls} = await GithubUtils.octokit.repos.listPullRequestsAssociatedWithCommit({
             owner: CONST.GITHUB_OWNER,
             repo: CONST.APP_REPO,
-            commit_sha: sha,
+            commit_sha: sourceSHA,
         });
         for (const pull of pulls) {
-            prNumbers.add(pull.number);
+            if (actorByPR.has(pull.number)) {
+                continue;
+            }
+            actorByPR.set(pull.number, actor);
         }
     }
-    return [...prNumbers];
+    return actorByPR;
+}
+
+/** Map every GitHub login in the employee whitelist to its Slack member ID. */
+async function getSlackIDsByGithubLogin(): Promise<Map<string, string>> {
+    const slackIDs = new Map<string, string>();
+    try {
+        const {data} = await GithubUtils.octokit.repos.getContent({
+            owner: CONST.GITHUB_OWNER,
+            repo: WHITELIST_REPO,
+            path: WHITELIST_PATH,
+        });
+        if (!('content' in data)) {
+            return slackIDs;
+        }
+        const whitelist = Buffer.from(data.content, 'base64').toString('utf8');
+        for (const match of whitelist.matchAll(WHITELIST_ENTRY_REGEX)) {
+            slackIDs.set(match[1], match[2]);
+        }
+    } catch (error) {
+        // Losing the mention is not worth failing the deploy over, so fall back to the plain GitHub login.
+        console.log('Could not read the employee whitelist, falling back to GitHub logins.', error);
+    }
+    return slackIDs;
+}
+
+/**
+ * Format a GitHub login the way Slack renders a clickable mention.
+ * People outside the whitelist (open source contributors) keep their plain login so QA can still identify them.
+ */
+function getSlackMention(githubLogin: string, slackIDsByGithubLogin: Map<string, string>): string {
+    if (!githubLogin) {
+        return EMPTY;
+    }
+    const slackID = slackIDsByGithubLogin.get(githubLogin);
+    return slackID ? `<@${slackID}>` : githubLogin;
 }
 
 /** Pull every App issue number linked anywhere in a PR body. */
@@ -137,6 +194,7 @@ function buildRetestPayload(hit: RetestHit): Record<string, string> {
         ghIssueLink: hit.blockerIssueURLs.join(' '),
         adhocLink: EMPTY,
         requesterName: hit.prAuthor || EMPTY,
+        author: hit.author || EMPTY,
         cpLink: hit.prURL,
         platforms: 'Android, iOS, Web',
     };
@@ -174,13 +232,14 @@ async function run(): Promise<void> {
     }
 
     const commitMessages = await getDeployedCommitMessages(deploySHA, deployTag);
-    const sourceSHAs = getCherryPickSourceSHAs(commitMessages);
-    if (sourceSHAs.length === 0) {
+    const cherryPicks = getCherryPicks(commitMessages);
+    if (cherryPicks.length === 0) {
         console.log('No cherry-pick source commits found in this deploy, nothing to do.');
         return;
     }
 
-    const candidatePRNumbers = await getPullRequestsForSHAs(sourceSHAs);
+    const cherryPickActorByPR = await getCherryPickActorByPullRequest(cherryPicks);
+    const candidatePRNumbers = [...cherryPickActorByPR.keys()];
     if (candidatePRNumbers.length === 0) {
         console.log('No original PRs resolved from cherry-pick source commits, nothing to do.');
         return;
@@ -197,6 +256,7 @@ async function run(): Promise<void> {
         throw error;
     }
 
+    const slackIDsByGithubLogin = await getSlackIDsByGithubLogin();
     const checklistPRNumbers = new Set(checklist.PRList.map((item) => item.number));
     const blockerIssueByNumber = new Map(checklist.deployBlockers.map((item) => [item.number, item.url]));
 
@@ -233,6 +293,7 @@ async function run(): Promise<void> {
             prAuthor: pull.user?.login ?? '',
             blockerIssueURLs,
             prTitle: pull.title,
+            author: getSlackMention(cherryPickActorByPR.get(prNumber) ?? '', slackIDsByGithubLogin),
         });
     }
 
@@ -261,5 +322,5 @@ if (require.main === module) {
 }
 
 export default run;
-export {getCherryPickSourceSHAs, getLinkedIssueNumbers, buildRetestPayload, getRetestMarker};
+export {getCherryPicks, getLinkedIssueNumbers, buildRetestPayload, getRetestMarker, getSlackMention};
 export type {RetestHit};

--- a/scripts/createRetestRequestForCP.ts
+++ b/scripts/createRetestRequestForCP.ts
@@ -154,15 +154,15 @@ async function getSlackIDsByGithubLogin(): Promise<Map<string, string>> {
 }
 
 /**
- * Format a GitHub login the way Slack renders a clickable mention.
+ * Give Slack the raw member ID for a GitHub login.
+ * The retest workflow wraps this into a mention itself, so sending anything pre-formatted would break it.
  * People outside the whitelist (open source contributors) keep their plain login so QA can still identify them.
  */
-function getSlackMention(githubLogin: string, slackIDsByGithubLogin: Map<string, string>): string {
+function getSlackAuthor(githubLogin: string, slackIDsByGithubLogin: Map<string, string>): string {
     if (!githubLogin) {
         return EMPTY;
     }
-    const slackID = slackIDsByGithubLogin.get(githubLogin);
-    return slackID ? `<@${slackID}>` : githubLogin;
+    return slackIDsByGithubLogin.get(githubLogin) ?? githubLogin;
 }
 
 /** Pull every App issue number linked anywhere in a PR body. */
@@ -293,7 +293,7 @@ async function run(): Promise<void> {
             prAuthor: pull.user?.login ?? '',
             blockerIssueURLs,
             prTitle: pull.title,
-            author: getSlackMention(cherryPickActorByPR.get(prNumber) ?? '', slackIDsByGithubLogin),
+            author: getSlackAuthor(cherryPickActorByPR.get(prNumber) ?? '', slackIDsByGithubLogin),
         });
     }
 
@@ -322,5 +322,5 @@ if (require.main === module) {
 }
 
 export default run;
-export {getCherryPicks, getLinkedIssueNumbers, buildRetestPayload, getRetestMarker, getSlackMention};
+export {getCherryPicks, getLinkedIssueNumbers, buildRetestPayload, getRetestMarker, getSlackAuthor};
 export type {RetestHit};

--- a/tests/tooling/createRetestRequestForCP.test.ts
+++ b/tests/tooling/createRetestRequestForCP.test.ts
@@ -2,23 +2,50 @@ import {describe, expect, it} from 'bun:test';
 
 import CONST from '@github/libs/CONST';
 
-import {buildRetestPayload, getCherryPickSourceSHAs, getLinkedIssueNumbers, getRetestMarker} from '@scripts/createRetestRequestForCP';
+import {buildRetestPayload, getCherryPicks, getLinkedIssueNumbers, getRetestMarker, getSlackMention} from '@scripts/createRetestRequestForCP';
 import type {RetestHit} from '@scripts/createRetestRequestForCP';
 
 describe('createRetestRequestForCP', () => {
-    describe('getCherryPickSourceSHAs', () => {
-        it('pulls the source SHA out of a cherry-pick trailer', () => {
-            const message = 'Fix the thing\n\n(cherry picked from commit 1234567890abcdef1234567890abcdef12345678)';
-            expect(getCherryPickSourceSHAs([message])).toEqual(['1234567890abcdef1234567890abcdef12345678']);
+    describe('getCherryPicks', () => {
+        it('pulls the source SHA and the requester out of the trailers', () => {
+            const message = 'Fix the thing\n\n(cherry picked from commit 1234567890abcdef1234567890abcdef12345678)\n\n(cherry-picked to staging by Julesssss)';
+            expect(getCherryPicks([message])).toEqual([{sourceSHA: '1234567890abcdef1234567890abcdef12345678', actor: 'Julesssss'}]);
         });
 
-        it('collects a SHA from each commit and dedupes repeats', () => {
-            const messages = ['(cherry picked from commit aaaaaaa)', '(cherry picked from commit bbbbbbb)', '(cherry picked from commit aaaaaaa)'];
-            expect(getCherryPickSourceSHAs(messages)).toEqual(['aaaaaaa', 'bbbbbbb']);
+        it('keeps each cherry-pick with its own requester and dedupes repeats', () => {
+            const messages = [
+                '(cherry picked from commit aaaaaaa)\n\n(cherry-picked to staging by mountiny)',
+                '(cherry picked from commit bbbbbbb)\n\n(cherry-picked to staging by Julesssss)',
+                '(cherry picked from commit aaaaaaa)\n\n(cherry-picked to staging by someoneElse)',
+            ];
+            expect(getCherryPicks(messages)).toEqual([
+                {sourceSHA: 'aaaaaaa', actor: 'mountiny'},
+                {sourceSHA: 'bbbbbbb', actor: 'Julesssss'},
+            ]);
+        });
+
+        it('still returns the SHA when the requester trailer is missing', () => {
+            expect(getCherryPicks(['(cherry picked from commit aaaaaaa)'])).toEqual([{sourceSHA: 'aaaaaaa', actor: ''}]);
         });
 
         it('returns nothing when no commit was cherry-picked', () => {
-            expect(getCherryPickSourceSHAs(['Merge pull request #1 from foo/bar', 'Update version to 1.2.3-4'])).toEqual([]);
+            expect(getCherryPicks(['Merge pull request #1 from foo/bar', 'Update version to 1.2.3-4'])).toEqual([]);
+        });
+    });
+
+    describe('getSlackMention', () => {
+        const slackIDs = new Map([['jasperhuangg', 'U01N2A6GYJH']]);
+
+        it('wraps a known login so Slack renders a clickable mention', () => {
+            expect(getSlackMention('jasperhuangg', slackIDs)).toBe('<@U01N2A6GYJH>');
+        });
+
+        it('falls back to the plain login for people outside the whitelist', () => {
+            expect(getSlackMention('some-oss-contributor', slackIDs)).toBe('some-oss-contributor');
+        });
+
+        it('sends N/A when there is no login at all', () => {
+            expect(getSlackMention('', slackIDs)).toBe('N/A');
         });
     });
 
@@ -46,6 +73,7 @@ describe('createRetestRequestForCP', () => {
             prAuthor: 'octocat',
             blockerIssueURLs: [`${CONST.APP_REPO_URL}/issues/42`],
             prTitle: 'Fix crash on staging',
+            author: '<@U01N2A6GYJH>',
         };
 
         it('maps a hit to the exact Slack workflow variables', () => {
@@ -56,6 +84,7 @@ describe('createRetestRequestForCP', () => {
                 ghIssueLink: `${CONST.APP_REPO_URL}/issues/42`,
                 adhocLink: 'N/A',
                 requesterName: 'octocat',
+                author: '<@U01N2A6GYJH>',
                 cpLink: `${CONST.APP_REPO_URL}/pull/123`,
                 platforms: 'Android, iOS, Web',
             });

--- a/tests/tooling/createRetestRequestForCP.test.ts
+++ b/tests/tooling/createRetestRequestForCP.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore Julesssss jasperhuangg GYJH
 import {describe, expect, it} from 'bun:test';
 
 import CONST from '@github/libs/CONST';

--- a/tests/tooling/createRetestRequestForCP.test.ts
+++ b/tests/tooling/createRetestRequestForCP.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, it} from 'bun:test';
 
 import CONST from '@github/libs/CONST';
 
-import {buildRetestPayload, getCherryPicks, getLinkedIssueNumbers, getRetestMarker, getSlackMention} from '@scripts/createRetestRequestForCP';
+import {buildRetestPayload, getCherryPicks, getLinkedIssueNumbers, getRetestMarker, getSlackAuthor} from '@scripts/createRetestRequestForCP';
 import type {RetestHit} from '@scripts/createRetestRequestForCP';
 
 describe('createRetestRequestForCP', () => {
@@ -33,19 +33,19 @@ describe('createRetestRequestForCP', () => {
         });
     });
 
-    describe('getSlackMention', () => {
+    describe('getSlackAuthor', () => {
         const slackIDs = new Map([['jasperhuangg', 'U01N2A6GYJH']]);
 
-        it('wraps a known login so Slack renders a clickable mention', () => {
-            expect(getSlackMention('jasperhuangg', slackIDs)).toBe('<@U01N2A6GYJH>');
+        it('sends the raw member ID, since the retest workflow builds the mention itself', () => {
+            expect(getSlackAuthor('jasperhuangg', slackIDs)).toBe('U01N2A6GYJH');
         });
 
         it('falls back to the plain login for people outside the whitelist', () => {
-            expect(getSlackMention('some-oss-contributor', slackIDs)).toBe('some-oss-contributor');
+            expect(getSlackAuthor('some-oss-contributor', slackIDs)).toBe('some-oss-contributor');
         });
 
         it('sends N/A when there is no login at all', () => {
-            expect(getSlackMention('', slackIDs)).toBe('N/A');
+            expect(getSlackAuthor('', slackIDs)).toBe('N/A');
         });
     });
 
@@ -73,7 +73,7 @@ describe('createRetestRequestForCP', () => {
             prAuthor: 'octocat',
             blockerIssueURLs: [`${CONST.APP_REPO_URL}/issues/42`],
             prTitle: 'Fix crash on staging',
-            author: '<@U01N2A6GYJH>',
+            author: 'U01N2A6GYJH',
         };
 
         it('maps a hit to the exact Slack workflow variables', () => {
@@ -84,7 +84,7 @@ describe('createRetestRequestForCP', () => {
                 ghIssueLink: `${CONST.APP_REPO_URL}/issues/42`,
                 adhocLink: 'N/A',
                 requesterName: 'octocat',
-                author: '<@U01N2A6GYJH>',
+                author: 'U01N2A6GYJH',
                 cpLink: `${CONST.APP_REPO_URL}/pull/123`,
                 platforms: 'Android, iOS, Web',
             });


### PR DESCRIPTION
### Explanation of Change

QA asked to know who to contact about an automated retest request. This adds an `author` field that names the person who requested the cherry-pick, formatted so Slack renders it as a real mention.

### How it works

1. A cherry-pick commit carries two trailers: the source SHA from `git cherry-pick -x`, and `(cherry-picked to staging by <login>)` added by the cherry-pick workflow.
2. We already read those commits, so each cherry-pick now keeps its own requester.
3. That GitHub login is looked up in the employee whitelist in Salt to get a Slack member ID.
4. The request sends that raw member ID. The retest workflow wraps it into a mention on their side, so we must not pre-format it.

People outside the whitelist (open source contributors) fall back to their plain GitHub login.

### Fixed Issues
$
PROPOSAL:

### Tests

This only runs in the staging deploy for a cherry-pick, so it can't be driven locally. The parsing and formatting are covered by unit tests:

1. Run `npx bun test ./tests/tooling/createRetestRequestForCP.test.ts`.
2. Verify all tests pass, including the trailer parsing and the Slack author lookup.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A, this runs in CI during a deploy.

### QA Steps

N/A. It only runs in the staging deploy workflow when a deploy-blocker fix is cherry-picked, so it can't be triggered on demand. Title includes `[No QA]`.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

N/A, this is a CI/deploy workflow change with no app UI.

<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>