### PR TITLE
[No QA] Fix latent lint errors that only surface on an uncached lint

### DIFF
--- a/src/libs/Navigation/helpers/linkTo/index.ts
+++ b/src/libs/Navigation/helpers/linkTo/index.ts
@@ -255,14 +255,9 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
                 } else {
                     // Navigate within the existing TAB_NAVIGATOR (tab switch) rather than pushing a new one.
                     const lastRouteInMatchingFullScreen = matchingFullScreenRoute.state?.routes?.at(-1);
-                    const additionalAction = CommonActions.navigate({
-                        name: NAVIGATORS.TAB_NAVIGATOR,
-                        params: {
-                            screen: matchingFullScreenRoute.name,
-                            params: lastRouteInMatchingFullScreen
-                                ? {screen: lastRouteInMatchingFullScreen.name, params: lastRouteInMatchingFullScreen.params}
-                                : matchingFullScreenRoute.params,
-                        },
+                    const additionalAction = CommonActions.navigate(NAVIGATORS.TAB_NAVIGATOR, {
+                        screen: matchingFullScreenRoute.name,
+                        params: lastRouteInMatchingFullScreen ? {screen: lastRouteInMatchingFullScreen.name, params: lastRouteInMatchingFullScreen.params} : matchingFullScreenRoute.params,
                     });
                     navigation.dispatch(additionalAction);
                 }

--- a/src/libs/actions/CompanyCards.ts
+++ b/src/libs/actions/CompanyCards.ts
@@ -219,7 +219,7 @@ function addNewCompanyCardsFeed(
     }
 
     const feedType = CardUtils.getFeedType(cardFeed, cardFeeds);
-    const newSelectedFeed = getCardFeedWithDomainID(feedType, workspaceAccountID) as CompanyCardFeedWithDomainID;
+    const newSelectedFeed = getCardFeedWithDomainID(feedType, workspaceAccountID);
 
     const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.LAST_SELECTED_FEED | typeof ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER>> = [
         {
@@ -1275,7 +1275,7 @@ function importCSVCompanyCards({
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.LAST_SELECTED_FEED}${policyID}`,
-            value: feedNameWithDomainID as CompanyCardFeedWithDomainID,
+            value: feedNameWithDomainID,
         },
     ];
 

--- a/src/pages/workspace/companyCards/WorkspaceCompanyCardFeedSelectorPage.tsx
+++ b/src/pages/workspace/companyCards/WorkspaceCompanyCardFeedSelectorPage.tsx
@@ -155,7 +155,7 @@ function WorkspaceCompanyCardFeedSelectorPage({route}: WorkspaceCompanyCardFeedS
         if (!feed.fundID) {
             return;
         }
-        const feedValue = getCardFeedWithDomainID(feed.feed, feed.fundID) as CompanyCardFeedWithDomainID;
+        const feedValue = getCardFeedWithDomainID(feed.feed, feed.fundID);
         linkCardFeedToPolicy(feed.fundID, policyID, CONST.COMPANY_CARD.LINK_FEED_TYPE.COMPANY_CARD, feed?.country, feed.feed)
             .then(() => {
                 updateSelectedFeed(feedValue, policyID);

--- a/src/pages/workspace/companyCards/addNew/CardInstructionsStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/CardInstructionsStep.tsx
@@ -20,7 +20,7 @@ import Navigation from '@navigation/Navigation';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {CardFeedProvider, CompanyCardFeedWithDomainID} from '@src/types/onyx/CardFeeds';
+import type {CardFeedProvider} from '@src/types/onyx/CardFeeds';
 
 import React from 'react';
 import {View} from 'react-native';
@@ -59,7 +59,7 @@ function CardInstructionsStep({policyID}: CardInstructionsStepProps) {
 
     const submit = () => {
         if (isStripeFeedProvider && policyID) {
-            updateSelectedFeed(getCardFeedWithDomainID(feedProvider, workspaceAccountID) as CompanyCardFeedWithDomainID, policyID);
+            updateSelectedFeed(getCardFeedWithDomainID(feedProvider, workspaceAccountID), policyID);
             Navigation.goBack();
             return;
         }


### PR DESCRIPTION
### Explanation of Change

Five ESLint errors that already exist on `main` but that most PRs never see.

The ESLint cache key hashes `config/eslint/**`, so a PR that touches that directory gets a cold, whole-repo re-lint instead of only its changed files — and then fails on errors it did not introduce. [#97199](https://github.com/Expensify/App/pull/97199) hit exactly this while adding an `evals` project to the ESLint config. Splitting the fix out so it can land on its own.

They aren't caught by `eslint-seatbelt` because the baseline lists these files under `@typescript-eslint/no-unsafe-type-assertion`, while the errors are `no-unnecessary-type-assertion` and `no-deprecated` — different rules, so nothing grandfathers them.

**Four redundant type assertions.** [`f2d5991a487`](https://github.com/Expensify/App/commit/f2d5991a487d9b98897c14fe85ce4f8394dfd696) gave `getCardFeedWithDomainID` overloads that already return `CompanyCardFeedWithDomainID`, so `as CompanyCardFeedWithDomainID` became a no-op at three call sites, plus a fourth that carried the same value through to an Onyx write. TypeScript reports these as assertions that don't change the type, so removing them changes nothing at runtime or in the type system. One type import became unused and is dropped with them.

**One deprecated navigation call.** `CommonActions.navigate`'s object form is deprecated in favour of `navigate(name, params, options)`. The call in `linkTo` passes only `name` and `params` — no `key`, no `merge` — so the positional form dispatches an identical action. It is the only `CommonActions.navigate(` call in `src/`.

### Fixed Issues
$
PROPOSAL:

### Tests
1. `npm run lint` completes without these five errors. To see them on `main`, a cached run won't do it — `bun scripts/lint.ts --no-cache src/libs/Navigation/helpers/linkTo/index.ts src/libs/actions/CompanyCards.ts src/pages/workspace/companyCards/WorkspaceCompanyCardFeedSelectorPage.tsx src/pages/workspace/companyCards/addNew/CardInstructionsStep.tsx` reports all five before this change and none after.
2. `npm run typecheck` passes. This is the meaningful check on the cast removals: if any assertion had been doing real work, dropping it would fail here.
3. `npx jest tests/navigation tests/unit/Navigation` passes (1007 tests, 65 suites), covering the `linkTo` change.

- [x] Verify that no errors appear in the JS console

### Offline tests
None — no runtime behaviour changes.

### QA Steps
None. No user-facing change: four removed no-op type assertions and one deprecated API call swapped for its non-deprecated equivalent.

- [x] Verify that no errors appear in the JS console

### Screenshots/Videos
n/a
