### PR TITLE
[CP Staging] Revert "Add search this user/agent to ProfilePage"

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -2068,8 +2068,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Profil-Avatar',
         customInstructions: 'Benutzerdefinierte Anweisungen',
         copilotIntoAccount: 'Copilot in Konto',
-        viewUserHistory: 'Nutzerverlauf anzeigen',
-        viewAgentHistory: 'Agentenverlauf anzeigen',
         publicSection: {
             title: 'Öffentlich',
             subtitle: 'Diese Angaben werden in deinem öffentlichen Profil angezeigt. Jede:r kann sie sehen.',

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -2120,8 +2120,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Εικόνα προφίλ',
         customInstructions: 'Προσαρμοσμένες οδηγίες',
         copilotIntoAccount: 'Οδηγός εντός λογαριασμού',
-        viewUserHistory: 'Προβολή ιστορικού χρήστη',
-        viewAgentHistory: 'Προβολή ιστορικού αντιπροσώπου',
         publicSection: {
             title: 'Δημόσιο',
             subtitle: 'Αυτές οι πληροφορίες εμφανίζονται στο δημόσιο προφίλ σας. Μπορεί να τις δει οποιοσδήποτε.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -2159,8 +2159,6 @@ const translations = {
         profileAvatar: 'Profile avatar',
         customInstructions: 'Custom instructions',
         copilotIntoAccount: 'Copilot into account',
-        viewUserHistory: 'View user history',
-        viewAgentHistory: 'View agent history',
         publicSection: {
             title: 'Public',
             subtitle: 'These details are displayed on your public profile. Anyone can see them.',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1988,8 +1988,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Perfil avatar',
         customInstructions: 'Instrucciones personalizadas',
         copilotIntoAccount: 'Copilot a la cuenta',
-        viewUserHistory: 'Ver historial del usuario',
-        viewAgentHistory: 'Ver historial del agente',
         publicSection: {
             title: 'Público',
             subtitle: 'Estos detalles se muestran en tu perfil público, a disposición de los demás.',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -2074,8 +2074,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Avatar de profil',
         customInstructions: 'Instructions personnalisées',
         copilotIntoAccount: 'Copilot dans le compte',
-        viewUserHistory: 'Voir l’historique de l’utilisateur',
-        viewAgentHistory: 'Voir l’historique de l’agent',
         publicSection: {
             title: 'Public',
             subtitle: 'Ces informations sont affichées sur votre profil public. Tout le monde peut les voir.',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -2065,8 +2065,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Avatar profilo',
         customInstructions: 'Istruzioni personalizzate',
         copilotIntoAccount: "Copilot nell'account",
-        viewUserHistory: 'Visualizza cronologia utente',
-        viewAgentHistory: 'Visualizza cronologia agente',
         publicSection: {
             title: 'Pubblico',
             subtitle: 'Questi dettagli vengono visualizzati nel tuo profilo pubblico. Chiunque può vederli.',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -2045,8 +2045,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'プロフィールアバター',
         customInstructions: 'カスタム指示',
         copilotIntoAccount: 'アカウントにCopilot',
-        viewUserHistory: 'ユーザー履歴を表示',
-        viewAgentHistory: 'エージェント履歴を表示',
         publicSection: {
             title: '公開',
             subtitle: 'これらの詳細はあなたの公開プロフィールに表示され、誰でも閲覧できます。',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -2060,8 +2060,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Profielavatar',
         customInstructions: 'Aangepaste instructies',
         copilotIntoAccount: 'Copilot naar account',
-        viewUserHistory: 'Gebruikersgeschiedenis bekijken',
-        viewAgentHistory: 'Agentgeschiedenis bekijken',
         publicSection: {
             title: 'Openbaar',
             subtitle: 'Deze gegevens worden weergegeven op je openbare profiel. Iedereen kan ze zien.',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -2057,8 +2057,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Awatar profilu',
         customInstructions: 'Niestandardowe instrukcje',
         copilotIntoAccount: 'Copilot do konta',
-        viewUserHistory: 'Zobacz historię użytkownika',
-        viewAgentHistory: 'Zobacz historię agenta',
         publicSection: {
             title: 'Public',
             subtitle: 'Te dane są wyświetlane w Twoim publicznym profilu. Każdy może je zobaczyć.',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -2055,8 +2055,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: 'Avatar do perfil',
         customInstructions: 'Instruções personalizadas',
         copilotIntoAccount: 'Copilot na conta',
-        viewUserHistory: 'Ver histórico do usuário',
-        viewAgentHistory: 'Ver histórico do agente',
         publicSection: {
             title: 'Público',
             subtitle: 'Esses detalhes são exibidos no seu perfil público. Qualquer pessoa pode vê-los.',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1989,8 +1989,6 @@ const translations: TranslationDeepObject<typeof en> = {
         profileAvatar: '个人头像',
         customInstructions: '自定义指令',
         copilotIntoAccount: 'Copilot 到账户',
-        viewUserHistory: '查看用户历史记录',
-        viewAgentHistory: '查看代理历史记录',
         publicSection: {
             title: '公开',
             subtitle: '这些详细信息会显示在你的公开资料中，任何人都可以看到。',

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -37,8 +37,6 @@ import {
     isHiddenForCurrentUser as isReportHiddenForCurrentUser,
     navigateToPrivateNotes,
 } from '@libs/ReportUtils';
-import {buildQueryStringFromFilterFormValues} from '@libs/SearchQueryUtils';
-import {isAgentEmail} from '@libs/SessionUtils';
 import {generateAccountID} from '@libs/UserUtils';
 import {isValidAccountRoute} from '@libs/ValidationUtils';
 
@@ -96,7 +94,7 @@ function ProfilePage({route}: ProfilePageProps) {
     const [guidedSetupAndTourStatus] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {selector: guidedSetupAndTourStatusSelector});
     const switchToDelegator = useSwitchToDelegator();
     const guideCalendarLink = account?.guideDetails?.calendarLink ?? '';
-    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Bug', 'MagnifyingGlass', 'Pencil', 'Phone', 'UserPlus']);
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Bug', 'Pencil', 'Phone', 'UserPlus']);
     const accountID = Number(route.params?.accountID ?? CONST.DEFAULT_NUMBER_ID);
     const [agentPrompt] = useOnyx(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${accountID}`);
     const isCurrentUser = currentUserAccountID === accountID;
@@ -293,18 +291,6 @@ function ProfilePage({route}: ProfilePageProps) {
                             ) : null}
                             {shouldShowLocalTime && <AutoUpdateTime timezone={timezone} />}
                         </View>
-                        {shouldShowNotificationPreference && (
-                            <View style={[styles.w100, styles.detailsPageSectionContainer]}>
-                                <MenuItemWithTopDescription
-                                    shouldShowRightIcon
-                                    title={notificationPreference}
-                                    description={translate('notificationPreferencesPage.label')}
-                                    onPress={() => {
-                                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.NOTIFICATION_PREFERENCES.getRoute(report.reportID)));
-                                    }}
-                                />
-                            </View>
-                        )}
                         {isCurrentUser && (
                             <MenuItemNavigation
                                 title={translate('common.editYourProfile')}
@@ -336,17 +322,13 @@ function ProfilePage({route}: ProfilePageProps) {
                                 onPress={() => switchToDelegator(login)}
                             />
                         )}
-                        {!!accountID && !isAnonymousUserSession() && !!login && (
-                            <MenuItem
+                        {shouldShowNotificationPreference && (
+                            <MenuItemWithTopDescription
                                 shouldShowRightIcon
-                                title={translate(isAgentEmail(login) ? 'profilePage.viewAgentHistory' : 'profilePage.viewUserHistory')}
-                                icon={expensifyIcons.MagnifyingGlass}
+                                title={notificationPreference}
+                                description={translate('notificationPreferencesPage.label')}
                                 onPress={() => {
-                                    const query = buildQueryStringFromFilterFormValues({
-                                        type: CONST.SEARCH.DATA_TYPES.CHAT,
-                                        from: [String(accountID)],
-                                    });
-                                    Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query, rawQuery: query}));
+                                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.NOTIFICATION_PREFERENCES.getRoute(report.reportID)));
                                 }}
                             />
                         )}

--- a/tests/ui/ProfilePageTest.tsx
+++ b/tests/ui/ProfilePageTest.tsx
@@ -9,16 +9,14 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 
 import * as AgentActions from '@libs/actions/Agent';
-import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
+import {navigationRef} from '@libs/Navigation/Navigation';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
-import type {ProfileNavigatorParamList, SettingsSplitNavigatorParamList} from '@libs/Navigation/types';
+import type {SettingsSplitNavigatorParamList} from '@libs/Navigation/types';
 
-import PublicProfilePage from '@pages/ProfilePage';
 import ProfilePage from '@pages/settings/Profile/ProfilePage';
 
-import CONST from '@src/CONST';
+import type CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {PersonalDetails, PersonalDetailsList} from '@src/types/onyx';
 
@@ -69,9 +67,6 @@ jest.mock('@react-navigation/native', () => {
         useRoute: jest.fn(() => ({params: {}})),
         createNavigationContainerRef: () => ({
             getState: () => jest.fn(),
-            // useRootNavigationState reads the ref on mount and subscribes to it, so the stub has to answer both.
-            isReady: () => false,
-            addListener: () => () => {},
         }),
         usePreventRemove: jest.fn(),
     };
@@ -484,135 +479,6 @@ describe('ProfilePage - agent account', () => {
 
         expect(mockUpdateAgentPrompt).not.toHaveBeenCalled();
         expect(screen.getByTestId('ai-prompt-input')).toBeDefined();
-    });
-});
-
-const PublicProfileStack = createPlatformStackNavigator<ProfileNavigatorParamList>();
-
-const CURRENT_USER_ACCOUNT_ID = 1;
-const CURRENT_USER_EMAIL = 'current@expensify.com';
-const PUBLIC_PROFILE_ACCOUNT_ID = 123;
-
-describe('ProfilePage - View user history', () => {
-    beforeAll(async () => {
-        Onyx.init({
-            keys: ONYXKEYS,
-        });
-
-        await act(async () => {
-            await Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, 'en' as const);
-        });
-        await waitForBatchedUpdatesWithAct();
-    });
-
-    afterEach(async () => {
-        jest.clearAllMocks();
-        await Onyx.clear();
-        await waitForBatchedUpdatesWithAct();
-    });
-
-    async function setUpPublicProfile(login: string) {
-        await TestHelper.signInWithTestUser(CURRENT_USER_ACCOUNT_ID, CURRENT_USER_EMAIL);
-
-        const personalDetails: PersonalDetailsList = {
-            [CURRENT_USER_ACCOUNT_ID]: {
-                accountID: CURRENT_USER_ACCOUNT_ID,
-                login: CURRENT_USER_EMAIL,
-                displayName: CURRENT_USER_EMAIL,
-            } as PersonalDetails,
-            [PUBLIC_PROFILE_ACCOUNT_ID]: {
-                accountID: PUBLIC_PROFILE_ACCOUNT_ID,
-                login,
-                displayName: login,
-                avatar: 'https://example.com/avatar.png',
-            } as PersonalDetails,
-        };
-
-        await act(async () => {
-            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
-            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
-        });
-        await waitForBatchedUpdatesWithAct();
-    }
-
-    function renderPublicProfilePage() {
-        return render(
-            <ComposeProviders components={[OnyxListItemProvider, CurrentUserPersonalDetailsProvider, LocaleContextProvider, CurrentReportIDContextProvider]}>
-                <PortalProvider>
-                    <NavigationContainer>
-                        <PublicProfileStack.Navigator>
-                            <PublicProfileStack.Screen
-                                name={SCREENS.DYNAMIC_PROFILE}
-                                component={PublicProfilePage}
-                                initialParams={{accountID: String(PUBLIC_PROFILE_ACCOUNT_ID), reportID: ''}}
-                            />
-                        </PublicProfileStack.Navigator>
-                    </NavigationContainer>
-                </PortalProvider>
-            </ComposeProviders>,
-        );
-    }
-
-    it('shows the search entry for a regular user', async () => {
-        await setUpPublicProfile('user@expensify.com');
-
-        renderPublicProfilePage();
-        await waitForBatchedUpdatesWithAct();
-
-        expect(screen.getByText('View user history')).toBeOnTheScreen();
-        expect(screen.queryByText('View agent history')).not.toBeOnTheScreen();
-    });
-
-    it('shows the agent wording for an agent account', async () => {
-        await setUpPublicProfile('agent_456@expensify.ai');
-
-        renderPublicProfilePage();
-        await waitForBatchedUpdatesWithAct();
-
-        expect(screen.getByText('View agent history')).toBeOnTheScreen();
-        expect(screen.queryByText('View user history')).not.toBeOnTheScreen();
-    });
-
-    it('navigates to a chat search filtered by the profile account when pressed', async () => {
-        await setUpPublicProfile('user@expensify.com');
-
-        renderPublicProfilePage();
-        await waitForBatchedUpdatesWithAct();
-
-        // MenuItem only forwards the press to onPress when it receives an event, so pass a minimal one.
-        fireEvent.press(screen.getByText('View user history'), {nativeEvent: {}});
-        await waitForBatchedUpdatesWithAct();
-
-        expect(Navigation.navigate).toHaveBeenCalledWith(
-            ROUTES.SEARCH_ROOT.getRoute({
-                query: `type:${CONST.SEARCH.DATA_TYPES.CHAT} from:${PUBLIC_PROFILE_ACCOUNT_ID}`,
-                rawQuery: `type:${CONST.SEARCH.DATA_TYPES.CHAT} from:${PUBLIC_PROFILE_ACCOUNT_ID}`,
-            }),
-        );
-    });
-
-    it('hides the search entry for an anonymous session', async () => {
-        await setUpPublicProfile('user@expensify.com');
-
-        await act(async () => {
-            await Onyx.merge(ONYXKEYS.SESSION, {authTokenType: CONST.AUTH_TOKEN_TYPES.ANONYMOUS});
-        });
-        await waitForBatchedUpdatesWithAct();
-
-        renderPublicProfilePage();
-        await waitForBatchedUpdatesWithAct();
-
-        expect(screen.queryByText('View user history')).not.toBeOnTheScreen();
-    });
-
-    it('hides the search entry when the account has no login', async () => {
-        await setUpPublicProfile('');
-
-        renderPublicProfilePage();
-        await waitForBatchedUpdatesWithAct();
-
-        expect(screen.queryByText('View user history')).not.toBeOnTheScreen();
-        expect(screen.queryByText('View agent history')).not.toBeOnTheScreen();
     });
 });
 


### PR DESCRIPTION
Reverts Expensify/App#98091 to $ https://github.com/Expensify/App/issues/99073

Holding on a potential [fix](https://github.com/Expensify/App/pull/99077)

Test steps to verify: https://github.com/Expensify/App/issues/99073

## Action Performed:
Precondition:
- Create a new Gmail account. Do not verify the account.
- Create an agent on Account > Agents.

1. Launch Expensify app.
2. Go to Account > Agents.
3. Tap on the agent.
4. Tap Chat with agent.
5. Tap on the chat header.
6. Tap View agent history.
7. Swipe back three times.

## Expected Result:
App will return to Agents page.