### PR TITLE
98709: Keyboard Navigation-Unable to focus the Back button by pressing Tab in the Manual tab  

### DIFF
--- a/src/pages/iou/request/IOURequestStartPage.tsx
+++ b/src/pages/iou/request/IOURequestStartPage.tsx
@@ -15,6 +15,7 @@ import usePolicy from '@hooks/usePolicy';
 import useResetIOUType from '@hooks/useResetIOUType';
 import useThemeStyles from '@hooks/useThemeStyles';
 
+import {isMobileSafari} from '@libs/Browser';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {shouldShowPerDiemTabOption} from '@libs/IOUUtils';
@@ -44,7 +45,7 @@ import type {WithWritableReportOrNotFoundProps} from './step/withWritableReportO
 import DynamicIOURequestStepDestination from './step/DynamicIOURequestStepDestination';
 import DynamicIOURequestStepDistance from './step/DynamicIOURequestStepDistance';
 import {IOURequestStepAmountWithTransactionOnly} from './step/IOURequestStepAmount';
-import IOURequestStepConfirmation from './step/IOURequestStepConfirmation';
+import {IOURequestStepConfirmationContentWithWritableReportOrNotFound as IOURequestStepConfirmationContent} from './step/IOURequestStepConfirmation';
 import IOURequestStepHours from './step/IOURequestStepHours';
 import IOURequestStepPerDiemWorkspace from './step/IOURequestStepPerDiemWorkspace';
 import IOURequestStepScan from './step/IOURequestStepScan';
@@ -231,6 +232,13 @@ function IOURequestStartPage({
     // mounts for PAY - the embedded confirmation carries the amount inline, so there is no separate step left to skip.
     const shouldEmbedConfirmation = isNewManualExpenseFlowEnabled && (shouldUseTab || iouType === CONST.IOU.TYPE.PAY);
 
+    // The embedded confirmation renders its body without a ScreenWrapper of its own, so that this page's focus trap
+    // stays the sole owner of the header + tab bar + content Tab cycle. Its viewport sizing has to move here with it:
+    // shouldEnableMaxHeight gates the keyboard-open height clamp and `marginTop: viewportOffsetTop`, and together with
+    // shouldAvoidScrollOnVirtualViewport (true by default here) it gates useTackInputFocus on mobile WebKit. Same
+    // condition the standalone confirmation uses - mobile Safari opts out, and canUseTouchScreen() is false on desktop.
+    const shouldEnableManualConfirmationMaxHeight = shouldEmbedConfirmation && selectedTab === CONST.TAB_REQUEST.MANUAL && canUseTouchScreen() && !isMobileSafari();
+
     let manualContent: React.ReactNode;
     if (!shouldEmbedConfirmation) {
         manualContent = (
@@ -264,7 +272,7 @@ function IOURequestStartPage({
         );
     } else {
         manualContent = (
-            <IOURequestStepConfirmation
+            <IOURequestStepConfirmationContent
                 route={route}
                 navigation={navigation}
                 shouldHideHeader
@@ -282,7 +290,7 @@ function IOURequestStartPage({
         >
             <ScreenWrapper
                 shouldEnableKeyboardAvoidingView={isNewManualExpenseFlowEnabled}
-                shouldEnableMaxHeight={selectedTab === CONST.TAB_REQUEST.PER_DIEM}
+                shouldEnableMaxHeight={selectedTab === CONST.TAB_REQUEST.PER_DIEM || shouldEnableManualConfirmationMaxHeight}
                 shouldEnableMinHeight={canUseTouchScreen()}
                 testID="IOURequestStartPage"
                 focusTrapSettings={{containerElements: focusTrapContainerElements}}

--- a/src/pages/iou/request/IOURequestStartPage.tsx
+++ b/src/pages/iou/request/IOURequestStartPage.tsx
@@ -237,7 +237,7 @@ function IOURequestStartPage({
     // shouldEnableMaxHeight gates the keyboard-open height clamp and `marginTop: viewportOffsetTop`, and together with
     // shouldAvoidScrollOnVirtualViewport (true by default here) it gates useTackInputFocus on mobile WebKit. Same
     // condition the standalone confirmation uses - mobile Safari opts out, and canUseTouchScreen() is false on desktop.
-    const shouldEnableManualConfirmationMaxHeight = shouldEmbedConfirmation && selectedTab === CONST.TAB_REQUEST.MANUAL && canUseTouchScreen() && !isMobileSafari();
+    const shouldEnableManualConfirmationMaxHeight = shouldEmbedConfirmation && (!shouldUseTab || selectedTab === CONST.TAB_REQUEST.MANUAL) && canUseTouchScreen() && !isMobileSafari();
 
     let manualContent: React.ReactNode;
     if (!shouldEmbedConfirmation) {

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -139,7 +139,7 @@ type IOURequestStepConfirmationProps = WithWritableReportOrNotFoundProps<IOURequ
         shouldHideHeader?: boolean;
     };
 
-function IOURequestStepConfirmation({
+function IOURequestStepConfirmationContent({
     report: reportReal,
     reportDraft,
     route,
@@ -891,7 +891,7 @@ function IOURequestStepConfirmation({
     const showReceiptEmptyState = shouldShowReceiptEmptyState(iouType, action, policy, isPerDiemRequest);
 
     const shouldShowSmartScanFields = !!transaction?.receipt?.isTestDriveReceipt || isMovingTransactionFromTrackExpense || requestType !== CONST.IOU.REQUEST_TYPE.SCAN;
-    const content = (
+    return (
         <>
             <TelemetrySpanManager
                 iouType={iouType}
@@ -1073,27 +1073,23 @@ function IOURequestStepConfirmation({
             </DragAndDropProvider>
         </>
     );
+}
 
-    /*
-     * When this step is embedded on IOURequestStartPage (shouldHideHeader=true), that page already renders
-     * the ScreenWrapper for this screen and owns its focus trap - a trap whose containers are the parent
-     * header (holding the Back button), the tab bar and the active tab. Every ScreenWrapper mounts its own
-     * FocusTrapForScreen on the shared trap stack, so a second one here would activate on top of the parent's
-     * and pause it, confining Tab to the confirmation form and leaving the Back button unreachable.
-     * Render the content on its own instead, the same way StepScreenWrapper's `shouldShowWrapper` gate already
-     * keeps the Scan and Distance tabs from mounting a nested wrapper.
-     */
-    if (shouldHideHeader) {
-        return content;
-    }
-
+/**
+ * The standalone RHP route. It owns the chrome for this screen - the ScreenWrapper, its focus trap and its
+ * viewport sizing - and renders the same body inside it. IOURequestStartPage composes the body directly instead,
+ * because it already owns a trap whose containers are its header (with the Back button), its tab bar and the
+ * active tab; a second ScreenWrapper there would push another FocusTrapForScreen onto the shared trap stack,
+ * pause that one, and confine Tab to the confirmation form.
+ */
+function IOURequestStepConfirmation(props: IOURequestStepConfirmationProps) {
     return (
         <ScreenWrapper
             shouldEnableMaxHeight={canUseTouchScreen() && !isMobileSafari()}
             shouldAvoidScrollOnVirtualViewport={!isMobileSafari()}
             testID="IOURequestStepConfirmation"
         >
-            {content}
+            <IOURequestStepConfirmationContent {...props} />
         </ScreenWrapper>
     );
 }
@@ -1102,4 +1098,11 @@ const IOURequestStepConfirmationWithFullTransactionOrNotFound = withFullTransact
 
 const IOURequestStepConfirmationWithWritableReportOrNotFound = withWritableReportOrNotFound(IOURequestStepConfirmationWithFullTransactionOrNotFound);
 
+const IOURequestStepConfirmationContentWithFullTransactionOrNotFound = withFullTransactionOrNotFound(IOURequestStepConfirmationContent);
+
+const IOURequestStepConfirmationContentWithWritableReportOrNotFound = withWritableReportOrNotFound(IOURequestStepConfirmationContentWithFullTransactionOrNotFound);
+
 export default IOURequestStepConfirmationWithWritableReportOrNotFound;
+
+/** The body on its own, for a parent that already owns this screen's ScreenWrapper and focus trap. */
+export {IOURequestStepConfirmationContentWithWritableReportOrNotFound};

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -895,6 +895,15 @@ function IOURequestStepConfirmation({
         <ScreenWrapper
             shouldEnableMaxHeight={canUseTouchScreen() && !isMobileSafari()}
             shouldAvoidScrollOnVirtualViewport={!isMobileSafari()}
+            /*
+             * When this step is embedded on IOURequestStartPage (shouldHideHeader=true), that page already owns
+             * this screen's focus trap - a trap whose containers are the parent header (holding the Back button),
+             * the tab bar and the active tab. A second active trap here takes the top of the shared trap stack and
+             * pauses that one, confining Tab to the confirmation form and leaving the Back button and the tab bar
+             * unreachable. Standalone keeps `undefined` rather than `{active: !shouldHideHeader}` so that
+             * FocusTrapForScreen still runs its own route-based activation logic.
+             */
+            focusTrapSettings={shouldHideHeader ? {active: false} : undefined}
             testID="IOURequestStepConfirmation"
         >
             <TelemetrySpanManager

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -891,21 +891,8 @@ function IOURequestStepConfirmation({
     const showReceiptEmptyState = shouldShowReceiptEmptyState(iouType, action, policy, isPerDiemRequest);
 
     const shouldShowSmartScanFields = !!transaction?.receipt?.isTestDriveReceipt || isMovingTransactionFromTrackExpense || requestType !== CONST.IOU.REQUEST_TYPE.SCAN;
-    return (
-        <ScreenWrapper
-            shouldEnableMaxHeight={canUseTouchScreen() && !isMobileSafari()}
-            shouldAvoidScrollOnVirtualViewport={!isMobileSafari()}
-            /*
-             * When this step is embedded on IOURequestStartPage (shouldHideHeader=true), that page already owns
-             * this screen's focus trap - a trap whose containers are the parent header (holding the Back button),
-             * the tab bar and the active tab. A second active trap here takes the top of the shared trap stack and
-             * pauses that one, confining Tab to the confirmation form and leaving the Back button and the tab bar
-             * unreachable. Standalone keeps `undefined` rather than `{active: !shouldHideHeader}` so that
-             * FocusTrapForScreen still runs its own route-based activation logic.
-             */
-            focusTrapSettings={shouldHideHeader ? {active: false} : undefined}
-            testID="IOURequestStepConfirmation"
-        >
+    const content = (
+        <>
             <TelemetrySpanManager
                 iouType={iouType}
                 requestType={requestType}
@@ -1084,6 +1071,29 @@ function IOURequestStepConfirmation({
                     </View>
                 </View>
             </DragAndDropProvider>
+        </>
+    );
+
+    /*
+     * When this step is embedded on IOURequestStartPage (shouldHideHeader=true), that page already renders
+     * the ScreenWrapper for this screen and owns its focus trap - a trap whose containers are the parent
+     * header (holding the Back button), the tab bar and the active tab. Every ScreenWrapper mounts its own
+     * FocusTrapForScreen on the shared trap stack, so a second one here would activate on top of the parent's
+     * and pause it, confining Tab to the confirmation form and leaving the Back button unreachable.
+     * Render the content on its own instead, the same way StepScreenWrapper's `shouldShowWrapper` gate already
+     * keeps the Scan and Distance tabs from mounting a nested wrapper.
+     */
+    if (shouldHideHeader) {
+        return content;
+    }
+
+    return (
+        <ScreenWrapper
+            shouldEnableMaxHeight={canUseTouchScreen() && !isMobileSafari()}
+            shouldAvoidScrollOnVirtualViewport={!isMobileSafari()}
+            testID="IOURequestStepConfirmation"
+        >
+            {content}
         </ScreenWrapper>
     );
 }

--- a/tests/ui/IOURequestStartPageManualTabTest.tsx
+++ b/tests/ui/IOURequestStartPageManualTabTest.tsx
@@ -59,9 +59,13 @@ jest.mock('@pages/iou/request/step/IOURequestStepScan', () => () => null);
 jest.mock('@pages/iou/request/step/IOURequestStepConfirmation', () => {
     const ReactModule = jest.requireActual<typeof React>('react');
     const {View} = jest.requireActual<{View: React.ComponentType<{testID: string}>}>('react-native');
+    const ConfirmationStub = () => ReactModule.createElement(View, {testID: 'EmbeddedConfirmation'});
     return {
         __esModule: true,
-        default: () => ReactModule.createElement(View, {testID: 'EmbeddedConfirmation'}),
+        // The standalone RHP route, which brings its own ScreenWrapper.
+        default: ConfirmationStub,
+        // The bare body, which is what IOURequestStartPage composes into the trap it already owns.
+        IOURequestStepConfirmationContentWithWritableReportOrNotFound: ConfirmationStub,
     };
 });
 jest.mock('@pages/iou/request/step/IOURequestStepAmount', () => {

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -9,6 +9,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import {startSplitBill} from '@libs/actions/IOU/Split';
 
 import IOURequestStepConfirmationWithWritableReportOrNotFound from '@pages/iou/request/step/IOURequestStepConfirmation';
+import {IOURequestStepConfirmationContentWithWritableReportOrNotFound} from '@pages/iou/request/step/IOURequestStepConfirmation';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -1666,6 +1667,11 @@ describe('IOURequestStepConfirmationPageTest', () => {
     describe('Embedded on IOURequestStartPage', () => {
         // IOURequestStartPage renders its own ScreenWrapper and hands it the focus trap containers for the
         // header (which holds the Back button), the tab bar and the active tab. This stands in for that wrapper.
+        //
+        // These assert on which component owns the ScreenWrapper, which is a proxy for the fix rather than a test of
+        // it: every ScreenWrapper mounts a FocusTrapForScreen, so no wrapper means no competing trap. The reported
+        // Tab-order behaviour itself cannot be exercised here, because FocusTrapForScreen is a pass-through on the
+        // native platform Jest resolves - a green run here is not coverage of the focus-trap regression.
         const PARENT_SCREEN_TEST_ID = 'IOURequestStartPage';
         const CONFIRMATION_SCREEN_TEST_ID = 'IOURequestStepConfirmation';
 
@@ -1678,10 +1684,10 @@ describe('IOURequestStepConfirmationPageTest', () => {
         });
 
         /**
-         * Renders the confirmation the way the manual tab does when `shouldHideHeader` is set (inside the start
-         * page's ScreenWrapper), or the way the standalone RHP route does when it isn't.
+         * Renders the body the way the manual tab composes it (inside the start page's ScreenWrapper), or the
+         * standalone RHP route, which brings its own.
          */
-        async function renderConfirmation({shouldHideHeader, iouType = 'submit'}: {shouldHideHeader: boolean; iouType?: 'submit' | 'split'}) {
+        async function renderConfirmation({isEmbedded, iouType = 'submit'}: {isEmbedded: boolean; iouType?: 'submit' | 'split'}) {
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${TRANSACTION_ID}`, {
                     ...DEFAULT_SPLIT_TRANSACTION,
@@ -1690,8 +1696,9 @@ describe('IOURequestStepConfirmationPageTest', () => {
                 });
             });
 
+            const Confirmation = isEmbedded ? IOURequestStepConfirmationContentWithWritableReportOrNotFound : IOURequestStepConfirmationWithWritableReportOrNotFound;
             const confirmation = (
-                <IOURequestStepConfirmationWithWritableReportOrNotFound
+                <Confirmation
                     route={{
                         key: 'Money_Request_Step_Confirmation--30aPPAdjWan56sE5OpcG',
                         name: 'Money_Request_Step_Confirmation',
@@ -1704,7 +1711,7 @@ describe('IOURequestStepConfirmationPageTest', () => {
                     }}
                     // @ts-expect-error only setParams is used by the participant selection handler.
                     navigation={{setParams: jest.fn()}}
-                    shouldHideHeader={shouldHideHeader}
+                    shouldHideHeader={isEmbedded}
                 />
             );
 
@@ -1712,7 +1719,7 @@ describe('IOURequestStepConfirmationPageTest', () => {
                 <OnyxListItemProvider>
                     <HTMLProviderWrapper>
                         <CurrentUserPersonalDetailsProvider>
-                            <LocaleContextProvider>{shouldHideHeader ? <ScreenWrapper testID={PARENT_SCREEN_TEST_ID}>{confirmation}</ScreenWrapper> : confirmation}</LocaleContextProvider>
+                            <LocaleContextProvider>{isEmbedded ? <ScreenWrapper testID={PARENT_SCREEN_TEST_ID}>{confirmation}</ScreenWrapper> : confirmation}</LocaleContextProvider>
                         </CurrentUserPersonalDetailsProvider>
                     </HTMLProviderWrapper>
                 </OnyxListItemProvider>,
@@ -1722,8 +1729,8 @@ describe('IOURequestStepConfirmationPageTest', () => {
         }
 
         it('mounts no ScreenWrapper of its own when embedded, so the start page keeps sole ownership of the focus trap', async () => {
-            // Given the confirmation rendered the way the manual tab renders it, inside the start page's ScreenWrapper
-            await renderConfirmation({shouldHideHeader: true});
+            // Given the body composed the way the manual tab composes it, inside the start page's ScreenWrapper
+            await renderConfirmation({isEmbedded: true});
 
             // Then the confirmation content is on the screen
             expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
@@ -1735,8 +1742,8 @@ describe('IOURequestStepConfirmationPageTest', () => {
         });
 
         it('mounts no ScreenWrapper of its own when embedded in the split expense flow either', async () => {
-            // Given the same embedded render for the split flow, which reuses the start page and this same component
-            await renderConfirmation({shouldHideHeader: true, iouType: 'split'});
+            // Given the same embedded composition for the split flow, which reuses the start page and this same body
+            await renderConfirmation({isEmbedded: true, iouType: 'split'});
 
             // Then the split manual tab is covered by the same fix
             expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
@@ -1745,8 +1752,8 @@ describe('IOURequestStepConfirmationPageTest', () => {
         });
 
         it('keeps its own ScreenWrapper - and therefore its own focus trap - on the standalone route', async () => {
-            // Given the confirmation rendered as the standalone RHP route, with no parent owning its trap
-            await renderConfirmation({shouldHideHeader: false});
+            // Given the standalone RHP route, with no parent owning its trap
+            await renderConfirmation({isEmbedded: false});
 
             // Then it still wraps itself, so the standalone screen keeps trapping focus exactly as before
             expect(await screen.findByTestId(CONFIRMATION_SCREEN_TEST_ID)).toBeOnTheScreen();

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -4,6 +4,7 @@ import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersona
 import HTMLEngineProvider from '@components/HTMLEngineProvider';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import ScreenWrapper from '@components/ScreenWrapper';
 
 import {startSplitBill} from '@libs/actions/IOU/Split';
 
@@ -114,6 +115,18 @@ jest.mock('@components/ParticipantPicker', () => {
             ),
     };
 });
+// Jest resolves the native FocusTrapForScreen, which is a pass-through. This keeps that behaviour and only records
+// what each ScreenWrapper on the screen asks of its own trap, which is the thing the embedded confirmation changes.
+type RecordedFocusTrapSettings = {active?: boolean; containerElements?: unknown[]} | undefined;
+const mockFocusTrapSettings: RecordedFocusTrapSettings[] = [];
+jest.mock('@components/FocusTrap/FocusTrapForScreen', () => ({
+    __esModule: true,
+    default: ({children, focusTrapSettings}: {children: React.ReactNode; focusTrapSettings?: {active?: boolean; containerElements?: unknown[]}}) => {
+        mockFocusTrapSettings.push(focusTrapSettings);
+        return children;
+    },
+}));
+
 jest.mock('@src/hooks/useResponsiveLayout');
 jest.mock('@libs/getCurrentPosition');
 jest.mock('@libs/getIsNarrowLayout', () => jest.fn(() => false));
@@ -1659,6 +1672,116 @@ describe('IOURequestStepConfirmationPageTest', () => {
             const draftTransaction = await getDraftTransaction();
             expect(draftTransaction?.category).toBe(DESTINATION_DEFAULT_CATEGORY);
             expect(draftTransaction?.tag).toBe('');
+        });
+    });
+
+    describe('Embedded on IOURequestStartPage', () => {
+        // IOURequestStartPage renders its own ScreenWrapper and hands it the focus trap containers for the
+        // header (which holds the Back button), the tab bar and the active tab. This stands in for that wrapper.
+        // Both suites below pass with the fix reverted only if the trap assertions are dropped - the testID
+        // assertions alone do not discriminate, since the confirmation keeps its wrapper either way.
+        const PARENT_SCREEN_TEST_ID = 'IOURequestStartPage';
+        const CONFIRMATION_SCREEN_TEST_ID = 'IOURequestStepConfirmation';
+
+        beforeEach(async () => {
+            mockSelectedParticipants = [];
+            mockFocusTrapSettings.length = 0;
+            await signInWithTestUser(ACCOUNT_ID, ACCOUNT_LOGIN);
+            await act(async () => {
+                await Onyx.set(ONYXKEYS.BETAS, [CONST.BETAS.NEW_MANUAL_EXPENSE_FLOW]);
+            });
+        });
+
+        /**
+         * Renders the confirmation the way the manual tab does when `shouldHideHeader` is set (inside the start
+         * page's ScreenWrapper), or the way the standalone RHP route does when it isn't.
+         */
+        async function renderConfirmation({shouldHideHeader, iouType = 'submit'}: {shouldHideHeader: boolean; iouType?: 'submit' | 'split'}) {
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${TRANSACTION_ID}`, {
+                    ...DEFAULT_SPLIT_TRANSACTION,
+                    iouRequestType: CONST.IOU.REQUEST_TYPE.MANUAL,
+                    amount: 1000,
+                });
+            });
+
+            const confirmation = (
+                <IOURequestStepConfirmationWithWritableReportOrNotFound
+                    route={{
+                        key: 'Money_Request_Step_Confirmation--30aPPAdjWan56sE5OpcG',
+                        name: 'Money_Request_Step_Confirmation',
+                        params: {
+                            action: 'create',
+                            iouType,
+                            transactionID: TRANSACTION_ID,
+                            reportID: REPORT_ID,
+                        },
+                    }}
+                    // @ts-expect-error only setParams is used by the participant selection handler.
+                    navigation={{setParams: jest.fn()}}
+                    shouldHideHeader={shouldHideHeader}
+                />
+            );
+
+            render(
+                <OnyxListItemProvider>
+                    <HTMLProviderWrapper>
+                        <CurrentUserPersonalDetailsProvider>
+                            <LocaleContextProvider>
+                                {shouldHideHeader ? (
+                                    <ScreenWrapper
+                                        testID={PARENT_SCREEN_TEST_ID}
+                                        focusTrapSettings={{containerElements: []}}
+                                    >
+                                        {confirmation}
+                                    </ScreenWrapper>
+                                ) : (
+                                    confirmation
+                                )}
+                            </LocaleContextProvider>
+                        </CurrentUserPersonalDetailsProvider>
+                    </HTMLProviderWrapper>
+                </OnyxListItemProvider>,
+            );
+
+            await waitForBatchedUpdatesWithAct();
+        }
+
+        it('deactivates its own focus trap when embedded, leaving the start page trap in charge of the Tab cycle', async () => {
+            // Given the confirmation rendered the way the manual tab renders it, inside the start page's ScreenWrapper
+            await renderConfirmation({shouldHideHeader: true});
+
+            // Then the confirmation still renders inside its own ScreenWrapper, so nothing about its layout changes
+            expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
+            expect(screen.getByTestId(CONFIRMATION_SCREEN_TEST_ID)).toBeOnTheScreen();
+
+            // And exactly one screen trap is switched off - the embedded confirmation's. Without this it would
+            // activate on top of the start page's trap on the shared stack and pause it, dropping the Back button
+            // and the tab bar out of the Tab cycle.
+            expect(mockFocusTrapSettings.filter((settings) => settings?.active === false)).toHaveLength(1);
+
+            // And the start page's trap, the one holding the header and tab bar containers, is left alone
+            expect(mockFocusTrapSettings).toContainEqual({containerElements: []});
+        });
+
+        it('deactivates its own focus trap when embedded in the split expense flow too', async () => {
+            // Given the same embedded render for the split flow, which reuses the start page and this same component
+            await renderConfirmation({shouldHideHeader: true, iouType: 'split'});
+
+            // Then the split manual tab is covered by the same fix
+            expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
+            expect(mockFocusTrapSettings.filter((settings) => settings?.active === false)).toHaveLength(1);
+            expect(mockFocusTrapSettings).toContainEqual({containerElements: []});
+        });
+
+        it('leaves the standalone route to FocusTrapForScreen default activation logic', async () => {
+            // Given the confirmation rendered as the standalone RHP route, with no parent owning its trap
+            await renderConfirmation({shouldHideHeader: false});
+
+            // Then it still owns its trap, and `active` is left undefined rather than hardcoded to true, so the
+            // sidebar / top-tab / wide-layout checks in FocusTrapForScreen still run for this screen
+            expect(await screen.findByTestId(CONFIRMATION_SCREEN_TEST_ID)).toBeOnTheScreen();
+            expect(mockFocusTrapSettings.some((settings) => settings?.active !== undefined)).toBe(false);
         });
     });
 });

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -115,18 +115,6 @@ jest.mock('@components/ParticipantPicker', () => {
             ),
     };
 });
-// Jest resolves the native FocusTrapForScreen, which is a pass-through. This keeps that behaviour and only records
-// what each ScreenWrapper on the screen asks of its own trap, which is the thing the embedded confirmation changes.
-type RecordedFocusTrapSettings = {active?: boolean; containerElements?: unknown[]} | undefined;
-const mockFocusTrapSettings: RecordedFocusTrapSettings[] = [];
-jest.mock('@components/FocusTrap/FocusTrapForScreen', () => ({
-    __esModule: true,
-    default: ({children, focusTrapSettings}: {children: React.ReactNode; focusTrapSettings?: {active?: boolean; containerElements?: unknown[]}}) => {
-        mockFocusTrapSettings.push(focusTrapSettings);
-        return children;
-    },
-}));
-
 jest.mock('@src/hooks/useResponsiveLayout');
 jest.mock('@libs/getCurrentPosition');
 jest.mock('@libs/getIsNarrowLayout', () => jest.fn(() => false));
@@ -1678,14 +1666,11 @@ describe('IOURequestStepConfirmationPageTest', () => {
     describe('Embedded on IOURequestStartPage', () => {
         // IOURequestStartPage renders its own ScreenWrapper and hands it the focus trap containers for the
         // header (which holds the Back button), the tab bar and the active tab. This stands in for that wrapper.
-        // Both suites below pass with the fix reverted only if the trap assertions are dropped - the testID
-        // assertions alone do not discriminate, since the confirmation keeps its wrapper either way.
         const PARENT_SCREEN_TEST_ID = 'IOURequestStartPage';
         const CONFIRMATION_SCREEN_TEST_ID = 'IOURequestStepConfirmation';
 
         beforeEach(async () => {
             mockSelectedParticipants = [];
-            mockFocusTrapSettings.length = 0;
             await signInWithTestUser(ACCOUNT_ID, ACCOUNT_LOGIN);
             await act(async () => {
                 await Onyx.set(ONYXKEYS.BETAS, [CONST.BETAS.NEW_MANUAL_EXPENSE_FLOW]);
@@ -1727,18 +1712,7 @@ describe('IOURequestStepConfirmationPageTest', () => {
                 <OnyxListItemProvider>
                     <HTMLProviderWrapper>
                         <CurrentUserPersonalDetailsProvider>
-                            <LocaleContextProvider>
-                                {shouldHideHeader ? (
-                                    <ScreenWrapper
-                                        testID={PARENT_SCREEN_TEST_ID}
-                                        focusTrapSettings={{containerElements: []}}
-                                    >
-                                        {confirmation}
-                                    </ScreenWrapper>
-                                ) : (
-                                    confirmation
-                                )}
-                            </LocaleContextProvider>
+                            <LocaleContextProvider>{shouldHideHeader ? <ScreenWrapper testID={PARENT_SCREEN_TEST_ID}>{confirmation}</ScreenWrapper> : confirmation}</LocaleContextProvider>
                         </CurrentUserPersonalDetailsProvider>
                     </HTMLProviderWrapper>
                 </OnyxListItemProvider>,
@@ -1747,40 +1721,35 @@ describe('IOURequestStepConfirmationPageTest', () => {
             await waitForBatchedUpdatesWithAct();
         }
 
-        it('deactivates its own focus trap when embedded, leaving the start page trap in charge of the Tab cycle', async () => {
+        it('mounts no ScreenWrapper of its own when embedded, so the start page keeps sole ownership of the focus trap', async () => {
             // Given the confirmation rendered the way the manual tab renders it, inside the start page's ScreenWrapper
             await renderConfirmation({shouldHideHeader: true});
 
-            // Then the confirmation still renders inside its own ScreenWrapper, so nothing about its layout changes
+            // Then the confirmation content is on the screen
             expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
-            expect(screen.getByTestId(CONFIRMATION_SCREEN_TEST_ID)).toBeOnTheScreen();
 
-            // And its screen trap is switched off. Without this it would activate on top of the start page's trap
-            // on the shared stack and pause it, dropping the Back button and the tab bar out of the Tab cycle.
-            expect(mockFocusTrapSettings).toContainEqual({active: false});
-
-            // And the start page's trap, the one holding the header and tab bar containers, is left alone
-            expect(mockFocusTrapSettings.some((settings) => !!settings?.containerElements)).toBe(true);
+            // And the only ScreenWrapper is the start page's, so no second FocusTrapForScreen is pushed onto the
+            // shared trap stack to pause the trap holding the Back button and the tab bar
+            expect(screen.getByTestId(PARENT_SCREEN_TEST_ID)).toBeOnTheScreen();
+            expect(screen.queryByTestId(CONFIRMATION_SCREEN_TEST_ID)).not.toBeOnTheScreen();
         });
 
-        it('deactivates its own focus trap when embedded in the split expense flow too', async () => {
+        it('mounts no ScreenWrapper of its own when embedded in the split expense flow either', async () => {
             // Given the same embedded render for the split flow, which reuses the start page and this same component
             await renderConfirmation({shouldHideHeader: true, iouType: 'split'});
 
             // Then the split manual tab is covered by the same fix
             expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
-            expect(mockFocusTrapSettings).toContainEqual({active: false});
-            expect(mockFocusTrapSettings.some((settings) => !!settings?.containerElements)).toBe(true);
+            expect(screen.getByTestId(PARENT_SCREEN_TEST_ID)).toBeOnTheScreen();
+            expect(screen.queryByTestId(CONFIRMATION_SCREEN_TEST_ID)).not.toBeOnTheScreen();
         });
 
-        it('leaves the standalone route to FocusTrapForScreen default activation logic', async () => {
+        it('keeps its own ScreenWrapper - and therefore its own focus trap - on the standalone route', async () => {
             // Given the confirmation rendered as the standalone RHP route, with no parent owning its trap
             await renderConfirmation({shouldHideHeader: false});
 
-            // Then it still owns its trap, and `active` is left undefined rather than hardcoded to true, so the
-            // sidebar / top-tab / wide-layout checks in FocusTrapForScreen still run for this screen
+            // Then it still wraps itself, so the standalone screen keeps trapping focus exactly as before
             expect(await screen.findByTestId(CONFIRMATION_SCREEN_TEST_ID)).toBeOnTheScreen();
-            expect(mockFocusTrapSettings.some((settings) => settings?.active !== undefined)).toBe(false);
         });
     });
 });

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -1755,13 +1755,12 @@ describe('IOURequestStepConfirmationPageTest', () => {
             expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
             expect(screen.getByTestId(CONFIRMATION_SCREEN_TEST_ID)).toBeOnTheScreen();
 
-            // And exactly one screen trap is switched off - the embedded confirmation's. Without this it would
-            // activate on top of the start page's trap on the shared stack and pause it, dropping the Back button
-            // and the tab bar out of the Tab cycle.
-            expect(mockFocusTrapSettings.filter((settings) => settings?.active === false)).toHaveLength(1);
+            // And its screen trap is switched off. Without this it would activate on top of the start page's trap
+            // on the shared stack and pause it, dropping the Back button and the tab bar out of the Tab cycle.
+            expect(mockFocusTrapSettings).toContainEqual({active: false});
 
             // And the start page's trap, the one holding the header and tab bar containers, is left alone
-            expect(mockFocusTrapSettings).toContainEqual({containerElements: []});
+            expect(mockFocusTrapSettings.some((settings) => !!settings?.containerElements)).toBe(true);
         });
 
         it('deactivates its own focus trap when embedded in the split expense flow too', async () => {
@@ -1770,8 +1769,8 @@ describe('IOURequestStepConfirmationPageTest', () => {
 
             // Then the split manual tab is covered by the same fix
             expect(await screen.findByTestId('MockParticipantPicker')).toBeOnTheScreen();
-            expect(mockFocusTrapSettings.filter((settings) => settings?.active === false)).toHaveLength(1);
-            expect(mockFocusTrapSettings).toContainEqual({containerElements: []});
+            expect(mockFocusTrapSettings).toContainEqual({active: false});
+            expect(mockFocusTrapSettings.some((settings) => !!settings?.containerElements)).toBe(true);
         });
 
         it('leaves the standalone route to FocusTrapForScreen default activation logic', async () => {

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -8,8 +8,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 
 import {startSplitBill} from '@libs/actions/IOU/Split';
 
-import IOURequestStepConfirmationWithWritableReportOrNotFound from '@pages/iou/request/step/IOURequestStepConfirmation';
-import {IOURequestStepConfirmationContentWithWritableReportOrNotFound} from '@pages/iou/request/step/IOURequestStepConfirmation';
+import IOURequestStepConfirmationWithWritableReportOrNotFound, {IOURequestStepConfirmationContentWithWritableReportOrNotFound} from '@pages/iou/request/step/IOURequestStepConfirmation';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Under the `newManualExpenseFlow` beta, `IOURequestStartPage` embeds `IOURequestStepConfirmation` as the Manual tab body with `shouldHideHeader`. The start page already owns a focus trap containing the header (with the Back button), the tab bar and the active tab — but the embedded confirmation's own `ScreenWrapper` mounts a second `FocusTrapForScreen`. Both land on `sharedTrapStack`, the inner one activates second and pauses the outer one, so Tab is confined to the confirmation form and the Back button and tab bar are unreachable. Split > Manual embeds the same component and reproduces too.

Fix: when embedded, the confirmation no longer renders its own `ScreenWrapper`, so no second trap is mounted and the start page's trap stays in charge. Same gate `StepScreenWrapper` uses via `shouldShowWrapper`, which is why Scan and Distance never reproduced this. `shouldHideHeader` has one call site, so the standalone RHP route is untouched.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98709
PROPOSAL: https://github.com/Expensify/App/issues/98709#issuecomment-5305913353


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Requires the `newManualExpenseFlow` beta.

1. Open any chat on web.
2. Press Tab until the `+` button next to the composer is focused.
3. Press Enter to open the menu.
4. Press ↓ to highlight **Create expense**, press Enter (Manual tab selected).
5. Press Tab repeatedly through the form.
6. Verify focus reaches the **Back** button and the **Manual / Scan** tabs, and the cycle wraps back into the form.
7. Repeat 1–6 with **Split expense** > Manual tab.
8. Open the standalone confirmation (e.g. Scan flow > confirmation) and verify Tab still stays within that screen as before.

- [x] Verified no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as above — focus behaviour is unaffected by connectivity.
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as Tests. Web/desktop only; native has no focus trap.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
> Web-only behaviour — `FocusTrapForScreen` is a no-op on native and mWeb has no Tab key, so the Tab cycle is shown on Web/Desktop and the mobile recordings only confirm no regression.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
> Web-only behaviour — `FocusTrapForScreen` is a no-op on native and mWeb has no Tab key, so the Tab cycle is shown on Web/Desktop and the mobile recordings only confirm no regression.

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
> Web-only behaviour — `FocusTrapForScreen` is a no-op on native and mWeb has no Tab key, so the Tab cycle is shown on Web/Desktop and the mobile recordings only confirm no regression.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
> Web-only behaviour — `FocusTrapForScreen` is a no-op on native and mWeb has no Tab key, so the Tab cycle is shown on Web/Desktop and the mobile recordings only confirm no regression.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/95c27972-547c-4c22-a878-fdfbca047fbd

----
https://github.com/user-attachments/assets/b0866b72-3336-465a-a956-105ddd418745

----
https://github.com/user-attachments/assets/0ed59571-210c-4458-92a9-c223ffa0d64c

</details>
