### PR TITLE
[No QA] Preserve function wrappers for incremental plural translations

### DIFF
--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -667,7 +667,7 @@ class TranslationGenerator {
         // Check if path is in either pathsToModify or pathsToAdd
         const allPathsToTranslate = new Set([...this.pathsToModify, ...this.pathsToAdd]);
         for (const targetPath of allPathsToTranslate) {
-            if (currentPath.startsWith(targetPath)) {
+            if (currentPath === targetPath || currentPath.startsWith(`${targetPath}.`)) {
                 return true;
             }
         }

--- a/scripts/utils/TSCompilerUtils.ts
+++ b/scripts/utils/TSCompilerUtils.ts
@@ -254,6 +254,10 @@ function extractKeyFromPropertyNode(node: ts.PropertyAssignment | ts.MethodDecla
     return undefined;
 }
 
+function isFunctionValuedProperty(node: ts.PropertyAssignment): boolean {
+    return ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer);
+}
+
 /**
  * Build a dot-notation path from a node by traversing up the AST to find property assignments.
  * Useful for building paths like "common.save" from a string literal node.
@@ -267,6 +271,9 @@ function buildDotNotationPath(node: ts.Node, rootNode?: ts.Node): string | null 
         if (ts.isPropertyAssignment(current)) {
             const key = extractKeyFromPropertyNode(current);
             if (key) {
+                if (isFunctionValuedProperty(current)) {
+                    pathParts.length = 0;
+                }
                 pathParts.unshift(key);
             }
         }

--- a/tests/tooling/generateTranslations.test.ts
+++ b/tests/tooling/generateTranslations.test.ts
@@ -1635,6 +1635,85 @@ describe('generateTranslations', () => {
             expect(translateSpy).toHaveBeenCalledTimes(2);
         });
 
+        it('does not retranslate a sibling key that only shares a prefix with a changed function key', async () => {
+            fs.writeFileSync(
+                EN_PATH,
+                Str.dedent(`
+                const strings = {
+                    iou: {
+                        deleteReport: 'Delete report',
+                        deleteReportConfirmation: () => ({
+                            one: 'Are you sure you want to delete this report?',
+                            other: (count: number) => \`Are you sure you want to delete these \${count} reports?\`,
+                        }),
+                    },
+                };
+                export default strings;
+            `),
+                'utf8',
+            );
+
+            fs.writeFileSync(
+                IT_PATH,
+                Str.dedent(`
+                import type en from './en';
+
+                const strings = {
+                    iou: {
+                        deleteReport: '[it] Delete report',
+                        deleteReportConfirmation: () => ({
+                            one: '[it] Are you sure you want to delete this report?',
+                            other: (count: number) => \`[it] Are you sure you want to delete these \${count} reports?\`,
+                        }),
+                    },
+                };
+                export default strings;
+            `),
+                'utf8',
+            );
+
+            mockIsValidRef.mockReturnValue(true);
+            mockDiff.mockReturnValue({
+                files: [
+                    {
+                        filePath: 'src/languages/en.ts',
+                        diffType: 'modified',
+                        hunks: [],
+                        addedLines: new Set(),
+                        removedLines: new Set(),
+                        modifiedLines: new Set([3]),
+                    },
+                ],
+                hasChanges: true,
+            });
+
+            mockShow.mockReturnValue(
+                Str.dedent(`
+                const strings = {
+                    iou: {
+                        deleteReport: 'Remove report',
+                        deleteReportConfirmation: () => ({
+                            one: 'Are you sure you want to delete this report?',
+                            other: (count: number) => \`Are you sure you want to delete these \${count} reports?\`,
+                        }),
+                    },
+                };
+                export default strings;
+            `),
+            );
+
+            process.argv = ['bun', 'generateTranslations.ts', '--dry-run', '--verbose', '--locales', 'it', '--compare-ref', 'main'];
+            const translateSpy = jest.spyOn(Translator.prototype, 'translate');
+
+            await generateTranslations();
+
+            expect(translateSpy).toHaveBeenCalledTimes(1);
+            expect(translateSpy).toHaveBeenCalledWith('it', 'Delete report', undefined, expect.anything());
+            expect(translateSpy).not.toHaveBeenCalledWith('it', 'Are you sure you want to delete this report?', undefined, expect.anything());
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(translateSpy).not.toHaveBeenCalledWith('it', 'Are you sure you want to delete these ${count} reports?', undefined, expect.anything());
+        });
+
         it('handles modifying existing string values with --compare-ref', async () => {
             // Create English source with a modified string value
             fs.writeFileSync(

--- a/tests/tooling/generateTranslations.test.ts
+++ b/tests/tooling/generateTranslations.test.ts
@@ -1493,6 +1493,148 @@ describe('generateTranslations', () => {
             expect(translateSpy).toHaveBeenCalledWith('it', 'New value added to existing nested structure', undefined, expect.anything());
         });
 
+        it('preserves the function wrapper when adding a plural translation key with --compare-ref', async () => {
+            fs.writeFileSync(
+                EN_PATH,
+                Str.dedent(`
+                const strings = {
+                    existingSection: {
+                        keep: 'Keep this existing translation',
+                    },
+                    codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({
+                        one: \`copied 1 merchant rule from \${sourcePolicyName}\`,
+                        other: (count: number) => \`copied \${count} merchant rules from \${sourcePolicyName}\`,
+                    }),
+                };
+                export default strings;
+            `),
+                'utf8',
+            );
+
+            fs.writeFileSync(
+                IT_PATH,
+                Str.dedent(`
+                import type en from './en';
+
+                const strings = {
+                    existingSection: {
+                        keep: '[it] Keep this existing translation',
+                    },
+                };
+                export default strings;
+            `),
+                'utf8',
+            );
+
+            mockIsValidRef.mockReturnValue(true);
+            mockDiff.mockReturnValue({
+                files: [
+                    {
+                        filePath: 'src/languages/en.ts',
+                        diffType: 'modified',
+                        hunks: [],
+                        addedLines: new Set([5, 6, 7, 8]),
+                        removedLines: new Set(),
+                        modifiedLines: new Set(),
+                    },
+                ],
+                hasChanges: true,
+            });
+
+            process.argv = ['bun', 'generateTranslations.ts', '--dry-run', '--verbose', '--locales', 'it', '--compare-ref', 'main'];
+            const translateSpy = jest.spyOn(Translator.prototype, 'translate');
+
+            await generateTranslations();
+            const itContent = fs.readFileSync(IT_PATH, 'utf8');
+
+            expect(itContent).toContain('[it] Keep this existing translation');
+            expect(itContent).toContain('codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({');
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(itContent).toContain('[it] copied 1 merchant rule from ${sourcePolicyName}');
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(itContent).toContain('[it] copied ${count} merchant rules from ${sourcePolicyName}');
+
+            expect(translateSpy).toHaveBeenCalledTimes(2);
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(translateSpy).toHaveBeenCalledWith('it', 'copied 1 merchant rule from ${sourcePolicyName}', undefined, expect.anything());
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(translateSpy).toHaveBeenCalledWith('it', 'copied ${count} merchant rules from ${sourcePolicyName}', undefined, expect.anything());
+        });
+
+        it('preserves the function wrapper when modifying a plural translation key with --compare-ref', async () => {
+            fs.writeFileSync(
+                EN_PATH,
+                Str.dedent(`
+                const strings = {
+                    codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({
+                        one: \`copied 1 merchant rule from \${sourcePolicyName}\`,
+                        other: (count: number) => \`copied \${count} merchant rules from \${sourcePolicyName}\`,
+                    }),
+                };
+                export default strings;
+            `),
+                'utf8',
+            );
+
+            fs.writeFileSync(
+                IT_PATH,
+                Str.dedent(`
+                import type en from './en';
+
+                const strings = {
+                    codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({
+                        one: \`[it] copied 1 rule from \${sourcePolicyName}\`,
+                        other: (count: number) => \`[it] copied \${count} rules from \${sourcePolicyName}\`,
+                    }),
+                };
+                export default strings;
+            `),
+                'utf8',
+            );
+
+            mockIsValidRef.mockReturnValue(true);
+            mockDiff.mockReturnValue({
+                files: [
+                    {
+                        filePath: 'src/languages/en.ts',
+                        diffType: 'modified',
+                        hunks: [],
+                        addedLines: new Set(),
+                        removedLines: new Set(),
+                        modifiedLines: new Set([3, 4]),
+                    },
+                ],
+                hasChanges: true,
+            });
+
+            mockShow.mockReturnValue(
+                Str.dedent(`
+                const strings = {
+                    codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({
+                        one: \`copied 1 rule from \${sourcePolicyName}\`,
+                        other: (count: number) => \`copied \${count} rules from \${sourcePolicyName}\`,
+                    }),
+                };
+                export default strings;
+            `),
+            );
+
+            process.argv = ['bun', 'generateTranslations.ts', '--dry-run', '--verbose', '--locales', 'it', '--compare-ref', 'main'];
+            const translateSpy = jest.spyOn(Translator.prototype, 'translate');
+
+            await generateTranslations();
+            const itContent = fs.readFileSync(IT_PATH, 'utf8');
+
+            expect(itContent).toContain('codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({');
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(itContent).toContain('[it] copied 1 merchant rule from ${sourcePolicyName}');
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(itContent).toContain('[it] copied ${count} merchant rules from ${sourcePolicyName}');
+            expect(itContent).not.toContain('[it] copied 1 rule from');
+
+            expect(translateSpy).toHaveBeenCalledTimes(2);
+        });
+
         it('handles modifying existing string values with --compare-ref', async () => {
             // Create English source with a modified string value
             fs.writeFileSync(

--- a/tests/unit/TSCompilerUtilsTest.ts
+++ b/tests/unit/TSCompilerUtilsTest.ts
@@ -777,6 +777,36 @@ describe('TSCompilerUtils', () => {
             const result = TSCompilerUtils.buildDotNotationPath(deepStringLiteral);
             expect(result).toBe('level1.level2.level3.deep');
         });
+
+        it('collapses paths inside a function-valued property to that property', () => {
+            const sourceFile = createSourceFile(
+                Str.dedent(`
+                    const strings = {
+                        workspace: {
+                            codingRules: ({sourcePolicyName}: {sourcePolicyName: string}) => ({
+                                one: \`copied 1 merchant rule from \${sourcePolicyName}\`,
+                                other: (count: number) => \`copied \${count} merchant rules from \${sourcePolicyName}\`,
+                            }),
+                        },
+                    };
+                `),
+            );
+
+            const stringsDeclaration = getStatement(sourceFile, 0, ts.isVariableStatement, 'variable statement');
+            const stringsObject = expectNode(stringsDeclaration.declarationList.declarations.at(0)?.initializer, ts.isObjectLiteralExpression, 'strings object');
+            const workspaceObject = getObjectLiteralInitializer(findPropertyAssignment(stringsObject, 'workspace'));
+            const codingRulesProperty = findPropertyAssignment(workspaceObject, 'codingRules');
+            const codingRulesFn = expectNode(codingRulesProperty.initializer, ts.isArrowFunction, 'codingRules arrow function');
+            const pluralObject = expectNode(codingRulesFn.body, ts.isParenthesizedExpression, 'parenthesized plural object').expression;
+            const pluralLiteral = expectNode(pluralObject, ts.isObjectLiteralExpression, 'plural object');
+
+            const oneTemplate = expectNode(findPropertyAssignment(pluralLiteral, 'one').initializer, ts.isTemplateExpression, 'one template');
+            const otherFn = expectNode(findPropertyAssignment(pluralLiteral, 'other').initializer, ts.isArrowFunction, 'other arrow function');
+            const otherTemplate = expectNode(otherFn.body, ts.isTemplateExpression, 'other template');
+
+            expect(TSCompilerUtils.buildDotNotationPath(oneTemplate)).toBe('workspace.codingRules');
+            expect(TSCompilerUtils.buildDotNotationPath(otherTemplate)).toBe('workspace.codingRules');
+        });
     });
 
     describe('parseCodeStringToExpression', () => {


### PR DESCRIPTION
### Explanation of Change
The incremental translation path built a leaf path such as `codingRules.other` for strings inside a function-valued plural key. `extractTranslatedNodes` then captured only the leaf initializers, and `injectDeepObjectValue` reassembled them as a plain object (`codingRules: {one, other}`), dropping the `(params) => (...)` wrapper.

`buildDotNotationPath` now collapses at the nearest function-valued property assignment, so the whole function is the translatable unit. Leaf strings inside it are still translated; the wrapper and params are preserved.

The secondary CLDR plural-forms concern from the issue is out of scope and should be a follow-up.

### Fixed Issues
$ https://github.com/Expensify/App/issues/94343
PROPOSAL: https://github.com/Expensify/App/issues/94343#issuecomment-4782114421

### Tests
Added unit tests.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — tooling-only change
</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — tooling-only change
</details>

<details>
<summary>iOS: Native</summary>

N/A — tooling-only change
</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — tooling-only change
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — tooling-only change
</details>