### PR TITLE
fix: prevent Select All button from spinning forever on Reports page

### DIFF
--- a/src/hooks/useSearchPageSetup.ts
+++ b/src/hooks/useSearchPageSetup.ts
@@ -84,8 +84,10 @@ function useSearchPageSetup(queryJSON: Readonly<SearchQueryJSON> | undefined) {
             lastSavedSearchHash = hash;
         }
 
-        // A stale-after-reload pending request can be restarted via dedup, but skip when a live request is already in flight.
-        if (isSnapshotDataLoaded && (!isInitialSearchPending || isSnapshotSearchLoading)) {
+        // A pending initial request may be stale after reload and can be restarted through request deduplication.
+        // Pagination must not restart page one. When data is loaded and a request THIS instance already
+        // fired is still in flight, skip — it's not stale, it's our own active request (e.g. a totals upgrade).
+        if (isSnapshotDataLoaded && (!isInitialSearchPending || (isSnapshotSearchLoading && requestedHashesRef.current.has(hash)))) {
             return;
         }
 

--- a/src/hooks/useSearchPageSetup.ts
+++ b/src/hooks/useSearchPageSetup.ts
@@ -84,9 +84,8 @@ function useSearchPageSetup(queryJSON: Readonly<SearchQueryJSON> | undefined) {
             lastSavedSearchHash = hash;
         }
 
-        // A pending initial request may be stale after reload and can be restarted through request deduplication.
-        // Pagination must not restart page one.
-        if (isSnapshotDataLoaded && !isInitialSearchPending) {
+        // A stale-after-reload pending request can be restarted via dedup, but skip when a live request is already in flight.
+        if (isSnapshotDataLoaded && (!isInitialSearchPending || isSnapshotSearchLoading)) {
             return;
         }
 

--- a/src/hooks/useSearchPageSetup.ts
+++ b/src/hooks/useSearchPageSetup.ts
@@ -85,9 +85,8 @@ function useSearchPageSetup(queryJSON: Readonly<SearchQueryJSON> | undefined) {
         }
 
         // A pending initial request may be stale after reload and can be restarted through request deduplication.
-        // Pagination must not restart page one. When data is loaded and a request THIS instance already
-        // fired is still in flight, skip — it's not stale, it's our own active request (e.g. a totals upgrade).
-        if (isSnapshotDataLoaded && (!isInitialSearchPending || (isSnapshotSearchLoading && requestedHashesRef.current.has(hash)))) {
+        // Pagination must not restart page one.
+        if (isSnapshotDataLoaded && !isInitialSearchPending) {
             return;
         }
 

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -1171,8 +1171,8 @@ function search({
         if (needsTotalsUpgrade || needsSaveRecentSearchUpgrade) {
             // Accumulate desired flags so a later upgrade for one dimension can't drop an earlier
             // upgrade for the other. Only a single pending re-fire is kept.
-            inFlightRequest.pendingShouldCalculateTotals = (inFlightRequest.pendingShouldCalculateTotals ?? false) || shouldCalculateTotals;
-            inFlightRequest.pendingShouldSaveRecentSearch = (inFlightRequest.pendingShouldSaveRecentSearch ?? false) || shouldSaveRecentSearch;
+            inFlightRequest.pendingShouldCalculateTotals = (inFlightRequest.pendingShouldCalculateTotals ?? inFlightRequest.shouldCalculateTotals) || shouldCalculateTotals;
+            inFlightRequest.pendingShouldSaveRecentSearch = (inFlightRequest.pendingShouldSaveRecentSearch ?? inFlightRequest.shouldSaveRecentSearch) || shouldSaveRecentSearch;
             inFlightRequest.pendingUpgradeRequest = () =>
                 search({
                     queryJSON,


### PR DESCRIPTION
### Explanation of Change

When clicking "Select all" on the Reports page, the green button with selected count spins forever. The root cause is a race between two Search callers:

1. `Search/index.tsx` fires a Search with `shouldCalculateTotals=true` when "Select all" is activated
2. The optimistic `state: 'loading'` causes `useSearchPageSetup` to re-fire a second Search with `shouldCalculateTotals=false` (it doesn't factor in `areAllMatchingItemsSelected`)
3. The dedup mechanism catches the collision but creates a `pendingUpgradeRequest` that loses the original `shouldCalculateTotals=true` flag because the accumulation seeds from `false` instead of the in-flight request's value
4. The pending re-fire clears `count/total/currency` via `shouldClearTotals` and the server response (without totals) never restores them

Two fixes applied:
- **Search.ts**: Seed pending flag accumulation from the original request's value (`?? inFlightRequest.shouldCalculateTotals` instead of `?? false`) so upgrades never downgrade existing flags
- **useSearchPageSetup.ts**: Skip re-fire when data is loaded and a live request is already in flight (`|| isSnapshotSearchLoading`), preventing the unnecessary collision entirely

### Fixed Issues
$ https://github.com/Expensify/App/issues/99298

### Tests

1. Navigate to Search, select the Reports tab with filters (e.g. `type:expense-report status:approved`)
2. Click "Select all"
3. Verify the green button shows the count of selected reports (not spinning forever)
4. Verify regular search, pagination, and tab switching still work as expected

Test 1: 

1. Log into NewDot (staging or production is closest to the report; local is https://dev.new.expensify.com:8082/).
2. Confirm you have >50 expense reports for the query you will use.
3. Open Search (Spend).
4. Switch to the Reports tab (type:expense-report). Optional: add a filter that still leaves >50 rows, e.g. type:expense-report status:approved.
5. Wait until the list is fully loaded (not a skeleton).
6. Click Select all (checkbox or “Select all” label) with nothing already selected.
7. In the popover, choose Select all — not Select all on this page.
8. Verify that the green button in the header stops spinning and shows the record count

Test 2:

1. Log into NewDot. Use an account with more than 50 expenses matching the query below
2. Open DevTools → Network, filter Search. Optional: throttle to Slow 3G so the first Search stays in flight.
3. Open Search → Expenses (type:expense). 
4. Run an ad-hoc query, for example type:expense merchant:Uber (any filter that is not a suggested/saved search).
5. Wait until rows are visible, but act while a Search for that hash is still in flight if you can (Slow 3G helps). 
6. Click Select all → Select all (not Select all on this page).
7. Verify that the green button in the header stops spinning and shows the record count

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Click "Select all" while online, verify count appears
2. Go offline mid-request, verify button falls back to local count (not stuck spinning)

### QA Steps

1. Log into a workspace with multiple approved expense reports
2. Go to Search, switch to Reports tab, apply filters (e.g. status:approved)
3. Click "Select all"
4. Verify the green button shows the selected count within a few seconds
5. Verify bulk actions (approve, pay, export) work after selecting all

Test 1: 

1. Log into NewDot (staging or production is closest to the report; local is https://dev.new.expensify.com:8082/).
2. Confirm you have >50 expense reports for the query you will use.
3. Open Search (Spend).
4. Switch to the Reports tab (type:expense-report). Optional: add a filter that still leaves >50 rows, e.g. type:expense-report status:approved.
5. Wait until the list is fully loaded (not a skeleton).
6. Click Select all (checkbox or “Select all” label) with nothing already selected.
7. In the popover, choose Select all — not Select all on this page.
8. Verify that the green button in the header stops spinning and shows the record count

Test 2:

1. Log into NewDot. Use an account with more than 50 expenses matching the query below
2. Open DevTools → Network, filter Search. Optional: throttle to Slow 3G so the first Search stays in flight.
3. Open Search → Expenses (type:expense). 
4. Run an ad-hoc query, for example type:expense merchant:Uber (any filter that is not a suggested/saved search).
5. Wait until rows are visible, but act while a Search for that hash is still in flight if you can (Slow 3G helps). 
6. Click Select all → Select all (not Select all on this page).
7. Verify that the green button in the header stops spinning and shows the record count

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/5c250eb0-a144-41bb-824a-9e270e2343a4




</details>