### PR TITLE
[No QA] Use passed personal details for option display names

### DIFF
--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -1160,17 +1160,16 @@ type CreateOptionParams = {
 /** Shared by createOption and shells so filtering uses the final display text. */
 type GetPersonalDetailOptionTextProps = {
     accountID: number | undefined;
-    hasReport: boolean;
     personalDetails: OnyxEntry<PersonalDetailsList>;
     login: string | undefined;
     translate: LocalizedTranslate;
 };
 
-function getPersonalDetailOptionText({accountID, hasReport, personalDetails, login, translate}: GetPersonalDetailOptionTextProps): string {
+function getPersonalDetailOptionText({accountID, personalDetails, login, translate}: GetPersonalDetailOptionTextProps): string {
     return (
         getDisplayNameForParticipant({
             accountID,
-            personalDetailsData: hasReport ? undefined : (personalDetails ?? undefined),
+            personalDetailsData: personalDetails ?? undefined,
             formatPhoneNumber: formatPhoneNumberPhoneUtils,
             translate,
         }) || formatPhoneNumberPhoneUtils(login ?? '')
@@ -1319,10 +1318,10 @@ function createOption({
                 : '');
 
         reportName = showPersonalDetails
-            ? getPersonalDetailOptionText({accountID: accountIDs.at(0), hasReport: true, personalDetails, login: personalDetail?.login, translate: translateFn})
+            ? getPersonalDetailOptionText({accountID: accountIDs.at(0), personalDetails, login: personalDetail?.login, translate: translateFn})
             : computedReportName;
     } else {
-        reportName = getPersonalDetailOptionText({accountID: accountIDs.at(0), hasReport: false, personalDetails, login: personalDetail?.login, translate: translateFn});
+        reportName = getPersonalDetailOptionText({accountID: accountIDs.at(0), personalDetails, login: personalDetail?.login, translate: translateFn});
         result.keyForList = String(accountIDs.at(0));
 
         result.alternateText = formatPhoneNumberPhoneUtils(personalDetails?.[accountIDs[0]]?.login ?? '');
@@ -1819,7 +1818,7 @@ function buildPersonalDetailsOptions(reportMapForAccountIDs: Record<number, Repo
         // Match createOption's personal-details lookup.
         const detail = getPersonalDetailForAccountID(accountID, personalDetails);
         // Keep shell text identical to the hydrated option.
-        const text = getPersonalDetailOptionText({accountID, hasReport: !!report, personalDetails, login: detail?.login, translate});
+        const text = getPersonalDetailOptionText({accountID, personalDetails, login: detail?.login, translate});
 
         // Do not capture the shell: getValidOptions mutates its transient marks.
         let built: HydratedPersonalDetailOption | undefined;


### PR DESCRIPTION
### Explanation of Change
`getPersonalDetailOptionText` ignored the `personalDetails` argument whenever the person already had a report, and resolved names from `ReportUtils` module-level `allPersonalDetails` instead.

That connect cache is emptied by `Onyx.clear()`. The `OptionsListUtils` suite builds `OPTIONS` in `beforeAll`, then `beforeEach` clears Onyx, so report holders fall back to emails (`tchalla@expensify.com`) instead of display names (`Black Panther`). Same failure shows up on every Onyx-bump App PR that inherits current `main`.

Always pass the caller-supplied `personalDetails` list into `getDisplayNameForParticipant`. No Onyx bump required.

This is the same one-file change as https://github.com/Expensify/App/pull/95893, extracted so it can land on `main` independently.

### Fixed Issues
$
PROPOSAL:

### Tests
1. Run `npm test -- tests/unit/OptionsListUtilsTest.tsx -t "orderOptions"`.
2. Confirm both `orderOptions()` cases expect display names (`Black Panther`, `Black Widow`, …) and pass.
3. Open a contact / share picker that lists people who already have 1:1 reports.
4. Confirm those rows show display names, not emails.

- [ ] Verify that no errors appear in the JS console

### Offline tests
1. Go offline.
2. Open a contact picker that includes people with existing 1:1 reports.
3. Confirm display names still resolve from the in-memory personal-details list.

### QA Steps
Same as tests. No user-facing product change beyond using the personal-details list the caller already has.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
