### PR TITLE
Replace pixelmatch with @blazediff/core in victory-chart-renderer tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3787,6 +3787,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@blazediff/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-AOQff0zgR7cGsZL+4E7hVkmujoPUpm0J9xzWGWZj5wCjd3gmxESXAPfKyuzs93VdpQNFhHlBhfOjrcZ+XTERtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@callstack/reassure-cli": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@callstack/reassure-cli/-/reassure-cli-1.4.1.tgz",
@@ -34864,19 +34871,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pixelmatch": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.2.0.tgz",
-      "integrity": "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^7.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "dev": true,
@@ -42537,8 +42531,8 @@
         "react-native-render-html": "6.3.1"
       },
       "devDependencies": {
+        "@blazediff/core": "^1.10.0",
         "@types/pngjs": "^6.0.5",
-        "pixelmatch": "^7.2.0",
         "pngjs": "^7.0.0"
       },
       "engines": {

--- a/server/victory-chart-renderer/package.json
+++ b/server/victory-chart-renderer/package.json
@@ -17,8 +17,8 @@
         "react-native-render-html": "6.3.1"
     },
     "devDependencies": {
+        "@blazediff/core": "^1.10.0",
         "@types/pngjs": "^6.0.5",
-        "pixelmatch": "^7.2.0",
         "pngjs": "^7.0.0"
     },
     "installConfig": {

--- a/server/victory-chart-renderer/tests/testUtils.ts
+++ b/server/victory-chart-renderer/tests/testUtils.ts
@@ -3,7 +3,7 @@ import {expect} from 'bun:test';
 import {readdirSync, readFileSync} from 'node:fs';
 import {arch, platform} from 'node:os';
 import {join} from 'node:path';
-import pixelmatch from 'pixelmatch';
+import blazediff from '@blazediff/core';
 import {PNG} from 'pngjs';
 
 const packageRoot = join(import.meta.dir, '..');
@@ -122,7 +122,7 @@ function comparePng(actualPath: string, goldenPath: string, expectedSize?: {widt
     }
 
     const diff = new PNG({width: actual.width, height: actual.height});
-    const mismatchedPixels = pixelmatch(actual.data, golden.data, diff.data, actual.width, actual.height, {
+    const mismatchedPixels = blazediff(actual.data, golden.data, diff.data, actual.width, actual.height, {
         threshold: 0.1,
     });
 


### PR DESCRIPTION
### Explanation of Change

Swaps `pixelmatch` for [`@blazediff/core`](https://github.com/teimurjan/blazediff) in the `victory-chart-renderer` golden-image tests. Identical signature and options, so only the import and the call name change.

**Faster.** Same fixtures, M1 Max, 50 runs, image IO excluded — ~62% faster on average ([full table](https://github.com/teimurjan/blazediff/blob/main/benchmarks/pixel-by-pixel.md)):

| Fixture | pixelmatch | @blazediff/core | Improvement |
| --- | --- | --- | --- |
| 4k/1 | 201.60ms | 96.52ms | 52.1% |
| 4k/2 | 222.73ms | 106.63ms | 52.1% |
| page/2 | 267.84ms | 142.53ms | 46.8% |
| 4k/1 (identical) | 23.79ms | 2.50ms | 89.5% |

The gain comes from a two-pass block-level scan that skips regions proven equal, instead of walking every pixel.

**Same results.** Both libraries run over all 8 fixtures in `tests/__golden__` at `threshold: 0.1`, identical and perturbed, return the exact same mismatch counts every time (`0`/`0`, `472`/`472`, `490`/`490`, …). Same YIQ perceptual delta and same anti-aliasing detection as pixelmatch, so accuracy is unchanged.

**One less transitive dep.** `pixelmatch` depends on `pngjs`; `@blazediff/core` has zero dependencies. `pngjs` stays as a direct devDep.

Background on the algorithm and the ports:
- [Building BlazeDiff: how I made the fastest image diff, up to 60% faster with block-level optimization](https://dev.to/teimurjan/building-blazediff-how-i-made-the-fastest-image-diff-up-to-60-faster-with-block-level-optimization-ok7)
- [Porting scientific algorithms from MATLAB to JavaScript](https://hackernoon.com/porting-scientific-algorithms-from-matlab-to-javascript)
- [Beating JavaScript performance limits with Rust and N-API](https://hackernoon.com/beating-javascript-performance-limits-with-rust-and-n-api-building-a-faster-image-diff-tool)

Already used by Vitest, Shopify (`@shopify/react-native-skia`, already a dependency of this package), Ant Design, AntV G, Ant Design X, GPT-Vis, Vega, ApexCharts and Avatune ([blazediff.dev](https://blazediff.dev)).

### Tests

1. `cd server/victory-chart-renderer && bun test` — all golden-image comparisons pass unchanged.
2. Edit a fixture PNG so it no longer matches its golden, re-run — the test fails with a mismatched-pixel count over the threshold.
