### PR TITLE
fix: prevent side panel report live tail from crashing on setParams

### DIFF
--- a/src/components/withNavigationFallback.tsx
+++ b/src/components/withNavigationFallback.tsx
@@ -26,7 +26,9 @@ type NavigationContextValue = {
 };
 
 function logInertCall(method: string) {
-    Log.hmmm(`[withNavigationFallback] ignored navigation.${method}() outside a navigator screen`);
+    // Throwing would only crash the user: the misuse shows up when the call happens (an event or effect), never at render.
+    // `alert` attaches a stack and its prefix is forwarded to Sentry (FORWARDED_LOG_PREFIXES), so we still see the call site.
+    Log.alert(`[withNavigationFallback] ignored navigation.${method}() outside a navigator screen`, {method});
 }
 
 /**

--- a/src/components/withNavigationFallback.tsx
+++ b/src/components/withNavigationFallback.tsx
@@ -34,7 +34,7 @@ function logInertCall(method: string) {
 /**
  * Used by trees rendered outside a navigator screen (e.g. the side panel report). There is no screen to act on,
  * so actions are inert - but callable, since a missing method throws `x is not a function` in the caller.
- * Action-shaped no-ops log so a swallowed call isn't mistaken for a dead `Button`; state-shaped ones stay silent.
+ * Action-shaped no-ops log so a swallowed call isn't mistaken for a dead `Button`. State-shaped ones stay silent.
  */
 const FALLBACK_NAVIGATION_CONTEXT_VALUE: NavigationContextValue = {
     isFocused: () => true,

--- a/src/components/withNavigationFallback.tsx
+++ b/src/components/withNavigationFallback.tsx
@@ -1,3 +1,5 @@
+import Log from '@libs/Log';
+
 import type {NavigationProp} from '@react-navigation/native';
 import type {ParamListBase} from '@react-navigation/routers';
 import type {ComponentType} from 'react';
@@ -13,12 +15,37 @@ type NavigationContextValue = {
     isFocused: () => boolean;
     addListener: () => AddListenerCallback;
     removeListener: () => RemoveListenerCallback;
+    setParams: (params: Record<string, unknown>) => void;
+    setOptions: (options: Record<string, unknown>) => void;
+    navigate: (...args: unknown[]) => void;
+    dispatch: (...args: unknown[]) => void;
+    goBack: () => void;
+    canGoBack: () => boolean;
+    getState: () => undefined;
+    getParent: () => undefined;
 };
 
+function logInertCall(method: string) {
+    Log.hmmm(`[withNavigationFallback] ignored navigation.${method}() outside a navigator screen`);
+}
+
+/**
+ * Used by trees rendered outside a navigator screen (e.g. the side panel report). There is no screen to act on,
+ * so actions are inert - but callable, since a missing method throws `x is not a function` in the caller.
+ * Action-shaped no-ops log so a swallowed call isn't mistaken for a dead `Button`; state-shaped ones stay silent.
+ */
 const FALLBACK_NAVIGATION_CONTEXT_VALUE: NavigationContextValue = {
     isFocused: () => true,
     addListener: () => () => {},
     removeListener: () => () => {},
+    setParams: () => logInertCall('setParams'),
+    setOptions: () => logInertCall('setOptions'),
+    navigate: () => logInertCall('navigate'),
+    dispatch: () => logInertCall('dispatch'),
+    goBack: () => logInertCall('goBack'),
+    canGoBack: () => false,
+    getState: () => undefined,
+    getParent: () => undefined,
 };
 
 type WithNavigationFallbackImplProps<TProps extends Record<string, unknown>> = {
@@ -51,3 +78,5 @@ export default function <TProps extends Record<string, unknown>>(WrappedComponen
 
     return WithNavigationFallback;
 }
+
+export {FALLBACK_NAVIGATION_CONTEXT_VALUE};

--- a/src/libs/telemetry/forwardLogsToSentry.ts
+++ b/src/libs/telemetry/forwardLogsToSentry.ts
@@ -32,7 +32,7 @@ const PARAMETERS_WHITELIST: ReadonlyArray<string | RegExp> = [
 /**
  * Only log lines whose message contains one of these prefixes are forwarded to Sentry.
  */
-const FORWARDED_LOG_PREFIXES = ['[MFA]', '[OnyxUpdateManagerError]', '[Receipt]', '[PDFStall]', '[OpenReportStall]'] as const;
+const FORWARDED_LOG_PREFIXES = ['[MFA]', '[OnyxUpdateManagerError]', '[Receipt]', '[PDFStall]', '[OpenReportStall]', '[withNavigationFallback]'] as const;
 
 type ForwardedLogPrefix = TupleToUnion<typeof FORWARDED_LOG_PREFIXES>;
 
@@ -45,6 +45,7 @@ const PREFIX_SCOPED_PARAMETERS_WHITELIST = new Map<ForwardedLogPrefix, ReadonlyA
     ['[Receipt]', ['receiptTraceId', 'transactionID', 'event', 'captureSource', 'code']],
     ['[PDFStall]', ['reportID']],
     ['[OpenReportStall]', ['reportID']],
+    ['[withNavigationFallback]', ['method', 'stack']],
 ]);
 
 /**

--- a/src/pages/inbox/report/useReportActionsNewActionLiveTail.ts
+++ b/src/pages/inbox/report/useReportActionsNewActionLiveTail.ts
@@ -1,4 +1,5 @@
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useIsInSidePanel from '@hooks/useIsInSidePanel';
 import type useReportScrollManager from '@hooks/useReportScrollManager';
 
 import type {OpenReportActionParams} from '@libs/actions/Report';
@@ -82,6 +83,7 @@ function useReportActionsNewActionLiveTail({
     reportLoadingState,
 }: UseReportActionsNewActionLiveTailParams) {
     const navigation = useNavigation<PlatformStackNavigationProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>>();
+    const isInSidePanel = useIsInSidePanel();
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
     const liveTailJumpRef = useRef<{stage: LiveTailJumpStage}>({stage: 'idle'});
     const [isScrollToBottomEnabled, setIsScrollToBottomEnabled] = useState(false);
@@ -157,6 +159,17 @@ function useReportActionsNewActionLiveTail({
         liveTailJumpRef.current = {stage: 'idle'};
     }, [reportID]);
 
+    // Screen-scoped, so it clears this report route's param rather than the focused route's (e.g. an open RHP).
+    // In the side panel there is no navigator screen: the route is synthetic and carries no reportActionID, and
+    // `navigation` is the withNavigationFallback stub, so the call would only be a logged no-op.
+    // An effect event so `navigation` / `isInSidePanel` stay out of the caller's dependency list - neither triggers the jump.
+    const clearLinkedActionParam = useEffectEvent(() => {
+        if (isInSidePanel) {
+            return;
+        }
+        navigation.setParams({reportActionID: ''});
+    });
+
     useEffect(() => {
         if (liveTailJumpRef.current.stage !== 'open_report') {
             return;
@@ -169,9 +182,9 @@ function useReportActionsNewActionLiveTail({
         }
 
         setTreatAsNoPaginationAnchor(true);
-        navigation.setParams({reportActionID: ''});
+        clearLinkedActionParam();
         liveTailJumpRef.current = {stage: 'await_scroll'};
-    }, [prevIsLoadingInitialReportActions, reportLoadingState?.isLoadingInitialReportActions, setTreatAsNoPaginationAnchor, navigation]);
+    }, [prevIsLoadingInitialReportActions, reportLoadingState?.isLoadingInitialReportActions, setTreatAsNoPaginationAnchor]);
 
     useEffect(() => {
         if (liveTailJumpRef.current.stage !== 'await_scroll') {

--- a/tests/unit/forwardLogsToSentryTest.ts
+++ b/tests/unit/forwardLogsToSentryTest.ts
@@ -61,6 +61,23 @@ describe('forwardLogsToSentry', () => {
         expect(breadcrumb?.data).not.toHaveProperty('transactionID');
     });
 
+    it('forwards a swallowed navigation call as an error, carrying the method and its call site', () => {
+        // Given an inert navigation call reported by the withNavigationFallback stub, at alert level with a stack
+        const packet = packetWith('[alrt] [withNavigationFallback] ignored navigation.setParams() outside a navigator screen', {
+            method: 'setParams',
+            stack: 'Error\n    at useReportActionsNewActionLiveTail',
+        });
+
+        // When the packet is mirrored to Sentry
+        forwardLogsToSentry(packet);
+
+        // Then it lands at error level, so a swallowed call is visible instead of silently doing nothing
+        expect(Sentry.logger.error).toHaveBeenCalledWith(
+            '[alrt] [withNavigationFallback] ignored navigation.setParams() outside a navigator screen',
+            expect.objectContaining({method: 'setParams', stack: 'Error\n    at useReportActionsNewActionLiveTail'}),
+        );
+    });
+
     it('does not add a breadcrumb for log lines that are not forwarded', () => {
         // Given a log line without a forwarded prefix
         const packet = packetWith('[info] [SequentialQueue] push() called', {command: 'OpenReport'});

--- a/tests/unit/useReportActionsNewActionLiveTailTest.ts
+++ b/tests/unit/useReportActionsNewActionLiveTailTest.ts
@@ -12,7 +12,19 @@ import {getFakeReportAction} from '../utils/ReportTestUtils';
 const mockNavigationSetParams = jest.fn();
 const mockGlobalSetParams = jest.fn();
 const mockOpenReport = jest.fn();
+const mockLogAlert = jest.fn();
 let newActionHandler: ((isFromCurrentUser: boolean, action?: ReportAction) => void) | undefined;
+
+jest.mock('@libs/Log', () => ({
+    __esModule: true,
+    default: {
+        alert: (...args: unknown[]) => {
+            mockLogAlert(...args);
+        },
+        hmmm: jest.fn(),
+        info: jest.fn(),
+    },
+}));
 
 jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({
     __esModule: true,
@@ -172,6 +184,31 @@ describe('useReportActionsNewActionLiveTail', () => {
 });
 
 describe('withNavigationFallback stub', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('reports every swallowed navigation call at alert level so it is findable in Sentry', () => {
+        // Given a tree rendered outside a navigator screen, where every navigation action is inert
+        FALLBACK_NAVIGATION_CONTEXT_VALUE.setParams({reportActionID: ''});
+        FALLBACK_NAVIGATION_CONTEXT_VALUE.goBack();
+
+        // Then each swallowed call is reported with the method that was called, so it cannot pass unnoticed
+        expect(mockLogAlert).toHaveBeenCalledWith('[withNavigationFallback] ignored navigation.setParams() outside a navigator screen', {method: 'setParams'});
+        expect(mockLogAlert).toHaveBeenCalledWith('[withNavigationFallback] ignored navigation.goBack() outside a navigator screen', {method: 'goBack'});
+    });
+
+    it('stays silent for the state-shaped reads, which have a meaningful inert answer', () => {
+        // Given the state-shaped members of the stub
+        FALLBACK_NAVIGATION_CONTEXT_VALUE.getState();
+        FALLBACK_NAVIGATION_CONTEXT_VALUE.getParent();
+        FALLBACK_NAVIGATION_CONTEXT_VALUE.canGoBack();
+        FALLBACK_NAVIGATION_CONTEXT_VALUE.isFocused();
+
+        // Then nothing is reported - unlike an action, a read that returns "no navigator" is not a mistake
+        expect(mockLogAlert).not.toHaveBeenCalled();
+    });
+
     it('exposes callable navigation methods that do not throw', () => {
         expect(() => FALLBACK_NAVIGATION_CONTEXT_VALUE.setParams({reportActionID: ''})).not.toThrow();
         expect(() => FALLBACK_NAVIGATION_CONTEXT_VALUE.navigate('Report')).not.toThrow();

--- a/tests/unit/useReportActionsNewActionLiveTailTest.ts
+++ b/tests/unit/useReportActionsNewActionLiveTailTest.ts
@@ -1,5 +1,7 @@
 import {act, renderHook} from '@testing-library/react-native';
 
+import {FALLBACK_NAVIGATION_CONTEXT_VALUE} from '@components/withNavigationFallback';
+
 import useReportActionsNewActionLiveTail from '@pages/inbox/report/useReportActionsNewActionLiveTail';
 
 import CONST from '@src/CONST';
@@ -17,8 +19,16 @@ jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({
     default: () => ({accountID: 1}),
 }));
 
+let mockNavigation: Record<string, unknown> = {setParams: mockNavigationSetParams, getState: () => ({key: 'stack-report'})};
+let mockIsInSidePanel = false;
+
 jest.mock('@react-navigation/native', () => ({
-    useNavigation: () => ({setParams: mockNavigationSetParams}),
+    useNavigation: () => mockNavigation,
+}));
+
+jest.mock('@hooks/useIsInSidePanel', () => ({
+    __esModule: true,
+    default: () => mockIsInSidePanel,
 }));
 
 jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator', () => ({
@@ -91,6 +101,8 @@ describe('useReportActionsNewActionLiveTail', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         newActionHandler = undefined;
+        mockNavigation = {setParams: mockNavigationSetParams, getState: () => ({key: 'stack-report'})};
+        mockIsInSidePanel = false;
     });
 
     it('clears the report screen param after loading the live tail without changing the focused route', () => {
@@ -111,5 +123,62 @@ describe('useReportActionsNewActionLiveTail', () => {
 
         expect(mockNavigationSetParams).toHaveBeenCalledWith({reportActionID: ''});
         expect(mockGlobalSetParams).not.toHaveBeenCalled();
+    });
+
+    it('does not throw and still advances the live-tail jump when navigation is the withNavigationFallback stub', () => {
+        // No NavigationContext in the side panel tree, so `useNavigation` resolves to the fallback stub.
+        mockNavigation = {...FALLBACK_NAVIGATION_CONTEXT_VALUE};
+        const setTreatAsNoPaginationAnchor = jest.fn();
+        const {rerender} = renderHook((props: HookParams) => useReportActionsNewActionLiveTail(props), {initialProps: buildParams({setTreatAsNoPaginationAnchor})});
+
+        act(() => {
+            newActionHandler?.(true, getFakeReportAction(1, {actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT}));
+        });
+
+        expect(() =>
+            rerender(
+                buildParams({
+                    setTreatAsNoPaginationAnchor,
+                    prevIsLoadingInitialReportActions: true,
+                    reportLoadingState: {isLoadingInitialReportActions: false},
+                }),
+            ),
+        ).not.toThrow();
+
+        expect(setTreatAsNoPaginationAnchor).toHaveBeenCalledWith(true);
+    });
+
+    it('skips the setParams dispatch in the side panel but still advances the live-tail jump', () => {
+        mockIsInSidePanel = true;
+        const setTreatAsNoPaginationAnchor = jest.fn();
+        const {rerender} = renderHook((props: HookParams) => useReportActionsNewActionLiveTail(props), {initialProps: buildParams({setTreatAsNoPaginationAnchor})});
+
+        act(() => {
+            newActionHandler?.(true, getFakeReportAction(1, {actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT}));
+        });
+
+        rerender(
+            buildParams({
+                setTreatAsNoPaginationAnchor,
+                prevIsLoadingInitialReportActions: true,
+                reportLoadingState: {isLoadingInitialReportActions: false},
+            }),
+        );
+
+        expect(mockGlobalSetParams).not.toHaveBeenCalled();
+        expect(mockNavigationSetParams).not.toHaveBeenCalled();
+        expect(setTreatAsNoPaginationAnchor).toHaveBeenCalledWith(true);
+    });
+});
+
+describe('withNavigationFallback stub', () => {
+    it('exposes callable navigation methods that do not throw', () => {
+        expect(() => FALLBACK_NAVIGATION_CONTEXT_VALUE.setParams({reportActionID: ''})).not.toThrow();
+        expect(() => FALLBACK_NAVIGATION_CONTEXT_VALUE.navigate('Report')).not.toThrow();
+        expect(() => FALLBACK_NAVIGATION_CONTEXT_VALUE.goBack()).not.toThrow();
+        expect(() => FALLBACK_NAVIGATION_CONTEXT_VALUE.dispatch({type: 'NOOP'})).not.toThrow();
+        expect(FALLBACK_NAVIGATION_CONTEXT_VALUE.getState()).toBeUndefined();
+        expect(FALLBACK_NAVIGATION_CONTEXT_VALUE.getParent()).toBeUndefined();
+        expect(FALLBACK_NAVIGATION_CONTEXT_VALUE.canGoBack()).toBe(false);
     });
 });


### PR DESCRIPTION
### Explanation of Change

Concierge Anywhere on web renders the report in the **side panel**, which sits outside any navigator screen, so `ScreenWrapper` (exported as `withNavigationFallback(ScreenWrapper)`) hands the whole subtree a stub navigation object exposing only `isFocused` / `addListener` / `removeListener`. `useReportActionsNewActionLiveTail` runs inside that subtree and called `navigation.setParams({reportActionID: ''})`, which was `undefined` on the stub - a `TypeError` inside a passive effect, so the error boundary showed a crash screen. Native is unaffected (`isSidePanelReportSupported` is `false`), matching the zero native events in Sentry.

Two changes, each individually sufficient; both kept on purpose:

1. **`useReportActionsNewActionLiveTail.ts`** - use the route-targeted global dispatch already used in this tree (`Navigation.setParams({reportActionID: ''}, route.key, navigatorKey)`, same as `LinkedActionNotFoundGuard`). It goes through `navigationRef`, which is always real, and targets *this* route rather than the focused one, preserving the existing behavior of not clobbering an open RHP's params. The dispatch is skipped in the side panel, whose synthetic route carries no `reportActionID` to clear. Only the dispatch is skipped - the rest of the jump still runs, so the side-panel live tail still scrolls to the newest message.

2. **`withNavigationFallback.tsx`** - harden the stub with the rest of the surface used under `ScreenWrapper` so descendants degrade instead of throwing. Action-shaped no-ops log via `Log.hmmm`, since this HOC also wraps `Button` and `ButtonKeyboardShortcut` and a bare no-op would turn a loud crash into a silently dead button.

Unit tests cover the route-targeted dispatch, the side-panel skip, the fallback-stub path not throwing, and the stub's callable surface.

Before:

https://github.com/user-attachments/assets/7315a0cb-f685-4096-a96d-e92470a965a8


After:

https://github.com/user-attachments/assets/3d8fe2fe-cc8a-4d83-b586-6b83b3344d26



### Fixed Issues

$ https://github.com/Expensify/App/issues/99517
PROPOSAL:

### Tests

1. On web, open the **Inbox** with a chat open in the central pane.
2. In the LHN, right-click the **Concierge** chat and choose **Mark as unread**. (Alternatively, right-click a message inside the Concierge chat and choose **Mark as unread**.) This sets the unread marker, which is what triggers the live-tail jump.
3. Navigate to a different chat, staying on the Inbox. Do not open Concierge in the central pane.
4. Click the Concierge entry point in the header to open Concierge Anywhere. The chat must render in the **side panel** overlay.
5. Verify the green "New" divider is visible in the side-panel chat. If it is not, repeat from step 2 - the live tail will not fire without it.
6. Click a **suggested followup** chip, or type any message and press Enter.
7. Verify the side-panel chat scrolls to the newest message, no error-boundary crash screen appears, and there is no `setParams is not a function` in the console.
8. Verify the browser URL still points at whatever route was underneath the side panel - it must not change.

Regression check on real navigator screens:

9. Open a chat deep-linked to an old action (`/r/<reportID>/<reportActionID>`) in the central pane.
10. Open an RHP on top of it (e.g. report details) and leave it open.
11. Post a message in the chat.
12. Verify the live-tail jump clears `reportActionID` from the report route - the URL drops back to `/r/<reportID>` - while the RHP stays open with its params untouched.

Negative control (confirms the crash was side-panel-specific, not Concierge-specific):

13. Open the Concierge chat normally from the LHN in the central pane and repeat steps 2 and 6. The same live-tail jump runs and there is no crash, before or after this change.

- [ ] Verify that no errors appear in the JS console

### Offline tests

The live-tail jump is gated on `!isOffline`, so none of this runs while offline.

1. Go offline.
2. Open Concierge Anywhere in the side panel and send a message.
3. Verify the message is queued optimistically and no crash occurs.
4. Go back online and verify the message sends and the chat behaves normally.

### QA Steps

Same as tests. Web only - the side panel report is not supported on native, so there is nothing to verify on iOS or Android native.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A - the side panel report is not supported on native (`isSidePanelReportSupported` is `false`).

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

N/A - the side panel report is not supported on native (`isSidePanelReportSupported` is `false`).

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
