### PR TITLE
Filter DELETE-pending transactions out of the SmartScan-fields RBR path

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -274,6 +274,7 @@ import {
     getTransactionID,
     getWaypoints,
     hasMissingSmartscanFields as hasMissingSmartscanFieldsTransactionUtils,
+    hasMissingSmartscanFieldsForRBR,
     hasNoticeTypeViolation,
     hasReceipt as hasReceiptTransactionUtils,
     hasViolation,
@@ -5703,15 +5704,11 @@ function getReportActionWithMissingSmartscanFields(
         if (isEmptyObject(transaction)) {
             return false;
         }
-        // Skip transactions queued for deletion so a reverted/deleted expense stops lighting the RBR red-dot
-        // while it waits for the server to confirm removal.
-        if (isTransactionPendingDelete(transaction)) {
-            return false;
-        }
         if (!wasActionTakenByCurrentUser(action, currentUserAccountID)) {
             return false;
         }
-        return hasMissingSmartscanFieldsTransactionUtils(transaction, iouReport);
+        // hasMissingSmartscanFieldsForRBR skips DELETE-pending transactions (see its doc).
+        return hasMissingSmartscanFieldsForRBR(transaction, iouReport);
     });
 }
 
@@ -11407,9 +11404,8 @@ function getReportActionWithSmartscanError(
 
         const transactionID = isSplitOrTrackAction ? getOriginalMessage(action)?.IOUTransactionID : undefined;
         const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-        // A transaction queued for deletion still lives in Onyx until the server confirms removal, so it must
-        // not keep lighting the RBR. This mirrors the DELETE-pending filter in getViolatingReportIDForRBRInLHN.
-        const isTransactionThreadError = isSplitOrTrackAction && !isTransactionPendingDelete(transaction) && hasMissingSmartscanFieldsTransactionUtils(transaction, report);
+        // hasMissingSmartscanFieldsForRBR skips DELETE-pending transactions (see its doc).
+        const isTransactionThreadError = isSplitOrTrackAction && hasMissingSmartscanFieldsForRBR(transaction, report);
 
         return isTransactionThreadError;
     });

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -5705,7 +5705,7 @@ function getReportActionWithMissingSmartscanFields(
         }
         // Skip transactions queued for deletion so a reverted/deleted expense stops lighting the RBR red-dot
         // while it waits for the server to confirm removal.
-        if (transaction.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+        if (isTransactionPendingDelete(transaction)) {
             return false;
         }
         if (!wasActionTakenByCurrentUser(action, currentUserAccountID)) {
@@ -11409,8 +11409,7 @@ function getReportActionWithSmartscanError(
         const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
         // A transaction queued for deletion still lives in Onyx until the server confirms removal, so it must
         // not keep lighting the RBR. This mirrors the DELETE-pending filter in getViolatingReportIDForRBRInLHN.
-        const isTransactionPendingDelete = transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
-        const isTransactionThreadError = isSplitOrTrackAction && !isTransactionPendingDelete && hasMissingSmartscanFieldsTransactionUtils(transaction, report);
+        const isTransactionThreadError = isSplitOrTrackAction && !isTransactionPendingDelete(transaction) && hasMissingSmartscanFieldsTransactionUtils(transaction, report);
 
         return isTransactionThreadError;
     });

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -5703,6 +5703,11 @@ function getReportActionWithMissingSmartscanFields(
         if (isEmptyObject(transaction)) {
             return false;
         }
+        // Skip transactions queued for deletion so a reverted/deleted expense stops lighting the RBR red-dot
+        // while it waits for the server to confirm removal.
+        if (transaction.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+            return false;
+        }
         if (!wasActionTakenByCurrentUser(action, currentUserAccountID)) {
             return false;
         }
@@ -11402,7 +11407,11 @@ function getReportActionWithSmartscanError(
 
         const transactionID = isSplitOrTrackAction ? getOriginalMessage(action)?.IOUTransactionID : undefined;
         const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-        const isTransactionThreadError = isSplitOrTrackAction && hasMissingSmartscanFieldsTransactionUtils(transaction, report);
+        // A transaction queued for deletion (e.g. after reverting a split) still lives in Onyx until the
+        // server confirms removal; it must not keep lighting the RBR red-dot. Mirrors the DELETE-pending
+        // filtering added to the violations path in getViolatingReportIDForRBRInLHN.
+        const isTransactionPendingDelete = transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
+        const isTransactionThreadError = isSplitOrTrackAction && !isTransactionPendingDelete && hasMissingSmartscanFieldsTransactionUtils(transaction, report);
 
         return isTransactionThreadError;
     });

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11408,7 +11408,7 @@ function getReportActionWithSmartscanError(
         const transactionID = isSplitOrTrackAction ? getOriginalMessage(action)?.IOUTransactionID : undefined;
         const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
         // A transaction queued for deletion (e.g. after reverting a split) still lives in Onyx until the
-        // server confirms removal; it must not keep lighting the RBR red-dot. Mirrors the DELETE-pending
+        // server confirms removal. It must not keep lighting the RBR red-dot. This mirrors the DELETE-pending
         // filtering added to the violations path in getViolatingReportIDForRBRInLHN.
         const isTransactionPendingDelete = transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
         const isTransactionThreadError = isSplitOrTrackAction && !isTransactionPendingDelete && hasMissingSmartscanFieldsTransactionUtils(transaction, report);

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11407,9 +11407,8 @@ function getReportActionWithSmartscanError(
 
         const transactionID = isSplitOrTrackAction ? getOriginalMessage(action)?.IOUTransactionID : undefined;
         const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-        // A transaction queued for deletion (e.g. after reverting a split) still lives in Onyx until the
-        // server confirms removal. It must not keep lighting the RBR red-dot. This mirrors the DELETE-pending
-        // filtering added to the violations path in getViolatingReportIDForRBRInLHN.
+        // A transaction queued for deletion still lives in Onyx until the server confirms removal, so it must
+        // not keep lighting the RBR. This mirrors the DELETE-pending filter in getViolatingReportIDForRBRInLHN.
         const isTransactionPendingDelete = transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
         const isTransactionThreadError = isSplitOrTrackAction && !isTransactionPendingDelete && hasMissingSmartscanFieldsTransactionUtils(transaction, report);
 

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -3193,6 +3193,15 @@ function isTransactionPendingDelete(transaction: OnyxEntry<Transaction>): boolea
 }
 
 /**
+ * Whether a transaction should light the SmartScan-fields RBR red-dot.
+ * A transaction queued for deletion still lives in Onyx until the server confirms removal, so it must
+ * not keep lighting the RBR while it waits.
+ */
+function hasMissingSmartscanFieldsForRBR(transaction: OnyxEntry<Transaction>, report: OnyxEntry<Report>): boolean {
+    return !isTransactionPendingDelete(transaction) && hasMissingSmartscanFields(transaction, report);
+}
+
+/**
  * Retrieves all "child" transactions associated with a given original transaction.
  */
 function getChildTransactions(transactions: OnyxCollection<Transaction>, originalTransactionID: string | undefined, isProduction: boolean) {
@@ -3493,6 +3502,7 @@ export {
     isCreatedMissing,
     areRequiredFieldsEmpty,
     hasMissingSmartscanFields,
+    hasMissingSmartscanFieldsForRBR,
     hasPendingRTERViolation,
     hasAnyPendingRTERViolation,
     hasValidModifiedAmount,

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -21696,6 +21696,34 @@ describe('ReportUtils', () => {
             await waitForBatchedUpdates();
         });
 
+        it('should NOT flag a report-preview action when its linked transaction is pending deletion', async () => {
+            // Mirrors the split/track guard for the report-preview path (getReportActionWithMissingSmartscanFields).
+            // Same missing-merchant shape as the positive test above, but the transaction is queued for deletion,
+            // so the RBR red-dot must clear instead of persisting until the server confirms removal (#96967).
+            const transactionMissingMerchant: Transaction = {
+                ...transaction,
+                merchant: '',
+                modifiedMerchant: '',
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+            };
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, transactionMissingMerchant);
+            await waitForBatchedUpdates();
+
+            const reportsCollection = {
+                [`${ONYXKEYS.COLLECTION.REPORT}${expenseReportID}`]: expenseReport,
+            };
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`]: transactionMissingMerchant,
+            };
+
+            expect(hasSmartscanError([reportPreviewAction], chatReport, allTransactions, currentUserAccountID, reportsCollection)).toBe(false);
+            expect(getReportActionWithSmartscanError([reportPreviewAction], chatReport, allTransactions, currentUserAccountID, reportsCollection)).toBeUndefined();
+
+            // Restore original transaction for subsequent tests
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, transaction);
+            await waitForBatchedUpdates();
+        });
+
         it('should NOT flag settled (reimbursed) expense reports even with missing fields', async () => {
             const settledExpenseReport: Report = {
                 ...expenseReport,

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -21719,8 +21719,8 @@ describe('ReportUtils', () => {
             expect(hasSmartscanError([reportPreviewAction], chatReport, allTransactions, currentUserAccountID, reportsCollection)).toBe(false);
             expect(getReportActionWithSmartscanError([reportPreviewAction], chatReport, allTransactions, currentUserAccountID, reportsCollection)).toBeUndefined();
 
-            // Restore original transaction for subsequent tests
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, transaction);
+            // Restore original transaction for subsequent tests (Onyx.set fully replaces, clearing pendingAction)
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, transaction);
             await waitForBatchedUpdates();
         });
 
@@ -21821,6 +21821,73 @@ describe('ReportUtils', () => {
 
             expect(hasSmartscanError([splitAction], chatReport, allTransactions, currentUserAccountID)).toBe(false);
             expect(getReportActionWithSmartscanError([splitAction], chatReport, allTransactions, currentUserAccountID)).toBeUndefined();
+        });
+
+        it('should NOT flag a track-expense action when its linked transaction is pending deletion (revert / delete)', () => {
+            // isSplitOrTrackAction also covers the track-expense branch, so a DELETE-pending track transaction with
+            // missing fields must clear the RBR too. Guards the OR against a future refactor that splits the paths.
+            const trackTransactionID = '575';
+            const trackAction: ReportAction = {
+                ...createRandomReportAction(Number(trackTransactionID)),
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                actorAccountID: currentUserAccountID,
+                originalMessage: {
+                    IOUTransactionID: trackTransactionID,
+                    type: CONST.IOU.REPORT_ACTION_TYPE.TRACK,
+                    amount: 0,
+                    currency: CONST.CURRENCY.USD,
+                    comment: '',
+                    participantAccountIDs: [currentUserAccountID],
+                },
+            };
+            // Same missing-fields shape as the split test above, but the transaction is queued for deletion.
+            const trackTransaction: Transaction = {
+                ...createRandomTransaction(Number(trackTransactionID)),
+                transactionID: trackTransactionID,
+                amount: 0,
+                merchant: 'Lunch',
+                modifiedMerchant: '',
+                created: testDate,
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+            };
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${trackTransactionID}`]: trackTransaction,
+            };
+
+            expect(hasSmartscanError([trackAction], chatReport, allTransactions, currentUserAccountID)).toBe(false);
+            expect(getReportActionWithSmartscanError([trackAction], chatReport, allTransactions, currentUserAccountID)).toBeUndefined();
+        });
+
+        it('should flag a track-expense action when its linked transaction has missing smartscan fields', () => {
+            // Positive control for the track branch: a non-DELETE track transaction with missing fields still lights the RBR.
+            const trackTransactionID = '585';
+            const trackAction: ReportAction = {
+                ...createRandomReportAction(Number(trackTransactionID)),
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                actorAccountID: currentUserAccountID,
+                originalMessage: {
+                    IOUTransactionID: trackTransactionID,
+                    type: CONST.IOU.REPORT_ACTION_TYPE.TRACK,
+                    amount: 0,
+                    currency: CONST.CURRENCY.USD,
+                    comment: '',
+                    participantAccountIDs: [currentUserAccountID],
+                },
+            };
+            const trackTransaction: Transaction = {
+                ...createRandomTransaction(Number(trackTransactionID)),
+                transactionID: trackTransactionID,
+                amount: 0,
+                merchant: 'Lunch',
+                modifiedMerchant: '',
+                created: testDate,
+            };
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${trackTransactionID}`]: trackTransaction,
+            };
+
+            expect(hasSmartscanError([trackAction], chatReport, allTransactions, currentUserAccountID)).toBe(true);
+            expect(getReportActionWithSmartscanError([trackAction], chatReport, allTransactions, currentUserAccountID)).toEqual(trackAction);
         });
 
         it('should NOT flag a split-bill action when its linked transaction has all required fields', () => {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -21760,6 +21760,43 @@ describe('ReportUtils', () => {
             expect(getReportActionWithSmartscanError([splitAction], chatReport, allTransactions, currentUserAccountID)).toEqual(splitAction);
         });
 
+        it('should NOT flag a split-bill action when its linked transaction is pending deletion (revert split / delete)', () => {
+            // Repro of the RBR-persists-after-revert class (cf. #96967 / PR #97706, which only fixed the
+            // violations path in getViolatingReportIDForRBRInLHN). The missing-smartscan-fields path never
+            // excludes DELETE-pending transactions, so a reverted/deleted expense with missing fields keeps
+            // lighting the LHN red-dot until the server confirms removal.
+            const splitTransactionID = '550';
+            const splitAction: ReportAction = {
+                ...createRandomReportAction(Number(splitTransactionID)),
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                actorAccountID: currentUserAccountID,
+                originalMessage: {
+                    IOUTransactionID: splitTransactionID,
+                    type: CONST.IOU.REPORT_ACTION_TYPE.SPLIT,
+                    amount: 0,
+                    currency: CONST.CURRENCY.USD,
+                    comment: '',
+                    participantAccountIDs: [currentUserAccountID],
+                },
+            };
+            // Same missing-fields shape as the positive test above, but the transaction is queued for deletion.
+            const splitTransaction: Transaction = {
+                ...createRandomTransaction(Number(splitTransactionID)),
+                transactionID: splitTransactionID,
+                amount: 0,
+                merchant: 'Lunch',
+                modifiedMerchant: '',
+                created: testDate,
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+            };
+            const allTransactions = {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${splitTransactionID}`]: splitTransaction,
+            };
+
+            expect(hasSmartscanError([splitAction], chatReport, allTransactions, currentUserAccountID)).toBe(false);
+            expect(getReportActionWithSmartscanError([splitAction], chatReport, allTransactions, currentUserAccountID)).toBeUndefined();
+        });
+
         it('should NOT flag a split-bill action when its linked transaction has all required fields', () => {
             const splitTransactionID = '600';
             const splitAction: ReportAction = {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -21761,10 +21761,8 @@ describe('ReportUtils', () => {
         });
 
         it('should NOT flag a split-bill action when its linked transaction is pending deletion (revert split / delete)', () => {
-            // Repro of the RBR-persists-after-revert class (cf. #96967 / PR #97706, which only fixed the
-            // violations path in getViolatingReportIDForRBRInLHN). The missing-smartscan-fields path never
-            // excludes DELETE-pending transactions, so a reverted/deleted expense with missing fields keeps
-            // lighting the LHN red-dot until the server confirms removal.
+            // The missing-smartscan-fields path never excluded DELETE-pending transactions (#97706 only fixed
+            // the violations path), so a reverted expense with missing fields kept lighting the RBR (#96967).
             const splitTransactionID = '550';
             const splitAction: ReportAction = {
                 ...createRandomReportAction(Number(splitTransactionID)),


### PR DESCRIPTION
### Explanation of Change

Follow-up to #97706, which filtered DELETE-pending transactions out of the LHN RBR aggregation but only for the **policy-violation** path (`getViolatingReportIDForRBRInLHN`).

The **missing SmartScan fields** path was left untouched, so the same symptom still reproduces there: a reverted/deleted expense that still has a missing required field (e.g. no merchant) keeps the LHN red-dot (RBR) lit until the server confirms the removal.

Both of these read the transaction straight from Onyx and call `hasMissingSmartscanFields` without checking `pendingAction === DELETE`:

- `getReportActionWithSmartscanError` (split/track path)
- `getReportActionWithMissingSmartscanFields` (report-preview path)

This PR adds a matching DELETE-pending guard in both functions so a transaction queued for deletion no longer keeps `hasSmartscanError` returning true, mirroring the fix already applied to the violations path.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96967
PROPOSAL: https://github.com/Expensify/App/issues/96967#issuecomment-5179935189

### Tests

1. Open a report and add an expense that shows the "missing details" red-dot (e.g. an expense with an empty merchant).
2. Go offline.
3. Delete the expense (or revert the split it belongs to) — the transaction is now queued for deletion (`pendingAction === DELETE`).
4. Open the report and check the LHN.
5. Verify the LHN red-dot (RBR) clears once the expense is queued for deletion, instead of persisting until the server confirms removal.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as the Tests section — the whole flow is exercised offline to hold the transaction in the DELETE-pending state.

### QA Steps

1. Add an expense with a missing required field (e.g. empty merchant) so the LHN shows the red-dot.
2. Go offline.
3. Delete the expense (or revert the split it belongs to).
4. Open the report and verify the LHN red-dot clears immediately rather than lingering.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

The red "Fix" (RBR) badge clears once the expense is queued for deletion.

https://github.com/user-attachments/assets/8cf0699d-d662-46aa-b977-00af2f6014f8



</details>

<details>
<summary>Android: mWeb Chrome</summary>

The red "Fix" (RBR) badge clears once the expense is queued for deletion.

https://github.com/user-attachments/assets/37ebec87-ae78-4494-a97a-eb481cfc3fef



</details>

<details>
<summary>iOS: mWeb Safari</summary>

The red "Fix" (RBR) badge clears once the expense is queued for deletion.


https://github.com/user-attachments/assets/e8432578-d424-4738-a469-d9cb2b051c28


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

**Before** — after the expense is deleted, the LHN red-dot persists:

https://github.com/user-attachments/assets/abc779e3-74d7-4fbc-9537-4658e6d8e419

**After** — the red-dot clears once the expense is queued for deletion:

https://github.com/user-attachments/assets/36e7d709-64ab-4b41-a802-7db576c1ed76

</details>
