### PR TITLE
Stop the changed-file lookup failing on very large PR diffs

### DIFF
--- a/.github/actions/javascript/getPullRequestIncrementalChanges/index.js
+++ b/.github/actions/javascript/getPullRequestIncrementalChanges/index.js
@@ -12766,24 +12766,54 @@ class Git {
     }
     /**
      * Get changed files with their status (added, modified, removed, renamed).
-     * In CI, uses the GitHub API with pagination for accuracy.
+     * In CI, uses the GitHub API for accuracy, falling back to a local git diff if it can't answer.
      * Locally, uses git diff against the provided ref.
      */
     static async getChangedFilesWithStatus(fromRef, toRef, shouldIncludeUntrackedFiles = false) {
         if (IS_CI) {
-            const files = await GithubUtils_1.default.paginate(GithubUtils_1.default.octokit.pulls.listFiles, {
-                owner: CONST_1.default.GITHUB_OWNER,
-                repo: CONST_1.default.APP_REPO,
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                pull_number: github_1.context.payload.pull_request?.number ?? 0,
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                per_page: 100,
-            });
-            return files.map((file) => ({
-                filename: file.filename,
-                status: file.status,
-                previousFilename: file.previous_filename,
-            }));
+            try {
+                const files = await GithubUtils_1.default.paginate(GithubUtils_1.default.octokit.pulls.listFiles, {
+                    owner: CONST_1.default.GITHUB_OWNER,
+                    repo: CONST_1.default.APP_REPO,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    pull_number: github_1.context.payload.pull_request?.number ?? 0,
+                    // GitHub builds every file's patch to answer this, and responds 422 ("Sorry, this diff is
+                    // taking too long to generate") when one page holds too much content. A PR that touches
+                    // several large generated files trips that at 100 per page but not at 30.
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    per_page: 30,
+                });
+                return files.map((file) => ({
+                    filename: file.filename,
+                    status: file.status,
+                    previousFilename: file.previous_filename,
+                }));
+            }
+            catch (error) {
+                // A big enough diff defeats the API at any page size, and a check that can't list the changed
+                // files shouldn't take the whole PR down with it. `git diff --name-status` compares the two trees
+                // directly, so it needs only those two commits and not the history between them - which is what
+                // makes it safe in CI's shallow checkout, where a merge-base diff wouldn't be. The trade-off is
+                // that it compares against `fromRef` itself rather than the merge base, so it also reports files
+                // changed only on the base branch. That errs towards reporting too many files rather than too
+                // few, which is the safe direction for the checks built on this.
+                (0, Logger_1.warn)("Could not list this PR's changed files via the GitHub API, falling back to a local git diff.", error);
+                const range = toRef ? `${fromRef} ${toRef}` : fromRef;
+                const { stdout } = await exec(`git diff --name-status -M ${range}`);
+                const statusByCode = { A: 'added', D: 'removed', M: 'modified', T: 'modified' };
+                return stdout
+                    .split('\n')
+                    .filter(Boolean)
+                    .map((line) => {
+                    // Renames and copies are reported as `R100\told\tnew`; everything else as `M\tpath`.
+                    const [rawStatus, firstPath, secondPath] = line.split('\t');
+                    if (rawStatus?.startsWith('R') || rawStatus?.startsWith('C')) {
+                        return { filename: secondPath ?? '', status: 'renamed', previousFilename: firstPath };
+                    }
+                    return { filename: firstPath ?? '', status: statusByCode[rawStatus ?? ''] ?? 'modified' };
+                })
+                    .filter((file) => !!file.filename);
+            }
         }
         const diffResult = this.diff(fromRef, toRef, undefined, shouldIncludeUntrackedFiles);
         return diffResult.files.map((file) => ({

--- a/scripts/utils/Git.ts
+++ b/scripts/utils/Git.ts
@@ -498,25 +498,57 @@ class Git {
 
     /**
      * Get changed files with their status (added, modified, removed, renamed).
-     * In CI, uses the GitHub API with pagination for accuracy.
+     * In CI, uses the GitHub API for accuracy, falling back to a local git diff if it can't answer.
      * Locally, uses git diff against the provided ref.
      */
     static async getChangedFilesWithStatus(fromRef: string, toRef?: string, shouldIncludeUntrackedFiles = false): Promise<ChangedFile[]> {
         if (IS_CI) {
-            const files = await GitHubUtils.paginate(GitHubUtils.octokit.pulls.listFiles, {
-                owner: CONST.GITHUB_OWNER,
-                repo: CONST.APP_REPO,
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                pull_number: context.payload.pull_request?.number ?? 0,
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                per_page: 100,
-            });
+            try {
+                const files = await GitHubUtils.paginate(GitHubUtils.octokit.pulls.listFiles, {
+                    owner: CONST.GITHUB_OWNER,
+                    repo: CONST.APP_REPO,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    pull_number: context.payload.pull_request?.number ?? 0,
+                    // GitHub builds every file's patch to answer this, and responds 422 ("Sorry, this diff is
+                    // taking too long to generate") when one page holds too much content. A PR that touches
+                    // several large generated files trips that at 100 per page but not at 30.
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    per_page: 30,
+                });
 
-            return files.map((file) => ({
-                filename: file.filename,
-                status: file.status as 'added' | 'modified' | 'removed' | 'renamed',
-                previousFilename: file.previous_filename,
-            }));
+                return files.map((file) => ({
+                    filename: file.filename,
+                    status: file.status as 'added' | 'modified' | 'removed' | 'renamed',
+                    previousFilename: file.previous_filename,
+                }));
+            } catch (error) {
+                // A big enough diff defeats the API at any page size, and a check that can't list the changed
+                // files shouldn't take the whole PR down with it. `git diff --name-status` compares the two trees
+                // directly, so it needs only those two commits and not the history between them - which is what
+                // makes it safe in CI's shallow checkout, where a merge-base diff wouldn't be. The trade-off is
+                // that it compares against `fromRef` itself rather than the merge base, so it also reports files
+                // changed only on the base branch. That errs towards reporting too many files rather than too
+                // few, which is the safe direction for the checks built on this.
+                logWarn("Could not list this PR's changed files via the GitHub API, falling back to a local git diff.", error);
+
+                const range = toRef ? `${fromRef} ${toRef}` : fromRef;
+                const {stdout} = await exec(`git diff --name-status -M ${range}`);
+
+                const statusByCode: Record<string, ChangedFile['status']> = {A: 'added', D: 'removed', M: 'modified', T: 'modified'};
+
+                return stdout
+                    .split('\n')
+                    .filter(Boolean)
+                    .map<ChangedFile>((line) => {
+                        // Renames and copies are reported as `R100\told\tnew`; everything else as `M\tpath`.
+                        const [rawStatus, firstPath, secondPath] = line.split('\t');
+                        if (rawStatus?.startsWith('R') || rawStatus?.startsWith('C')) {
+                            return {filename: secondPath ?? '', status: 'renamed', previousFilename: firstPath};
+                        }
+                        return {filename: firstPath ?? '', status: statusByCode[rawStatus ?? ''] ?? 'modified'};
+                    })
+                    .filter((file) => !!file.filename);
+            }
         }
 
         const diffResult = this.diff(fromRef, toRef, undefined, shouldIncludeUntrackedFiles);

--- a/tests/tooling/Git.test.ts
+++ b/tests/tooling/Git.test.ts
@@ -1,6 +1,10 @@
 import type {Mock} from 'bun:test';
-import {afterEach, beforeEach, describe, expect, it, jest, mock} from 'bun:test';
+import {afterEach, beforeAll, beforeEach, describe, expect, it, jest, mock} from 'bun:test';
 
+import GitHubUtils from '@github/libs/GithubUtils';
+import type {InternalOctokit} from '@github/libs/GithubUtils';
+
+import {context} from '@actions/github';
 import * as childProcess from 'child_process';
 import {Str} from 'expensify-common';
 import fs from 'fs';
@@ -14,10 +18,33 @@ import createMock from '../utils/createMock';
 // Typed to the single overload Git.ts actually uses (it always passes `encoding: 'utf8'`), so the test's
 // string-returning stubs type-check against it.
 const mockExecSync = jest.fn<(command: string, options?: childProcess.ExecSyncOptions) => string>();
-await mock.module('child_process', () => ({...childProcess, execSync: mockExecSync}));
+
+// `Git.ts` wraps the callback-style `exec` in `util.promisify`. The mock carries no `util.promisify.custom`
+// symbol, so promisify resolves with whatever single value the callback is handed - hence the `{stdout, stderr}`
+// object, matching what the real `exec`'s custom promisified form returns.
+type ExecCallback = (error: Error | null, result: {stdout: string; stderr: string}) => void;
+const mockExec = jest.fn<(command: string, options: unknown, callback: ExecCallback) => void>();
+await mock.module('child_process', () => ({...childProcess, execSync: mockExecSync, exec: mockExec}));
 
 // Must be imported after the mock.module() call above so it picks up the mock.
 const {default: Git} = await import('@scripts/utils/Git');
+
+// `Git.ts` reads `process.env.CI` once at module scope, so the CI-only branch of `getChangedFilesWithStatus`
+// needs a second evaluation of the module with CI set. The query string gives Bun a distinct module cache key,
+// making `GitInCI` an independent instance from the `Git` above, which the rest of this file uses for the local
+// code paths. It is held in a variable so TypeScript treats the specifier as dynamic and does not try to resolve
+// the query string as part of a module path.
+const CI_GIT_MODULE_SPECIFIER = '@scripts/utils/Git?ci=true';
+const ORIGINAL_CI = typeof process.env.CI === 'string' ? process.env.CI : undefined;
+process.env.CI = 'true';
+// A dynamic specifier resolves to `any`, so the annotation is what gives `GitInCI` the same type as `Git`.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const {default: GitInCI}: {default: typeof Git} = await import(CI_GIT_MODULE_SPECIFIER);
+if (ORIGINAL_CI === undefined) {
+    delete process.env.CI;
+} else {
+    process.env.CI = ORIGINAL_CI;
+}
 
 // Test constants for untracked files tests
 const MOCK_COMPONENT_CONTENT = 'const Component = () => null;\n';
@@ -1367,6 +1394,98 @@ describe('Git', () => {
 
             expect(result.hasChanges).toBe(false);
             expect(result.files).toHaveLength(0);
+        });
+    });
+
+    describe('getChangedFilesWithStatus in CI', () => {
+        let internalOctokit: InternalOctokit;
+        let paginateSpy: Mock<InternalOctokit['paginate']>;
+
+        beforeAll(() => {
+            GitHubUtils.initOctokitWithToken('fake_token');
+            const initializedOctokit = GitHubUtils.internalOctokit;
+            if (!initializedOctokit) {
+                throw new Error('Expected GithubUtils to initialize an Octokit client.');
+            }
+            internalOctokit = initializedOctokit;
+        });
+
+        beforeEach(() => {
+            // The outer beforeEach calls restoreAllMocks(), so the spy has to be re-created for every test.
+            paginateSpy = jest.spyOn(internalOctokit, 'paginate');
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            context.payload = {pull_request: {number: 123}};
+        });
+
+        /** Stubs the promisified `exec` used by the fallback with a fixed `git diff --name-status` output. */
+        function mockNameStatusOutput(stdout: string) {
+            mockExec.mockImplementation((command, options, callback) => callback(null, {stdout, stderr: ''}));
+        }
+
+        it('maps the API response and requests few enough files per page for GitHub to build the diff', async () => {
+            paginateSpy.mockResolvedValue([
+                {filename: 'src/added.ts', status: 'added'},
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                {filename: 'src/new.ts', status: 'renamed', previous_filename: 'src/old.ts'},
+            ]);
+
+            const result = await GitInCI.getChangedFilesWithStatus('main');
+
+            expect(result).toEqual([
+                {filename: 'src/added.ts', status: 'added', previousFilename: undefined},
+                {filename: 'src/new.ts', status: 'renamed', previousFilename: 'src/old.ts'},
+            ]);
+            expect(paginateSpy).toHaveBeenCalledWith(
+                GitHubUtils.octokit.pulls.listFiles,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                expect.objectContaining({per_page: 30}),
+            );
+            expect(mockExec).not.toHaveBeenCalled();
+        });
+
+        it('falls back to a local git diff when the API cannot list the changed files', async () => {
+            paginateSpy.mockRejectedValue(new Error('Sorry, this diff is taking too long to generate.'));
+            mockNameStatusOutput('A\tsrc/added.ts\nM\tsrc/modified.ts\nD\tsrc/removed.ts\nT\tsrc/retyped.ts\n');
+
+            const result = await GitInCI.getChangedFilesWithStatus('main');
+
+            expect(result).toEqual([
+                {filename: 'src/added.ts', status: 'added'},
+                {filename: 'src/modified.ts', status: 'modified'},
+                {filename: 'src/removed.ts', status: 'removed'},
+                {filename: 'src/retyped.ts', status: 'modified'},
+            ]);
+            expect(mockExec).toHaveBeenCalledWith('git diff --name-status -M main', expect.anything(), expect.any(Function));
+        });
+
+        it('reports renames and copies with the previous filename', async () => {
+            paginateSpy.mockRejectedValue(new Error('diff not available'));
+            mockNameStatusOutput('R100\tsrc/old.ts\tsrc/new.ts\nR086\tsrc/wasHere.ts\tsrc/isHere.ts\nC075\tsrc/source.ts\tsrc/copy.ts\n');
+
+            const result = await GitInCI.getChangedFilesWithStatus('main');
+
+            expect(result).toEqual([
+                {filename: 'src/new.ts', status: 'renamed', previousFilename: 'src/old.ts'},
+                {filename: 'src/isHere.ts', status: 'renamed', previousFilename: 'src/wasHere.ts'},
+                {filename: 'src/copy.ts', status: 'renamed', previousFilename: 'src/source.ts'},
+            ]);
+        });
+
+        it('diffs the two refs directly when a toRef is given, so a shallow checkout is enough', async () => {
+            paginateSpy.mockRejectedValue(new Error('diff not available'));
+            mockNameStatusOutput('M\tsrc/modified.ts\n');
+
+            const result = await GitInCI.getChangedFilesWithStatus('abc123', 'def456');
+
+            expect(result).toEqual([{filename: 'src/modified.ts', status: 'modified'}]);
+            expect(mockExec).toHaveBeenCalledWith('git diff --name-status -M abc123 def456', expect.anything(), expect.any(Function));
+        });
+
+        it('returns an empty list when the fallback diff finds no changes', async () => {
+            paginateSpy.mockRejectedValue(new Error('diff not available'));
+            mockNameStatusOutput('\n');
+
+            expect(await GitInCI.getChangedFilesWithStatus('main')).toEqual([]);
         });
     });
 });


### PR DESCRIPTION
### Explanation of Change

`Git.getChangedFilesWithStatus` in [`scripts/utils/Git.ts`](https://github.com/Expensify/App/blob/main/scripts/utils/Git.ts) calls `pulls.listFiles` when `CI=true`. GitHub builds every changed file's patch to answer that endpoint, and returns HTTP 422 when a single page holds too much content:

```
HttpError: Server Error: Sorry, this diff is taking too long to generate.
{"resource":"PullRequest","field":"diff","code":"not_available"} - 422
```

There was no error handling around that call, so any PR whose diff GitHub can't generate hard-fails every check built on it — today that's **React Compiler Compliance**, via `checkChangedFiles` in `scripts/react-compiler-compliance-check.ts`. The failure is doubly unhelpful: the check is unrelated to what the author changed (a React Compiler check failing on a GitHub API call), and the raw 422 gives no path forward.

This was measured, not guessed, against [the esbuild bundler migration PR](https://github.com/Expensify/App/pull/95257), which regenerated 24 bundled GitHub Action `index.js` files (~4.1M lines of diff at the time):

| `per_page` | result |
|---|---|
| 30 | ok |
| 40 | ok |
| 50 | **422** |
| 100 (previous setting) | **422** |

It is deterministic, not a transient hiccup — five consecutive calls at `per_page=100` returned 422 every time, so a retry does not help. Once that PR's diff shrank to ~2.8M lines, `per_page=100` began succeeding again (also verified five times), which confirms the trigger is total page content rather than anything PR-specific.

This PR applies two mitigations, because neither is sufficient alone:

1. **Request 30 files per page instead of 100.** That resolves the measured cases, but the 40 → 50 cliff means the margin is thin, so it can't be the only change.
2. **Fall back to a local `git diff --name-status -M` when the API call throws**, instead of failing the check, and log a warning saying so.

**Why `--name-status` rather than the existing `this.diff()` path:** `git diff <a> <b> --name-status` compares two trees, so it needs only those two commits and not the history between them. That's what makes it safe in CI's shallow checkout — `getMainBranchCommitHash` shallow-fetches with `--depth=1`, so a merge-base diff would *not* be safe there. It also keeps the output tiny; `this.diff()` runs `git diff -U0`, which on a bundle-heavy branch is ~117 MB and would be wasteful to parse just for filenames.

**Trade-off, documented in a code comment:** the fallback resolves against `fromRef` itself rather than the merge base, so it can also report files that changed only on the base branch. That errs toward reporting *too many* files rather than too few, which is the safe direction for the checks consuming it — a check that runs on a few extra files is a nuisance, one that silently skips a changed file is a hole.

Unit tests were added to `tests/tooling/Git.test.ts` covering the API path (including that it asks for 30 per page), the fallback engaging when the API rejects, the `A`/`M`/`D`/`T` status codes, the `R100\told\tnew` rename/copy shape, the two-ref range, and an empty diff.

`.github/actions/javascript/getPullRequestIncrementalChanges/index.js` is the rebuilt action bundle (`npm run gh-actions-build`), which embeds `scripts/utils/Git.ts`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99012
PROPOSAL: N/A - internal CI tooling, no external proposal


### Tests

1. Check out this branch and run `npm install`.
2. Run `npx tsgo --noEmit` and verify it reports no errors.
3. Run `NODE_OPTIONS=--max_old_space_size=12288 npx eslint scripts/ .github/` and verify it reports 0 errors.
4. Run `TZ=utc bun test --parallel --preload ./scripts/stubReactNative.js --preload ./tests/tooling/setup.ts ./tests/tooling/Git.test.ts` and verify all tests pass, including the new `getChangedFilesWithStatus in CI` block.
5. Run `TZ=utc bun test --parallel --preload ./scripts/stubReactNative.js --preload ./tests/tooling/setup.ts ./tests/tooling` and verify the whole tooling suite still passes.
6. Run `./.github/scripts/verifyActions.sh` and verify the rebuilt action bundles produce no diff.
7. Verify the `React Compiler Compliance` check passes on this PR (it consumes `getChangedFilesWithStatus`).

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A - internal CI tooling only, this code runs on GitHub Actions runners and is not part of the app bundle.

### QA Steps

N/A - internal CI tooling only

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline) — N/A, CI-only tooling
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability). — N/A, CI-only tooling
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) — N/A, no UI change
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

N/A - internal CI tooling only, no user-facing change.
