### PR TITLE
Perf: stop returning Sets and Maps from useOnyx collection selectors

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
@@ -20,7 +20,7 @@ import type * as OnyxTypes from '@src/types/onyx';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
 
 import type {GestureResponderEvent} from 'react-native';
-import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
+import type {OnyxCollection} from 'react-native-onyx';
 
 import {findFocusedRoute} from '@react-navigation/native';
 import React, {startTransition, useCallback, useEffect, useMemo} from 'react';
@@ -28,18 +28,6 @@ import React, {startTransition, useCallback, useEffect, useMemo} from 'react';
 type MoneyRequestReportRHPNavigationButtonsProps = {
     currentTransactionID: string;
     isFromReviewDuplicates?: boolean;
-};
-
-const parentReportActionIDsSelector = (reportActions: OnyxEntry<OnyxTypes.ReportActions>) => {
-    const parentActions = new Map<string, OnyxTypes.ReportAction>();
-    for (const action of Object.values(reportActions ?? {})) {
-        const transactionID = isMoneyRequestAction(action) ? getOriginalMessage(action)?.IOUTransactionID : undefined;
-        if (!transactionID) {
-            continue;
-        }
-        parentActions.set(transactionID, action);
-    }
-    return parentActions;
 };
 
 function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromReviewDuplicates}: MoneyRequestReportRHPNavigationButtonsProps) {
@@ -78,37 +66,41 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
         selector: prevNextTransactionsSelector,
     });
 
+    // Only the prev/next parent actions are ever read, so resolve them inside the selector instead of returning
+    // a Map of every money request action on the three parent reports (fast-equals compares Maps in O(n^2)).
     const parentReportActionsSelector = useCallback(
         (allReportActions: OnyxCollection<OnyxTypes.ReportActions>) => {
-            let reportActions = {};
-            for (const transaction of [currentTransaction, prevTransaction, nextTransaction]) {
-                reportActions = {
-                    ...reportActions,
-                    ...allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${transaction?.reportID}`],
-                };
+            let prevParentReportAction: OnyxTypes.ReportAction | undefined;
+            let nextParentReportAction: OnyxTypes.ReportAction | undefined;
+            if (!prevTransactionID && !nextTransactionID) {
+                return {prevParentReportAction, nextParentReportAction};
             }
-            return parentReportActionIDsSelector(reportActions);
+            const parentReportIDs = new Set([currentTransaction?.reportID, prevTransaction?.reportID, nextTransaction?.reportID]);
+            for (const parentReportID of parentReportIDs) {
+                for (const action of Object.values(allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`] ?? {})) {
+                    const transactionID = isMoneyRequestAction(action) ? getOriginalMessage(action)?.IOUTransactionID : undefined;
+                    if (!transactionID) {
+                        continue;
+                    }
+                    if (transactionID === prevTransactionID) {
+                        prevParentReportAction = action;
+                    }
+                    if (transactionID === nextTransactionID) {
+                        nextParentReportAction = action;
+                    }
+                }
+            }
+            return {prevParentReportAction, nextParentReportAction};
         },
-        [currentTransaction, nextTransaction, prevTransaction],
+        [currentTransaction?.reportID, nextTransaction?.reportID, nextTransactionID, prevTransaction?.reportID, prevTransactionID],
     );
 
-    const [parentReportActions = new Map<string, OnyxTypes.ReportAction>()] = useOnyx(ONYXKEYS.COLLECTION.REPORT_ACTIONS, {
+    const [parentReportActions] = useOnyx(ONYXKEYS.COLLECTION.REPORT_ACTIONS, {
         selector: parentReportActionsSelector,
     });
 
-    const {prevParentReportAction, nextParentReportAction} = useMemo(() => {
-        if (!transactionIDsList || transactionIDsList.length < 2) {
-            return {
-                prevParentReportAction: undefined,
-                nextParentReportAction: undefined,
-            };
-        }
-
-        return {
-            prevParentReportAction: prevTransactionID ? parentReportActions.get(prevTransactionID) : undefined,
-            nextParentReportAction: nextTransactionID ? parentReportActions.get(nextTransactionID) : undefined,
-        };
-    }, [nextTransactionID, parentReportActions, prevTransactionID, transactionIDsList]);
+    const prevParentReportAction = parentReportActions?.prevParentReportAction;
+    const nextParentReportAction = parentReportActions?.nextParentReportAction;
 
     const [prevParentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${prevTransaction?.reportID}`);
     const [nextParentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${nextTransaction?.reportID}`);

--- a/src/hooks/useTransactionViolation.ts
+++ b/src/hooks/useTransactionViolation.ts
@@ -5,19 +5,20 @@ import type {OnyxCollection} from 'react-native-onyx';
 
 import useOnyx from './useOnyx';
 
-const transactionViolationsSelector = (violations: OnyxCollection<TransactionViolations>, eligibleTransactionIDs?: Set<string>) => {
-    if (!eligibleTransactionIDs || eligibleTransactionIDs.size === 0) {
+const transactionViolationsSelector = (violations: OnyxCollection<TransactionViolations>, eligibleTransactionIDs?: string[]) => {
+    if (!eligibleTransactionIDs?.length) {
         return undefined;
     }
+    const eligibleTransactionIDSet = new Set(eligibleTransactionIDs);
     return Object.fromEntries(
         Object.entries(violations ?? {}).filter(([key]) => {
             const id = key.replace(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS, '');
-            return eligibleTransactionIDs?.has(id);
+            return eligibleTransactionIDSet.has(id);
         }),
     );
 };
 
-function useTransactionViolation(eligibleTransactionIDs?: Set<string>) {
+function useTransactionViolation(eligibleTransactionIDs?: string[]) {
     const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS, {
         selector: (violations: OnyxCollection<TransactionViolations>) => transactionViolationsSelector(violations, eligibleTransactionIDs),
     });

--- a/src/pages/workspace/distanceRates/PolicyDistanceRateDetailsPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRateDetailsPage.tsx
@@ -57,12 +57,13 @@ function PolicyDistanceRateDetailsPage({route}: PolicyDistanceRateDetailsPagePro
 
     const policyReportsSelector = useCallback(
         (reports: OnyxCollection<Report>) => {
-            return Object.values(reports ?? {}).reduce((reportIDs, report) => {
+            const reportIDs: Record<string, true> = {};
+            for (const report of Object.values(reports ?? {})) {
                 if (report?.policyID === policyID) {
-                    reportIDs.add(report.reportID);
+                    reportIDs[report.reportID] = true;
                 }
-                return reportIDs;
-            }, new Set<string>());
+            }
+            return reportIDs;
         },
         [policyID],
     );
@@ -73,17 +74,17 @@ function PolicyDistanceRateDetailsPage({route}: PolicyDistanceRateDetailsPagePro
 
     const transactionsSelector = useCallback(
         (transactions: OnyxCollection<Transaction>) => {
-            return Object.values(transactions ?? {}).reduce((transactionIDs, transaction) => {
+            return Object.values(transactions ?? {}).reduce<string[]>((transactionIDs, transaction) => {
                 if (
                     transaction?.reportID &&
-                    policyReports?.has(transaction.reportID) &&
+                    policyReports?.[transaction.reportID] &&
                     transaction?.comment?.customUnit?.customUnitRateID &&
                     transaction?.comment?.customUnit?.customUnitRateID === rateID
                 ) {
-                    transactionIDs.add(transaction?.transactionID);
+                    transactionIDs.push(transaction?.transactionID);
                 }
                 return transactionIDs;
-            }, new Set<string>());
+            }, []);
         },
         [rateID, policyReports],
     );
@@ -151,7 +152,7 @@ function PolicyDistanceRateDetailsPage({route}: PolicyDistanceRateDetailsPagePro
     };
 
     const deleteRate = () => {
-        deletePolicyDistanceRates(policyID, customUnit, [rateID], Array.from(eligibleTransactionIDs ?? []), transactionViolations);
+        deletePolicyDistanceRates(policyID, customUnit, [rateID], eligibleTransactionIDs ?? [], transactionViolations);
         Navigation.setNavigationActionToMicrotaskQueue(() => Navigation.goBack());
     };
 

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -88,12 +88,13 @@ function PolicyDistanceRatesPage({
 
     const policyReportsSelector = useCallback(
         (reports: OnyxCollection<Report>) => {
-            return Object.values(reports ?? {}).reduce((reportIDs, report) => {
+            const reportIDs: Record<string, true> = {};
+            for (const report of Object.values(reports ?? {})) {
                 if (report?.policyID === policyID) {
-                    reportIDs.add(report.reportID);
+                    reportIDs[report.reportID] = true;
                 }
-                return reportIDs;
-            }, new Set<string>());
+            }
+            return reportIDs;
         },
         [policyID],
     );
@@ -111,11 +112,11 @@ function PolicyDistanceRatesPage({
                 (transactionsData, transaction) => {
                     if (
                         transaction?.reportID &&
-                        policyReports?.has(transaction.reportID) &&
+                        policyReports?.[transaction.reportID] &&
                         transaction?.comment?.customUnit?.customUnitRateID &&
                         rateIDs.has(transaction?.comment?.customUnit?.customUnitRateID)
                     ) {
-                        transactionsData.transactionIDs.add(transaction.transactionID);
+                        transactionsData.transactionIDs.push(transaction.transactionID);
                         if (!transactionsData.rateIDToTransactionIDsMap[transaction?.comment?.customUnit?.customUnitRateID]) {
                             // eslint-disable-next-line no-param-reassign
                             transactionsData.rateIDToTransactionIDsMap[transaction?.comment?.customUnit?.customUnitRateID] = [];
@@ -124,7 +125,7 @@ function PolicyDistanceRatesPage({
                     }
                     return transactionsData;
                 },
-                {transactionIDs: new Set<string>(), rateIDToTransactionIDsMap: {} as Record<string, string[]>},
+                {transactionIDs: [] as string[], rateIDToTransactionIDsMap: {} as Record<string, string[]>},
             );
         },
         [customUnit?.customUnitID, rateIDs, policyReports],


### PR DESCRIPTION
### Explanation of Change

Part of the [#99168](https://github.com/Expensify/App/issues/99168) `useOnyx` collection-selector audit, covering the five selectors that returned a `Set` or a `Map`.

`fast-equals` compares `Set`s and `Map`s by nested iteration over a matched-index array (`areSetsEqual` / `areMapsEqual`), with no hash lookup even when the members are primitives. Every write to any member of the subscribed collection therefore cost O(n^2) comparisons. A `Set` of 5k report IDs is about 25M string compares per write, and a `Map` of report actions is O(n^2) full-object `deepEqual`s.

`policyReportsSelector` now returns `Record<string, true>`, and both `transactionsSelector`s return `string[]`, so comparison drops to O(n) while lookups stay O(1). The `MoneyRequestReportTransactionsNavigation` selector resolves `{prevParentReportAction, nextParentReportAction}` instead of building a `Map` of every money-request action on the three parent reports.

`useTransactionViolation` has two callers, both distance-rate pages, so it now takes `string[]` and builds its lookup `Set` internally where `deepEqual` never sees it. That makes the downstream `useMemo` in the navigation component redundant, so it's deleted. The parent report IDs are also deduped, since prev/next siblings usually share the current parent report.

### Fixed Issues
$ https://github.com/Expensify/App/issues/99168
PROPOSAL:

### Tests
1. Open Spend tab, go to reports
2. Open report with multiple transactions
3. Navigate next and back using navigation in top right corner
4. Verify it navigates correctly

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
