### PR TITLE
Pass isSandbox=true for IES connections on staging

### DIFF
--- a/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
+++ b/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
@@ -42,7 +42,6 @@ function BaseConnectToQuickbooksOnlineFlow({policyID, isIntuitEnterpriseSuite, o
     const icons = useMemoizedLazyExpensifyIcons(['LinkCopy']);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
     const isAuthError = isAuthenticationError(policy, CONST.POLICY.CONNECTIONS.NAME.QBO);
-    // IES shows the production/sandbox selector in development and staging so testers can pick the OAuth configuration.
     const shouldShowConnectionOptions = !!isIntuitEnterpriseSuite && (environment === CONST.ENVIRONMENT.DEV || environment === CONST.ENVIRONMENT.STAGING) && !isAuthError;
     const [isConnectionOptionsPopoverOpen, setIsConnectionOptionsPopoverOpen] = useState(shouldShowConnectionOptions);
     const [connectionOptionsPopoverPosition, setConnectionOptionsPopoverPosition] = useState<AnchorPosition | null>(null);

--- a/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
+++ b/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
@@ -64,7 +64,9 @@ function BaseConnectToQuickbooksOnlineFlow({policyID, isIntuitEnterpriseSuite, o
         enablePolicyTaxes(policyID, false);
         // Reconnect starts from the overflow menu, so there is no connection button to anchor this popover to.
         if (!shouldShowConnectionOptions) {
-            onConnect(false);
+            // IES on staging must use the sandbox OAuth configuration; all other non-DEV connections use production.
+            const isSandbox = isIntuitEnterpriseSuite && environment === CONST.ENVIRONMENT.STAGING;
+            onConnect(isSandbox);
         }
     }, [onConnect, policyID, shouldShowConnectionOptions]);
 

--- a/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
+++ b/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
@@ -42,7 +42,8 @@ function BaseConnectToQuickbooksOnlineFlow({policyID, isIntuitEnterpriseSuite, o
     const icons = useMemoizedLazyExpensifyIcons(['LinkCopy']);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
     const isAuthError = isAuthenticationError(policy, CONST.POLICY.CONNECTIONS.NAME.QBO);
-    const shouldShowConnectionOptions = !!isIntuitEnterpriseSuite && environment === CONST.ENVIRONMENT.DEV && !isAuthError;
+    // IES shows the production/sandbox selector in development and staging so testers can pick the OAuth configuration.
+    const shouldShowConnectionOptions = !!isIntuitEnterpriseSuite && (environment === CONST.ENVIRONMENT.DEV || environment === CONST.ENVIRONMENT.STAGING) && !isAuthError;
     const [isConnectionOptionsPopoverOpen, setIsConnectionOptionsPopoverOpen] = useState(shouldShowConnectionOptions);
     const [connectionOptionsPopoverPosition, setConnectionOptionsPopoverPosition] = useState<AnchorPosition | null>(null);
     const didInitialize = useRef(false);
@@ -64,9 +65,7 @@ function BaseConnectToQuickbooksOnlineFlow({policyID, isIntuitEnterpriseSuite, o
         enablePolicyTaxes(policyID, false);
         // Reconnect starts from the overflow menu, so there is no connection button to anchor this popover to.
         if (!shouldShowConnectionOptions) {
-            // IES on staging must use the sandbox OAuth configuration; all other non-DEV connections use production.
-            const isSandbox = isIntuitEnterpriseSuite && environment === CONST.ENVIRONMENT.STAGING;
-            onConnect(isSandbox);
+            onConnect(false);
         }
     }, [onConnect, policyID, shouldShowConnectionOptions]);
 

--- a/tests/unit/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.test.tsx
+++ b/tests/unit/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.test.tsx
@@ -109,7 +109,8 @@ describe('BaseConnectToQuickbooksOnlineFlow', () => {
 
     it.each([
         ['QuickBooks Online in development', false, CONST.ENVIRONMENT.DEV, false],
-        ['Intuit Enterprise Suite outside development', true, CONST.ENVIRONMENT.PRODUCTION, false],
+        ['QuickBooks Online on staging', false, CONST.ENVIRONMENT.STAGING, false],
+        ['Intuit Enterprise Suite on production', true, CONST.ENVIRONMENT.PRODUCTION, false],
         ['Intuit Enterprise Suite reconnect after an authentication error', true, CONST.ENVIRONMENT.DEV, true],
     ])('connects to production immediately for %s', async (_caseName, isIntuitEnterpriseSuite, environment, isAuthError) => {
         setEnvironment(environment);
@@ -124,34 +125,23 @@ describe('BaseConnectToQuickbooksOnlineFlow', () => {
         expect(mockPopoverMenu).not.toHaveBeenCalled();
     });
 
-    it('connects to sandbox immediately for Intuit Enterprise Suite on staging', async () => {
-        setEnvironment(CONST.ENVIRONMENT.STAGING);
-        const onConnect = renderFlow({isIntuitEnterpriseSuite: true});
+    it.each([
+        ['development', CONST.ENVIRONMENT.DEV],
+        ['staging', CONST.ENVIRONMENT.STAGING],
+    ])('shows the connection options for Intuit Enterprise Suite on %s', async (_environmentName, environment) => {
+        setEnvironment(environment);
+        renderFlow({isIntuitEnterpriseSuite: true});
 
         await waitFor(() => {
-            expect(onConnect).toHaveBeenCalledTimes(1);
+            expect(mockPopoverMenu).toHaveBeenCalled();
         });
-
-        expect(onConnect).toHaveBeenCalledWith(true);
-        expect(mockPopoverMenu).not.toHaveBeenCalled();
-    });
-
-    it('connects to production immediately for QuickBooks Online on staging', async () => {
-        setEnvironment(CONST.ENVIRONMENT.STAGING);
-        const onConnect = renderFlow({isIntuitEnterpriseSuite: false});
-
-        await waitFor(() => {
-            expect(onConnect).toHaveBeenCalledTimes(1);
-        });
-
-        expect(onConnect).toHaveBeenCalledWith(false);
-        expect(mockPopoverMenu).not.toHaveBeenCalled();
     });
 
     it.each([
         ['production', 0, false],
         ['sandbox', 1, true],
-    ])('connects to %s once when selected for Intuit Enterprise Suite in development', async (_connectionName, itemIndex, isSandbox) => {
+    ])('connects to %s once when selected for Intuit Enterprise Suite on staging', async (_connectionName, itemIndex, isSandbox) => {
+        setEnvironment(CONST.ENVIRONMENT.STAGING);
         const onConnect = renderFlow({isIntuitEnterpriseSuite: true});
 
         await waitFor(() => {

--- a/tests/unit/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.test.tsx
+++ b/tests/unit/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.test.tsx
@@ -124,6 +124,30 @@ describe('BaseConnectToQuickbooksOnlineFlow', () => {
         expect(mockPopoverMenu).not.toHaveBeenCalled();
     });
 
+    it('connects to sandbox immediately for Intuit Enterprise Suite on staging', async () => {
+        setEnvironment(CONST.ENVIRONMENT.STAGING);
+        const onConnect = renderFlow({isIntuitEnterpriseSuite: true});
+
+        await waitFor(() => {
+            expect(onConnect).toHaveBeenCalledTimes(1);
+        });
+
+        expect(onConnect).toHaveBeenCalledWith(true);
+        expect(mockPopoverMenu).not.toHaveBeenCalled();
+    });
+
+    it('connects to production immediately for QuickBooks Online on staging', async () => {
+        setEnvironment(CONST.ENVIRONMENT.STAGING);
+        const onConnect = renderFlow({isIntuitEnterpriseSuite: false});
+
+        await waitFor(() => {
+            expect(onConnect).toHaveBeenCalledTimes(1);
+        });
+
+        expect(onConnect).toHaveBeenCalledWith(false);
+        expect(mockPopoverMenu).not.toHaveBeenCalled();
+    });
+
     it.each([
         ['production', 0, false],
         ['sandbox', 1, true],


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
`BaseConnectToQuickbooksOnlineFlow` only shows the production/sandbox selector in `DEV`. For every other environment it calls `onConnect(false)`, so an Intuit Enterprise Suite (IES) connection started on staging opens the production OAuth configuration instead of the IES sandbox.

This change shows the same production/sandbox selector for IES on staging that already exists in `DEV`, so testers can pick the OAuth configuration. Standard QuickBooks Online on staging, production connections, and the existing `DEV` selector are unchanged.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/674578
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. On staging, open a workspace and go to the accounting setup for Intuit Enterprise Suite.
2. Start the IES connection flow and confirm the production/sandbox selector appears (same as in `DEV`).
3. Select "Connect to sandbox" and confirm the opened URL contains `isSandbox=true` and Intuit shows the sandbox companies.
4. Select the production option and confirm the opened URL has no `isSandbox`.
5. On staging, start a standard QuickBooks Online connection and confirm it still opens production with no selector.
6. On staging, reconnect IES after an authentication error and confirm it connects to production with no selector.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests. The connection URL is built from local state and does not depend on the network.

### QA Steps
1. On staging, open a workspace and start the Intuit Enterprise Suite connection flow.
2. Confirm the production/sandbox selector appears (same as in `DEV`).
3. Select "Connect to sandbox" and confirm the connection opens the IES sandbox OAuth configuration (`isSandbox=true`).
4. Select the "Connect" option and confirm it opens the non-sandbox flow.
5. On staging, start a standard QuickBooks Online connection and confirm it opens production with no selector.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

