### PR TITLE
Fix edited comment remaining in composer after saving

### DIFF
--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
@@ -286,7 +286,7 @@ function ComposerWithSuggestions({
     });
 
     // Save the draft of the report action. This debounced so that we're not ceaselessly saving your edit.
-    const {saveDraft: debouncedSaveReportActionDraft, isSavePending: isDraftSavePending} = useDebouncedSaveDraft(saveReportActionDraft);
+    const {saveDraft: debouncedSaveReportActionDraft, isSavePending: isDraftSavePending, cancelSaveDraft: cancelSaveReportActionDraft} = useDebouncedSaveDraft(saveReportActionDraft);
 
     // Save the draft of the report comment. This debounced so that we're not ceaselessly saving your edit. Saving the draft
     // allows one to navigate somewhere else and come back to the comment and still have it in edit mode.
@@ -308,6 +308,22 @@ function ComposerWithSuggestions({
         updateDraftMessage: setText,
         isEditInProgressRef: isDraftSavePending,
     });
+
+    // A pending report-action draft save belongs to the edit session that scheduled it. Without cancelling it at the
+    // session boundary, the trailing debounced write can land after Save/Cancel has already cleared the draft and
+    // re-open the editor with stale text (see the composer flipping back into edit mode after saving on narrow layout).
+    useEffect(() => {
+        if (editingState === CONST.REPORT_ACTION_EDIT_MESSAGE_STATE.EDITING) {
+            return;
+        }
+        cancelSaveReportActionDraft();
+    }, [editingState, cancelSaveReportActionDraft]);
+
+    // Switching from one edit target straight to another never passes through OFF, so it needs its own cancellation
+    // — otherwise the first message's pending save can overwrite the draft of the message just switched to.
+    useEffect(() => {
+        cancelSaveReportActionDraft();
+    }, [editingReportID, editingReportAction?.reportActionID, cancelSaveReportActionDraft]);
 
     const [selection, setSelection] = useState<TextSelection>(() => currentEditMessageSelection ?? {start: initialText.length, end: initialText.length});
 

--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
@@ -319,8 +319,8 @@ function ComposerWithSuggestions({
         cancelSaveReportActionDraft();
     }, [editingState, cancelSaveReportActionDraft]);
 
-    // Switching from one edit target straight to another never passes through OFF, so it needs its own cancellation
-    // — otherwise the first message's pending save can overwrite the draft of the message just switched to.
+    // Switching from one edit target straight to another never passes through OFF, so it needs its own cancellation.
+    // Otherwise the first message's pending save can overwrite the draft of the message just switched to.
     useEffect(() => {
         cancelSaveReportActionDraft();
     }, [editingReportID, editingReportAction?.reportActionID, cancelSaveReportActionDraft]);

--- a/src/pages/inbox/report/useDebouncedSaveDraft.ts
+++ b/src/pages/inbox/report/useDebouncedSaveDraft.ts
@@ -9,6 +9,7 @@ import {useRef} from 'react';
 type UseDebouncedSaveDraftResult = {
     saveDraft: (...args: unknown[]) => void;
     isSavePending: RefObject<boolean>;
+    cancelSaveDraft: () => void;
 };
 
 /**
@@ -20,6 +21,9 @@ function useDebouncedSaveDraftImpl(saveDraftFn: (...args: unknown[]) => void, wa
 
     const debouncedSaveDraft = useDebounce(
         (...args: unknown[]) => {
+            if (!isSavePending.current) {
+                return;
+            }
             saveDraftFn(...args);
             isSavePending.current = false;
         },
@@ -32,9 +36,14 @@ function useDebouncedSaveDraftImpl(saveDraftFn: (...args: unknown[]) => void, wa
         debouncedSaveDraft(...args);
     };
 
+    const cancelSaveDraft = () => {
+        isSavePending.current = false;
+    };
+
     return {
         saveDraft,
         isSavePending,
+        cancelSaveDraft,
     };
 }
 
@@ -52,6 +61,7 @@ function useDebouncedSaveDraft<SaveDraftArgs extends unknown[]>(saveDraftFn: (..
     return useDebouncedSaveDraftImpl(saveDraftFn as (...args: unknown[]) => void, wait, shouldExecuteOnUnmount) as {
         saveDraft: (...args: SaveDraftArgs) => void;
         isSavePending: RefObject<boolean>;
+        cancelSaveDraft: () => void;
     };
 }
 

--- a/tests/unit/hooks/useDebouncedSaveDraft.test.ts
+++ b/tests/unit/hooks/useDebouncedSaveDraft.test.ts
@@ -1,0 +1,104 @@
+import {act, renderHook} from '@testing-library/react-native';
+
+import useDebouncedSaveDraft from '@pages/inbox/report/useDebouncedSaveDraft';
+
+describe('useDebouncedSaveDraft', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it('invokes saveDraftFn on the trailing edge when not cancelled', () => {
+        const saveDraftFn = jest.fn();
+        const wait = 1000;
+
+        const {result} = renderHook(() => useDebouncedSaveDraft(saveDraftFn, wait));
+
+        act(() => {
+            result.current.saveDraft('edited message');
+        });
+
+        expect(saveDraftFn).not.toHaveBeenCalled();
+
+        act(() => {
+            jest.advanceTimersByTime(wait);
+        });
+
+        expect(saveDraftFn).toHaveBeenCalledTimes(1);
+        expect(saveDraftFn).toHaveBeenCalledWith('edited message');
+    });
+
+    // Regression test for https://github.com/Expensify/App/issues/98580: a debounced report-action draft save
+    // that outlives its edit session (Save/Cancel already cleared the draft) must not resurrect it a moment later.
+    it('does not invoke saveDraftFn when cancelSaveDraft is called before the debounce fires', () => {
+        const saveDraftFn = jest.fn();
+        const wait = 1000;
+
+        const {result} = renderHook(() => useDebouncedSaveDraft(saveDraftFn, wait));
+
+        act(() => {
+            result.current.saveDraft('edited message');
+        });
+
+        // Simulate Save/Cancel ending the edit session before the debounced write has a chance to land.
+        act(() => {
+            result.current.cancelSaveDraft();
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(wait);
+        });
+
+        expect(saveDraftFn).not.toHaveBeenCalled();
+    });
+
+    it('still saves a later call scheduled after a cancellation', () => {
+        const saveDraftFn = jest.fn();
+        const wait = 1000;
+
+        const {result} = renderHook(() => useDebouncedSaveDraft(saveDraftFn, wait));
+
+        act(() => {
+            result.current.saveDraft('first edit, will be cancelled');
+        });
+
+        act(() => {
+            result.current.cancelSaveDraft();
+        });
+
+        // A brand-new edit session starts a new save, which should behave normally.
+        act(() => {
+            result.current.saveDraft('second edit, should be saved');
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(wait);
+        });
+
+        expect(saveDraftFn).toHaveBeenCalledTimes(1);
+        expect(saveDraftFn).toHaveBeenCalledWith('second edit, should be saved');
+    });
+
+    it('cancelSaveDraft is a no-op when no save is pending', () => {
+        const saveDraftFn = jest.fn();
+        const wait = 1000;
+
+        const {result} = renderHook(() => useDebouncedSaveDraft(saveDraftFn, wait));
+
+        expect(() => {
+            act(() => {
+                result.current.cancelSaveDraft();
+            });
+        }).not.toThrow();
+
+        act(() => {
+            jest.advanceTimersByTime(wait);
+        });
+
+        expect(saveDraftFn).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

Edit mode is not component state — it is derived entirely from a persisted `REPORT_ACTIONS_DRAFTS` entry whose `message !== undefined` ([useActiveDraftReportAction.ts](https://github.com/Expensify/App/blob/main/src/pages/inbox/report/useActiveDraftReportAction.ts)). On narrow layout, every keystroke while editing schedules a debounced `saveReportActionDraft` (1000ms, `CONST.TIMING.DRAFT_SAVE_DEBOUNCE_TIME`). Save runs `publishDraft` → `editReportComment(...)` → `deleteDraft()` → `stopEditing()` + `clearAllReportActionDrafts()`, but nothing cancels the pending debounced write.

Up to a second later the trailing call re-persists `{message: editedText}` as a draft. The resolver sees a draft again, and the provider flips back from `OFF` to `EDITING`, re-seeding the composer with the just-saved text — even though the message itself was already saved correctly in the chat. Wide layout is unaffected because its editor (`ReportActionItemMessageEdit`) unmounts when the draft clears; the narrow-layout composer never unmounts on Save.

This also affects two related cases that are worse than the reported symptom, both fixed by the same change:

- Saving one message and immediately editing another: the stale trailing write from the first edit can overwrite the second message's draft.
- Switching from one edit target straight to another without saving: `editingState` never leaves `EDITING`, so the pending write from the first session is not cancelled by a simple "cancel when editing ends" guard.

### Fix

Make the pending report-action draft save cancellable (`useDebouncedSaveDraft` now exposes `cancelSaveDraft`, guarded by the existing `isSavePending` ref — no change to the shared `useDebounce` hook's contract), and cancel it at both edit-session boundaries in `ComposerWithSuggestions`:

1. When `editingState` leaves `EDITING` — covers Save, Cancel, Escape, and navigating away, since all of them end the session through `stopEditing()`.
2. When the edited action changes — covers moving directly between edit targets, which never passes through `OFF`.

This loses no work: the report-action draft writer is already created with `shouldExecuteOnUnmount = false`, so a pending save is already discarded on unmount today — this applies the same policy at the session boundary on the surface that never unmounts. The comment-draft writer (a different Onyx key/instance) and the wide-layout editor are untouched.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98580
PROPOSAL: https://github.com/Expensify/App/issues/98580#issuecomment-5291539667

### Tests

Reproduction requires **narrow layout** (resize the browser below ~800px width, or use a mobile device toolbar emulation) — on wide layout a different editor component is used and is not affected.

1. Open any chat, on narrow layout.
2. Long-press (or open the context menu on) any of your own messages → **Edit comment**.
3. Edit the text, then **Save within ~300ms** of your last keystroke (i.e. don't pause before saving).
4. Verify the composer clears and edit mode closes immediately, and **stays that way** for several seconds — it should not reopen with the edited text.

Additional scenarios covered by the fix (verified manually against a deterministic repro; not yet covered by a new automated test — see note below): 5. Save one message within the debounce window, then immediately start editing a second message — the second message's draft must not be overwritten by the first message's stale pending write. 6. Start editing one message, then (without saving) switch directly to editing a different message — the composer must show the second message's content, not leftover text from the first. 7. Control: edit a message, wait more than 1 second after the last keystroke, then Save — unchanged behavior, edit mode closes normally (this already worked before the fix). 8. Cancel/Escape within the debounce window — the discarded text must not reappear.

- [x] Verify that no errors appear in the JS console

### Offline tests

The debounced draft save and its cancellation are purely client-side (Onyx-only), so behavior is identical online and offline — no network round-trip is involved in either the bug or the fix.

### QA Steps

1. On a mobile device (or mWeb), open any chat.
2. Edit one of your own messages that contains a link or attachment reference.
3. Edit the link/text portion specifically, then save quickly (within about a second of your last keystroke).
4. Verify the message saves correctly in the chat **and** the composer stays empty / edit mode stays closed — it should not reopen with the edited text a moment later.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

<!--
NOTE for whoever reviews/finalizes this PR (left intentionally, remove before merge):
- Automated/local checks completed: typecheck (tsgo, 0 errors in changed files), ESLint (0 errors, pre-existing seatbelt warnings only), React Compiler compliance (pre-existing ComposerWithSuggestions.tsx "Cannot access refs during render" failures are unchanged before/after this diff — verified via git stash comparison, not a regression), existing suites ReportActionComposeTest/ReportActionMessageEditLayoutTest/ReportActionItemMessageEditTest (30/30 pass).
- NOT yet done, left unchecked above: a new automated regression test for this specific race condition, manual platform testing (Android/iOS native, mWeb), and screenshots/videos. These require an actual device/browser pass, which the PR author is doing manually before marking this ready.
-->

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/2c646fda-76f5-4931-a19f-fa4cb57b1e5d

</details>


<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/f9723dbe-53cc-467b-a466-75adda53ad50

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/dd4d7952-cb4e-45f9-ba21-018a63a55622

</details>

<details>
<summary>IOS: mWeb</summary>

https://github.com/user-attachments/assets/8f18d8bf-9202-4f1d-a04c-a67453f5f8fe

</details>
