### PR TITLE
[Exploratory] iOS - Fix screen flicker when tapping Cancel to exit edit mode

### DIFF
--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions.tsx
@@ -353,7 +353,7 @@ function ComposerWithSuggestions({
     const ignoreEditSelectionResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
     const handleEditFocus = useCallback(() => {
-        focus(true, undefined, true);
+        focus(true, undefined, editingState === CONST.REPORT_ACTION_EDIT_MESSAGE_STATE.EDITING);
         onFocus();
 
         if (editingState === CONST.REPORT_ACTION_EDIT_MESSAGE_STATE.EDITING) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

On iOS, tapping Cancel to exit edit mode re-focuses the main composer through `useEditComposerToggle`'s exit branch, which calls `handleEditFocus` → `focus(true, undefined, true)`. The third arg (`forceKeyboardIfAlreadyFocused`) was hardcoded `true`, so even though the composer never lost focus on cancel, `focusComposerWithDelay` still took the already-focused branch and called `requestKeyboardForFocusedComposer` (native-only) after `CONST.COMPOSER_FOCUS_DELAY`. On iOS, `KeyboardController.setFocusTo('current')` tears down and rebuilds the already-visible keyboard (`inputView = nil; reloadInputViews(); focus()`), causing the report list to render blank for a single frame.

The flag was added for Android in `489139080be` to force the keyboard back up when _entering_ edit mode. This change only forces it while `editingState === CONST.REPORT_ACTION_EDIT_MESSAGE_STATE.EDITING` (i.e. on entry), so exiting edit mode (Cancel or Save, both go through the same `stopEditing()` → `OFF` branch) no longer forces a keyboard reload.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97768
PROPOSAL: https://github.com/Expensify/App/issues/97768#issuecomment-5368742584

### Tests

1. Open any chat and tap an existing message you sent to edit it
2. Tap Cancel (the ✕ next to the composer) instead of saving
3. Verify the composer reverts to the normal (non-edit) state and the message list does not flash/flicker
4. Repeat with Save instead of Cancel — same exit path, same expectation
5. Re-enter edit mode on a message on Android/iOS and verify the keyboard still comes up (this is the original behavior the forced flag exists for, on entry only)

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests — this is a pure focus/keyboard-timing change with no network dependency.

### QA Steps

1. On iOS, open a chat and edit one of your own messages
2. Tap Cancel
3. Verify there's no visible flash/flicker of the chat list right after cancelling

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/92f0271c-b5fc-4f23-bab8-61517cda1554



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/d9d8087b-ddd7-4433-a2b5-b5ddeb89a79e


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/cddf7323-dc26-4ed0-8581-c23cab728f39

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/81bc44e8-9d20-4c3b-ba39-35bc45cfceff


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/340fedb3-240a-46e3-ae59-b4131c58e925

</details>
