### PR TITLE
[No QA] Prevent sticky disks from growing unboundedly V2

### DIFF
--- a/.github/actions/composite/setupNode/action.yml
+++ b/.github/actions/composite/setupNode/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - id: stickydisk-node-modules
       if: steps.runner-info.outputs.use-sticky-disk == 'true'
-      uses: useblacksmith/stickydisk@6d373c96a74cbde0c99fedc5ea5d3a7ba66ba494 # v1.4.0
+      uses: useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151 # v1.6.0
       with:
         key: ${{ format('{0}-{1}-{2}-node-modules-{3}', github.repository, runner.os, runner.arch, inputs.IS_HYBRID_BUILD == 'true' && hashFiles('normalized-package-lock.json', 'patches/**', 'Mobile-Expensify/patches/**') || hashFiles('normalized-package-lock.json', 'patches/**')) }}
         path: node_modules
@@ -47,7 +47,7 @@ runs:
 
     - id: stickydisk-old-dot-node-modules
       if: steps.runner-info.outputs.use-sticky-disk == 'true' && inputs.IS_HYBRID_BUILD == 'true'
-      uses: useblacksmith/stickydisk@6d373c96a74cbde0c99fedc5ea5d3a7ba66ba494 # v1.4.0
+      uses: useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151 # v1.6.0
       with:
         key: ${{ format('{0}-{1}-{2}-old-dot-node-modules-{3}', github.repository, runner.os, runner.arch, hashFiles('Mobile-Expensify/package-lock.json', 'Mobile-Expensify/patches/**')) }}
         path: Mobile-Expensify/node_modules
@@ -55,7 +55,7 @@ runs:
 
     - id: stickydisk-npm
       if: steps.runner-info.outputs.use-sticky-disk == 'true'
-      uses: useblacksmith/stickydisk@6d373c96a74cbde0c99fedc5ea5d3a7ba66ba494 # v1.4.0
+      uses: useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151 # v1.6.0
       with:
         key: ${{ format('{0}-{1}-{2}-npm', github.repository, runner.os, runner.arch) }}
         path: ~/.npm

--- a/.github/actions/composite/setupNode/action.yml
+++ b/.github/actions/composite/setupNode/action.yml
@@ -7,6 +7,13 @@ inputs:
     description: 'Indicates if node is set up for hybrid app'
     required: false
     default: 'false'
+  SEED_STICKY_DISKS:
+    description: |
+      'true' only in the seedStickyDisks workflow, which installs dependencies and nothing else.
+      Everywhere else the disks are mounted read-through so no job can persist build artifacts or
+      tool caches into the snapshot.
+    required: false
+    default: 'false'
 
 outputs:
   cache-hit:
@@ -36,6 +43,7 @@ runs:
       with:
         key: ${{ format('{0}-{1}-{2}-node-modules-{3}', github.repository, runner.os, runner.arch, inputs.IS_HYBRID_BUILD == 'true' && hashFiles('normalized-package-lock.json', 'patches/**', 'Mobile-Expensify/patches/**') || hashFiles('normalized-package-lock.json', 'patches/**')) }}
         path: node_modules
+        commit: ${{ inputs.SEED_STICKY_DISKS == 'true' && 'if-missing' || 'false' }}
 
     - id: stickydisk-old-dot-node-modules
       if: steps.runner-info.outputs.use-sticky-disk == 'true' && inputs.IS_HYBRID_BUILD == 'true'
@@ -43,6 +51,7 @@ runs:
       with:
         key: ${{ format('{0}-{1}-{2}-old-dot-node-modules-{3}', github.repository, runner.os, runner.arch, hashFiles('Mobile-Expensify/package-lock.json', 'Mobile-Expensify/patches/**')) }}
         path: Mobile-Expensify/node_modules
+        commit: ${{ inputs.SEED_STICKY_DISKS == 'true' && 'if-missing' || 'false' }}
 
     - id: stickydisk-npm
       if: steps.runner-info.outputs.use-sticky-disk == 'true'
@@ -50,6 +59,7 @@ runs:
       with:
         key: ${{ format('{0}-{1}-{2}-npm', github.repository, runner.os, runner.arch) }}
         path: ~/.npm
+        commit: on-change
 
     - id: cache-node-modules
       if: steps.runner-info.outputs.use-sticky-disk != 'true'

--- a/.github/workflows/seedStickyDisks.yml
+++ b/.github/workflows/seedStickyDisks.yml
@@ -1,0 +1,39 @@
+name: Seed sticky disks
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  seedStandalone:
+    name: Seed standalone node_modules
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
+
+      - name: Setup Node (seed)
+        uses: ./.github/actions/composite/setupNode
+        with:
+          SEED_STICKY_DISKS: 'true'
+
+  seedHybrid:
+    name: Seed hybrid node_modules
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
+        with:
+          submodules: true
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Setup Node (seed)
+        uses: ./.github/actions/composite/setupNode
+        with:
+          IS_HYBRID_BUILD: 'true'
+          SEED_STICKY_DISKS: 'true'


### PR DESCRIPTION
### Explanation of Change

#### The problem

A Blacksmith sticky disk is not a tarball of files like `actions/cache` - it is an ext4 block device stored in Blacksmith's Ceph cluster. When a job mounts one, the last committed snapshot is cloned and mounted at the given path, when the job finishes, the clone is committed back and becomes the new snapshot.

The important part is when that commit happens: the sticky disk action commits in its post-job phase, so the snapshot always captures the state of the mounted path at the very end of the job. There is no API to commit at the end of a specific step - we cannot say "snapshot `node_modules` right after `npm ci` and ignore everything written afterwards". Everything a job writes into the mount before it ends is part of the snapshot.

That matters because plenty of tooling writes into `node_modules` during a job:

- ESLint, Babel, rspack and other tools default their caches to `node_modules/.cache`.
- Android builds compile native React Native libraries from source, and Gradle/CMake write their outputs straight into the packages: `node_modules/<lib>/android/build`, `.cxx` object files per ABI, generated codegen sources.

Because every job committed (`commit` defaults to `true`), each run layered its own generated files into the snapshot, and the next run started from that fatter snapshot and added more. It compounds, and on the block level it is worse than the file listing suggests: deleting or rewriting a file inside the mount frees ext4 blocks, but the freed blocks are never returned to the storage layer - `fstrim` on a sticky disk mount fails with `the discard operation is not supported`. The billed size therefore tracks every block ever written, not the blocks currently in use.

The result: `node_modules` that is 3.8 GB after a clean `npm ci` grew into disks reporting 30 GB of live files and 103 GB of allocated blocks in the Blacksmith dashboard after ~3 weeks on the same key. Inspecting one of those disks showed exactly the expected culprits - `react-native-reanimated` at 4.0 GB, `react-native-worklets` at 3.2 GB, `react-native-quick-crypto` at 2.9 GB, and so on for every library with native code, against ~50 MB each when freshly installed. Sticky disk storage is billed at $0.50/GB/month, so a single such key cost ~$50/month on its own.

#### The fix

Separate "who produces the snapshot" from "who consumes it". `setupNode` takes a new `SEED_STICKY_DISKS` input that controls the `commit` mode of the `node_modules` disks:

- The new `seedStickyDisks.yml` workflow passes `SEED_STICKY_DISKS: 'true'` and gets `commit: if-missing`. It installs dependencies and does nothing else, so the snapshot it writes is a clean `npm ci` result by construction. It runs on every push to `main`, once a key has a snapshot, the seed is a no-op that mounts it and exits.
- Every other workflow keeps the default and mounts with `commit: false`. Jobs still read `node_modules` from the snapshot and may write whatever they like into their own clone - caches, Gradle output, `.cxx` and all of it is discarded when the clone is unmounted instead of being committed. Disks stay at the size of a clean install permanently.
- The `~/.npm` disk keeps committing, with `commit: on-change`. Its key has no hash in it, so it has to keep absorbing new package tarballs across lockfile bumps, and it does not suffer the same growth: tarballs are content-addressed, it sits at ~6 GB, and `on-change` skips the commit on the majority of runs that never touch it.

Cache-hit detection is unchanged: the `node_modules/.stickydisk-installed` marker is written at the end of `setupNode`, so it lands in the seed's snapshot and consumers skip `npm ci` when they see it.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98593
$ https://github.com/Expensify/App/issues/98563

### Tests

No QA

### Offline tests

N/A 

### QA Steps

No QA

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.