### PR TITLE
Update getWorkspaceRules to include flag for review and field requirement

### DIFF
--- a/src/libs/actions/Policy/CopyPolicySettings.ts
+++ b/src/libs/actions/Policy/CopyPolicySettings.ts
@@ -8,6 +8,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {CopyPolicySettings as CopyPolicySettingsState, Policy, PolicyCategories, PolicyTagLists} from '@src/types/onyx';
 import type {CustomUnit, PolicyFeatureName} from '@src/types/onyx/Policy';
+import type {PolicyCategory} from '@src/types/onyx/PolicyCategory';
 
 import type {OnyxCollection, OnyxUpdate} from 'react-native-onyx';
 
@@ -216,6 +217,58 @@ function buildTravelSettingsPatch(sourcePolicy: Policy, targetPolicy: Policy): P
 }
 
 /**
+ * Mirror Backend logic for the category field of flag for review and field requirement
+ */
+const CATEGORY_RULE_FIELDS = [
+    'maxExpenseAmount',
+    'expenseLimitType',
+    'maxAmountNoReceipt',
+    'maxAmountNoItemizedReceipt',
+    'areCommentsRequired',
+    'areAttendeesRequired',
+    'commentHint',
+] as const satisfies ReadonlyArray<keyof PolicyCategory>;
+
+/**
+ * Returns the categories patch to merge onto a target when `rules` is copied without `categories`.
+ */
+function buildCategoryRulesPatch(sourceCategories: PolicyCategories, targetCategories: PolicyCategories): PolicyCategories | undefined {
+    const patch: PolicyCategories = {};
+
+    for (const sourceCategory of Object.values(sourceCategories)) {
+        if (sourceCategory.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+            continue;
+        }
+        const targetCategory = targetCategories[sourceCategory.name];
+        if (!targetCategory || targetCategory.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+            continue;
+        }
+
+        const categoryPatch: Partial<PolicyCategory> = {};
+        for (const field of CATEGORY_RULE_FIELDS) {
+            if (sourceCategory[field] === undefined) {
+                continue;
+            }
+            // The CATEGORY_RULE_FIELDS values are typed as keyof PolicyCategory, so this assignment is safe.
+            (categoryPatch as Record<string, unknown>)[field] = sourceCategory[field];
+        }
+        if (Object.keys(categoryPatch).length === 0) {
+            continue;
+        }
+
+        // The Rules page hides disabled categories, so rules copied onto a disabled target category would be
+        // invisible - enable it so the copy is actually usable.
+        patch[sourceCategory.name] = {
+            ...targetCategory,
+            ...categoryPatch,
+            ...(sourceCategory.enabled && !targetCategory.enabled ? {enabled: true} : {}),
+        };
+    }
+
+    return Object.keys(patch).length > 0 ? patch : undefined;
+}
+
+/**
  * Returns the partial Policy patch derived from the selected `parts`, excluding fields whose
  * mapping is handled separately (customUnits, timeTracking, receiptPartners, categories, tags collection keys).
  */
@@ -289,6 +342,7 @@ function buildCopyPolicySettingsData(
     const isTimeTrackingSelected = parts.includes('timeTracking');
     const isReceiptPartnersSelected = parts.includes('receiptPartners');
     const isCodingRulesSelected = parts.includes('codingRules');
+    const isRulesSelected = parts.includes('rules');
     const isTravelSelected = parts.includes('travel');
     const timeTrackingPendingFields = isTimeTrackingSelected
         ? {
@@ -396,6 +450,25 @@ function buildCopyPolicySettingsData(
                 key: targetCategoriesKey,
                 value: previousCategories,
             });
+        }
+
+        // When categories are copied too, the SET above already carries the source's category rules across.
+        if (isRulesSelected && !isCategoriesSelected) {
+            const targetCategoriesKey = `${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${targetPolicy.id}` as const;
+            const previousCategories = allPolicyCategories?.[targetCategoriesKey];
+            const categoryRulesPatch = previousCategories ? buildCategoryRulesPatch(sourceCategories, previousCategories) : undefined;
+            if (previousCategories && categoryRulesPatch) {
+                optimisticData.push({
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: targetCategoriesKey,
+                    value: categoryRulesPatch,
+                });
+                failureData.push({
+                    onyxMethod: Onyx.METHOD.SET,
+                    key: targetCategoriesKey,
+                    value: previousCategories,
+                });
+            }
         }
 
         if (isTagsSelected) {

--- a/src/libs/actions/Policy/CopyPolicySettings.ts
+++ b/src/libs/actions/Policy/CopyPolicySettings.ts
@@ -2,13 +2,14 @@ import {write} from '@libs/API';
 import type {CopyPolicySettingsParams} from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
+import {hasExplicitFlagAmount} from '@libs/FlagForReviewRulesUtils';
 import {generateHexadecimalValue} from '@libs/NumberUtils';
+import {categoryHasAnyRequireFieldsRule} from '@libs/RequireFieldsRulesUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {CopyPolicySettings as CopyPolicySettingsState, Policy, PolicyCategories, PolicyTagLists} from '@src/types/onyx';
+import type {CopyPolicySettings as CopyPolicySettingsState, Policy, PolicyCategories, PolicyTagLists, PolicyCategory} from '@src/types/onyx';
 import type {CustomUnit, PolicyFeatureName} from '@src/types/onyx/Policy';
-import type {PolicyCategory} from '@src/types/onyx/PolicyCategory';
 
 import type {OnyxCollection, OnyxUpdate} from 'react-native-onyx';
 
@@ -217,7 +218,7 @@ function buildTravelSettingsPatch(sourcePolicy: Policy, targetPolicy: Policy): P
 }
 
 /**
- * Mirror Backend logic for the category field of flag for review and field requirement
+ * The category fields the backend copies for Flag for review and Field requirements rules.
  */
 const CATEGORY_RULE_FIELDS = [
     'maxExpenseAmount',
@@ -246,7 +247,11 @@ function buildCategoryRulesPatch(sourceCategories: PolicyCategories, targetCateg
 
         const categoryPatch: Partial<PolicyCategory> = {};
         for (const field of CATEGORY_RULE_FIELDS) {
-            if (sourceCategory[field] === undefined) {
+            if (sourceCategory[field] === undefined || sourceCategories?.[field].pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+                continue;
+            }
+
+            if (!hasExplicitFlagAmount(sourceCategory.maxExpenseAmount) && !categoryHasAnyRequireFieldsRule(sourceCategory) && !sourceCategory.commentHint) {
                 continue;
             }
             // The CATEGORY_RULE_FIELDS values are typed as keyof PolicyCategory, so this assignment is safe.
@@ -457,6 +462,7 @@ function buildCopyPolicySettingsData(
             const targetCategoriesKey = `${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${targetPolicy.id}` as const;
             const previousCategories = allPolicyCategories?.[targetCategoriesKey];
             const categoryRulesPatch = previousCategories ? buildCategoryRulesPatch(sourceCategories, previousCategories) : undefined;
+            // We should only copy when there's matched target category
             if (previousCategories && categoryRulesPatch) {
                 optimisticData.push({
                     onyxMethod: Onyx.METHOD.MERGE,

--- a/src/libs/actions/Policy/CopyPolicySettings.ts
+++ b/src/libs/actions/Policy/CopyPolicySettings.ts
@@ -245,13 +245,15 @@ function buildCategoryRulesPatch(sourceCategories: PolicyCategories, targetCateg
             continue;
         }
 
+        // expenseLimitType and commentHint can be set without a rule existing, so gate on the rule predicates
+        // themselves - otherwise a category carrying no rule would still patch (and force-enable) the target.
+        if (!hasExplicitFlagAmount(sourceCategory.maxExpenseAmount) && !categoryHasAnyRequireFieldsRule(sourceCategory) && !sourceCategory.commentHint) {
+            continue;
+        }
+
         const categoryPatch: Partial<PolicyCategory> = {};
         for (const field of CATEGORY_RULE_FIELDS) {
-            if (sourceCategory[field] === undefined || sourceCategories?.[field].pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-                continue;
-            }
-
-            if (!hasExplicitFlagAmount(sourceCategory.maxExpenseAmount) && !categoryHasAnyRequireFieldsRule(sourceCategory) && !sourceCategory.commentHint) {
+            if (sourceCategory[field] === undefined || sourceCategory.pendingFields?.[field] === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
                 continue;
             }
             // The CATEGORY_RULE_FIELDS values are typed as keyof PolicyCategory, so this assignment is safe.

--- a/src/pages/workspace/copyPolicySettings/CopyPolicySettingsSelectFeaturesPage.tsx
+++ b/src/pages/workspace/copyPolicySettings/CopyPolicySettingsSelectFeaturesPage.tsx
@@ -112,7 +112,7 @@ function CopyPolicySettingsSelectFeaturesPage() {
     const perDiemCount = Object.values(perDiemRates).filter((rate) => rate.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE).length;
     const formattedAddress = !isEmptyObject(sourcePolicy) && !isEmptyObject(sourcePolicy.address) ? formatAddressToString(sourcePolicy.address) : '';
     const workflows = getWorkflowRules(sourcePolicy, translate);
-    const rules = getWorkspaceRules(sourcePolicy, translate);
+    const rules = getWorkspaceRules(sourcePolicy, translate, policyCategories);
     const shouldShowCurrency = hasCurrencyConflictWithAnyTarget(sourcePolicy, targetPolicies);
     const currencyBlockedByBA = isCurrencyBlockedByTargetBA(sourcePolicy, targetPolicies);
     const currencyNeededForWorkflows = needsCurrencyForWorkflows(sourcePolicy, targetPolicies);

--- a/src/pages/workspace/duplicate/WorkspaceDuplicateSelectFeaturesForm.tsx
+++ b/src/pages/workspace/duplicate/WorkspaceDuplicateSelectFeaturesForm.tsx
@@ -89,7 +89,8 @@ function WorkspaceDuplicateSelectFeaturesForm({policyID}: WorkspaceDuplicateForm
     const formattedAddress = !isEmptyObject(policy) && !isEmptyObject(policy.address) ? formatAddressToString(policy.address) : '';
 
     const items = useMemo(() => {
-        const rules = getWorkspaceRules(policy, translate, policyCategories);
+        // Duplication copies category-stored rules only as part of the categories themselves, so they belong to the Categories row rather than the Rules row.
+        const rules = getWorkspaceRules(policy, translate);
         const workflows = getWorkflowRules(policy, translate);
 
         const result = [
@@ -203,7 +204,6 @@ function WorkspaceDuplicateSelectFeaturesForm({policyID}: WorkspaceDuplicateForm
         connectedIntegration,
         totalTags,
         categoriesCount,
-        policyCategories,
         taxesLength,
         ratesCount,
         isCollect,

--- a/src/pages/workspace/duplicate/WorkspaceDuplicateSelectFeaturesForm.tsx
+++ b/src/pages/workspace/duplicate/WorkspaceDuplicateSelectFeaturesForm.tsx
@@ -89,7 +89,7 @@ function WorkspaceDuplicateSelectFeaturesForm({policyID}: WorkspaceDuplicateForm
     const formattedAddress = !isEmptyObject(policy) && !isEmptyObject(policy.address) ? formatAddressToString(policy.address) : '';
 
     const items = useMemo(() => {
-        const rules = getWorkspaceRules(policy, translate);
+        const rules = getWorkspaceRules(policy, translate, policyCategories);
         const workflows = getWorkflowRules(policy, translate);
 
         const result = [
@@ -203,6 +203,7 @@ function WorkspaceDuplicateSelectFeaturesForm({policyID}: WorkspaceDuplicateForm
         connectedIntegration,
         totalTags,
         categoriesCount,
+        policyCategories,
         taxesLength,
         ratesCount,
         isCollect,

--- a/src/pages/workspace/duplicate/WorkspaceDuplicateSelectFeaturesForm.tsx
+++ b/src/pages/workspace/duplicate/WorkspaceDuplicateSelectFeaturesForm.tsx
@@ -89,7 +89,6 @@ function WorkspaceDuplicateSelectFeaturesForm({policyID}: WorkspaceDuplicateForm
     const formattedAddress = !isEmptyObject(policy) && !isEmptyObject(policy.address) ? formatAddressToString(policy.address) : '';
 
     const items = useMemo(() => {
-        // Duplication copies category-stored rules only as part of the categories themselves, so they belong to the Categories row rather than the Rules row.
         const rules = getWorkspaceRules(policy, translate);
         const workflows = getWorkflowRules(policy, translate);
 

--- a/src/pages/workspace/duplicate/utils.ts
+++ b/src/pages/workspace/duplicate/utils.ts
@@ -1,16 +1,18 @@
 import type {LocaleContextProps} from '@components/LocaleContextProvider';
 
+import {hasExplicitFlagAmount} from '@libs/FlagForReviewRulesUtils';
 import {getCorrectedAutoReportingFrequency, getWorkflowApprovalsUnavailable} from '@libs/PolicyUtils';
+import {categoryHasAnyRequireFieldsRule} from '@libs/RequireFieldsRulesUtils';
 
 import {getAutoReportingFrequencyDisplayNames} from '@pages/workspace/workflows/WorkspaceAutoReportingFrequencyPage';
 
 import {isAuthenticationError, isConnectionUnverified} from '@userActions/connections';
 
 import CONST from '@src/CONST';
-import type {Policy} from '@src/types/onyx';
+import type {Policy, PolicyCategories} from '@src/types/onyx';
 import type {ConnectionName} from '@src/types/onyx/Policy';
 
-function getWorkspaceRules(policy: Policy | undefined, translate: LocaleContextProps['translate']) {
+function getWorkspaceRules(policy: Policy | undefined, translate: LocaleContextProps['translate'], policyCategories?: PolicyCategories) {
     const workflowApprovalsUnavailable = getWorkflowApprovalsUnavailable(policy);
     const autoPayApprovedReportsUnavailable =
         !policy?.areWorkflowsEnabled || policy?.reimbursementChoice !== CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES || !policy?.achAccount?.bankAccountID;
@@ -59,6 +61,15 @@ function getWorkspaceRules(policy: Policy | undefined, translate: LocaleContextP
     // (disabledFields) both indicate a non-default cash expense rule worth copying.
     if (policy?.defaultReimbursable === false || Object.values(policy?.disabledFields ?? {}).some(Boolean)) {
         total.push(translate('workspace.rules.individualExpenseRules.cashExpenseDefault'));
+    }
+
+    // Field requirements and flag for review rules are stored on the categories rather than on the policy.
+    const enabledCategories = Object.values(policyCategories ?? {}).filter((category) => category.enabled && category.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+    if (enabledCategories.some((category) => categoryHasAnyRequireFieldsRule(category))) {
+        total.push(translate('workspace.rules.tabs.requireFields'));
+    }
+    if (enabledCategories.some((category) => hasExplicitFlagAmount(category.maxExpenseAmount))) {
+        total.push(translate('workspace.rules.tabs.flagForReview'));
     }
 
     return total.length > 0 ? total : null;

--- a/tests/actions/CopyPolicySettingsTest.ts
+++ b/tests/actions/CopyPolicySettingsTest.ts
@@ -350,6 +350,7 @@ describe('actions/Policy/CopyPolicySettings', () => {
                     Software: {name: 'Software', enabled: true, maxExpenseAmount: 1000},
                 };
                 const targetCategories: PolicyCategories = {
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
                     Food: {name: 'Food', enabled: true, maxExpenseAmount: 100, 'GL Code': 'GL-1'},
                     Travel: {name: 'Travel', enabled: false},
                     Office: {name: 'Office', enabled: true},
@@ -372,6 +373,7 @@ describe('actions/Policy/CopyPolicySettings', () => {
                         expenseLimitType: CONST.POLICY.EXPENSE_LIMIT_TYPES.EXPENSE,
                         areCommentsRequired: true,
                         commentHint: 'Why?',
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
                         'GL Code': 'GL-1',
                     },
                     Travel: {name: 'Travel', enabled: true, areAttendeesRequired: true},

--- a/tests/actions/CopyPolicySettingsTest.ts
+++ b/tests/actions/CopyPolicySettingsTest.ts
@@ -339,6 +339,75 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(failureData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
             });
 
+            it('merges category rule fields onto same-named target categories when rules is selected without categories', () => {
+                const sourceCategories: PolicyCategories = {
+                    Food: {name: 'Food', enabled: true, maxExpenseAmount: 5000, expenseLimitType: CONST.POLICY.EXPENSE_LIMIT_TYPES.EXPENSE, areCommentsRequired: true, commentHint: 'Why?'},
+                    // Disabled on the target, so the copy enables it - otherwise the Rules page would hide the rules just copied.
+                    Travel: {name: 'Travel', enabled: true, areAttendeesRequired: true},
+                    // Has no rule fields, so it must not touch the target category.
+                    Office: {name: 'Office', enabled: true},
+                    // Only exists on the source, so there is nothing to apply it to.
+                    Software: {name: 'Software', enabled: true, maxExpenseAmount: 1000},
+                };
+                const targetCategories: PolicyCategories = {
+                    Food: {name: 'Food', enabled: true, maxExpenseAmount: 100, 'GL Code': 'GL-1'},
+                    Travel: {name: 'Travel', enabled: false},
+                    Office: {name: 'Office', enabled: true},
+                };
+
+                const allPolicyCategories: OnyxCollection<PolicyCategories> = {
+                    [SOURCE_CATEGORIES_KEY]: sourceCategories,
+                    [TARGET_CATEGORIES_KEY]: targetCategories,
+                };
+
+                const {optimisticData, failureData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['rules'], allPolicyCategories, {});
+
+                const optimisticMerge = optimisticData.find((u) => u.key === TARGET_CATEGORIES_KEY && u.onyxMethod === Onyx.METHOD.MERGE);
+                expect(optimisticMerge?.value).toEqual({
+                    // The target's own GL Code survives; only the rule fields come from the source.
+                    Food: {
+                        name: 'Food',
+                        enabled: true,
+                        maxExpenseAmount: 5000,
+                        expenseLimitType: CONST.POLICY.EXPENSE_LIMIT_TYPES.EXPENSE,
+                        areCommentsRequired: true,
+                        commentHint: 'Why?',
+                        'GL Code': 'GL-1',
+                    },
+                    Travel: {name: 'Travel', enabled: true, areAttendeesRequired: true},
+                });
+
+                const failureSet = failureData.find((u) => u.key === TARGET_CATEGORIES_KEY && u.onyxMethod === Onyx.METHOD.SET);
+                expect(failureSet?.value).toEqual(targetCategories);
+            });
+
+            it('does not emit a category rules merge when categories is selected too, since the SET already carries them', () => {
+                const sourceCategories: PolicyCategories = {Food: {name: 'Food', enabled: true, maxExpenseAmount: 5000}};
+                const targetCategories: PolicyCategories = {Food: {name: 'Food', enabled: true}};
+
+                const allPolicyCategories: OnyxCollection<PolicyCategories> = {
+                    [SOURCE_CATEGORIES_KEY]: sourceCategories,
+                    [TARGET_CATEGORIES_KEY]: targetCategories,
+                };
+
+                const {optimisticData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['rules', 'categories'], allPolicyCategories, {});
+
+                expect(optimisticData.some((u) => u.key === TARGET_CATEGORIES_KEY && u.onyxMethod === Onyx.METHOD.MERGE)).toBe(false);
+                expect(optimisticData.find((u) => u.key === TARGET_CATEGORIES_KEY && u.onyxMethod === Onyx.METHOD.SET)?.value).toEqual(sourceCategories);
+            });
+
+            it('does not emit a category rules merge when no source category defines a rule field', () => {
+                const allPolicyCategories: OnyxCollection<PolicyCategories> = {
+                    [SOURCE_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: true}},
+                    [TARGET_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: true}},
+                };
+
+                const {optimisticData, failureData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['rules'], allPolicyCategories, {});
+
+                expect(optimisticData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
+                expect(failureData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
+            });
+
             it('falls back to empty object when source has no categories', () => {
                 const {optimisticData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['categories'], {}, {});
 

--- a/tests/actions/CopyPolicySettingsTest.ts
+++ b/tests/actions/CopyPolicySettingsTest.ts
@@ -410,6 +410,65 @@ describe('actions/Policy/CopyPolicySettings', () => {
                 expect(failureData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
             });
 
+            it('does not emit a category rules merge when the source only carries expenseLimitType without a flag amount', () => {
+                const allPolicyCategories: OnyxCollection<PolicyCategories> = {
+                    [SOURCE_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: true, expenseLimitType: CONST.POLICY.EXPENSE_LIMIT_TYPES.EXPENSE}},
+                    // Disabled, so a spurious patch would also wrongly force-enable it.
+                    [TARGET_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: false}},
+                };
+
+                const {optimisticData, failureData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['rules'], allPolicyCategories, {});
+
+                expect(optimisticData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
+                expect(failureData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
+            });
+
+            it('does not emit a category rules merge when the source flag amount is the disabled sentinel', () => {
+                const allPolicyCategories: OnyxCollection<PolicyCategories> = {
+                    [SOURCE_CATEGORIES_KEY]: {
+                        Food: {name: 'Food', enabled: true, maxExpenseAmount: CONST.DISABLED_MAX_EXPENSE_VALUE, expenseLimitType: CONST.POLICY.EXPENSE_LIMIT_TYPES.EXPENSE},
+                    },
+                    [TARGET_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: false}},
+                };
+
+                const {optimisticData, failureData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['rules'], allPolicyCategories, {});
+
+                expect(optimisticData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
+                expect(failureData.some((u) => u.key === TARGET_CATEGORIES_KEY)).toBe(false);
+            });
+
+            it('copies a category whose only rule is a description hint, enabling the target so the hint is reachable', () => {
+                const allPolicyCategories: OnyxCollection<PolicyCategories> = {
+                    [SOURCE_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: true, commentHint: 'Add the attendee list'}},
+                    [TARGET_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: false}},
+                };
+
+                const {optimisticData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['rules'], allPolicyCategories, {});
+
+                const optimisticMerge = optimisticData.find((u) => u.key === TARGET_CATEGORIES_KEY && u.onyxMethod === Onyx.METHOD.MERGE);
+                expect(optimisticMerge?.value).toEqual({Food: {name: 'Food', enabled: true, commentHint: 'Add the attendee list'}});
+            });
+
+            it('skips rule fields the source has pending delete', () => {
+                const allPolicyCategories: OnyxCollection<PolicyCategories> = {
+                    [SOURCE_CATEGORIES_KEY]: {
+                        Food: {
+                            name: 'Food',
+                            enabled: true,
+                            maxExpenseAmount: 5000,
+                            areAttendeesRequired: true,
+                            pendingFields: {areAttendeesRequired: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE},
+                        },
+                    },
+                    [TARGET_CATEGORIES_KEY]: {Food: {name: 'Food', enabled: true}},
+                };
+
+                const {optimisticData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['rules'], allPolicyCategories, {});
+
+                const optimisticMerge = optimisticData.find((u) => u.key === TARGET_CATEGORIES_KEY && u.onyxMethod === Onyx.METHOD.MERGE);
+                expect(optimisticMerge?.value).toEqual({Food: {name: 'Food', enabled: true, maxExpenseAmount: 5000}});
+            });
+
             it('falls back to empty object when source has no categories', () => {
                 const {optimisticData} = buildCopyPolicySettingsData(makeSourcePolicy(), [makeTargetPolicy()], ['categories'], {}, {});
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
`getWorkspaceRules` logic only relies on `policy` data, it won't inlcude `Flag for review` and `Field requirement` since they're based on `policyCategories` data.
<!-- Explain what your change does and how it addresses the linked issue -->
https://github.com/Expensify/App/blob/1e33d08616b0f2283ba7f5512440dab5996f2a3f/src/pages/workspace/duplicate/utils.ts#L13

In this PR, I added `policyCategories` to `getWorkspaceRules` so we can check if `Flag for review` or `Field requirement` are enabled on that workspace.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95354
PROPOSAL: N/A

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA steps.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as QA steps.
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
1. Create `Flag for review` or `Field requirements` rules in your workspace.
2. Go to workspace list > More > Copy settings > Choose any workspace.
3. Verify in `Rules` section will display correct settings.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ce94f351-5284-4538-9b71-725ff9fdb3db

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ce94f351-5284-4538-9b71-725ff9fdb3db

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/641477db-eb02-42ac-9150-7cb1f6a07324

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/e36bdd8d-1089-47e1-ba35-364286987bef


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/bd3b213e-5fbe-428e-9d8d-772afbc5f47d


</details>
