### PR TITLE
[NoQA] Fix `CenteredModalLayout` on native wider screens

### DIFF
--- a/src/components/CenteredModalLayout/index.tsx
+++ b/src/components/CenteredModalLayout/index.tsx
@@ -52,7 +52,7 @@ function CenteredModalLayout({children, width, height, onBackdropPress, contentS
     const isInLandscapeMode = isInLandscapeModeUtil(windowWidth, windowHeight);
     const safeAreaHorizontalPadding = useSafeAreaHorizontalPadding();
     const safeAreaStyle = useBottomSafeSafeAreaPaddingStyle({
-        addBottomSafeAreaPadding: addBottomSafeAreaPadding && !isInLandscapeMode,
+        addBottomSafeAreaPadding: addBottomSafeAreaPadding && !isInLandscapeMode && shouldDockToBottom,
         style: [shouldDockToBottom && styles.pt2, !isInLandscapeMode && styles.pb5, safeAreaHorizontalPadding, contentStyle],
     });
 

--- a/src/components/CenteredModalLayout/index.tsx
+++ b/src/components/CenteredModalLayout/index.tsx
@@ -44,14 +44,16 @@ type CenteredModalLayoutProps = {
 
 function CenteredModalLayout({children, width, height, onBackdropPress, contentStyle, addBottomSafeAreaPadding = true}: CenteredModalLayoutProps) {
     const styles = useThemeStyles();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {onboardingIsMediumOrLargerScreenWidth} = useResponsiveLayout();
     const {windowWidth, windowHeight} = useWindowDimensions();
+
+    const shouldDockToBottom = !onboardingIsMediumOrLargerScreenWidth;
 
     const isInLandscapeMode = isInLandscapeModeUtil(windowWidth, windowHeight);
     const safeAreaHorizontalPadding = useSafeAreaHorizontalPadding();
     const safeAreaStyle = useBottomSafeSafeAreaPaddingStyle({
         addBottomSafeAreaPadding: addBottomSafeAreaPadding && !isInLandscapeMode,
-        style: [shouldUseNarrowLayout && styles.pt2, !isInLandscapeMode && styles.pb5, safeAreaHorizontalPadding, contentStyle],
+        style: [shouldDockToBottom && styles.pt2, !isInLandscapeMode && styles.pb5, safeAreaHorizontalPadding, contentStyle],
     });
 
     useKeyboardShortcut(CONST.KEYBOARD_SHORTCUTS.ESCAPE, onBackdropPress, {shouldBubble: false});
@@ -61,10 +63,10 @@ function CenteredModalLayout({children, width, height, onBackdropPress, contentS
             <CenteredModalLayoutOverlay onBackdropPress={onBackdropPress} />
             <View
                 pointerEvents="box-none"
-                style={[styles.flex1, styles.alignItemsCenter, styles.getCenteredModalOuterView(shouldUseNarrowLayout)]}
+                style={[styles.flex1, styles.alignItemsCenter, styles.getCenteredModalOuterView(shouldDockToBottom)]}
             >
                 <FocusTrapForScreen>
-                    <View style={styles.getCenteredModalInnerView(shouldUseNarrowLayout, width, height)}>
+                    <View style={styles.getCenteredModalInnerView(shouldDockToBottom, width, height)}>
                         <View style={safeAreaStyle}>{children}</View>
                     </View>
                 </FocusTrapForScreen>

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -7007,16 +7007,16 @@ const dynamicStyles = (theme: ThemeColors) =>
             maxWidth: '100%',
         }),
 
-        getCenteredModalOuterView: (shouldUseNarrowLayout: boolean) =>
+        getCenteredModalOuterView: (shouldDockToBottom: boolean) =>
             ({
-                justifyContent: shouldUseNarrowLayout ? 'flex-end' : 'center',
+                justifyContent: shouldDockToBottom ? 'flex-end' : 'center',
             }) as const,
 
-        getCenteredModalInnerView: (shouldUseNarrowLayout: boolean, width?: number, height?: DimensionValue) => {
-            const borderBottomRadius = shouldUseNarrowLayout ? 0 : variables.componentBorderRadiusLarge;
+        getCenteredModalInnerView: (shouldDockToBottom: boolean, width?: number, height?: DimensionValue) => {
+            const borderBottomRadius = shouldDockToBottom ? 0 : variables.componentBorderRadiusLarge;
 
             return {
-                width: shouldUseNarrowLayout ? '100%' : (width ?? variables.featureTrainingModalWidth),
+                width: shouldDockToBottom ? '100%' : (width ?? variables.featureTrainingModalWidth),
                 // No default height - the card hugs its content (children must have intrinsic height)
                 height,
                 maxHeight: '100%' as const,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

`CenteredModalLayout` used `shouldUseNarrowLayout`, which is always `true` on native, so the modal was always docked to the bottom full-width even on tablets. It now uses `onboardingIsMediumOrLargerScreenWidth` (via a `shouldDockToBottom` flag), so wide native screens get a centered modal.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98770
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. On iOS/Android tablet trigger a modal that uses CenteredModalLayout (AI Feature Promo Modal/Track Training/Auto Submit, etc.)
2. Verify the modal is centered on the screen and that it does not have any empty white space

Verify these modals stay bottom docked on iOS/Android phones (native app) without changes


To trigger AI Feature Promo Modal:

- set `isAIPromoModalDismissed` and `isEligible` to `false` in `useAIFeaturesPromoModal` and open the `Spend` screen

To trigger Auto Submit/Track Training add this to `src/hooks/useOnboardingFlow.ts` inside the useEffect:


```ts

                if (true) {
                    Navigation.navigate(ROUTES.TRACK_TRAINING_MODAL);
                    // Navigation.navigate(ROUTES.AUTO_SUBMIT_MODAL_ROOT);
                    return;
                }

```

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — the change is layout-only and does not touch API calls, data fetching, or Onyx.

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
- [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="748" height="763" alt="Screenshot 2026-08-19 at 12 56 31" src="https://github.com/user-attachments/assets/a9186b0a-fe4f-46b4-8678-1d402deafa33" />

<img width="362" height="768" alt="Screenshot 2026-08-19 at 13 30 04" src="https://github.com/user-attachments/assets/0fd61e89-e38c-4453-9515-a1b9274a626b" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<img width="640" height="852" alt="Screenshot 2026-08-19 at 12 56 38" src="https://github.com/user-attachments/assets/bb5a76b7-0791-4659-8609-871c144029e6" />

<img width="854" height="663" alt="Screenshot 2026-08-19 at 12 56 43" src="https://github.com/user-attachments/assets/33fb9978-4c71-49c6-a829-746bfc147c4f" />

<!-- add screenshots or videos here -->

<img width="400" height="842" alt="Screenshot 2026-08-19 at 13 31 32" src="https://github.com/user-attachments/assets/92011e76-5f5f-42fb-95ce-2ea2fa6e28f3" />

<img width="648" height="857" alt="Screenshot 2026-08-20 at 11 03 37" src="https://github.com/user-attachments/assets/e4f5b611-058e-424e-8821-ee302899d4d7" />

<img width="664" height="858" alt="Screenshot 2026-08-20 at 11 03 25" src="https://github.com/user-attachments/assets/beba5f43-dfa3-476f-aae1-82b242fbcfbc" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/02a5b2a9-4924-40a2-a96d-c2141f84009b


<!-- add screenshots or videos here -->

</details>
