### PR TITLE
Add Send to my employer option to expense More menu

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -1569,6 +1569,7 @@ const CONST = {
             DUPLICATE: 'duplicate',
             MOVE_EXPENSE: 'moveExpense',
             SEND_TO_SOMEONE: 'sendToSomeone',
+            SEND_TO_EMPLOYER: 'sendToEmployer',
         },
         SELECTED_TRANSACTIONS_BULK_ACTION_TYPES: {
             HOLD: 'hold',

--- a/src/components/MoneyRequestHeaderSecondaryActions.tsx
+++ b/src/components/MoneyRequestHeaderSecondaryActions.tsx
@@ -122,7 +122,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
     const theme = useTheme();
     const {translate, localeCompare, formatPhoneNumber, dateFnsLocale} = useLocalize();
     const isInSidePanel = useIsInSidePanel();
-    const {login: currentUserLogin, accountID, localCurrencyCode, displayName: currentUserDisplayName} = useCurrentUserPersonalDetails();
+    const {login: currentUserLogin, email: currentUserEmail, accountID, localCurrencyCode, displayName: currentUserDisplayName} = useCurrentUserPersonalDetails();
     const delegateAccountID = useDelegateAccountID();
     const personalDetails = usePersonalDetails();
 
@@ -190,7 +190,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
     const activePolicy = useActivePolicy();
     const lastWorkspaceNumber = useLastWorkspaceNumber();
     const {isRestrictedToPreferredPolicy, preferredPolicyID} = usePreferredPolicy();
-    const filteredPoliciesInfoSelector = useMemo(() => createFilteredPoliciesInfoSelector(currentUserLogin), [currentUserLogin]);
+    const filteredPoliciesInfoSelector = useMemo(() => createFilteredPoliciesInfoSelector(currentUserEmail), [currentUserEmail]);
     const [filteredPoliciesInfo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: filteredPoliciesInfoSelector});
     const draftTransactionIDs = useMemo(() => Object.keys(transactionDrafts ?? {}), [transactionDrafts]);
 
@@ -354,7 +354,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
     })();
 
     // Shared params for converting a self-tracked expense through the participant selector, used by both
-    // "Send to someone" (friend) and "Send to my employer" (employer) menu actions. Mirrors the Inbox
+    // "Send to someone" (friend) and "Submit to my employer" (employer) menu actions. Mirrors the Inbox
     // track-expense whisper flow (see ChatActionableButtons' baseDraftTransactionParams).
     const sendTrackedExpenseParams = {
         reportID: parentReport?.reportID,
@@ -371,7 +371,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
         preferredPolicyID,
         transaction,
         currentUserAccountID: accountID,
-        currentUserEmail: currentUserLogin ?? '',
+        currentUserEmail: currentUserEmail ?? '',
         currentUserLocalCurrency: localCurrencyCode ?? CONST.CURRENCY.USD,
         filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
         firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
@@ -663,7 +663,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
             },
         },
         [CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER]: {
-            text: translate('iou.sendToEmployer'),
+            text: translate('iou.submitToEmployer'),
             icon: expensifyIcons.Building,
             value: CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER,
             onSelected: () => {
@@ -675,7 +675,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
                 createDraftTransactionAndNavigateToParticipantSelector({
                     ...sendTrackedExpenseParams,
                     submitDestination: CONST.IOU.SUBMIT_DESTINATION.EMPLOYER,
-                    defaultWorkspaceName: generateDefaultWorkspaceName(currentUserLogin ?? '', lastWorkspaceNumber, translate, currentUserDisplayName),
+                    defaultWorkspaceName: generateDefaultWorkspaceName(currentUserEmail ?? '', lastWorkspaceNumber, translate, currentUserDisplayName),
                 });
             },
         },

--- a/src/components/MoneyRequestHeaderSecondaryActions.tsx
+++ b/src/components/MoneyRequestHeaderSecondaryActions.tsx
@@ -10,6 +10,7 @@ import useEnvironment from '@hooks/useEnvironment';
 import useGetIOUReportFromReportAction from '@hooks/useGetIOUReportFromReportAction';
 import useHasMultipleSplitChildren from '@hooks/useHasMultipleSplitChildren';
 import useIsInSidePanel from '@hooks/useIsInSidePanel';
+import useLastWorkspaceNumber from '@hooks/useLastWorkspaceNumber';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useMoneyRequestPolicyTagsForReport from '@hooks/useMoneyRequestPolicyTagsForReport';
@@ -33,6 +34,7 @@ import useTransactionViolations from '@hooks/useTransactionViolations';
 import {duplicateExpenseTransaction as duplicateTransactionAction} from '@libs/actions/IOU/Duplicate';
 import {deleteTrackExpense} from '@libs/actions/IOU/TrackExpense';
 import {setupMergeTransactionDataAndNavigate} from '@libs/actions/MergeTransaction';
+import {generateDefaultWorkspaceName} from '@libs/actions/Policy/Policy';
 import initSplitExpense from '@libs/actions/SplitExpenses';
 import {setNameValuePair} from '@libs/actions/User';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
@@ -120,13 +122,14 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
     const theme = useTheme();
     const {translate, localeCompare, formatPhoneNumber, dateFnsLocale} = useLocalize();
     const isInSidePanel = useIsInSidePanel();
-    const {login: currentUserLogin, accountID, localCurrencyCode} = useCurrentUserPersonalDetails();
+    const {login: currentUserLogin, accountID, localCurrencyCode, displayName: currentUserDisplayName} = useCurrentUserPersonalDetails();
     const delegateAccountID = useDelegateAccountID();
     const personalDetails = usePersonalDetails();
 
     const expensifyIcons = useMemoizedLazyExpensifyIcons([
         'ArrowCollapse',
         'ArrowSplit',
+        'Building',
         'Checkmark',
         'DocumentMerge',
         'ExpenseCopy',
@@ -185,6 +188,7 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
     const isTrackIntentUser = isTrackOnboardingChoice(introSelected?.choice);
 
     const activePolicy = useActivePolicy();
+    const lastWorkspaceNumber = useLastWorkspaceNumber();
     const {isRestrictedToPreferredPolicy, preferredPolicyID} = usePreferredPolicy();
     const filteredPoliciesInfoSelector = useMemo(() => createFilteredPoliciesInfoSelector(currentUserLogin), [currentUserLogin]);
     const [filteredPoliciesInfo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: filteredPoliciesInfoSelector});
@@ -348,6 +352,30 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
             hasWorkspaceToSubmitTo,
         });
     })();
+
+    // Shared params for converting a self-tracked expense through the participant selector, used by both
+    // "Send to someone" (friend) and "Send to my employer" (employer) menu actions. Mirrors the Inbox
+    // track-expense whisper flow (see ChatActionableButtons' baseDraftTransactionParams).
+    const sendTrackedExpenseParams = {
+        reportID: parentReport?.reportID,
+        actionName: CONST.IOU.ACTION.SUBMIT,
+        reportActionID: getTrackExpenseActionableWhisper(transaction?.transactionID, parentReport?.reportID, parentReportActions)?.reportActionID,
+        reportActions: parentReportActions,
+        introSelected,
+        draftTransactionIDs,
+        activePolicy,
+        userBillingGracePeriodEnds,
+        amountOwed,
+        ownerBillingGracePeriodEnd,
+        isRestrictedToPreferredPolicy,
+        preferredPolicyID,
+        transaction,
+        currentUserAccountID: accountID,
+        currentUserEmail: currentUserLogin ?? '',
+        currentUserLocalCurrency: localCurrencyCode ?? CONST.CURRENCY.USD,
+        filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
+        firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
+    };
 
     const secondaryActionsImplementation: Partial<
         Record<ValueOf<typeof CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS>, DropdownOption<ValueOf<typeof CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS>>>
@@ -631,25 +659,23 @@ function MoneyRequestHeaderSecondaryActions({reportID, onBackButtonPress}: Money
                     return;
                 }
 
+                createDraftTransactionAndNavigateToParticipantSelector(sendTrackedExpenseParams);
+            },
+        },
+        [CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER]: {
+            text: translate('iou.sendToEmployer'),
+            icon: expensifyIcons.Building,
+            value: CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER,
+            onSelected: () => {
+                if (isDelegateAccessRestricted) {
+                    showDelegateNoAccessModal();
+                    return;
+                }
+
                 createDraftTransactionAndNavigateToParticipantSelector({
-                    reportID: parentReport?.reportID,
-                    actionName: CONST.IOU.ACTION.SUBMIT,
-                    reportActionID: getTrackExpenseActionableWhisper(transaction?.transactionID, parentReport?.reportID, parentReportActions)?.reportActionID,
-                    reportActions: parentReportActions,
-                    introSelected,
-                    draftTransactionIDs,
-                    activePolicy,
-                    userBillingGracePeriodEnds,
-                    amountOwed,
-                    ownerBillingGracePeriodEnd,
-                    isRestrictedToPreferredPolicy,
-                    preferredPolicyID,
-                    transaction,
-                    currentUserAccountID: accountID,
-                    currentUserEmail: currentUserLogin ?? '',
-                    currentUserLocalCurrency: localCurrencyCode ?? CONST.CURRENCY.USD,
-                    filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
-                    firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
+                    ...sendTrackedExpenseParams,
+                    submitDestination: CONST.IOU.SUBMIT_DESTINATION.EMPLOYER,
+                    defaultWorkspaceName: generateDefaultWorkspaceName(currentUserLogin ?? '', lastWorkspaceNumber, translate, currentUserDisplayName),
                 });
             },
         },

--- a/src/hooks/useLastWorkspaceNumber.ts
+++ b/src/hooks/useLastWorkspaceNumber.ts
@@ -5,12 +5,17 @@ import type {Policy} from '@src/types/onyx';
 
 import type {OnyxCollection} from 'react-native-onyx';
 
+import {useMemo} from 'react';
+
 import useOnyx from './useOnyx';
 
 function useLastWorkspaceNumber(email?: string) {
     const [sessionEmail] = useOnyx(ONYXKEYS.SESSION, {selector: emailSelector});
-    const lastWorkspaceNumberSelectorWithEmail = (policies: OnyxCollection<Policy>) => lastWorkspaceNumberSelector(policies, email ?? sessionEmail ?? '');
-    const [lastWorkspaceNumber] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: lastWorkspaceNumberSelectorWithEmail});
+    const resolvedEmail = email ?? sessionEmail ?? '';
+    // Memoize so the POLICY-collection regex scan only re-runs when the resolved email changes, not on every render
+    // of consumers (e.g. the expense header renders this on every expense).
+    const selector = useMemo(() => (policies: OnyxCollection<Policy>) => lastWorkspaceNumberSelector(policies, resolvedEmail), [resolvedEmail]);
+    const [lastWorkspaceNumber] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector});
     return lastWorkspaceNumber;
 }
 

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1551,7 +1551,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Wallet aktivieren',
         hold: 'Warteschleife',
         sendToSomeone: 'An jemanden senden',
-        sendToEmployer: 'An meinen Arbeitgeber senden',
+        submitToEmployer: 'An meinen Arbeitgeber senden',
         unhold: 'Zurückhalten aufheben',
         holdExpense: () => ({
             one: 'Ausgabe zurückhalten',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1551,6 +1551,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Wallet aktivieren',
         hold: 'Warteschleife',
         sendToSomeone: 'An jemanden senden',
+        sendToEmployer: 'An meinen Arbeitgeber senden',
         unhold: 'Zurückhalten aufheben',
         holdExpense: () => ({
             one: 'Ausgabe zurückhalten',

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -1611,6 +1611,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Ενεργοποίηση πορτοφολιού',
         hold: 'Σε αναμονή',
         sendToSomeone: 'Αποστολή σε κάποιον',
+        sendToEmployer: 'Αποστολή στον εργοδότη μου',
         unhold: 'Αφαίρεση κράτησης',
         holdExpense: () => ({
             one: 'Αναστολή δαπάνης',

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -1611,7 +1611,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Ενεργοποίηση πορτοφολιού',
         hold: 'Σε αναμονή',
         sendToSomeone: 'Αποστολή σε κάποιον',
-        sendToEmployer: 'Αποστολή στον εργοδότη μου',
+        submitToEmployer: 'Υποβολή στον εργοδότη μου',
         unhold: 'Αφαίρεση κράτησης',
         holdExpense: () => ({
             one: 'Αναστολή δαπάνης',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1631,6 +1631,7 @@ const translations = {
         enableWallet: 'Enable wallet',
         hold: 'Hold',
         sendToSomeone: 'Send to someone',
+        sendToEmployer: 'Send to my employer',
         unhold: 'Remove hold',
         holdExpense: () => ({
             one: 'Hold expense',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1631,7 +1631,7 @@ const translations = {
         enableWallet: 'Enable wallet',
         hold: 'Hold',
         sendToSomeone: 'Send to someone',
-        sendToEmployer: 'Send to my employer',
+        submitToEmployer: 'Submit to my employer',
         unhold: 'Remove hold',
         holdExpense: () => ({
             one: 'Hold expense',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1603,6 +1603,7 @@ const translations: TranslationDeepObject<typeof en> = {
         approveOnly: 'Solo aprobar',
         hold: 'Retener',
         sendToSomeone: 'Enviar a alguien',
+        sendToEmployer: 'Enviar a mi empleador',
         unhold: 'Desbloquear',
         holdEducationalTitle: '¿Deberías retener este gasto?',
         whatIsHoldExplain: 'Retener es como presionar "pausa" en un gasto hasta que estés listo para enviarlo.',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1603,7 +1603,7 @@ const translations: TranslationDeepObject<typeof en> = {
         approveOnly: 'Solo aprobar',
         hold: 'Retener',
         sendToSomeone: 'Enviar a alguien',
-        sendToEmployer: 'Enviar a mi empleador',
+        submitToEmployer: 'Enviar a mi empleador',
         unhold: 'Desbloquear',
         holdEducationalTitle: '¿Deberías retener este gasto?',
         whatIsHoldExplain: 'Retener es como presionar "pausa" en un gasto hasta que estés listo para enviarlo.',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1557,7 +1557,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Activer le portefeuille',
         hold: 'En attente',
         sendToSomeone: 'Envoyer à quelqu’un',
-        sendToEmployer: 'Envoyer à mon employeur',
+        submitToEmployer: 'Soumettre à mon employeur',
         unhold: 'Supprimer la mise en attente',
         holdExpense: () => ({
             one: 'Mettre la dépense en attente',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1557,6 +1557,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Activer le portefeuille',
         hold: 'En attente',
         sendToSomeone: 'Envoyer à quelqu’un',
+        sendToEmployer: 'Envoyer à mon employeur',
         unhold: 'Supprimer la mise en attente',
         holdExpense: () => ({
             one: 'Mettre la dépense en attente',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1550,7 +1550,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Abilita portafoglio',
         hold: 'Metti in attesa',
         sendToSomeone: 'Invia a qualcuno',
-        sendToEmployer: 'Invia al mio datore di lavoro',
+        submitToEmployer: 'Invia al mio datore di lavoro',
         unhold: 'Rimuovi blocco',
         holdExpense: () => ({
             one: 'Metti in sospeso la spesa',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1550,6 +1550,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Abilita portafoglio',
         hold: 'Metti in attesa',
         sendToSomeone: 'Invia a qualcuno',
+        sendToEmployer: 'Invia al mio datore di lavoro',
         unhold: 'Rimuovi blocco',
         holdExpense: () => ({
             one: 'Metti in sospeso la spesa',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1531,6 +1531,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'ウォレットを有効にする',
         hold: '保留',
         sendToSomeone: '誰かに送る',
+        sendToEmployer: '雇用主に送る',
         unhold: '保留を解除',
         holdExpense: () => ({
             one: '経費を保留',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1531,7 +1531,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'ウォレットを有効にする',
         hold: '保留',
         sendToSomeone: '誰かに送る',
-        sendToEmployer: '雇用主に送る',
+        submitToEmployer: '勤務先に送信する',
         unhold: '保留を解除',
         holdExpense: () => ({
             one: '経費を保留',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1546,7 +1546,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Portemonnee inschakelen',
         hold: 'Vasthouden',
         sendToSomeone: 'Naar iemand sturen',
-        sendToEmployer: 'Naar mijn werkgever sturen',
+        submitToEmployer: 'Indienen bij mijn werkgever',
         unhold: 'Blokkering opheffen',
         holdExpense: () => ({
             one: 'Uitgave vasthouden',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1546,6 +1546,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Portemonnee inschakelen',
         hold: 'Vasthouden',
         sendToSomeone: 'Naar iemand sturen',
+        sendToEmployer: 'Naar mijn werkgever sturen',
         unhold: 'Blokkering opheffen',
         holdExpense: () => ({
             one: 'Uitgave vasthouden',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1541,6 +1541,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Włącz portfel',
         hold: 'Wstrzymaj',
         sendToSomeone: 'Wyślij do kogoś',
+        sendToEmployer: 'Wyślij do mojego pracodawcy',
         unhold: 'Usuń blokadę',
         holdExpense: () => ({
             one: 'Wstrzymaj wydatek',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1541,7 +1541,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Włącz portfel',
         hold: 'Wstrzymaj',
         sendToSomeone: 'Wyślij do kogoś',
-        sendToEmployer: 'Wyślij do mojego pracodawcy',
+        submitToEmployer: 'Prześlij do mojego pracodawcy',
         unhold: 'Usuń blokadę',
         holdExpense: () => ({
             one: 'Wstrzymaj wydatek',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1545,6 +1545,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Ativar carteira',
         hold: 'Reter',
         sendToSomeone: 'Enviar para alguém',
+        sendToEmployer: 'Enviar para meu empregador',
         unhold: 'Remover bloqueio',
         holdExpense: () => ({
             one: 'Reter despesa',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1545,7 +1545,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: 'Ativar carteira',
         hold: 'Reter',
         sendToSomeone: 'Enviar para alguém',
-        sendToEmployer: 'Enviar para meu empregador',
+        submitToEmployer: 'Enviar para meu empregador',
         unhold: 'Remover bloqueio',
         holdExpense: () => ({
             one: 'Reter despesa',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1491,6 +1491,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: '启用钱包',
         hold: '暂挂',
         sendToSomeone: '发送给某人',
+        sendToEmployer: '发送给我的雇主',
         unhold: '解除保留',
         holdExpense: () => ({
             one: '暂挂报销',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1491,7 +1491,7 @@ const translations: TranslationDeepObject<typeof en> = {
         enableWallet: '启用钱包',
         hold: '暂挂',
         sendToSomeone: '发送给某人',
-        sendToEmployer: '发送给我的雇主',
+        submitToEmployer: '提交给我的雇主',
         unhold: '解除保留',
         holdExpense: () => ({
             one: '暂挂报销',

--- a/src/libs/PopoverMenuSections.ts
+++ b/src/libs/PopoverMenuSections.ts
@@ -28,8 +28,8 @@ const REPORT_MORE_MENU_SECTIONS = [
 ];
 
 const TRANSACTION_MORE_MENU_SECTIONS = [
-    // "Send to someone" sits in its own top section so it renders first with a divider beneath it.
-    [TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE],
+    // "Send to someone" and "Send to my employer" sit in their own top section so they render first with a divider beneath.
+    [TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE, TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER],
     [
         TRANSACTION_SECONDARY_ACTIONS.HOLD,
         TRANSACTION_SECONDARY_ACTIONS.REMOVE_HOLD,

--- a/src/libs/ReportSecondaryActionUtils.ts
+++ b/src/libs/ReportSecondaryActionUtils.ts
@@ -1252,19 +1252,23 @@ function getSecondaryTransactionThreadActions({
         options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.MOVE_EXPENSE);
     }
 
-    // Show "Send to someone" and "Send to my employer" only for an unreported self-tracked expense in personal space,
-    // reusing the track-expense whisper's convert-from-track flow (once submitted, parentReport is no longer a self-DM
-    // so these hide). A self-DM split can only go to a workspace: for a split we still surface both rows when the user
-    // has a workspace (the participant selector routes the split into it), and hide both otherwise. Also require write
-    // access (like MOVE_EXPENSE) so the rows hide on an archived self-DM.
+    // Offer the track-expense convert-from-track flow only for an unreported self-tracked expense in personal space
+    // (once submitted, parentReport is no longer a self-DM so these hide), and only with write access (like
+    // MOVE_EXPENSE) so the rows hide on an archived self-DM. These conditions mirror the Inbox track-expense whisper
+    // in ChatActionableButtons.
     const {isExpenseSplit: isSelfDMExpenseSplit} = getOriginalTransactionWithSplitInfo(reportTransaction, originalTransaction);
-    if (
-        isTrackExpenseReportNew(transactionThreadReport, parentReport, reportAction) &&
-        (!isSelfDMExpenseSplit || hasWorkspaceToSubmitTo) &&
-        canUserPerformWriteActionReportUtils(parentReport, isChatReportArchived)
-    ) {
-        options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
-        options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+    const canConvertFromTrack = isTrackExpenseReportNew(transactionThreadReport, parentReport, reportAction) && canUserPerformWriteActionReportUtils(parentReport, isChatReportArchived);
+    if (canConvertFromTrack) {
+        // A self-DM split has no personal destination, so it can never go to a friend (matches ChatActionableButtons,
+        // which hides "Submit to a friend" for a split unconditionally).
+        if (!isSelfDMExpenseSplit) {
+            options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
+        }
+        // A split can still go to a workspace, but only one that already exists: the create-a-workspace fallback in
+        // createDraftTransactionAndNavigateToParticipantSelector is not wired for splits.
+        if (!isSelfDMExpenseSplit || hasWorkspaceToSubmitTo) {
+            options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+        }
     }
 
     options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.VIEW_DETAILS);

--- a/src/libs/ReportSecondaryActionUtils.ts
+++ b/src/libs/ReportSecondaryActionUtils.ts
@@ -1252,10 +1252,11 @@ function getSecondaryTransactionThreadActions({
         options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.MOVE_EXPENSE);
     }
 
-    // Show "Send to someone" only for an unreported self-tracked expense in personal space, reusing the track-expense
-    // whisper's convert-from-track flow (once submitted, parentReport is no longer a self-DM so this hides).
-    // A self-DM split can only go to a workspace, so hide it for a split unless the user has one; also require write
-    // access (like MOVE_EXPENSE) so the row hides on an archived self-DM.
+    // Show "Send to someone" and "Send to my employer" only for an unreported self-tracked expense in personal space,
+    // reusing the track-expense whisper's convert-from-track flow (once submitted, parentReport is no longer a self-DM
+    // so these hide). A self-DM split can only go to a workspace: for a split we still surface both rows when the user
+    // has a workspace (the participant selector routes the split into it), and hide both otherwise. Also require write
+    // access (like MOVE_EXPENSE) so the rows hide on an archived self-DM.
     const {isExpenseSplit: isSelfDMExpenseSplit} = getOriginalTransactionWithSplitInfo(reportTransaction, originalTransaction);
     if (
         isTrackExpenseReportNew(transactionThreadReport, parentReport, reportAction) &&
@@ -1263,6 +1264,7 @@ function getSecondaryTransactionThreadActions({
         canUserPerformWriteActionReportUtils(parentReport, isChatReportArchived)
     ) {
         options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
+        options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
     }
 
     options.push(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.VIEW_DETAILS);

--- a/tests/unit/ReportSecondaryActionUtilsTest.ts
+++ b/tests/unit/ReportSecondaryActionUtilsTest.ts
@@ -4998,6 +4998,22 @@ describe('getSecondaryTransactionThreadActions', () => {
         it('hides SEND_TO_SOMEONE on an archived self-DM (no write access)', () => {
             expect(getSendToSomeoneResult(false, false, true)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
         });
+
+        it('includes SEND_TO_EMPLOYER for an unreported self-tracked expense that is not a split', () => {
+            expect(getSendToSomeoneResult(false, false)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+        });
+
+        it('hides SEND_TO_EMPLOYER for a self-DM split expense when the user has no workspace to submit to', () => {
+            expect(getSendToSomeoneResult(true, false)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+        });
+
+        it('includes SEND_TO_EMPLOYER for a self-DM split expense when the user has a workspace to submit to', () => {
+            expect(getSendToSomeoneResult(true, true)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+        });
+
+        it('hides SEND_TO_EMPLOYER on an archived self-DM (no write access)', () => {
+            expect(getSendToSomeoneResult(false, false, true)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+        });
     });
 
     it('includes the SPLIT option when grandParentReport is a selfDM report (transaction thread inside selfDM)', () => {

--- a/tests/unit/ReportSecondaryActionUtilsTest.ts
+++ b/tests/unit/ReportSecondaryActionUtilsTest.ts
@@ -4952,16 +4952,16 @@ describe('getSecondaryTransactionThreadActions', () => {
         expect(result.includes(CONST.REPORT.SECONDARY_ACTIONS.SPLIT)).toBe(true);
     });
 
-    describe('SEND_TO_SOMEONE gate', () => {
+    describe('self-DM convert-from-track actions gate (SEND_TO_SOMEONE / SEND_TO_EMPLOYER)', () => {
         // These cases install persistent spies (mockReturnValue); the enclosing beforeEach only clears call data, not
         // implementations, so restore them here to avoid leaking into later getSecondaryTransactionThreadActions tests.
         afterEach(() => {
             jest.restoreAllMocks();
         });
 
-        function getSendToSomeoneResult(isExpenseSplit: boolean, hasWorkspaceToSubmitTo: boolean, isChatReportArchived = false) {
+        function getSelfDMConvertActionsResult(isExpenseSplit: boolean, hasWorkspaceToSubmitTo: boolean, isChatReportArchived = false) {
             jest.spyOn(ReportUtils, 'isTrackExpenseReportNew').mockReturnValue(true);
-            // An archived self-DM has no write access; mirror that so the write-action guard on SEND_TO_SOMEONE is exercised.
+            // An archived self-DM has no write access; mirror that so the shared write-action guard is exercised.
             jest.spyOn(ReportUtils, 'canUserPerformWriteAction').mockReturnValue(!isChatReportArchived);
             jest.spyOn(TransactionUtils, 'getOriginalTransactionWithSplitInfo').mockReturnValue({
                 originalTransaction: createMock<Transaction>({}),
@@ -4984,35 +4984,35 @@ describe('getSecondaryTransactionThreadActions', () => {
         }
 
         it('includes SEND_TO_SOMEONE for an unreported self-tracked expense that is not a split', () => {
-            expect(getSendToSomeoneResult(false, false)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
+            expect(getSelfDMConvertActionsResult(false, false)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
         });
 
         it('hides SEND_TO_SOMEONE for a self-DM split expense when the user has no workspace to submit to', () => {
-            expect(getSendToSomeoneResult(true, false)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
+            expect(getSelfDMConvertActionsResult(true, false)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
         });
 
-        it('includes SEND_TO_SOMEONE for a self-DM split expense when the user has a workspace to submit to', () => {
-            expect(getSendToSomeoneResult(true, true)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
+        it('hides SEND_TO_SOMEONE for a self-DM split expense even when the user has a workspace, since a split has no personal destination', () => {
+            expect(getSelfDMConvertActionsResult(true, true)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
         });
 
         it('hides SEND_TO_SOMEONE on an archived self-DM (no write access)', () => {
-            expect(getSendToSomeoneResult(false, false, true)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
+            expect(getSelfDMConvertActionsResult(false, false, true)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE);
         });
 
         it('includes SEND_TO_EMPLOYER for an unreported self-tracked expense that is not a split', () => {
-            expect(getSendToSomeoneResult(false, false)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+            expect(getSelfDMConvertActionsResult(false, false)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
         });
 
         it('hides SEND_TO_EMPLOYER for a self-DM split expense when the user has no workspace to submit to', () => {
-            expect(getSendToSomeoneResult(true, false)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+            expect(getSelfDMConvertActionsResult(true, false)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
         });
 
         it('includes SEND_TO_EMPLOYER for a self-DM split expense when the user has a workspace to submit to', () => {
-            expect(getSendToSomeoneResult(true, true)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+            expect(getSelfDMConvertActionsResult(true, true)).toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
         });
 
         it('hides SEND_TO_EMPLOYER on an archived self-DM (no write access)', () => {
-            expect(getSendToSomeoneResult(false, false, true)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
+            expect(getSelfDMConvertActionsResult(false, false, true)).not.toContain(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER);
         });
     });
 

--- a/tests/unit/libs/PopoverMenuSectionsTest.ts
+++ b/tests/unit/libs/PopoverMenuSectionsTest.ts
@@ -1,6 +1,6 @@
 import type {DropdownOption} from '@components/ButtonWithDropdownMenu/types';
 
-import {REPORT_MORE_MENU_SECTIONS, sortAndSectionPopoverMenuItems} from '@libs/PopoverMenuSections';
+import {REPORT_MORE_MENU_SECTIONS, sortAndSectionPopoverMenuItems, TRANSACTION_MORE_MENU_SECTIONS} from '@libs/PopoverMenuSections';
 
 import CONST from '@src/CONST';
 
@@ -61,5 +61,27 @@ describe('sortAndSectionPopoverMenuItems', () => {
 
         expect(result.at(0)?.value).toBe(CONST.REPORT.SECONDARY_ACTIONS.RECEIVED_PAYMENT);
         expect(result.at(0)?.addSeparatorBefore).toBeUndefined();
+    });
+
+    it('renders SEND_TO_SOMEONE and SEND_TO_EMPLOYER first, together in the top section with a divider before the next section', () => {
+        expect(TRANSACTION_MORE_MENU_SECTIONS.at(0)).toEqual([CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE, CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER]);
+
+        const items = [
+            makeItem(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.VIEW_DETAILS),
+            makeItem(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER),
+            makeItem(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE),
+        ];
+        const result = sortAndSectionPopoverMenuItems(items, TRANSACTION_MORE_MENU_SECTIONS);
+
+        // Both convert-from-track rows sort to the top section, in their original order, with no divider between them.
+        expect(result.map((item) => item.value)).toEqual([
+            CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_EMPLOYER,
+            CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.SEND_TO_SOMEONE,
+            CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.VIEW_DETAILS,
+        ]);
+        expect(result.at(0)?.addSeparatorBefore).toBeUndefined();
+        expect(result.at(1)?.addSeparatorBefore).toBeUndefined();
+        // VIEW_DETAILS is in a later section, so it gets the divider.
+        expect(result.at(2)?.addSeparatorBefore).toBe(true);
     });
 });


### PR DESCRIPTION
### Explanation of Change

When a "Looking Around" user (someone who chose the "Something else" onboarding intent) creates an expense, they land on the Spend page. Opening the expense and its **More** menu previously offered only **Send to someone** — but the personal-space Concierge in Inbox offers two options: **Send to someone** and **Submit to my employer**.

This PR adds a **Submit to my employer** option to the expense More menu, reusing the exact same flow as the Inbox Concierge "Submit to my employer" action. Both call `createDraftTransactionAndNavigateToParticipantSelector` with `actionName: SUBMIT` and `submitDestination: EMPLOYER`, so the destination resolves identically:
- No accessible workspace: a new Submit workspace is created and the expense drops into its draft confirmation screen.
- Exactly one workspace: skips the picker and goes straight to that workspace's confirmation screen.
- Multiple workspaces: opens the workspaces-only destination picker.

The new row is gated on the same condition as "Send to someone" (an unreported self-tracked expense in personal space, with write access), and sits in the same top section of the menu.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97881
PROPOSAL:

### Tests

1. Sign up as a new user and select the **Something else** onboarding intent (this qualifies you as a "Looking Around" user).
2. Create an expense — you land on the Spend page.
3. Open the expense, then open the **More** menu.
4. Verify a **Submit to my employer** option appears in the top section, alongside **Send to someone**.
5. Tap **Submit to my employer** and verify it behaves the same as the Inbox Concierge "Submit to my employer" option:
   - With no workspace: a new Submit workspace is created and you land on the confirmation screen.
   - With exactly one workspace: you go straight to that workspace's confirmation screen.
   - With multiple workspaces: the workspaces-only destination picker opens.
6. Open the same expense from the Inbox personal space via Concierge and confirm the "Submit to my employer" outcome matches the More-menu one.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open a self-tracked expense's **More** menu and verify **Submit to my employer** still appears (it is built from local Onyx state).
3. Select it and verify the flow proceeds and the request is queued, matching the Inbox behavior offline.

### QA Steps

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
