### PR TITLE
Don't grey out sidebar menu rows while a navigation is in flight

### DIFF
--- a/src/pages/domain/DomainInitialPage.tsx
+++ b/src/pages/domain/DomainInitialPage.tsx
@@ -155,7 +155,7 @@ function DomainInitialPage({route}: DomainInitialPageProps) {
                         {domainMenuItems.map((item) => (
                             <HighlightableMenuItem
                                 key={item.translationKey}
-                                disabled={isExecuting}
+                                disabled={isExecuting && !(item.screenName && activeRoute?.startsWith(item.screenName))}
                                 title={translate(item.translationKey)}
                                 icon={item.icon}
                                 onPress={item.action}
@@ -165,6 +165,7 @@ function DomainInitialPage({route}: DomainInitialPageProps) {
                                 focused={!!(item.screenName && activeRoute?.startsWith(item.screenName))}
                                 badgeText={item.badgeText}
                                 shouldIconUseAutoWidthStyle
+                                shouldGreyOutWhenDisabled={false}
                             />
                         ))}
                     </View>

--- a/src/pages/settings/SettingsMenuItem.tsx
+++ b/src/pages/settings/SettingsMenuItem.tsx
@@ -55,7 +55,7 @@ function SettingsMenuItem({item, isFocused, keyTitle, isExecuting, isScreenFocus
             title={keyTitle}
             icon={item.icon}
             iconType={item.iconType}
-            disabled={isExecuting}
+            disabled={isExecuting && !isFocused}
             onPress={onPress}
             iconStyles={item.iconStyles}
             badgeText={item.badgeText}
@@ -76,6 +76,7 @@ function SettingsMenuItem({item, isFocused, keyTitle, isExecuting, isScreenFocus
             iconRight={item.iconRight}
             shouldShowRightIcon={item.shouldShowRightIcon}
             shouldIconUseAutoWidthStyle
+            shouldGreyOutWhenDisabled={false}
         />
     );
 }

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -578,7 +578,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
                             {workspaceMenuItems.map((item) => (
                                 <HighlightableMenuItem
                                     key={item.translationKey}
-                                    disabled={hasPolicyCreationError || isExecuting}
+                                    disabled={hasPolicyCreationError || (isExecuting && !(item.screenName && activeRoute?.startsWith(item.screenName)))}
                                     interactive={!hasPolicyCreationError}
                                     title={translate(item.translationKey)}
                                     icon={item.icon}
@@ -591,6 +591,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
                                     badgeText={item.badgeText}
                                     shouldIconUseAutoWidthStyle
                                     sentryLabel={item.sentryLabel}
+                                    shouldGreyOutWhenDisabled={false}
                                 />
                             ))}
                         </View>

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -591,7 +591,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
                                     badgeText={item.badgeText}
                                     shouldIconUseAutoWidthStyle
                                     sentryLabel={item.sentryLabel}
-                                    shouldGreyOutWhenDisabled={false}
+                                    shouldGreyOutWhenDisabled={hasPolicyCreationError}
                                 />
                             ))}
                         </View>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

While a `useSingleExecution` navigation is in flight, the Settings, Workspace and Domain sidebars disabled every menu row — dimming all of them and dropping the focused row's highlight, since `getButtonState` returns `DISABLED` before `ACTIVE`. The focused row is now excluded from that disable, and `shouldGreyOutWhenDisabled={false}` removes the dim, so the other rows stay unpressable but undimmed.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98493
PROPOSAL:

### Tests

> [!NOTE]
> This only reproduces on **native**. On web `useSingleExecution` returns `isExecuting: false` unconditionally (`src/hooks/useSingleExecution/index.ts`), so no row is ever disabled there.

**1. Settings sidebar**

1. Run the app on an iOS or Android native build.
2. Open the **Settings** tab.
3. Tap **Profile** and watch the settings menu rows during the screen transition.
4. Verify that no menu row is greyed out at any point during the transition.
5. Verify that the tapped row keeps its focused highlight throughout the transition and after the new screen has landed.
6. While the transition is still running, tap a different row.
7. Verify that nothing happens — the other rows are still not pressable and show no pressed state.
8. Swipe back from the Profile screen and verify that the revealed settings rows are not greyed out at any point of the gesture.

**2. Workspace sidebar**

1. On the same native build, open **Workspaces** and open any workspace.
2. Tap **Members** and watch the workspace menu rows during the screen transition.
3. Verify that no menu row is greyed out and that the tapped row keeps its focused highlight.
4. Swipe back to the workspace sidebar and verify the rows are never greyed out mid-gesture.

**3. Domain sidebar**

1. On the same native build, open **Domains** and open a domain.
2. Tap any domain menu row and watch the sidebar during the screen transition.
3. Verify that no menu row is greyed out and that the tapped row keeps its focused highlight.

### Offline tests

N/A — the change is purely visual. No API calls, data fetching or Onyx operations were touched.

### QA Steps

Same as tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
