### PR TITLE
[No QA] Fix stale artifacts cache on iOS

### DIFF
--- a/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
+++ b/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
@@ -49,9 +49,7 @@ module PatchedIOSArtifacts
         ReactNativeCoreUtils.class_variable_set(:@@patched_github_token, resolution['githubToken'])
         ReactNativeCoreUtils.class_variable_set(:@@patched_build_from_source, resolution['buildFromSource'])
 
-        # Content identity of this install's artifacts. Merged-dSYM tarballs are stamped apart
-        # from pristine ones: flipping the flag must count as a change, or symbols silently
-        # appear/disappear without the tarballs being rebuilt.
+        # Content identity of this install's artifacts; '+dsym' so flipping the flag counts as a change.
         @artifacts_stamp = @using_prebuilt ?
             "#{resolution['version']}#{ENV['RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS'] == '1' ? '+dsym' : ''}" : nil
 
@@ -62,13 +60,10 @@ module PatchedIOSArtifacts
         File.join(Pod::Config.instance.project_pods_root, 'ReactNativeCore-artifacts', '.artifacts-version')
     end
 
-    # Our React-Core-prebuilt podspec is dynamic — its source comes from the resolver — but
-    # CocoaPods memoizes external :podspec sources as static and skips re-reading them on a
-    # warm sandbox (analyzer#dependencies_to_fetch). When the tarballs the last evaluation
-    # produced no longer match this install's resolution, drop the memoized copy through the
-    # sandbox API: a missing stored podspec forces CocoaPods to re-evaluate the file, which
-    # re-runs our download (and the dSYM merge). The re-evaluated podspec is byte-identical
-    # (the source path never changes), so the lockfile checksum — and Podfile.lock — stay put.
+    # CocoaPods memoizes external :podspec sources and may skip re-reading ours, whose source is
+    # resolved dynamically. When the tarballs in Pods don't match this install's resolution, drop
+    # the memoized copy so CocoaPods re-evaluates the podspec, re-running our download (and dSYM
+    # merge). The re-read podspec is byte-identical, so Podfile.lock stays put.
     def self.force_rncore_podspec_reevaluation
         return if File.exist?(artifacts_stamp_path) && File.read(artifacts_stamp_path) == @artifacts_stamp
 
@@ -76,19 +71,10 @@ module PatchedIOSArtifacts
         log("Artifacts changed to #{@artifacts_stamp}; the React-Core-prebuilt podspec will be re-evaluated.")
     end
 
-    # Post-install half of the sync: setup (above) guarantees the tarballs in Pods match this
-    # install's resolution; the build-time prelude added here guarantees the EXTRACTED
-    # framework follows. CocoaPods cannot do that part either — its download cache keys the
-    # extraction on our never-changing source URL. The prelude (sync-prebuilt-rncore.sh) only
-    # compares stamps and, on mismatch, invalidates react-native's config marker so
-    # replace-rncore-version.js, running right after it, re-extracts from the fresh tarballs.
-    #
-    # Prepended INTO react-native's '[RNCore] Replace ...' phase rather than added as a phase
-    # of its own: CocoaPods sorts build phases by name when saving the Pods project — after
-    # the post_install hooks (PodsProjectWriter#save_projects) — so a separate phase cannot
-    # be kept ahead of '[RNCore]'. Inside one phase the order is the script itself, and the
-    # marker is consumed in the same build that sets it. Re-applied each install because
-    # CocoaPods regenerates the Pods project.
+    # Prepends sync-prebuilt-rncore.sh to react-native's '[RNCore] Replace ...' build phase, so a
+    # build re-extracts the prebuilt React Core when the artifact version changed — CocoaPods won't,
+    # as its caches key on our never-changing source URL. Prepended into that phase (not added as
+    # its own) because CocoaPods sorts phases by name on save, which would push ours after [RNCore].
     def self.add_sync_prebuilt_script_phase(installer)
         return unless @using_prebuilt
 
@@ -278,9 +264,7 @@ class ReactNativeCoreUtils
             process_dsyms(release, download_stable_rncore(@@react_native_path, @@react_native_version, :release, true))
         end
 
-        # Content version of the flat tarballs, for the sync build phase — their names cannot
-        # carry it (replace-rncore-version.js hardcodes them), and merged-dSYM tarballs differ
-        # from the pristine ones the phase would otherwise copy over them from our cache.
+        # Content version of the flat tarballs — their names can't carry it, replace-rncore-version.js hardcodes them.
         File.write(File.join(File.dirname(debug), '.artifacts-version'),
                    "#{@@patched_version}#{@@download_dsyms ? '+dsym' : ''}")
 

--- a/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
+++ b/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
@@ -48,6 +48,59 @@ module PatchedIOSArtifacts
         ReactNativeCoreUtils.class_variable_set(:@@patched_artifact_url_prefix, resolution['artifactUrlPrefix'])
         ReactNativeCoreUtils.class_variable_set(:@@patched_github_token, resolution['githubToken'])
         ReactNativeCoreUtils.class_variable_set(:@@patched_build_from_source, resolution['buildFromSource'])
+
+        # Content identity of this install's artifacts. Merged-dSYM tarballs are stamped apart
+        # from pristine ones: flipping the flag must count as a change, or symbols silently
+        # appear/disappear without the tarballs being rebuilt.
+        @artifacts_stamp = @using_prebuilt ?
+            "#{resolution['version']}#{ENV['RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS'] == '1' ? '+dsym' : ''}" : nil
+
+        force_rncore_podspec_reevaluation if @using_prebuilt
+    end
+
+    def self.artifacts_stamp_path
+        File.join(Pod::Config.instance.project_pods_root, 'ReactNativeCore-artifacts', '.artifacts-version')
+    end
+
+    # Our React-Core-prebuilt podspec is dynamic — its source comes from the resolver — but
+    # CocoaPods memoizes external :podspec sources as static and skips re-reading them on a
+    # warm sandbox (analyzer#dependencies_to_fetch). When the tarballs the last evaluation
+    # produced no longer match this install's resolution, drop the memoized copy through the
+    # sandbox API: a missing stored podspec forces CocoaPods to re-evaluate the file, which
+    # re-runs our download (and the dSYM merge). The re-evaluated podspec is byte-identical
+    # (the source path never changes), so the lockfile checksum — and Podfile.lock — stay put.
+    def self.force_rncore_podspec_reevaluation
+        return if File.exist?(artifacts_stamp_path) && File.read(artifacts_stamp_path) == @artifacts_stamp
+
+        Pod::Config.instance.sandbox.remove_local_podspec('React-Core-prebuilt')
+        log("Artifacts changed to #{@artifacts_stamp}; the React-Core-prebuilt podspec will be re-evaluated.")
+    end
+
+    # Post-install half of the sync: setup (above) guarantees the tarballs in Pods match this
+    # install's resolution; the build-time prelude added here guarantees the EXTRACTED
+    # framework follows. CocoaPods cannot do that part either — its download cache keys the
+    # extraction on our never-changing source URL. The prelude (sync-prebuilt-rncore.sh) only
+    # compares stamps and, on mismatch, invalidates react-native's config marker so
+    # replace-rncore-version.js, running right after it, re-extracts from the fresh tarballs.
+    #
+    # Prepended INTO react-native's '[RNCore] Replace ...' phase rather than added as a phase
+    # of its own: CocoaPods sorts build phases by name when saving the Pods project — after
+    # the post_install hooks (PodsProjectWriter#save_projects) — so a separate phase cannot
+    # be kept ahead of '[RNCore]'. Inside one phase the order is the script itself, and the
+    # marker is consumed in the same build that sets it. Re-applied each install because
+    # CocoaPods regenerates the Pods project.
+    def self.add_sync_prebuilt_script_phase(installer)
+        return unless @using_prebuilt
+
+        target = installer.pods_project.targets.find { |t| t.name == 'React-Core-prebuilt' }
+        phase = target&.shell_script_build_phases&.find { |p| p.name.to_s.include?('[RNCore] Replace') }
+        unless phase
+            log("The [RNCore] Replace build phase was not found; the extracted prebuilt React Core won't follow version changes.", :error)
+            return
+        end
+
+        prelude = %(bash "#{File.join(NEW_DOT_ROOT, 'scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh')}"\n)
+        phase.shell_script = prelude + phase.shell_script unless phase.shell_script.start_with?(prelude)
     end
 
     # True only when a matching prebuilt artifact resolved and prebuilds are enabled.
@@ -224,6 +277,12 @@ class ReactNativeCoreUtils
             process_dsyms(debug, download_stable_rncore(@@react_native_path, @@react_native_version, :debug, true))
             process_dsyms(release, download_stable_rncore(@@react_native_path, @@react_native_version, :release, true))
         end
+
+        # Content version of the flat tarballs, for the sync build phase — their names cannot
+        # carry it (replace-rncore-version.js hardcodes them), and merged-dSYM tarballs differ
+        # from the pristine ones the phase would otherwise copy over them from our cache.
+        File.write(File.join(File.dirname(debug), '.artifacts-version'),
+                   "#{@@patched_version}#{@@download_dsyms ? '+dsym' : ''}")
 
         # URI::File.build validates path components as ASCII, so escape the filesystem path first —
         # matches RN 0.86's own ReactNativePodsUtils.local_file_uri, which this replaces.

--- a/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
+++ b/scripts/artifacts-utils/ios/patched_ios_artifacts.rb
@@ -80,12 +80,10 @@ module PatchedIOSArtifacts
 
         target = installer.pods_project.targets.find { |t| t.name == 'React-Core-prebuilt' }
         phase = target&.shell_script_build_phases&.find { |p| p.name.to_s.include?('[RNCore] Replace') }
-        unless phase
-            log("The [RNCore] Replace build phase was not found; the extracted prebuilt React Core won't follow version changes.", :error)
-            return
-        end
+        raise "#{LOG_PREFIX} The [RNCore] Replace build phase was not found on the React-Core-prebuilt target, " \
+              'so the extracted prebuilt React Core would keep following a stale artifact version.' unless phase
 
-        prelude = %(bash "#{File.join(NEW_DOT_ROOT, 'scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh')}"\n)
+        prelude = %(bash "#{File.join(NEW_DOT_ROOT, 'scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh')}" || exit 1\n)
         phase.shell_script = prelude + phase.shell_script unless phase.shell_script.start_with?(prelude)
     end
 

--- a/scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh
+++ b/scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Runs as a prelude inside react-native's '[RNCore] Replace ...' build phase (prepended by
+# PatchedIOSArtifacts.add_sync_prebuilt_script_phase). When the extracted framework is a
+# different patched artifact version than the tarballs in Pods, invalidates react-native's
+# .last_build_configuration marker: 'stale' matches no configuration, so
+# replace-rncore-version.js, running right after this in the same phase, re-extracts from
+# the tarballs — the same swap it performs on every Debug/Release switch, retried until an
+# extraction succeeds and writes a real configuration back.
+#
+# The tarballs themselves are guaranteed fresh by pod install: PatchedIOSArtifacts.setup
+# forces the React-Core-prebuilt podspec to re-evaluate (re-download + dSYM merge) whenever
+# the resolved artifacts change, and stamps them with .artifacts-version.
+set -euo pipefail
+
+TARBALLS_STAMP="$PODS_ROOT/ReactNativeCore-artifacts/.artifacts-version"
+PREBUILT_DIR="$PODS_ROOT/React-Core-prebuilt"
+
+# No stamp: the last install built react-native from source — nothing to sync.
+[ -f "$TARBALLS_STAMP" ] || exit 0
+
+TARBALLS=$(cat "$TARBALLS_STAMP")
+EXTRACTED=$(cat "$PREBUILT_DIR/.patched-version" 2>/dev/null || true)
+[ "$TARBALLS" = "$EXTRACTED" ] && exit 0
+
+echo "[PatchedArtifacts] Extracted prebuilt React Core is '${EXTRACTED:-<none>}', tarballs are '$TARBALLS' — marking for re-extraction."
+mkdir -p "$PREBUILT_DIR"
+# No trailing newlines: replace-rncore-version.js compares its marker verbatim.
+printf 'stale' > "$PREBUILT_DIR/.last_build_configuration"
+printf '%s' "$TARBALLS" > "$PREBUILT_DIR/.patched-version"

--- a/scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh
+++ b/scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh
@@ -5,10 +5,14 @@
 # .last_build_configuration marker so replace-rncore-version.js, running right after this,
 # re-extracts from the tarballs. Needed because our tarball path carries no patches version,
 # so a version change is invisible to CocoaPods and it can keep a stale extraction.
+#
+# Expected Xcode environment variables:
+#   PODS_ROOT
 set -euo pipefail
 
 TARBALLS_STAMP="$PODS_ROOT/ReactNativeCore-artifacts/.artifacts-version"
 PREBUILT_DIR="$PODS_ROOT/React-Core-prebuilt"
+readonly TARBALLS_STAMP PREBUILT_DIR
 
 # No stamp: the last install built react-native from source — nothing to sync.
 [ -f "$TARBALLS_STAMP" ] || exit 0

--- a/scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh
+++ b/scripts/artifacts-utils/ios/sync-prebuilt-rncore.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
-# Runs as a prelude inside react-native's '[RNCore] Replace ...' build phase (prepended by
-# PatchedIOSArtifacts.add_sync_prebuilt_script_phase). When the extracted framework is a
-# different patched artifact version than the tarballs in Pods, invalidates react-native's
-# .last_build_configuration marker: 'stale' matches no configuration, so
-# replace-rncore-version.js, running right after this in the same phase, re-extracts from
-# the tarballs — the same swap it performs on every Debug/Release switch, retried until an
-# extraction succeeds and writes a real configuration back.
-#
-# The tarballs themselves are guaranteed fresh by pod install: PatchedIOSArtifacts.setup
-# forces the React-Core-prebuilt podspec to re-evaluate (re-download + dSYM merge) whenever
-# the resolved artifacts change, and stamps them with .artifacts-version.
+# Prelude of react-native's '[RNCore] Replace ...' build phase (prepended by
+# PatchedIOSArtifacts.add_sync_prebuilt_script_phase). When the extracted prebuilt React Core
+# is a different patched artifact version than the tarballs in Pods, invalidates the
+# .last_build_configuration marker so replace-rncore-version.js, running right after this,
+# re-extracts from the tarballs. Needed because our tarball path carries no patches version,
+# so a version change is invisible to CocoaPods and it can keep a stale extraction.
 set -euo pipefail
 
 TARBALLS_STAMP="$PODS_ROOT/ReactNativeCore-artifacts/.artifacts-version"
@@ -20,10 +15,13 @@ PREBUILT_DIR="$PODS_ROOT/React-Core-prebuilt"
 
 TARBALLS=$(cat "$TARBALLS_STAMP")
 EXTRACTED=$(cat "$PREBUILT_DIR/.patched-version" 2>/dev/null || true)
+# Fast path, taken on every build: what is extracted matches the tarballs.
 [ "$TARBALLS" = "$EXTRACTED" ] && exit 0
 
 echo "[PatchedArtifacts] Extracted prebuilt React Core is '${EXTRACTED:-<none>}', tarballs are '$TARBALLS' — marking for re-extraction."
 mkdir -p "$PREBUILT_DIR"
+# 'stale' matches no configuration, so replace-rncore-version.js re-extracts; it stays until
+# an extraction succeeds and writes a real configuration back, so a failed build retries.
 # No trailing newlines: replace-rncore-version.js compares its marker verbatim.
 printf 'stale' > "$PREBUILT_DIR/.last_build_configuration"
 printf '%s' "$TARBALLS" > "$PREBUILT_DIR/.patched-version"


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

CocoaPods caches our prebuilt React Native artifacts by their source URL. That URL carries only the
plain react-native version, so a new patches version lands at the same path and CocoaPods keeps the
old extraction. It may not even re-read the podspec that downloads the tarballs. The app then
silently builds against a stale artifact.

Upstream RN has the same issue with Debug and Release artifacts (the cache does not distinguish
them either) and solves it outside CocoaPods. Its `[RNCore]` build phase re-extracts the framework
whenever the `.last_build_configuration` marker does not match the current configuration. This PR
extends that pattern to the patches version.

During `pod install`, when the resolved version does not match the `.artifacts-version` stamp of
the tarballs in Pods, we drop CocoaPods' memoized podspec with `sandbox.remove_local_podspec`. This
forces a re-evaluation of the podspec, which re-runs podspec evaluation and the dSYM merge. The re-read
podspec is byte-identical, so `Podfile.lock` is unaffected.

During the build, a small prelude prepended into the `[RNCore]` phase compares the tarballs' stamp
with the extracted framework's stamp. On mismatch it writes `stale` into
`.last_build_configuration`, and RN's own script re-extracts from the fresh tarballs right after.
This reuses the upstream extraction machinery instead of duplicating it. It lives inside that phase
because CocoaPods sorts phases by name on save, so a separate phase could not run first.

The change covers patches version changes, the `RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS` toggle, warm
sandboxes, removed Pods and interrupted builds. Debug and Release switching is untouched. When
nothing changed, both pieces are no-ops costing a couple of file reads.

---

**Why this approach instead of a solution where we make CocoaPods differentiate between our patched versions?** That would require significantly more effort and more patches to React Native internals. I’d prefer to keep our patched artifacts as close to upstream as possible to minimize the maintenance cost.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/99187
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:



--->

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/14066

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Prerequisites:** HybridApp iOS dev setup, `npm i` done, `gh auth login` (Maven access), with successful `pod install` + build on this branch with the latest artifacts version (latest `main` on both repos should be set).

#### 1. Note the current artifact version

- [ ] Run `cat Mobile-Expensify/ios/Pods/ReactNativeCore-artifacts/.artifacts-version` and note the version (e.g. `0.86.0-5`) — referred to as `<current>` below

#### 2. Force an older artifact version

- [ ] In `scripts/artifacts-utils/lib/artifactsResolver.ts`, add as the **first line** of `findMatchingArtifactsVersion`:
  ```ts
  return '0.86.0-0'; // TEST ONLY — remove after
  ```

#### 3. Run pod install and verify it invalidates

- [ ] Run `cd Mobile-Expensify/ios && bundle exec pod install`
- [ ] Verify the output contains `[PatchedArtifacts] Using patched react-native artifacts: react-hybrid:0.86.0-0`
- [ ] Verify the output contains `[PatchedArtifacts] Artifacts changed to 0.86.0-0; the React-Core-prebuilt podspec will be re-evaluated.`
- [ ] Verify `cat Pods/ReactNativeCore-artifacts/.artifacts-version` prints `0.86.0-0`
- [ ] Verify `git -C .. diff iOS/Podfile.lock` shows no new changes

#### 4. Build and verify the extraction log

- [ ] Build the app via Xcode to see detailed logs
- [ ] In the build log, verify the line: `[PatchedArtifacts] Extracted prebuilt React Core is '<current>', tarballs are '0.86.0-0' — marking for re-extraction.`
- [ ] Verify it is immediately followed by react-native's `Extracting the tarball to temp dir …`
- [ ] Verify the build succeeds
- [ ] Verify `cat Pods/React-Core-prebuilt/.patched-version` prints `0.86.0-0`

#### 5. Verify the no-op fast path

- [ ] Build again **without any changes**
- [ ] Verify the `marking for re-extraction` line does NOT appear (silent = versions match)
- [ ] Verify there is no tarball extraction for `React-Core-prebuilt`

#### 6. Revert and verify the round trip

- [ ] Remove the hardcoded line from `artifactsResolver.ts`
- [ ] Run `cd Mobile-Expensify/ios && bundle exec pod install` and verify the output contains `Artifacts changed to <current> …`
- [ ] Build once more and verify the log line:
  `… is '0.86.0-0', tarballs are '<current>' — marking for re-extraction.` followed by the extraction
- [ ] Verify `cat Pods/React-Core-prebuilt/.patched-version` is back to `<current>`
- [ ] Verify app on <current> works **without crashing**

#### Byte-level checks

- [ ] Run `dwarfdump --uuid Mobile-Expensify/ios/Pods/React-Core-prebuilt/React.xcframework/ios-arm64_x86_64-simulator/React.framework/React`
- [ ] Run `dwarfdump --uuid <DerivedData>/Build/Products/Debug-iphonesimulator/Expensify.app/Frameworks/React.framework/React`
- [ ] Verify the arm64 UUIDs are equal and match the resolved version (`0.86.0-0`: `6F445E91-…`, `0.86.0-5`: `7AFB6212-…`)

> Note: versions `-3`/`-4`/`-5` ship an identical iOS debug binary, so the optional UUID checks only discriminate with a genuinely different version like `0.86.0-0`. Steps 3–6 (logs + stamps) work with any older version.
> Note2: possibly on build using old artifact the app will crash due to wrong ABI. On the latest artifact version the app should work as expected.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
-

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
