### PR TITLE
[POC] RHP centered modals (refreshed)

### DIFF
--- a/src/components/TimeModalPicker.tsx
+++ b/src/components/TimeModalPicker.tsx
@@ -1,6 +1,7 @@
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import DateUtils from '@libs/DateUtils';
+import useIsCenteredRHPModal from '@libs/Navigation/AppNavigator/useIsCenteredRHPModal';
 
 import CONST from '@src/CONST';
 
@@ -15,6 +16,18 @@ import Modal from './Modal';
 import ScreenWrapper from './ScreenWrapper';
 import TimePicker from './TimePicker/TimePicker';
 
+/** Configuration handed to the parent step so it can render the picker inline within the same modal. */
+type InlineTimePickerConfig = {
+    /** The currently selected value (ISO datetime string). */
+    value?: string;
+
+    /** Header label for the picker. */
+    label: string;
+
+    /** Called with the selected 12-hour time string when the user saves. */
+    onSubmit: (time: string) => void;
+};
+
 type TimeModalPickerProps = {
     /** Current value of the selected item */
     value?: string;
@@ -28,12 +41,16 @@ type TimeModalPickerProps = {
     /** Label for the picker */
     label: string;
 
+    /** When provided (centered RHP modal), tapping the row asks the parent step to render the picker inline instead of opening a separate modal. */
+    onRequestOpenInline?: (config: InlineTimePickerConfig) => void;
+
     /** Reference to the outer element */
     ref?: ForwardedRef<View>;
 };
 
-function TimeModalPicker({value, errorText, label, onInputChange = () => {}, ref}: TimeModalPickerProps) {
+function TimeModalPicker({value, errorText, label, onInputChange = () => {}, onRequestOpenInline, ref}: TimeModalPickerProps) {
     const styles = useThemeStyles();
+    const isCenteredModal = useIsCenteredRHPModal();
     const [isPickerVisible, setIsPickerVisible] = useState(false);
     const currentTime = value ? DateUtils.extractTime12Hour(value) : undefined;
 
@@ -47,45 +64,51 @@ function TimeModalPicker({value, errorText, label, onInputChange = () => {}, ref
         hidePickerModal();
     };
 
+    // Inside a centered RHP modal, render the picker inline via the parent step instead of opening a second modal.
+    const shouldRenderInline = isCenteredModal && !!onRequestOpenInline;
+
     return (
         <>
             <MenuItemWithTopDescription
                 shouldShowRightIcon
                 title={currentTime}
                 description={label}
-                onPress={() => setIsPickerVisible(true)}
+                onPress={() => (shouldRenderInline ? onRequestOpenInline?.({value, label, onSubmit: updateInput}) : setIsPickerVisible(true))}
                 brickRoadIndicator={errorText ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined}
                 errorText={errorText}
                 ref={ref}
             />
-            <Modal
-                type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
-                isVisible={isPickerVisible}
-                onClose={hidePickerModal}
-                onModalHide={hidePickerModal}
-                enableEdgeToEdgeBottomSafeAreaPadding
-            >
-                <ScreenWrapper
-                    style={styles.pb0}
-                    includePaddingTop={false}
-                    includeSafeAreaPaddingBottom
-                    testID="TimeModalPicker"
+            {!shouldRenderInline && (
+                <Modal
+                    type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
+                    isVisible={isPickerVisible}
+                    onClose={hidePickerModal}
+                    onModalHide={hidePickerModal}
+                    enableEdgeToEdgeBottomSafeAreaPadding
                 >
-                    <HeaderWithBackButton
-                        title={label}
-                        onBackButtonPress={hidePickerModal}
-                    />
-                    <View style={styles.flex1}>
-                        <TimePicker
-                            defaultValue={value}
-                            onSubmit={updateInput}
-                            shouldValidateFutureTime={false}
+                    <ScreenWrapper
+                        style={styles.pb0}
+                        includePaddingTop={false}
+                        includeSafeAreaPaddingBottom
+                        testID="TimeModalPicker"
+                    >
+                        <HeaderWithBackButton
+                            title={label}
+                            onBackButtonPress={hidePickerModal}
                         />
-                    </View>
-                </ScreenWrapper>
-            </Modal>
+                        <View style={styles.flex1}>
+                            <TimePicker
+                                defaultValue={value}
+                                onSubmit={updateInput}
+                                shouldValidateFutureTime={false}
+                            />
+                        </View>
+                    </ScreenWrapper>
+                </Modal>
+            )}
         </>
     );
 }
 
 export default TimeModalPicker;
+export type {InlineTimePickerConfig};

--- a/src/components/ValuePicker/index.tsx
+++ b/src/components/ValuePicker/index.tsx
@@ -1,5 +1,6 @@
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 
+import useIsCenteredRHPModal from '@libs/Navigation/AppNavigator/useIsCenteredRHPModal';
 import Navigation from '@libs/Navigation/Navigation';
 
 import CONST from '@src/CONST';
@@ -28,7 +29,9 @@ function ValuePicker({
     addBottomSafeAreaPadding = true,
     disableKeyboardShortcuts = false,
     alternateNumberOfSupportedLines,
+    onRequestOpenInline,
 }: ValuePickerProps) {
+    const isCenteredModal = useIsCenteredRHPModal();
     const [isPickerVisible, setIsPickerVisible] = useState(false);
 
     const showPickerModal = () => {
@@ -49,6 +52,9 @@ function ValuePicker({
 
     const selectedItem = items?.find((item) => item.value === value);
 
+    // Inside a centered RHP modal, render the selection list inline via the parent step instead of opening a second modal.
+    const shouldRenderInline = isCenteredModal && !!onRequestOpenInline;
+
     return (
         <View>
             {shouldShowModal ? (
@@ -59,25 +65,27 @@ function ValuePicker({
                         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                         title={selectedItem?.label || placeholder || ''}
                         description={label}
-                        onPress={showPickerModal}
+                        onPress={() => (shouldRenderInline ? onRequestOpenInline?.({label, items, selectedItem, onItemSelected: updateInput, shouldShowTooltips}) : showPickerModal())}
                         furtherDetails={furtherDetails}
                         brickRoadIndicator={errorText ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined}
                         errorText={errorText}
                         forwardedFSClass={forwardedFSClass}
                     />
-                    <ValueSelectorModal
-                        isVisible={isPickerVisible}
-                        label={label}
-                        selectedItem={selectedItem}
-                        items={items}
-                        onClose={hidePickerModal}
-                        onItemSelected={updateInput}
-                        shouldShowTooltips={shouldShowTooltips}
-                        onBackdropPress={Navigation.dismissModal}
-                        shouldEnableKeyboardAvoidingView={false}
-                        addBottomSafeAreaPadding={addBottomSafeAreaPadding}
-                        alternateNumberOfSupportedLines={alternateNumberOfSupportedLines}
-                    />
+                    {!shouldRenderInline && (
+                        <ValueSelectorModal
+                            isVisible={isPickerVisible}
+                            label={label}
+                            selectedItem={selectedItem}
+                            items={items}
+                            onClose={hidePickerModal}
+                            onItemSelected={updateInput}
+                            shouldShowTooltips={shouldShowTooltips}
+                            onBackdropPress={Navigation.dismissModal}
+                            shouldEnableKeyboardAvoidingView={false}
+                            addBottomSafeAreaPadding={addBottomSafeAreaPadding}
+                            alternateNumberOfSupportedLines={alternateNumberOfSupportedLines}
+                        />
+                    )}
                 </>
             ) : (
                 <ValueSelectionList

--- a/src/components/ValuePicker/types.ts
+++ b/src/components/ValuePicker/types.ts
@@ -74,6 +74,9 @@ type ValueSelectionListProps = Pick<
     isVisible?: boolean;
 };
 
+/** Config handed to the parent step so it can render the value selection list inline within the same centered modal. */
+type InlineValuePickerConfig = Pick<ValueSelectorModalProps, 'label' | 'items' | 'selectedItem' | 'onItemSelected' | 'shouldShowTooltips'>;
+
 type ValuePickerProps = ForwardedFSClassProps & {
     /** Item to display */
     value?: string;
@@ -116,6 +119,9 @@ type ValuePickerProps = ForwardedFSClassProps & {
 
     /** Number of lines to show for alternate text */
     alternateNumberOfSupportedLines?: number;
+
+    /** When provided (centered RHP modal), tapping the row asks the parent step to render the selection list inline instead of opening a separate modal. */
+    onRequestOpenInline?: (config: InlineValuePickerConfig) => void;
 };
 
-export type {ValuePickerItem, ValueSelectorModalProps, ValuePickerProps, ValueSelectionListProps};
+export type {ValuePickerItem, ValueSelectorModalProps, ValuePickerProps, ValueSelectionListProps, InlineValuePickerConfig};

--- a/src/components/WideRHPContextProvider/index.native.tsx
+++ b/src/components/WideRHPContextProvider/index.native.tsx
@@ -9,15 +9,11 @@ import type {WideRHPActionsContextType, WideRHPStateContextType} from './types';
 import {defaultWideRHPActionsContextValue, defaultWideRHPStateContextValue} from './default';
 
 const secondOverlayWideRHPProgress = new Animated.Value(0);
-const secondOverlayRHPOnWideRHPProgress = new Animated.Value(0);
-const secondOverlayRHPOnSuperWideRHPProgress = new Animated.Value(0);
-const thirdOverlayProgress = new Animated.Value(0);
 
 const animatedReceiptPaneRHPWidth = new Animated.Value(0);
 const animatedWideRHPWidth = new Animated.Value(0);
 const animatedSuperWideRHPWidth = new Animated.Value(0);
 
-const modalStackOverlaySuperWideRHPPositionLeft = new Animated.Value(0);
 const modalStackOverlayWideRHPPositionLeft = new Animated.Value(0);
 
 const expandedRHPProgress = new Animated.Value(0);
@@ -47,12 +43,8 @@ export {
     animatedSuperWideRHPWidth,
     animatedWideRHPWidth,
     expandedRHPProgress,
-    modalStackOverlaySuperWideRHPPositionLeft,
     modalStackOverlayWideRHPPositionLeft,
-    secondOverlayRHPOnSuperWideRHPProgress,
-    secondOverlayRHPOnWideRHPProgress,
     secondOverlayWideRHPProgress,
-    thirdOverlayProgress,
     useWideRHPState,
     useWideRHPActions,
 };

--- a/src/components/WideRHPContextProvider/index.tsx
+++ b/src/components/WideRHPContextProvider/index.tsx
@@ -341,12 +341,8 @@ export {
     animatedSuperWideRHPWidth,
     animatedWideRHPWidth,
     expandedRHPProgress,
-    modalStackOverlaySuperWideRHPPositionLeft,
     modalStackOverlayWideRHPPositionLeft,
     secondOverlayWideRHPProgress,
-    secondOverlayRHPOnWideRHPProgress,
-    secondOverlayRHPOnSuperWideRHPProgress,
-    thirdOverlayProgress,
     useWideRHPState,
     useWideRHPActions,
 };

--- a/src/components/WideRHPOverlayWrapper/index.tsx
+++ b/src/components/WideRHPOverlayWrapper/index.tsx
@@ -1,12 +1,4 @@
-import {
-    animatedReceiptPaneRHPWidth,
-    modalStackOverlaySuperWideRHPPositionLeft,
-    modalStackOverlayWideRHPPositionLeft,
-    secondOverlayRHPOnSuperWideRHPProgress,
-    secondOverlayRHPOnWideRHPProgress,
-    secondOverlayWideRHPProgress,
-    useWideRHPState,
-} from '@components/WideRHPContextProvider';
+import {modalStackOverlayWideRHPPositionLeft, secondOverlayWideRHPProgress, useWideRHPState} from '@components/WideRHPContextProvider';
 
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 
@@ -16,54 +8,30 @@ import {useRoute} from '@react-navigation/native';
 import React from 'react';
 
 function SecondaryOverlay() {
-    const {shouldRenderSecondaryOverlayForRHPOnSuperWideRHP, shouldRenderSecondaryOverlayForRHPOnWideRHP, shouldRenderSecondaryOverlayForWideRHP, superWideRHPRouteKeys, wideRHPRouteKeys} =
-        useWideRHPState();
+    const {shouldRenderSecondaryOverlayForWideRHP, superWideRHPRouteKeys} = useWideRHPState();
 
     const route = useRoute();
 
-    const isWide = !!route?.key && wideRHPRouteKeys.includes(route.key);
     const isSuperWide = !!route?.key && superWideRHPRouteKeys.includes(route.key);
 
-    const isRHPDisplayedOnWideRHP = shouldRenderSecondaryOverlayForRHPOnWideRHP && isWide;
-    const isRHPDisplayedOnSuperWideRHP = shouldRenderSecondaryOverlayForRHPOnSuperWideRHP && isSuperWide;
     const isWideRHPDisplayedOnSuperWideRHP = shouldRenderSecondaryOverlayForWideRHP && isSuperWide;
 
     /**
-     * These overlays are used to cover the space under the narrower RHP screen when more than one RHP width is displayed on the screen
-     * Their position is calculated as follows:
+     * This overlay is used to cover the space under the narrower RHP screen when more than one RHP width is displayed on the screen.
+     * Its position is calculated as follows:
      * The width of the window for which we calculate the overlay positions is the width of the RHP window, for example for Super Wide RHP it will be 1260 px on a wide layout.
      * We need to move the overlay left from the left edge of the RHP below to the left edge of the RHP above.
      * To calculate this, subtract the width of the widest RHP from the width of the RHP above.
-     * Please note that in these cases, the overlay is rendered from the RHP screen displayed below. For example, if we display RHP on Wide RHP, the secondary overlay is rendered from Wide RHP, etc.
-     * Three cases were described for the secondary overlay:
-     * 1. Single RHP is displayed on Wide RHP
-     * 2. Single RHP is displayed on Super Wide RHP
-     * 3. Wide RHP is displayed on Super Wide RHP route.
+     * Please note that in this case, the overlay is rendered from the RHP screen displayed below (the Wide RHP).
+     *
+     * The "single RHP displayed on (super) wide RHP" cases are not handled here: those small RHPs are centered modals with their
+     * own dim (see ModalStackNavigators index). Only "Wide RHP displayed on Super Wide RHP" remains.
      *  */
-    if (isRHPDisplayedOnWideRHP) {
-        return (
-            <Overlay
-                progress={secondOverlayRHPOnWideRHPProgress}
-                // If RHP is displayed on Wide RHP which is displayed above the Super Wide RHP, the secondary overlay's position left should be calculated from the left edge of the super wide RHP.
-                positionLeftValue={animatedReceiptPaneRHPWidth}
-            />
-        );
-    }
-
     if (isWideRHPDisplayedOnSuperWideRHP) {
         return (
             <Overlay
                 progress={secondOverlayWideRHPProgress}
                 positionLeftValue={modalStackOverlayWideRHPPositionLeft}
-            />
-        );
-    }
-
-    if (isRHPDisplayedOnSuperWideRHP) {
-        return (
-            <Overlay
-                progress={secondOverlayRHPOnSuperWideRHPProgress}
-                positionLeftValue={modalStackOverlaySuperWideRHPPositionLeft}
             />
         );
     }

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -60,6 +60,7 @@ import createRootStackNavigator from './createRootStackNavigator';
 import {screensWithEnteringAnimation} from './createRootStackNavigator/GetStateForActionHandlers';
 import defaultScreenOptions from './defaultScreenOptions';
 import DelegatorConnectGuard from './DelegatorConnectGate';
+import doesRHPStackHaveWidePane from './doesRHPStackHaveWidePane';
 import hideKeyboardOnSwipe from './hideKeyboardOnSwipe';
 import KeyboardShortcutsHandler from './KeyboardShortcutsHandler';
 import {ShareModalStackNavigator} from './ModalStackNavigators';
@@ -72,6 +73,7 @@ import SubmitPlanWelcomeModalNavigator from './Navigators/SubmitPlanWelcomeModal
 import TestToolsModalNavigator from './Navigators/TestToolsModalNavigator';
 import TestDriveDemoNavigator from './TestDriveDemoNavigator';
 import ThreeDSAuthHandler from './ThreeDSAuthHandler';
+import useIsCenteredRHPModal from './useIsCenteredRHPModal';
 import useModalCardStyleInterpolator from './useModalCardStyleInterpolator';
 import useRootNavigatorScreenOptions from './useRootNavigatorScreenOptions';
 import UserStatusHandler from './UserStatusHandler';
@@ -132,6 +134,7 @@ function AuthScreens() {
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const rootNavigatorScreenOptions = useRootNavigatorScreenOptions();
     const modalCardStyleInterpolator = useModalCardStyleInterpolator();
+    const isCenteredRHPModal = useIsCenteredRHPModal();
     const {isOnboardingCompleted} = useOnboardingFlowRouter();
     const shouldSuppressPromotionalUI = useShouldSuppressPromotionalUI();
 
@@ -142,6 +145,23 @@ function AuthScreens() {
             NavBarManager.setButtonStyle(CONST.NAVIGATION_BAR_BUTTONS_STYLE.LIGHT);
         };
     }, [theme]);
+
+    // Dynamic options for RIGHT_MODAL_NAVIGATOR: on wide layout a standalone small RHP fades the whole navigator in place
+    // (matching centered/alert modals, so there's no lateral movement). Wide expense/report panes and narrow layout keep the slide entrance.
+    const getRightModalNavigatorOptions = ({route}: {route: RouteProp<AuthScreensParamList, typeof NAVIGATORS.RIGHT_MODAL_NAVIGATOR>}) => {
+        const baseOptions = rootNavigatorScreenOptions.rightModalNavigator;
+        if (!isCenteredRHPModal || doesRHPStackHaveWidePane(route)) {
+            return baseOptions;
+        }
+        return {
+            ...baseOptions,
+            web: {
+                ...baseOptions.web,
+                // A centered modal is positioned independently (fixed, centered box), so the right-docked side-panel offset doesn't apply.
+                cardStyleInterpolator: (props: StackCardInterpolationProps) => modalCardStyleInterpolator({props, enter: {kind: 'fade'}}),
+            },
+        };
+    };
 
     // Dynamic options for TAB_NAVIGATOR: supports entering animation for pushed instances
     const getTabNavigatorOptions = ({route}: {route: RouteProp<AuthScreensParamList>}) => {
@@ -298,7 +318,7 @@ function AuthScreens() {
                         />
                         <RootStack.Screen
                             name={NAVIGATORS.RIGHT_MODAL_NAVIGATOR}
-                            options={rootNavigatorScreenOptions.rightModalNavigator}
+                            options={getRightModalNavigatorOptions}
                             getComponent={loadRightModalNavigator}
                             listeners={modalScreenListenersWithCancelSearch}
                         />

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -62,6 +62,12 @@ import type {Screen} from '@src/SCREENS';
 import SCREENS from '@src/SCREENS';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 
+import type {ParamListBase} from '@react-navigation/routers';
+import type {ViewStyle} from 'react-native';
+
+import React, {useCallback, useMemo} from 'react';
+import {View} from 'react-native';
+
 import useModalStackScreenOptions from './useModalStackScreenOptions';
 
 const loadAttachmentModalScreen = () => require<ReactComponentModule>('../../../../pages/media/AttachmentModalScreen').default;

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -1,7 +1,11 @@
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 
+import Overlay from '@libs/Navigation/AppNavigator/Navigators/Overlay';
+import useCenteredRHPModalState from '@libs/Navigation/AppNavigator/useCenteredRHPModalState';
+import useCenteredRHPModalStyle from '@libs/Navigation/AppNavigator/useCenteredRHPModalStyle';
 import withAgentAccessDenied from '@libs/Navigation/AppNavigator/withAgentAccessDenied';
+import Navigation from '@libs/Navigation/Navigation';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import Animations from '@libs/Navigation/PlatformStackNavigation/navigationOptions/animation';
 import type {PlatformStackNavigationOptions} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -57,11 +61,6 @@ import type {
 import type {Screen} from '@src/SCREENS';
 import SCREENS from '@src/SCREENS';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
-
-import type {ParamListBase} from '@react-navigation/routers';
-
-import React, {useCallback} from 'react';
-import {View} from 'react-native';
 
 import useModalStackScreenOptions from './useModalStackScreenOptions';
 
@@ -132,10 +131,18 @@ function createModalStackNavigator<ParamList extends ParamListBase>(screens: Scr
     function ModalStack() {
         const styles = useThemeStyles();
         const screenOptions = useModalStackScreenOptions();
+        const {isCenteredModal, hasWidePane} = useCenteredRHPModalState();
 
         // We have to use the isSmallScreenWidth instead of shouldUseNarrow layout, because we want to have information about screen width without the context of side modal.
         // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
         const {isSmallScreenWidth} = useResponsiveLayout();
+
+        // A centered modal above a wide pane gets a full-screen dim backdrop (dismisses on outside press) plus the centered box.
+        const isCenteredModalOverWidePane = isCenteredModal && hasWidePane;
+
+        // Geometry of the centered box; we constrain the inner navigator to it so taps outside fall through to the backdrop.
+        const centeredModalGeometry = useCenteredRHPModalStyle();
+        const centeredBoxStyle = useMemo<ViewStyle>(() => ({position: 'absolute', ...centeredModalGeometry, overflow: 'hidden'}), [centeredModalGeometry]);
 
         const getScreenOptions = useCallback<typeof screenOptions>(
             ({route: optionRoute}) => {
@@ -148,25 +155,41 @@ function createModalStackNavigator<ParamList extends ParamListBase>(screens: Scr
             [screenOptions],
         );
 
+        const navigatorElement = (
+            <ModalStackNavigator.Navigator>
+                {Object.keys(screens as Required<Screens>).map((name) => (
+                    <ModalStackNavigator.Screen
+                        key={name}
+                        name={name}
+                        getComponent={(screens as Required<Screens>)[name as Screen]}
+                        // For some reason, screenOptions is not working with function as options so we have to pass it to every screen.
+                        options={getScreenOptions}
+                    />
+                ))}
+            </ModalStackNavigator.Navigator>
+        );
+
         return (
             // This container is necessary to hide card translation during transition. Without it the user would see un-clipped cards.
+            // On wide layout a centered modal fills the (centered & clipped) content card instead of docking right; on narrow layout it keeps full-width behavior.
             <View
-                style={[styles.modalStackNavigatorContainer, styles.modalStackNavigatorContainerWidth(isSmallScreenWidth)]}
+                style={[styles.modalStackNavigatorContainer, isSmallScreenWidth ? styles.modalStackNavigatorContainerWidth(isSmallScreenWidth) : styles.fullScreen]}
+                // On wide layout pass through touches around the centered box so they reach the dim backdrop; on narrow the full-width RHP captures everything.
+                pointerEvents={isSmallScreenWidth ? undefined : 'box-none'}
                 accessibilityViewIsModal={isSmallScreenWidth}
                 aria-modal={isSmallScreenWidth || undefined}
                 role={isSmallScreenWidth ? 'dialog' : undefined}
             >
-                <ModalStackNavigator.Navigator>
-                    {Object.keys(screens as Required<Screens>).map((name) => (
-                        <ModalStackNavigator.Screen
-                            key={name}
-                            name={name}
-                            getComponent={(screens as Required<Screens>)[name as Screen]}
-                            // For some reason, screenOptions is not working with function as options so we have to pass it to every screen.
-                            options={getScreenOptions}
-                        />
-                    ))}
-                </ModalStackNavigator.Navigator>
+                {isCenteredModalOverWidePane ? (
+                    <>
+                        {/* Full-screen dim on top of the wide pane; dismisses the modal on outside press. The primary RHP overlay stays mounted underneath so closing only fades this dim away. */}
+                        <Overlay onPress={() => Navigation.dismissToPreviousRHP()} />
+                        {/* Constrain the inner navigator to the centered box so taps outside fall through to the overlay. */}
+                        <View style={centeredBoxStyle}>{navigatorElement}</View>
+                    </>
+                ) : (
+                    navigatorElement
+                )}
             </View>
         );
     }

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/useModalStackScreenOptions.ts
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/useModalStackScreenOptions.ts
@@ -9,13 +9,16 @@ import RHP_WEB_TRANSITION_SPEC from '@libs/Navigation/AppNavigator/RHPTransition
 import useModalCardStyleInterpolator from '@libs/Navigation/AppNavigator/useModalCardStyleInterpolator';
 import type {PlatformStackNavigationOptions, PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 
+import variables from '@styles/variables';
+
 import CONST from '@src/CONST';
 
 import type {ParamListBase} from '@react-navigation/native';
 import type {StackCardStyleInterpolator} from '@react-navigation/stack';
+import type {ViewStyle} from 'react-native';
 
 import {CardStyleInterpolators} from '@react-navigation/stack';
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
 function useWideModalStackScreenOptions() {
     const styles = useThemeStyles();
@@ -28,11 +31,27 @@ function useWideModalStackScreenOptions() {
     const {isSmallScreenWidth} = useResponsiveLayout();
     const {wideRHPRouteKeys, superWideRHPRouteKeys} = useWideRHPState();
 
+    // A centered card needs rounded corners on the card itself, because the fixed-positioned card escapes the container's borderRadius clip.
+    const roundedCardStyle = useMemo(
+        () => ({...styles.navigationScreenCardStyle, borderRadius: variables.componentBorderRadiusLarge, overflow: 'hidden' as const}),
+        [styles.navigationScreenCardStyle],
+    );
+
+    // Override the base `position: 'fixed'` card style so a centered card fills the inner navigator's wrapper box instead of the full viewport.
+    const filledCenteredCardStyle = useMemo<ViewStyle>(() => ({...styles.fullScreen, overflow: 'hidden'}), [styles.fullScreen]);
+
     return useCallback<({route}: {route: PlatformStackRouteProp<ParamListBase, string>}) => PlatformStackNavigationOptions>(
         ({route}) => {
             const baseInterpolator: StackCardStyleInterpolator = isSmallScreenWidth
                 ? CardStyleInterpolators.forHorizontalIOS
                 : (props) => modalCardStyleInterpolator({props, enter: {kind: 'slide-and-fade', distancePx: CONST.MODAL.RHP_ENTER_OFFSET_PX_WEB}});
+
+            const isWideRoute = superWideRHPRouteKeys.includes(route.key) || wideRHPRouteKeys.includes(route.key);
+            const hasWidePane = superWideRHPRouteKeys.length > 0 || wideRHPRouteKeys.length > 0;
+
+            // A small RHP on wide layout is always a centered modal (alone, or floating above a wide pane). Wide panes keep their corners.
+            const isCenteredCard = !isSmallScreenWidth && !isWideRoute;
+            const navigationScreenCardStyle = isCenteredCard ? roundedCardStyle : styles.navigationScreenCardStyle;
 
             let cardStyleInterpolator: StackCardStyleInterpolator = baseInterpolator;
 
@@ -45,10 +64,10 @@ function useWideModalStackScreenOptions() {
                     cardStyleInterpolator = enhanceCardStyleInterpolator(baseInterpolator, {
                         cardStyle: styles.wideRHPExtendedCardInterpolatorStyles,
                     });
-                    // single RHPs displayed above the wide RHP need to be positioned
-                } else if (superWideRHPRouteKeys.length > 0 || wideRHPRouteKeys.length > 0) {
+                    // A centered modal on top of a wide pane fills the inner navigator's wrapper box.
+                } else if (hasWidePane) {
                     cardStyleInterpolator = enhanceCardStyleInterpolator(baseInterpolator, {
-                        cardStyle: styles.singleRHPExtendedCardInterpolatorStyles,
+                        cardStyle: filledCenteredCardStyle,
                     });
                 }
             }
@@ -58,16 +77,18 @@ function useWideModalStackScreenOptions() {
                 headerShown: false,
                 animationTypeForReplace: 'pop',
                 native: {
-                    contentStyle: styles.navigationScreenCardStyle,
+                    contentStyle: navigationScreenCardStyle,
                 },
                 web: {
-                    cardStyle: styles.navigationScreenCardStyle,
+                    cardStyle: navigationScreenCardStyle,
                     cardStyleInterpolator,
+                    // Expensify dims via its own Overlay components, so disable React Navigation's default card overlay (else an extra dim band appears).
+                    cardOverlayEnabled: false,
                     transitionSpec: isSmallScreenWidth ? undefined : RHP_WEB_TRANSITION_SPEC,
                 },
             };
         },
-        [isSmallScreenWidth, modalCardStyleInterpolator, styles, superWideRHPRouteKeys, wideRHPRouteKeys],
+        [isSmallScreenWidth, modalCardStyleInterpolator, roundedCardStyle, filledCenteredCardStyle, styles, superWideRHPRouteKeys, wideRHPRouteKeys],
     );
 }
 

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -1,15 +1,6 @@
 import {DialogLabelProvider, useDialogLabelData} from '@components/DialogLabelContext';
 import NoDropZone from '@components/DragAndDrop/NoDropZone';
-import {
-    animatedWideRHPWidth,
-    expandedRHPProgress,
-    secondOverlayRHPOnSuperWideRHPProgress,
-    secondOverlayRHPOnWideRHPProgress,
-    secondOverlayWideRHPProgress,
-    thirdOverlayProgress,
-    useWideRHPActions,
-    useWideRHPState,
-} from '@components/WideRHPContextProvider';
+import {animatedWideRHPWidth, expandedRHPProgress, secondOverlayWideRHPProgress, useWideRHPActions, useWideRHPState} from '@components/WideRHPContextProvider';
 
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSidePanelState from '@hooks/useSidePanelState';
@@ -21,6 +12,8 @@ import {clearTwoFactorAuthData} from '@libs/actions/TwoFactorAuthActions';
 import hideKeyboardOnSwipe from '@libs/Navigation/AppNavigator/hideKeyboardOnSwipe';
 import * as ModalStackNavigators from '@libs/Navigation/AppNavigator/ModalStackNavigators';
 import useModalStackScreenOptions from '@libs/Navigation/AppNavigator/ModalStackNavigators/useModalStackScreenOptions';
+import useCenteredRHPModalState from '@libs/Navigation/AppNavigator/useCenteredRHPModalState';
+import useCenteredRHPModalStyle from '@libs/Navigation/AppNavigator/useCenteredRHPModalStyle';
 import useRHPScreenOptions from '@libs/Navigation/AppNavigator/useRHPScreenOptions';
 import calculateReceiptPaneRHPWidth from '@libs/Navigation/helpers/calculateReceiptPaneRHPWidth';
 import calculateSuperWideRHPWidth from '@libs/Navigation/helpers/calculateSuperWideRHPWidth';
@@ -44,7 +37,7 @@ import SCREENS from '@src/SCREENS';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 
 import type {NavigatorScreenParams} from '@react-navigation/native';
-import type {View} from 'react-native';
+import type {StyleProp, View, ViewStyle} from 'react-native';
 
 import {useFocusEffect} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
@@ -78,7 +71,7 @@ function SearchAdvancedFiltersWithContext(props: Record<string, unknown>) {
 }
 
 function SecondaryOverlay() {
-    const {shouldRenderSecondaryOverlayForWideRHP, shouldRenderSecondaryOverlayForRHPOnWideRHP, shouldRenderSecondaryOverlayForRHPOnSuperWideRHP} = useWideRHPState();
+    const {shouldRenderSecondaryOverlayForWideRHP} = useWideRHPState();
     const {sidePanelOffset} = useSidePanelState();
 
     if (shouldRenderSecondaryOverlayForWideRHP) {
@@ -91,26 +84,7 @@ function SecondaryOverlay() {
         );
     }
 
-    if (shouldRenderSecondaryOverlayForRHPOnWideRHP) {
-        return (
-            <Overlay
-                progress={secondOverlayRHPOnWideRHPProgress}
-                positionRightValue={Animated.add(sidePanelOffset.current, variables.sideBarWidth)}
-                onPress={Navigation.dismissToPreviousRHP}
-            />
-        );
-    }
-
-    if (shouldRenderSecondaryOverlayForRHPOnSuperWideRHP) {
-        return (
-            <Overlay
-                progress={secondOverlayRHPOnSuperWideRHPProgress}
-                positionRightValue={Animated.add(sidePanelOffset.current, variables.sideBarWidth)}
-                onPress={Navigation.dismissToSuperWideRHP}
-            />
-        );
-    }
-
+    // Small RHPs over a wide/super-wide pane are centered modals with their own dim (see ModalStackNavigators), so no docked secondary overlay here.
     return null;
 }
 
@@ -128,6 +102,9 @@ type RightModalDialogFrameProps = {
     /** Callback ref for the container node so the provider can observe node identity changes. */
     onContainerRef: (node: View | null) => void;
 
+    /** Passthrough pointer events. Set to 'box-none' so a full-viewport centered modal lets clicks reach the dim behind it. */
+    pointerEvents?: React.ComponentProps<typeof Animated.View>['pointerEvents'];
+
     /** RHP stack navigator rendered inside the dialog frame. */
     children: React.ReactNode;
 };
@@ -140,7 +117,7 @@ type RightModalDialogFrameProps = {
  * aria-label is applied only once the visible title is registered so JAWS can announce a named dialog;
  * Header also announces "{title}, dialog" via a polite live region when the title is ready.
  */
-function RightModalDialogFrame({hasDialogSemantics, style, onContainerRef, children}: RightModalDialogFrameProps) {
+function RightModalDialogFrame({hasDialogSemantics, style, onContainerRef, pointerEvents, children}: RightModalDialogFrameProps) {
     const {dialogAriaLabel} = useDialogLabelData();
     const hasName = !!dialogAriaLabel;
 
@@ -152,6 +129,7 @@ function RightModalDialogFrame({hasDialogSemantics, style, onContainerRef, child
             aria-label={hasDialogSemantics && hasName ? dialogAriaLabel : undefined}
             // Focusable so SRs / claimDialogFocus can land on the dialog when it has no nested controls.
             tabIndex={hasDialogSemantics ? -1 : undefined}
+            pointerEvents={pointerEvents}
             style={style}
         >
             {children}
@@ -168,12 +146,11 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
     });
     const isExecutingRef = useRef<boolean>(false);
     const screenOptions = useRHPScreenOptions();
-    const {superWideRHPRouteKeys, wideRHPRouteKeys, shouldRenderTertiaryOverlay} = useWideRHPState();
+    const {superWideRHPRouteKeys, wideRHPRouteKeys} = useWideRHPState();
     const {clearWideRHPKeys, syncRHPKeys} = useWideRHPActions();
     const {windowWidth} = useWindowDimensions();
     const modalStackScreenOptions = useModalStackScreenOptions();
     const styles = useThemeStyles();
-    const {sidePanelOffset} = useSidePanelState();
 
     // When a fullscreen route is pre-inserted under the RHP, disable the slide-out animation
     // so the dismiss reveals the destination instantly. If the pre-insert is later cleaned up
@@ -205,6 +182,19 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
             width: shouldUseNarrowLayout ? '100%' : animatedWidth,
         } as const;
     }, [animatedWidth, shouldUseNarrowLayout]);
+
+    // Render "small" RHPs (everything except the wide/super-wide expense & report panes) as a centered modal on wide layout.
+    const {isCenteredModal, hasWidePane, isFocusedOverWidePane} = useCenteredRHPModalState();
+    const centeredModalStyle = useCenteredRHPModalStyle();
+
+    let containerLayoutStyle: StyleProp<ViewStyle> = [styles.r0, styles.h100, animatedWidthStyle];
+    if (isFocusedOverWidePane) {
+        // Small RHP floating above a wide/super-wide pane: full-viewport container so the centered card isn't clipped.
+        containerLayoutStyle = [styles.t0, styles.l0, styles.r0, styles.b0];
+    } else if (isCenteredModal && !hasWidePane) {
+        // Standalone small RHP (no wide pane in the stack): the container itself is the centered box.
+        containerLayoutStyle = centeredModalStyle;
+    }
 
     const overlayPositionLeft = useMemo(() => -1 * calculateSuperWideRHPWidth(windowWidth), [windowWidth]);
 
@@ -269,6 +259,7 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
     return (
         <NarrowPaneContextProvider>
             <NoDropZone>
+                {/* The original RHP dim, kept mounted even while a centered modal (with its own dim on top) is open, so closing the modal never blinks this one. */}
                 {!shouldUseNarrowLayout && (
                     <Overlay
                         positionLeftValue={overlayPositionLeft}
@@ -284,7 +275,8 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
                     <RightModalDialogFrame
                         hasDialogSemantics={!isSmallScreenWidth}
                         onContainerRef={setContainerNodeFromRef}
-                        style={[styles.pAbsolute, styles.r0, styles.h100, styles.overflowHidden, animatedWidthStyle]}
+                        pointerEvents={isFocusedOverWidePane ? 'box-none' : undefined}
+                        style={[styles.pAbsolute, styles.overflowHidden, containerLayoutStyle]}
                     >
                         <Stack.Navigator
                             parentRoute={route}
@@ -537,13 +529,6 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
                 {/* Clicking on these overlays redirects you to the RHP screen below them. */}
                 {/* The width of these overlays is equal to the width of the screen minus the width of the currently focused RHP screen (positionRightValue) */}
                 {!shouldUseNarrowLayout && <SecondaryOverlay />}
-                {!shouldUseNarrowLayout && shouldRenderTertiaryOverlay && (
-                    <Overlay
-                        progress={thirdOverlayProgress}
-                        positionRightValue={Animated.add(sidePanelOffset.current, variables.sideBarWidth)}
-                        onPress={Navigation.dismissToPreviousRHP}
-                    />
-                )}
             </NoDropZone>
         </NarrowPaneContextProvider>
     );

--- a/src/libs/Navigation/AppNavigator/doesRHPStackHaveWidePane.ts
+++ b/src/libs/Navigation/AppNavigator/doesRHPStackHaveWidePane.ts
@@ -1,0 +1,27 @@
+import {ALL_WIDE_RIGHT_MODALS} from '@components/WideRHPContextProvider/WIDE_RIGHT_MODALS';
+
+import type {AuthScreensParamList} from '@libs/Navigation/types';
+
+import type NAVIGATORS from '@src/NAVIGATORS';
+
+import type {NavigationState, PartialState, RouteProp} from '@react-navigation/native';
+
+type RightModalNavigatorRoute = RouteProp<AuthScreensParamList, typeof NAVIGATORS.RIGHT_MODAL_NAVIGATOR> & {
+    state?: NavigationState | PartialState<NavigationState>;
+};
+
+/**
+ * Whether the RHP stack currently contains a wide/super-wide expense or report pane.
+ * Reads the route directly (no WideRHPContextProvider), so it can be used above that provider — e.g. when
+ * choosing the RightModalNavigator's root entrance animation. Wide panes keep sliding; everything else can fade.
+ */
+function doesRHPStackHaveWidePane(route: RightModalNavigatorRoute): boolean {
+    if (route.state?.routes?.length) {
+        return route.state.routes.some((nestedRoute) => ALL_WIDE_RIGHT_MODALS.has(nestedRoute.name));
+    }
+    // Before the nested state hydrates (initial mount), the focused screen comes through params.
+    const screen = route.params?.screen;
+    return !!screen && ALL_WIDE_RIGHT_MODALS.has(screen);
+}
+
+export default doesRHPStackHaveWidePane;

--- a/src/libs/Navigation/AppNavigator/useCenteredRHPModalState.ts
+++ b/src/libs/Navigation/AppNavigator/useCenteredRHPModalState.ts
@@ -1,0 +1,21 @@
+import {useWideRHPState} from '@components/WideRHPContextProvider';
+
+import useIsCenteredRHPModal from './useIsCenteredRHPModal';
+
+/**
+ * Shared centered-modal conditions for the navigator side (avoids recomputing them per file).
+ * - `isCenteredModal`: wide layout, so small RHPs should render as centered modals.
+ * - `hasWidePane`: a wide/super-wide pane exists in the stack (focused or below).
+ * - `isFocusedOverWidePane`: a centered modal is the focused card above a wide/super-wide pane.
+ */
+function useCenteredRHPModalState() {
+    const isCenteredModal = useIsCenteredRHPModal();
+    const {wideRHPRouteKeys, superWideRHPRouteKeys, shouldRenderSecondaryOverlayForRHPOnWideRHP, shouldRenderSecondaryOverlayForRHPOnSuperWideRHP} = useWideRHPState();
+
+    const hasWidePane = wideRHPRouteKeys.length > 0 || superWideRHPRouteKeys.length > 0;
+    const isFocusedOverWidePane = isCenteredModal && (shouldRenderSecondaryOverlayForRHPOnWideRHP || shouldRenderSecondaryOverlayForRHPOnSuperWideRHP);
+
+    return {isCenteredModal, hasWidePane, isFocusedOverWidePane};
+}
+
+export default useCenteredRHPModalState;

--- a/src/libs/Navigation/AppNavigator/useCenteredRHPModalStyle.ts
+++ b/src/libs/Navigation/AppNavigator/useCenteredRHPModalStyle.ts
@@ -7,7 +7,7 @@ import type {ViewStyle} from 'react-native';
 
 import {useMemo} from 'react';
 
-const CENTERED_MODAL_VERTICAL_MARGIN = 32;
+const CENTERED_MODAL_VERTICAL_MARGIN = 60;
 
 /** Geometry of the centered RHP modal box (width/height/position/radius). Shared so the container and its inner content stay aligned. */
 function useCenteredRHPModalStyle(): ViewStyle {

--- a/src/libs/Navigation/AppNavigator/useCenteredRHPModalStyle.ts
+++ b/src/libs/Navigation/AppNavigator/useCenteredRHPModalStyle.ts
@@ -1,0 +1,35 @@
+import useTheme from '@hooks/useTheme';
+import useWindowDimensions from '@hooks/useWindowDimensions';
+
+import variables from '@styles/variables';
+
+import type {ViewStyle} from 'react-native';
+
+import {useMemo} from 'react';
+
+const CENTERED_MODAL_VERTICAL_MARGIN = 32;
+
+/** Geometry of the centered RHP modal box (width/height/position/radius). Shared so the container and its inner content stay aligned. */
+function useCenteredRHPModalStyle(): ViewStyle {
+    const {windowWidth, windowHeight} = useWindowDimensions();
+    const theme = useTheme();
+
+    return useMemo(() => {
+        // Height tracks the viewport (minus the vertical margin on each side) but is capped so the box keeps modal-like proportions on large screens.
+        const modalHeight = Math.min(windowHeight - 2 * CENTERED_MODAL_VERTICAL_MARGIN, variables.rhpCenteredModalMaxHeight);
+        return {
+            width: variables.rhpCenteredModalWidth,
+            height: modalHeight,
+            // Pin to a fixed top offset rather than centering: equal margins read as centered until the cap is reached, after which the box stays anchored near the top.
+            top: CENTERED_MODAL_VERTICAL_MARGIN,
+            left: (windowWidth - variables.rhpCenteredModalWidth) / 2,
+            borderRadius: variables.componentBorderRadiusLarge,
+            // Same drop shadow we use for centered/alert and big attachment modals.
+            boxShadow: theme.shadow,
+            // Without it, Safari drops the containment once the fade entry settles and the modal stretches to the bottom of the screen.
+            transform: [{translateX: 0}],
+        };
+    }, [windowHeight, windowWidth, theme.shadow]);
+}
+
+export default useCenteredRHPModalStyle;

--- a/src/libs/Navigation/AppNavigator/useIsCenteredRHPModal.ts
+++ b/src/libs/Navigation/AppNavigator/useIsCenteredRHPModal.ts
@@ -1,0 +1,12 @@
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+
+/** On wide layout every "small" RHP renders as a centered modal instead of a right-docked panel; on narrow layout it stays full-screen. */
+function useIsCenteredRHPModal(): boolean {
+    // Raw screen width (ignoring the side-modal context) so the value is identical across the RHP container and the modal stack screens it wraps.
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
+    const {isSmallScreenWidth} = useResponsiveLayout();
+
+    return !isSmallScreenWidth;
+}
+
+export default useIsCenteredRHPModal;

--- a/src/libs/Navigation/AppNavigator/useRHPScreenOptions.ts
+++ b/src/libs/Navigation/AppNavigator/useRHPScreenOptions.ts
@@ -8,12 +8,13 @@ import Animations from '@libs/Navigation/PlatformStackNavigation/navigationOptio
 import Presentation from '@libs/Navigation/PlatformStackNavigation/navigationOptions/presentation';
 import type {PlatformStackNavigationOptions} from '@libs/Navigation/PlatformStackNavigation/types/NavigationOptions';
 
-import type {StackCardInterpolationProps} from '@react-navigation/stack';
+import type {StackCardInterpolationProps, StackCardStyleInterpolator} from '@react-navigation/stack';
 
 import {CardStyleInterpolators} from '@react-navigation/stack';
 import {useMemo} from 'react';
 
 import RHP_WEB_TRANSITION_SPEC from './RHPTransitionSpec';
+import useCenteredRHPModalState from './useCenteredRHPModalState';
 import useModalCardStyleInterpolator from './useModalCardStyleInterpolator';
 
 // This function is necessary for proper animation if a wide format RHP screen is visible.
@@ -35,6 +36,7 @@ const useRHPScreenOptions = (): PlatformStackNavigationOptions => {
     const styles = useThemeStyles();
     const customInterpolator = useModalCardStyleInterpolator();
     const {wideRHPRouteKeys} = useWideRHPState();
+    const {isCenteredModal, hasWidePane, isFocusedOverWidePane} = useCenteredRHPModalState();
 
     // We have to use the isSmallScreenWidth instead of shouldUseNarrow layout, because we want to have information about screen width without the context of side modal.
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
@@ -43,16 +45,29 @@ const useRHPScreenOptions = (): PlatformStackNavigationOptions => {
     // Adjust props on wide layout and when the wide RHP is visible
     const shouldAdjustInterpolatorProps = !isSmallScreenWidth && wideRHPRouteKeys.length;
 
+    // A small centered modal fades in place (matching centered/alert modals) so there's no lateral movement:
+    // either it's focused over a wide pane (a slide would drag its dim across the screen), or it's a standalone
+    // centered modal with no wide pane in the stack. Wide expense/report panes (hasWidePane && !focused over) keep sliding.
+    const shouldFadeCenteredModal = isFocusedOverWidePane || (isCenteredModal && !hasWidePane);
+
+    const cardStyleInterpolator = useMemo<StackCardStyleInterpolator>(() => {
+        if (shouldFadeCenteredModal) {
+            return (props) => customInterpolator({props, enter: {kind: 'fade'}});
+        }
+        // The .forHorizontalIOS interpolator from `@react-navigation` is misbehaving on Safari, so we override it with Expensify custom interpolator
+        if (isSafari()) {
+            return (props) => customInterpolator({props, enter: {kind: 'slide-from-width'}});
+        }
+        return (props) => CardStyleInterpolators.forHorizontalIOS(shouldAdjustInterpolatorProps ? getModifiedCardStyleInterpolatorProps(props) : props);
+    }, [customInterpolator, shouldFadeCenteredModal, shouldAdjustInterpolatorProps]);
+
     return useMemo<PlatformStackNavigationOptions>(() => {
         return {
             headerShown: false,
             animation: Animations.SLIDE_FROM_RIGHT,
             gestureDirection: 'horizontal',
             web: {
-                // The .forHorizontalIOS interpolator from `@react-navigation` is misbehaving on Safari, so we override it with Expensify custom interpolator
-                cardStyleInterpolator: isSafari()
-                    ? (props) => customInterpolator({props, enter: {kind: 'slide-from-width'}})
-                    : (props) => CardStyleInterpolators.forHorizontalIOS(shouldAdjustInterpolatorProps ? getModifiedCardStyleInterpolatorProps(props) : props),
+                cardStyleInterpolator,
                 presentation: Presentation.TRANSPARENT_MODAL,
                 cardOverlayEnabled: false,
                 cardStyle: styles.navigationScreenCardStyle,
@@ -60,7 +75,7 @@ const useRHPScreenOptions = (): PlatformStackNavigationOptions => {
                 transitionSpec: isSmallScreenWidth ? undefined : RHP_WEB_TRANSITION_SPEC,
             },
         };
-    }, [customInterpolator, shouldAdjustInterpolatorProps, isSmallScreenWidth, styles.navigationScreenCardStyle]);
+    }, [cardStyleInterpolator, isSmallScreenWidth, styles.navigationScreenCardStyle]);
 };
 
 export default useRHPScreenOptions;

--- a/src/pages/iou/request/step/DynamicIOURequestStepSubrate.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepSubrate.tsx
@@ -9,6 +9,8 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import TextInput from '@components/TextInput';
 import ValuePicker from '@components/ValuePicker';
+import type {InlineValuePickerConfig} from '@components/ValuePicker/types';
+import ValueSelectionList from '@components/ValuePicker/ValueSelectionList';
 
 import useConfirmModal from '@hooks/useConfirmModal';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
@@ -113,6 +115,8 @@ function DynamicIOURequestStepSubrate({
     const currentSubrate: CommentSubrate | undefined = allSubrates.at(parsedIndex) ?? undefined;
     const totalSubrateCount = allPossibleSubrates.length;
     const filledSubrateCount = allSubrates.length;
+    // When set (centered RHP modal), the subrate selection list is rendered inline here over the still-mounted form instead of in a second modal.
+    const [activeValuePicker, setActiveValuePicker] = useState<InlineValuePickerConfig | null>(null);
     const [subrateValue, setSubrateValue] = useState(currentSubrate?.id);
     const [quantityValue, setQuantityValue] = useState(() => (currentSubrate?.quantity ? String(currentSubrate.quantity) : undefined));
 
@@ -218,6 +222,8 @@ function DynamicIOURequestStepSubrate({
         [CONST.IOU.TYPE.INVOICE]: translate('workspace.invoices.sendInvoice'),
         [CONST.IOU.TYPE.CREATE]: translate('iou.createExpense'),
     };
+    const titleDefault = isEditPage ? translate('common.subrate') : tabTitles[iouType];
+    const title = shouldDisableEditor || !activeValuePicker ? titleDefault : (activeValuePicker.label ?? '');
 
     return (
         <ScreenWrapper
@@ -227,10 +233,10 @@ function DynamicIOURequestStepSubrate({
         >
             <FullPageNotFoundView shouldShow={shouldDisableEditor}>
                 <HeaderWithBackButton
-                    title={isEditPage ? translate('common.subrate') : tabTitles[iouType]}
+                    title={title}
                     shouldShowBackButton
-                    onBackButtonPress={goBack}
-                    shouldShowThreeDotsButton={shouldShowThreeDotsButton}
+                    onBackButtonPress={activeValuePicker ? () => setActiveValuePicker(null) : goBack}
+                    shouldShowThreeDotsButton={!activeValuePicker && shouldShowThreeDotsButton}
                     shouldSetModalVisibility={false}
                     threeDotsMenuItems={[
                         {
@@ -243,57 +249,74 @@ function DynamicIOURequestStepSubrate({
                         },
                     ]}
                 />
-                <FormProvider
-                    style={[styles.flexGrow1, styles.mh5]}
-                    formID={ONYXKEYS.FORMS.MONEY_REQUEST_SUBRATE_FORM}
-                    enabledWhenOffline
-                    validate={validate}
-                    onSubmit={submit}
-                    shouldValidateOnChange
-                    shouldValidateOnBlur={false}
-                    submitButtonText={translate('common.save')}
-                >
-                    <Text style={[styles.pv3]}>{translate('iou.subrateSelection')}</Text>
-                    <View style={[styles.mhn5]}>
-                        <InputWrapperWithRef
-                            InputComponent={ValuePicker}
-                            inputID={`subrate${pageIndex}`}
-                            label={translate('common.subrate')}
-                            value={subrateValue}
-                            defaultValue={currentSubrate?.id}
-                            items={validOptions}
-                            onValueChange={(value) => {
-                                setSubrateValue(value as string);
+                <View style={[styles.flex1, styles.pRelative]}>
+                    <FormProvider
+                        style={[styles.flexGrow1, styles.mh5]}
+                        formID={ONYXKEYS.FORMS.MONEY_REQUEST_SUBRATE_FORM}
+                        enabledWhenOffline
+                        validate={validate}
+                        onSubmit={submit}
+                        shouldValidateOnChange
+                        shouldValidateOnBlur={false}
+                        submitButtonText={translate('common.save')}
+                    >
+                        <Text style={[styles.pv3]}>{translate('iou.subrateSelection')}</Text>
+                        <View style={[styles.mhn5]}>
+                            <InputWrapperWithRef
+                                InputComponent={ValuePicker}
+                                inputID={`subrate${pageIndex}`}
+                                label={translate('common.subrate')}
+                                value={subrateValue}
+                                defaultValue={currentSubrate?.id}
+                                items={validOptions}
+                                onRequestOpenInline={setActiveValuePicker}
+                                onValueChange={(value) => {
+                                    setSubrateValue(value as string);
 
-                                // Focus the Quantity input after the ValuePicker modal closes.
-                                // TransitionTracker's callback fires synchronously inside Reanimated's animation
-                                // callback (outside React's event handler), so React flushes state updates async
-                                // via MessageChannel. requestIdleCallback ensures focus() runs after React commits
-                                // and the modal's FocusTrap (web) deactivates, preventing focus from being stolen.
-                                TransitionTracker.runAfterTransitions({
-                                    callback: () => {
-                                        requestIdleCallback(() => textInputRef.current?.focus());
-                                    },
-                                    waitForUpcomingTransition: true,
-                                });
-                            }}
-                            onOpen={() => {
-                                textInputRef.current?.blur();
-                            }}
+                                    // Focus the Quantity input after the ValuePicker modal closes.
+                                    // TransitionTracker's callback fires synchronously inside Reanimated's animation
+                                    // callback (outside React's event handler), so React flushes state updates async
+                                    // via MessageChannel. requestIdleCallback ensures focus() runs after React commits
+                                    // and the modal's FocusTrap (web) deactivates, preventing focus from being stolen.
+                                    TransitionTracker.runAfterTransitions({
+                                        callback: () => {
+                                            requestIdleCallback(() => textInputRef.current?.focus());
+                                        },
+                                        waitForUpcomingTransition: true,
+                                    });
+                                }}
+                                onOpen={() => {
+                                    textInputRef.current?.blur();
+                                }}
+                            />
+                        </View>
+                        <InputWrapperWithRef
+                            InputComponent={TextInput}
+                            inputID={`quantity${pageIndex}`}
+                            ref={textInputRef}
+                            containerStyles={[styles.mt4]}
+                            label={translate('iou.quantity')}
+                            value={quantityValue}
+                            inputMode={CONST.INPUT_MODE.NUMERIC}
+                            maxLength={CONST.IOU.QUANTITY_MAX_LENGTH}
+                            onChangeText={onChangeQuantity}
                         />
-                    </View>
-                    <InputWrapperWithRef
-                        InputComponent={TextInput}
-                        inputID={`quantity${pageIndex}`}
-                        ref={textInputRef}
-                        containerStyles={[styles.mt4]}
-                        label={translate('iou.quantity')}
-                        value={quantityValue}
-                        inputMode={CONST.INPUT_MODE.NUMERIC}
-                        maxLength={CONST.IOU.QUANTITY_MAX_LENGTH}
-                        onChangeText={onChangeQuantity}
-                    />
-                </FormProvider>
+                    </FormProvider>
+                    {!!activeValuePicker && (
+                        // Overlay the selection list on the still-mounted form so its onItemSelected stays valid.
+                        <View style={[styles.pAbsolute, styles.t0, styles.l0, styles.r0, styles.b0, styles.appBG]}>
+                            <ValueSelectionList
+                                items={activeValuePicker.items}
+                                selectedItem={activeValuePicker.selectedItem}
+                                shouldShowTooltips={activeValuePicker.shouldShowTooltips}
+                                onItemSelected={(item) => {
+                                    activeValuePicker.onItemSelected?.(item);
+                                    setActiveValuePicker(null);
+                                }}
+                            />
+                        </View>
+                    )}
+                </View>
             </FullPageNotFoundView>
         </ScreenWrapper>
     );

--- a/src/pages/iou/request/step/DynamicIOURequestStepTime.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepTime.tsx
@@ -4,6 +4,8 @@ import InputWrapper from '@components/Form/InputWrapper';
 import type {FormOnyxValues} from '@components/Form/types';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import TimeModalPicker from '@components/TimeModalPicker';
+import type {InlineTimePickerConfig} from '@components/TimeModalPicker';
+import TimePicker from '@components/TimePicker/TimePicker';
 
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
@@ -31,7 +33,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
-import React, {useMemo} from 'react';
+import React, {useMemo, useState} from 'react';
 import {View} from 'react-native';
 
 import type {WithWritableReportOrNotFoundProps} from './withWritableReportOrNotFound';
@@ -74,6 +76,8 @@ function DynamicIOURequestStepTime({
     });
 
     const {translate} = useLocalize();
+    // When set (centered RHP modal), the time picker is rendered inline here over the still-mounted form instead of in a second modal.
+    const [activeTimePicker, setActiveTimePicker] = useState<InlineTimePickerConfig | null>(null);
     const currentDateAttributes = transaction?.comment?.customUnit?.attributes?.dates;
     const currentStartDate = currentDateAttributes?.start ? DateUtils.extractDate(currentDateAttributes.start) : undefined;
     const currentEndDate = currentDateAttributes?.end ? DateUtils.extractDate(currentDateAttributes.end) : undefined;
@@ -153,54 +157,74 @@ function DynamicIOURequestStepTime({
         return <FullScreenLoadingIndicator style={[styles.flex1, styles.pRelative]} />;
     }
 
+    const headerTitle = activeTimePicker?.label ?? (isEditPage ? translate('iou.time') : tabTitles[iouType]);
+
     return (
+        // While editing a time field inside a centered RHP modal, the picker renders over the (still-mounted) form so onInputChange stays valid.
         <StepScreenWrapper
-            headerTitle={isEditPage ? translate('iou.time') : tabTitles[iouType]}
-            onBackButtonPress={navigateBack}
+            headerTitle={headerTitle}
+            onBackButtonPress={activeTimePicker ? () => setActiveTimePicker(null) : navigateBack}
             shouldShowNotFoundPage={shouldShowNotFound}
             shouldShowWrapper
             testID="DynamicIOURequestStepTime"
             includeSafeAreaPaddingBottom
         >
-            <FormProvider
-                style={[styles.flexGrow1, styles.ph5]}
-                formID={ONYXKEYS.FORMS.MONEY_REQUEST_TIME_FORM}
-                validate={validate}
-                onSubmit={updateTime}
-                submitButtonText={translate('common.save')}
-                enabledWhenOffline
-            >
-                <InputWrapper
-                    InputComponent={DatePicker}
-                    inputID={INPUT_IDS.START_DATE}
-                    label={translate('iou.startDate')}
-                    defaultValue={currentStartDate}
-                    maxDate={CONST.CALENDAR_PICKER.MAX_DATE}
-                />
-                <View style={[styles.mt2, styles.mhn5]}>
+            <View style={[styles.flex1, styles.pRelative]}>
+                <FormProvider
+                    style={[styles.flexGrow1, styles.ph5]}
+                    formID={ONYXKEYS.FORMS.MONEY_REQUEST_TIME_FORM}
+                    validate={validate}
+                    onSubmit={updateTime}
+                    submitButtonText={translate('common.save')}
+                    enabledWhenOffline
+                >
                     <InputWrapper
-                        InputComponent={TimeModalPicker}
-                        inputID={INPUT_IDS.START_TIME}
-                        label={translate('iou.startTime')}
-                        defaultValue={currentDateAttributes?.start}
+                        InputComponent={DatePicker}
+                        inputID={INPUT_IDS.START_DATE}
+                        label={translate('iou.startDate')}
+                        defaultValue={currentStartDate}
+                        maxDate={CONST.CALENDAR_PICKER.MAX_DATE}
                     />
-                </View>
-                <InputWrapper
-                    InputComponent={DatePicker}
-                    inputID={INPUT_IDS.END_DATE}
-                    label={translate('iou.endDate')}
-                    defaultValue={currentEndDate}
-                    maxDate={CONST.CALENDAR_PICKER.MAX_DATE}
-                />
-                <View style={[styles.mt2, styles.mhn5]}>
+                    <View style={[styles.mt2, styles.mhn5]}>
+                        <InputWrapper
+                            InputComponent={TimeModalPicker}
+                            inputID={INPUT_IDS.START_TIME}
+                            label={translate('iou.startTime')}
+                            defaultValue={currentDateAttributes?.start}
+                            onRequestOpenInline={setActiveTimePicker}
+                        />
+                    </View>
                     <InputWrapper
-                        InputComponent={TimeModalPicker}
-                        inputID={INPUT_IDS.END_TIME}
-                        label={translate('iou.endTime')}
-                        defaultValue={currentDateAttributes?.end}
+                        InputComponent={DatePicker}
+                        inputID={INPUT_IDS.END_DATE}
+                        label={translate('iou.endDate')}
+                        defaultValue={currentEndDate}
+                        maxDate={CONST.CALENDAR_PICKER.MAX_DATE}
                     />
-                </View>
-            </FormProvider>
+                    <View style={[styles.mt2, styles.mhn5]}>
+                        <InputWrapper
+                            InputComponent={TimeModalPicker}
+                            inputID={INPUT_IDS.END_TIME}
+                            label={translate('iou.endTime')}
+                            defaultValue={currentDateAttributes?.end}
+                            onRequestOpenInline={setActiveTimePicker}
+                        />
+                    </View>
+                </FormProvider>
+                {!!activeTimePicker && (
+                    // Overlay the picker on the still-mounted form so its onInputChange stays valid.
+                    <View style={[styles.pAbsolute, styles.t0, styles.l0, styles.r0, styles.b0, styles.appBG]}>
+                        <TimePicker
+                            defaultValue={activeTimePicker.value}
+                            onSubmit={(time) => {
+                                activeTimePicker.onSubmit(time);
+                                setActiveTimePicker(null);
+                            }}
+                            shouldValidateFutureTime={false}
+                        />
+                    </View>
+                )}
+            </View>
         </StepScreenWrapper>
     );
 }

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -112,6 +112,8 @@ export default {
     sidePanelWidth: 375,
     // Screen inset shared by the top- and bottom-anchored growl containers so both stay in sync.
     growlNotificationInset: 20,
+    rhpCenteredModalWidth: 480,
+    rhpCenteredModalMaxHeight: 960,
     receiptPaneRHPMaxWidth: 465,
     receiptPreviewMaxWidth: 440,
     receiptPreviewMaxHeight: 440,


### PR DESCRIPTION
### Explanation of Change

Prototype that renders RHP modals centered on wide layout instead of docked to the right edge. This is a refresh of the earlier POC ([#93074](https://github.com/Expensify/App/pull/93074)) rebased onto current `main`, which had since heavily refactored the RHP layer (dialog-label context, `RightModalDialogFrame`, dynamic IOU step routes, extracted `RHP_WEB_TRANSITION_SPEC`).

Small RHPs (everything except the wide/super-wide expense & report panes) render as a centered modal on wide layout:
- Standalone small RHP → the container itself is the centered box.
- Small RHP floating above a wide/super-wide pane → full-viewport container with its own dim backdrop; taps outside the centered box fall through and dismiss.
- Centered modals fade in place instead of sliding; wide panes keep sliding.
- `ValuePicker` / `TimeModalPicker` render their selection inline within the same centered modal (via `onRequestOpenInline`) instead of opening a second modal.

New helpers: `useCenteredRHPModalState`, `useCenteredRHPModalStyle`, `useIsCenteredRHPModal`, `doesRHPStackHaveWidePane`.

### Fixed Issues
$ N/A — design prototype, no linked issue
PROPOSAL: N/A

### Tests
1. On a wide layout (desktop web), open any small RHP (e.g. a settings page, profile, report details). Verify it appears centered on screen rather than docked to the right edge.
2. Open a small RHP on top of a wide pane (e.g. expense report → a sub-RHP). Verify the small RHP is centered over a full-screen dim, and clicking outside the centered box dismisses it.
3. Open the per-diem Time step and Subrate step. Verify the time picker / value picker render inline within the same centered modal instead of opening a second modal, and the back button returns to the form.
4. Resize to narrow layout. Verify RHPs revert to full-width docked behavior.
5. Verify that no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as tests — behavior is presentation-only and unaffected by network state.

### QA Steps
[No QA] — design prototype, not for staging QA.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
