### PR TITLE
Prevent self-parented report when preexistingReportID equals parentReportID

### DIFF
--- a/src/libs/actions/replaceOptimisticReportWithActualReport.ts
+++ b/src/libs/actions/replaceOptimisticReportWithActualReport.ts
@@ -73,6 +73,11 @@ function replaceOptimisticReportWithActualReport(report: Report, draftReportComm
         return;
     }
 
+    // API sometimes returns the parent as the preexisting report, which would parent it to itself
+    if (preexistingReportID === parentReportID) {
+        return;
+    }
+
     // Handle cleanup of stale optimistic IOU report and its report preview separately
     if (isMoneyRequestReport(report) && parentReportID && parentReportActionID) {
         Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {

--- a/tests/actions/ReplaceOptimisticReportWithActualReportTest.ts
+++ b/tests/actions/ReplaceOptimisticReportWithActualReportTest.ts
@@ -1412,4 +1412,94 @@ describe('replaceOptimisticReportWithActualReport', () => {
         // And it should be updated to point to the preexisting report
         expect(parentActions?.[reportActionID]?.childReportID).toBe(preexistingReportID);
     });
+
+    const setUpParentReturnedAsPreexistingReport = async () => {
+        const parentReportID = '9999';
+        const optimisticReportID = '1234';
+        const reportActionID = 'action123';
+
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${parentReportID}`, {
+            reportID: parentReportID,
+            type: CONST.REPORT.TYPE.CHAT,
+            chatType: CONST.REPORT.CHAT_TYPE.SELF_DM,
+            reportName: 'Self DM',
+        });
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+            [reportActionID]: {
+                reportActionID,
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE, IOUTransactionID: 'trans123'},
+                childReportID: optimisticReportID,
+            },
+        });
+
+        const optimisticReport = {
+            reportID: optimisticReportID,
+            type: CONST.REPORT.TYPE.CHAT,
+            parentReportID,
+            parentReportActionID: reportActionID,
+            preexistingReportID: parentReportID,
+        };
+
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${optimisticReportID}`, optimisticReport);
+        await waitForBatchedUpdates();
+
+        return {parentReportID, optimisticReportID, reportActionID, optimisticReport};
+    };
+
+    it('should not overwrite the parent report when the preexisting report is the parent report', async () => {
+        // Given the API returned the parent report itself as the preexisting report
+        const {parentReportID, optimisticReport} = await setUpParentReturnedAsPreexistingReport();
+
+        // When replaceOptimisticReportWithActualReport is called
+        replaceOptimisticReportWithActualReport(optimisticReport, undefined, 1);
+        await waitForBatchedUpdates();
+
+        // Then the parent report keeps its own data and is not left parented to itself
+        const parentReport = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${parentReportID}`);
+        expect(parentReport?.parentReportID).toBeUndefined();
+        expect(parentReport?.chatType).toBe(CONST.REPORT.CHAT_TYPE.SELF_DM);
+        expect(parentReport?.reportName).toBe('Self DM');
+    });
+
+    it('should keep the optimistic report when the preexisting report is the parent report', async () => {
+        // Given the API returned the parent report itself as the preexisting report
+        const {parentReportID, optimisticReportID, reportActionID, optimisticReport} = await setUpParentReturnedAsPreexistingReport();
+
+        // When replaceOptimisticReportWithActualReport is called
+        replaceOptimisticReportWithActualReport(optimisticReport, undefined, 1);
+        await waitForBatchedUpdates();
+
+        // Then the optimistic report is not cleared, so the parent action's childReportID does not dangle
+        const keptReport = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT}${optimisticReportID}`);
+        expect(keptReport).toBeDefined();
+
+        const parentActions = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`);
+        expect(parentActions?.[reportActionID]?.childReportID).toBe(optimisticReportID);
+    });
+
+    it('should not navigate away when the preexisting report is the parent report and the user is viewing the optimistic report', async () => {
+        // Given the user is viewing the optimistic report
+        mockIsReady.mockReturnValue(true);
+        mockGetCurrentRoute.mockReturnValue({name: SCREENS.REPORT, params: {}});
+
+        // And the API returned the parent report itself as the preexisting report
+        const {optimisticReportID, optimisticReport} = await setUpParentReturnedAsPreexistingReport();
+        mockGetActiveRoute.mockReturnValue(`/r/${optimisticReportID}`);
+
+        let capturedEventData: SwitchReportEventData | undefined;
+        const subscription = DeviceEventEmitter.addListener(`switchToPreExistingReport_${optimisticReportID}`, (data: SwitchReportEventData) => {
+            capturedEventData = data;
+        });
+
+        // When replaceOptimisticReportWithActualReport is called
+        replaceOptimisticReportWithActualReport(optimisticReport, undefined, 1);
+        await waitForBatchedUpdates();
+
+        // Then the user is not switched to the parent report
+        expect(capturedEventData).toBeUndefined();
+        expect(mockSetParams).not.toHaveBeenCalled();
+
+        subscription.remove();
+    });
 });


### PR DESCRIPTION
### Explanation of Change

The API can return `preexistingReportID` equal to the optimistic report's own `parentReportID`. When that happens, `replaceOptimisticReportWithActualReport` copies `parentReportID` verbatim onto the preexisting report via `Onyx.set`, producing a report where `reportID === parentReportID`. Every function that walks report ancestry (`getAncestors`, `isSelfDMOrSelfDMThread`, `getRootParentReport`) then loops forever — `getAncestors` freezes the web app and `isSelfDMOrSelfDMThread` throws `RangeError: Maximum call stack size exceeded` from `MoneyRequestView`.

This adds an early return in `replaceOptimisticReportWithActualReport` when `preexistingReportID === parentReportID`, before any Onyx write. Nothing is deleted and nothing is overwritten, so the optimistic report stays intact and the parent action's `childReportID` keeps pointing at a report that exists. Three unit tests cover the new branch: the parent report keeps its own data, the optimistic report is not cleared, and the user is not navigated away.

### Fixed Issues
$ https://github.com/Expensify/App/issues/99594
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests

### QA Steps

Ping @mountiny to test, we need to suppotal to the customer account https://expensify.slack.com/archives/C05LX9D6E07/p1787656510726119

Same as tests.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
