### PR TITLE
Fix not-found flash after Control to Collect downgrade

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -205,7 +205,7 @@ function isControlPolicyOnlyRole(role: string | undefined): boolean {
 function hasPolicyFeaturePermission(policy: OnyxInputOrEntry<Policy>, login: string, feature: PolicyFeature, requiredAccess: PolicyFeatureAccess): boolean {
     const role = (login ? policy?.employeeList?.[login]?.role : undefined) ?? getPolicyRole(policy, login);
     // The API demotes control-only roles to user when a workspace is downgraded from Control to Collect.
-    // A leftover control-only role on a non-Control policy is not a valid denied state, so use the user bundle.
+    // Collect does not support these roles. Treat the member as a user so they can still open the workspace.
     const effectiveRole = isControlPolicyOnlyRole(role) && (!policy || !isControlPolicy(policy)) ? CONST.POLICY.ROLE.USER : role;
 
     const access = effectiveRole ? ROLE_PERMISSION_BUNDLES[effectiveRole]?.[feature] : undefined;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -204,7 +204,7 @@ function isControlPolicyOnlyRole(role: string | undefined): boolean {
 
 function hasPolicyFeaturePermission(policy: OnyxInputOrEntry<Policy>, login: string, feature: PolicyFeature, requiredAccess: PolicyFeatureAccess): boolean {
     const role = (login ? policy?.employeeList?.[login]?.role : undefined) ?? getPolicyRole(policy, login);
-    // Auth demotes control-only roles to user when a workspace is downgraded from Control to Collect.
+    // The API demotes control-only roles to user when a workspace is downgraded from Control to Collect.
     // Onyx can apply policy.type before employeeList.role, so keep member access using the user bundle until the stale role is updated.
     const effectiveRole = isControlPolicyOnlyRole(role) && (!policy || !isControlPolicy(policy)) ? CONST.POLICY.ROLE.USER : role;
 

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -205,7 +205,7 @@ function isControlPolicyOnlyRole(role: string | undefined): boolean {
 function hasPolicyFeaturePermission(policy: OnyxInputOrEntry<Policy>, login: string, feature: PolicyFeature, requiredAccess: PolicyFeatureAccess): boolean {
     const role = (login ? policy?.employeeList?.[login]?.role : undefined) ?? getPolicyRole(policy, login);
     // The API demotes control-only roles to user when a workspace is downgraded from Control to Collect.
-    // Onyx can apply policy.type before employeeList.role, so keep member access using the user bundle until the stale role is updated.
+    // A leftover control-only role on a non-Control policy is not a valid denied state, so use the user bundle.
     const effectiveRole = isControlPolicyOnlyRole(role) && (!policy || !isControlPolicy(policy)) ? CONST.POLICY.ROLE.USER : role;
 
     const access = effectiveRole ? ROLE_PERMISSION_BUNDLES[effectiveRole]?.[feature] : undefined;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -204,11 +204,11 @@ function isControlPolicyOnlyRole(role: string | undefined): boolean {
 
 function hasPolicyFeaturePermission(policy: OnyxInputOrEntry<Policy>, login: string, feature: PolicyFeature, requiredAccess: PolicyFeatureAccess): boolean {
     const role = (login ? policy?.employeeList?.[login]?.role : undefined) ?? getPolicyRole(policy, login);
-    if (isControlPolicyOnlyRole(role) && (!policy || !isControlPolicy(policy))) {
-        return false;
-    }
+    // Auth demotes control-only roles to user when a workspace is downgraded from Control to Collect.
+    // Onyx can apply policy.type before employeeList.role, so keep member access using the user bundle until the stale role is updated.
+    const effectiveRole = isControlPolicyOnlyRole(role) && !isControlPolicy(policy) ? CONST.POLICY.ROLE.USER : role;
 
-    const access = role ? ROLE_PERMISSION_BUNDLES[role]?.[feature] : undefined;
+    const access = effectiveRole ? ROLE_PERMISSION_BUNDLES[effectiveRole]?.[feature] : undefined;
 
     if (requiredAccess === CONST.POLICY.POLICY_FEATURE_ACCESS.READ) {
         return access === CONST.POLICY.POLICY_FEATURE_ACCESS.READ || access === CONST.POLICY.POLICY_FEATURE_ACCESS.WRITE;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -206,7 +206,7 @@ function hasPolicyFeaturePermission(policy: OnyxInputOrEntry<Policy>, login: str
     const role = (login ? policy?.employeeList?.[login]?.role : undefined) ?? getPolicyRole(policy, login);
     // Auth demotes control-only roles to user when a workspace is downgraded from Control to Collect.
     // Onyx can apply policy.type before employeeList.role, so keep member access using the user bundle until the stale role is updated.
-    const effectiveRole = isControlPolicyOnlyRole(role) && !isControlPolicy(policy) ? CONST.POLICY.ROLE.USER : role;
+    const effectiveRole = isControlPolicyOnlyRole(role) && (!policy || !isControlPolicy(policy)) ? CONST.POLICY.ROLE.USER : role;
 
     const access = effectiveRole ? ROLE_PERMISSION_BUNDLES[effectiveRole]?.[feature] : undefined;
 

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -361,6 +361,18 @@ describe('PolicyUtils', () => {
             expect(canMemberAssignRole(policy, memberLogin, CONST.POLICY.ROLE.PAYMENTS_ADMIN)).toBe(false);
         });
 
+        it('treats a stale control-only role on a Collect policy as a user', () => {
+            const policy = {
+                ...buildPolicy(CONST.POLICY.ROLE.PEOPLE_ADMIN),
+                type: CONST.POLICY.TYPE.TEAM,
+            };
+
+            expect(canMemberRead(policy, memberLogin, CONST.POLICY.POLICY_FEATURE.OVERVIEW)).toBe(true);
+            expect(canMemberRead(policy, memberLogin, CONST.POLICY.POLICY_FEATURE.MEMBERS)).toBe(true);
+            expect(canMemberWrite(policy, memberLogin, CONST.POLICY.POLICY_FEATURE.MEMBERS)).toBe(false);
+            expect(canMemberWrite(policy, memberLogin, CONST.POLICY.POLICY_FEATURE.WORKFLOWS_APPROVALS)).toBe(false);
+        });
+
         it('allows Submit workspace editors to manage editor memberships without assigning roles', () => {
             const policy = {
                 ...buildPolicy(CONST.POLICY.ROLE.EDITOR),


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
After a Control workspace is downgraded to Collect, Auth changes control-only roles (including People Admin) to user. Onyx can apply `policy.type` before `employeeList.role`, so the client still sees `peopleAdmin` on a Collect policy.

`hasPolicyFeaturePermission` treated that mix as no access, so Overview and Members showed "Hmm... it's not here" until the role update arrived. This change uses the user permission bundle for a stale control-only role on a non-Control policy, which matches the role Auth already assigned.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95223
PROPOSAL:


<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Create a Control workspace as the owner.
2. Invite a second account and set its role to People Admin.
3. As the owner, open Workspace settings, then Overview, then Plan type.
4. Choose Collect, save, and confirm the workspace downgrade.
5. Sign in as the People Admin account.
6. Open the workspace settings.
7. Confirm Overview loads with no "Hmm... it's not here" flash.
8. Open Members and confirm the page loads.
9. Confirm the former People Admin is now a Member and cannot edit other members' roles.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Repeat the downgrade while the People Admin account is online so Onyx receives the type change.
2. Turn on airplane mode on the People Admin device.
3. Open the workspace settings.
4. Confirm Overview still loads from cached data and does not show "Hmm... it's not here".

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/0e3d12b8-4018-47fa-814a-5b46ee7cc9e7



</details>
