### PR TITLE
Fix #91985: [Due for payment 2026-08-27] [$250] Required 2FA setup screen is unresponsive, b

### DIFF
--- a/src/pages/RequireTwoFactorAuthenticationOverlay.tsx
+++ b/src/pages/RequireTwoFactorAuthenticationOverlay.tsx
@@ -69,7 +69,7 @@ function RequireTwoFactorAuthenticationOverlay() {
 
     const snapshotOnboardingResumePathIfNeeded = useCallback(() => {
         const activeRoute = Navigation.getActiveRoute();
-        if (activeRoute.startsWith(`/${ROUTES.ONBOARDING_ROOT.route}`)) {
+        if (activeRoute?.startsWith(`/${ROUTES.ONBOARDING_ROOT.route}`)) {
             updateOnboardingLastVisitedPath(activeRoute);
             return;
         }


### PR DESCRIPTION
$ #91985

Se evita que el flujo de configuración 2FA falle cuando no existe una ruta activa de navegación, permitiendo que el botón continúe hacia la pantalla de configuración.

Submitted by novastreamdev.