### PR TITLE
Test book travel

### DIFF
--- a/src/components/Search/SearchRouter/useCreateNavigationSuggestions.ts
+++ b/src/components/Search/SearchRouter/useCreateNavigationSuggestions.ts
@@ -18,7 +18,10 @@ import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import getCreateReportRoute, {getReportsRootRoute, navigateToCreateReportWorkspaceSelection} from '@libs/Navigation/helpers/getCreateReportRoute';
 import Navigation from '@libs/Navigation/Navigation';
-import {canSendInvoice, getDefaultChatEnabledPolicy, getGroupPoliciesWhereReportCanBeCreated, shouldShowPolicy} from '@libs/PolicyUtils';
+import {openTravelDotLink} from '@libs/openTravelDotLink';
+import Permissions from '@libs/Permissions';
+// eslint-disable-next-line no-restricted-imports -- TravelDot booking requires a paid workspace, matching the existing FAB behavior.
+import {canSendInvoice, getDefaultChatEnabledPolicy, getGroupPoliciesWhereReportCanBeCreated, hasAcceptedTravelTerms, isPaidGroupPolicy, shouldShowPolicy} from '@libs/PolicyUtils';
 import {generateReportID} from '@libs/ReportUtils';
 
 import isOnSearchMoneyRequestReportPage from '@navigation/helpers/isOnSearchMoneyRequestReportPage';
@@ -27,12 +30,14 @@ import {clearLastSearchParams} from '@userActions/ReportNavigation';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {DYNAMIC_ROUTES} from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
+import {primaryLoginSelector} from '@src/selectors/Account';
 import {isTrackIntentUserSelector} from '@src/selectors/Onboarding';
 import {emailSelector} from '@src/selectors/Session';
 import {validTransactionDraftIDsSelector} from '@src/selectors/TransactionDraft';
 import type IconAsset from '@src/types/utils/IconAsset';
 
+import {Str} from 'expensify-common';
 import {useState} from 'react';
 
 import type {NavigationSuggestionSourceItem} from './SearchRouterHelpers';
@@ -72,9 +77,18 @@ function replaceTopmostModalWithAction(action: () => void) {
     Navigation.dismissModal({afterTransition: action});
 }
 
+function openBookTravel(policyID: string | undefined, isTravelEnabled: boolean) {
+    if (isTravelEnabled) {
+        openTravelDotLink(policyID);
+        return;
+    }
+
+    Navigation.navigate(ROUTES.TRAVEL_MY_TRIPS.getRoute(policyID));
+}
+
 function useCreateNavigationSuggestions(query = ''): NavigationSuggestionSourceItem[] {
     const {translate} = useLocalize();
-    const icons = useMemoizedLazyExpensifyIcons(['Coins', 'Receipt', 'Cash', 'Transfer', 'MoneyCircle', 'Location', 'Document', 'ChatBubble', 'InvoiceGeneric', 'NewWorkspace']);
+    const icons = useMemoizedLazyExpensifyIcons(['Coins', 'Receipt', 'Cash', 'Transfer', 'MoneyCircle', 'Location', 'Document', 'ChatBubble', 'InvoiceGeneric', 'Suitcase', 'NewWorkspace']);
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const {getCurrencyDecimals} = useCurrencyListActions();
     const {isBetaEnabled} = usePermissions();
@@ -84,10 +98,12 @@ function useCreateNavigationSuggestions(query = ''): NavigationSuggestionSourceI
     const [reportID] = useState(() => generateReportID());
     const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {selector: validTransactionDraftIDsSelector});
     const [lastDistanceExpenseType] = useOnyx(ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE);
+    const [primaryLogin] = useOnyx(ONYXKEYS.ACCOUNT, {selector: primaryLoginSelector});
     const [sessionEmail] = useOnyx(ONYXKEYS.SESSION, {selector: emailSelector});
     const [allBetas] = useOnyx(ONYXKEYS.BETAS);
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     const [activePolicy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${activePolicyID}`);
+    const [travelSettings] = useOnyx(ONYXKEYS.NVP_TRAVEL_SETTINGS);
 
     // Match Quick Creation and Search actions by using shared report eligibility rules.
     const groupPoliciesWithChatEnabled = getGroupPoliciesWhereReportCanBeCreated(allPolicies ?? null, sessionEmail);
@@ -96,12 +112,22 @@ function useCreateNavigationSuggestions(query = ''): NavigationSuggestionSourceI
 
     const defaultChatEnabledPolicy = getDefaultChatEnabledPolicy([...groupPoliciesWithChatEnabled], activePolicy);
     const isInvoiceVisible = canSendInvoice(allPolicies ?? null, sessionEmail);
+    const isTravelVisible = !!activePolicy?.isTravelEnabled;
+    const isBlockedFromSpotnanaTravel = Permissions.isBetaEnabled(CONST.BETAS.PREVENT_SPOTNANA_TRAVEL, allBetas);
+    const primaryContactMethod = primaryLogin ?? sessionEmail ?? '';
+    const isTravelEnabled =
+        !isBlockedFromSpotnanaTravel &&
+        !!primaryContactMethod &&
+        !Str.isSMSLogin(primaryContactMethod) &&
+        isPaidGroupPolicy(activePolicy) &&
+        hasAcceptedTravelTerms(activePolicy, travelSettings);
 
     const createExpenseMatchTerms = [translate('iou.createExpense'), translate('iou.addExpense'), translate('homePage.gettingStartedSection.createExpense')];
     const createReportMatchTerms = [translate('report.newReport.createReport')];
     const trackDistanceMatchTerms = [translate('iou.trackDistance')];
     const chatMatchTerms = [translate('sidebarScreen.fabNewChat'), `${translate('common.new')} ${translate('common.chat')}`];
     const invoiceMatchTerms = [translate('workspace.invoices.sendInvoice')];
+    const travelMatchTerms = [translate('travel.bookTravel')];
     const workspaceMatchTerms = [translate('workspace.new.newWorkspace'), translate('onboarding.workspace.createWorkspace'), translate('homePage.gettingStartedSection.createWorkspace')];
     const matchQuery = stripNavigationIntentPrefix(query);
     const shouldPrepareCreateReport =
@@ -204,6 +230,17 @@ function useCreateNavigationSuggestions(query = ''): NavigationSuggestionSourceI
                     });
                 }),
             keyForList: 'create_invoice',
+        },
+        {
+            visible: isTravelVisible,
+            text: translate('travel.bookTravel'),
+            icon: icons.Suitcase,
+            matchTerms: travelMatchTerms,
+            action: () =>
+                replaceTopmostModalWithAction(() => {
+                    interceptAnonymousUser(() => openBookTravel(activePolicy?.id, isTravelEnabled));
+                }),
+            keyForList: 'create_travel',
         },
         {
             visible: shouldShowNewWorkspaceButton,

--- a/tests/unit/SearchRouterNavigationTest.ts
+++ b/tests/unit/SearchRouterNavigationTest.ts
@@ -336,6 +336,7 @@ describe('Create Search Router navigation source', () => {
         {visible: true, text: 'Track distance', icon: mockIcon, action: createAction, keyForList: 'create_trackDistance'},
         {visible: true, text: 'Start chat', icon: mockIcon, action: createAction, keyForList: 'create_chat', matchTerms: ['Start chat', 'New chat screen']},
         {visible: false, text: 'Create invoice', icon: mockIcon, action: createAction, keyForList: 'create_invoice'},
+        {visible: true, text: 'Book travel', icon: mockIcon, action: createAction, keyForList: 'create_travel'},
         {visible: false, text: 'New workspace', icon: mockIcon, action: createAction, keyForList: 'create_workspace', matchTerms: ['New workspace', 'Create workspace']},
     ];
 
@@ -346,13 +347,13 @@ describe('Create Search Router navigation source', () => {
     it('builds visible Create rows with direct action labels and excludes unavailable items', () => {
         const items = CreateNavigationSuggestions.buildCreateNavigationItems(createItems);
 
-        expect(items.map((item) => item.text)).toEqual(['Create expense', 'Create report', 'Track distance', 'Start chat']);
-        expect(items.map((item) => item.keyForList)).toEqual(['create_expense', 'create_report', 'create_trackDistance', 'create_chat']);
-        expect(items.map((item) => item.singleIcon)).toEqual([mockIcon, mockIcon, mockIcon, mockIcon]);
-        expect(items.map((item) => item.matchTerms)).toEqual([['Create expense', 'Add expense'], ['Create report'], ['Track distance'], ['Start chat', 'New chat screen']]);
+        expect(items.map((item) => item.text)).toEqual(['Create expense', 'Create report', 'Track distance', 'Start chat', 'Book travel']);
+        expect(items.map((item) => item.keyForList)).toEqual(['create_expense', 'create_report', 'create_trackDistance', 'create_chat', 'create_travel']);
+        expect(items.map((item) => item.singleIcon)).toEqual([mockIcon, mockIcon, mockIcon, mockIcon, mockIcon]);
+        expect(items.map((item) => item.matchTerms)).toEqual([['Create expense', 'Add expense'], ['Create report'], ['Track distance'], ['Start chat', 'New chat screen'], ['Book travel']]);
         expect(items.some((item) => item.text?.startsWith('Go to'))).toBe(false);
         expect(items.some((item) => item.keyForList === 'create_invoice' || item.keyForList === 'create_workspace')).toBe(false);
-        expect(items.some((item) => item.keyForList === 'create_travel' || item.keyForList === 'create_quickAction')).toBe(false);
+        expect(items.some((item) => item.keyForList === 'create_quickAction')).toBe(false);
     });
 
     it('matches Create rows through the existing navigation suggestion pipeline', () => {
@@ -362,6 +363,9 @@ describe('Create Search Router navigation source', () => {
         expect(buildNavigationSuggestions('add expense', [items], localeCompare).map((item) => item.keyForList)).toEqual(['create_expense']);
         expect(buildNavigationSuggestions('new chat', [items], localeCompare).map((item) => item.keyForList)).toEqual(['create_chat']);
         expect(buildNavigationSuggestions('go to track distance', [items], localeCompare).map((item) => item.keyForList)).toEqual(['create_trackDistance']);
+        expect(buildNavigationSuggestions('book travel', [items], localeCompare).map((item) => item.keyForList)).toEqual(['create_travel']);
+        expect(buildNavigationSuggestions('BOOK TRAVEL', [items], localeCompare).map((item) => item.keyForList)).toEqual(['create_travel']);
+        expect(buildNavigationSuggestions('go to book     travel', [items], localeCompare).map((item) => item.keyForList)).toEqual(['create_travel']);
     });
 
     it('matches hidden Create aliases without changing row text', () => {

--- a/tests/unit/useCreateNavigationSuggestionsTest.ts
+++ b/tests/unit/useCreateNavigationSuggestionsTest.ts
@@ -6,11 +6,13 @@ import {startDistanceRequest, startMoneyRequest} from '@libs/actions/IOU/MoneyRe
 import {createNewReport, startNewChat} from '@libs/actions/Report';
 import {navigateToCreateReportWorkspaceSelection} from '@libs/Navigation/helpers/getCreateReportRoute';
 import Navigation from '@libs/Navigation/Navigation';
+import {openTravelDotLink} from '@libs/openTravelDotLink';
 
 import {clearLastSearchParams} from '@userActions/ReportNavigation';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 
 type MockUseCreateReportParams = {
     onCreateReport: (shouldDismissEmptyReportsConfirmation?: boolean) => void;
@@ -36,6 +38,9 @@ const mockCanSendInvoice = jest.fn<boolean, unknown[]>(() => false);
 const mockGetDefaultChatEnabledPolicy = jest.fn((policies: unknown[]) => (policies.length === 1 ? policies.at(0) : undefined));
 const mockGetGroupPoliciesWhereReportCanBeCreated = jest.fn<unknown[], [policies: unknown, currentUserLogin?: string]>();
 const mockShouldShowPolicy = jest.fn<boolean, unknown[]>(() => true);
+const mockHasAcceptedTravelTerms = jest.fn(() => false);
+const mockIsPaidGroupPolicy = jest.fn(() => false);
+const mockIsPermissionsBetaEnabled = jest.fn(() => false);
 const mockIsOnSearchMoneyRequestReportPage = jest.fn(() => false);
 const mockGetCurrencyDecimals = jest.fn();
 let mockIsRestrictedPolicyCreation = false;
@@ -62,6 +67,7 @@ jest.mock('@hooks/useLazyAsset', () => ({
         Location: mockIcon,
         ChatBubble: mockIcon,
         InvoiceGeneric: mockIcon,
+        Suitcase: mockIcon,
         NewWorkspace: mockIcon,
     }),
 }));
@@ -81,6 +87,7 @@ jest.mock('@hooks/useLocalize', () => ({
                 ['onboarding.workspace.createWorkspace', 'Create workspace'],
                 ['report.newReport.createReport', 'Create report'],
                 ['sidebarScreen.fabNewChat', 'Start chat'],
+                ['travel.bookTravel', 'Book travel'],
                 ['workspace.invoices.sendInvoice', 'Send invoice'],
                 ['workspace.new.newWorkspace', 'New workspace'],
             ]);
@@ -151,10 +158,23 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     },
 }));
 
+jest.mock('@libs/openTravelDotLink', () => ({
+    openTravelDotLink: jest.fn(),
+}));
+
+jest.mock('@libs/Permissions', () => ({
+    __esModule: true,
+    default: {
+        isBetaEnabled: () => mockIsPermissionsBetaEnabled(),
+    },
+}));
+
 jest.mock('@libs/PolicyUtils', () => ({
     canSendInvoice: (...args: unknown[]) => mockCanSendInvoice(...args),
     getDefaultChatEnabledPolicy: (policies: unknown[]) => mockGetDefaultChatEnabledPolicy(policies),
     getGroupPoliciesWhereReportCanBeCreated: (policies: unknown, currentUserLogin?: string) => mockGetGroupPoliciesWhereReportCanBeCreated(policies, currentUserLogin),
+    hasAcceptedTravelTerms: () => mockHasAcceptedTravelTerms(),
+    isPaidGroupPolicy: () => mockIsPaidGroupPolicy(),
     shouldShowPolicy: (...args: unknown[]) => mockShouldShowPolicy(...args),
 }));
 
@@ -180,11 +200,13 @@ function setupUseOnyx() {
         [ONYXKEYS.COLLECTION.POLICY, policies],
         [ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {}],
         [ONYXKEYS.NVP_LAST_DISTANCE_EXPENSE_TYPE, CONST.IOU.REQUEST_TYPE.DISTANCE_MAP],
+        [ONYXKEYS.ACCOUNT, {primaryLogin: session.email}],
         [ONYXKEYS.SESSION, session],
         [ONYXKEYS.BETAS, []],
         [ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS, {}],
         [ONYXKEYS.NVP_ACTIVE_POLICY_ID, submitPolicy.id],
         [`${ONYXKEYS.COLLECTION.POLICY}${submitPolicy.id}`, submitPolicy],
+        [ONYXKEYS.NVP_TRAVEL_SETTINGS, undefined],
         [ONYXKEYS.NVP_INTRO_SELECTED, false],
         [ONYXKEYS.IS_LOADING_APP, false],
     ]);
@@ -201,6 +223,9 @@ describe('useCreateNavigationSuggestions', () => {
         setupUseOnyx();
         mockCanSendInvoice.mockReturnValue(false);
         mockShouldShowPolicy.mockReturnValue(true);
+        mockHasAcceptedTravelTerms.mockReturnValue(false);
+        mockIsPaidGroupPolicy.mockReturnValue(false);
+        mockIsPermissionsBetaEnabled.mockReturnValue(false);
         mockGetGroupPoliciesWhereReportCanBeCreated.mockReturnValue([]);
         mockIsOnSearchMoneyRequestReportPage.mockReturnValue(false);
         mockIsRestrictedPolicyCreation = false;
@@ -290,6 +315,57 @@ describe('useCreateNavigationSuggestions', () => {
 
         expect(result.current.some((item) => item.keyForList === 'create_invoice')).toBe(true);
         expect(result.current.some((item) => item.keyForList === 'create_workspace')).toBe(false);
+    });
+
+    it('uses only the active workspace to control Book travel visibility', () => {
+        const otherTravelPolicy = {id: 'other-travel-policy', type: CONST.POLICY.TYPE.TEAM, isTravelEnabled: true};
+        mockOnyxValues.set(ONYXKEYS.COLLECTION.POLICY, {
+            ...policies,
+            [`${ONYXKEYS.COLLECTION.POLICY}${otherTravelPolicy.id}`]: otherTravelPolicy,
+        });
+
+        const {result} = renderHook(() => useCreateNavigationSuggestions());
+
+        expect(result.current.some((item) => item.keyForList === 'create_travel')).toBe(false);
+    });
+
+    it('shows Book travel when Travel is enabled on the active workspace', () => {
+        mockOnyxValues.set(`${ONYXKEYS.COLLECTION.POLICY}${submitPolicy.id}`, {...submitPolicy, isTravelEnabled: true});
+
+        const {result} = renderHook(() => useCreateNavigationSuggestions());
+
+        expect(result.current.find((item) => item.keyForList === 'create_travel')).toMatchObject({text: 'Book travel', singleIcon: mockIcon, matchTerms: ['Book travel']});
+    });
+
+    it('opens TravelDot when the active workspace is ready for travel', () => {
+        mockOnyxValues.set(`${ONYXKEYS.COLLECTION.POLICY}${submitPolicy.id}`, {...submitPolicy, isTravelEnabled: true});
+        mockIsPaidGroupPolicy.mockReturnValue(true);
+        mockHasAcceptedTravelTerms.mockReturnValue(true);
+        const {result} = renderHook(() => useCreateNavigationSuggestions());
+
+        act(() => result.current.find((item) => item.keyForList === 'create_travel')?.action?.());
+
+        expect(openTravelDotLink).toHaveBeenCalledWith(submitPolicy.id);
+        expect(Navigation.navigate).not.toHaveBeenCalledWith(ROUTES.TRAVEL_MY_TRIPS.getRoute(submitPolicy.id));
+    });
+
+    it.each([
+        ['Travel is blocked', true, session.email, true, true],
+        ['the primary login is an SMS login', false, '+15555550123', true, true],
+        ['the active workspace is not paid', false, session.email, false, true],
+        ['Travel terms are not accepted', false, session.email, true, false],
+    ])('opens the Travel page when %s', (_condition, isBlocked, primaryLogin, isPaid, hasAcceptedTerms) => {
+        mockOnyxValues.set(`${ONYXKEYS.COLLECTION.POLICY}${submitPolicy.id}`, {...submitPolicy, isTravelEnabled: true});
+        mockOnyxValues.set(ONYXKEYS.ACCOUNT, {primaryLogin});
+        mockIsPermissionsBetaEnabled.mockReturnValue(isBlocked);
+        mockIsPaidGroupPolicy.mockReturnValue(isPaid);
+        mockHasAcceptedTravelTerms.mockReturnValue(hasAcceptedTerms);
+        const {result} = renderHook(() => useCreateNavigationSuggestions());
+
+        act(() => result.current.find((item) => item.keyForList === 'create_travel')?.action?.());
+
+        expect(openTravelDotLink).not.toHaveBeenCalled();
+        expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.TRAVEL_MY_TRIPS.getRoute(submitPolicy.id));
     });
 
     it('passes Submit eligibility and exposes permission-gated actions', () => {


### PR DESCRIPTION
### Explanation of Change
Adds a localized **Book travel** action to the Search Router Create suggestions. The action uses the active workspace and mirrors the existing FAB behavior: it appears only when Travel is enabled, opens TravelDot when the user and workspace are ready, and otherwise opens the existing Travel/My Trips flow. It also preserves anonymous-user interception, replaces an existing RHP instead of stacking, and leaves Quick Action excluded.

This draft currently contains the focused Book Travel implementation and tests. After Workspace PR #97972 and Domain PR #98753 merge, it will be rebased onto `main` and extended with final cross-source integration coverage.

### Fixed Issues
$ https://github.com/Expensify/App/issues/92752


### Tests
**Book Travel matching**
1. Sign in with an active workspace that has Travel enabled.
2. Open Search Router and search `book travel`.
3. Repeat with `BOOK TRAVEL`, `go to book travel`, and `go to book     travel`.
4. Verify each query shows the direct `Book travel` action without a `Go to` prefix.

**Active workspace visibility**
1. Make a workspace without Travel enabled active while another workspace has Travel enabled.
2. Open Search Router and search `book travel`.
3. Verify `Book travel` is not shown.
4. Make the Travel-enabled workspace active and repeat.
5. Verify `Book travel` is shown with the Suitcase icon.

**Travel-ready action**
1. Use a paid, Travel-enabled active workspace with accepted Travel terms, a non-SMS primary login, and no blocked Travel beta.
2. Search for and select `Book travel`.
3. Verify TravelDot opens for the active workspace.

**Travel fallback action**
1. Use a Travel-enabled active workspace that is not Travel-ready because it is unpaid, terms are not accepted, the primary login is SMS, or Travel is blocked.
2. Search for and select `Book travel`.
3. Verify the existing Travel/My Trips flow opens instead of TravelDot.

**RHP replacement and existing Create actions**
1. Open an RHP, then open Search Router and select `Book travel`.
2. Verify the existing RHP closes before Travel opens and no RHPs stack.
3. Search for existing Create actions such as `create expense`, `create report`, `track distance`, and `start chat`.
4. Verify they remain available and unchanged, and Quick Action is not shown.

- [ ] Verify that no errors appear in the JS console

### Offline tests
1. Load a Travel-enabled workspace while online.
2. Go offline, open Search Router, and search `book travel`.
3. Verify the cached active-workspace rules control whether `Book travel` appears and selecting it follows the existing offline Travel behavior without an app error.

### QA Steps
Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
- [ ] I followed proper code patterns
- [ ] I added unit tests for the new behavior
- [ ] I tested this PR with a High Traffic account
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the tests on all platforms

### Screenshots/Videos
<details><summary>Android: Native</summary><!-- add screenshots or videos here --></details>
<details><summary>Android: mWeb Chrome</summary><!-- add screenshots or videos here --></details>
<details><summary>iOS: Native</summary><!-- add screenshots or videos here --></details>
<details><summary>iOS: mWeb Safari</summary><!-- add screenshots or videos here --></details>
<details><summary>MacOS: Chrome / Safari</summary><!-- add screenshots or videos here --></details>
