### PR TITLE
[No QA] Upgrade React Compiler to oxc-transform-react 0.145.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ The skill provides guidance on:
 
 ### Memoization
 
-React Compiler auto-memoizes object literals, callbacks, JSX, and derived values inside components and hooks (excluding `tests/`). Two different compilers run it: `babel-plugin-react-compiler` on native/Jest (see `babel.config.js`) and `oxc-transform` on web (see `config/rsbuild/`). They do not always agree, so a file can be memoized on one platform but not the other. The compliance check and the ESLint processor both run BOTH compilers via the shared helpers in `config/reactCompiler/` and only relax manual-memoization rules when both compilers memoize the file.
+React Compiler auto-memoizes object literals, callbacks, JSX, and derived values inside components and hooks (excluding `tests/`). Two different compilers run it: `babel-plugin-react-compiler` on native/Jest (see `babel.config.js`) and `oxc-transform-react` on web (see `config/rsbuild/`). They do not always agree, so a file can be memoized on one platform but not the other. The compliance check and the ESLint processor both run BOTH compilers via the shared helpers in `config/reactCompiler/` and only relax manual-memoization rules when both compilers memoize the file.
 
 ### Code Quality
 

--- a/config/babel/reactCompilerConfig.js
+++ b/config/babel/reactCompilerConfig.js
@@ -3,7 +3,7 @@
  * - babel.config.js (build pipeline, extends with `sources` filter)
  * - react-compiler-compliance-check (CI and local checking)
  *
- * ESLint uses oxc-transform via config/reactCompiler/checkWithOxc.mjs instead.
+ * ESLint uses oxc-transform-react via config/reactCompiler/checkWithOxc.mjs instead.
  *
  * Intentionally omits `sources` since that's only relevant for the Babel build pipeline.
  */

--- a/config/eslint/processors/eslint-processor-react-compiler-compat.mjs
+++ b/config/eslint/processors/eslint-processor-react-compiler-compat.mjs
@@ -5,7 +5,7 @@
  * React Compiler automatically memoizes components and hooks, making rules like
  * `react/jsx-no-constructed-context-values` redundant for memoized files. But the app
  * runs two different compilers -- Babel (babel-plugin-react-compiler) on native/Jest and
- * OXC (oxc-transform) on web -- and they don't always agree. A file that only one compiler
+ * OXC (oxc-transform-react) on web -- and they don't always agree. A file that only one compiler
  * memoizes still ships without memoization on the other platform, so the manual memoization
  * (and the lint rules that enforce it) is still needed there.
  *

--- a/config/reactCompiler/checkBoth.mjs
+++ b/config/reactCompiler/checkBoth.mjs
@@ -2,7 +2,7 @@
  * Runs both React Compilers (Babel + OXC) against a single source file and reports
  * whether they disagree on memoization.
  *
- * The web build uses OXC (oxc-transform) while Metro/Jest use babel-plugin-react-compiler.
+ * The web build uses OXC (oxc-transform-react) while Metro/Jest use babel-plugin-react-compiler.
  * When one compiler memoizes a file and the other does not, that file ships without
  * memoization on one platform. `isDivergent` captures exactly that gap by comparing the
  * `memoized` signal (did the compiler actually emit a `_c(...)` cache?) rather than the

--- a/config/reactCompiler/checkWithOxc.mjs
+++ b/config/reactCompiler/checkWithOxc.mjs
@@ -12,6 +12,14 @@
  * A file where one function violates the Rules of React reports `memoized: false`,
  * rather than the partial memoization the compiler would otherwise emit for its remaining functions.
  * `didBothCompilersMemoizeFile` relies on that, since it will only suppress manual-memoization lint rules when the whole file is memoized.
+ *
+ * `status` and `memoized` answer different questions and are derived separately. `memoized` comes
+ * only from the emitted memo cache: targeting React 19 the compiler can memoize solely by importing
+ * `react/compiler-runtime` and allocating `_c(n)` slots, so the marker below is exact. `status`
+ * additionally counts a file the compiler rewrote without memoizing it as `compiled`. Deriving
+ * `memoized` from that same rewrite would overstate it -- the compiler perturbs output for reasons
+ * that have nothing to do with memoization, such as expanding a concise arrow body or dropping a
+ * comment, and Babel reports no memo blocks for every file in `src/` where it does.
  */
 import path from 'node:path';
 import {transformSync} from 'oxc-transform-react';
@@ -93,6 +101,19 @@ function checkReactCompilerWithOxc(source, filename) {
             return {
                 status: 'compiled',
                 memoized: true,
+                errors: [],
+            };
+        }
+
+        // No memo cache, but the compiler may still have processed the file -- a hook that only wraps
+        // useState compiles cleanly with nothing worth memoizing. Diffing against a plain transform
+        // separates that from a file the compiler found nothing to do in, which is what lets the
+        // compliance check tell "compiled on main, broken on this branch" from "never compiled".
+        const plainResult = transformSync(filename, source, {lang, reactCompiler: false});
+        if (result.code && plainResult.code && result.code !== plainResult.code) {
+            return {
+                status: 'compiled',
+                memoized: false,
                 errors: [],
             };
         }

--- a/config/reactCompiler/checkWithOxc.mjs
+++ b/config/reactCompiler/checkWithOxc.mjs
@@ -5,24 +5,18 @@
  * Mirrors web build options from config/rsbuild/rsbuild.common.ts.
  *
  * `panicThreshold: 'critical_errors'` is what splits the two kinds of diagnostic apart:
- * a Rules-of-React violation aborts the whole transform (`fatal`, severity `Error`), while a
- * compiler limitation the code can't do anything about -- unsupported syntax, an unhandled node
- * type -- stays a `Warning` and still emits code. Only the former counts as `failed`, so
- * contributors are never blocked by a gap in the compiler itself.
+ * a Rules-of-React violation aborts the whole transform, while a
+ * compiler limitation the code can't do anything about stays a `Warning` and still emits code.
+ * Only the former counts as `failed`, so contributors are never blocked by a gap in the compiler itself.
  *
- * Aborting on the first violation also keeps `memoized` conservative: a file where one function
- * violates the Rules of React reports `memoized: false` rather than the partial memoization the
- * compiler would otherwise emit for its remaining functions. `didBothCompilersMemoizeFile` relies
- * on that, since it may only suppress manual-memoization lint rules when the whole file is memoized.
- *
- * Memoization is detected purely from the emitted memo cache. Targeting React 19 the compiler can
- * only memoize by importing `react/compiler-runtime` and allocating `_c(n)` slots, so the marker
- * below is both necessary and sufficient -- verified across every `src/` file, none of which emits
- * a memo cache the marker misses.
+ * A file where one function violates the Rules of React reports `memoized: false`,
+ * rather than the partial memoization the compiler would otherwise emit for its remaining functions.
+ * `didBothCompilersMemoizeFile` relies on that, since it will only suppress manual-memoization lint rules when the whole file is memoized.
  */
 import path from 'node:path';
 import {transformSync} from 'oxc-transform-react';
 
+// Any file compiled by React Compiler will have a _c marker in it
 const REACT_COMPILER_MARKER_PATTERN = /_c\(|react\/compiler-runtime/;
 
 function getLang(ext) {

--- a/config/reactCompiler/checkWithOxc.mjs
+++ b/config/reactCompiler/checkWithOxc.mjs
@@ -14,6 +14,11 @@
  * violates the Rules of React reports `memoized: false` rather than the partial memoization the
  * compiler would otherwise emit for its remaining functions. `didBothCompilersMemoizeFile` relies
  * on that, since it may only suppress manual-memoization lint rules when the whole file is memoized.
+ *
+ * Memoization is detected purely from the emitted memo cache. Targeting React 19 the compiler can
+ * only memoize by importing `react/compiler-runtime` and allocating `_c(n)` slots, so the marker
+ * below is both necessary and sufficient -- verified across every `src/` file, none of which emits
+ * a memo cache the marker misses.
  */
 import path from 'node:path';
 import {transformSync} from 'oxc-transform-react';
@@ -91,17 +96,6 @@ function checkReactCompilerWithOxc(source, filename) {
         }
 
         if (result.code && REACT_COMPILER_MARKER_PATTERN.test(result.code)) {
-            return {
-                status: 'compiled',
-                memoized: true,
-                errors: [],
-            };
-        }
-
-        // Hook-only .ts files compile successfully without emitting _c(...) markers.
-        // Compare against a plain transform to detect compiler activity.
-        const plainResult = transformSync(filename, source, {lang, reactCompiler: false});
-        if (result.code && plainResult.code && result.code !== plainResult.code) {
             return {
                 status: 'compiled',
                 memoized: true,

--- a/config/reactCompiler/checkWithOxc.mjs
+++ b/config/reactCompiler/checkWithOxc.mjs
@@ -1,11 +1,22 @@
 /**
- * React Compiler analysis via oxc-transform (sync).
+ * React Compiler analysis via oxc-transform-react (sync).
  *
- * Shared 3-state API for ESLint processor and future CI compliance check migration.
+ * Shared 3-state API for the ESLint processor and the CI compliance check.
  * Mirrors web build options from config/rsbuild/rsbuild.common.ts.
+ *
+ * `panicThreshold: 'critical_errors'` is what splits the two kinds of diagnostic apart:
+ * a Rules-of-React violation aborts the whole transform (`fatal`, severity `Error`), while a
+ * compiler limitation the code can't do anything about -- unsupported syntax, an unhandled node
+ * type -- stays a `Warning` and still emits code. Only the former counts as `failed`, so
+ * contributors are never blocked by a gap in the compiler itself.
+ *
+ * Aborting on the first violation also keeps `memoized` conservative: a file where one function
+ * violates the Rules of React reports `memoized: false` rather than the partial memoization the
+ * compiler would otherwise emit for its remaining functions. `didBothCompilersMemoizeFile` relies
+ * on that, since it may only suppress manual-memoization lint rules when the whole file is memoized.
  */
 import path from 'node:path';
-import {transformSync} from 'oxc-transform';
+import {transformSync} from 'oxc-transform-react';
 
 const REACT_COMPILER_MARKER_PATTERN = /_c\(|react\/compiler-runtime/;
 
@@ -42,12 +53,11 @@ function offsetToLoc(source, offset) {
 }
 
 function mapOxcError(error, source) {
-    const reason = (error.message ?? 'Unknown compiler error').replace(/^\[ReactCompiler\]\s*/u, '');
     const label = error.labels?.[0];
     const loc = label?.start !== undefined ? offsetToLoc(source, label.start) : undefined;
 
     return {
-        reason,
+        reason: error.message ?? 'Unknown compiler error',
         severity: error.severity ?? 'Error',
         loc,
     };
@@ -60,21 +70,23 @@ function checkReactCompilerWithOxc(source, filename) {
         lang,
         reactCompiler: {
             target: '19',
-            panicThreshold: 'none',
+            panicThreshold: 'critical_errors',
+            // Kept in sync with the web build: see the `eslintSuppressionRules` comment in
+            // config/rsbuild/rsbuild.common.ts.
+            eslintSuppressionRules: [],
         },
     };
 
     try {
         const result = transformSync(filename, source, transformOptions);
 
-        const reactCompilerErrors = (result.errors ?? []).filter((error) => error.message?.includes('[ReactCompiler]'));
-        const fatalReactCompilerErrors = reactCompilerErrors.filter((error) => (error.severity ?? 'Error') === 'Error');
+        const fatalErrors = (result.errors ?? []).filter((error) => error.severity === 'Error');
 
-        if (fatalReactCompilerErrors.length > 0 || (!result.code && reactCompilerErrors.length > 0)) {
+        if (result.fatal || fatalErrors.length > 0) {
             return {
                 status: 'failed',
                 memoized: false,
-                errors: reactCompilerErrors.map((error) => mapOxcError(error, source)),
+                errors: fatalErrors.map((error) => mapOxcError(error, source)),
             };
         }
 
@@ -88,7 +100,7 @@ function checkReactCompilerWithOxc(source, filename) {
 
         // Hook-only .ts files compile successfully without emitting _c(...) markers.
         // Compare against a plain transform to detect compiler activity.
-        const plainResult = transformSync(filename, source, {lang});
+        const plainResult = transformSync(filename, source, {lang, reactCompiler: false});
         if (result.code && plainResult.code && result.code !== plainResult.code) {
             return {
                 status: 'compiled',

--- a/config/rsbuild/loaders/oxc-react-compiler-loader.mjs
+++ b/config/rsbuild/loaders/oxc-react-compiler-loader.mjs
@@ -1,17 +1,17 @@
 /**
- * Thin wrapper around oxc-transform that adds React Compiler support while
- * demoting non-fatal React Compiler diagnostics from hard build errors to
- * webpack warnings.
+ * Thin wrapper around oxc-transform-react that runs the React Compiler over app source and
+ * demotes its diagnostics from hard build errors to webpack warnings.
  *
- * This works around oxc-project/oxc#23587 (fixed in a future
- * release), which caused the build to fail instead of bailing out on components
- * that violate the Rules of React — the same behaviour as babel-plugin-react-compiler.
- * We need the workaround for now until a new oxc release containing the fix adds back `reactCompiler`.
+ * With `panicThreshold: 'none'` the React Compiler never aborts the transform: it skips
+ * optimizing the offending component and reports the reason as a `Warning`. Everything that
+ * genuinely stops the file being transformed (parse errors, semantic analysis, invalid options)
+ * arrives as an `Error` and sets `fatal` on the result, which is what fails the build here.
+ * That mirrors babel-plugin-react-compiler's behaviour on the Metro/Jest side.
  */
 
 import remapping from '@jridgewell/remapping';
 import path from 'node:path';
-import {transform} from 'oxc-transform';
+import {transform} from 'oxc-transform-react';
 
 function getLang(ext) {
     if (ext === 'tsx') {
@@ -35,41 +35,27 @@ export default async function oxcReactCompilerLoader(source, inputSourceMap) {
         const ext = path.extname(resourcePath).slice(1);
         const lang = getLang(ext);
 
-        const transformOptions = {
+        const result = await transform(resourcePath, source, {
             lang,
-            target: options.target,
             jsx: options.jsx,
             reactCompiler: options.reactCompiler,
             sourcemap: sourceMaps,
-            cwd: this.rootContext,
-        };
+        });
 
-        let result = await transform(resourcePath, source, transformOptions);
+        const fatalErrors = (result.errors || []).filter((e) => e.severity === 'Error');
 
-        // Demote React Compiler diagnostics to webpack warnings instead of
-        // hard errors (workaround for oxc-project/oxc#23587).
-        const rcErrors = (result.errors || []).filter((e) => e.message && e.message.includes('[ReactCompiler]'));
-        const fatalErrors = (result.errors || []).filter((e) => !e.message?.includes('[ReactCompiler]'));
-
-        for (const e of rcErrors) {
-            this.emitWarning(new Error(`oxc-react-compiler-loader: ${e.message}`));
-        }
-
-        if (fatalErrors.length > 0) {
+        if (result.fatal || fatalErrors.length > 0) {
             const msg = fatalErrors.map((e) => `${e.message}${e.codeframe ? `\n${e.codeframe}` : ''}`).join('\n\n');
             callback(new Error(`Oxc transform errors:\n${msg}`));
             return;
         }
 
-        // A React Compiler error makes oxc-transform bail out
-        // of the whole transform and return empty code, not just skip the optimization.
-        // Re-run without the compiler to fall back to plain JSX/TS transform output.
-        if (!result.code && rcErrors.length > 0) {
-            result = await transform(resourcePath, source, {...transformOptions, reactCompiler: false});
+        for (const e of result.errors || []) {
+            this.emitWarning(new Error(`oxc-react-compiler-loader: ${e.message}`));
         }
 
         if (sourceMaps && result.map) {
-            // oxc-transform has no equivalent of Babel's `inputSourceMap` option, so a map from an
+            // oxc-transform-react has no equivalent of Babel's `inputSourceMap` option, so a map from an
             // earlier loader (e.g. fullstory-annotation-loader) has to be composed in manually —
             // otherwise it'd be discarded and stack traces would point into fullstory's intermediate
             // output instead of the original source.

--- a/config/rsbuild/rsbuild.common.ts
+++ b/config/rsbuild/rsbuild.common.ts
@@ -49,8 +49,21 @@ function getOxcAndWorkletsLoaders(isDevServer: boolean) {
         {
             loader: path.resolve(dirname, './loaders/oxc-react-compiler-loader.mjs'),
             options: {
-                reactCompiler: {target: '19', panicThreshold: 'none', isDev: isDevServer},
-                target: 'node20',
+                reactCompiler: {
+                    target: '19',
+                    panicThreshold: 'none',
+                    isDev: isDevServer,
+                    // `sources` is a filename allowlist: the compiler only runs on files whose path
+                    // contains one of these strings. Every path contains the empty string, so this
+                    // replaces the default filter (which skips `node_modules`) and keeps the compiler
+                    // running over INCLUDED_NODE_MODULES the same way it does over app source.
+                    sources: [''],
+                    // The compiler treats `react-hooks/exhaustive-deps` and `react-hooks/rules-of-hooks`
+                    // suppressions as an opt-out by default. babel-plugin-react-compiler disables that
+                    // default whenever exhaustive-memo and hooks-usage validation are both on, which is
+                    // its own default, so an empty list keeps web and Metro/Jest compiling the same files.
+                    eslintSuppressionRules: [],
+                },
                 jsx: {runtime: 'automatic', development: isDevServer, refresh: isDevServer},
             },
         },

--- a/config/rsbuild/rsbuild.common.ts
+++ b/config/rsbuild/rsbuild.common.ts
@@ -52,7 +52,6 @@ function getOxcAndWorkletsLoaders(isDevServer: boolean) {
                 reactCompiler: {
                     target: '19',
                     panicThreshold: 'none',
-                    isDev: isDevServer,
                     // `sources` is a filename allowlist: the compiler only runs on files whose path
                     // contains one of these strings. Every path contains the empty string, so this
                     // replaces the default filter (which skips `node_modules`) and keeps the compiler

--- a/contributingGuides/REACT_COMPILER.md
+++ b/contributingGuides/REACT_COMPILER.md
@@ -4,11 +4,11 @@
 
 [React Compiler](https://react.dev/learn/react-compiler) is a tool designed to enhance the performance of React applications by automatically memoizing components that lack optimizations.
 
-React Compiler is enabled in the web build pipeline via `oxc-transform` (the Rust React Compiler) and in the Metro (mobile) build pipeline via `babel-plugin-react-compiler`. Because these are two different implementations, they don't always memoize a file the same way: a file can be auto-memoized on native but not on web, or vice versa. To catch that, both the CI check and the ESLint processor run BOTH compilers, via the shared helpers in `config/reactCompiler/` (`checkWithBabel.mjs`, `checkWithOxc.mjs`, and `checkBoth.mjs`).
+React Compiler is enabled in the web build pipeline via `oxc-transform-react` (the Rust React Compiler) and in the Metro (mobile) build pipeline via `babel-plugin-react-compiler`. Because these are two different implementations, they don't always memoize a file the same way: a file can be auto-memoized on native but not on web, or vice versa. To catch that, both the CI check and the ESLint processor run BOTH compilers, via the shared helpers in `config/reactCompiler/` (`checkWithBabel.mjs`, `checkWithOxc.mjs`, and `checkBoth.mjs`).
 
 ## React Compiler CI check
 
-A CI check runs on every PR that modifies `.ts` or `.tsx` files. For each changed file it runs both `babel-plugin-react-compiler` and `oxc-transform` and reports, for each, whether the file compiles and whether it is actually memoized.
+A CI check runs on every PR that modifies `.ts` or `.tsx` files. For each changed file it runs both `babel-plugin-react-compiler` and `oxc-transform-react` and reports, for each, whether the file compiles and whether it is actually memoized.
 
 ### What the CI check enforces
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,7 +265,7 @@
         "nitrogen": "0.36.3",
         "onchange": "^7.1.0",
         "openai": "^7.0.0",
-        "oxc-transform": "0.136.0",
+        "oxc-transform-react": "0.145.0",
         "oxfmt": "^0.55.0",
         "patch-package": "^8.1.0-canary.1",
         "peggy": "^4.0.3",
@@ -12645,10 +12645,10 @@
         "win32"
       ]
     },
-    "node_modules/@oxc-transform/binding-android-arm-eabi": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.136.0.tgz",
-      "integrity": "sha512-zWyz4qFxPXplAgPMTr02oIAuN/8/DbONjj8/xYp2r6n6N2wnWWZuEAMNMixu+DJuA0BcMmAaHlIhjKAgyfFuXw==",
+    "node_modules/@oxc-transform-react/binding-android-arm-eabi": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm-eabi/-/binding-android-arm-eabi-0.145.0.tgz",
+      "integrity": "sha512-KuK3zAp10yFyeAxIXlZn2ycsFpaKLxUmj5BVRS1io4XfwnKTozb/goZakgKD5JEiHOVOtEKt1r7pTrmW/pFxxA==",
       "cpu": [
         "arm"
       ],
@@ -12662,10 +12662,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-android-arm64": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.136.0.tgz",
-      "integrity": "sha512-WyR+ZOAHaMsGSANAeluwfTEL+1u4mvWYtW3FANKROgMxwJeASZzU0zHtH7Cmms0ORbp+0SVUViNQ4Hht4XbkAg==",
+    "node_modules/@oxc-transform-react/binding-android-arm64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm64/-/binding-android-arm64-0.145.0.tgz",
+      "integrity": "sha512-eDUKx6MAgRAF67JPScjLF6h8lL2qmlvFrXGSG8mYFIVJb++NMyDygiIo8TAKdWQNguoBElUZw/SK2EPRaKsryQ==",
       "cpu": [
         "arm64"
       ],
@@ -12679,10 +12679,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-darwin-arm64": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.136.0.tgz",
-      "integrity": "sha512-NPWct7Cft+Ekm7/qIwfnKwCqWY72nb/l1Mm2Izozry5wRRjBs+dyMB8Z+m6iQSVfQRIWsu3jy45Of6Zef32K9A==",
+    "node_modules/@oxc-transform-react/binding-darwin-arm64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-arm64/-/binding-darwin-arm64-0.145.0.tgz",
+      "integrity": "sha512-msCgwbVLswJ08JaUOjfPddieVJwE4IT1Y23A1DDyKVyzZp2ormo9a4ffDEu9nmmovdEj8VqAyFgggsgzIkBVrA==",
       "cpu": [
         "arm64"
       ],
@@ -12696,10 +12696,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-darwin-x64": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.136.0.tgz",
-      "integrity": "sha512-i+6lFZR070hG7+BfNUZS9sBfgf1t+NLYWS6IquoXyoV+QDAiCOf/UDPDqOjkKDgQQmGZ3qWzL+WEeH1GlYMO+w==",
+    "node_modules/@oxc-transform-react/binding-darwin-x64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-x64/-/binding-darwin-x64-0.145.0.tgz",
+      "integrity": "sha512-R0PtsoOCsARulmWhLG1fFInT+98TRl/H6w6ifi8XOLvpdsksD1rxsw4Ol84lHbdHCcMNjfJTckZzQIZBMiXkLg==",
       "cpu": [
         "x64"
       ],
@@ -12713,10 +12713,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-freebsd-x64": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.136.0.tgz",
-      "integrity": "sha512-fPgYtBata14S53LeuhowbBYNIJ3SJwk1Aw3ear+j7F9gLpiWIkL4e8gOma8SCgOLtTOMbYdOyKk13KDFAqoMGQ==",
+    "node_modules/@oxc-transform-react/binding-freebsd-x64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-freebsd-x64/-/binding-freebsd-x64-0.145.0.tgz",
+      "integrity": "sha512-/MJ7+IvxfutSGqn6hIXU92wGNk5FlkqbTHM+kEl7ytLLOSAyivYhF2gxdYMmXTwOG56k2XviMcE0D/TBjdyoRA==",
       "cpu": [
         "x64"
       ],
@@ -12730,10 +12730,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.136.0.tgz",
-      "integrity": "sha512-irYpUBJnMxQr62MHWe1y3Oefb4FSF9+/ZiO6efMmh6FVPYlbh6bcQi/t+eG2KORMsf9YLt3qh5dmdfpQbiAIWA==",
+    "node_modules/@oxc-transform-react/binding-linux-arm-gnueabihf": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.145.0.tgz",
+      "integrity": "sha512-ssHZ0W2wSjQwaBQdkg8u+A7dTdw2vkGSK0hRfCoDCkRkETu+19Q8Tae7NNxlYHcP1iUQYhEj8Qfgpq+S/MdrYA==",
       "cpu": [
         "arm"
       ],
@@ -12747,10 +12747,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.136.0.tgz",
-      "integrity": "sha512-luUqj3eHnT5GyfK88O0HIXcnnURAn62KvcONEBs7zNje/At5Vides2Rx5NuT1X/cvSWLqR8yknBz2UMwVQeqyw==",
+    "node_modules/@oxc-transform-react/binding-linux-arm-musleabihf": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.145.0.tgz",
+      "integrity": "sha512-adJy4lQVcoIW6CUzQYbDgbHZMDSLoizwCinG2Dex29jdACKwIgXQQrIAHAgfveaZleKIB/rf3usGoRcOGyfz7Q==",
       "cpu": [
         "arm"
       ],
@@ -12764,14 +12764,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.136.0.tgz",
-      "integrity": "sha512-WdxFWJAE3PvJMrekaKYzmx2Abr6YVeJGOjyMI1iTiSeMJdazXKqH5sWR7td4BWTQ1ZSkd2FptuhDPVhVGElfYA==",
+    "node_modules/@oxc-transform-react/binding-linux-arm64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.145.0.tgz",
+      "integrity": "sha512-7KRa0CC1FaSKx5sy+bDtqGvXF+RiVoMmSe8OmTKm9kRZkNVdmsmpnsQhgravehTohlWDveo5aoGMwcFtffGDmw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12781,14 +12784,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-arm64-musl": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.136.0.tgz",
-      "integrity": "sha512-rFHkHUQIz/KgAQDZgiFGFj2OQiL+csw+tDI5aCrFY3v9RTUiQRkaxXcjGgV6gMhdEd81357vw6K3xucVmRP+cw==",
+    "node_modules/@oxc-transform-react/binding-linux-arm64-musl": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.145.0.tgz",
+      "integrity": "sha512-fGhZkDnk2RoMp6THas9HFGorF0A1wwPPA/2Lu9IUO1ip5MJqS/JG7/conmiz0DBG0PWBtnKl2Y8sA/VBiD/oQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12798,14 +12804,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.136.0.tgz",
-      "integrity": "sha512-B86BlWTVD68V3T78/gp17etSPvjLWVN6WJDexZzMzOP92hzVdK8c6KT8mL8a+UY3RlSUwsquVfxtHv2Z1tYLtw==",
+    "node_modules/@oxc-transform-react/binding-linux-ppc64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.145.0.tgz",
+      "integrity": "sha512-VBaUTjRZYRypD2tL7cmbM2Fn6fvTnacLQ1GdsU1Y6A3fkqA/z+wc5Vy1QnnuFe9sIwb9xCvSS2tJVlucR39FYw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12815,14 +12824,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.136.0.tgz",
-      "integrity": "sha512-lIVizI3eTCPuk9NBFYaHArxoJ0/LC1e4hipcIateeofUNOEXqehfkVwrMI07k4DAW/2ya/ZnUVgaLY+x4wg+NA==",
+    "node_modules/@oxc-transform-react/binding-linux-riscv64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.145.0.tgz",
+      "integrity": "sha512-s2cimMVAmWe9dtjyWdGsYtevi9C7gJoOXwrCZD0BX7hgyGmuBO3iWQjx4W48hdXlWS176NoxuFIHAN72N86upA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12832,14 +12844,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.136.0.tgz",
-      "integrity": "sha512-80igJtLGGWYp5qK3pS3/jAqD/m4jre0Fwu3YXHyHSIj197os9qIy3pn4NN35rogE4pVV4/mcx4SmqB3DsG51bA==",
+    "node_modules/@oxc-transform-react/binding-linux-riscv64-musl": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.145.0.tgz",
+      "integrity": "sha512-hFPrsL2nKL4aa8vFmheR53PcrxQgym8bnaSD1pMX9IoyQq+/ksAuw1CDJSV9c5xhxxZdw/KTPVer7M/6OQvfoA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12849,14 +12864,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.136.0.tgz",
-      "integrity": "sha512-SNAHfIhq8TjaxiTV1jFZwFReP49E9nwOalEcIh5xs4O6UAiy8I6QYuve2vTuJrvKNOkIse6RotUzywirkoV6Pg==",
+    "node_modules/@oxc-transform-react/binding-linux-s390x-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.145.0.tgz",
+      "integrity": "sha512-YLKhySqqu0JAtT0z8GuaFF7Hht3IvQLZShTH0DxeV28NwSthva+qJ7GN09ALT1bqRVvMjNGycgPHaGSWBUIt7A==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12866,14 +12884,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-x64-gnu": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.136.0.tgz",
-      "integrity": "sha512-HXMySHa9hcPsYf2byqUEKixrsBakGvYWpA9I3r7R00Zs2OJu7foPsVIYfQeP8jhvNpactigBpptWvXM3E64Jcw==",
+    "node_modules/@oxc-transform-react/binding-linux-x64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.145.0.tgz",
+      "integrity": "sha512-WqgJ+0M9mwQ1cRfSgk4vzYudD2imLSBhUZ2QFes06vUjigts5Dw4NajWKc2JibPHYsoiUA9Zj39zWwC5AxXEGQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12883,14 +12904,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-linux-x64-musl": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.136.0.tgz",
-      "integrity": "sha512-d2NQ3HMV6cltpJpJ6y9ENY37+6CQcY6/tuPLY1BzGmsdVVvajwu7uIbyWz56GZDiPf2pow+j2qDSCb0xy6VyvQ==",
+    "node_modules/@oxc-transform-react/binding-linux-x64-musl": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-musl/-/binding-linux-x64-musl-0.145.0.tgz",
+      "integrity": "sha512-eIre/TjGt07IVKoWUrUOkPxN7UKeWxbiGvCywoGLDRe1/2K50MrA2vQahZ8AlW5CLmajOr9ePKrkRzLg1fa0cQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12900,10 +12924,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-openharmony-arm64": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.136.0.tgz",
-      "integrity": "sha512-ZDDZvFWEIhAo+BXeoAcF+kswaHA2j6DgYmnsVxXgoKaJp5LpMMbK8stqX80KJbydpT+ik02nvy5XMSSfY9LTbw==",
+    "node_modules/@oxc-transform-react/binding-openharmony-arm64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-openharmony-arm64/-/binding-openharmony-arm64-0.145.0.tgz",
+      "integrity": "sha512-zhWiyJ+9XD4cuhSZIT6aozuXDHcZHNdoVe88xVmx2XN00anjZ6VAGj31rhD8ndha/F8NllcQEr8Q61Dr2MHv5Q==",
       "cpu": [
         "arm64"
       ],
@@ -12917,63 +12941,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-wasm32-wasi": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.136.0.tgz",
-      "integrity": "sha512-EFNYyWFmj4wF7K7+c9DsPQCTAFfiTVNasJ4X0ZuwjPNQUcV161z5YXeZJepgqDicqdmWCsRqJP4NPsngiWWJRw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.5"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.136.0.tgz",
-      "integrity": "sha512-jyRyFVci/T6hMtCIPCCkW/ZFYhK989hXFy27aLUnyvdJYAaMlq2h7lahh/MkTNv0ll5hokXWwQ3Hwak8EeSXoA==",
+    "node_modules/@oxc-transform-react/binding-win32-arm64-msvc": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.145.0.tgz",
+      "integrity": "sha512-Q0oiZfrfYyhmpqH2K0dylDTooIadecGsoiQks7G0AbuszCu2I7zYyJo4ArFc3d5Hj49Jjc5dDAE5WP/Sg2p8hw==",
       "cpu": [
         "arm64"
       ],
@@ -12987,10 +12958,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.136.0.tgz",
-      "integrity": "sha512-jdmNkL0+vLYvaSVVtbs39eaVHDqPFRSTWCksC7hADlZWlKlp93fE291scodjNMIOObC/ABOc5jf95JY3/qJzSg==",
+    "node_modules/@oxc-transform-react/binding-win32-ia32-msvc": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.145.0.tgz",
+      "integrity": "sha512-ERpriVJY5S8hXd3BJi4UtzsIVsEQnntmpqTgRqh0XCaflLRLTQnPWpkO8rgtI7xye5MRhfhA+qsxKg2olJs4qA==",
       "cpu": [
         "ia32"
       ],
@@ -13004,10 +12975,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-transform/binding-win32-x64-msvc": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.136.0.tgz",
-      "integrity": "sha512-cPmcOHoAyfYxH0OKYP54fiu8SJudF9RBoI9QFcnBttEOSdmapOU+dDO7pvuvcbUY5rLZMek8OZi2r9fA/jwZ4g==",
+    "node_modules/@oxc-transform-react/binding-win32-x64-msvc": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.145.0.tgz",
+      "integrity": "sha512-sa781BGPLDw8+7ATrgUpLr0f4t0Q14O+zk3fOuQbUpjW5jERc9a3k1xIYKX1JkTG/sszoFhi8LzyCoMC49tkWA==",
       "cpu": [
         "x64"
       ],
@@ -34354,10 +34325,10 @@
         "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
       }
     },
-    "node_modules/oxc-transform": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.136.0.tgz",
-      "integrity": "sha512-7mVjRVgUAFl2OKCQMFjWmfrdx5Hcr20VQBLHm/SS/a/JJalal8gRVH2AoPymp9h5efJjB3REukK662aWJk4MsA==",
+    "node_modules/oxc-transform-react": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform-react/-/oxc-transform-react-0.145.0.tgz",
+      "integrity": "sha512-y8cfjow11WKvDekonySPVvRUvNuIvqNT0LZ0Aey6j5dsNUD6k4hy6Mae/SLmng5egmb1GdJS11GduJ+IoEAXEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -34367,26 +34338,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-transform/binding-android-arm-eabi": "0.136.0",
-        "@oxc-transform/binding-android-arm64": "0.136.0",
-        "@oxc-transform/binding-darwin-arm64": "0.136.0",
-        "@oxc-transform/binding-darwin-x64": "0.136.0",
-        "@oxc-transform/binding-freebsd-x64": "0.136.0",
-        "@oxc-transform/binding-linux-arm-gnueabihf": "0.136.0",
-        "@oxc-transform/binding-linux-arm-musleabihf": "0.136.0",
-        "@oxc-transform/binding-linux-arm64-gnu": "0.136.0",
-        "@oxc-transform/binding-linux-arm64-musl": "0.136.0",
-        "@oxc-transform/binding-linux-ppc64-gnu": "0.136.0",
-        "@oxc-transform/binding-linux-riscv64-gnu": "0.136.0",
-        "@oxc-transform/binding-linux-riscv64-musl": "0.136.0",
-        "@oxc-transform/binding-linux-s390x-gnu": "0.136.0",
-        "@oxc-transform/binding-linux-x64-gnu": "0.136.0",
-        "@oxc-transform/binding-linux-x64-musl": "0.136.0",
-        "@oxc-transform/binding-openharmony-arm64": "0.136.0",
-        "@oxc-transform/binding-wasm32-wasi": "0.136.0",
-        "@oxc-transform/binding-win32-arm64-msvc": "0.136.0",
-        "@oxc-transform/binding-win32-ia32-msvc": "0.136.0",
-        "@oxc-transform/binding-win32-x64-msvc": "0.136.0"
+        "@oxc-transform-react/binding-android-arm-eabi": "0.145.0",
+        "@oxc-transform-react/binding-android-arm64": "0.145.0",
+        "@oxc-transform-react/binding-darwin-arm64": "0.145.0",
+        "@oxc-transform-react/binding-darwin-x64": "0.145.0",
+        "@oxc-transform-react/binding-freebsd-x64": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm-gnueabihf": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm-musleabihf": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm64-musl": "0.145.0",
+        "@oxc-transform-react/binding-linux-ppc64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-riscv64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-riscv64-musl": "0.145.0",
+        "@oxc-transform-react/binding-linux-s390x-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-x64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-x64-musl": "0.145.0",
+        "@oxc-transform-react/binding-openharmony-arm64": "0.145.0",
+        "@oxc-transform-react/binding-win32-arm64-msvc": "0.145.0",
+        "@oxc-transform-react/binding-win32-ia32-msvc": "0.145.0",
+        "@oxc-transform-react/binding-win32-x64-msvc": "0.145.0"
       }
     },
     "node_modules/oxfmt": {

--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
     "nitrogen": "0.36.3",
     "onchange": "^7.1.0",
     "openai": "^7.0.0",
-    "oxc-transform": "0.136.0",
+    "oxc-transform-react": "0.145.0",
     "oxfmt": "^0.55.0",
     "patch-package": "^8.1.0-canary.1",
     "peggy": "^4.0.3",

--- a/scripts/check-both-compilers-runner.mjs
+++ b/scripts/check-both-compilers-runner.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * CLI wrapper for checkBothCompilers used by Jest tests (oxc-transform is ESM-only and
+ * CLI wrapper for checkBothCompilers used by Jest tests (oxc-transform-react is ESM-only and
  * cannot be loaded directly in the Jest environment).
  *
  * Usage: node scripts/check-both-compilers-runner.mjs <filename> <sourcePath>

--- a/scripts/check-react-compiler-with-oxc-runner.mjs
+++ b/scripts/check-react-compiler-with-oxc-runner.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * CLI wrapper for checkReactCompilerWithOxc used by Jest tests (oxc-transform is ESM-only).
+ * CLI wrapper for checkReactCompilerWithOxc used by Jest tests (oxc-transform-react is ESM-only).
  *
  * Usage: node scripts/check-react-compiler-with-oxc-runner.mjs <filename> <sourcePath>
  */

--- a/scripts/react-compiler-compliance-check.ts
+++ b/scripts/react-compiler-compliance-check.ts
@@ -3,7 +3,7 @@
  * React Compiler Compliance Check
  *
  * Checks how React components and hooks fare under BOTH React Compilers: Babel
- * (babel-plugin-react-compiler, used by Metro/Jest) and OXC (oxc-transform, used
+ * (babel-plugin-react-compiler, used by Metro/Jest) and OXC (oxc-transform-react, used
  * by the web build). Two modes:
  *   - `check <files...>` -- check specific files, report per-file dual status
  *   - `check-changed`    -- check files changed in a PR, enforce:
@@ -13,9 +13,9 @@
  *          other does not) that did not already exist on main
  *
  * The Babel analysis lives inline here (kept OXC-free at module scope) because this module's
- * `checkReactCompilerCompliance` export is imported by a Jest unit test, and oxc-transform is
+ * `checkReactCompilerCompliance` export is imported by a Jest unit test, and oxc-transform-react is
  * excluded from Jest's transform. The OXC analysis is loaded via a dynamic import that only runs
- * in the (bun) CLI paths, so importing this module in Jest never pulls in oxc-transform.
+ * in the (bun) CLI paths, so importing this module in Jest never pulls in oxc-transform-react.
  */
 import {transformSync} from '@babel/core';
 import CLI from 'expensify-common/CLI';
@@ -375,7 +375,7 @@ async function main() {
     const {remote} = cli.namedArgs;
     const {verbose} = cli.flags;
 
-    // Dynamically import the OXC checker so that importing this module in Jest (where oxc-transform
+    // Dynamically import the OXC checker so that importing this module in Jest (where oxc-transform-react
     // is not transformable) never pulls it in -- the CLI paths below are never executed under Jest.
     // The explicit .mjs extension is required for Node/bun ESM resolution of this JS module.
     // eslint-disable-next-line import/extensions

--- a/scripts/react-compiler-divergence-audit.ts
+++ b/scripts/react-compiler-divergence-audit.ts
@@ -2,7 +2,7 @@
 /**
  * React Compiler Divergence Audit
  *
- * Runs BOTH React Compilers (Babel via babel-plugin-react-compiler, OXC via oxc-transform)
+ * Runs BOTH React Compilers (Babel via babel-plugin-react-compiler, OXC via oxc-transform-react)
  * over the source tree and reports every file where the two disagree on memoization.
  *
  * A file is "divergent" when exactly one compiler memoizes it (`compiled` XOR not-`compiled`).


### PR DESCRIPTION
### Explanation of Change

Upgrades the OXC React Compiler used by the web build from `oxc-transform@0.136.0` to `oxc-transform-react@0.145.0`.

As of 0.144.0 the React Compiler no longer ships inside `oxc-transform` — it moved to a dedicated `oxc-transform-react` package. `oxc-transform@0.145.0` has no `reactCompiler` option at all, so this is a package swap rather than a version bump. `oxc-transform` had no other callers in the repo, so it is removed outright.

**What changed, and why**

1. **`config/rsbuild/loaders/oxc-react-compiler-loader.mjs`** — imports `oxc-transform-react`. Two things fall out of the new release:
   - The workaround for [oxc#23587](https://github.com/oxc-project/oxc/issues/23587) is deleted. A Rules-of-React violation used to bail the whole transform and return empty code, so the loader had to re-run the transform with `reactCompiler: false`. [Downgrade nonfatal compiler diagnostics](https://github.com/oxc-project/oxc/pull/25418) fixed that: the compiler now skips the offending component and still emits code. Measured on `src/`, 16 files were paying for that second transform.
   - Diagnostic triage now uses `severity` and the new `fatal` result flag instead of matching a `[ReactCompiler]` string prefix (see below).
   - `target: 'node20'` is dropped — `oxc-transform-react` has no `target` option. Verified to be a no-op: transforming all 6,879 `src/` files plus 800 files across the included `node_modules` with and without it produced byte-identical output in every case.
   - `cwd` is dropped for the same reason. Sourcemap `sources` entries are unchanged, because the loader passes absolute paths.

2. **`config/reactCompiler/checkWithOxc.mjs`** — the shared analysis helper behind the compliance check and the ESLint processor. Rewritten against the new diagnostics; details in the section below. It also stops deriving `memoized` from its second `transformSync` call — see "`status` and `memoized` are now derived separately" below.

3. **Two option defaults changed upstream and are pinned back to current behaviour:**
   - `eslintSuppressionRules` now defaults to `['react-hooks/exhaustive-deps', 'react-hooks/rules-of-hooks']`, so a file carrying either suppression opts out of compilation. `babel-plugin-react-compiler` suppresses that default whenever `validateExhaustiveMemoizationDependencies` and `validateHooksUsage` are both on, which is its own default, so web would have silently stopped memoizing 184 files that Metro/Jest still memoize. Set to `[]`.
   - `sources` now defaults to skipping `node_modules`. That would drop React Compiler memoization for the `INCLUDED_NODE_MODULES` allowlist (`react-native-web`, `react-native-reanimated`, `@react-navigation/*`, …) — 59 of 800 sampled files are memoized there today. Set to `['']` to keep compiling them.
   - Both are called out because they are defensible the other way: adopting the new defaults would align web with `babel.config.js`, which already excludes `node_modules`, and would remove a real Babel/OXC divergence. That is a behaviour change on its own merits, so it is deliberately not bundled into a version upgrade.

4. **`isDev` is removed** from the loader options — it was a real `ReactCompilerOptions` field in 0.136 and no longer exists in 0.145, where it is silently ignored. Fast Refresh is driven by `jsx.refresh`, which is unchanged and verified working.

**React Compiler Compliance Check**

[Standardize diagnostics](https://github.com/oxc-project/oxc/pull/25702) does break the check, and it fails open rather than closed. Both `checkWithOxc.mjs` and the loader keyed off a `[ReactCompiler]` message prefix that 0.145 no longer emits, and severity moved too:

| | 0.136.0 | 0.145.0 |
|---|---|---|
| Rules-of-React violation | `Error` · `[ReactCompiler] Refs: Cannot access refs during render` | `Warning` · `Cannot access refs during render` |
| Compiler limitation | `Warning` · `[ReactCompiler] Todo: …` | `Warning` · `…` |

Running the pre-upgrade logic verbatim against 0.145 classifies both `RefViolation.tsx` and `HookOrderViolation.tsx` as `no-components` — no diagnostic matches the prefix, so the OXC half of the check goes permanently green.

The prefix carried a second job: the category (`Refs` vs `Todo`) was what separated "this code violates the Rules of React" from "the compiler cannot handle this syntax yet". 0.145 reports both as `Warning`, and the category now only appears inside the rendered `codeframe` string. Rather than parse that, `checkWithOxc.mjs` uses `panicThreshold: 'critical_errors'`, which makes the compiler abort on a real violation (`fatal: true`, severity `Error`) while leaving a limitation as a non-fatal `Warning`. That reproduces the old Error/Warning split from a structured signal, and keeps contributors from being blocked by gaps in the compiler itself. The loader keeps `panicThreshold: 'none'` so the build never fails on compiler diagnostics.

It also keeps `memoized` conservative. Under `panicThreshold: 'none'`, 0.145 emits partial memoization for a file where one function violates the rules; `didBothCompilersMemoizeFile` would then report the file as fully memoized and let the ESLint processor suppress manual-memoization rules that are still needed.

Across all 6,879 `src/` files, 25 (0.36%) change classification, all traceable to upstream compiler fixes: 20 move `failed` → `no-components` (0.136 raised `MemoDependencies: Found missing memoization dependencies` as a hard error; 0.145 reports `Existing memoization could not be preserved` as non-fatal), 3 improve to `compiled`, 1 is newly detected as a genuine ref violation, and 1 gains memoization. None can produce a false CI failure: rule 1 only applies to newly added files, and rules 2 and 3 evaluate the base branch with the same checker, so grandfathering holds.

**`status` and `memoized` are now derived separately**

`checkWithOxc.mjs` falls back to a second, plain `reactCompiler: false` transform when the first emits no `_c(` marker, and used the result to set **both** `status: 'compiled'` and `memoized: true`. Those answer different questions, and using one signal for both overstated memoization:

- 16 of the 3,288 files that reach the fallback came back `memoized: true`. `babel-plugin-react-compiler` reports `memoBlocks: 0` for **all 16**.
- What the diff actually detects is the compiler rewriting the file, which it does for reasons unrelated to memoization. In `useSidePanelState.tsx` it expanded `() => useContext(x)` into a block body; in `useThemePreferenceWithStaticOverride.ts` it dropped two comment lines. Neither gains a memo slot.
- Because it inflated only the OXC side, it manufactured 16 phantom Babel/OXC divergences for rule 3 and the divergence audit.

`memoized` now comes solely from the memo cache marker. Targeting React 19 the compiler can only memoize by importing `react/compiler-runtime` and allocating `_c(n)` slots, so the marker is exact — verified across all 6,879 `src/` files, none of which emits a memo cache it misses (also checked `useMemoCache` and `$[n]` slot patterns).

`status` keeps using the fallback. A hook that merely wraps `useState` compiles cleanly with nothing worth memoizing, and it still needs to read as `compiled` so rule 2 can tell "compiled on main, broken on this branch" from "never compiled". `status` counts across `src/` are unchanged from before this PR (3,529 `compiled`, 3,272 `no-components`, 78 `failed`); only `memoized` moves, on those 16 files.

**Performance**

Clean production web build, interleaved A/B on one machine (`rm -rf node_modules/.cache dist` before every run, alternating versions to cancel thermal drift):

| Pair | 0.136.0 | 0.145.0 | Delta |
|---|---|---|---|
| 1 | 18.52s | 17.42s | −1.10s |
| 2 | 18.72s | 17.03s | −1.69s |
| 3 | 15.81s | 14.48s | −1.33s |
| 4 | 18.68s | 18.32s | −0.36s |
| 5 | 20.45s | 15.64s | −4.81s |

Median 18.68s → 17.03s (−8.8%), faster in 5 of 5 pairs. Non-interleaved batches of 3 runs each gave medians of 15.62s → 14.73s. Note the two batches disagree on absolute numbers by ~3s, which is why the paired result is the one worth reading.

The compiler is not the bottleneck in a full production build, so isolating the transform step is more informative. Transforming all 6,879 `src/` files single-threaded, 5 iterations, median:

| | Total | Per file |
|---|---|---|
| `oxc-transform@0.136.0` | 19,779 ms | 2.88 ms |
| `oxc-transform-react@0.145.0` | 4,430 ms | 0.64 ms |

**4.46x faster.** The native binary also shrinks from 7.3 MB to 4.0 MB (−45%).

That figure is single-threaded. The loader uses the async `transform`, which dispatches to a napi worker pool, and that is worth keeping: over the same 6,879 files, `transformSync` sequentially takes 4,570 ms against 1,174 ms for async issued concurrently (3.89x). Swapping the loader to `transformSync` costs a measurable amount of real build time — interleaved A/B, 4 pairs:

| Pair | `transformSync` | `transform` (async) | Delta |
|---|---|---|---|
| 1 | 19.40s | 13.77s | −5.63s |
| 2 | 20.28s | 14.78s | −5.50s |
| 3 | 20.01s | 17.19s | −2.82s |
| 4 | 24.25s | 22.03s | −2.22s |

Median 20.15s → 15.99s (−21%), async faster in 4 of 4 pairs. `checkWithOxc.mjs` deliberately stays on `transformSync`: ESLint processors have a synchronous `preprocess` hook, so it cannot await, and the compliance check only ever walks a PR's changed files.

Bundle output grows marginally: 55,910.3 kB → 55,946.7 kB raw (+0.07%), 22,004.2 kB → 22,019.0 kB gzipped (+0.07%), from the handful of components 0.145 successfully memoizes that 0.136 bailed on.

### Fixed Issues
$
PROPOSAL:

### Tests

1. Run `npm install` to pick up `oxc-transform-react` and drop `oxc-transform`.
2. Run `npm run build` and verify it completes with no `Oxc transform errors`.
3. Run `npm run web`, open the app, and verify it loads and renders normally.
4. Edit any component's JSX while the dev server is running and verify Fast Refresh applies the change without a full reload.
5. Run `npm run react-compiler-compliance-check check src/GlobalModals.tsx` and verify OXC reports `Cannot access refs during render` with no `[ReactCompiler]` prefix.
6. Create a new file `src/Probe.tsx` containing a component that reads `ref.current` during render, run `npm run react-compiler-compliance-check check-changed`, and verify it fails with `New file fails to compile with the oxc React Compiler`.
7. Replace that file's body with a component that has no Rules-of-React violation, re-run `npm run react-compiler-compliance-check check-changed`, and verify it passes.
8. Delete `src/Probe.tsx`.
9. Run `npm run lint` and verify it exits 0.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this changes build tooling only. No runtime code, network behaviour, or Onyx interaction is affected.

### QA Steps

N/A — `[No QA]`. There is no user-facing change; the compiled output is equivalent apart from a handful of components that gain React Compiler memoization.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — build tooling change, web build only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — build tooling change, web build only.

</details>

<details>
<summary>iOS: Native</summary>

N/A — build tooling change, web build only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — build tooling change, web build only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

n/a - no visual change.

</details>
