### PR TITLE
[CP Staging] fix: rename the hold reason report query param to holdReportID

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -370,8 +370,8 @@ const DYNAMIC_ROUTES = {
     MONEY_REQUEST_HOLD_REASON: {
         path: 'hold-reason',
         entryScreens: [SCREENS.REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT],
-        getRoute: (transactionID: string, reportID: string | undefined) => getUrlWithParams('hold-reason', {transactionID, reportID}),
-        queryParams: ['transactionID', 'reportID'],
+        getRoute: (transactionID: string, holdReportID: string | undefined) => getUrlWithParams('hold-reason', {transactionID, holdReportID}),
+        queryParams: ['transactionID', 'holdReportID'],
     },
     MONEY_REQUEST_RECEIPT_VIEW: {
         path: 'receipt-view',

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -2267,7 +2267,8 @@ type MoneyRequestNavigatorParamList = {
         transactionID: string;
 
         /** ID of the report that user is providing hold reason to */
-        reportID?: string;
+        /** Deliberately not named `reportID` so it cannot inherit the base path's report. */
+        holdReportID?: string;
     };
     [SCREENS.MONEY_REQUEST.REJECT]: {
         /** ID of the transaction the page was opened for */

--- a/src/pages/iou/DynamicHoldReasonPage.tsx
+++ b/src/pages/iou/DynamicHoldReasonPage.tsx
@@ -41,9 +41,9 @@ function DynamicHoldReasonPage({route}: DynamicHoldReasonPageProps) {
     const delegateAccountID = useDelegateAccountID();
     const backPath = useDynamicBackPath(DYNAMIC_ROUTES.MONEY_REQUEST_HOLD_REASON.path);
 
-    const {transactionID, reportID} = route.params;
+    const {transactionID, holdReportID} = route.params;
 
-    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${holdReportID}`);
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`);
     const [transactionViolations] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`);
     const {isOffline} = useNetwork();
@@ -76,7 +76,18 @@ function DynamicHoldReasonPage({route}: DynamicHoldReasonPageProps) {
             return;
         }
 
-        putOnHold(transactionID, values.comment, reportID, isOffline, currentUserLogin ?? '', currentUserAccountID, transactionViolations, isTrackIntentUser, delegateAccountID, ancestors);
+        putOnHold(
+            transactionID,
+            values.comment,
+            holdReportID,
+            isOffline,
+            currentUserLogin ?? '',
+            currentUserAccountID,
+            transactionViolations,
+            isTrackIntentUser,
+            delegateAccountID,
+            ancestors,
+        );
         Navigation.goBack(backPath);
     };
 

--- a/tests/navigation/holdReasonDynamicRouteParamsTest.ts
+++ b/tests/navigation/holdReasonDynamicRouteParamsTest.ts
@@ -32,13 +32,6 @@ function resolveHoldReason(basePath: string, holdReportID?: string): FocusedRout
     return getFocusedRoute(getStateFromPath(url));
 }
 
-/**
- * A dynamic route inherits the params of the screen it is opened on top of, so a query param that shares a name with a
- * base screen param silently falls back to the base value when it is absent. The hold reason page is the case where
- * that is harmful: its report is the transaction thread, which does not exist yet for a freshly created expense.
- * Holding from a report preview then wrote the hold actions into the parent chat instead of a new thread.
- * Regression test for https://github.com/Expensify/App/issues/98936.
- */
 describe('hold reason dynamic route params', () => {
     it.each([
         ['a chat report', `/r/${CHAT_REPORT_ID}`],

--- a/tests/navigation/holdReasonDynamicRouteParamsTest.ts
+++ b/tests/navigation/holdReasonDynamicRouteParamsTest.ts
@@ -1,0 +1,70 @@
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
+import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
+
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
+
+import type {NavigationState, PartialState} from '@react-navigation/native';
+
+const CHAT_REPORT_ID = '8951981506501769';
+const EXPENSE_REPORT_ID = '7778889990001112';
+const SEARCH_REPORT_ID = '9998887776665554';
+const TRANSACTION_ID = '1234567890123456';
+const HOLD_REPORT_ID = '6543210987654321';
+
+type FocusedRoute = {name?: string; params?: unknown};
+
+function getFocusedRoute(state: PartialState<NavigationState>): FocusedRoute {
+    let current: PartialState<NavigationState> | undefined = state;
+    let route: FocusedRoute = {};
+
+    while (current?.routes) {
+        const nextRoute = current.routes.at(current.index ?? current.routes.length - 1);
+        route = {name: nextRoute?.name, params: nextRoute?.params};
+        current = nextRoute?.state;
+    }
+
+    return route;
+}
+
+function resolveHoldReason(basePath: string, holdReportID?: string): FocusedRoute {
+    const url = createDynamicRoute(DYNAMIC_ROUTES.MONEY_REQUEST_HOLD_REASON.getRoute(TRANSACTION_ID, holdReportID), basePath);
+    return getFocusedRoute(getStateFromPath(url));
+}
+
+/**
+ * A dynamic route inherits the params of the screen it is opened on top of, so a query param that shares a name with a
+ * base screen param silently falls back to the base value when it is absent. The hold reason page is the case where
+ * that is harmful: its report is the transaction thread, which does not exist yet for a freshly created expense.
+ * Holding from a report preview then wrote the hold actions into the parent chat instead of a new thread.
+ * Regression test for https://github.com/Expensify/App/issues/98936.
+ */
+describe('hold reason dynamic route params', () => {
+    it.each([
+        ['a chat report', `/r/${CHAT_REPORT_ID}`],
+        ['an expense report RHP', `/e/${EXPENSE_REPORT_ID}`],
+        ['a search report RHP', `/search/view/${SEARCH_REPORT_ID}`],
+    ])('does not inherit the report of %s when the transaction thread does not exist yet', (_label, basePath) => {
+        const route = resolveHoldReason(basePath);
+
+        expect(route.name).toBe(SCREENS.MONEY_REQUEST.DYNAMIC_HOLD_REASON);
+        expect(route.params).toMatchObject({transactionID: TRANSACTION_ID});
+        expect(route.params).not.toHaveProperty('holdReportID');
+    });
+
+    it('passes the transaction thread through when it already exists', () => {
+        const route = resolveHoldReason(`/r/${CHAT_REPORT_ID}`, HOLD_REPORT_ID);
+
+        expect(route.name).toBe(SCREENS.MONEY_REQUEST.DYNAMIC_HOLD_REASON);
+        expect(route.params).toMatchObject({holdReportID: HOLD_REPORT_ID, transactionID: TRANSACTION_ID});
+    });
+
+    it('keeps the transaction thread out of the URL when it does not exist yet', () => {
+        expect(createDynamicRoute(DYNAMIC_ROUTES.MONEY_REQUEST_HOLD_REASON.getRoute(TRANSACTION_ID, undefined), `/r/${CHAT_REPORT_ID}`)).toBe(
+            `/r/${CHAT_REPORT_ID}/hold-reason?transactionID=${TRANSACTION_ID}`,
+        );
+        expect(createDynamicRoute(DYNAMIC_ROUTES.MONEY_REQUEST_HOLD_REASON.getRoute(TRANSACTION_ID, HOLD_REPORT_ID), `/r/${CHAT_REPORT_ID}`)).toBe(
+            `/r/${CHAT_REPORT_ID}/hold-reason?transactionID=${TRANSACTION_ID}&holdReportID=${HOLD_REPORT_ID}`,
+        );
+    });
+});


### PR DESCRIPTION
### Explanation of Change
<!-- 
Deploy blocker follow-up to #98751. Holding an expense from a report preview / expense row wrote "Held this expense" and the reason into the **workspace chat** instead of the transaction thread.

Root cause is a param name collision introduced by the migration, not the hold logic itself:

1. A freshly created expense has no transaction thread yet, so `reportAction.childReportID` is `undefined` when `changeMoneyRequestHoldStatus` builds the route.
2. `getUrlWithParams` only serializes truthy values, so the generated URL carried no `reportID` at all: `/r/<chatReportID>/hold-reason?transactionID=…`.
3. A dynamic route inherits the params of the screen underneath it — `getStateFromPath` merges the base screen's params and `getStateForDynamicRoute` only overrides the keys the query actually contains. With `reportID` absent from the query, the hold reason screen resolved `route.params.reportID` to the **chat** report of the base path (`/r/:reportID`).
4. `putOnHold` treats a truthy `initialReportID` as an existing transaction thread and skips creating one, so both hold actions landed in `REPORT_ACTIONS_<chatReportID>`.

Before the migration the static route only ever read its own params, so `reportID` stayed `undefined` and `putOnHold` built a fresh transaction thread — which is why this reproduces on staging but not production.
-->
Fix: the hold reason screen's query param is now named **`holdReportID`**. `reportID` means the chat/expense report on every base path (`/r/:reportID`, `/e/:reportID`, `/search/view/:reportID`, `/search/r/:reportID`) but means the transaction thread on this screen, so the two must not share a key. With a distinct name, an absent value stays `undefined` and `putOnHold` recreates the thread exactly as it did before the migration. `DynamicHoldReasonPage` reads the renamed param everywhere it used the old one (`useOnyx(REPORT + …)`, which feeds `policyType`, `parentReportOwnerAccountID`, `ancestors` and `canEditMoneyRequest`, plus the `putOnHold` call), with no fallback to `reportID`.


### Fixed Issues

$ https://github.com/Expensify/App/issues/98936
PROPOSAL:

### Tests

Prerequisite: Account has at least one workspace.

1. Open any workspace chat.
2. Create a manual expense.
3. Right click on report preview > "Hold"
4. Enter any reason and hold the expense.
5. Open report.

Verify: "Held this expense" and reason messages should only be visible inside expense report.


- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Hold an expense that has no transaction thread yet and submit a reason.
3. Verify the optimistic "Held this expense" and reason messages appear in the transaction thread (greyed out / pending), **not** in the workspace chat.
4. Go back online and verify the actions stay in the transaction thread after the server response.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/8d5fdaaf-d1e9-4e0e-82dc-b87d0ed182e8



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/0410ccd9-910e-4a84-a303-1827c6e7db77


<details>
<summary>Automation test</summary>

Hold from the workspace chat when the transaction thread does not exist yet — the URL carries no `holdReportID`:

<img width="1600" height="1000" alt="1 1-1-before-workspace-chat-before-hold" src="https://github.com/user-attachments/assets/cece2baf-4af9-49ca-93f4-293108fd0190" />
<img width="1600" height="1000" alt="1 1-2-entry-hold-page-from-chat-no-thread" src="https://github.com/user-attachments/assets/30e25c52-0786-4d30-aa44-abbfdcaaec5d" />
<img width="1600" height="1000" alt="1 1-3-after-submit-after-hold-submitted" src="https://github.com/user-attachments/assets/03227363-1fb9-4fc2-8b3c-eaf85f94aa4e" />


After submitting the reason the chat has no hold messages, while the transaction thread has both:

<img width="1600" height="1000" alt="1 2-1-before-chat-has-no-hold-messages" src="https://github.com/user-attachments/assets/e4ec4fc4-6315-4dcf-9ee0-dbb064c9de21" />
<img width="1600" height="1000" alt="1 2-2-entry-transaction-thread-has-hold-messages" src="https://github.com/user-attachments/assets/19cae07a-8481-46d7-a824-f1d089c652d8" />


Hold from a transaction thread that already exists — the URL carries `holdReportID` and the actions stay in that thread:

<!-- 1.6-2-entry-hold-page-from-thread-more-menu.png -->

<img width="1600" height="1000" alt="1 6-1-before-transaction-thread-more-menu" src="https://github.com/user-attachments/assets/0d6c56da-53cb-474b-a2a8-f01cdd04c27c" />
<img width="1600" height="1000" alt="1 6-2-entry-hold-page-from-thread-more-menu" src="https://github.com/user-attachments/assets/48d9a97d-3971-423b-a972-e8a960294c5d" />

<!-- 1.3-3-after-submit-hold-actions-in-existing-thread.png -->
<img width="1600" height="1000" alt="1 3-2-entry-hold-page-with-existing-thread" src="https://github.com/user-attachments/assets/52359806-5ca3-4dfd-9dc5-b3df83c35094" />
<img width="1600" height="1000" alt="1 3-3-after-submit-hold-actions-in-existing-thread" src="https://github.com/user-attachments/assets/521af685-5fb2-4c74-b8bb-ad734e6af9da" />


Refresh on the dynamic URL restores the page, and back returns to the source screen:

<!-- 1.4-2-entry-hold-page-refresh-restored.png -->
<img width="1600" height="1000" alt="1 4-1-before-hold-page-before-refresh" src="https://github.com/user-attachments/assets/179fef0b-2b3d-4905-90fe-5dd98cc2711d" />
<img width="1600" height="1000" alt="1 4-2-entry-hold-page-refresh-restored" src="https://github.com/user-attachments/assets/b55f5c41-701a-435a-ac81-a79d32f525ec" />
<img width="1600" height="1000" alt="1 4-3-after-back-back-to-chat" src="https://github.com/user-attachments/assets/be340455-ff8a-4f97-bf80-8c6877cd95d8" />
<img width="1600" height="1000" alt="1 5-1-before-transaction-thread-on-hold" src="https://github.com/user-attachments/assets/e8c9c53a-b18e-46bd-b601-9cde6a858569" />
<img width="1600" height="1000" alt="1 5-3-after-submit-after-unhold" src="https://github.com/user-attachments/assets/ed81c34c-d855-47fb-bc17-b578e86bb4eb" />


</details>

</details>

</details>
