### PR TITLE
Fix permissions check on Resume GPS trip

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepDistanceGPS/GPSButtons/index.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceGPS/GPSButtons/index.tsx
@@ -131,7 +131,7 @@ function GPSButtons({navigateToNextStep, setShouldShowStartError, setShouldShowP
             {isTripStopped ? (
                 <View style={[styles.gap2, styles.flexRow]}>
                     <Button
-                        onPress={resumeGpsTrip}
+                        onPress={checkSettingsAndPermissions}
                         size={CONST.BUTTON_SIZE.LARGE}
                         style={[styles.flex1]}
                         sentryLabel={CONST.SENTRY_LABEL.IOU_REQUEST_STEP.GPS_DISCARD_BUTTON}
@@ -172,7 +172,7 @@ function GPSButtons({navigateToNextStep, setShouldShowStartError, setShouldShowP
                 startPermissionsFlow={startPermissionsFlow}
                 setStartPermissionsFlow={setStartPermissionsFlow}
                 // eslint-disable-next-line @typescript-eslint/no-misused-promises
-                onGrant={startGpsTrip}
+                onGrant={isTripStopped ? resumeGpsTrip : startGpsTrip}
                 onDeny={() => setShowLocationRequiredModal(true)}
             />
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The "Resume" button on a stopped GPS trip called `resumeGpsTrip` directly, skipping the location services and background permissions checks that "Start" performs. It now calls `checkSettingsAndPermissions`, and `BackgroundLocationPermissionsFlow`'s `onGrant` resolves to `resumeGpsTrip` when the trip is stopped, otherwise `startGpsTrip`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98954
PROPOSAL: N/A


<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. FAB > Track distance > GPS
2. Start a GPS trip
3. Cover some distance
4. Stop the GPS trip so that it has start and stop waypoints
5. Go to location permissions settings and change them to Don't allow/Never
6. Go back to the app
7. Tap Resume
8. Verify user is asked to allow location permissions to continue the trip and that no error is shown above the Resume button
9. Verify that steps 6.-8. apply to all other permissions settings apart from "Always allowed + Precise location enabled" combination



- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
- [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/1b3deba1-44a1-498c-a547-804fe7af542e


<!-- add screenshots or videos here -->

</details>



<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/ae050b33-1ba8-4b42-a8da-5533900c9cda


<!-- add screenshots or videos here -->

</details>

